### PR TITLE
fix(swarm): prevent deadlock and abort race in orchestrator

### DIFF
--- a/assistant/src/__tests__/swarm-orchestrator.test.ts
+++ b/assistant/src/__tests__/swarm-orchestrator.test.ts
@@ -314,4 +314,80 @@ describe('executeSwarm', () => {
     expect(aEnd).toBeGreaterThan(-1);
     expect(cStart).toBeLessThan(aEnd);
   });
+
+  test('abort waits for in-flight workers before emitting done', async () => {
+    const events: OrchestratorEvent[] = [];
+    const controller = new AbortController();
+
+    const plan = makePlan({
+      tasks: [
+        { id: 'fast', role: 'coder', objective: 'fast', dependencies: [] },
+        { id: 'slow', role: 'coder', objective: 'slow', dependencies: [] },
+      ],
+    });
+
+    const backend = makeBackend({
+      runTask: async (input) => {
+        if (input.prompt.includes('fast')) {
+          // Fast task finishes quickly and triggers abort
+          await new Promise((r) => setTimeout(r, 5));
+          controller.abort();
+        } else {
+          // Slow task is still running when abort fires
+          await new Promise((r) => setTimeout(r, 80));
+        }
+        return {
+          success: true,
+          output: '```json\n{"summary":"Done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+          durationMs: 10,
+        };
+      },
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: resolveSwarmLimits({ ...DEFAULT_LIMITS, maxWorkers: 2 }),
+      backend,
+      workingDir: '/tmp',
+      onStatus: (event) => events.push(event),
+      signal: controller.signal,
+    });
+
+    const doneIdx = events.findIndex((e) => e.kind === 'done');
+    const lastCompletedIdx = events.reduce(
+      (max, e, i) => (e.kind === 'task_completed' ? i : max), -1,
+    );
+
+    // done must come after all task_completed events
+    expect(doneIdx).toBeGreaterThan(-1);
+    expect(lastCompletedIdx).toBeGreaterThan(-1);
+    expect(doneIdx).toBeGreaterThan(lastCompletedIdx);
+
+    // Both tasks should have completed (in-flight worker was waited on)
+    expect(summary.stats.completed).toBe(2);
+  });
+
+  test('does not deadlock when onStatus callback throws', async () => {
+    const plan = makePlan({
+      tasks: [
+        { id: 'a', role: 'coder', objective: 'A', dependencies: [] },
+      ],
+    });
+
+    // The onStatus callback throws on task_started, which happens inside
+    // runTask before the try/catch in runWorkerTask. The .catch() guard on
+    // the fire-and-forget promise should prevent a deadlock.
+    const summary = await executeSwarm({
+      plan,
+      limits: DEFAULT_LIMITS,
+      backend: makeBackend(),
+      workingDir: '/tmp',
+      onStatus: (event) => {
+        if (event.kind === 'task_started') throw new Error('boom');
+      },
+    });
+
+    // The swarm should still complete (via the .catch guard) rather than hang
+    expect(summary.stats.totalTasks).toBe(1);
+  });
 });

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -169,14 +169,28 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
     while (ready.length > 0 && activeCount < limits.maxWorkers) {
       const task = ready.shift()!;
       activeCount++;
-      // Fire-and-forget — completion is handled inside runTask
-      runTask(task);
+      // Fire-and-forget — completion is handled inside runTask.
+      // The .catch guard ensures activeCount is decremented even if an
+      // unexpected error (e.g. a throwing onStatus callback) propagates
+      // past runTask's internal try/catch, preventing a deadlock where
+      // the main loop waits on signalProgress() that never fires.
+      runTask(task).catch(() => {
+        activeCount--;
+        signalProgress();
+      });
     }
 
     // Nothing left to launch and nothing running — we're done
     if (activeCount === 0 && ready.length === 0) break;
 
     // Wait until a running task completes (or a new task becomes ready)
+    await waitForProgress();
+  }
+
+  // Let in-flight workers settle before finalizing — if we broke out of the
+  // loop due to abort, workers may still be running and would otherwise emit
+  // events (task_completed / task_failed) after the 'done' event.
+  while (activeCount > 0) {
     await waitForProgress();
   }
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2521:

- **Deadlock prevention**: Added `.catch()` guard on fire-and-forget `runTask()` calls so unexpected errors (e.g. throwing `onStatus` callbacks) still decrement `activeCount` and signal progress, preventing an infinite hang in the main scheduling loop.
- **Abort race fix**: After the main loop exits due to abort, the orchestrator now waits for all in-flight workers to settle before emitting the `done` event. This prevents `task_completed`/`task_failed` events from firing after `done` and ensures stats accurately reflect completed work.

## Test plan

- [x] Added test: abort waits for in-flight workers before emitting `done`
- [x] Added test: no deadlock when `onStatus` callback throws
- [x] All 13 swarm orchestrator tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
