### PR TITLE
fix: correct IPC metric over-counting in blob transport and parse logging

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -431,7 +431,7 @@ export class DaemonServer {
             chunkReceivedAtMs,
             parsedAtMs,
             parseDurationMs,
-            chunkBytes: Buffer.byteLength(data),
+            messageBytes: Buffer.byteLength(JSON.stringify(msg), 'utf8'),
           }, 'IPC_METRIC cu_observation_parse');
         }
         const result = validateClientMessage(msg);

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -519,7 +519,7 @@ final class ComputerUseSession: ObservableObject {
         let axTreeUsedBlob = axTreeBlobRef != nil
         let axDiffBytes = axDiffText?.utf8.count ?? 0
         let secondaryWindowsBytes = secondaryWindowsText?.utf8.count ?? 0
-        let payloadJSONBytes = screenshotBase64Bytes + axTreeBytes + axDiffBytes + secondaryWindowsBytes + 256
+        let payloadJSONBytes = screenshotBase64Bytes + (axTreeUsedBlob ? 0 : axTreeBytes) + axDiffBytes + secondaryWindowsBytes + 256
         let buildTimestampMs = Int(Date().timeIntervalSince1970 * 1_000)
         log.info(
             "[\(stepNumber)] IPC_METRIC cu_observation_build buildTsMs=\(buildTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotRawBytes=\(screenshotRawBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) screenshotUsedBlob=\(screenshotUsedBlob) axTreeBytes=\(axTreeBytes) axTreeUsedBlob=\(axTreeUsedBlob) axDiffBytes=\(axDiffBytes) secondaryWindowsBytes=\(secondaryWindowsBytes)"


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2553:

- **Swift (Session.swift)**: `payloadJSONBytes` was including `axTreeBytes` even when the AX tree was sent via blob transport (where `axTreeInline` is nil and the tree is not in the JSON payload). Now excludes AX tree bytes when `axTreeUsedBlob` is true.

- **TypeScript (server.ts)**: `chunkBytes` metric logged the full socket `data` buffer size for each message. When TCP coalescing delivers multiple JSON lines in a single `data` event, this over-attributes bytes to each observation. Changed to `messageBytes` which computes the byte length of the individual serialized message.

Both issues were flagged by Devin and Codex reviewers on #2553.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
