### PR TITLE
M4: Add Swift WatchSession and ChatViewModel integration

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -61,6 +61,10 @@ public final class AmbientAgent: ObservableObject {
     private let rejectionRefreshInterval: TimeInterval = 600
     private let rejectionFailureRetryInterval: TimeInterval = 60
 
+    /// When a WatchSession is active, ambient capture cycles are skipped
+    /// to avoid conflicting screen observations.
+    var activeWatchSession: WatchSession?
+
     weak var appDelegate: AppDelegate?
 
     var knowledge: KnowledgeStore { knowledgeStore }
@@ -176,6 +180,12 @@ public final class AmbientAgent: ObservableObject {
     }
 
     private func runCycle() async {
+        // Skip capture when a WatchSession is active to avoid conflicting observations
+        if activeWatchSession != nil {
+            log.debug("Watch session active — skipping ambient cycle")
+            return
+        }
+
         cycleCount += 1
         let cycle = cycleCount
 

--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -1,0 +1,140 @@
+import Foundation
+import AppKit
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "WatchSession")
+
+@MainActor
+public final class WatchSession: ObservableObject {
+    public enum State { case idle, capturing, complete, cancelled }
+
+    @Published public var state: State = .idle
+    @Published public var captureCount: Int = 0
+    @Published public var totalExpected: Int = 0
+    @Published public var elapsedSeconds: Double = 0
+    @Published public var currentApp: String = ""
+
+    public let watchId: String
+    public let sessionId: String
+    public let durationSeconds: Int
+    public let intervalSeconds: Int
+
+    private var daemonClient: DaemonClient?
+    private var captureTask: Task<Void, Never>?
+    private let screenCapture = ScreenCapture()
+    private let ocr = ScreenOCR()
+    private var previousOcrText: String = ""
+
+    public init(watchId: String, sessionId: String, durationSeconds: Int, intervalSeconds: Int) {
+        self.watchId = watchId
+        self.sessionId = sessionId
+        self.durationSeconds = durationSeconds
+        self.intervalSeconds = intervalSeconds
+    }
+
+    public func start(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        state = .capturing
+        totalExpected = durationSeconds / intervalSeconds
+        log.info("Watch session started: watchId=\(self.watchId) duration=\(self.durationSeconds)s interval=\(self.intervalSeconds)s")
+        captureTask = Task { await captureLoop() }
+    }
+
+    public func stop() {
+        captureTask?.cancel()
+        captureTask = nil
+        state = .cancelled
+        log.info("Watch session stopped: watchId=\(self.watchId)")
+    }
+
+    private func captureLoop() async {
+        let startTime = Date()
+
+        while !Task.isCancelled && elapsedSeconds < Double(durationSeconds) {
+            // Try AX capture first
+            let snapshot = await AmbientAXCapture.capture()
+            var screenContent: String
+            var appName: String
+            var windowTitle: String?
+            var bundleIdentifier: String?
+
+            if let snapshot, AmbientAXCapture.isUseful(snapshot) {
+                screenContent = AmbientAXCapture.format(snapshot)
+                appName = snapshot.focusedAppName
+                windowTitle = snapshot.focusedWindowTitle
+                bundleIdentifier = snapshot.focusedApp
+            } else {
+                // Fall back to screenshot + OCR
+                guard PermissionManager.screenRecordingStatus() == .granted else {
+                    log.debug("Screen recording not permitted - skipping OCR fallback")
+                    try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+                    elapsedSeconds = Date().timeIntervalSince(startTime)
+                    continue
+                }
+
+                let screenshotData: Data
+                do {
+                    screenshotData = try await screenCapture.captureScreen()
+                } catch {
+                    log.warning("Screenshot failed: \(error.localizedDescription)")
+                    try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+                    elapsedSeconds = Date().timeIntervalSince(startTime)
+                    continue
+                }
+                screenContent = await ocr.recognizeText(from: screenshotData)
+                appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "Unknown"
+                windowTitle = NSWorkspace.shared.frontmostApplication?.localizedName
+                bundleIdentifier = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+            }
+
+            currentApp = appName
+
+            // Skip empty content
+            guard !screenContent.isEmpty else {
+                try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+                elapsedSeconds = Date().timeIntervalSince(startTime)
+                continue
+            }
+
+            // Similarity check - skip if >85% similar to previous capture
+            if ScreenOCR.similarity(screenContent, previousOcrText) > 0.85 {
+                log.debug("Screen unchanged (similarity > 0.85) - skipping observation")
+                try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+                elapsedSeconds = Date().timeIntervalSince(startTime)
+                continue
+            }
+            previousOcrText = screenContent
+
+            captureCount += 1
+
+            // Send watch_observation to daemon
+            let observation = WatchObservationMessage(
+                watchId: watchId,
+                sessionId: sessionId,
+                ocrText: screenContent,
+                appName: appName,
+                windowTitle: windowTitle,
+                bundleIdentifier: bundleIdentifier,
+                timestamp: Date().timeIntervalSince1970 * 1000,
+                captureIndex: Double(captureCount),
+                totalExpected: Double(totalExpected)
+            )
+
+            do {
+                try daemonClient?.send(observation)
+                log.info("Sent watch observation \(self.captureCount)/\(self.totalExpected) for \(appName)")
+            } catch {
+                log.warning("Failed to send watch observation: \(error.localizedDescription)")
+            }
+
+            try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+            elapsedSeconds = Date().timeIntervalSince(startTime)
+        }
+
+        if !Task.isCancelled {
+            state = .complete
+            log.info("Watch session complete: watchId=\(self.watchId) captures=\(self.captureCount)")
+        }
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -108,6 +108,7 @@ public final class ChatViewModel: ObservableObject {
     @Published public var isRecording: Bool = false
     @Published public var isWorkspaceRefinementInFlight: Bool = false
     @Published public var pendingSkillInvocation: SkillInvocationData?
+    @Published public var isWatchSessionActive: Bool = false
 
     /// Maximum file size per attachment (20 MB).
     private static let maxFileSize = 20 * 1024 * 1024
@@ -155,6 +156,14 @@ public final class ChatViewModel: ObservableObject {
     /// Called to determine whether this ChatViewModel should accept a `confirmationRequest`.
     /// Set by ThreadManager to coordinate routing when multiple ChatViewModels are active.
     public var shouldAcceptConfirmation: (() -> Bool)?
+
+    /// Called when the daemon sends a `watch_started` message to begin a watch session.
+    /// The closure receives the WatchStartedMessage and the DaemonClient so the macOS
+    /// layer can create and start a WatchSession.
+    public var onWatchStarted: ((WatchStartedMessage, DaemonClient) -> Void)?
+
+    /// Called when the daemon sends a `watch_complete_request` to stop the active watch session.
+    public var onWatchCompleteRequest: ((WatchCompleteRequestMessage) -> Void)?
 
     /// Whether this view model has had its history loaded from the daemon.
     public var isHistoryLoaded: Bool = false
@@ -1034,6 +1043,16 @@ public final class ChatViewModel: ObservableObject {
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
             }
+
+        case .watchStarted(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            isWatchSessionActive = true
+            onWatchStarted?(msg, daemonClient)
+
+        case .watchCompleteRequest(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            isWatchSessionActive = false
+            onWatchCompleteRequest?(msg)
 
         default:
             break


### PR DESCRIPTION
Part of #2618: Watch While I Work

Adds the Swift-side watch session management:
- **WatchSession.swift**: `@MainActor` `ObservableObject` that manages the capture loop (AX tree → screenshot+OCR fallback), similarity filtering, and observation IPC via `WatchObservationMessage`
- **ChatViewModel**: handles `watchStarted`/`watchCompleteRequest` server messages, exposes `isWatchSessionActive` flag and callback hooks (`onWatchStarted`, `onWatchCompleteRequest`) for the macOS layer to wire up `WatchSession` creation/teardown
- **AmbientAgent**: guards against capture during active watch session via `activeWatchSession` property

Closes #2622
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
