### PR TITLE
M2: Add daemon tool and state management for screen watch

### DIFF
--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -13,6 +13,7 @@ import { memorySearchTool, memorySaveTool, memoryUpdateTool } from './memory/reg
 import { credentialStoreTool } from './credentials/vault.js';
 import { accountManageTool } from './credentials/account-registry.js';
 import { pomodoroTool } from './timer/pomodoro.js';
+import { screenWatchTool } from './watch/screen-watch.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -46,6 +47,7 @@ export const explicitTools: Tool[] = [
   credentialStoreTool,
   accountManageTool,
   pomodoroTool,
+  screenWatchTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────

--- a/assistant/src/tools/watch/screen-watch.ts
+++ b/assistant/src/tools/watch/screen-watch.ts
@@ -1,0 +1,128 @@
+import crypto from 'node:crypto';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { getLogger } from '../../util/logger.js';
+import {
+  watchSessions,
+  getActiveWatchSession,
+  fireWatchStartNotifier,
+  fireWatchCompletionNotifier,
+} from './watch-state.js';
+import type { WatchSession } from './watch-state.js';
+
+const log = getLogger('screen-watch');
+
+class ScreenWatchTool implements Tool {
+  name = 'start_screen_watch';
+  description = 'Start observing the screen at regular intervals for a specified duration. Captures OCR text from the active window and provides periodic commentary.';
+  category = 'observation';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          duration_minutes: {
+            type: 'number',
+            description: 'How long to watch in minutes (1-15, default 5)',
+          },
+          interval_seconds: {
+            type: 'number',
+            description: 'Seconds between screen captures (5-30, default 10)',
+          },
+          focus_area: {
+            type: 'string',
+            description: 'What to focus on observing',
+          },
+        },
+        required: ['focus_area'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const { sessionId } = context;
+
+    // Validate focus_area
+    const focusArea = typeof input.focus_area === 'string' && input.focus_area.length > 0
+      ? input.focus_area
+      : undefined;
+
+    if (!focusArea) {
+      return {
+        content: 'Error: focus_area is required and must be a non-empty string',
+        isError: true,
+      };
+    }
+
+    // Clamp duration to 1-15 minutes
+    let durationMinutes = typeof input.duration_minutes === 'number' ? input.duration_minutes : 5;
+    durationMinutes = Math.max(1, Math.min(15, durationMinutes));
+
+    // Clamp interval to 5-30 seconds
+    let intervalSeconds = typeof input.interval_seconds === 'number' ? input.interval_seconds : 10;
+    intervalSeconds = Math.max(5, Math.min(30, intervalSeconds));
+
+    // Check for existing active session
+    const existing = getActiveWatchSession(sessionId);
+    if (existing) {
+      return {
+        content: `Error: An active watch session already exists for this conversation (watchId: ${existing.watchId}, focus: "${existing.focusArea}"). Cancel or wait for it to complete before starting a new one.`,
+        isError: true,
+      };
+    }
+
+    // Generate watchId
+    const watchId = crypto.randomUUID().slice(0, 8);
+    const now = Date.now();
+    const durationSeconds = durationMinutes * 60;
+
+    // Create session
+    const session: WatchSession = {
+      watchId,
+      sessionId,
+      focusArea,
+      durationSeconds,
+      intervalSeconds,
+      observations: [],
+      commentaryCount: 0,
+      status: 'active',
+      startedAt: now,
+    };
+
+    // Store in sessions map
+    watchSessions.set(watchId, session);
+
+    // Fire start notifier
+    fireWatchStartNotifier(sessionId, session);
+
+    // Set timeout for duration expiry
+    session.timeoutHandle = setTimeout(() => {
+      session.status = 'completing';
+      session.timeoutHandle = undefined;
+      log.info({ watchId, focusArea }, 'Watch session duration expired, marking as completing');
+      fireWatchCompletionNotifier(sessionId, session);
+    }, durationSeconds * 1000);
+
+    log.info({ watchId, sessionId, focusArea, durationMinutes, intervalSeconds }, 'Screen watch session started');
+
+    const expectedCaptures = Math.floor(durationSeconds / intervalSeconds);
+    const content = [
+      `Screen watch started (watchId: ${watchId})`,
+      `Focus: ${focusArea}`,
+      `Duration: ${durationMinutes} minute${durationMinutes !== 1 ? 's' : ''}`,
+      `Interval: every ${intervalSeconds} seconds`,
+      `Expected captures: ~${expectedCaptures}`,
+      `Started at: ${new Date(now).toISOString()}`,
+      `Expected end: ${new Date(now + durationSeconds * 1000).toISOString()}`,
+    ].join('\n');
+
+    return { content, isError: false };
+  }
+}
+
+export const screenWatchTool = new ScreenWatchTool();

