### PR TITLE
fix(conflict-store): use explicit undefined checks and require scopeId

### DIFF
--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -141,6 +141,7 @@ describe('conflict-store', () => {
   test('allows a new pending row for the same pair after resolution', () => {
     const pair = insertItemPair('reopen');
     const first = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: pair.existingItemId,
       candidateItemId: pair.candidateItemId,
       relationship: 'ambiguous_contradiction',
@@ -154,6 +155,7 @@ describe('conflict-store', () => {
     expect(typeof resolved?.resolvedAt).toBe('number');
 
     const reopened = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: pair.existingItemId,
       candidateItemId: pair.candidateItemId,
       relationship: 'ambiguous_contradiction',
@@ -203,6 +205,7 @@ describe('conflict-store', () => {
   test('markConflictAsked updates lastAskedAt', () => {
     const pair = insertItemPair('asked');
     const conflict = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: pair.existingItemId,
       candidateItemId: pair.candidateItemId,
       relationship: 'ambiguous_contradiction',
@@ -234,6 +237,7 @@ describe('conflict-store', () => {
   test('applyConflictResolution keeps candidate and resolves conflict row', () => {
     const pair = insertItemPair('apply-candidate');
     const conflict = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: pair.existingItemId,
       candidateItemId: pair.candidateItemId,
       relationship: 'ambiguous_contradiction',
@@ -259,6 +263,7 @@ describe('conflict-store', () => {
   test('applyConflictResolution merge updates existing item statement', () => {
     const pair = insertItemPair('apply-merge');
     const conflict = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: pair.existingItemId,
       candidateItemId: pair.candidateItemId,
       relationship: 'ambiguous_contradiction',

--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -367,6 +367,7 @@ describe('Memory lifecycle E2E regression', () => {
     ]).run();
 
     const gatedConflict = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: 'item-ui-existing',
       candidateItemId: 'item-ui-candidate',
       relationship: 'ambiguous_contradiction',
@@ -436,6 +437,7 @@ describe('Memory lifecycle E2E regression', () => {
     ]).run();
 
     const backgroundConflict = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: 'item-runtime-existing',
       candidateItemId: 'item-runtime-candidate',
       relationship: 'ambiguous_contradiction',

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -1067,6 +1067,7 @@ describe('Memory regressions', () => {
       ]).run();
 
       const conflict = createOrUpdatePendingConflict({
+        scopeId: 'default',
         existingItemId: 'cleanup-config-existing',
         candidateItemId: 'cleanup-config-candidate',
         relationship: 'ambiguous_contradiction',
@@ -1178,16 +1179,19 @@ describe('Memory regressions', () => {
     ]).run();
 
     const staleResolved = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: 'cleanup-conflict-existing-a',
       candidateItemId: 'cleanup-conflict-candidate-a',
       relationship: 'ambiguous_contradiction',
     });
     const pendingConflict = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: 'cleanup-conflict-existing-b',
       candidateItemId: 'cleanup-conflict-candidate-b',
       relationship: 'ambiguous_contradiction',
     });
     const recentResolved = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: 'cleanup-conflict-existing-c',
       candidateItemId: 'cleanup-conflict-candidate-c',
       relationship: 'ambiguous_contradiction',
@@ -1377,11 +1381,13 @@ describe('Memory regressions', () => {
     ]).run();
 
     const pending = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: 'status-conflict-existing',
       candidateItemId: 'status-conflict-candidate',
       relationship: 'ambiguous_contradiction',
     });
     const resolved = createOrUpdatePendingConflict({
+      scopeId: 'default',
       existingItemId: 'status-conflict-existing-2',
       candidateItemId: 'status-conflict-candidate-2',
       relationship: 'ambiguous_contradiction',

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -35,7 +35,7 @@ export interface MemoryItemConflict {
 }
 
 export interface CreatePendingConflictInput {
-  scopeId?: string;
+  scopeId: string;
   existingItemId: string;
   candidateItemId: string;
   relationship: string;
@@ -64,14 +64,14 @@ export interface ApplyConflictResolutionInput {
 export function createOrUpdatePendingConflict(input: CreatePendingConflictInput): MemoryItemConflict {
   const db = getDb();
   const now = Date.now();
-  const scopeId = input.scopeId ?? 'default';
+  const scopeId = input.scopeId;
   const existing = getPendingConflictByPair(scopeId, input.existingItemId, input.candidateItemId);
 
   if (existing) {
     db.update(memoryItemConflicts)
       .set({
         relationship: input.relationship,
-        clarificationQuestion: input.clarificationQuestion ?? existing.clarificationQuestion,
+        clarificationQuestion: input.clarificationQuestion !== undefined ? input.clarificationQuestion : existing.clarificationQuestion,
         updatedAt: now,
       })
       .where(eq(memoryItemConflicts.id, existing.id))
@@ -235,7 +235,7 @@ export function resolveConflict(conflictId: string, input: ResolveConflictInput)
   db.update(memoryItemConflicts)
     .set({
       status: input.status,
-      resolutionNote: input.resolutionNote ?? existing.resolutionNote,
+      resolutionNote: input.resolutionNote !== undefined ? input.resolutionNote : existing.resolutionNote,
       resolvedAt: now,
       updatedAt: now,
     })


### PR DESCRIPTION
## Summary
- Replace `??` with `!== undefined` ternary for `clarificationQuestion` in `createOrUpdatePendingConflict` and `resolutionNote` in `resolveConflict`, so callers can explicitly set these fields to `null` to clear them (addresses Devin review on PR #2420)
- Make `scopeId` required in `CreatePendingConflictInput` to prevent silent misrouting of conflicts into the wrong scope (addresses Codex review on PR #2420)
- Update all test call sites across `conflict-store.test.ts`, `memory-lifecycle-e2e.test.ts`, and `memory-regressions.test.ts` to pass `scopeId` explicitly

## Testing
- `bunx tsc --noEmit` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
