### PR TITLE
Fix captureIndex/totalExpected codegen to use Int

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -164,6 +164,8 @@ const INT_PATTERNS = [
   /Calls$/,
   /^sequence$/,
   /[Ll]ength$/,
+  /[Ii]ndex$/,
+  /[Ee]xpected$/,
 ];
 
 function shouldBeInt(propName: string): boolean {

--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -117,8 +117,8 @@ public final class WatchSession: ObservableObject {
                 windowTitle: windowTitle,
                 bundleIdentifier: bundleIdentifier,
                 timestamp: Date().timeIntervalSince1970 * 1000,
-                captureIndex: Double(captureCount),
-                totalExpected: Double(totalExpected)
+                captureIndex: captureCount,
+                totalExpected: totalExpected
             )
 
             do {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -702,6 +702,17 @@ public struct IPCSharedAppsListResponseApp: Codable, Sendable {
     public let updateAvailable: Bool?
 }
 
+public struct IPCShareToSlackRequest: Codable, Sendable {
+    public let type: String
+    public let appId: String
+}
+
+public struct IPCShareToSlackResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let error: String?
+}
+
 public struct IPCSignBundlePayloadRequest: Codable, Sendable {
     public let type: String
     public let payload: String
@@ -875,6 +886,19 @@ public struct IPCSkillsUninstallRequest: Codable, Sendable {
 public struct IPCSkillsUpdateRequest: Codable, Sendable {
     public let type: String
     public let name: String
+}
+
+public struct IPCSlackWebhookConfigRequest: Codable, Sendable {
+    public let type: String
+    public let action: String
+    public let webhookUrl: String?
+}
+
+public struct IPCSlackWebhookConfigResponse: Codable, Sendable {
+    public let type: String
+    public let webhookUrl: String?
+    public let success: Bool
+    public let error: String?
 }
 
 public struct IPCSuggestionRequest: Codable, Sendable {
@@ -1172,8 +1196,8 @@ public struct IPCWatchObservation: Codable, Sendable {
     public let windowTitle: String?
     public let bundleIdentifier: String?
     public let timestamp: Double
-    public let captureIndex: Double
-    public let totalExpected: Double
+    public let captureIndex: Int
+    public let totalExpected: Int
 }
 
 public struct IPCWatchStarted: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -198,7 +198,7 @@ extension IPCAmbientObservation {
 public typealias WatchObservationMessage = IPCWatchObservation
 
 extension IPCWatchObservation {
-    public init(watchId: String, sessionId: String, ocrText: String, appName: String?, windowTitle: String?, bundleIdentifier: String?, timestamp: Double, captureIndex: Double, totalExpected: Double) {
+    public init(watchId: String, sessionId: String, ocrText: String, appName: String?, windowTitle: String?, bundleIdentifier: String?, timestamp: Double, captureIndex: Int, totalExpected: Int) {
         self.init(type: "watch_observation", watchId: watchId, sessionId: sessionId, ocrText: ocrText, appName: appName, windowTitle: windowTitle, bundleIdentifier: bundleIdentifier, timestamp: timestamp, captureIndex: captureIndex, totalExpected: totalExpected)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Index` and `Expected` suffix patterns to `INT_PATTERNS` in `generate-swift.ts` so `captureIndex` and `totalExpected` are generated as `Int` instead of `Double`
- Updates convenience init in `IPCMessages.swift` to match the new `Int` types
- Removes unnecessary `Double()` casts in `WatchSession.swift`

Addresses feedback on #2625.

## Test plan
- [x] `bun run generate:ipc` produces `Int` for `captureIndex` and `totalExpected` in `IPCContractGenerated.swift`
- [x] `bunx tsc --noEmit` passes
- [x] `ipc:check-swift-drift` shows only pre-existing drift (gallery/sharing responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
