### PR TITLE
chore: remove tautological abort-check comments

### DIFF
--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -63,7 +63,6 @@ export const claudeCodeTool: Tool = {
   },
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    // Early abort check
     if (context.signal?.aborted) {
       return { content: 'Cancelled', isError: true };
     }

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -98,7 +98,6 @@ export const swarmDelegateTool: Tool = {
       }
       context.onOutput?.('\nExecuting...\n');
 
-      // Check abort before starting execution
       if (context.signal?.aborted) {
         return { content: 'Cancelled before execution', isError: true };
       }


### PR DESCRIPTION
## Summary
- Removes `// Early abort check` comment in `claude-code.ts` that restated the adjacent `if` condition
- Removes `// Check abort before starting execution` comment in `delegate.ts` that similarly restated the code

Both comments violated the project guideline that comments should explain **why**, not **what**. The abort-check code is self-explanatory without them.

Addresses feedback from PR #2440.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] No functional changes — comment-only removals
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
