### PR TITLE
fix(memory): delete entity links in superseded item cleanup

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -1220,7 +1220,7 @@ describe('Memory regressions', () => {
     expect(recentRow?.status).toBe('resolved_keep_candidate');
   });
 
-  test('cleanup_stale_superseded_items removes stale superseded rows and embeddings', async () => {
+  test('cleanup_stale_superseded_items removes stale superseded rows, embeddings, and entity links', async () => {
     const db = getDb();
     const now = Date.now();
 
@@ -1280,6 +1280,22 @@ describe('Memory regressions', () => {
       },
     ]).run();
 
+    // Create entity links for both items (no FK cascade on this table)
+    db.insert(memoryEntities).values({
+      id: 'cleanup-entity',
+      name: 'Deployment',
+      type: 'concept',
+      aliases: JSON.stringify([]),
+      description: null,
+      firstSeenAt: now - 200_000,
+      lastSeenAt: now - 200_000,
+      mentionCount: 2,
+    }).run();
+    db.insert(memoryItemEntities).values([
+      { memoryItemId: 'cleanup-stale-item', entityId: 'cleanup-entity' },
+      { memoryItemId: 'cleanup-recent-item', entityId: 'cleanup-entity' },
+    ]).run();
+
     enqueueMemoryJob('cleanup_stale_superseded_items', { retentionMs: 10_000 });
     const processed = await runMemoryJobsOnce();
     expect(processed).toBe(1);
@@ -1289,10 +1305,16 @@ describe('Memory regressions', () => {
     const staleEmbedding = db.select().from(memoryEmbeddings).where(eq(memoryEmbeddings.id, 'cleanup-embed-stale')).get();
     const recentEmbedding = db.select().from(memoryEmbeddings).where(eq(memoryEmbeddings.id, 'cleanup-embed-recent')).get();
 
+    // Entity links for stale item should be removed; recent item's links should remain
+    const staleEntityLinks = db.select().from(memoryItemEntities).where(eq(memoryItemEntities.memoryItemId, 'cleanup-stale-item')).all();
+    const recentEntityLinks = db.select().from(memoryItemEntities).where(eq(memoryItemEntities.memoryItemId, 'cleanup-recent-item')).all();
+
     expect(staleItem).toBeUndefined();
     expect(recentItem).toBeDefined();
     expect(staleEmbedding).toBeUndefined();
     expect(recentEmbedding).toBeDefined();
+    expect(staleEntityLinks).toHaveLength(0);
+    expect(recentEntityLinks).toHaveLength(1);
   });
 
   test('memory admin status reports pending/resolved conflicts and oldest pending age', () => {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -41,6 +41,7 @@ import { getQdrantClient } from './qdrant-client.js';
 import {
   memoryEmbeddings,
   memoryItemConflicts,
+  memoryItemEntities,
   memoryItems,
   memoryItemSources,
   memorySegments,
@@ -494,6 +495,9 @@ function cleanupStaleSupersededItemsJob(job: MemoryJob, config: AssistantConfig)
   if (stale.length === 0) return;
 
   const ids = stale.map((row) => row.id);
+  db.delete(memoryItemEntities)
+    .where(inArray(memoryItemEntities.memoryItemId, ids))
+    .run();
   db.delete(memoryEmbeddings)
     .where(and(
       eq(memoryEmbeddings.targetType, 'item'),


### PR DESCRIPTION
## Summary
- Delete `memory_item_entities` rows before removing stale superseded items in `cleanupStaleSupersededItemsJob`
- Without this, orphaned entity links accumulate and inflate candidate-ID sets in `getEntityLinkedItemCandidates`, degrading query performance over time
- Follows the same cleanup pattern used in `conversation-store.ts` for orphaned item deletion
- Updated the regression test to verify entity links are cleaned up alongside items and embeddings

Addresses feedback from Codex review on #2444.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Regression test updated and passing with 7 assertions (2 new for entity links)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
