### PR TITLE
fix(conflicts): tighten clarification reply gate to prevent false positives

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -473,6 +473,47 @@ describe('Session conflict soft gate', () => {
     expect(runCalls).toHaveLength(1);
   });
 
+  test('unrelated statement without question mark does not accidentally resolve conflict', async () => {
+    pendingConflicts = [{
+      id: 'conflict-unrelated-no-qmark',
+      scopeId: 'default',
+      existingItemId: 'existing-unrelated2',
+      candidateItemId: 'candidate-unrelated2',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Should I assume Postgres or MySQL?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use Postgres as the default database.',
+      candidateStatement: 'Use MySQL as the default database.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // First turn: triggers clarification ask.
+    await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
+    expect(resolverCallCount).toBe(1);
+    expect(markAskedCalls).toEqual(['conflict-unrelated-no-qmark']);
+
+    resolverResult = {
+      resolution: 'keep_candidate',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'Directional clarification received.',
+    };
+
+    // Unrelated statement with cue word "new" but no question mark and > 4 words.
+    // Should NOT resolve the conflict.
+    await session.processMessage('I started a new project today', [], () => {});
+
+    expect(resolverCallCount).toBe(1);
+    expect(runCalls).toHaveLength(1);
+  });
+
   test('cooldown prevents repeated asks on subsequent turns', async () => {
     pendingConflicts = [{
       id: 'conflict-cooldown',
@@ -557,9 +598,23 @@ describe('looksLikeClarificationReply', () => {
     expect(looksLikeClarificationReply('use that')).toBe(true);
   });
 
-  test('rejects questions', () => {
+  test('rejects questions with question mark', () => {
     expect(looksLikeClarificationReply("what's new in Bun?")).toBe(false);
     expect(looksLikeClarificationReply('which option?')).toBe(false);
+  });
+
+  test('rejects questions without question mark', () => {
+    expect(looksLikeClarificationReply("what's new in Bun")).toBe(false);
+    expect(looksLikeClarificationReply('how do I use option A')).toBe(false);
+    expect(looksLikeClarificationReply('where is the new config')).toBe(false);
+  });
+
+  test('rejects longer direction-only messages (false-positive prevention)', () => {
+    // These contain directional cues but no action verb and are > 4 words,
+    // so they are likely unrelated statements, not clarification replies.
+    expect(looksLikeClarificationReply('try the old approach instead')).toBe(false);
+    expect(looksLikeClarificationReply('I started a new project today')).toBe(false);
+    expect(looksLikeClarificationReply('check out the latest release notes')).toBe(false);
   });
 
   test('rejects long statements', () => {

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -169,12 +169,27 @@ const DIRECTIONAL_CUES = new Set([
 
 const MAX_REPLY_WORD_COUNT = 12;
 
+// Direction-only matches (no action verb) must be very short to avoid
+// false positives from unrelated statements that happen to contain
+// common words like "new", "old", "option", etc.
+const MAX_DIRECTION_ONLY_WORD_COUNT = 4;
+
+// Messages starting with a question word are unlikely to be clarification
+// replies even when they lack a trailing question mark.
+const QUESTION_WORD_PREFIXES = new Set([
+  'what', 'how', 'why', 'where', 'when', 'which', 'who', 'whom', 'whose',
+]);
+
 /**
  * Determines whether a user message looks like a deliberate reply to a
  * recently asked conflict clarification (e.g. "keep the new one", "both",
  * "option B", "new one"). Requires at least one action or directional cue,
  * and the message must be short. Questions and longer statements are excluded
  * to prevent accidental resolution from unrelated messages.
+ *
+ * When only directional cues are present (no action verb), the message must
+ * be very short (<= 4 words) to avoid false positives from unrelated messages
+ * like "What's new in Bun" or "try the old approach".
  */
 export function looksLikeClarificationReply(userMessage: string): boolean {
   const trimmed = userMessage.trim();
@@ -184,7 +199,18 @@ export function looksLikeClarificationReply(userMessage: string): boolean {
   if (words.length === 0 || words.length > MAX_REPLY_WORD_COUNT) return false;
 
   const normalized = words.map((w) => w.replace(/[^a-z]/g, ''));
+
+  // Reject messages that start with a question word (even without '?').
+  // Use startsWith to handle contractions like "what's", "where's", etc.
+  const firstWord = words[0];
+  for (const qw of QUESTION_WORD_PREFIXES) {
+    if (firstWord.startsWith(qw)) return false;
+  }
+
   const hasAction = normalized.some((w) => ACTION_CUES.has(w));
   const hasDirection = normalized.some((w) => DIRECTIONAL_CUES.has(w));
-  return hasAction || hasDirection;
+
+  if (hasAction) return true;
+  if (hasDirection) return words.length <= MAX_DIRECTION_ONLY_WORD_COUNT;
+  return false;
 }


### PR DESCRIPTION
## Summary

Addresses review feedback on #2571: the `hasAction || hasDirection` relaxation was too permissive — unrelated messages containing common directional cue words (e.g. "new", "old", "option") could accidentally trigger conflict resolution.

**Changes:**
- Direction-only matches (no action verb) now require <= 4 words, so "both", "option B", "new one" still pass but "I started a new project today" does not
- Messages starting with question words (what, how, why, etc.) are rejected even without a trailing question mark
- Added integration test for unrelated statement without question mark during cooldown
- Added unit tests for question-word prefix and long direction-only rejection

## Test plan

- [x] All 16 conflict gate tests pass (including 2 new)
- [x] Type-check clean (`bunx tsc --noEmit`)
- [x] Verified "both", "option B", "new one" still resolve (direction-only, <= 4 words)
- [x] Verified "keep it", "use that" still resolve (action cue present)
- [x] Verified "What's new in Bun" rejected (question word prefix)
- [x] Verified "I started a new project today" rejected (direction-only, > 4 words)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
