### PR TITLE
fix(memory): enqueue relation backfill on exact-multiple-of-200 boundary

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3126,6 +3126,80 @@ describe('Memory regressions', () => {
     }
   });
 
+  test('backfill enqueues relation backfill when message count is exact multiple of 200', async () => {
+    const db = getDb();
+    const now = 1_700_004_000_000;
+    const originalEnabled = TEST_CONFIG.memory.entity.enabled;
+    const originalRelationsEnabled = TEST_CONFIG.memory.entity.extractRelations.enabled;
+    TEST_CONFIG.memory.entity.enabled = true;
+    TEST_CONFIG.memory.entity.extractRelations.enabled = true;
+
+    try {
+      db.insert(conversations).values({
+        id: 'conv-exact-200',
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+
+      // Insert exactly 200 messages so the first backfill batch is full
+      for (let i = 0; i < 200; i++) {
+        db.insert(messages).values({
+          id: `msg-exact-200-${String(i).padStart(4, '0')}`,
+          conversationId: 'conv-exact-200',
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: `Message ${i}` }]),
+          createdAt: now + i + 1,
+        }).run();
+      }
+
+      // First backfill: processes 200 messages, should enqueue another backfill
+      enqueueMemoryJob('backfill', {});
+      await runMemoryJobsOnce();
+
+      // Should have enqueued a follow-up backfill (batch was full)
+      const followUpBackfill = db
+        .select()
+        .from(memoryJobs)
+        .where(and(eq(memoryJobs.type, 'backfill'), eq(memoryJobs.status, 'pending')))
+        .all();
+      expect(followUpBackfill).toHaveLength(1);
+
+      // No relation backfill yet (batch was full, more work expected)
+      const relationBefore = db
+        .select()
+        .from(memoryJobs)
+        .where(and(eq(memoryJobs.type, 'backfill_entity_relations'), eq(memoryJobs.status, 'pending')))
+        .all();
+      expect(relationBefore).toHaveLength(0);
+
+      // Clear all non-backfill pending jobs so the next runMemoryJobsOnce
+      // picks up the follow-up backfill job (claimMemoryJobs has a concurrency
+      // limit and processes jobs in creation order)
+      db.run(`DELETE FROM memory_jobs WHERE type != 'backfill' AND status = 'pending'`);
+
+      // Second backfill: reads 0 messages (terminal empty batch), should
+      // still enqueue the relation backfill
+      await runMemoryJobsOnce();
+
+      const relationAfter = db
+        .select()
+        .from(memoryJobs)
+        .where(and(eq(memoryJobs.type, 'backfill_entity_relations'), eq(memoryJobs.status, 'pending')))
+        .all();
+      expect(relationAfter).toHaveLength(1);
+    } finally {
+      TEST_CONFIG.memory.entity.enabled = originalEnabled;
+      TEST_CONFIG.memory.entity.extractRelations.enabled = originalRelationsEnabled;
+    }
+  });
+
   test('relation backfill respects extractFromAssistant=false config', async () => {
     const db = getDb();
     const now = 1_700_003_000_000;

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -770,30 +770,31 @@ function backfillJob(job: MemoryJob, config: AssistantConfig): void {
     .orderBy(asc(messages.createdAt), asc(messages.id))
     .limit(200)
     .all();
-  if (batch.length === 0) return;
-  for (const message of batch) {
-    indexMessageNow({
-      messageId: message.id,
-      conversationId: message.conversationId,
-      role: message.role,
-      content: message.content,
-      createdAt: message.createdAt,
-    }, config.memory);
+
+  if (batch.length > 0) {
+    for (const message of batch) {
+      indexMessageNow({
+        messageId: message.id,
+        conversationId: message.conversationId,
+        role: message.role,
+        content: message.content,
+        createdAt: message.createdAt,
+      }, config.memory);
+    }
+    const lastMessage = batch[batch.length - 1];
+    writeMessageCursorCheckpoint(BACKFILL_CHECKPOINT_KEY, BACKFILL_CHECKPOINT_ID_KEY, {
+      createdAt: lastMessage.createdAt,
+      messageId: lastMessage.id,
+    });
   }
-  const lastMessage = batch[batch.length - 1];
-  writeMessageCursorCheckpoint(BACKFILL_CHECKPOINT_KEY, BACKFILL_CHECKPOINT_ID_KEY, {
-    createdAt: lastMessage.createdAt,
-    messageId: lastMessage.id,
-  });
 
   if (batch.length === 200) {
     enqueueMemoryJob('backfill', {});
   } else if (config.memory.entity.enabled && config.memory.entity.extractRelations.enabled) {
-    // Enqueue only after the final batch so the relation backfill does not
+    // Enqueue after the terminal batch (including an empty batch when total
+    // messages are an exact multiple of 200) so the relation backfill does not
     // overlap with messages the normal backfill already covered via
-    // indexMessageNow → extract_items → extract_entities.  Never forward the
-    // force flag: the relation backfill's own checkpoint tracks which messages
-    // still need entity extraction independently of the normal backfill.
+    // indexMessageNow → extract_items → extract_entities.
     enqueueBackfillEntityRelationsJob();
   }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `backfillJob` skipped enqueuing `backfill_entity_relations` when the total message count was an exact multiple of 200. In that edge case, the last backfill batch processed exactly 200 messages and enqueued a follow-up backfill. The follow-up read an empty batch and returned early, never reaching the `else if` that triggers the relation backfill.

**Fix**: Replaced the early `return` on empty batch with a conditional block so the terminal empty batch still falls through to the relation backfill enqueue.

**Test**: Added a regression test that inserts exactly 200 messages, runs two backfill passes, and verifies `backfill_entity_relations` is enqueued after the terminal empty batch.

Addresses codex P1 feedback on #2371.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
