### PR TITLE
fix(test): mock getMemoryConflictAndCleanupStats in session-slash-unknown test

### DIFF
--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -91,6 +91,13 @@ mock.module('../memory/retriever.js', () => ({
   stripMemoryRecallMessages: (msgs: Message[]) => msgs,
 }));
 
+mock.module('../memory/admin.js', () => ({
+  getMemoryConflictAndCleanupStats: () => ({
+    conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
+    cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
+  }),
+}));
+
 mock.module('../context/window-manager.js', () => ({
   ContextWindowManager: class {
     constructor() {}


### PR DESCRIPTION
## Summary
- Add missing `getMemoryConflictAndCleanupStats` mock to `session-slash-unknown.test.ts`
- Same root cause as #2585 and #2589 — `memory/admin` hits SQLite in CI where no DB exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