--- a/assistant/src/tools/watch/watch-state.ts
+++ b/assistant/src/tools/watch/watch-state.ts
@@ -1,0 +1,107 @@
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('watch');
+
+export interface WatchObservationEntry {
+  ocrText: string;
+  appName?: string;
+  windowTitle?: string;
+  bundleIdentifier?: string;
+  timestamp: number;
+  captureIndex: number;
+}
+
+export interface WatchSession {
+  watchId: string;
+  sessionId: string;
+  focusArea: string;
+  durationSeconds: number;
+  intervalSeconds: number;
+  observations: WatchObservationEntry[];
+  commentaryCount: number;
+  status: 'active' | 'completing' | 'completed' | 'cancelled';
+  startedAt: number;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+}
+
+/** Module-level map of watch sessions keyed by watchId. */
+export const watchSessions = new Map<string, WatchSession>();
+
+// ── Start notifiers ─────────────────────────────────────────────────
+const startNotifiers = new Map<string, (session: WatchSession) => void>();
+
+export function registerWatchStartNotifier(sessionId: string, callback: (session: WatchSession) => void): void {
+  startNotifiers.set(sessionId, callback);
+}
+
+export function unregisterWatchStartNotifier(sessionId: string): void {
+  startNotifiers.delete(sessionId);
+}
+
+export function fireWatchStartNotifier(sessionId: string, session: WatchSession): void {
+  startNotifiers.get(sessionId)?.(session);
+}
+
+// ── Commentary notifiers ────────────────────────────────────────────
+const commentaryNotifiers = new Map<string, (session: WatchSession) => void>();
+
+export function registerWatchCommentaryNotifier(sessionId: string, callback: (session: WatchSession) => void): void {
+  commentaryNotifiers.set(sessionId, callback);
+}
+
+export function unregisterWatchCommentaryNotifier(sessionId: string): void {
+  commentaryNotifiers.delete(sessionId);
+}
+
+export function fireWatchCommentaryNotifier(sessionId: string, session: WatchSession): void {
+  commentaryNotifiers.get(sessionId)?.(session);
+}
+
+// ── Completion notifiers ────────────────────────────────────────────
+const completionNotifiers = new Map<string, (session: WatchSession) => void>();
+
+export function registerWatchCompletionNotifier(sessionId: string, callback: (session: WatchSession) => void): void {
+  completionNotifiers.set(sessionId, callback);
+}
+
+export function unregisterWatchCompletionNotifier(sessionId: string): void {
+  completionNotifiers.delete(sessionId);
+}
+
+export function fireWatchCompletionNotifier(sessionId: string, session: WatchSession): void {
+  completionNotifiers.get(sessionId)?.(session);
+}
+
+// ── Session helpers ─────────────────────────────────────────────────
+
+/** Find the first active watch session for a given sessionId. */
+export function getActiveWatchSession(sessionId: string): WatchSession | undefined {
+  for (const session of watchSessions.values()) {
+    if (session.sessionId === sessionId && session.status === 'active') {
+      return session;
+    }
+  }
+  return undefined;
+}
+
+/** Add an observation to a watch session. */
+export function addObservation(watchId: string, observation: WatchObservationEntry): void {
+  const session = watchSessions.get(watchId);
+  if (!session) {
+    log.warn({ watchId }, 'Cannot add observation: session not found');
+    return;
+  }
+  session.observations.push(observation);
+  log.info({ watchId, captureIndex: observation.captureIndex }, 'Observation added');
+}
+
+/** Remove completed/cancelled sessions for a given sessionId. */
+export function pruneWatchSessions(sessionId: string): void {
+  for (const [watchId, session] of watchSessions) {
+    if (session.sessionId !== sessionId) continue;
+    if (session.status === 'completed' || session.status === 'cancelled') {
+      if (session.timeoutHandle) clearTimeout(session.timeoutHandle);
+      watchSessions.delete(watchId);
+    }
+  }
+}


### PR DESCRIPTION
Part of #2618: Watch While I Work

Creates the screen watch tool and state management layer:
- watch-state.ts: Module-level session state with notifier pattern (following pomodoro.ts)
- screen-watch.ts: start_screen_watch tool definition with validation and session creation
- Registers screenWatchTool in tool-manifest.ts explicitTools

Closes #2620
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
