### PR TITLE
fix(lint): remove `as any` cast in session-profile-injection test

### DIFF
--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -347,7 +347,7 @@ describe('Session dynamic profile injection', () => {
     // Simulate tool_result user message appended by agent loop
     const toolResultUser: Message = {
       role: 'user',
-      content: [{ type: 'tool_result' as 'text', tool_use_id: 'tu-1', content: 'result' } as any],
+      content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'result' }],
     };
     const msgs = [injectedUser, assistantMsg, toolResultUser];
     const stripped = stripDynamicProfileMessages(msgs, profile);


### PR DESCRIPTION
## Summary
- Removed `as any` cast on line 350 of `session-profile-injection.test.ts` that was causing ESLint `@typescript-eslint/no-explicit-any` error
- `ToolResultContent` is already part of the `ContentBlock` union, so the object literal can be used directly without casting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
