### PR TITLE
fix(settings): acquire trust-rules lock before presenting sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -228,6 +228,7 @@ struct SettingsPanel: View {
                             }
                             Spacer()
                             VButton(label: "Manage...", style: .ghost) {
+                                daemonClient?.isTrustRulesSheetOpen = true
                                 showingTrustRules = true
                             }
                             .disabled(store.isAnyTrustRulesSheetOpen)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -190,6 +190,7 @@ public struct SettingsView: View {
                         }
                         Spacer()
                         Button("Manage Trust Rules...") {
+                            daemonClient.isTrustRulesSheetOpen = true
                             showingTrustRules = true
                         }
                         .disabled(store.isAnyTrustRulesSheetOpen)


### PR DESCRIPTION
## Summary

- Fixes a race condition identified by Codex on #2515 where two trust-rules sheets could be opened simultaneously
- Sets `daemonClient.isTrustRulesSheetOpen = true` immediately in the button action (in both `SettingsPanel` and `SettingsView`), before the local `showingTrustRules` state triggers sheet presentation
- This blocks the other surface's button instantly, closing the window between button click and `TrustRulesView.onAppear`

## Test plan

- [ ] Open settings panel and standalone settings window side by side
- [ ] Click "Manage..." / "Manage Trust Rules..." in one surface — verify the other surface's button is immediately disabled
- [ ] Dismiss the trust rules sheet — verify both surfaces re-enable their button
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
