### PR TITLE
fix: responseModel fallback uses effective model with overrides

### DIFF
--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -68,7 +68,7 @@ export class GeminiProvider implements Provider {
       let finishReason = 'unknown';
       let promptTokens = 0;
       let outputTokens = 0;
-      let responseModel = this.model;
+      let responseModel = modelOverride ?? this.model;
 
       for await (const chunk of stream) {
         // Extract text delta

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -74,7 +74,7 @@ export class OpenAIProvider implements Provider {
       let contentText = '';
       const toolCallMap = new Map<number, { id: string; name: string; args: string }>();
       let finishReason = 'unknown';
-      let responseModel = this.model;
+      let responseModel = modelOverride ?? this.model;
       let promptTokens = 0;
       let completionTokens = 0;
 


### PR DESCRIPTION
## Summary

Fixes incorrect `responseModel` fallback in Gemini and OpenAI providers when `config.model` override is active.

When `modelOverride` is provided via `config.model`, the `responseModel` variable was initialized to `this.model` (the provider's default) instead of `modelOverride ?? this.model` (the model actually sent to the API). For the Gemini provider, where `chunk.modelVersion` is only conditionally set, this caused the response to report the wrong model — impacting cost tracking, logging, and downstream logic.

Addresses review feedback from Devin on PR #2535.

## Changes

- `assistant/src/providers/gemini/client.ts` — Initialize `responseModel` to `modelOverride ?? this.model`
- `assistant/src/providers/openai/client.ts` — Same fix for consistency (OpenAI always overwrites via `chunk.model`, but the fallback should still be correct)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
