### PR TITLE
M3: Add daemon handler and session integration for watch

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -64,6 +64,7 @@ import { addRule, removeRule, updateRule, getAllRules } from '../permissions/tru
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
 import { handleAmbientObservation } from './ambient-handler.js';
+import { handleWatchObservation } from './watch-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp, createApp } from '../memory/app-store.js';
 import { defaultGallery } from '../gallery/default-gallery.js';
@@ -389,7 +390,7 @@ const handlers: DispatchMap = {
   cu_session_abort: handleCuSessionAbort,
   cu_observation: handleCuObservation,
   ambient_observation: handleAmbientObservation,
-  watch_observation: (_msg, _socket, _ctx) => { /* TODO: handle watch observations */ },
+  watch_observation: handleWatchObservation,
   task_submit: handleTaskSubmit,
   app_data_request: handleAppDataRequest,
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -30,6 +30,17 @@ import { classifySessionError, isUserCancellation, buildSessionErrorMessage } fr
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
 import { registerTimerCompletionNotifier, unregisterTimerCompletionNotifier, pruneSessionTimers } from '../tools/timer/pomodoro.js';
+import {
+  registerWatchStartNotifier,
+  unregisterWatchStartNotifier,
+  registerWatchCommentaryNotifier,
+  unregisterWatchCommentaryNotifier,
+  registerWatchCompletionNotifier,
+  unregisterWatchCompletionNotifier,
+  pruneWatchSessions,
+} from '../tools/watch/watch-state.js';
+import type { WatchSession } from '../tools/watch/watch-state.js';
+import { lastCommentaryBySession, lastSummaryBySession } from './watch-handler.js';
 import { createToolDomainEventPublisher } from '../events/tool-domain-event-publisher.js';
 import { registerToolMetricsLoggingListener } from '../events/tool-metrics-listener.js';
 import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
@@ -147,6 +158,49 @@ export class Session {
         durationMinutes: timer.durationMinutes,
       });
     });
+
+    registerWatchStartNotifier(conversationId, (session: WatchSession) => {
+      this.sendToClient({
+        type: 'watch_started',
+        sessionId: conversationId,
+        watchId: session.watchId,
+        durationSeconds: session.durationSeconds,
+        intervalSeconds: session.intervalSeconds,
+      });
+    });
+
+    registerWatchCommentaryNotifier(conversationId, (_session: WatchSession) => {
+      const commentary = lastCommentaryBySession.get(conversationId);
+      if (commentary) {
+        lastCommentaryBySession.delete(conversationId);
+        this.sendToClient({
+          type: 'assistant_text_delta',
+          text: commentary,
+          sessionId: conversationId,
+        });
+        this.sendToClient({
+          type: 'message_complete',
+          sessionId: conversationId,
+        });
+      }
+    });
+
+    registerWatchCompletionNotifier(conversationId, (_session: WatchSession) => {
+      const summary = lastSummaryBySession.get(conversationId);
+      if (summary) {
+        lastSummaryBySession.delete(conversationId);
+        this.sendToClient({
+          type: 'assistant_text_delta',
+          text: summary,
+          sessionId: conversationId,
+        });
+        this.sendToClient({
+          type: 'message_complete',
+          sessionId: conversationId,
+        });
+      }
+    });
+
     this.executor = new ToolExecutor(this.prompter);
     registerToolMetricsLoggingListener(this.eventBus);
     registerToolNotificationListener(this.eventBus, (msg) => this.sendToClient(msg));
