### PR TITLE
fix(evaluate-ts): use lastIndexOf for unbounded result extraction

### DIFF
--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -210,23 +210,22 @@ export class EvaluateTypescriptTool implements Tool {
         let truncated = false;
 
         // Extract structured result from raw stdout before truncation.
-        // Scan from the end since the runner prints __eval_result last,
-        // so post-processing cost stays bounded regardless of output size.
+        // Use lastIndexOf to find the marker directly, so extraction cost
+        // is bounded regardless of output size and works for any result length.
         let result: unknown = undefined;
         if (code === 0) {
-          const searchRegion = stdout.slice(-4096);
-          const lines = searchRegion.split('\n');
-          for (let i = lines.length - 1; i >= 0; i--) {
-            const line = lines[i];
-            if (!line) continue;
+          const markerIdx = stdout.lastIndexOf('__eval_result');
+          if (markerIdx !== -1) {
+            const lineStart = stdout.lastIndexOf('\n', markerIdx) + 1;
+            const lineEnd = stdout.indexOf('\n', markerIdx);
+            const line = stdout.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
             try {
               const parsed = JSON.parse(line);
               if (parsed && typeof parsed === 'object' && '__eval_result' in parsed) {
                 result = parsed.__eval_result;
-                break;
               }
             } catch {
-              // not the result line
+              // malformed result line
             }
           }
         }


### PR DESCRIPTION
Addresses review feedback on PR #2564.

Both Codex and Devin flagged that `stdout.slice(-4096)` silently drops results when the serialized `__eval_result` JSON line exceeds ~4KB. This replaces the fixed-size window with a `lastIndexOf` search for the `__eval_result` marker, then extracts the full line by finding the surrounding newlines. Extraction cost remains bounded (single string search + one slice) while supporting arbitrarily large result payloads.

**Files changed:** `assistant/src/tools/terminal/evaluate-typescript.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
