### PR TITLE
fix(IpcBlobStore): remove tilde expansion to match daemon behavior

### DIFF
--- a/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
@@ -133,10 +133,4 @@ final class IpcBlobStoreTests: XCTestCase {
         XCTAssertEqual(resolved, expected)
     }
 
-    func testResolveBlobDirExpandsTildeInBaseDataDir() {
-        let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "~/custom"])
-        let expected = URL(fileURLWithPath: NSHomeDirectory() + "/custom")
-            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
-        XCTAssertEqual(resolved, expected)
-    }
 }

--- a/clients/shared/IPC/IpcBlobStore.swift
+++ b/clients/shared/IPC/IpcBlobStore.swift
@@ -13,12 +13,7 @@ func resolveBlobDir(environment: [String: String]? = nil) -> URL {
     let env = environment ?? ProcessInfo.processInfo.environment
     let root: String
     if let baseDataDir = env["BASE_DATA_DIR"], !baseDataDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-        let trimmed = baseDataDir.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("~/") {
-            root = NSHomeDirectory() + "/" + String(trimmed.dropFirst(2))
-        } else {
-            root = trimmed
-        }
+        root = baseDataDir.trimmingCharacters(in: .whitespacesAndNewlines)
     } else {
         root = NSHomeDirectory()
     }


### PR DESCRIPTION
## Summary

Addresses review feedback on #2518: the `resolveBlobDir()` function in the Swift client was expanding `~/` prefixes in `BASE_DATA_DIR`, but the daemon's `getRootDir()` does **not** perform tilde expansion on that env var. This mismatch would cause the client and daemon to resolve to different directories when `BASE_DATA_DIR` contains `~/...`, breaking blob transport.

- Removed the `~/` expansion branch from `resolveBlobDir()` in `IpcBlobStore.swift`
- Removed the `testResolveBlobDirExpandsTildeInBaseDataDir` test that validated the divergent behavior

## Test plan

- [x] `swift build` passes
- [x] Remaining `resolveBlobDir` tests still pass (default, custom root, empty)
- [x] Behavior now matches daemon's `getRootDir()` which uses `BASE_DATA_DIR.trim()` directly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
