### PR TITLE
fix(chat): reset refinement flag immediately in happy cancel path

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1140,6 +1140,7 @@ public final class ChatViewModel: ObservableObject {
         // (via generation_cancelled or message_complete) to prevent the
         // user from sending a new message before the daemon has stopped.
         isCancelling = true
+        isWorkspaceRefinementInFlight = false
         isThinking = false
 
         // Mark current assistant message as stopped and complete any in-progress tool calls


### PR DESCRIPTION
## Summary

- Reset `isWorkspaceRefinementInFlight` immediately when the cancel message is sent successfully (the "happy" cancel path)
- Previously, the flag stayed true until the daemon acknowledged the cancel (up to 5s), keeping the "Refining..." indicator visible
- `isCancelling` already suppresses late-arriving events, so the refinement flag can be cleared immediately

Addresses feedback on #2526.

## Test plan

- [ ] Cancel during a workspace refinement — "Refining..." indicator should disappear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
