### PR TITLE
fix(conflicts): use exact match for question-word prefix rejection

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -609,6 +609,13 @@ describe('looksLikeClarificationReply', () => {
     expect(looksLikeClarificationReply('where is the new config')).toBe(false);
   });
 
+  test('accepts words that share a question-word prefix but are not questions', () => {
+    // "whichever" starts with "which", "however" starts with "how", etc.
+    // These should NOT be rejected by the question-word gate.
+    expect(looksLikeClarificationReply('whichever option')).toBe(true);
+    expect(looksLikeClarificationReply('however you want')).toBe(true);
+  });
+
   test('rejects longer direction-only messages (false-positive prevention)', () => {
     // These contain directional cues but no action verb and are > 4 words,
     // so they are likely unrelated statements, not clarification replies.

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -201,10 +201,12 @@ export function looksLikeClarificationReply(userMessage: string): boolean {
   const normalized = words.map((w) => w.replace(/[^a-z]/g, ''));
 
   // Reject messages that start with a question word (even without '?').
-  // Use startsWith to handle contractions like "what's", "where's", etc.
+  // Match exact question words or contractions (e.g. "what's", "where's"),
+  // but not words that merely share a prefix (e.g. "whichever", "however").
   const firstWord = words[0];
+  const firstNorm = normalized[0];
   for (const qw of QUESTION_WORD_PREFIXES) {
-    if (firstWord.startsWith(qw)) return false;
+    if (firstNorm === qw || (firstWord.startsWith(qw) && firstWord[qw.length] === "'")) return false;
   }
 
   const hasAction = normalized.some((w) => ACTION_CUES.has(w));


### PR DESCRIPTION
## Summary

Addresses review feedback on #2584: the `startsWith` check for question-word prefixes was too broad. Words like "whichever", "however", "whoever", "whereas" were incorrectly rejected because they share a prefix with question words ("which", "how", "who", "where").

**Changes:**
- Question-word gate now uses exact match on the normalized (punctuation-stripped) first word, or allows contractions (apostrophe after the question word, e.g. "what's") but rejects other continuations like "whichever" or "however"
- Added unit tests for "whichever option" and "however you want" — both now correctly pass the gate

## Test plan

- [x] All 17 conflict gate tests pass (including 2 new)
- [x] Type-check clean (`bunx tsc --noEmit`)
- [x] "whichever option" now correctly resolves (was incorrectly rejected)
- [x] "however you want" now correctly resolves (was incorrectly rejected)
- [x] "what's new in Bun" still rejected (contraction of question word)
- [x] "how do I use option A" still rejected (exact question word)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
