### PR TITLE
chore(git): ignore .build-ios directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ yarn-error.log*
 *.xcactivitylog
 DerivedData/
 **/Library/Logs/CoreSimulator/
+.build-ios/
 
 # drizzle
 web/drizzle/


### PR DESCRIPTION
## Summary

Adds `.build-ios/` to gitignore to exclude iOS build artifacts from version control.

## Changes

- Added `.build-ios/` to the xcode / spm build artifacts section of .gitignore

This directory contains iOS build artifacts and should not be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
