### PR TITLE
fix(chat): use maxWidth instead of fixedSize for dynamic preview

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -77,8 +77,9 @@ public struct InlineSurfaceRouter: View {
             }
         }
         .vShadow(VShadow.sm)
-        // Dynamic page previews should wrap their content, not stretch to fill
-        .fixedSize(horizontal: isDynamicPreview, vertical: false)
+        // Dynamic page previews should be compact, not stretch to fill.
+        // Use maxWidth instead of fixedSize so narrow parent views still constrain the card.
+        .frame(maxWidth: isDynamicPreview ? 350 : .infinity, alignment: .leading)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- Replace `.fixedSize(horizontal: isDynamicPreview, vertical: false)` with `.frame(maxWidth: isDynamicPreview ? 350 : .infinity, alignment: .leading)`
- `fixedSize` makes the view ignore parent width constraints, causing overflow on narrow screens (e.g. iOS devices with `Spacer(minLength: 60)` on the trailing side)
- `maxWidth: 350` preserves the compact look while respecting the parent's proposed width

Addresses feedback on #2525.

## Test plan

- [ ] Dynamic page preview cards still appear compact (not full-width) on macOS
- [ ] Preview cards don't overflow on narrow parent views

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
