### PR TITLE
fix(swarm): use capable model for worker tasks, not planner model

### DIFF
--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -117,7 +117,7 @@ export const swarmDelegateTool: Tool = {
         limits,
         backend,
         workingDir: context.workingDir,
-        model: config.swarm.plannerModel,
+        model: config.swarm.synthesizerModel,
         synthesisProvider,
         synthesisModel: config.swarm.synthesizerModel,
         signal: context.signal,


### PR DESCRIPTION
## Summary
- Fixes a bug where `executeSwarm` received `config.swarm.plannerModel` (Haiku) as the worker model, causing all swarm worker tasks (coding, research, review) to run with the cheap planner model instead of the intended capable model (Sonnet).
- Changes the `model` parameter passed to `executeSwarm` from `plannerModel` to `synthesizerModel`.
- The planner model continues to be used for `generatePlan` (task decomposition) as intended.

Addresses review feedback on PR #2437.

## Test plan
- [x] `bun test src/__tests__/swarm-tool.test.ts` -- all 5 tests pass
- [x] TypeScript type-check passes (no new errors)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
