### PR TITLE
fix(chat): reset refinement flag in all stopGenerating paths

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1062,6 +1062,7 @@ public final class ChatViewModel: ObservableObject {
             pendingUserMessage = nil
             pendingUserAttachments = nil
             bootstrapCorrelationId = nil
+            isWorkspaceRefinementInFlight = false
             isThinking = false
             isSending = false
             return
@@ -1073,6 +1074,7 @@ public final class ChatViewModel: ObservableObject {
         // stuck isCancelling flag that would suppress future assistant deltas.
         guard daemonClient.isConnected else {
             log.warning("Cannot send cancel: daemon not connected")
+            isWorkspaceRefinementInFlight = false
             isSending = false
             isThinking = false
             isCancelling = false
@@ -1105,6 +1107,7 @@ public final class ChatViewModel: ObservableObject {
             // Cancel failed to send, so no generationCancelled or
             // messageComplete event will arrive from the daemon. Reset
             // all transient state now to avoid stuck UI.
+            isWorkspaceRefinementInFlight = false
             isSending = false
             isThinking = false
             isCancelling = false
@@ -1158,6 +1161,7 @@ public final class ChatViewModel: ObservableObject {
             guard let self, !Task.isCancelled else { return }
             guard self.isCancelling else { return }
             log.warning("Cancel acknowledgment timed out after 5s — force-resetting UI state")
+            self.isWorkspaceRefinementInFlight = false
             self.isCancelling = false
             self.isSending = false
             self.currentAssistantMessageId = nil


### PR DESCRIPTION
## Summary

- Reset `isWorkspaceRefinementInFlight` in all 4 early-return code paths of `stopGenerating()`:
  1. Bootstrap path (no session yet)
  2. Daemon disconnected path
  3. Cancel-send-failure path
  4. Cancel timeout path
- Without this, cancelling during a workspace refinement leaves the "Refining..." indicator stuck permanently and suppresses all future `assistantTextDelta`, `toolUseStart`, and `toolResult` events

Addresses feedback on #2505.

## Test plan

- [ ] Start a workspace refinement, then immediately cancel (stop button)
- [ ] Verify "Refining..." indicator disappears
- [ ] Send a new message and verify assistant responses appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
