### PR TITLE
fix(types): add missing toolCallsBeforeText in http-server history

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -250,6 +250,7 @@ export class RuntimeHttpServer {
         text: rendered.text,
         timestamp: msg.createdAt,
         toolCalls: rendered.toolCalls,
+        toolCallsBeforeText: rendered.toolCallsBeforeText,
         id: msg.id,
       };
     });


### PR DESCRIPTION
## Summary
- Added missing `toolCallsBeforeText` field to the parsed history message object in `http-server.ts`
- The field is already returned by `renderHistoryContent()` but was omitted when constructing the object, causing a TS2345 type error against `ParsedHistoryMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
