### PR TITLE
fix(ipc): keep oversized AX trees inline when exceeding blob limit

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -471,14 +471,17 @@ final class ComputerUseSession: ObservableObject {
 
         let screenSizePt = screenshotData != nil ? screenCapture.screenSize() : nil
 
-        // Transport AX tree via blob when large (>8KB) and blob transport available
+        // Transport AX tree via blob when large (>8KB) and blob transport available.
+        // Cap at 2MB to match the daemon's MAX_AX_BLOB_SIZE — trees above that limit
+        // would be rejected on hydration, losing the data entirely since inline was cleared.
         var axTreeInline = axTreeText
         var axTreeBlobRef: IPCIpcBlobRef?
         let axTreeBlobThreshold = 8 * 1024 // 8KB
+        let axTreeBlobMaxSize = 2 * 1024 * 1024 // 2MB — must match daemon's MAX_AX_BLOB_SIZE
 
         if let tree = axTreeText, daemonClient.isBlobTransportAvailable {
             let treeData = Data(tree.utf8)
-            if treeData.count > axTreeBlobThreshold {
+            if treeData.count > axTreeBlobThreshold && treeData.count <= axTreeBlobMaxSize {
                 if let ref = IpcBlobStore.shared.writeBlob(data: treeData, kind: "ax_tree", encoding: "utf8") {
                     axTreeBlobRef = ref
                     axTreeInline = nil
@@ -486,6 +489,8 @@ final class ComputerUseSession: ObservableObject {
                 } else {
                     log.warning("[\(stepNumber)] Blob write failed for AX tree, keeping inline")
                 }
+            } else if treeData.count > axTreeBlobMaxSize {
+                log.info("[\(stepNumber)] AX tree exceeds blob max size (\(treeData.count) bytes > \(axTreeBlobMaxSize)), keeping inline")
             }
         }
 


### PR DESCRIPTION
## Summary
- Adds a sender-side 2MB cap on AX tree blob transport, matching the daemon's `MAX_AX_BLOB_SIZE`
- AX trees between 8KB–2MB continue to use blob transport as before
- AX trees exceeding 2MB now stay inline instead of being written as blobs that the daemon would reject
- Prevents data loss where oversized blobs were rejected on hydration with no inline fallback

Addresses review feedback on #2393: trees > 2MB were dropped entirely because the client cleared the inline value before sending the blob, but the daemon rejects blobs above `MAX_AX_BLOB_SIZE` (2MB).

## Files changed
- `clients/macos/vellum-assistant/ComputerUse/Session.swift`

## Test plan
- [x] `swift build` succeeds
- Verified that the blob threshold condition now requires `treeData.count <= axTreeBlobMaxSize`
- Oversized trees log an info message and stay inline

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
