### PR TITLE
Add Share to Slack via webhook

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -408,6 +408,20 @@ exports[`IPC message snapshots ClientMessage types share_app_cloud serializes to
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types share_to_slack serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "share_to_slack",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types slack_webhook_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "slack_webhook_config",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
   "sessionId": "sess-001",
@@ -1152,42 +1166,6 @@ exports[`IPC message snapshots ServerMessage types ipc_blob_probe_result seriali
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types fork_shared_app serializes to expected JSON 1`] = `
-{
-  "type": "fork_shared_app",
-  "uuid": "abc-123-def",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types gallery_list serializes to expected JSON 1`] = `
-{
-  "type": "gallery_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types gallery_install serializes to expected JSON 1`] = `
-{
-  "galleryAppId": "gallery-pomodoro-timer",
-  "type": "gallery_install",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types share_app_cloud serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "type": "share_app_cloud",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types fork_shared_app_response serializes to expected JSON 1`] = `
-{
-  "appId": "new-app-id",
-  "name": "My App (Fork)",
-  "success": true,
-  "type": "fork_shared_app_response",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types gallery_list_response serializes to expected JSON 1`] = `
 {
   "gallery": {
@@ -1221,5 +1199,20 @@ exports[`IPC message snapshots ServerMessage types share_app_cloud_response seri
   "shareUrl": "http://localhost:7821/v1/apps/shared/abc123def456",
   "success": true,
   "type": "share_app_cloud_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types share_to_slack_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "share_to_slack_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types slack_webhook_config_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "slack_webhook_config_response",
+  "webhookUrl": "https://hooks.slack.com/services/T00/B00/xxx",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -263,6 +263,14 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'share_app_cloud',
     appId: 'app-001',
   },
+  share_to_slack: {
+    type: 'share_to_slack',
+    appId: 'app-001',
+  },
+  slack_webhook_config: {
+    type: 'slack_webhook_config',
+    action: 'get',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -753,6 +761,15 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     success: true,
     shareToken: 'abc123def456',
     shareUrl: 'http://localhost:7821/v1/apps/shared/abc123def456',
+  },
+  share_to_slack_response: {
+    type: 'share_to_slack_response',
+    success: true,
+  },
+  slack_webhook_config_response: {
+    type: 'slack_webhook_config_response',
+    webhookUrl: 'https://hooks.slack.com/services/T00/B00/xxx',
+    success: true,
   },
 };
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -50,7 +50,10 @@ import type {
   IpcBlobProbe,
   GalleryListRequest,
   GalleryInstallRequest,
+  ShareToSlackRequest,
+  SlackWebhookConfigRequest,
 } from './ipc-protocol.js';
+import { postToSlackWebhook } from '../slack/slack-webhook.js';
 import { createHash } from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { existsSync, rmSync, readdirSync, readFileSync } from 'node:fs';
@@ -423,6 +426,8 @@ const handlers: DispatchMap = {
   },
   gallery_list: (_msg, socket, ctx) => handleGalleryList(socket, ctx),
   gallery_install: handleGalleryInstall,
+  share_to_slack: handleShareToSlack,
+  slack_webhook_config: handleSlackWebhookConfig,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ipc_blob_probe: handleIpcBlobProbe,
   ui_surface_action: (msg, _socket, ctx) => {
@@ -2053,6 +2058,108 @@ function handleGalleryInstall(
     log.error({ err, galleryAppId: msg.galleryAppId }, 'Failed to install gallery app');
     ctx.send(socket, {
       type: 'gallery_install_response',
+      success: false,
+      error: message,
+    });
+  }
+}
+
+// ─── Slack handlers ─────────────────────────────────────────────────────────
+
+function getVellumConfigPath(): string {
+  return join(homedir(), '.vellum', 'config.json');
+}
+
+function readVellumConfig(): Record<string, unknown> {
+  const configPath = getVellumConfigPath();
+  if (!existsSync(configPath)) return {};
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeVellumConfig(config: Record<string, unknown>): void {
+  const { writeFileSync, mkdirSync } = require('node:fs') as typeof import('node:fs');
+  const configPath = getVellumConfigPath();
+  const dir = join(configPath, '..');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2));
+}
+
+async function handleShareToSlack(
+  msg: ShareToSlackRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    const config = readVellumConfig();
+    const webhookUrl = config.slackWebhookUrl as string | undefined;
+    if (!webhookUrl) {
+      ctx.send(socket, {
+        type: 'share_to_slack_response',
+        success: false,
+        error: 'No Slack webhook URL configured. Set one in Settings.',
+      });
+      return;
+    }
+
+    const app = getApp(msg.appId);
+    if (!app) {
+      ctx.send(socket, {
+        type: 'share_to_slack_response',
+        success: false,
+        error: `App not found: ${msg.appId}`,
+      });
+      return;
+    }
+
+    await postToSlackWebhook(
+      webhookUrl,
+      app.name,
+      app.description ?? '',
+      '\u{1F4F1}',
+    );
+
+    ctx.send(socket, { type: 'share_to_slack_response', success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, appId: msg.appId }, 'Failed to share app to Slack');
+    ctx.send(socket, {
+      type: 'share_to_slack_response',
+      success: false,
+      error: message,
+    });
+  }
+}
+
+function handleSlackWebhookConfig(
+  msg: SlackWebhookConfigRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const config = readVellumConfig();
+    if (msg.action === 'get') {
+      ctx.send(socket, {
+        type: 'slack_webhook_config_response',
+        webhookUrl: (config.slackWebhookUrl as string) ?? undefined,
+        success: true,
+      });
+    } else {
+      config.slackWebhookUrl = msg.webhookUrl ?? '';
+      writeVellumConfig(config);
+      ctx.send(socket, {
+        type: 'slack_webhook_config_response',
+        success: true,
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to handle Slack webhook config');
+    ctx.send(socket, {
+      type: 'slack_webhook_config_response',
       success: false,
       error: message,
     });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -330,6 +330,17 @@ export interface ShareAppCloudRequest {
   appId: string;
 }
 
+export interface ShareToSlackRequest {
+  type: 'share_to_slack';
+  appId: string;
+}
+
+export interface SlackWebhookConfigRequest {
+  type: 'slack_webhook_config';
+  action: 'get' | 'set';
+  webhookUrl?: string;
+}
+
 export interface IpcBlobProbe {
   type: 'ipc_blob_probe';
   probeId: string;
@@ -499,6 +510,8 @@ export type ClientMessage =
   | GetSigningIdentityResponse
   | IpcBlobProbe
   | ShareAppCloudRequest
+  | ShareToSlackRequest
+  | SlackWebhookConfigRequest
   | SessionsClearRequest
   | GalleryListRequest
   | GalleryInstallRequest;
@@ -1019,6 +1032,19 @@ export interface GalleryInstallResponse {
   error?: string;
 }
 
+export interface ShareToSlackResponse {
+  type: 'share_to_slack_response';
+  success: boolean;
+  error?: string;
+}
+
+export interface SlackWebhookConfigResponse {
+  type: 'slack_webhook_config_response';
+  webhookUrl?: string;
+  success: boolean;
+  error?: string;
+}
+
 export interface TimerCompleted {
   type: 'timer_completed';
   sessionId: string;
@@ -1183,7 +1209,9 @@ export type ServerMessage =
   | ShareAppCloudResponse
   | TraceEvent
   | GalleryListResponse
-  | GalleryInstallResponse;
+  | GalleryInstallResponse
+  | ShareToSlackResponse
+  | SlackWebhookConfigResponse;
 
 // === Contract schema ===
 

--- a/assistant/src/slack/slack-webhook.ts
+++ b/assistant/src/slack/slack-webhook.ts
@@ -1,0 +1,61 @@
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('slack-webhook');
+
+/**
+ * Post a rich Block Kit message to a Slack Incoming Webhook URL.
+ *
+ * Uses the Block Kit format so the message renders nicely in Slack with
+ * a header, description section, and context footer.
+ */
+export async function postToSlackWebhook(
+  webhookUrl: string,
+  appName: string,
+  appDescription: string,
+  appIcon: string,
+): Promise<void> {
+  const blocks = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: `${appIcon} ${appName}`,
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: appDescription || '_No description_',
+      },
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `Shared from Vellum Assistant`,
+        },
+      ],
+    },
+  ];
+
+  const payload = {
+    blocks,
+    text: `${appIcon} ${appName}: ${appDescription || 'No description'}`,
+  };
+
+  log.info({ appName }, 'Posting app to Slack webhook');
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Slack webhook returned ${response.status}: ${body}`);
+  }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -40,6 +40,10 @@ struct GeneratedPanel: View {
     // Track how many list responses we're waiting for
     @State private var pendingResponses = 0
 
+    // Slack sharing state
+    @State private var slackSharingAppId: String?
+    @State private var slackShareResult: (appId: String, success: Bool)?
+
     init(onClose: @escaping () -> Void, isExpanded: Binding<Bool> = .constant(false), daemonClient: DaemonClient, onOpenApp: ((UiSurfaceShowMessage) -> Void)? = nil) {
         self.onClose = onClose
         self._isExpanded = isExpanded
@@ -234,6 +238,10 @@ struct GeneratedPanel: View {
                     } else {
                         shareButton(for: item)
 
+                        if let localId = item.localAppId {
+                            slackShareButton(for: item, localAppId: localId)
+                        }
+
                         if item.isShared {
                             forkButton(for: item)
                             deleteButton(for: item)
@@ -369,6 +377,56 @@ struct GeneratedPanel: View {
     private func deleteButton(for item: DisplayAppItem) -> some View {
         VIconButton(label: "Delete", icon: "trash", iconOnly: true) {
             deleteSharedApp(item)
+        }
+    }
+
+    @ViewBuilder
+    private func slackShareButton(for item: DisplayAppItem, localAppId: String) -> some View {
+        let isSharing = slackSharingAppId == item.id
+        let result = slackShareResult.flatMap { $0.appId == item.id ? $0 : nil }
+
+        if isSharing {
+            ProgressView()
+                .controlSize(.mini)
+                .frame(width: 24, height: 24)
+        } else if let result = result {
+            Image(systemName: result.success ? "checkmark.circle.fill" : "xmark.circle.fill")
+                .foregroundColor(result.success ? VColor.success : VColor.error)
+                .frame(width: 24, height: 24)
+        } else {
+            VIconButton(label: "Share to Slack", icon: "paperplane", iconOnly: true) {
+                shareToSlack(appId: localAppId, itemId: item.id)
+            }
+        }
+    }
+
+    private func shareToSlack(appId: String, itemId: String) {
+        slackSharingAppId = itemId
+
+        Task { @MainActor in
+            daemonClient.onShareToSlackResponse = { response in
+                self.slackSharingAppId = nil
+                self.slackShareResult = (appId: itemId, success: response.success)
+
+                // Clear the result indicator after 2 seconds
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    if self.slackShareResult?.appId == itemId {
+                        self.slackShareResult = nil
+                    }
+                }
+            }
+
+            do {
+                try daemonClient.sendShareToSlack(appId: appId)
+            } catch {
+                self.slackSharingAppId = nil
+                self.slackShareResult = (appId: itemId, success: false)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    if self.slackShareResult?.appId == itemId {
+                        self.slackShareResult = nil
+                    }
+                }
+            }
         }
     }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -140,6 +140,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `history_response` message.
     public var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `share_to_slack_response` message.
+    public var onShareToSlackResponse: ((ShareToSlackResponseMessage) -> Void)?
+
+    /// Called when the daemon sends a `slack_webhook_config_response` message.
+    public var onSlackWebhookConfigResponse: ((SlackWebhookConfigResponseMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -623,6 +629,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(ForkSharedAppRequestMessage(uuid: uuid))
     }
 
+    /// Share a local app to Slack via configured webhook.
+    public func sendShareToSlack(appId: String) throws {
+        try send(ShareToSlackRequestMessage(appId: appId))
+    }
+
+    /// Get or set the Slack webhook URL configuration.
+    public func sendSlackWebhookConfig(action: String, webhookUrl: String? = nil) throws {
+        try send(SlackWebhookConfigRequestMessage(action: action, webhookUrl: webhookUrl))
+    }
+
     // MARK: - Signing Identity (macOS only)
 
     #if os(macOS)
@@ -831,6 +847,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSessionListResponse?(msg)
         case .historyResponse(let msg):
             onHistoryResponse?(msg)
+        case .shareToSlackResponse(let msg):
+            onShareToSlackResponse?(msg)
+        case .slackWebhookConfigResponse(let msg):
+            onSlackWebhookConfigResponse?(msg)
         case .memoryStatus(let msg):
             latestMemoryStatus = msg
         case .traceEvent(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1150,6 +1150,41 @@ extension IPCOpenBundleResponseManifest {
 }
 
 
+// MARK: - Slack Webhook Messages (Manual)
+
+public struct ShareToSlackRequestMessage: Encodable, Sendable {
+    public let type = "share_to_slack"
+    public let appId: String
+
+    public init(appId: String) {
+        self.appId = appId
+    }
+}
+
+public struct SlackWebhookConfigRequestMessage: Encodable, Sendable {
+    public let type = "slack_webhook_config"
+    public let action: String
+    public let webhookUrl: String?
+
+    public init(action: String, webhookUrl: String? = nil) {
+        self.action = action
+        self.webhookUrl = webhookUrl
+    }
+}
+
+public struct ShareToSlackResponseMessage: Decodable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let error: String?
+}
+
+public struct SlackWebhookConfigResponseMessage: Decodable, Sendable {
+    public let type: String
+    public let webhookUrl: String?
+    public let success: Bool
+    public let error: String?
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 public enum ServerMessage: Decodable, Sendable {
@@ -1197,6 +1232,8 @@ public enum ServerMessage: Decodable, Sendable {
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
     case signBundlePayload(SignBundlePayloadMessage)
+    case shareToSlackResponse(ShareToSlackResponseMessage)
+    case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
     case ipcBlobProbeResult(IpcBlobProbeResultMessage)
     case daemonStatus(DaemonStatusMessage)
     case getSigningIdentity
@@ -1341,6 +1378,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "trace_event":
             let message = try TraceEventMessage(from: decoder)
             self = .traceEvent(message)
+        case "share_to_slack_response":
+            let message = try ShareToSlackResponseMessage(from: decoder)
+            self = .shareToSlackResponse(message)
+        case "slack_webhook_config_response":
+            let message = try SlackWebhookConfigResponseMessage(from: decoder)
+            self = .slackWebhookConfigResponse(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
## Summary
- Adds `share_to_slack` and `slack_webhook_config` IPC message types for posting app info to a configured Slack incoming webhook
- Creates `slack-webhook.ts` with Slack Block Kit message formatting (header, description, context)
- Stores webhook URL in `~/.vellum/config.json` via get/set config handlers
- Adds "Share to Slack" button (paperplane SF Symbol) in GeneratedPanel hover actions for local apps with spinner and success/error feedback
- Updates Swift `IPCMessages.swift`, `DaemonClient.swift`, and IPC snapshot tests

Part of #2603 (Shared Apps Wave 2). Closes #2606.

## Test plan
- [ ] Configure a Slack webhook URL via `slack_webhook_config` set action
- [ ] Verify `slack_webhook_config` get action returns the stored URL
- [ ] Click "Share to Slack" on a local app and verify Block Kit message appears in Slack channel
- [ ] Verify success checkmark feedback after successful share
- [ ] Verify error feedback when no webhook URL is configured
- [ ] Verify error feedback when webhook URL is invalid
- [ ] Run `bunx tsc --noEmit` — passes
- [ ] Run `bun test src/__tests__/ipc-snapshot.test.ts` — 101 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
