### PR TITLE
fix(test): correct risk level for managed skill checker tests

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -29,6 +29,12 @@ import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } f
 import { RiskLevel } from '../permissions/types.js';
 import { addRule, clearCache } from '../permissions/trust-store.js';
 
+// Import managed skill tools so they register in the tool registry.
+// Without this, classifyRisk falls through to RiskLevel.Medium (unknown tool)
+// instead of the declared RiskLevel.High — producing wrong test behavior.
+import '../tools/skills/scaffold-managed.js';
+import '../tools/skills/delete-managed.js';
+
 function writeSkill(skillId: string, name: string, description = 'Test skill'): void {
   const skillDir = join(checkerTestDir, 'skills', skillId);
   mkdirSync(skillDir, { recursive: true });
@@ -371,10 +377,11 @@ describe('Permission Checker', () => {
       expect(result.matchedRule?.id).toBe('default:ask-delete_managed_skill-global');
     });
 
-    test('allow rule for scaffold_managed_skill overrides default ask', async () => {
+    test('allow rule for scaffold_managed_skill still prompts (High risk)', async () => {
       addRule('scaffold_managed_skill', 'scaffold_managed_skill:my-skill', 'everywhere', 'allow', 2000);
       const result = await check('scaffold_managed_skill', { skill_id: 'my-skill' }, '/tmp');
-      expect(result.decision).toBe('allow');
+      // High-risk tools always prompt even with allow rules (checker.ts line 302)
+      expect(result.decision).toBe('prompt');
     });
 
     test('allow rule for scaffold_managed_skill does not match other skill ids', async () => {
@@ -383,10 +390,11 @@ describe('Permission Checker', () => {
       expect(result.decision).toBe('prompt');
     });
 
-    test('wildcard allow rule for delete_managed_skill covers all ids', async () => {
+    test('wildcard allow rule for delete_managed_skill still prompts (High risk)', async () => {
       addRule('delete_managed_skill', 'delete_managed_skill:*', 'everywhere', 'allow', 2000);
       const result = await check('delete_managed_skill', { skill_id: 'any-skill' }, '/tmp');
-      expect(result.decision).toBe('allow');
+      // High-risk tools always prompt even with allow rules (checker.ts line 302)
+      expect(result.decision).toBe('prompt');
     });
 
     test('cu_click prompts by default via computer-use ask rule', async () => {


### PR DESCRIPTION
## Summary
- Import `scaffold-managed.js` and `delete-managed.js` in checker tests so tools register in the registry with `RiskLevel.High` (matching production)
- Update two tests that expected `allow` to correctly expect `prompt`, since High-risk tools intentionally ignore allow rules (checker.ts line 302)
- Addresses Devin review feedback on PR #2413: tests were passing under `RiskLevel.Medium` (unknown tool fallback) instead of the declared `RiskLevel.High`

## Test plan
- [x] 119 checker tests pass (0 failures)
- [x] 4 lifecycle tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)

Addresses feedback from #2413
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
