### PR TITLE
fix(IpcBlobStore): use URL(filePath:) to prevent implicit tilde expansion

### DIFF
--- a/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
@@ -114,23 +114,30 @@ final class IpcBlobStoreTests: XCTestCase {
 
     func testResolveBlobDirDefaultsToHomeDotVellum() {
         let resolved = resolveBlobDir(environment: [:])
-        let expected = URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        let home = NSHomeDirectory()
+        let expected = URL(filePath: home + "/.vellum/data/ipc-blobs", directoryHint: .isDirectory)
         XCTAssertEqual(resolved, expected)
     }
 
     func testResolveBlobDirHonorsBaseDataDir() {
         let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "/tmp/custom-root"])
-        let expected = URL(fileURLWithPath: "/tmp/custom-root")
-            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        let expected = URL(filePath: "/tmp/custom-root/.vellum/data/ipc-blobs", directoryHint: .isDirectory)
         XCTAssertEqual(resolved, expected)
     }
 
     func testResolveBlobDirIgnoresEmptyBaseDataDir() {
         let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "  "])
-        let expected = URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        let home = NSHomeDirectory()
+        let expected = URL(filePath: home + "/.vellum/data/ipc-blobs", directoryHint: .isDirectory)
         XCTAssertEqual(resolved, expected)
+    }
+
+    func testResolveBlobDirDoesNotExpandTildeInBaseDataDir() {
+        // The daemon's getRootDir() keeps BASE_DATA_DIR literal via path.join(),
+        // so the Swift client must NOT expand "~/" either.
+        let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "~/custom"])
+        XCTAssertTrue(resolved.path.contains("~/custom"), "tilde should remain literal, got: \(resolved.path)")
+        XCTAssertFalse(resolved.path.contains(NSHomeDirectory()), "home dir should NOT appear in path")
     }
 
 }

--- a/clients/shared/IPC/IpcBlobStore.swift
+++ b/clients/shared/IPC/IpcBlobStore.swift
@@ -17,8 +17,12 @@ func resolveBlobDir(environment: [String: String]? = nil) -> URL {
     } else {
         root = NSHomeDirectory()
     }
-    return URL(fileURLWithPath: root)
-        .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+    // Build the path as a plain string (mirroring the daemon's path.join()),
+    // then use URL(filePath:) which — unlike URL(fileURLWithPath:) — does NOT
+    // perform implicit tilde expansion. This ensures the client and daemon
+    // resolve to the same directory even when BASE_DATA_DIR contains "~/".
+    let fullPath = root + "/.vellum/data/ipc-blobs"
+    return URL(filePath: fullPath, directoryHint: .isDirectory)
 }
 
 /// Manages local blob files for zero-copy IPC transport.


### PR DESCRIPTION
## Summary

Addresses review feedback on #2570: `URL(fileURLWithPath:)` silently expands `~/` prefixes, so even after #2570 removed the explicit tilde expansion, `BASE_DATA_DIR="~/custom"` would still resolve to a home-directory-based path on the Swift side while the daemon's `path.join()` keeps it literal — causing client/daemon blob directory mismatch.

- Replaced `URL(fileURLWithPath:).appendingPathComponent(...)` with `URL(filePath:directoryHint:)` which does NOT perform tilde expansion (available since macOS 13, our target is macOS 14+)
- Updated existing test assertions to use the new URL construction
- Added `testResolveBlobDirDoesNotExpandTildeInBaseDataDir` to verify tildes remain literal

## Test plan

- [x] `swift build` passes
- [x] `bunx tsc --noEmit` passes
- [x] New test asserts tilde is preserved literally in resolved path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
