### PR TITLE
docs(swarm): clarify recursion guard scope and abort signal propagation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1303,8 +1303,8 @@ sequenceDiagram
 
 ### Key design decisions
 
-- **Recursion guard**: Only one swarm can execute per session. Nested invocations return an error.
-- **Abort signal**: The tool checks `context.signal?.aborted` before planning and before execution.
+- **Recursion guard**: A module-level `Set<sessionId>` prevents concurrent swarms within the same session while allowing independent sessions to run their own swarms in parallel.
+- **Abort signal**: The tool checks `context.signal?.aborted` before planning and before execution. The signal is also forwarded into `executeSwarm` and the worker backend, enabling cooperative cancellation of in-flight workers.
 - **DAG scheduling**: Tasks with dependencies are topologically ordered. Independent tasks run in parallel up to `maxWorkers`.
 - **Per-task retries**: Failed tasks retry up to `maxRetriesPerTask` before being marked failed. Dependents are transitively blocked.
 - **Role-scoped profiles**: Workers run with restricted tool access based on their role (coder, researcher, reviewer, general).

--- a/benchmarking/assistant/swarm-smoke.md
+++ b/benchmarking/assistant/swarm-smoke.md
@@ -90,7 +90,7 @@ Ensure `config.swarm.enabled = true` and a valid Anthropic API key is configured
 
 **Expected behavior**:
 - Tool returns `{ content: 'Cancelled', isError: true }` or the abort races through the agent loop
-- No hanging workers
+- Workers observe the abort signal cooperatively; in-flight LLM calls may finish their current turn before exiting
 - Session can accept new messages after cancel
 
 ## Recording Results


### PR DESCRIPTION
## Summary
Address Codex review feedback from PR #2443:

- **ARCHITECTURE.md**: Clarify that the recursion guard uses a `Set<sessionId>` (not a single boolean), allowing independent sessions to run their own swarms in parallel. Document that the abort signal propagates through `executeSwarm` and into the worker backend for cooperative cancellation.
- **swarm-smoke.md**: Replace the "No hanging workers" expectation in Scenario 5 with accurate cooperative cancellation semantics — in-flight LLM calls may finish their current turn before exiting.

## Test plan
- [x] No code changes — docs only
- [x] TypeScript type-check passes (pre-existing errors unrelated to this PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
