### PR TITLE
fix(memory): skip superseding when item has pending_clarification

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -265,6 +265,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
       .get();
 
     let memoryItemId: string;
+    let effectiveStatus: string = 'active';
     if (existing) {
       memoryItemId = existing.id;
       // Promote verification state if re-seen from a more trusted source
@@ -273,12 +274,12 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
           ? 'user_reported'
           : existing.verificationState;
       // Preserve pending_clarification if this item has an unresolved conflict
-      const nextStatus = existing.status === 'pending_clarification' && hasPendingConflict(existing.id)
+      effectiveStatus = existing.status === 'pending_clarification' && hasPendingConflict(existing.id)
         ? 'pending_clarification'
         : 'active';
       db.update(memoryItems)
         .set({
-          status: nextStatus,
+          status: effectiveStatus,
           confidence: Math.max(existing.confidence, item.confidence),
           importance: Math.max(existing.importance ?? 0, item.importance),
           lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
@@ -305,7 +306,11 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
       upserted += 1;
     }
 
-    if (SUPERSEDE_KINDS.has(item.kind)) {
+    // Only supersede other items when this item is active — a
+    // pending_clarification item should not demote the existing active
+    // item, since that would leave no retrievable memory until manual
+    // conflict resolution occurs.
+    if (SUPERSEDE_KINDS.has(item.kind) && effectiveStatus === 'active') {
       db.update(memoryItems)
         .set({ status: 'superseded' })
         .where(and(


### PR DESCRIPTION
## Summary

Addresses Codex review feedback from PR #2562:

- **Gated supersede logic on effective status**: When a re-extracted item preserves its `pending_clarification` status (due to an unresolved conflict), the `SUPERSEDE_KINDS` update now skips. Previously it would still demote the existing active item of the same kind/subject, leaving no active memory retrievable until manual conflict resolution.
- **Hoisted status variable**: Replaced the block-scoped `nextStatus` with a hoisted `effectiveStatus` that is reused for both the upsert and the supersede guard, eliminating redundant `hasPendingConflict()` calls.

### The bug

When `extractAndUpsertMemoryItemsForMessage` re-extracted an item that was in `pending_clarification`:
1. The status was correctly preserved as `pending_clarification` (from PR #2562)
2. But the `SUPERSEDE_KINDS` block ran unconditionally, superseding the existing active item
3. Result: no active memory item existed for that kind/subject until conflict resolution

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Contradiction checker tests pass
- [x] Conflict store tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
