### PR TITLE
fix(swarm): replace batch-barrier scheduling with eager DAG execution

### DIFF
--- a/assistant/src/__tests__/swarm-orchestrator.test.ts
+++ b/assistant/src/__tests__/swarm-orchestrator.test.ts
@@ -267,4 +267,51 @@ describe('executeSwarm', () => {
     expect(summary.stats.completed).toBe(4);
     expect(summary.stats.blocked).toBe(0);
   });
+
+  test('schedules dependents eagerly without waiting for batch peers', async () => {
+    // A (slow) and B (fast) are independent. C depends only on B.
+    // With eager scheduling, C should start while A is still running.
+    const timeline: { taskId: string; event: 'start' | 'end' }[] = [];
+
+    const plan = makePlan({
+      tasks: [
+        { id: 'A', role: 'coder', objective: 'slow', dependencies: [] },
+        { id: 'B', role: 'coder', objective: 'fast', dependencies: [] },
+        { id: 'C', role: 'coder', objective: 'dep-on-B', dependencies: ['B'] },
+      ],
+    });
+
+    const backend = makeBackend({
+      runTask: async (input) => {
+        const id = input.prompt.includes('slow') ? 'A'
+          : input.prompt.includes('fast') ? 'B' : 'C';
+        timeline.push({ taskId: id, event: 'start' });
+        // A is deliberately slower than B so C should start before A finishes
+        if (id === 'A') await new Promise((r) => setTimeout(r, 80));
+        else await new Promise((r) => setTimeout(r, 5));
+        timeline.push({ taskId: id, event: 'end' });
+        return {
+          success: true,
+          output: '```json\n{"summary":"Done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+          durationMs: 10,
+        };
+      },
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: resolveSwarmLimits({ ...DEFAULT_LIMITS, maxWorkers: 3 }),
+      backend,
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.completed).toBe(3);
+
+    // C must start before A ends — proves eager scheduling
+    const cStart = timeline.findIndex((e) => e.taskId === 'C' && e.event === 'start');
+    const aEnd = timeline.findIndex((e) => e.taskId === 'A' && e.event === 'end');
+    expect(cStart).toBeGreaterThan(-1);
+    expect(aEnd).toBeGreaterThan(-1);
+    expect(cStart).toBeLessThan(aEnd);
+  });
 });

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -73,24 +73,78 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
     }
   }
 
