### PR TITLE
fix(swarm): honor model override and improve plan parser reliability

### DIFF
--- a/assistant/src/__tests__/swarm-router-planner.test.ts
+++ b/assistant/src/__tests__/swarm-router-planner.test.ts
@@ -65,6 +65,21 @@ describe('parsePlanJSON', () => {
   test('returns null for empty string', () => {
     expect(parsePlanJSON('')).toBeNull();
   });
+
+  test('finds plan JSON in second fenced block when first is not valid JSON', () => {
+    const raw = '```\nHere is my thinking about the plan\n```\n\n```json\n{"tasks":[{"id":"a","role":"coder","objective":"do stuff","dependencies":[]}]}\n```';
+    const result = parsePlanJSON(raw);
+    expect(result).not.toBeNull();
+    expect(result!.tasks).toHaveLength(1);
+    expect(result!.tasks[0].id).toBe('a');
+  });
+
+  test('finds plan JSON in second fenced block when first has no tasks array', () => {
+    const raw = '```json\n{"note":"not a plan"}\n```\n\n```json\n{"tasks":[{"id":"b","role":"researcher","objective":"research","dependencies":[]}]}\n```';
+    const result = parsePlanJSON(raw);
+    expect(result).not.toBeNull();
+    expect(result!.tasks[0].id).toBe('b');
+  });
 });
 
 describe('makeFallbackPlan', () => {

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -27,7 +27,9 @@ export class GeminiProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
-    const maxTokens = (config as Record<string, unknown> | undefined)?.max_tokens as number | undefined;
+    const configObj = config as Record<string, unknown> | undefined;
+    const maxTokens = configObj?.max_tokens as number | undefined;
+    const modelOverride = configObj?.model as string | undefined;
 
     try {
       const geminiContents = this.toGeminiContents(messages);
@@ -55,7 +57,7 @@ export class GeminiProvider implements Provider {
       }
 
       const stream = await this.client.models.generateContentStream({
-        model: this.model,
+        model: modelOverride ?? this.model,
         contents: geminiContents,
         config: geminiConfig,
       });

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -39,13 +39,15 @@ export class OpenAIProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
-    const maxTokens = (config as Record<string, unknown> | undefined)?.max_tokens as number | undefined;
+    const configObj = config as Record<string, unknown> | undefined;
+    const maxTokens = configObj?.max_tokens as number | undefined;
+    const modelOverride = configObj?.model as string | undefined;
 
     try {
       const openaiMessages = this.toOpenAIMessages(messages, systemPrompt);
 
       const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
-        model: this.model,
+        model: modelOverride ?? this.model,
         messages: openaiMessages,
         stream: true as const,
         stream_options: { include_usage: true },

--- a/assistant/src/swarm/router-planner.ts
+++ b/assistant/src/swarm/router-planner.ts
@@ -55,13 +55,22 @@ export async function generatePlan(opts: {
 
 /**
  * Parse the LLM output as a plan JSON. Handles bare JSON objects and
- * fenced code blocks.
+ * fenced code blocks (tries all fenced blocks, not just the first).
  */
 export function parsePlanJSON(raw: string): { tasks: Array<{ id: string; role: string; objective: string; dependencies: string[] }> } | null {
-  // Try extracting from fenced code block first
-  const fenced = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
-  const jsonStr = fenced ? fenced[1] : raw;
+  // Try all fenced code blocks — LLMs sometimes emit non-JSON blocks before the plan
+  const fencedRegex = /```(?:json)?\s*\n?([\s\S]*?)\n?```/g;
+  let match;
+  while ((match = fencedRegex.exec(raw)) !== null) {
+    const result = tryParsePlan(match[1]);
+    if (result) return result;
+  }
 
+  // Fall back to parsing the raw string as bare JSON
+  return tryParsePlan(raw);
+}
+
+function tryParsePlan(jsonStr: string): { tasks: Array<{ id: string; role: string; objective: string; dependencies: string[] }> } | null {
   try {
     const parsed = JSON.parse(jsonStr.trim());
     if (parsed && Array.isArray(parsed.tasks)) {


### PR DESCRIPTION
## Summary
- OpenAI and Gemini providers now respect `config.model` override, allowing the planner to use a different model than the provider's default (Anthropic already supported this via `...config` spread)
- `parsePlanJSON` now tries all fenced code blocks instead of only the first, so responses with multiple fences (e.g. thinking block before the plan JSON) no longer cause unnecessary fallbacks

Addresses Codex review feedback from PR #2435.

## Test plan
- [x] `bun test src/__tests__/swarm-router-planner.test.ts` — 16/16 pass (2 new tests for multi-fenced-block parsing)
- [x] `bunx tsc --noEmit` — no new errors (pre-existing errors in unrelated files)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
