### PR TITLE
fix(ipc): pre-read size check and cross-platform path containment

### DIFF
--- a/assistant/src/__tests__/ipc-blob-store.test.ts
+++ b/assistant/src/__tests__/ipc-blob-store.test.ts
@@ -206,38 +206,30 @@ describe('ipc-blob-store', () => {
       await expect(readBlob(ref)).rejects.toThrow('Blob SHA-256 mismatch');
     });
 
-    test('rejects oversized ax_tree blob', async () => {
+    test('rejects oversized ax_tree blob before reading file', async () => {
       const id = randomUUID();
-      // 2 MB + 1 byte
-      const content = Buffer.alloc(2 * 1024 * 1024 + 1);
-
-      writeBlobFile(id, content);
-
+      // Declare a size over 2 MB limit — file doesn't even need to exist
       const ref: IpcBlobRef = {
         id,
         kind: 'ax_tree',
         encoding: 'utf8',
-        byteLength: content.byteLength,
+        byteLength: 2 * 1024 * 1024 + 1,
       };
 
-      await expect(readBlob(ref)).rejects.toThrow('exceeds size limit');
+      await expect(readBlob(ref)).rejects.toThrow('declared size exceeds limit');
     });
 
-    test('rejects oversized screenshot_jpeg blob', async () => {
+    test('rejects oversized screenshot_jpeg blob before reading file', async () => {
       const id = randomUUID();
-      // 10 MB + 1 byte
-      const content = Buffer.alloc(10 * 1024 * 1024 + 1);
-
-      writeBlobFile(id, content);
-
+      // Declare a size over 10 MB limit — file doesn't even need to exist
       const ref: IpcBlobRef = {
         id,
         kind: 'screenshot_jpeg',
         encoding: 'binary',
-        byteLength: content.byteLength,
+        byteLength: 10 * 1024 * 1024 + 1,
       };
 
-      await expect(readBlob(ref)).rejects.toThrow('exceeds size limit');
+      await expect(readBlob(ref)).rejects.toThrow('declared size exceeds limit');
     });
 
     test('accepts screenshot_jpeg blob at exactly 10 MB', async () => {

--- a/assistant/src/daemon/ipc-blob-store.ts
+++ b/assistant/src/daemon/ipc-blob-store.ts
@@ -9,7 +9,7 @@ import {
   realpathSync,
 } from 'node:fs';
 import { readFile, readdir, lstat, realpath, unlink } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, resolve, relative, sep } from 'node:path';
 import { createHash } from 'node:crypto';
 
 const log = getLogger('ipc-blob-store');
@@ -44,9 +44,10 @@ export function resolveBlobPath(id: string): string {
   const candidate = resolve(join(blobDir, `${id}${BLOB_EXTENSION}`));
 
   // Symlink protection: verify the resolved path stays within the blob dir.
-  // Use resolve() on the blob dir itself to normalize it consistently.
+  // Use relative() for separator-agnostic containment check.
   const normalizedBlobDir = resolve(blobDir);
-  if (!candidate.startsWith(normalizedBlobDir + '/') && candidate !== normalizedBlobDir) {
+  const rel = relative(normalizedBlobDir, candidate);
+  if (rel.startsWith('..') || rel.startsWith(sep + sep) || rel === '') {
     throw new Error(`Blob path escapes blob directory: ${id}`);
   }
 
@@ -66,7 +67,8 @@ async function assertRegularFileInBlobDir(filePath: string): Promise<void> {
   const real = await realpath(filePath);
   // Realpath both the file and the blob dir so macOS /var → /private/var is handled
   const realBlobDir = await realpath(getIpcBlobDir());
-  if (!real.startsWith(realBlobDir + '/')) {
+  const realRel = relative(realBlobDir, real);
+  if (realRel.startsWith('..') || realRel.startsWith(sep + sep) || realRel === '') {
     throw new Error(`Blob realpath escapes blob directory: ${real}`);
   }
 }
@@ -81,7 +83,8 @@ function assertRegularFileInBlobDirSync(filePath: string): void {
   }
   const real = realpathSync(filePath);
   const realBlobDir = realpathSync(getIpcBlobDir());
-  if (!real.startsWith(realBlobDir + '/')) {
+  const realRel = relative(realBlobDir, real);
+  if (realRel.startsWith('..') || realRel.startsWith(sep + sep) || realRel === '') {
     throw new Error(`Blob realpath escapes blob directory: ${real}`);
   }
 }
@@ -122,20 +125,28 @@ export function validateBlobKindEncoding(
 export async function readBlob(ref: IpcBlobRef): Promise<Buffer> {
   const filePath = resolveBlobPath(ref.id);
 
-  // Symlink-safe: verify the file is a regular file with realpath inside blob dir
+  // Enforce hard size limits by kind against declared byteLength before any I/O
+  const maxSize = ref.kind === 'screenshot_jpeg' ? MAX_SCREENSHOT_BLOB_SIZE : MAX_AX_BLOB_SIZE;
+  if (ref.byteLength > maxSize) {
+    throw new Error(
+      `Blob ${ref.id} declared size exceeds limit for kind "${ref.kind}": ${ref.byteLength} > ${maxSize}`,
+    );
+  }
+
+  // Symlink-safe: verify the file is a regular file with realpath inside blob dir.
+  // assertRegularFileInBlobDir also lstat()s, giving us symlink detection.
   await assertRegularFileInBlobDir(filePath);
 
   const buf = await readFile(filePath);
 
-  // Validate size matches declared byteLength
+  // Validate actual size matches declared byteLength
   if (buf.byteLength !== ref.byteLength) {
     throw new Error(
       `Blob size mismatch for ${ref.id}: expected ${ref.byteLength} bytes, got ${buf.byteLength}`,
     );
   }
 
-  // Enforce hard size limits by kind
-  const maxSize = ref.kind === 'screenshot_jpeg' ? MAX_SCREENSHOT_BLOB_SIZE : MAX_AX_BLOB_SIZE;
+  // Double-check actual size against limit (in case byteLength was spoofed to be small)
   if (buf.byteLength > maxSize) {
     throw new Error(
       `Blob ${ref.id} exceeds size limit for kind "${ref.kind}": ${buf.byteLength} > ${maxSize}`,


### PR DESCRIPTION
## Summary
- Enforce blob size limits against declared `byteLength` **before** reading the file into memory, preventing OOM from oversized blobs (addresses Devin + Codex feedback on #2380)
- Keep a post-read size check as defense-in-depth against spoofed `byteLength`
- Replace hardcoded `/` separator with `path.relative()` for cross-platform containment checks in `resolveBlobPath`, `assertRegularFileInBlobDir`, and `assertRegularFileInBlobDirSync` (addresses Codex feedback on #2380)
- Update tests to verify early rejection without needing a file on disk

## Test plan
- [x] All 24 blob store tests pass
- [x] No new lint or type errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
