### PR TITLE
fix(architecture): correct recall query builder label

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -602,7 +602,7 @@ graph TB
     end
 
     subgraph "Read Path (Memory Recall)"
-        QUERY["Recall Query Builder<br/>User request + compacted context summary<br/>+ conversation summary + weekly summary"]
+        QUERY["Recall Query Builder<br/>User request + compacted context summary"]
         CONFLICT_GATE["Soft Conflict Gate<br/>resolve pending conflicts from user turn<br/>relevance + cooldown ask-once behavior"]
         PROFILE_BUILD["Dynamic Profile Compiler<br/>active trusted profile memories<br/>user_confirmed > user_reported > assistant_inferred"]
         PROFILE_INJECT["Inject profile context block<br/>into runtime user tail<br/>(strict token cap)"]


### PR DESCRIPTION
## Summary
- Remove incorrect "conversation summary + weekly summary" from the Recall Query Builder label in the Memory System architecture diagram
- `buildMemoryQuery()` only composes user request + optional compacted context summary; conversation and weekly summaries are retrieval candidates, not query inputs

Addresses feedback from PR #2402.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