-  // Process tasks with bounded concurrency
-  while (ready.length > 0 || isAnyRunning()) {
-    if (signal?.aborted) break;
+  // Concurrent DAG executor — schedule tasks as soon as their prerequisites
+  // finish, bounded by maxWorkers.  Unlike wave/batch execution, a newly
+  // unblocked task can start immediately when a worker slot opens up rather
+  // than waiting for the entire previous batch to complete.
+  let activeCount = 0;
+  let resolve: (() => void) | null = null;
 
-    // Launch up to maxWorkers tasks
-    const batch = ready.splice(0, limits.maxWorkers);
+  // Resolves whenever a running task completes (or the ready queue is refilled)
+  // so the main loop can re-evaluate whether to launch more work.
+  function signalProgress(): void {
+    if (resolve) {
+      const r = resolve;
+      resolve = null;
+      r();
+    }
+  }
 
-    const promises = batch.map(async (task) => {
-      onStatus?.({ kind: 'task_started', taskId: task.id });
+  function waitForProgress(): Promise<void> {
+    return new Promise<void>((r) => { resolve = r; });
+  }
 
-      const depOutputs = task.dependencies
-        .map((depId) => {
-          const r = results.get(depId);
-          return r ? { taskId: depId, summary: r.summary } : null;
-        })
-        .filter((d): d is { taskId: string; summary: string } => d !== null);
+  function processResult(result: SwarmTaskResult): void {
+    results.set(result.taskId, result);
+    remaining.delete(result.taskId);
 
-      let result = await runWorkerTask({
+    if (result.status === 'completed') {
+      onStatus?.({ kind: 'task_completed', taskId: result.taskId });
+      // Immediately unblock dependents so they enter the ready queue
+      for (const depId of dependents.get(result.taskId) ?? []) {
+        const pending = pendingDeps.get(depId);
+        if (pending) {
+          pending.delete(result.taskId);
+          if (pending.size === 0) {
+            pendingDeps.delete(depId);
+            const task = plan.tasks.find((t) => t.id === depId);
+            if (task && !blocked.has(depId)) {
+              ready.push(task);
+            }
+          }
+        }
+      }
+    } else {
+      onStatus?.({ kind: 'task_failed', taskId: result.taskId });
+      blockDependents(result.taskId, dependents, blocked, onStatus);
+    }
+  }
+
+  async function runTask(task: SwarmTaskNode): Promise<void> {
+    onStatus?.({ kind: 'task_started', taskId: task.id });
+
+    const depOutputs = task.dependencies
+      .map((depId) => {
+        const r = results.get(depId);
+        return r ? { taskId: depId, summary: r.summary } : null;
+      })
+      .filter((d): d is { taskId: string; summary: string } => d !== null);
+
+    let result = await runWorkerTask({
+      task,
+      upstreamContext: plan.objective,
+      dependencyOutputs: depOutputs,
+      backend,
+      workingDir,
+      model,
+      timeoutMs: limits.workerTimeoutSec * 1000,
+      signal,
+    });
+
+    let retries = 0;
+    while (result.status === 'failed' && retries < limits.maxRetriesPerTask && !signal?.aborted) {
+      retries++;
+      result = await runWorkerTask({
         task,
         upstreamContext: plan.objective,
         dependencyOutputs: depOutputs,
@@ -100,55 +154,30 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
         timeoutMs: limits.workerTimeoutSec * 1000,
         signal,
       });
-
-      // Retry loop — skip retries when the swarm is being cancelled
-      let retries = 0;
-      while (result.status === 'failed' && retries < limits.maxRetriesPerTask && !signal?.aborted) {
-        retries++;
-        result = await runWorkerTask({
-          task,
-          upstreamContext: plan.objective,
-          dependencyOutputs: depOutputs,
-          backend,
-          workingDir,
-          model,
-          timeoutMs: limits.workerTimeoutSec * 1000,
-          signal,
-        });
-      }
-      result.retryCount = retries;
-
-      return result;
-    });
-
-    const batchResults = await Promise.all(promises);
-
-    for (const result of batchResults) {
-      results.set(result.taskId, result);
-      remaining.delete(result.taskId);
-
-      if (result.status === 'completed') {
-        onStatus?.({ kind: 'task_completed', taskId: result.taskId });
-        // Unblock dependents
-        for (const depId of dependents.get(result.taskId) ?? []) {
-          const pending = pendingDeps.get(depId);
-          if (pending) {
-            pending.delete(result.taskId);
-            if (pending.size === 0) {
-              pendingDeps.delete(depId);
-              const task = plan.tasks.find((t) => t.id === depId);
-              if (task && !blocked.has(depId)) {
-                ready.push(task);
-              }
-            }
-          }
-        }
-      } else {
-        onStatus?.({ kind: 'task_failed', taskId: result.taskId });
-        // Block all transitive dependents
-        blockDependents(result.taskId, dependents, blocked, onStatus);
-      }
     }
+    result.retryCount = retries;
+
+    activeCount--;
+    processResult(result);
+    signalProgress();
+  }
+
+  while (ready.length > 0 || activeCount > 0) {
+    if (signal?.aborted) break;
+
+    // Launch as many ready tasks as worker slots allow
+    while (ready.length > 0 && activeCount < limits.maxWorkers) {
+      const task = ready.shift()!;
+      activeCount++;
+      // Fire-and-forget — completion is handled inside runTask
+      runTask(task);
+    }
+
+    // Nothing left to launch and nothing running — we're done
+    if (activeCount === 0 && ready.length === 0) break;
+
+    // Wait until a running task completes (or a new task becomes ready)
+    await waitForProgress();
   }
 
   // Mark any remaining tasks that were never reached as blocked
@@ -193,12 +222,6 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       totalDurationMs,
     },
   };
-
-  // Placeholder — there's no true async tracking in this sync loop,
-  // but the structure supports it.
-  function isAnyRunning(): boolean {
-    return false;
-  }
 }
 
 function blockDependents(


### PR DESCRIPTION
## Summary
- Replace wave-based `Promise.all` batch execution with an eager concurrent DAG scheduler
- Tasks are now dispatched immediately when their prerequisites complete and a worker slot is free, rather than waiting for the entire batch to finish
- Addresses Codex review feedback on PR #2436 (P2: schedule newly unblocked tasks without batch barriers)

## Changes
- **`assistant/src/swarm/orchestrator.ts`**: Replaced batch loop with progress-signaling concurrency model — `runTask` fires concurrently, `processResult` pushes newly-ready tasks, and the main loop fills worker slots eagerly
- **`assistant/src/__tests__/swarm-orchestrator.test.ts`**: Added test proving eager scheduling (dependent C starts while slow peer A is still running)

## Test plan
- [x] `bun test src/__tests__/swarm-orchestrator.test.ts` — 11/11 pass (including new eager scheduling test)
- [x] `bunx tsc --noEmit` — no new type errors

Closes feedback on #2436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
