### PR TITLE
fix(memory): filter empty text blocks and scope profile strip to last user message

### DIFF
--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -223,6 +223,10 @@ mock.module('../agent/loop.js', () => ({
 }));
 
 import { Session } from '../daemon/session.js';
+import {
+  injectDynamicProfileIntoUserMessage,
+  stripDynamicProfileMessages,
+} from '../daemon/session-dynamic-profile.js';
 
 function makeSession(): Session {
   const provider = {
@@ -278,9 +282,55 @@ describe('Session dynamic profile injection', () => {
       expect(persistedText).not.toContain('[Dynamic profile context start]');
       expect(persistedText).not.toContain('[Dynamic User Profile]');
       expect(persistedText).not.toContain('[Dynamic profile context end]');
+      // No empty text blocks should remain after stripping
+      const emptyBlocks = persistedUser.content.filter(
+        (b) => b.type === 'text' && (b as { text: string }).text === '',
+      );
+      expect(emptyBlocks).toHaveLength(0);
     }
     expect(profileCompilerCalls).toBe(1);
     expect(events.some((event) => event.type === 'message_complete')).toBe(true);
+  });
+
+  test('strip removes empty text blocks left by dedicated injection block', () => {
+    const profile = 'timezone: US/Pacific';
+    const userMsg: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'hello' }],
+    };
+    const injected = injectDynamicProfileIntoUserMessage(userMsg, profile);
+    // The injected message has 2 content blocks: original + profile
+    expect(injected.content).toHaveLength(2);
+    const stripped = stripDynamicProfileMessages([injected], profile);
+    // After stripping, the dedicated profile block should be removed entirely
+    expect(stripped[0].content).toHaveLength(1);
+    expect(stripped[0].content.every((b) => {
+      return b.type !== 'text' || (b as { text: string }).text.length > 0;
+    })).toBe(true);
+  });
+
+  test('strip only targets the last user message, not earlier ones', () => {
+    const profile = 'timezone: US/Pacific';
+    const profileMarker = '[Dynamic profile context start]';
+    const earlyUser: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: `I pasted: ${profileMarker}\ntimezone: US/Pacific\n[Dynamic profile context end]` }],
+    };
+    const assistant: Message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ok' }],
+    };
+    const latestUser: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'follow up' }],
+    };
+    const injected = injectDynamicProfileIntoUserMessage(latestUser, profile);
+    const msgs = [earlyUser, assistant, injected];
+    const stripped = stripDynamicProfileMessages(msgs, profile);
+    // Earlier user message should be untouched
+    expect(messageText(stripped[0])).toContain(profileMarker);
+    // Latest user message should have profile removed
+    expect(messageText(stripped[2])).not.toContain(profileMarker);
   });
 
   test('skips profile compilation/injection when memory.profile.enabled is false', async () => {

--- a/assistant/src/daemon/session-dynamic-profile.ts
+++ b/assistant/src/daemon/session-dynamic-profile.ts
@@ -28,19 +28,26 @@ export function stripDynamicProfileMessages(messages: Message[], profileText: st
   const trimmedProfile = profileText.trim();
   if (trimmedProfile.length === 0) return messages;
   const injectedBlock = `\n\n[Dynamic profile context start]\n${trimmedProfile}\n[Dynamic profile context end]`;
-  return messages.map((message) => {
-    if (message.role !== 'user') return message;
-    let changed = false;
-    const nextContent = message.content.map((block) => {
-      if (block.type !== 'text') return block;
-      const nextText = block.text.split(injectedBlock).join('');
-      if (nextText === block.text) return block;
-      changed = true;
-      return {
-        ...block,
-        text: nextText.replace(/\n{3,}/g, '\n\n').trimEnd(),
-      };
-    });
-    return changed ? { ...message, content: nextContent } : message;
-  });
+  // Only strip from the last user message — that's the one we injected into.
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') { lastUserIdx = i; break; }
+  }
+  if (lastUserIdx === -1) return messages;
+  const message = messages[lastUserIdx];
+  let changed = false;
+  const nextContent = message.content.map((block) => {
+    if (block.type !== 'text') return block;
+    const nextText = block.text.split(injectedBlock).join('');
+    if (nextText === block.text) return block;
+    changed = true;
+    const stripped = nextText.replace(/\n{3,}/g, '\n\n').trimEnd();
+    return stripped.length > 0 ? { ...block, text: stripped } : null;
+  }).filter((block): block is NonNullable<typeof block> => block !== null);
+  if (!changed) return messages;
+  return [
+    ...messages.slice(0, lastUserIdx),
+    { ...message, content: nextContent },
+    ...messages.slice(lastUserIdx + 1),
+  ];
 }


### PR DESCRIPTION
## Summary
- Filter out empty `{ type: 'text', text: '' }` content blocks left behind after stripping the injected profile block — prevents Anthropic API errors on subsequent turns
- Scope `stripDynamicProfileMessages` to only the last user message (where injection happened) instead of scanning all user messages, preventing silent rewriting of user-authored history
- Add direct unit tests for empty-block filtering and scoped stripping behavior

Addresses feedback from PR #2438.

## Testing
```bash
export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/session-profile-injection.test.ts
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
