### PR TITLE
fix(memory): upgrade candidate source during merge dedup

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -730,8 +730,8 @@ describe('Memory Recall Quality', () => {
         insertItem(db, {
           id: itemId,
           kind: 'fact',
-          subject: `atlas tool ${index}`,
-          statement: `AtlasTool${index} emits generic observability metrics`,
+          subject: `monitoring tool ${index}`,
+          statement: `ObservabilityTool${index} emits generic telemetry metrics`,
           importance: 0.35,
           firstSeenAt: now + index,
         });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1090,6 +1090,13 @@ function mergeCandidates(
     if (candidate.text.length > existing.text.length) {
       existing.text = candidate.text;
     }
+    // Upgrade source to whichever has the higher weight so scoring and caps
+    // reflect the strongest retrieval signal for this candidate.
+    const existingWeight = SOURCE_WEIGHTS[existing.source] ?? 1.0;
+    const candidateWeight = SOURCE_WEIGHTS[candidate.source] ?? 1.0;
+    if (candidateWeight > existingWeight) {
+      existing.source = candidate.source;
+    }
   }
 
   // Build 1-based rank maps from each list (sorted by native score desc)


### PR DESCRIPTION
## Summary
- When `mergeCandidates` deduplicates candidates found in multiple retrieval sources, it now upgrades the `source` field to whichever has the higher `SOURCE_WEIGHT`. Previously, the source from whichever list was iterated first was kept — meaning a candidate found by both `entity_relation` (weight 0.72) and `item_direct` (weight 0.95) would retain `entity_relation`, causing ~24% scoring penalty and incorrect source cap accounting.
- Updated the recall quality test fixture noise items to avoid query-token overlap in their subject/statement text, ensuring they are only reachable via relation expansion (not also via direct item search).

Addresses review feedback from PR #2381.

## Test plan
- [x] `bun test src/__tests__/memory-recall-quality.test.ts` — 15/15 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
