### PR TITLE
Enable sandboxMode for shared apps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -77,7 +77,8 @@ struct SurfaceContainerView: View {
                     },
                     appId: viewModel.appId,
                     onDataRequest: viewModel.onDataRequest,
-                    onCoordinatorReady: viewModel.onCoordinatorReady
+                    onCoordinatorReady: viewModel.onCoordinatorReady,
+                    sandboxMode: viewModel.sandboxMode
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -15,6 +15,7 @@ final class SurfaceViewModel: ObservableObject {
     let appId: String?
     let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
     let onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)?
+    let sandboxMode: Bool
 
     init(
         surface: Surface,
@@ -22,7 +23,8 @@ final class SurfaceViewModel: ObservableObject {
         onDismiss: @escaping () -> Void,
         appId: String? = nil,
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
-        onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)? = nil
+        onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)? = nil,
+        sandboxMode: Bool = false
     ) {
         self.surface = surface
         self.onAction = onAction
@@ -30,6 +32,7 @@ final class SurfaceViewModel: ObservableObject {
         self.appId = appId
         self.onDataRequest = onDataRequest
         self.onCoordinatorReady = onCoordinatorReady
+        self.sandboxMode = sandboxMode
     }
 }
 
@@ -124,6 +127,7 @@ final class SurfaceManager: ObservableObject {
         }
 
         let appId = surfaceAppIds[surface.id]
+        let isSandboxed = message.sessionId == "shared-app"
 
         let viewModel = SurfaceViewModel(
             surface: surface,
@@ -148,7 +152,8 @@ final class SurfaceManager: ObservableObject {
             } : nil,
             onCoordinatorReady: appId != nil ? { [weak self] coordinator in
                 self?.surfaceCoordinators[surface.id] = coordinator
-            } : nil
+            } : nil,
+            sandboxMode: isSandboxed
         )
         viewModels[surface.id] = viewModel
 


### PR DESCRIPTION
## Summary
- Add sandboxMode property to SurfaceViewModel
- Set sandboxMode=true when sessionId is "shared-app" (shared .vellumapp bundles)
- Pass sandboxMode through SurfaceContainerView to DynamicPageSurfaceView

When enabled, the existing WKContentRuleList in DynamicPageSurfaceView blocks all external network requests, preventing shared apps from phoning home.

Fixes #2592
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
