### PR TITLE
fix(tools): sanitize frontmatter values in scaffold_managed_skill

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -107,6 +107,28 @@ describe('scaffold_managed_skill tool', () => {
     }
   });
 
+  test('sanitizes embedded newlines in name/description/emoji to prevent frontmatter injection', async () => {
+    const result = await tool.execute({
+      skill_id: 'inject-test',
+      name: 'Test\ninjected_field: "evil"',
+      description: 'Desc\rwith\r\ncarriage returns',
+      body_markdown: 'Body content.',
+      emoji: '🔥\nextra: true',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const skillFile = join(TEST_DIR, 'skills', 'inject-test', 'SKILL.md');
+    const content = readFileSync(skillFile, 'utf-8');
+
+    // Newlines must not appear inside frontmatter values
+    const frontmatter = content.split('---')[1];
+    const fmLines = frontmatter.split('\n').filter(l => l.trim());
+    // Each frontmatter line must start with a known key -- no injected keys
+    for (const line of fmLines) {
+      expect(line).toMatch(/^(name|description|emoji|user-invocable|disable-model-invocation):\s/);
+    }
+  });
+
   test('rejects invalid skill_id', async () => {
     const result = await tool.execute({
       skill_id: '../escape',

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -4,6 +4,11 @@ import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { createManagedSkill } from '../../skills/managed-store.js';
 
+/** Strip embedded newlines/carriage returns to prevent YAML frontmatter injection. */
+function sanitizeFrontmatterValue(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ').trim();
+}
+
 export class ScaffoldManagedSkillTool implements Tool {
   name = 'scaffold_managed_skill';
   description = 'Create or update a managed skill in ~/.vellum/skills. The skill becomes available for skill_load immediately.';
@@ -82,10 +87,10 @@ export class ScaffoldManagedSkillTool implements Tool {
 
     const result = createManagedSkill({
       id: skillId.trim(),
-      name: name.trim(),
-      description: description.trim(),
+      name: sanitizeFrontmatterValue(name),
+      description: sanitizeFrontmatterValue(description),
       bodyMarkdown: bodyMarkdown,
-      emoji: typeof input.emoji === 'string' ? input.emoji : undefined,
+      emoji: typeof input.emoji === 'string' ? sanitizeFrontmatterValue(input.emoji) : undefined,
       userInvocable: typeof input.user_invocable === 'boolean' ? input.user_invocable : undefined,
       disableModelInvocation: typeof input.disable_model_invocation === 'boolean' ? input.disable_model_invocation : undefined,
       overwrite: input.overwrite === true,


### PR DESCRIPTION
## Summary
- Sanitize `name`, `description`, and `emoji` inputs in `scaffold_managed_skill` tool by stripping embedded newlines/carriage returns before passing to `createManagedSkill`
- Adds defense-in-depth against YAML frontmatter injection (embedded `\n` could inject arbitrary frontmatter keys via the line-based parser)
- Add test verifying that newline-containing inputs cannot inject extra frontmatter keys

Addresses review feedback from PR #2379.

## Test plan
- [x] `bun test src/__tests__/scaffold-managed-skill-tool.test.ts` — 5 tests pass (including new injection test)
- [x] `bun test src/__tests__/delete-managed-skill-tool.test.ts` — 4 tests pass, no regressions
- [x] `bunx tsc --noEmit` — clean

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
