### PR TITLE
fix(ui): preserve skill id during toggle state reconstruction

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -137,22 +137,7 @@ final class SkillsSettingsViewModel: ObservableObject {
                    response.operation == operation {
                     if response.success {
                         if let index = skills.firstIndex(where: { $0.name == op.name }) {
-                            let updated = skills[index]
-                            skills[index] = SkillInfo(
-                                name: updated.name,
-                                description: updated.description,
-                                emoji: updated.emoji,
-                                homepage: updated.homepage,
-                                source: updated.source,
-                                state: newState,
-                                degraded: updated.degraded,
-                                missingRequirements: updated.missingRequirements,
-                                installedVersion: updated.installedVersion,
-                                latestVersion: updated.latestVersion,
-                                updateAvailable: updated.updateAvailable,
-                                userInvocable: updated.userInvocable,
-                                clawhub: updated.clawhub
-                            )
+                            skills[index] = skills[index].withState(newState)
                         }
                     }
                     return

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -740,6 +740,11 @@ extension IPCSkillsListResponseSkill {
     public init(name: String, description: String, emoji: String?, homepage: String?, source: String, state: String, degraded: Bool, missingRequirements: IPCSkillsListResponseSkillMissingRequirements?, installedVersion: String?, latestVersion: String?, updateAvailable: Bool, userInvocable: Bool, clawhub: IPCSkillsListResponseSkillClawhub?) {
         self.init(id: name, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: state, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub)
     }
+
+    /// Returns a copy with a different `state`, preserving all other fields including `id`.
+    public func withState(_ newState: String) -> Self {
+        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub)
+    }
 }
 
 /// Backward-compatible alias for code referencing the old name.


### PR DESCRIPTION
## Summary
- Fixes bug where toggling a managed skill (enable/disable) then trying to uninstall it would fail with "Skill not found"
- Root cause: `processNextOperation` in `SkillsSettingsView` reconstructed `SkillInfo` using the backward-compatible init that defaults `id` to `name`, losing the original directory-key `id`
- Adds `withState()` helper to `SkillInfo` that creates a copy preserving all fields including `id`, replacing the manual 14-field reconstruction

## Test plan
- [x] `swift build` passes
- [x] Verified `withState()` uses the internal memberwise init with explicit `id:` parameter
- [x] Verified no other call sites need the same fix (SkillsManager and AgentPanel don't reconstruct SkillInfo)

Addresses feedback from PR #2410.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
