### PR TITLE
fix(test): exercise recursion guard with concurrent swarm calls

### DIFF
--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -210,19 +210,27 @@ describe('swarm regression tests', () => {
   });
 
   test('recursion guard blocks concurrent invocation', async () => {
-    // Start a swarm that resolves instantly (via mock)
-    const result1 = await swarmDelegateTool.execute(
-      { objective: 'First' },
-      makeContext(),
-    );
+    const ctx = makeContext();
+
+    // Start first swarm without awaiting — execute runs synchronously up to
+    // its first internal `await`, which adds the sessionKey to activeSessions
+    // before yielding back to us.
+    const first = swarmDelegateTool.execute({ objective: 'First' }, ctx);
+
+    // While the first call is still in-flight, a second call on the same
+    // session should be rejected by the recursion guard.
+    const result2 = await swarmDelegateTool.execute({ objective: 'Second' }, ctx);
+    expect(result2.isError).toBe(true);
+    expect(result2.content).toContain('already executing');
+
+    // Let the first call finish and verify it succeeded
+    const result1 = await first;
     expect(result1.isError).toBeFalsy();
 
-    // After first completes, second should also succeed (flag reset)
-    const result2 = await swarmDelegateTool.execute(
-      { objective: 'Second' },
-      makeContext(),
-    );
-    expect(result2.isError).toBeFalsy();
+    // After the first call completes, the guard should be released —
+    // a subsequent call must succeed.
+    const result3 = await swarmDelegateTool.execute({ objective: 'Third' }, ctx);
+    expect(result3.isError).toBeFalsy();
   });
 
   test('worker backend reports unavailable when no API key', async () => {


### PR DESCRIPTION
## Summary
- Fixes the recursion guard test in `swarm-session-integration.test.ts` to actually exercise concurrent invocation
- The original test awaited the first call before starting the second, so `activeSessions` was already cleared — the guard was never triggered
- Now starts the first call without awaiting, makes a second call while it's in-flight, and verifies the guard rejects it

Addresses feedback on #2442.

## Test plan
- [x] All 7 integration tests pass (`bun test src/__tests__/swarm-session-integration.test.ts`)
- [x] No new TypeScript type errors (pre-existing errors in unrelated files only)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
