### PR TITLE
Add app forking: create local copies of shared apps

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -220,6 +220,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'shared_app_delete',
     uuid: 'abc-123-def',
   },
+  fork_shared_app: {
+    type: 'fork_shared_app',
+    uuid: 'abc-123-def',
+  },
   open_bundle: {
     type: 'open_bundle',
     filePath: '/tmp/My_App.vellumapp',
@@ -647,6 +651,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   shared_app_delete_response: {
     type: 'shared_app_delete_response',
     success: true,
+  },
+  fork_shared_app_response: {
+    type: 'fork_shared_app_response',
+    success: true,
+    appId: 'new-app-id',
+    name: 'My App (Fork)',
   },
   open_bundle_response: {
     type: 'open_bundle_response',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -44,6 +44,7 @@ import type {
   UpdateTrustRule,
   BundleAppRequest,
   SharedAppDeleteRequest,
+  ForkSharedAppRequest,
   UiSurfaceShow,
   IpcBlobProbe,
 } from './ipc-protocol.js';
@@ -57,7 +58,7 @@ import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../confi
 import { resolveSkillStates } from '../config/skill-state.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
-import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp } from '../memory/app-store.js';
+import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp, createApp } from '../memory/app-store.js';
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 import { parseSlashCandidate } from '../skills/slash-commands.js';
@@ -403,6 +404,7 @@ const handlers: DispatchMap = {
   apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
   shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
   shared_app_delete: handleSharedAppDelete,
+  fork_shared_app: handleForkSharedApp,
   sign_bundle_payload_response: (_msg, _socket, _ctx) => {
     // TODO(signing): Route to pending promise resolution once the daemon-driven
     // IPC signing orchestration is wired up. Currently a no-op placeholder to
@@ -1745,6 +1747,64 @@ function handleSharedAppDelete(
   } catch (err) {
     log.error({ err }, 'Failed to delete shared app');
     ctx.send(socket, { type: 'shared_app_delete_response', success: false });
+  }
+}
+
+function handleForkSharedApp(
+  msg: ForkSharedAppRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const appUuid = msg.uuid;
+    // Validate UUID to prevent path traversal
+    if (appUuid.includes('/') || appUuid.includes('\\') || appUuid.includes('..') || /\s/.test(appUuid)) {
+      ctx.send(socket, { type: 'fork_shared_app_response', success: false, error: 'Invalid UUID' });
+      return;
+    }
+
+    const dir = getSharedAppsDir();
+    const metaFile = join(dir, `${appUuid}-meta.json`);
+
+    if (!existsSync(metaFile)) {
+      ctx.send(socket, { type: 'fork_shared_app_response', success: false, error: 'Shared app not found' });
+      return;
+    }
+
+    const metaRaw = readFileSync(metaFile, 'utf-8');
+    const meta = JSON.parse(metaRaw);
+    const appName = meta.name ?? 'Untitled';
+    const appDescription = meta.description;
+
+    // Read the HTML from the shared app's entry file
+    const entry = meta.entry ?? 'index.html';
+    const htmlPath = join(dir, appUuid, entry);
+
+    if (!existsSync(htmlPath)) {
+      ctx.send(socket, { type: 'fork_shared_app_response', success: false, error: 'Shared app HTML not found' });
+      return;
+    }
+
+    const htmlContent = readFileSync(htmlPath, 'utf-8');
+
+    // Create a new local app via the app store
+    const newApp = createApp({
+      name: `${appName} (Fork)`,
+      description: appDescription,
+      schemaJson: JSON.stringify({ type: 'object', properties: {} }),
+      htmlDefinition: htmlContent,
+    });
+
+    ctx.send(socket, {
+      type: 'fork_shared_app_response',
+      success: true,
+      appId: newApp.id,
+      name: newApp.name,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to fork shared app');
+    ctx.send(socket, { type: 'fork_shared_app_response', success: false, error: message });
   }
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -286,6 +286,11 @@ export interface SharedAppDeleteRequest {
   uuid: string;
 }
 
+export interface ForkSharedAppRequest {
+  type: 'fork_shared_app';
+  uuid: string;
+}
+
 export interface BundleAppRequest {
   type: 'bundle_app';
   appId: string;
@@ -472,6 +477,7 @@ export type ClientMessage =
   | AppOpenRequest
   | SharedAppsListRequest
   | SharedAppDeleteRequest
+  | ForkSharedAppRequest
   | OpenBundleRequest
   | SignBundlePayloadResponse
   | GetSigningIdentityResponse
@@ -900,6 +906,14 @@ export interface SharedAppDeleteResponse {
   success: boolean;
 }
 
+export interface ForkSharedAppResponse {
+  type: 'fork_shared_app_response';
+  success: boolean;
+  appId?: string;
+  name?: string;
+  error?: string;
+}
+
 export interface BundleAppResponse {
   type: 'bundle_app_response';
   bundlePath: string;
@@ -1114,6 +1128,7 @@ export type ServerMessage =
   | AppsListResponse
   | SharedAppsListResponse
   | SharedAppDeleteResponse
+  | ForkSharedAppResponse
   | OpenBundleResponse
   | SignBundlePayloadRequest
   | GetSigningIdentityRequest

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -223,6 +223,7 @@ struct GeneratedPanel: View {
                         shareButton(for: item)
 
                         if item.isShared {
+                            forkButton(for: item)
                             deleteButton(for: item)
                         }
                     }
@@ -330,6 +331,12 @@ struct GeneratedPanel: View {
                     reshareApp(uuid: uuid, itemId: item.id)
                 }
             }
+        }
+    }
+
+    private func forkButton(for item: DisplayAppItem) -> some View {
+        VIconButton(label: "Fork", icon: "arrow.triangle.branch", iconOnly: true) {
+            forkSharedApp(item)
         }
     }
 
@@ -529,6 +536,26 @@ struct GeneratedPanel: View {
 
             do {
                 try daemonClient.sendSharedAppDelete(uuid: uuid)
+            } catch {
+                // Silently fail
+            }
+        }
+    }
+
+    // MARK: - Fork Shared App
+
+    private func forkSharedApp(_ item: DisplayAppItem) {
+        guard let uuid = item.sharedUUID else { return }
+
+        Task { @MainActor in
+            daemonClient.onForkSharedAppResponse = { response in
+                if response.success {
+                    self.fetchApps()
+                }
+            }
+
+            do {
+                try daemonClient.sendForkSharedApp(uuid: uuid)
             } catch {
                 // Silently fail
             }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -125,6 +125,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `shared_app_delete_response` message.
     public var onSharedAppDeleteResponse: ((SharedAppDeleteResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `fork_shared_app_response` message.
+    public var onForkSharedAppResponse: ((ForkSharedAppResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `bundle_app_response` message.
     public var onBundleAppResponse: ((BundleAppResponseMessage) -> Void)?
 
@@ -615,6 +618,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(SharedAppDeleteRequestMessage(uuid: uuid))
     }
 
+    /// Fork a shared app into a local editable copy.
+    public func sendForkSharedApp(uuid: String) throws {
+        try send(ForkSharedAppRequestMessage(uuid: uuid))
+    }
+
     // MARK: - Signing Identity (macOS only)
 
     #if os(macOS)
@@ -813,6 +821,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSharedAppsListResponse?(msg)
         case .sharedAppDeleteResponse(let msg):
             onSharedAppDeleteResponse?(msg)
+        case .forkSharedAppResponse(let msg):
+            onForkSharedAppResponse?(msg)
         case .bundleAppResponse(let msg):
             onBundleAppResponse?(msg)
         case .openBundleResponse(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -313,6 +313,20 @@ extension IPCSharedAppDeleteRequest {
     }
 }
 
+/// Sent to fork (create a local copy of) a shared app by UUID.
+public struct ForkSharedAppRequestMessage: Encodable, Sendable {
+    public let type: String = "fork_shared_app"
+    public let uuid: String
+}
+
+/// Response from forking a shared app.
+public struct ForkSharedAppResponseMessage: Decodable, Sendable {
+    public let success: Bool
+    public let appId: String?
+    public let name: String?
+    public let error: String?
+}
+
 /// Sent to request bundling an app for sharing.
 /// Backed by generated `IPCBundleAppRequest`.
 public typealias BundleAppRequestMessage = IPCBundleAppRequest
@@ -1179,6 +1193,7 @@ public enum ServerMessage: Decodable, Sendable {
     case appsListResponse(AppsListResponseMessage)
     case sharedAppsListResponse(SharedAppsListResponseMessage)
     case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
+    case forkSharedAppResponse(ForkSharedAppResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
     case signBundlePayload(SignBundlePayloadMessage)
@@ -1314,6 +1329,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "shared_app_delete_response":
             let message = try SharedAppDeleteResponseMessage(from: decoder)
             self = .sharedAppDeleteResponse(message)
+        case "fork_shared_app_response":
+            let message = try ForkSharedAppResponseMessage(from: decoder)
+            self = .forkSharedAppResponse(message)
         case "bundle_app_response":
             let message = try BundleAppResponseMessage(from: decoder)
             self = .bundleAppResponse(message)


### PR DESCRIPTION
## Summary
- Add `fork_shared_app` IPC message type and handler in the daemon
- Handler reads shared app HTML and metadata, creates local app copy via `createApp()` with "(Fork)" suffix
- Add Fork button in GeneratedPanel for shared apps using the same hover-reveal pattern as share/delete buttons
- Includes UUID validation (rejects `/`, `\`, `..`, whitespace) to prevent path traversal

## Test plan
- [ ] Receive a shared app, verify the Fork button appears on hover alongside share/delete
- [ ] Click Fork, verify a new local app appears in the list with "(Fork)" suffix
- [ ] Open the forked app, verify it renders the same HTML as the original shared app
- [ ] Verify the forked app is fully editable as a local app
- [ ] TypeScript type-check passes (`bunx tsc --noEmit`)

Fixes #2594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
