### PR TITLE
fix(webview): clear stale insets in didFinish when desired are zero

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -519,7 +519,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             // changed since then (e.g. composer expanded). Apply the current desired values.
             let top = desiredTopInset
             let bottom = desiredBottomInset
-            guard top > 0 || bottom > 0 else { return }
+            guard top > 0 || bottom > 0 || lastTopInset > 0 || lastBottomInset > 0 else { return }
             lastTopInset = top
             lastBottomInset = bottom
             let fadeHeight = bottom + 32


### PR DESCRIPTION
## Summary

- Expand the `didFinish` guard to also check `lastTopInset > 0 || lastBottomInset > 0`
- Fixes edge case where insets were non-zero at view creation but later become zero — the stale WKUserScript padding was never cleared after HTML reload

Addresses feedback on #2509.

## Test plan

- [ ] Verify content insets work correctly after HTML reloads
- [ ] Edge case: if insets transition from non-zero to zero, padding should be cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
