### PR TITLE
fix(memory): preserve pending_clarification across re-extraction

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -8,7 +8,7 @@ import { getLogger } from '../util/logger.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { getDb } from './db.js';
-import { memoryItems, memoryItemSources, messages } from './schema.js';
+import { memoryItemConflicts, memoryItems, memoryItemSources, messages } from './schema.js';
 
 const log = getLogger('memory-items-extractor');
 
@@ -272,9 +272,13 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
         existing.verificationState === 'assistant_inferred' && verificationState === 'user_reported'
           ? 'user_reported'
           : existing.verificationState;
+      // Preserve pending_clarification if this item has an unresolved conflict
+      const nextStatus = existing.status === 'pending_clarification' && hasPendingConflict(existing.id)
+        ? 'pending_clarification'
+        : 'active';
       db.update(memoryItems)
         .set({
-          status: 'active',
+          status: nextStatus,
           confidence: Math.max(existing.confidence, item.confidence),
           importance: Math.max(existing.importance ?? 0, item.importance),
           lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
@@ -426,4 +430,19 @@ function parseScore(value: unknown, fallback: number): number {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+/** Returns true if the given memory item is the candidate in an unresolved conflict. */
+function hasPendingConflict(itemId: string): boolean {
+  const db = getDb();
+  const row = db
+    .select({ id: memoryItemConflicts.id })
+    .from(memoryItemConflicts)
+    .where(and(
+      eq(memoryItemConflicts.candidateItemId, itemId),
+      eq(memoryItemConflicts.status, 'pending_clarification'),
+    ))
+    .limit(1)
+    .get();
+  return row != null;
 }


### PR DESCRIPTION
## Summary
- Fix bug where `extractAndUpsertMemoryItemsForMessage` unconditionally reset a memory item's status to `active` on re-extraction, silently undoing `pending_clarification` status set by the contradiction checker
- When a fingerprint-matched item already has `pending_clarification` status and an unresolved conflict row exists, the status is now preserved
- Addresses Codex review feedback on #2423

## Changes
- `assistant/src/memory/items-extractor.ts`: Added `hasPendingConflict()` helper that checks for unresolved conflict rows where the item is the candidate; upsert path now preserves `pending_clarification` status when a conflict is pending

## Test plan
- [x] Existing contradiction-checker tests pass (`bun test src/__tests__/contradiction-checker.test.ts`)
- [x] Existing conflict-store tests pass (`bun test src/__tests__/conflict-store.test.ts`)
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
