### PR TITLE
ci: increase checks job timeout from 5 to 15 minutes

### DIFF
--- a/.github/workflows/ci-assistant.yml
+++ b/.github/workflows/ci-assistant.yml
@@ -12,7 +12,7 @@ jobs:
   checks:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: assistant


### PR DESCRIPTION
## Summary
- Increases the `timeout-minutes` on the CI `checks` job from 5 to 15 minutes
- The 5-minute timeout covered the entire job (checkout, setup, install, IPC checks, type check, lint, and per-file test execution in separate Bun processes), which can legitimately exceed 5 minutes on clean or slower runners
- 15 minutes provides adequate headroom while still preventing indefinite hangs

Addresses review feedback on #2580.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
