### PR TITLE
fix(chat): preserve text-before-tool ordering in history

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -124,6 +124,7 @@ describe('renderHistoryContent', () => {
     expect(output.toolCalls).toEqual([
       { name: 'web_fetch', input: { url: 'https://example.com' } },
     ]);
+    expect(output.toolCallsBeforeText).toBe(true);
   });
 
   test('pairs tool_result with matching tool_use by id', () => {
@@ -159,6 +160,27 @@ describe('renderHistoryContent', () => {
     expect(output.toolCalls).toHaveLength(1);
     expect(output.toolCalls[0].name).toBe('web_fetch');
     expect(output.toolCalls[0].result).toBe('page content here');
+    expect(output.toolCallsBeforeText).toBe(false);
+  });
+
+  test('sets toolCallsBeforeText true when tool_use precedes text', () => {
+    const output = renderHistoryContent([
+      { type: 'tool_use', id: 'tu_1', name: 'bash', input: { command: 'ls' } },
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'file.txt' },
+      { type: 'text', text: 'Here are the files.' },
+    ]);
+
+    expect(output.toolCallsBeforeText).toBe(true);
+    expect(output.text).toBe('Here are the files.');
+    expect(output.toolCalls).toHaveLength(1);
+  });
+
+  test('sets toolCallsBeforeText false when no tool calls exist', () => {
+    const output = renderHistoryContent([
+      { type: 'text', text: 'Just text.' },
+    ]);
+
+    expect(output.toolCallsBeforeText).toBe(false);
   });
 
   test('handles orphan tool_result without matching tool_use', () => {
@@ -175,16 +197,18 @@ describe('renderHistoryContent', () => {
 describe('mergeToolResults', () => {
   test('merges tool_result user messages into preceding assistant toolCalls', () => {
     const result = mergeToolResults([
-      { role: 'user', text: 'fetch this page', timestamp: 1, toolCalls: [] },
+      { role: 'user', text: 'fetch this page', timestamp: 1, toolCalls: [], toolCallsBeforeText: false },
       {
         role: 'assistant', text: '', timestamp: 2,
         toolCalls: [{ name: 'web_fetch', input: { url: 'https://example.com' } }],
+        toolCallsBeforeText: true,
       },
       {
         role: 'user', text: '', timestamp: 3,
         toolCalls: [{ name: 'unknown', input: {}, result: 'page content', isError: false }],
+        toolCallsBeforeText: false,
       },
-      { role: 'assistant', text: 'Here is what I found.', timestamp: 4, toolCalls: [] },
+      { role: 'assistant', text: 'Here is what I found.', timestamp: 4, toolCalls: [], toolCallsBeforeText: false },
     ]);
 
     expect(result).toHaveLength(3);
@@ -201,14 +225,16 @@ describe('mergeToolResults', () => {
 
   test('suppresses tool_result-only user messages from visible history', () => {
     const result = mergeToolResults([
-      { role: 'user', text: 'hello', timestamp: 1, toolCalls: [] },
+      { role: 'user', text: 'hello', timestamp: 1, toolCalls: [], toolCallsBeforeText: false },
       {
         role: 'assistant', text: '', timestamp: 2,
         toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
+        toolCallsBeforeText: true,
       },
       {
         role: 'user', text: '', timestamp: 3,
         toolCalls: [{ name: 'unknown', input: {}, result: 'file.txt', isError: false }],
+        toolCallsBeforeText: false,
       },
     ]);
 
@@ -221,6 +247,7 @@ describe('mergeToolResults', () => {
       {
         role: 'user', text: 'user typed something', timestamp: 1,
         toolCalls: [{ name: 'unknown', input: {}, result: 'data', isError: false }],
+        toolCallsBeforeText: false,
       },
     ]);
 
@@ -236,6 +263,7 @@ describe('mergeToolResults', () => {
           { name: 'bash', input: { command: 'ls' } },
           { name: 'bash', input: { command: 'pwd' } },
         ],
+        toolCallsBeforeText: true,
       },
       {
         role: 'user', text: '', timestamp: 2,
@@ -243,6 +271,7 @@ describe('mergeToolResults', () => {
           { name: 'unknown', input: {}, result: 'file.txt', isError: false },
           { name: 'unknown', input: {}, result: '/home/user', isError: false },
         ],
+        toolCallsBeforeText: false,
       },
     ]);
 
@@ -256,10 +285,12 @@ describe('mergeToolResults', () => {
       {
         role: 'assistant', text: '', timestamp: 1,
         toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
+        toolCallsBeforeText: true,
       },
       {
         role: 'user', text: '', timestamp: 2,
         toolCalls: [{ name: 'unknown', input: {}, result: 'output', isError: false }],
+        toolCallsBeforeText: false,
       },
     ];
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -217,6 +217,8 @@ export interface HistoryToolCall {
 export interface RenderedHistoryContent {
   text: string;
   toolCalls: HistoryToolCall[];
+  /** True when the first tool_use block appeared before any text block. */
+  toolCallsBeforeText: boolean;
 }
 
 export function renderHistoryContent(content: unknown): RenderedHistoryContent {
@@ -229,19 +231,23 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     } else {
       text = String(content);
     }
-    return { text, toolCalls: [] };
+    return { text, toolCalls: [], toolCallsBeforeText: false };
   }
 
   const textParts: string[] = [];
   const attachmentParts: string[] = [];
   const toolCalls: HistoryToolCall[] = [];
   const pendingToolUses = new Map<string, HistoryToolCall>();
+  let seenText = false;
+  let seenToolUse = false;
+  let toolCallsBeforeText = false;
 
   for (const block of content) {
     if (!isRecord(block) || typeof block.type !== 'string') continue;
 
     if (block.type === 'text' && typeof block.text === 'string') {
       textParts.push(block.text);
+      seenText = true;
       continue;
     }
     if (block.type === 'file') {
@@ -259,6 +265,10 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       const entry: HistoryToolCall = { name, input };
       toolCalls.push(entry);
       if (id) pendingToolUses.set(id, entry);
+      if (!seenToolUse) {
+        seenToolUse = true;
+        if (!seenText) toolCallsBeforeText = true;
+      }
       continue;
     }
     if (block.type === 'tool_result') {
@@ -300,7 +310,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     rendered = `${text}\n${attachmentParts.join('\n')}`;
   }
 
-  return { text: rendered, toolCalls };
+  return { text: rendered, toolCalls, toolCallsBeforeText };
 }
 
 /**
@@ -705,6 +715,7 @@ export interface ParsedHistoryMessage {
   text: string;
   timestamp: number;
   toolCalls: HistoryToolCall[];
+  toolCallsBeforeText: boolean;
 }
 
 function handleHistoryRequest(
@@ -716,16 +727,18 @@ function handleHistoryRequest(
   const parsed: ParsedHistoryMessage[] = dbMessages.map((m) => {
     let text = '';
     let toolCalls: HistoryToolCall[] = [];
+    let toolCallsBeforeText = false;
     try {
       const content = JSON.parse(m.content);
       const rendered = renderHistoryContent(content);
       text = rendered.text;
       toolCalls = rendered.toolCalls;
+      toolCallsBeforeText = rendered.toolCallsBeforeText;
     } catch (err) {
       log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
       text = m.content;
     }
-    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls };
+    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls, toolCallsBeforeText };
   });
 
   // Merge tool_result data from user messages into the preceding assistant
@@ -750,7 +763,7 @@ function handleHistoryRequest(
       role: m.role,
       text: m.text,
       timestamp: m.timestamp,
-      ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
+      ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls, toolCallsBeforeText: m.toolCallsBeforeText } : {}),
       ...(attachments ? { attachments } : {}),
     };
   });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -613,6 +613,8 @@ export interface HistoryResponse {
     text: string;
     timestamp: number;
     toolCalls?: HistoryResponseToolCall[];
+    /** True when tool_use blocks appeared before any text block in the original content. */
+    toolCallsBeforeText?: boolean;
     attachments?: UserMessageAttachment[];
   }>;
 }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1616,8 +1616,8 @@ final class ChatViewModelTests: XCTestCase {
             data: "iVBORw0KGgo=", extractedText: nil
         )
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
-            IPCHistoryResponseMessage(role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, attachments: nil),
-            IPCHistoryResponseMessage(role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, attachments: [attachment]),
+            IPCHistoryResponseMessage(role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil),
+            IPCHistoryResponseMessage(role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment]),
         ]
 
         viewModel.populateFromHistory(historyItems)
@@ -1635,7 +1635,7 @@ final class ChatViewModelTests: XCTestCase {
             data: "JVBER", extractedText: nil
         )
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
-            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, attachments: [attachment]),
+            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment]),
         ]
 
         viewModel.populateFromHistory(historyItems)
@@ -1649,7 +1649,7 @@ final class ChatViewModelTests: XCTestCase {
 
     func testPopulateFromHistorySkipsEmptyMessagesWithNoAttachments() {
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
-            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, attachments: nil),
+            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil),
         ]
 
         viewModel.populateFromHistory(historyItems)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1420,6 +1420,7 @@ public final class ChatViewModel: ObservableObject {
         for item in historyMessages {
             let role: ChatRole = item.role == "assistant" ? .assistant : .user
             var toolCalls: [ToolCallData] = []
+            let toolsBeforeText = item.toolCallsBeforeText ?? true
             if let historyToolCalls = item.toolCalls {
                 toolCalls = historyToolCalls.map { tc in
                     ToolCallData(
@@ -1428,6 +1429,7 @@ public final class ChatViewModel: ObservableObject {
                         result: tc.result,
                         isError: tc.isError ?? false,
                         isComplete: true,
+                        arrivedBeforeText: toolsBeforeText,
                         imageData: tc.imageData
                     )
                 }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -352,6 +352,8 @@ public struct IPCHistoryResponseMessage: Codable, Sendable {
     public let text: String
     public let timestamp: Double
     public let toolCalls: [IPCHistoryResponseToolCall]?
+    /// True when tool_use blocks appeared before any text block in the original content.
+    public let toolCallsBeforeText: Bool?
     public let attachments: [IPCUserMessageAttachment]?
 }
 


### PR DESCRIPTION
## Summary

Addresses the Codex P2 review feedback on PR #2506: restored history turns where text preceded `tool_use` blocks were incorrectly showing tool call chips above the text bubble.

- Added `toolCallsBeforeText` boolean to `renderHistoryContent()` output by tracking the order of text vs tool_use content blocks
- Propagated the field through the IPC history response (`ipc-contract.ts` + generated Swift types)
- `populateFromHistory` now uses this flag to set `arrivedBeforeText` on each restored `ToolCallData`, so the UI preserves the original chronological display order

## Test plan

- [x] `bun test server-history-render.test.ts` — 22 tests pass, including 3 new tests for `toolCallsBeforeText` ordering
- [x] `bun test ipc-snapshot.test.ts` — 109 tests pass
- [x] `swift build` compiles cleanly
- [x] Pre-commit IPC codegen check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
