### PR TITLE
fix(skills): best-effort index cleanup in deleteManagedSkill

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -475,4 +475,36 @@ describe('deleteManagedSkill', () => {
     const indexContent = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
     expect(indexContent).toContain('- keep-index');
   });
+
+  test('succeeds even when index cleanup throws', () => {
+    createManagedSkill({
+      id: 'index-fail',
+      name: 'Index Fail',
+      description: 'Index removal will throw',
+      bodyMarkdown: 'Body.',
+    });
+
+    // Intercept the atomic write (.tmp- file) used by removeSkillsIndexEntry
+    const skillsDir = join(TEST_DIR, 'skills');
+    const originalWrite = fs.writeFileSync;
+    const spy = spyOn(fs, 'writeFileSync').mockImplementation(((
+      path: fs.PathOrFileDescriptor,
+      data: string | NodeJS.ArrayBufferView,
+      options?: fs.WriteFileOptions,
+    ) => {
+      if (typeof path === 'string' && path.startsWith(skillsDir) && path.includes('.tmp-')) {
+        throw new Error('Simulated write failure');
+      }
+      return originalWrite(path, data, options);
+    }) as typeof fs.writeFileSync);
+
+    try {
+      const result = deleteManagedSkill('index-fail');
+      expect(result.deleted).toBe(true);
+      expect(result.indexUpdated).toBe(false);
+      expect(existsSync(join(skillsDir, 'index-fail'))).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -214,8 +214,13 @@ export function deleteManagedSkill(
 
   let indexUpdated = false;
   if (removeFromIndex) {
-    removeSkillsIndexEntry(id);
-    indexUpdated = true;
+    try {
+      removeSkillsIndexEntry(id);
+      indexUpdated = true;
+    } catch (err) {
+      // Best-effort: skill dir is already gone, don't fail the whole delete
+      log.warn({ id, err }, 'Failed to update skills index after deleting managed skill');
+    }
   }
 
   return { deleted: true, indexUpdated };


### PR DESCRIPTION
## Summary
- Wraps `removeSkillsIndexEntry` in a try/catch inside `deleteManagedSkill` so that if SKILLS.md cannot be rewritten after the skill directory is already removed, the function still reports `deleted: true` with `indexUpdated: false` instead of throwing
- This matches the best-effort semantics used by the namespaced-slug path in `handleSkillsUninstall` (line 1130 of handlers.ts)
- Addresses Codex review feedback on PR #2409: the delegated path could report uninstall failure and skip config cleanup/broadcast despite the skill already being deleted on disk

## Test plan
- [x] New test: `succeeds even when index cleanup throws` — verifies `deleted: true`, `indexUpdated: false` when write fails
- [x] All 36 managed-store tests pass
- [x] TypeScript type-check passes

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
