### PR TITLE
fix(ipc): capture CU observation receive timestamp before blob I/O

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1918,6 +1918,8 @@ async function handleCuObservation(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
+  const receiveTimestampMs = Date.now();
+
   // Hydrate blob refs to inline values before any other processing.
   // Strategy: blob-first, inline-fallback, cu_error if neither available.
   if (msg.axTreeBlob) {
@@ -1958,7 +1960,6 @@ async function handleCuObservation(
     }
   }
 
-  const receiveTimestampMs = Date.now();
   const previousSequence = cuObservationSequenceBySession.get(msg.sessionId) ?? 0;
   const sequence = previousSequence + 1;
   cuObservationSequenceBySession.set(msg.sessionId, sequence);


### PR DESCRIPTION
## Summary
- Moves `receiveTimestampMs = Date.now()` to the top of `handleCuObservation`, before the async blob hydration awaits
- Fixes the `IPC_METRIC cu_observation_daemon_receive` timestamp being skewed by blob file I/O latency (up to 10 MB reads)
- Addresses review feedback from PR #2391 (Devin comment about timestamp accuracy)

## Review feedback addressed
1. **receiveTimestampMs after async I/O** (Devin) -- Fixed by moving timestamp capture before any `await` calls
2. **Blob leak when inline present** (Devin) -- Already addressed in the merged PR's blob-first strategy (no conditional skip)
3. **Observation ordering** (Codex) -- Pre-existing architectural pattern in the dispatcher; not specific to blob hydration

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All 9 blob hydration tests pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
