### PR TITLE
fix(ipc): address zero-copy baseline metrics review feedback

### DIFF
--- a/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
+++ b/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
@@ -83,6 +83,7 @@ function createTestContext(sessionId: string): {
     socketToSession: new Map(),
     cuSessions,
     socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new Map(),

--- a/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
+++ b/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
@@ -60,6 +60,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new Map(),

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -320,6 +320,7 @@ export interface HandlerContext {
   socketToSession: Map<net.Socket, string>;
   cuSessions: Map<string, ComputerUseSession>;
   socketToCuSession: Map<net.Socket, Set<string>>;
+  cuObservationParseSequence: Map<string, number>;
   socketSandboxOverride: Map<net.Socket, boolean>;
   sharedRequestTimestamps: number[];
   debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
@@ -1835,6 +1836,7 @@ function removeCuSessionReferences(
   }
   ctx.cuSessions.delete(sessionId);
   cuObservationSequenceBySession.delete(sessionId);
+  ctx.cuObservationParseSequence.delete(sessionId);
   for (const [sock, ids] of ctx.socketToCuSession) {
     if (ids.delete(sessionId) && ids.size === 0) {
       ctx.socketToCuSession.delete(sock);

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -431,7 +431,7 @@ export class DaemonServer {
             chunkReceivedAtMs,
             parsedAtMs,
             parseDurationMs,
-            payloadJsonBytes: Buffer.byteLength(JSON.stringify(msg), 'utf8'),
+            chunkBytes: Buffer.byteLength(data),
           }, 'IPC_METRIC cu_observation_parse');
         }
         const result = validateClientMessage(msg);
@@ -608,6 +608,7 @@ export class DaemonServer {
       socketToSession: this.socketToSession,
       cuSessions: this.cuSessions,
       socketToCuSession: this.socketToCuSession,
+      cuObservationParseSequence: this.cuObservationParseSequence,
       socketSandboxOverride: this.socketSandboxOverride,
       sharedRequestTimestamps: this.sharedRequestTimestamps,
       debounceTimers: this.debounceTimers,

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -519,7 +519,7 @@ final class ComputerUseSession: ObservableObject {
         let axTreeUsedBlob = axTreeBlobRef != nil
         let axDiffBytes = axDiffText?.utf8.count ?? 0
         let secondaryWindowsBytes = secondaryWindowsText?.utf8.count ?? 0
-        let payloadJSONBytes = (try? JSONEncoder().encode(observation).count) ?? 0
+        let payloadJSONBytes = screenshotBase64Bytes + axTreeBytes + axDiffBytes + secondaryWindowsBytes + 256
         let buildTimestampMs = Int(Date().timeIntervalSince1970 * 1_000)
         log.info(
             "[\(stepNumber)] IPC_METRIC cu_observation_build buildTsMs=\(buildTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotRawBytes=\(screenshotRawBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) screenshotUsedBlob=\(screenshotUsedBlob) axTreeBytes=\(axTreeBytes) axTreeUsedBlob=\(axTreeUsedBlob) axDiffBytes=\(axDiffBytes) secondaryWindowsBytes=\(secondaryWindowsBytes)"


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #2374 (zero-copy baseline instrumentation):

- **Memory leak fix**: Clean up `cuObservationParseSequence` entries when CU sessions end via `removeCuSessionReferences`, not just on socket close. Prevents unbounded map growth in long-lived daemons.
- **Avoid expensive re-serialization (TS)**: Replace `JSON.stringify(msg)` with `Buffer.byteLength(data)` in the daemon parse metric. The original call re-serialized multi-MB CU observations (5-10 MB with base64 screenshots) synchronously on every observation just for a byte count.
- **Avoid double-encoding (Swift)**: Replace `JSONEncoder().encode(observation)` with field-size summation in the Swift build metric. The original call encoded the entire observation a second time purely for byte counting, doubling CPU and memory cost.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `swift build` succeeds
- [x] No behavior change — metrics are log-only

Addresses feedback from #2374.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
