### PR TITLE
Fix WatchSession OCR fallback to use actual window title

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -84,7 +84,7 @@ public final class WatchSession: ObservableObject {
                 }
                 screenContent = await ocr.recognizeText(from: screenshotData)
                 appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "Unknown"
-                windowTitle = NSWorkspace.shared.frontmostApplication?.localizedName
+                windowTitle = currentWindowTitle()
                 bundleIdentifier = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
             }
 
@@ -136,5 +136,20 @@ public final class WatchSession: ObservableObject {
             state = .complete
             log.info("Watch session complete: watchId=\(self.watchId) captures=\(self.captureCount)")
         }
+    }
+
+    private func currentWindowTitle() -> String? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        let appRef = AXUIElementCreateApplication(app.processIdentifier)
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute as CFString, &value) == .success else {
+            return nil
+        }
+        let window = value as! AXUIElement
+        var titleValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success else {
+            return nil
+        }
+        return titleValue as? String
     }
 }


### PR DESCRIPTION
Addresses feedback on #2627. Uses AX APIs to get real window title instead of app name in OCR fallback path.

## Summary
- Added `currentWindowTitle()` private helper to `WatchSession` that queries `kAXFocusedWindowAttribute` + `kAXTitleAttribute` via Accessibility APIs
- Updated OCR fallback to use `currentWindowTitle()` instead of `NSWorkspace.shared.frontmostApplication?.localizedName` for `windowTitle`

## Test plan
- [x] Verified the code compiles correctly (same pattern as `AmbientAgent.currentWindowTitle()`)
- [ ] Manual test: trigger OCR fallback path and verify window title is correct
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
