### PR TITLE
fix: unescape frontmatter values to match buildSkillMarkdown escaping

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -25,6 +25,7 @@ import {
   createManagedSkill,
   deleteManagedSkill,
 } from '../skills/managed-store.js';
+import { loadSkillCatalog } from '../config/skills.js';
 
 beforeEach(() => {
   TEST_DIR = mkdtempSync(join(tmpdir(), 'managed-store-test-'));
@@ -134,6 +135,39 @@ describe('buildSkillMarkdown', () => {
       bodyMarkdown: 'Body.',
     });
     expect(result).toContain('name: "back\\\\slash"');
+  });
+
+  test('round-trips special characters through write and load', () => {
+    // Write a skill with special chars in name/description
+    createManagedSkill({
+      id: 'roundtrip-test',
+      name: 'Say "hello" & back\\slash',
+      description: 'Line1\nLine2\r\nLine3',
+      bodyMarkdown: 'Body content.',
+    });
+
+    // Load it back via loadSkillCatalog (which uses parseFrontmatter)
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, 'skills')]);
+    const skill = catalog.find((s) => s.id === 'roundtrip-test');
+    expect(skill).toBeDefined();
+    expect(skill!.name).toBe('Say "hello" & back\\slash');
+    expect(skill!.description).toBe('Line1\nLine2\r\nLine3');
+  });
+
+  test('round-trips backslash-n literal (not a newline) correctly', () => {
+    // A name containing a literal backslash followed by 'n' (not a newline)
+    const nameWithBackslashN = 'path\\name';
+    createManagedSkill({
+      id: 'backslash-n-test',
+      name: nameWithBackslashN,
+      description: 'test',
+      bodyMarkdown: 'Body.',
+    });
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, 'skills')]);
+    const skill = catalog.find((s) => s.id === 'backslash-n-test');
+    expect(skill).toBeDefined();
+    expect(skill!.name).toBe('path\\name');
   });
 });
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -193,6 +193,13 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
       (value.startsWith('\'') && value.endsWith('\''))
     ) {
       value = value.slice(1, -1);
+      // Unescape sequences produced by buildSkillMarkdown's esc().
+      // Single-pass to avoid misinterpreting \\n (escaped backslash + n) as a newline.
+      value = value.replace(/\\(["\\nr])/g, (_, ch) => {
+        if (ch === 'n') return '\n';
+        if (ch === 'r') return '\r';
+        return ch; // handles \\ → \ and \" → "
+      });
     }
     fields[key] = value;
   }


### PR DESCRIPTION
## Summary
- Adds unescape logic in `parseFrontmatter` (`config/skills.ts`) to reverse the escape sequences (`\"`, `\\`, `\n`, `\r`) produced by `buildSkillMarkdown`'s `esc()` helper
- Uses single-pass regex replacement to correctly handle edge cases like `\\n` (escaped backslash + literal n) vs `\n` (newline)
- Adds round-trip tests verifying special characters survive write-then-load cycle

## Context
Addresses review feedback on PR #2530 from both Codex and Devin, which identified that `parseFrontmatter` only stripped outer quotes without unescaping, causing managed skills with quotes/backslashes/newlines in name/description to display with literal backslash escapes.

## Test plan
- [x] All 38 managed-store tests pass (including 2 new round-trip tests)
- [x] TypeScript type-check passes
- [x] Verified edge case: literal `\n` in name (backslash + n, not newline) round-trips correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
