### PR TITLE
fix(evaluate-ts): fallback scan for malformed marker lines

### DIFF
--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -210,12 +210,15 @@ export class EvaluateTypescriptTool implements Tool {
         let truncated = false;
 
         // Extract structured result from raw stdout before truncation.
-        // Use lastIndexOf to find the marker directly, so extraction cost
-        // is bounded regardless of output size and works for any result length.
+        // Scan backward from the end for the marker; if the last occurrence
+        // is on a malformed line, keep searching earlier occurrences so a
+        // valid result is not missed due to trailing marker-like log output.
         let result: unknown = undefined;
         if (code === 0) {
-          const markerIdx = stdout.lastIndexOf('__eval_result');
-          if (markerIdx !== -1) {
+          let searchFrom = stdout.length;
+          while (searchFrom > 0) {
+            const markerIdx = stdout.lastIndexOf('__eval_result', searchFrom - 1);
+            if (markerIdx === -1) break;
             const lineStart = stdout.lastIndexOf('\n', markerIdx) + 1;
             const lineEnd = stdout.indexOf('\n', markerIdx);
             const line = stdout.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
@@ -223,10 +226,12 @@ export class EvaluateTypescriptTool implements Tool {
               const parsed = JSON.parse(line);
               if (parsed && typeof parsed === 'object' && '__eval_result' in parsed) {
                 result = parsed.__eval_result;
+                break;
               }
             } catch {
-              // malformed result line
+              // malformed line — continue scanning earlier occurrences
             }
+            searchFrom = lineStart;
           }
         }
 


### PR DESCRIPTION
Addresses review feedback from Codex on PR #2581.

The `lastIndexOf` approach introduced in #2581 only checked the single last occurrence of `__eval_result`. If that line was malformed (e.g., from a trailing async `console.log` containing the marker text), the valid result earlier in stdout was silently missed — a correctness regression from the original backward loop.

This replaces the single-shot extraction with a backward scanning loop that tries each `__eval_result` occurrence from the end until it finds a parseable JSON line with the expected structure. Extraction cost remains bounded (at most a handful of iterations in practice).

**Files changed:** `assistant/src/tools/terminal/evaluate-typescript.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
