### PR TITLE
fix: session hot-path perf + pre-commit hash bypass safety

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -200,7 +200,15 @@ while IFS= read -r -d '' FILE; do
                 fi
                 CONTENT="${line#*:}"
                 if matches_safe_line_pattern "$CONTENT"; then
-                    continue
+                    # Strip safe-line portions and re-check: a real secret
+                    # on the same line (e.g. minified JSON) must not be masked.
+                    STRIPPED="$CONTENT"
+                    for sp in "${SAFE_LINE_PATTERNS[@]}"; do
+                        STRIPPED=$(printf '%s\n' "$STRIPPED" | sed -E "s/$sp//g" 2>/dev/null || printf '%s\n' "$STRIPPED")
+                    done
+                    if ! printf '%s\n' "$STRIPPED" | grep -iE -- "$PATTERN" >/dev/null 2>&1; then
+                        continue
+                    fi
                 fi
                 FILTERED_MATCHES="${FILTERED_MATCHES}${line}"$'\n'
             done <<< "$MATCHES"

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -207,7 +207,7 @@ mock.module('../memory/clarification-resolver.js', () => ({
 }));
 
 mock.module('../memory/admin.js', () => ({
-  getMemorySystemStatus: () => ({
+  getMemoryConflictAndCleanupStats: () => ({
     conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
     cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
   }),

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -183,7 +183,7 @@ mock.module('../memory/clarification-resolver.js', () => ({
 }));
 
 mock.module('../memory/admin.js', () => ({
-  getMemorySystemStatus: () => ({
+  getMemoryConflictAndCleanupStats: () => ({
     conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
     cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
   }),

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -53,7 +53,7 @@ import { computeRecallBudget } from '../memory/retrieval-budget.js';
 import { recordUsageEvent } from '../memory/llm-usage-store.js';
 import { getApp } from '../memory/app-store.js';
 import { compileDynamicProfile } from '../memory/profile-compiler.js';
-import { getMemorySystemStatus } from '../memory/admin.js';
+import { getMemoryConflictAndCleanupStats } from '../memory/admin.js';
 import { ConflictGate } from './session-conflict-gate.js';
 import { injectDynamicProfileIntoUserMessage, stripDynamicProfileMessages } from './session-dynamic-profile.js';
 import { MessageQueue } from './session-queue-manager.js';
@@ -682,7 +682,7 @@ export class Session {
         signal: abortController.signal,
         maxInjectTokensOverride: recallBudget,
       });
-      const memoryStatus = getMemorySystemStatus();
+      const memoryStatus = getMemoryConflictAndCleanupStats();
 
       onEvent({
         type: 'memory_status',

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -38,11 +38,77 @@ export interface MemorySystemStatus {
   jobs: Record<string, number>;
 }
 
+export interface MemoryConflictAndCleanupStats {
+  conflicts: MemorySystemStatus['conflicts'];
+  cleanup: MemorySystemStatus['cleanup'];
+}
+
+/** Lightweight query for conflict/cleanup metrics only — no table counts or job totals. */
+export function getMemoryConflictAndCleanupStats(): MemoryConflictAndCleanupStats {
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { get: (...args: unknown[]) => unknown } } }).$client;
+  const conflictStats = raw.query(`
+    SELECT
+      SUM(CASE WHEN status = 'pending_clarification' THEN 1 ELSE 0 END) AS pending_count,
+      SUM(CASE WHEN status != 'pending_clarification' THEN 1 ELSE 0 END) AS resolved_count,
+      MIN(CASE WHEN status = 'pending_clarification' THEN created_at END) AS oldest_pending_created_at
+    FROM memory_item_conflicts
+  `).get() as {
+    pending_count: number | null;
+    resolved_count: number | null;
+    oldest_pending_created_at: number | null;
+  } | null;
+  const pending = conflictStats?.pending_count ?? 0;
+  const oldestPendingCreatedAt = conflictStats?.oldest_pending_created_at ?? null;
+  const oldestPendingAgeMs = oldestPendingCreatedAt === null
+    ? null
+    : Math.max(0, Date.now() - oldestPendingCreatedAt);
+  const throughputWindowStartMs = Date.now() - (24 * 60 * 60 * 1000);
+  const cleanupStats = raw.query(`
+    SELECT
+      SUM(CASE
+        WHEN type = 'cleanup_resolved_conflicts' AND status IN ('pending', 'running')
+        THEN 1 ELSE 0 END
+      ) AS resolved_backlog,
+      SUM(CASE
+        WHEN type = 'cleanup_stale_superseded_items' AND status IN ('pending', 'running')
+        THEN 1 ELSE 0 END
+      ) AS superseded_backlog,
+      SUM(CASE
+        WHEN type = 'cleanup_resolved_conflicts' AND status = 'completed' AND updated_at >= ?
+        THEN 1 ELSE 0 END
+      ) AS resolved_completed_24h,
+      SUM(CASE
+        WHEN type = 'cleanup_stale_superseded_items' AND status = 'completed' AND updated_at >= ?
+        THEN 1 ELSE 0 END
+      ) AS superseded_completed_24h
+    FROM memory_jobs
+  `).get(throughputWindowStartMs, throughputWindowStartMs) as {
+    resolved_backlog: number | null;
+    superseded_backlog: number | null;
+    resolved_completed_24h: number | null;
+    superseded_completed_24h: number | null;
+  } | null;
+  return {
+    conflicts: {
+      pending,
+      resolved: conflictStats?.resolved_count ?? 0,
+      oldestPendingAgeMs,
+    },
+    cleanup: {
+      resolvedBacklog: cleanupStats?.resolved_backlog ?? 0,
+      supersededBacklog: cleanupStats?.superseded_backlog ?? 0,
+      resolvedCompleted24h: cleanupStats?.resolved_completed_24h ?? 0,
+      supersededCompleted24h: cleanupStats?.superseded_completed_24h ?? 0,
+    },
+  };
+}
+
 export function getMemorySystemStatus(): MemorySystemStatus {
   const config = getConfig();
   const backend = getMemoryBackendStatus(config);
   const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { get: () => unknown } } }).$client;
+  const raw = (db as unknown as { $client: { query: (q: string) => { get: (...args: unknown[]) => unknown } } }).$client;
   const counts = {
     segments: countTable('memory_segments'),
     items: countTable('memory_items'),


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2497:

- **P1 — Stop querying full memory status in request hot path**: Extracted a lightweight `getMemoryConflictAndCleanupStats()` function that only queries conflict/cleanup metrics from `memory_item_conflicts` and `memory_jobs` tables. The session message handler now uses this instead of `getMemorySystemStatus()`, which was unnecessarily computing row counts across 4 tables (`memory_segments`, `memory_items`, `memory_summaries`, `memory_embeddings`) and job totals on every prompt.

- **P2 — Narrow hash fixture bypass to avoid masking real secrets**: The pre-commit safe-line filter now strips hash/checksum portions from the line and re-checks for secret patterns, so a real credential on the same line as a hash fixture (e.g. in minified JSON) is still caught.

- **Bonus**: Fixed a pre-existing TypeScript error where the SQLite `raw.query().get()` type assertion didn't accept bind parameters.

## Test plan

- [x] `bunx tsc --noEmit` passes (only pre-existing unrelated error remains)
- [x] `swift build` succeeds
- [x] `bash .githooks/pre-commit --self-test` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
