### PR TITLE
fix(conflicts): accept concise directional replies for conflict resolution

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -234,6 +234,7 @@ mock.module('../agent/loop.js', () => ({
 }));
 
 import { Session } from '../daemon/session.js';
+import { looksLikeClarificationReply } from '../daemon/session-conflict-gate.js';
 
 function makeSession(): Session {
   const provider = {
@@ -390,6 +391,46 @@ describe('Session conflict soft gate', () => {
     expect(runCalls).toHaveLength(1);
   });
 
+  test('concise directional replies like "both" or "option B" resolve recently asked conflicts', async () => {
+    pendingConflicts = [{
+      id: 'conflict-concise',
+      scopeId: 'default',
+      existingItemId: 'existing-concise',
+      candidateItemId: 'candidate-concise',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Should I assume Postgres or MySQL?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use Postgres as the default database.',
+      candidateStatement: 'Use MySQL as the default database.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // First turn asks the clarification.
+    await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
+    expect(resolverCallCount).toBe(1);
+    expect(markAskedCalls).toEqual(['conflict-concise']);
+
+    resolverResult = {
+      resolution: 'merge',
+      strategy: 'heuristic',
+      resolvedStatement: 'Support both Postgres and MySQL.',
+      explanation: 'User wants both.',
+    };
+
+    // Short directional reply with no action verb should still resolve.
+    await session.processMessage('both', [], () => {});
+
+    expect(resolverCallCount).toBe(2);
+    expect(runCalls).toHaveLength(1);
+  });
+
   test('unrelated message during cooldown does not accidentally resolve conflict', async () => {
     pendingConflicts = [{
       id: 'conflict-unrelated',
@@ -493,5 +534,42 @@ describe('Session conflict soft gate', () => {
     expect(runCalls).toHaveLength(1);
     expect(resolverCallCount).toBe(0);
     expect(markAskedCalls).toEqual([]);
+  });
+});
+
+describe('looksLikeClarificationReply', () => {
+  test('accepts action + direction combo', () => {
+    expect(looksLikeClarificationReply('keep the new one')).toBe(true);
+    expect(looksLikeClarificationReply('use the existing')).toBe(true);
+    expect(looksLikeClarificationReply('go with option A')).toBe(true);
+  });
+
+  test('accepts directional-only replies', () => {
+    expect(looksLikeClarificationReply('both')).toBe(true);
+    expect(looksLikeClarificationReply('option B')).toBe(true);
+    expect(looksLikeClarificationReply('new one')).toBe(true);
+    expect(looksLikeClarificationReply('the existing one')).toBe(true);
+    expect(looksLikeClarificationReply('merge them')).toBe(true);
+  });
+
+  test('accepts action-only replies', () => {
+    expect(looksLikeClarificationReply('keep it')).toBe(true);
+    expect(looksLikeClarificationReply('use that')).toBe(true);
+  });
+
+  test('rejects questions', () => {
+    expect(looksLikeClarificationReply("what's new in Bun?")).toBe(false);
+    expect(looksLikeClarificationReply('which option?')).toBe(false);
+  });
+
+  test('rejects long statements', () => {
+    expect(looksLikeClarificationReply(
+      'I was thinking about this and I believe we should keep the new one because it is better',
+    )).toBe(false);
+  });
+
+  test('rejects messages with no cue words', () => {
+    expect(looksLikeClarificationReply('hello world')).toBe(false);
+    expect(looksLikeClarificationReply('sounds good')).toBe(false);
   });
 });

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -171,10 +171,10 @@ const MAX_REPLY_WORD_COUNT = 12;
 
 /**
  * Determines whether a user message looks like a deliberate reply to a
- * recently asked conflict clarification (e.g. "keep the new one", "option B").
- * Requires both an action cue and a directional cue, and the message must be
- * short. Questions and longer statements are excluded to prevent accidental
- * resolution from messages like "what's new in Bun?".
+ * recently asked conflict clarification (e.g. "keep the new one", "both",
+ * "option B", "new one"). Requires at least one action or directional cue,
+ * and the message must be short. Questions and longer statements are excluded
+ * to prevent accidental resolution from unrelated messages.
  */
 export function looksLikeClarificationReply(userMessage: string): boolean {
   const trimmed = userMessage.trim();
@@ -186,5 +186,5 @@ export function looksLikeClarificationReply(userMessage: string): boolean {
   const normalized = words.map((w) => w.replace(/[^a-z]/g, ''));
   const hasAction = normalized.some((w) => ACTION_CUES.has(w));
   const hasDirection = normalized.some((w) => DIRECTIONAL_CUES.has(w));
-  return hasAction && hasDirection;
+  return hasAction || hasDirection;
 }


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on #2524: requiring both an action cue AND a directional cue in `looksLikeClarificationReply` was too strict, causing legitimate short follow-up replies like `"both"`, `"option B"`, and `"new one"` to be treated as non-replies.

**Change:** Relax the condition from `hasAction && hasDirection` to `hasAction || hasDirection`. The existing guards (question-mark exclusion, max 12-word length limit) are sufficient to prevent false positives from unrelated messages.

## Test plan

- Added integration test: concise directional reply `"both"` resolves a recently asked conflict
- Added unit tests for `looksLikeClarificationReply`:
  - Accepts action+direction combos (`"keep the new one"`)
  - Accepts directional-only replies (`"both"`, `"option B"`, `"new one"`, `"merge them"`)
  - Accepts action-only replies (`"keep it"`, `"use that"`)
  - Rejects questions (`"what's new in Bun?"`)
  - Rejects long statements
  - Rejects messages with no cue words
- All 13 tests pass, type-check clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
