### PR TITLE
fix(hooks): restore short-form key qualifiers to prevent false negatives

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -44,7 +44,7 @@ declare -a PATTERNS=(
 
     # Generic secret patterns
     "['\"]?[a-z0-9_]*secret[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][^'\"]{8,}['\"]"
-    "['\"]?[a-z0-9_]*(api|access|private|secret|client|encryption|jwt|signing|auth|hmac|master|symmetric|asymmetric|verification|decryption|service|deploy|registry|webhook|database)[a-z0-9_]*key[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-]{16,}['\"]"
+    "['\"]?[a-z0-9_]*(api|access|private|secret|client|encryption|encrypt|jwt|signing|sign|auth|hmac|master|symmetric|asymmetric|shared|session|verification|verify|decryption|decrypt|service|deploy|registry|webhook|database|db)[a-z0-9_]*key[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-]{16,}['\"]"
 
     # Slack tokens
     "xox[baprs]-[0-9a-zA-Z]{10,}"
@@ -99,9 +99,17 @@ if [ "${1:-}" = "--self-test" ]; then
     SERVICE_KEY_LINE='service_key="svc_key_abcdefghij1234567890"'
     DATABASE_KEY_LINE='database_key="db_secret_key_1234567890abcde"'
 
+    # Short-form qualifiers that the longer forms (encryption, signing, etc.) do NOT cover
+    ENCRYPT_KEY_LINE='encrypt_key="ABCDEFGHIJKLMNOPQRSTUVWX"'
+    SIGN_KEY_LINE='sign_key="ab2c3d4e5f6g7h8i9j0klmnopqrst"'
+    VERIFY_KEY_LINE='verify_key="ab2c3d4e5f6g7h8i9j0klmnopqrst"'
+    DECRYPT_KEY_LINE='decrypt_key="ABCDEFGHIJKLMNOPQRSTUVWX"'
+    DB_KEY_LINE='db_key="db_secret_key_1234567890abcde"'
+    SESSION_KEY_LINE='session_key="session_abcdef123456789012"'
+    SHARED_KEY_LINE='shared_key="shared_abcdef12345678901"'
+
     # False-positive lines that must NOT match (plain identifiers, not secrets)
     SAFE_CACHE_KEY_LINE='redis.get("user_session_key_prefix")'
-    SAFE_SESSION_KEY_LINE='session_key = "user_session_key_prefix"'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -151,12 +159,36 @@ if [ "${1:-}" = "--self-test" ]; then
         echo -e "${RED}Self-test failed:${NC} database_key secret did not match"
         exit 1
     fi
-    if matches_secret_pattern "$SAFE_CACHE_KEY_LINE"; then
-        echo -e "${RED}Self-test failed:${NC} cache key identifier false positive"
+    if ! matches_secret_pattern "$ENCRYPT_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} encrypt_key secret did not match"
         exit 1
     fi
-    if matches_secret_pattern "$SAFE_SESSION_KEY_LINE"; then
-        echo -e "${RED}Self-test failed:${NC} session key assignment false positive"
+    if ! matches_secret_pattern "$SIGN_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} sign_key secret did not match"
+        exit 1
+    fi
+    if ! matches_secret_pattern "$VERIFY_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} verify_key secret did not match"
+        exit 1
+    fi
+    if ! matches_secret_pattern "$DECRYPT_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} decrypt_key secret did not match"
+        exit 1
+    fi
+    if ! matches_secret_pattern "$DB_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} db_key secret did not match"
+        exit 1
+    fi
+    if ! matches_secret_pattern "$SESSION_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} session_key secret did not match"
+        exit 1
+    fi
+    if ! matches_secret_pattern "$SHARED_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} shared_key secret did not match"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_CACHE_KEY_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} cache key identifier false positive"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

Addresses review feedback on #2574: the PR removed short qualifiers (`encrypt`, `sign`, `verify`, `decrypt`, `db`, `session`, `shared`) from the generic key regex assuming they were redundant substrings of the kept longer forms (`encryption`, `signing`, etc.). Both Codex and Devin correctly identified that this reasoning was backwards — in regex alternation, `encryption` does NOT match `encrypt_key`; only `encrypt` does.

**Changes:**
- Restores all 7 removed qualifiers to the generic key regex pattern
- Adds explicit self-tests for each short-form qualifier (`encrypt_key`, `sign_key`, `verify_key`, `decrypt_key`, `db_key`, `session_key`, `shared_key`)
- Removes the `session_key` false-positive assertion — a `session_key` with a 16+ char alphanumeric value should be flagged as a potential secret

## Test plan
- [x] `bash .githooks/pre-commit --self-test` passes
- [x] All existing real-secret test cases still match
- [x] New short-form qualifier tests all pass
- [x] `bunx tsc --noEmit` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
