### PR TITLE
fix(ipc): clean up orphaned blobs and degrade gracefully on hydration failure

### DIFF
--- a/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
+++ b/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
@@ -212,7 +212,7 @@ describe('handleCuObservation blob hydration', () => {
     expect(observations[0].axTree).toBe(inlineAxTree);
   });
 
-  test('blob failure with no inline fallback: emits cu_error', async () => {
+  test('blob failure with no inline fallback: continues with partial observation', async () => {
     const sessionId = randomUUID();
     // Create a blob ref that points to a non-existent file
     const blobRef: IpcBlobRef = {
@@ -234,15 +234,11 @@ describe('handleCuObservation blob hydration', () => {
     handleMessage(msg, fakeSocket, ctx);
     await new Promise((r) => setTimeout(r, 50));
 
-    // Should NOT forward to session
-    expect(observations).toHaveLength(0);
-    // Should send cu_error
-    expect(sent).toHaveLength(1);
-    expect(sent[0].type).toBe('cu_error');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing union-narrowed property
-    expect((sent[0] as any).message).toContain('Failed to hydrate axTreeBlob');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((sent[0] as any).message).toContain('no inline fallback');
+    // Should still forward to session with partial data (no axTree)
+    expect(observations).toHaveLength(1);
+    expect(observations[0].axTree).toBeUndefined();
+    // Should NOT send cu_error
+    expect(sent).toHaveLength(0);
   });
 
   test('wrong blob kind: fails validation and falls back to inline', async () => {
@@ -267,9 +263,12 @@ describe('handleCuObservation blob hydration', () => {
     expect(observations).toHaveLength(1);
     // Should fall back to inline because kind validation failed
     expect(observations[0].screenshot).toBe(inlineScreenshot);
+
+    // Blob file should still be cleaned up despite validation failure
+    expect(existsSync(join(blobDir, `${blobRef.id}.blob`))).toBe(false);
   });
 
-  test('wrong blob kind with no inline fallback: emits cu_error', async () => {
+  test('wrong blob kind with no inline fallback: continues with partial observation', async () => {
     const sessionId = randomUUID();
     // Create a blob with wrong kind for screenshotBlob field, no inline fallback
     const blobRef = writeBlobFile(Buffer.from([0xFF, 0xD8]), 'ax_tree', 'utf8');
@@ -286,13 +285,14 @@ describe('handleCuObservation blob hydration', () => {
     handleMessage(msg, fakeSocket, ctx);
     await new Promise((r) => setTimeout(r, 50));
 
-    // Should NOT forward to session
-    expect(observations).toHaveLength(0);
-    // Should send cu_error
-    expect(sent).toHaveLength(1);
-    expect(sent[0].type).toBe('cu_error');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing union-narrowed property
-    expect((sent[0] as any).message).toContain('Failed to hydrate screenshotBlob');
+    // Should still forward to session with partial data (no screenshot)
+    expect(observations).toHaveLength(1);
+    expect(observations[0].screenshot).toBeUndefined();
+    // Should NOT send cu_error
+    expect(sent).toHaveLength(0);
+
+    // Blob file should still be cleaned up despite validation failure
+    expect(existsSync(join(blobDir, `${blobRef.id}.blob`))).toBe(false);
   });
 
   test('inline-only unchanged: no blob refs, observation passes through', async () => {

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1932,13 +1932,9 @@ async function handleCuObservation(
       deleteBlob(msg.axTreeBlob.id);
     } catch (err) {
       log.warn({ err, blobId: msg.axTreeBlob.id }, 'Failed to hydrate axTreeBlob, checking inline fallback');
+      deleteBlob(msg.axTreeBlob.id);
       if (!msg.axTree) {
-        ctx.send(socket, {
-          type: 'cu_error',
-          sessionId: msg.sessionId,
-          message: `Failed to hydrate axTreeBlob (id=${msg.axTreeBlob.id}) and no inline fallback available`,
-        });
-        return;
+        log.warn({ blobId: msg.axTreeBlob.id }, 'No inline axTree fallback; continuing with partial observation');
       }
     }
   }
@@ -1951,13 +1947,9 @@ async function handleCuObservation(
       deleteBlob(msg.screenshotBlob.id);
     } catch (err) {
       log.warn({ err, blobId: msg.screenshotBlob.id }, 'Failed to hydrate screenshotBlob, checking inline fallback');
+      deleteBlob(msg.screenshotBlob.id);
       if (!msg.screenshot) {
-        ctx.send(socket, {
-          type: 'cu_error',
-          sessionId: msg.sessionId,
-          message: `Failed to hydrate screenshotBlob (id=${msg.screenshotBlob.id}) and no inline fallback available`,
-        });
-        return;
+        log.warn({ blobId: msg.screenshotBlob.id }, 'No inline screenshot fallback; continuing with partial observation');
       }
     }
   }


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2411:

- **Blob cleanup on failure** (Devin): Added `deleteBlob` calls in catch blocks for both `axTreeBlob` and `screenshotBlob` hydration so orphaned blob files don't accumulate on disk when validation or read fails.
- **Graceful degradation** (Codex): Replaced `cu_error` + early `return` with warn-and-continue when blob hydration fails without an inline fallback. Downstream session logic supports partial observations, so aborting the entire observation on a single optional field failure was overly aggressive.
- **Updated tests** to assert the new partial-observation behavior and blob cleanup on failure paths.

## Test plan

- [x] All 9 blob hydration tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
