### PR TITLE
ci: add 5-minute timeout to PR assistant checks

### DIFF
--- a/.github/workflows/ci-assistant.yml
+++ b/.github/workflows/ci-assistant.yml
@@ -12,6 +12,7 @@ jobs:
   checks:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     defaults:
       run:
         working-directory: assistant


### PR DESCRIPTION
## Summary
- Added `timeout-minutes: 5` to the `checks` job in `ci-assistant.yml` to prevent CI runs from hanging indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
