### PR TITLE
fix(lint): remove unused withMockOllamaQueryEmbedding

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -127,24 +127,6 @@ describe('Memory regressions', () => {
     }
   });
 
-  async function withMockOllamaQueryEmbedding<T>(run: () => Promise<T>): Promise<T> {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => (
-      new Response(
-        JSON.stringify({ data: [{ embedding: [1, 0, 0] }] }),
-        {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        },
-      )
-    )) as unknown as typeof globalThis.fetch;
-    try {
-      return await run();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  }
-
   function semanticRecallConfig() {
     return {
       ...DEFAULT_CONFIG,


### PR DESCRIPTION
## Summary
- Remove dead `withMockOllamaQueryEmbedding` function from `memory-regressions.test.ts` (it was moved to the experimental test file and is still used there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