@@ -335,6 +389,10 @@ export class Session {
       this.surfaceState.clear();
       unregisterTimerCompletionNotifier(this.conversationId);
       pruneSessionTimers(this.conversationId);
+      unregisterWatchStartNotifier(this.conversationId);
+      unregisterWatchCommentaryNotifier(this.conversationId);
+      unregisterWatchCompletionNotifier(this.conversationId);
+      pruneWatchSessions(this.conversationId);
 
       // Clear queued messages and notify each caller with a session-scoped
       // cancel event so other sessions do not receive cross-thread errors.

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -1,0 +1,146 @@
+import type * as net from 'node:net';
+import Anthropic from '@anthropic-ai/sdk';
+import { getLogger } from '../util/logger.js';
+import type { WatchObservation } from './ipc-protocol.js';
+import type { HandlerContext } from './handlers.js';
+import {
+  watchSessions,
+  addObservation,
+  fireWatchCommentaryNotifier,
+  fireWatchCompletionNotifier,
+} from '../tools/watch/watch-state.js';
+import type { WatchSession, WatchObservationEntry } from '../tools/watch/watch-state.js';
+
+const log = getLogger('watch-handler');
+
+/**
+ * Module-level maps to store commentary/summary text so that session
+ * notifier callbacks can retrieve it from the WatchSession's sessionId.
+ */
+export const lastCommentaryBySession = new Map<string, string>();
+export const lastSummaryBySession = new Map<string, string>();
+
+export async function handleWatchObservation(
+  msg: WatchObservation,
+  _socket: net.Socket,
+  _ctx: HandlerContext,
+): Promise<void> {
+  try {
+    // 1. Find the WatchSession by watchId
+    const session = watchSessions.get(msg.watchId);
+
+    // 2. If not found or not active (and not completing), log warning and return
+    if (!session) {
+      log.warn({ watchId: msg.watchId }, 'Watch session not found for observation');
+      return;
+    }
+    if (session.status !== 'active' && session.status !== 'completing') {
+      log.warn({ watchId: msg.watchId, status: session.status }, 'Watch session not active');
+      return;
+    }
+
+    // 3. Create a WatchObservationEntry and add it
+    const entry: WatchObservationEntry = {
+      ocrText: msg.ocrText,
+      appName: msg.appName,
+      windowTitle: msg.windowTitle,
+      bundleIdentifier: msg.bundleIdentifier,
+      timestamp: msg.timestamp,
+      captureIndex: msg.captureIndex,
+    };
+    addObservation(msg.watchId, entry);
+
+    // 4. Every 3 observations: call Haiku for live commentary
+    if (session.observations.length % 3 === 0) {
+      await generateCommentary(session);
+    }
+
+    // 5. If session is completing, generate final summary
+    if (session.status === 'completing') {
+      await generateSummary(session);
+    }
+  } catch (err) {
+    log.error({ err, watchId: msg.watchId }, 'Error handling watch observation');
+  }
+}
+
+async function generateCommentary(session: WatchSession): Promise<void> {
+  try {
+    const client = new Anthropic();
+    const lastThree = session.observations.slice(-3);
+    const userContent = lastThree
+      .map(
+        (obs, i) =>
+          `Observation ${i + 1}:\n- App: ${obs.appName ?? 'unknown'}\n- Text: ${obs.ocrText}`,
+      )
+      .join('\n\n');
+
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 200,
+      system:
+        'You are observing someone\'s screen. Give a brief 1-2 sentence commentary on what you see, or respond with SKIP if nothing interesting.',
+      messages: [{ role: 'user', content: userContent }],
+    });
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    const commentaryText =
+      textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+
+    if (commentaryText && commentaryText !== 'SKIP') {
+      lastCommentaryBySession.set(session.sessionId, commentaryText);
+      fireWatchCommentaryNotifier(session.sessionId, session);
+      session.commentaryCount++;
+    }
+  } catch (err) {
+    log.error({ err, watchId: session.watchId }, 'Error generating watch commentary');
+  }
+}
+
+async function generateSummary(session: WatchSession): Promise<void> {
+  try {
+    const client = new Anthropic();
+
+    // Build observations text with truncation
+    let observations = session.observations;
+    let totalChars = observations.reduce((sum, obs) => sum + obs.ocrText.length, 0);
+
+    if (totalChars > 50_000) {
+      // Trim older observations, keeping most recent
+      const trimmed: WatchObservationEntry[] = [];
+      let charCount = 0;
+      for (let i = observations.length - 1; i >= 0; i--) {
+        charCount += observations[i].ocrText.length;
+        if (charCount > 50_000) break;
+        trimmed.unshift(observations[i]);
+      }
+      observations = trimmed;
+    }
+
+    const userContent = observations
+      .map(
+        (obs) =>
+          `[${new Date(obs.timestamp).toISOString()}] App: ${obs.appName ?? 'unknown'}\n${obs.ocrText}`,
+      )
+      .join('\n\n---\n\n');
+
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 2000,
+      system: 'Summarize the user\'s workflow based on screen observations.',
+      messages: [{ role: 'user', content: userContent }],
+    });
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    const summaryText =
+      textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+
+    if (summaryText) {
+      lastSummaryBySession.set(session.sessionId, summaryText);
+      fireWatchCompletionNotifier(session.sessionId, session);
+      session.status = 'completed';
+    }
+  } catch (err) {
+    log.error({ err, watchId: session.watchId }, 'Error generating watch summary');
+  }
+}


### PR DESCRIPTION
Part of #2618: Watch While I Work

Adds the daemon-side handler and session wiring:
- **watch-handler.ts**: Handles `watch_observation` messages, calls Haiku for periodic commentary (every 3 observations) and Sonnet for final summary
- **handlers.ts**: Routes `watch_observation` to the handler
- **session.ts**: Registers watch notifiers (start/commentary/completion) and cleanup in abort()

Closes #2621
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
