### PR TITLE
fix(swarm): prevent double-decrement of activeCount in orchestrator

### DIFF
--- a/assistant/src/__tests__/swarm-orchestrator.test.ts
+++ b/assistant/src/__tests__/swarm-orchestrator.test.ts
@@ -367,7 +367,7 @@ describe('executeSwarm', () => {
     expect(summary.stats.completed).toBe(2);
   });
 
-  test('does not deadlock when onStatus callback throws', async () => {
+  test('does not deadlock when onStatus callback throws on task_started', async () => {
     const plan = makePlan({
       tasks: [
         { id: 'a', role: 'coder', objective: 'A', dependencies: [] },
@@ -375,8 +375,8 @@ describe('executeSwarm', () => {
     });
 
     // The onStatus callback throws on task_started, which happens inside
-    // runTask before the try/catch in runWorkerTask. The .catch() guard on
-    // the fire-and-forget promise should prevent a deadlock.
+    // runTask before the worker runs. The .finally() guard on the
+    // fire-and-forget promise should prevent a deadlock.
     const summary = await executeSwarm({
       plan,
       limits: DEFAULT_LIMITS,
@@ -387,7 +387,42 @@ describe('executeSwarm', () => {
       },
     });
 
-    // The swarm should still complete (via the .catch guard) rather than hang
+    // The swarm should still complete (via the .finally guard) rather than hang
     expect(summary.stats.totalTasks).toBe(1);
+  });
+
+  test('does not double-decrement activeCount when onStatus throws on task_completed', async () => {
+    // Regression: when onStatus threw inside processResult (after the task
+    // finished), the old .catch() guard would decrement activeCount a second
+    // time, driving it negative and causing early termination / incorrect stats.
+    const plan = makePlan({
+      tasks: [
+        { id: 'a', role: 'coder', objective: 'A', dependencies: [] },
+        { id: 'b', role: 'coder', objective: 'B', dependencies: [] },
+        { id: 'c', role: 'coder', objective: 'C', dependencies: ['a'] },
+      ],
+    });
+
+    let throwCount = 0;
+    const summary = await executeSwarm({
+      plan,
+      limits: resolveSwarmLimits({ ...DEFAULT_LIMITS, maxWorkers: 2 }),
+      backend: makeBackend(),
+      workingDir: '/tmp',
+      onStatus: (event) => {
+        // Throw only on the first task_completed to simulate the bug scenario
+        if (event.kind === 'task_completed' && throwCount === 0) {
+          throwCount++;
+          throw new Error('callback boom');
+        }
+      },
+    });
+
+    // Despite the throw, the remaining tasks should still run correctly.
+    // With the old double-decrement bug, activeCount would go negative and
+    // the orchestrator could terminate early or produce wrong stats.
+    expect(summary.stats.totalTasks).toBe(3);
+    // At least 2 tasks should complete (b always succeeds, plus either a or c)
+    expect(summary.stats.completed).toBeGreaterThanOrEqual(2);
   });
 });

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -157,9 +157,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
     }
     result.retryCount = retries;
 
-    activeCount--;
     processResult(result);
-    signalProgress();
   }
 
   while (ready.length > 0 || activeCount > 0) {
@@ -170,14 +168,16 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       const task = ready.shift()!;
       activeCount++;
       // Fire-and-forget — completion is handled inside runTask.
-      // The .catch guard ensures activeCount is decremented even if an
-      // unexpected error (e.g. a throwing onStatus callback) propagates
-      // past runTask's internal try/catch, preventing a deadlock where
-      // the main loop waits on signalProgress() that never fires.
-      runTask(task).catch(() => {
-        activeCount--;
-        signalProgress();
-      });
+      // .finally() ensures activeCount is decremented exactly once
+      // regardless of where an error occurs (e.g. a throwing onStatus
+      // callback inside processResult). .catch() suppresses the
+      // unhandled rejection for fire-and-forget usage.
+      runTask(task)
+        .finally(() => {
+          activeCount--;
+          signalProgress();
+        })
+        .catch(() => {});
     }
 
     // Nothing left to launch and nothing running — we're done


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2567 (both Codex and Devin flagged the same issue):

- **Moved `activeCount--` and `signalProgress()` out of `runTask`** and into a `.finally()` handler on the fire-and-forget promise. This guarantees the decrement happens exactly once regardless of where an error occurs.
- **Replaced `.catch()` guard with `.finally()` + `.catch()`**: `.finally()` handles the decrement, `.catch()` suppresses unhandled rejections for fire-and-forget usage.
- **Added regression test**: verifies no double-decrement when `onStatus` throws on `task_completed` (the actual bug scenario — the old `.catch()` would decrement a second time after `runTask` already decremented internally).

### The bug

When `onStatus` threw inside `processResult` (e.g. on `task_completed`), the execution flow was:
1. `runTask` line 160: `activeCount--` (e.g. 1 -> 0)
2. `processResult` calls `onStatus({kind: 'task_completed', ...})` which throws
3. `signalProgress()` never reached
4. `.catch()` handler fires: `activeCount--` again (0 -> **-1**)

With `activeCount` at -1, the concurrency guard `activeCount < limits.maxWorkers` was always true, allowing more workers than `maxWorkers` and producing incorrect stats.

## Test plan

- [x] All 14 swarm orchestrator tests pass
- [x] New test: `does not double-decrement activeCount when onStatus throws on task_completed`
- [x] Renamed existing test for clarity: `does not deadlock when onStatus callback throws on task_started`
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
