### PR TITLE
Fix watch-handler race condition and prompt formatting

### DIFF
--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -57,6 +57,7 @@ export async function handleWatchObservation(
 
     // 5. If session is completing, generate final summary
     if (session.status === 'completing') {
+      session.status = 'completed';
       await generateSummary(session);
     }
   } catch (err) {
@@ -156,12 +157,12 @@ async function generateSummary(session: WatchSession): Promise<void> {
       `Focus area: ${session.focusArea}`,
       `Observation period: ${elapsedMinutes} minute(s) (planned: ${expectedMinutes} minute(s))`,
       `Total observations: ${session.observations.length}`,
-      wasTruncated
-        ? `Note: Older observations were trimmed due to size. Showing the most recent ${observations.length} of ${session.observations.length} total.`
-        : '',
-      wasCancelled
-        ? 'Note: The observation period was ended early by the user. Provide your best analysis based on the data available.'
-        : '',
+      ...(wasTruncated
+        ? [`Note: Older observations were trimmed due to size. Showing the most recent ${observations.length} of ${session.observations.length} total.`]
+        : []),
+      ...(wasCancelled
+        ? ['Note: The observation period was ended early by the user. Provide your best analysis based on the data available.']
+        : []),
       '',
       '--- Observations ---',
       '',
@@ -169,9 +170,7 @@ async function generateSummary(session: WatchSession): Promise<void> {
         (obs) =>
           `[${new Date(obs.timestamp).toISOString()}] App: ${obs.appName ?? 'unknown'} | Window: ${obs.windowTitle ?? 'unknown'}\n${obs.ocrText}`,
       ),
-    ]
-      .filter(Boolean)
-      .join('\n\n');
+    ].join('\n\n');
 
     const systemPrompt = [
       'You are a productivity analyst reviewing a series of screen observations captured from a user\'s computer.',
@@ -199,12 +198,10 @@ async function generateSummary(session: WatchSession): Promise<void> {
       '- Base your analysis strictly on what you can see in the observations. Do not invent details.',
       '- Reference specific apps, window titles, and content when possible.',
       '- Keep the tone helpful and professional, not judgmental.',
-      wasCancelled
-        ? '- The observation period was cut short. Acknowledge this briefly and provide the best analysis you can with the available data.'
-        : '',
-    ]
-      .filter(Boolean)
-      .join('\n');
+      ...(wasCancelled
+        ? ['- The observation period was cut short. Acknowledge this briefly and provide the best analysis you can with the available data.']
+        : []),
+    ].join('\n');
 
     const response = await client.messages.create({
       model: 'claude-sonnet-4-5-20250929',
@@ -220,7 +217,6 @@ async function generateSummary(session: WatchSession): Promise<void> {
     if (summaryText) {
       lastSummaryBySession.set(session.sessionId, summaryText);
       fireWatchCompletionNotifier(session.sessionId, session);
-      session.status = 'completed';
     }
   } catch (err) {
     log.error({ err, watchId: session.watchId }, 'Error generating watch summary');


### PR DESCRIPTION
Addresses feedback on #2628 (race condition in summary generation) and #2629 (filter(Boolean) removing blank separators).

## Changes
- Set `session.status = 'completed'` before `await generateSummary()` to prevent multiple concurrent observations from each triggering summary generation.
- Replace ternary-to-empty-string + `filter(Boolean)` with conditional spread (`...(cond ? ['text'] : [])`) in both `systemPrompt` and `userContent` arrays to preserve intentional blank-line separators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
