### PR TITLE
fix(evaluate-ts): bound result extraction to last 4KB of stdout

### DIFF
--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -209,11 +209,16 @@ export class EvaluateTypescriptTool implements Tool {
         let stderr = Buffer.concat(stderrChunks).toString();
         let truncated = false;
 
-        // Extract structured result from raw stdout before truncation
+        // Extract structured result from raw stdout before truncation.
+        // Scan from the end since the runner prints __eval_result last,
+        // so post-processing cost stays bounded regardless of output size.
         let result: unknown = undefined;
         if (code === 0) {
-          const lines = stdout.split('\n');
-          for (const line of lines) {
+          const searchRegion = stdout.slice(-4096);
+          const lines = searchRegion.split('\n');
+          for (let i = lines.length - 1; i >= 0; i--) {
+            const line = lines[i];
+            if (!line) continue;
             try {
               const parsed = JSON.parse(line);
               if (parsed && typeof parsed === 'object' && '__eval_result' in parsed) {


### PR DESCRIPTION
Addresses Codex review on PR #2510.

The `__eval_result` marker is always the last line printed by the runner. Previously, result extraction split all of stdout into lines and scanned from the beginning, meaning post-processing cost scaled with total output size even when `max_output_chars` was small.

Now slices only the last 4096 bytes of stdout and scans backwards, capping extraction cost to a constant regardless of output volume.

**Files changed:** `assistant/src/tools/terminal/evaluate-typescript.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
