### PR TITLE
fix(docs): remove dangling .private/ reference from closeout report

### DIFF
--- a/docs/refactor/FINAL.md
+++ b/docs/refactor/FINAL.md
@@ -1,6 +1,6 @@
 # Refactor Plan — Closeout Report
 
-**Plan:** `.private/plans/REFACTOR.md` (18 PRs across 5 phases)
+**Plan:** 18 PRs across 5 phases (baseline, dead code removal, daemon refactors, macOS state refactors, cleanup)
 **Completed:** 2026-02-15
 
 ---


### PR DESCRIPTION
## Summary

- Replaces the dangling `.private/plans/REFACTOR.md` reference in `docs/refactor/FINAL.md` with an inline plan description
- The `.private/` directory is gitignored, so fresh clones could not verify the 18-PR refactor summary — this made the audit trail non-reproducible for other contributors
- The closeout report already documents the full plan in its body, so the external reference was redundant

Addresses codex review feedback on PR #2522.

## Test plan
- [x] Verify no remaining references to `.private/` in `docs/refactor/`
- [x] Confirm the closeout report reads coherently without the external plan link
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
