### PR TITLE
fix(memory): require reply intent before resolving recently asked conflicts

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -380,6 +380,48 @@ describe('Session conflict soft gate', () => {
     expect(runCalls).toHaveLength(1);
   });
 
+  test('unrelated message during cooldown does not accidentally resolve conflict', async () => {
+    pendingConflicts = [{
+      id: 'conflict-unrelated',
+      scopeId: 'default',
+      existingItemId: 'existing-unrelated',
+      candidateItemId: 'candidate-unrelated',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Should I assume Postgres or MySQL?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use Postgres as the default database.',
+      candidateStatement: 'Use MySQL as the default database.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // First turn: relevant question triggers clarification ask.
+    await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
+    expect(resolverCallCount).toBe(1);
+    expect(markAskedCalls).toEqual(['conflict-unrelated']);
+
+    // Second turn: unrelated question containing the cue word "new" should NOT
+    // resolve the conflict — it is not a clarification reply.
+    resolverResult = {
+      resolution: 'keep_candidate',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'Directional clarification received.',
+    };
+    await session.processMessage("What's new in Bun?", [], () => {});
+
+    // The resolver should NOT have been called again for this unrelated question.
+    expect(resolverCallCount).toBe(1);
+    // Normal agent loop should still run.
+    expect(runCalls).toHaveLength(1);
+  });
+
   test('cooldown prevents repeated asks on subsequent turns', async () => {
     pendingConflicts = [{
       id: 'conflict-cooldown',

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -40,7 +40,12 @@ export class ConflictGate {
     const pendingBeforeResolve = listPendingConflictDetails('default', 50);
     const candidatesBeforeResolve = pendingBeforeResolve.filter((conflict) => {
       const relevance = computeConflictRelevance(userMessage, conflict);
-      return relevance >= threshold || this.wasRecentlyAsked(conflict.id, cooldownTurns);
+      if (relevance >= threshold) return true;
+      // Only try to resolve recently-asked conflicts when the user message
+      // looks like a short clarification reply (e.g. "keep the new one"),
+      // not a full unrelated question that happens to contain cue words.
+      return this.wasRecentlyAsked(conflict.id, cooldownTurns)
+        && looksLikeClarificationReply(userMessage);
     });
     await this.resolvePendingConflicts(
       userMessage,
@@ -147,4 +152,39 @@ function overlapRatio(left: Set<string>, right: Set<string>): number {
     if (right.has(token)) overlap += 1;
   }
   return overlap / Math.max(left.size, right.size);
+}
+
+// Action verbs that signal the user is making a deliberate choice.
+const ACTION_CUES = new Set([
+  'keep', 'use', 'prefer', 'go', 'pick', 'choose', 'take', 'want', 'select',
+]);
+
+// Directional/merge cue words mirrored from clarification-resolver.ts heuristics.
+const DIRECTIONAL_CUES = new Set([
+  'existing', 'old', 'previous', 'first', 'earlier', 'original',
+  'candidate', 'new', 'latest', 'second', 'updated', 'instead', 'replace',
+  'both', 'merge', 'combine', 'together', 'either', 'mix',
+  'option', 'former', 'latter',
+]);
+
+const MAX_REPLY_WORD_COUNT = 12;
+
+/**
+ * Determines whether a user message looks like a deliberate reply to a
+ * recently asked conflict clarification (e.g. "keep the new one", "option B").
+ * Requires both an action cue and a directional cue, and the message must be
+ * short. Questions and longer statements are excluded to prevent accidental
+ * resolution from messages like "what's new in Bun?".
+ */
+export function looksLikeClarificationReply(userMessage: string): boolean {
+  const trimmed = userMessage.trim();
+  if (trimmed.endsWith('?')) return false;
+
+  const words = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0 || words.length > MAX_REPLY_WORD_COUNT) return false;
+
+  const normalized = words.map((w) => w.replace(/[^a-z]/g, ''));
+  const hasAction = normalized.some((w) => ACTION_CUES.has(w));
+  const hasDirection = normalized.some((w) => DIRECTIONAL_CUES.has(w));
+  return hasAction && hasDirection;
 }


### PR DESCRIPTION
## Summary
- Addresses codex review feedback on #2474 (P2: accidental conflict resolution)
- Adds a `looksLikeClarificationReply` gate that requires both an action cue (keep, use, prefer, etc.) and a directional cue (new, old, both, etc.) in a short non-question message before bypassing the relevance filter for recently asked conflicts
- Prevents unrelated messages like "what's new in Bun?" from accidentally resolving a pending Postgres vs MySQL conflict during the cooldown window

## Test plan
- [x] Existing test "recently asked conflicts still resolve directional clarification replies" passes — "Keep the new one." matches action+directional cues
- [x] New test "unrelated message during cooldown does not accidentally resolve conflict" — "What's new in Bun?" is rejected (question mark, no action cue)
- [x] All 5 session-conflict-gate tests pass
- [x] Pre-existing type errors only (unrelated to this change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
