### PR TITLE
fix(memory): skip superseding siblings when item is pending_clarification

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -265,6 +265,8 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
       .get();
 
     let memoryItemId: string;
+    // Preserve pending_clarification if this item has an unresolved conflict
+    let nextStatus: 'active' | 'pending_clarification' = 'active';
     if (existing) {
       memoryItemId = existing.id;
       // Promote verification state if re-seen from a more trusted source
@@ -272,10 +274,9 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
         existing.verificationState === 'assistant_inferred' && verificationState === 'user_reported'
           ? 'user_reported'
           : existing.verificationState;
-      // Preserve pending_clarification if this item has an unresolved conflict
-      const nextStatus = existing.status === 'pending_clarification' && hasPendingConflict(existing.id)
-        ? 'pending_clarification'
-        : 'active';
+      if (existing.status === 'pending_clarification' && hasPendingConflict(existing.id)) {
+        nextStatus = 'pending_clarification';
+      }
       db.update(memoryItems)
         .set({
           status: nextStatus,
@@ -305,7 +306,9 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
       upserted += 1;
     }
 
-    if (SUPERSEDE_KINDS.has(item.kind)) {
+    // Only supersede siblings when this item is active — a pending_clarification
+    // item shouldn't demote the current active item before the conflict is resolved.
+    if (SUPERSEDE_KINDS.has(item.kind) && nextStatus === 'active') {
       db.update(memoryItems)
         .set({ status: 'superseded' })
         .where(and(


### PR DESCRIPTION
## Summary
- When a re-extracted memory item preserves `pending_clarification` status (due to an unresolved conflict), the `SUPERSEDE_KINDS` logic would still supersede other active items with the same kind/subject
- This left no active memory item to retrieve until manual conflict resolution — a regression from the status preservation in #2562
- Fix: hoist `nextStatus` so the supersede guard can check it, and only run supersession when the item is actually `active`

## Changes
- `assistant/src/memory/items-extractor.ts`: Hoist `nextStatus` variable above the if/else block; gate `SUPERSEDE_KINDS` update on `nextStatus === 'active'`

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Existing memory/contradiction tests unaffected

Addresses Codex review feedback on #2562.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
