### PR TITLE
fix(test): mock getMemoryConflictAndCleanupStats in session-queue test

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -76,6 +76,13 @@ mock.module('../security/secret-allowlist.js', () => ({
   resetAllowlist: () => {},
 }));
 
+mock.module('../memory/admin.js', () => ({
+  getMemoryConflictAndCleanupStats: () => ({
+    conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
+    cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
+  }),
+}));
+
 mock.module('../memory/conversation-store.js', () => ({
   getMessages: () => [],
   getConversation: () => ({


### PR DESCRIPTION
## Summary
- Add missing `mock.module('../memory/admin.js', ...)` to `session-queue.test.ts`
- Without this mock, `getMemoryConflictAndCleanupStats()` tries to access the real SQLite DB, which doesn't exist in CI — causing all 23 non-experimental tests to timeout at `waitForPendingRun`
- Matches the same mock pattern already used in `session-abort-tool-results`, `session-profile-injection`, `session-conflict-gate`, `session-provider-retry-repair`, and `session-pre-run-repair` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
