### PR TITLE
fix: strip profile from injected message, not last user message

### DIFF
--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -333,6 +333,30 @@ describe('Session dynamic profile injection', () => {
     expect(messageText(stripped[2])).not.toContain(profileMarker);
   });
 
+  test('strip finds injected message even when tool_result user messages follow it', () => {
+    const profile = 'timezone: US/Pacific';
+    const profileMarker = '[Dynamic profile context start]';
+    const injectedUser = injectDynamicProfileIntoUserMessage(
+      { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+      profile,
+    );
+    const assistantMsg: Message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'calling tool' }],
+    };
+    // Simulate tool_result user message appended by agent loop
+    const toolResultUser: Message = {
+      role: 'user',
+      content: [{ type: 'tool_result' as 'text', tool_use_id: 'tu-1', content: 'result' } as any],
+    };
+    const msgs = [injectedUser, assistantMsg, toolResultUser];
+    const stripped = stripDynamicProfileMessages(msgs, profile);
+    // The injected profile should be stripped from the first user message
+    expect(messageText(stripped[0])).not.toContain(profileMarker);
+    // tool_result message should be untouched
+    expect(stripped[2]).toBe(toolResultUser);
+  });
+
   test('skips profile compilation/injection when memory.profile.enabled is false', async () => {
     profileEnabled = false;
     const session = makeSession();

--- a/assistant/src/daemon/session-dynamic-profile.ts
+++ b/assistant/src/daemon/session-dynamic-profile.ts
@@ -28,10 +28,15 @@ export function stripDynamicProfileMessages(messages: Message[], profileText: st
   const trimmedProfile = profileText.trim();
   if (trimmedProfile.length === 0) return messages;
   const injectedBlock = `\n\n[Dynamic profile context start]\n${trimmedProfile}\n[Dynamic profile context end]`;
-  // Only strip from the last user message — that's the one we injected into.
+  // Find the last user message that actually contains the injected profile block.
+  // We can't just target the last user message by role — tool_result messages also
+  // have role 'user', so after tool use the last user message won't be the one
+  // we injected the profile into.
   let lastUserIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === 'user') { lastUserIdx = i; break; }
+    if (messages[i].role === 'user' && messages[i].content.some(
+      (b) => b.type === 'text' && b.text.includes(injectedBlock),
+    )) { lastUserIdx = i; break; }
   }
   if (lastUserIdx === -1) return messages;
   const message = messages[lastUserIdx];


### PR DESCRIPTION
## Summary

Addresses review feedback from Devin and Codex on PR #2552.

- **Bug**: `stripDynamicProfileMessages` searched backwards for the last `user` message by role. After tool use, the agent loop appends `tool_result` messages with `role: 'user'`, so the strip logic targeted the wrong message and the profile markers leaked into persisted history.
- **Fix**: Search backwards for the last user message whose content actually **contains** the injected profile block text, instead of just the last user message by role.
- **Test**: Added a new test case covering the tool-result scenario.

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 6 session-profile-injection tests pass, including new tool-result test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
