### PR TITLE
fix(session): guard profile and conflict sub-features on memory.enabled

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -6,6 +6,7 @@ import type { ServerMessage } from '../daemon/ipc-protocol.js';
 let runCalls: Message[][] = [];
 let resolverCallCount = 0;
 let markAskedCalls: string[] = [];
+let memoryEnabled = true;
 let pendingConflicts: Array<{
   id: string;
   scopeId: string;
@@ -68,6 +69,7 @@ mock.module('../config/loader.js', () => ({
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     apiKeys: {},
     memory: {
+      enabled: memoryEnabled,
       retrieval: {
         injectionStrategy: 'prepend_user_block',
         dynamicBudget: {
@@ -204,6 +206,13 @@ mock.module('../memory/clarification-resolver.js', () => ({
   },
 }));
 
+mock.module('../memory/admin.js', () => ({
+  getMemorySystemStatus: () => ({
+    conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
+    cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
+  }),
+}));
+
 mock.module('../memory/llm-usage-store.js', () => ({
   recordUsageEvent: () => ({ id: 'usage-1', createdAt: Date.now() }),
 }));
@@ -253,6 +262,7 @@ describe('Session conflict soft gate', () => {
     runCalls = [];
     resolverCallCount = 0;
     markAskedCalls = [];
+    memoryEnabled = true;
     pendingConflicts = [];
     persistedMessages.length = 0;
     resolverResult = {
@@ -410,5 +420,36 @@ describe('Session conflict soft gate', () => {
     expect(firstUserText).toContain('Memory clarification request');
     expect(secondUserText).not.toContain('Memory clarification request');
     expect(markAskedCalls).toEqual(['conflict-cooldown']);
+  });
+
+  test('skips conflict gate when top-level memory.enabled is false', async () => {
+    memoryEnabled = false;
+    pendingConflicts = [{
+      id: 'conflict-disabled',
+      scopeId: 'default',
+      existingItemId: 'existing-d',
+      candidateItemId: 'candidate-d',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Do you want React or Vue for frontend work?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use React for frontend work.',
+      candidateStatement: 'Use Vue for frontend work.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: ServerMessage[] = [];
+    await session.processMessage('Should I use React or Vue here?', [], (event) => events.push(event));
+
+    // Agent loop should run normally — conflict gate should be bypassed
+    expect(runCalls).toHaveLength(1);
+    expect(resolverCallCount).toBe(0);
+    expect(markAskedCalls).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -6,6 +6,7 @@ import type { ServerMessage } from '../daemon/ipc-protocol.js';
 let runCalls: Message[][] = [];
 let profileCompilerCalls = 0;
 let profileEnabled = true;
+let memoryEnabled = true;
 let profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles';
 
 const persistedMessages: Array<{ id: string; role: string; content: string; createdAt: number }> = [];
@@ -41,6 +42,7 @@ mock.module('../config/loader.js', () => ({
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     apiKeys: {},
     memory: {
+      enabled: memoryEnabled,
       retrieval: {
         injectionStrategy: 'prepend_user_block',
         dynamicBudget: {
@@ -180,6 +182,13 @@ mock.module('../memory/clarification-resolver.js', () => ({
   }),
 }));
 
+mock.module('../memory/admin.js', () => ({
+  getMemorySystemStatus: () => ({
+    conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
+    cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
+  }),
+}));
+
 mock.module('../memory/profile-compiler.js', () => ({
   compileDynamicProfile: () => {
     profileCompilerCalls += 1;
@@ -243,6 +252,7 @@ describe('Session dynamic profile injection', () => {
     persistedMessages.length = 0;
     profileCompilerCalls = 0;
     profileEnabled = true;
+    memoryEnabled = true;
     profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles';
   });
 
@@ -279,6 +289,20 @@ describe('Session dynamic profile injection', () => {
     await session.loadFromDb();
 
     await session.processMessage('Explain rebase strategy', [], () => {});
+
+    expect(runCalls).toHaveLength(1);
+    const runtimeUser = runCalls[0][runCalls[0].length - 1];
+    const runtimeText = messageText(runtimeUser);
+    expect(runtimeText).not.toContain('[Dynamic profile context start]');
+    expect(profileCompilerCalls).toBe(0);
+  });
+
+  test('skips profile injection when top-level memory.enabled is false', async () => {
+    memoryEnabled = false;
+    const session = makeSession();
+    await session.loadFromDb();
+
+    await session.processMessage('What is my timezone?', [], () => {});
 
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -620,7 +620,8 @@ export class Session {
       let pendingDirectiveDisplayBuffer = '';
       let lastAssistantMessageId: string | undefined;
       const runtimeConfig = getConfig();
-      const conflictConfig = runtimeConfig.memory?.conflicts;
+      const memoryEnabled = runtimeConfig.memory?.enabled !== false;
+      const conflictConfig = memoryEnabled ? runtimeConfig.memory?.conflicts : undefined;
       const conflictGate = conflictConfig
         ? await this.conflictGate.evaluate(content, conflictConfig)
         : null;
@@ -653,7 +654,7 @@ export class Session {
       const softConflictInstruction = conflictGate && !conflictGate.relevant
         ? conflictGate.question
         : null;
-      const profileConfig = runtimeConfig.memory?.profile;
+      const profileConfig = memoryEnabled ? runtimeConfig.memory?.profile : undefined;
       const dynamicProfile = profileConfig?.enabled
         ? compileDynamicProfile({
             scopeId: 'default',


### PR DESCRIPTION
## Summary

Addresses review feedback on #2503: when `memory.enabled` is `false`, sub-features (profile injection, conflict gate) should be effectively disabled regardless of their individual `enabled` flags.

- Add `memoryEnabled` guard in `session.ts` so `conflictConfig` and `profileConfig` are only read when the top-level `memory.enabled` flag is truthy
- Add test cases in both `session-conflict-gate.test.ts` and `session-profile-injection.test.ts` verifying the guard
- Add missing `getMemorySystemStatus` mock to both test files (was causing crashes due to accessing `config.memory.embeddings.provider`)

## Test plan

- [x] `bun test session-conflict-gate.test.ts` passes (5/5 including new guard test)
- [x] `bun test session-profile-injection.test.ts` passes (3/3 including new guard test)

Fixes feedback from #2503.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
