### PR TITLE
fix(chat): compact dynamic page preview card and reposition arrow icon

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -18,24 +18,22 @@ public struct InlineDynamicPagePreview: View {
             onViewOutput()
         } label: {
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                HStack(alignment: .top, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
                     if let icon = preview.icon {
                         Text(icon)
                             .font(.system(size: 24))
                     }
 
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                        Text(preview.title)
-                            .font(VFont.headline)
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(2)
+                    Text(preview.title)
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(2)
 
-                        if let subtitle = preview.subtitle {
-                            Text(subtitle)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textSecondary)
-                                .lineLimit(1)
-                        }
+                    if let subtitle = preview.subtitle {
+                        Text(subtitle)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(1)
                     }
                 }
 
@@ -53,16 +51,6 @@ public struct InlineDynamicPagePreview: View {
                         }
                     }
                 }
-            }
-            .overlay(alignment: .topTrailing) {
-                Image(systemName: "arrow.up.right")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
-                    .padding(VSpacing.xs)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(VColor.surfaceBorder.opacity(isHovered ? 0.6 : 0.3))
-                    )
             }
             .contentShape(Rectangle())
         }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -20,6 +20,14 @@ public struct InlineSurfaceRouter: View {
         return false
     }
 
+    /// Dynamic page previews render as compact cards that wrap their content.
+    private var isDynamicPreview: Bool {
+        if case .dynamicPage(let data) = surface.data, data.preview != nil {
+            return true
+        }
+        return false
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Template cards handle their own header — skip the generic title
@@ -44,7 +52,33 @@ public struct InlineSurfaceRouter: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
         )
+        .overlay(alignment: .topTrailing) {
+            if isDynamicPreview {
+                Button {
+                    if let msg = surface.surfaceMessage {
+                        NotificationCenter.default.post(
+                            name: Notification.Name("MainWindow.openDynamicWorkspace"),
+                            object: nil,
+                            userInfo: ["surfaceMessage": msg]
+                        )
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(VColor.textSecondary)
+                        .padding(VSpacing.xs)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(VColor.surfaceBorder.opacity(0.3))
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(VSpacing.sm)
+            }
+        }
         .vShadow(VShadow.sm)
+        // Dynamic page previews should wrap their content, not stretch to fill
+        .fixedSize(horizontal: isDynamicPreview, vertical: false)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Make dynamic page preview cards compact (content-wrapped) instead of stretching to fill the full chat width, using `fixedSize` on the router for dynamic page cases
- Move the arrow icon overlay from the inner preview content to the router's card chrome so it appears at the card's actual top-right corner with a clickable button that opens the workspace
- Stack the header vertically (icon above title/subtitle) to prevent title truncation in the narrower compact layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
