### PR TITLE
fix(tests): correct large-scenario blob ref and assertion threshold

### DIFF
--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -1646,12 +1646,18 @@ final class SessionTests: XCTestCase {
             executionResult: nil,
             executionError: nil,
             axTreeBlob: largeAxBlobRef,
-            screenshotBlob: blobRef
+            screenshotBlob: IPCIpcBlobRef(
+                id: "screenshot-blob-id",
+                kind: "screenshot_jpeg",
+                encoding: "binary",
+                byteLength: 300_000,
+                sha256: String(repeating: "c", count: 64)
+            )
         )
         let blobLargeJSON = try JSONEncoder().encode(blobLarge)
 
-        // Large scenario: inline >800KB, blob <1KB (both payloads offloaded)
-        XCTAssertGreaterThan(inlineLargeJSON.count, 800_000)
+        // Large scenario: inline >400KB (300KB screenshot → 400KB base64 + 12KB AX tree), blob <1KB
+        XCTAssertGreaterThan(inlineLargeJSON.count, 400_000)
         XCTAssertLessThan(blobLargeJSON.count, 1_000)
     }
 }


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2439:

- **Blob ref mismatch**: The large-scenario test reused the p50 screenshot blob ref (`byteLength: 150_000`) instead of creating one matching the 300KB screenshot. Now uses a dedicated `IPCIpcBlobRef` with `byteLength: 300_000`.
- **Impossible assertion**: The inline JSON size assertion checked `> 800_000` bytes, but 300KB binary base64-encodes to ~400KB + 12KB AX tree = ~413KB total. Fixed threshold to `> 400_000`.

## Test plan

- [x] `swift build` passes
- [ ] `swift test --filter testBlobTransport_reducesPayloadSize` passes (requires Xcode environment)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
