### PR TITLE
M1: Add IPC contract types for watch messages

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -108,6 +108,18 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     windowTitle: 'Google',
     timestamp: 1700000000,
   },
+  watch_observation: {
+    type: 'watch_observation',
+    watchId: 'watch-001',
+    sessionId: 'sess-001',
+    ocrText: 'Screen text captured during watch',
+    appName: 'Xcode',
+    windowTitle: 'Project.swift',
+    bundleIdentifier: 'com.apple.dt.Xcode',
+    timestamp: 1700000000,
+    captureIndex: 0,
+    totalExpected: 10,
+  },
   task_submit: {
     type: 'task_submit',
     task: 'Open Safari and search for weather',
@@ -604,6 +616,18 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     timerId: 'tmr-001',
     label: 'Focus time',
     durationMinutes: 25,
+  },
+  watch_started: {
+    type: 'watch_started',
+    sessionId: 'sess-001',
+    watchId: 'watch-001',
+    durationSeconds: 300,
+    intervalSeconds: 5,
+  },
+  watch_complete_request: {
+    type: 'watch_complete_request',
+    sessionId: 'sess-001',
+    watchId: 'watch-001',
   },
   trust_rules_list_response: {
     type: 'trust_rules_list_response',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -385,6 +385,7 @@ const handlers: DispatchMap = {
   cu_session_abort: handleCuSessionAbort,
   cu_observation: handleCuObservation,
   ambient_observation: handleAmbientObservation,
+  watch_observation: (_msg, _socket, _ctx) => { /* TODO: handle watch observations */ },
   task_submit: handleTaskSubmit,
   app_data_request: handleAppDataRequest,
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -166,6 +166,19 @@ export interface AmbientObservation {
   timestamp: number;
 }
 
+export interface WatchObservation {
+  type: 'watch_observation';
+  watchId: string;
+  sessionId: string;
+  ocrText: string;
+  appName?: string;
+  windowTitle?: string;
+  bundleIdentifier?: string;
+  timestamp: number;
+  captureIndex: number;
+  totalExpected: number;
+}
+
 export interface AppDataRequest {
   type: 'app_data_request';
   surfaceId: string;
@@ -469,6 +482,7 @@ export type ClientMessage =
   | CuSessionAbort
   | CuObservation
   | AmbientObservation
+  | WatchObservation
   | TaskSubmit
   | UiSurfaceAction
   | AppDataRequest
@@ -1020,6 +1034,20 @@ export interface TimerCompleted {
   durationMinutes: number;
 }
 
+export interface WatchStarted {
+  type: 'watch_started';
+  sessionId: string;
+  watchId: string;
+  durationSeconds: number;
+  intervalSeconds: number;
+}
+
+export interface WatchCompleteRequest {
+  type: 'watch_complete_request';
+  sessionId: string;
+  watchId: string;
+}
+
 export type TraceEventKind =
   | 'request_received'
   | 'request_queued'
@@ -1163,6 +1191,8 @@ export type ServerMessage =
   | MessageQueued
   | MessageDequeued
   | TimerCompleted
+  | WatchStarted
+  | WatchCompleteRequest
   | TrustRulesListResponse
   | BundleAppResponse
   | AppsListResponse

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -292,6 +292,19 @@ public struct IPCFileUploadSurfaceData: Codable, Sendable {
     public let maxSizeBytes: Int?
 }
 
+public struct IPCForkSharedAppRequest: Codable, Sendable {
+    public let type: String
+    public let uuid: String
+}
+
+public struct IPCForkSharedAppResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let appId: String?
+    public let name: String?
+    public let error: String?
+}
+
 public struct IPCFormField: Codable, Sendable {
     public let id: String
     public let type: String
@@ -311,6 +324,28 @@ public struct IPCFormSurfaceData: Codable, Sendable {
     public let description: String?
     public let fields: [IPCFormField]
     public let submitLabel: String?
+}
+
+public struct IPCGalleryInstallRequest: Codable, Sendable {
+    public let type: String
+    public let galleryAppId: String
+}
+
+public struct IPCGalleryInstallResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let appId: String?
+    public let name: String?
+    public let error: String?
+}
+
+public struct IPCGalleryListRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCGalleryListResponse: Codable, Sendable {
+    public let type: String
+    public let gallery: IPCGalleryManifest
 }
 
 public struct IPCGenerationCancelled: Codable, Sendable {
@@ -612,6 +647,19 @@ public struct IPCSessionsClearResponse: Codable, Sendable {
 public struct IPCSessionSwitchRequest: Codable, Sendable {
     public let type: String
     public let sessionId: String
+}
+
+public struct IPCShareAppCloudRequest: Codable, Sendable {
+    public let type: String
+    public let appId: String
+}
+
+public struct IPCShareAppCloudResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let shareToken: String?
+    public let shareUrl: String?
+    public let error: String?
 }
 
 public struct IPCSharedAppDeleteRequest: Codable, Sendable {
@@ -1098,4 +1146,31 @@ public struct IPCUserMessageAttachment: Codable, Sendable {
     public let mimeType: String
     public let data: String
     public let extractedText: String?
+}
+
+public struct IPCWatchCompleteRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let watchId: String
+}
+
+public struct IPCWatchObservation: Codable, Sendable {
+    public let type: String
+    public let watchId: String
+    public let sessionId: String
+    public let ocrText: String
+    public let appName: String?
+    public let windowTitle: String?
+    public let bundleIdentifier: String?
+    public let timestamp: Double
+    public let captureIndex: Double
+    public let totalExpected: Double
+}
+
+public struct IPCWatchStarted: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let watchId: String
+    public let durationSeconds: Double
+    public let intervalSeconds: Double
 }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -193,6 +193,16 @@ extension IPCAmbientObservation {
     }
 }
 
+/// Sent by the watch agent with OCR text from periodic screen captures.
+/// Backed by generated `IPCWatchObservation`.
+public typealias WatchObservationMessage = IPCWatchObservation
+
+extension IPCWatchObservation {
+    public init(watchId: String, sessionId: String, ocrText: String, appName: String?, windowTitle: String?, bundleIdentifier: String?, timestamp: Double, captureIndex: Double, totalExpected: Double) {
+        self.init(type: "watch_observation", watchId: watchId, sessionId: sessionId, ocrText: ocrText, appName: appName, windowTitle: windowTitle, bundleIdentifier: bundleIdentifier, timestamp: timestamp, captureIndex: captureIndex, totalExpected: totalExpected)
+    }
+}
+
 /// Sent to create a new Q&A session.
 /// Backed by generated `IPCSessionCreateRequest`.
 public typealias SessionCreateMessage = IPCSessionCreateRequest
@@ -1007,6 +1017,14 @@ public struct SessionErrorMessage: Decodable, Sendable {
 /// Backed by generated `IPCTimerCompleted`.
 public typealias TimerCompletedMessage = IPCTimerCompleted
 
+/// Watch session started notification from daemon.
+/// Backed by generated `IPCWatchStarted`.
+public typealias WatchStartedMessage = IPCWatchStarted
+
+/// Watch session complete request from daemon.
+/// Backed by generated `IPCWatchCompleteRequest`.
+public typealias WatchCompleteRequestMessage = IPCWatchCompleteRequest
+
 /// Tool execution started.
 /// Backed by generated `IPCToolUseStart`.
 public typealias ToolUseStartMessage = IPCToolUseStart
@@ -1188,6 +1206,8 @@ public enum ServerMessage: Decodable, Sendable {
     case toolOutputChunk(ToolOutputChunkMessage)
     case toolResult(ToolResultMessage)
     case timerCompleted(TimerCompletedMessage)
+    case watchStarted(WatchStartedMessage)
+    case watchCompleteRequest(WatchCompleteRequestMessage)
     case traceEvent(TraceEventMessage)
     case trustRulesListResponse(TrustRulesListResponseMessage)
     case appsListResponse(AppsListResponseMessage)
@@ -1317,6 +1337,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "timer_completed":
             let message = try TimerCompletedMessage(from: decoder)
             self = .timerCompleted(message)
+        case "watch_started":
+            let message = try WatchStartedMessage(from: decoder)
+            self = .watchStarted(message)
+        case "watch_complete_request":
+            let message = try WatchCompleteRequestMessage(from: decoder)
+            self = .watchCompleteRequest(message)
         case "trust_rules_list_response":
             let message = try TrustRulesListResponseMessage(from: decoder)
             self = .trustRulesListResponse(message)


### PR DESCRIPTION
Part of #2618: Watch While I Work

Adds 3 new IPC message types for the screen watch feature:
- WatchObservation (client→server): screen capture data sent from Swift client
- WatchStarted (server→client): confirms watch session started
- WatchCompleteRequest (server→client): signals watch duration elapsed

Runs codegen to generate Swift types and adds typealiases + ServerMessage cases in IPCMessages.swift.

Closes #2619
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
