### PR TITLE
fix: use raw line byte length for IPC metrics instead of re-serializing

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -18,34 +18,50 @@ export function serialize(msg: ClientMessage | ServerMessage): string {
   return JSON.stringify(msg) + '\n';
 }
 
+export interface ParsedMessage<T = ClientMessage | ServerMessage> {
+  msg: T;
+  rawByteLength: number;
+}
+
 export function createMessageParser(options?: { maxLineSize?: number }) {
   let buffer = '';
   const maxLineSize = options?.maxLineSize;
 
+  function parseLines(): Array<ParsedMessage> {
+    const lines = buffer.split('\n');
+    // Keep the last partial line in the buffer
+    buffer = lines.pop() ?? '';
+    const results: Array<ParsedMessage> = [];
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed) {
+        try {
+          results.push({
+            msg: JSON.parse(trimmed),
+            rawByteLength: Buffer.byteLength(trimmed, 'utf8'),
+          });
+        } catch {
+          // Skip malformed messages
+        }
+      }
+    }
+    if (maxLineSize != null && buffer.length > maxLineSize) {
+      buffer = '';
+      throw new Error(
+        `IPC message exceeds maximum line size of ${maxLineSize} bytes. Message discarded.`,
+      );
+    }
+    return results;
+  }
+
   return {
     feed(data: string): Array<ClientMessage | ServerMessage> {
       buffer += data;
-      const messages: Array<ClientMessage | ServerMessage> = [];
-      const lines = buffer.split('\n');
-      // Keep the last partial line in the buffer
-      buffer = lines.pop() ?? '';
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (trimmed) {
-          try {
-            messages.push(JSON.parse(trimmed));
-          } catch {
-            // Skip malformed messages
-          }
-        }
-      }
-      if (maxLineSize != null && buffer.length > maxLineSize) {
-        buffer = '';
-        throw new Error(
-          `IPC message exceeds maximum line size of ${maxLineSize} bytes. Message discarded.`,
-        );
-      }
-      return messages;
+      return parseLines().map((r) => r.msg);
+    },
+    feedRaw(data: string): Array<ParsedMessage> {
+      buffer += data;
+      return parseLines();
     },
   };
 }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -407,9 +407,9 @@ export class DaemonServer {
     socket.on('data', (data) => {
       const chunkReceivedAtMs = Date.now();
       const parseStartNs = process.hrtime.bigint();
-      let messages;
+      let parsed;
       try {
-        messages = parser.feed(data.toString());
+        parsed = parser.feedRaw(data.toString());
       } catch (err) {
         log.error({ err }, 'IPC parse error (malformed JSON or message exceeded size limit), dropping client');
         socket.write(serialize({ type: 'error', message: `IPC parse error: ${(err as Error).message}` }));
@@ -418,7 +418,7 @@ export class DaemonServer {
       }
       const parsedAtMs = Date.now();
       const parseDurationMs = Number(process.hrtime.bigint() - parseStartNs) / 1_000_000;
-      for (const msg of messages) {
+      for (const { msg, rawByteLength } of parsed) {
         if (typeof msg === 'object' && msg !== null && (msg as { type?: unknown }).type === 'cu_observation') {
           const maybeSessionId = (msg as { sessionId?: unknown }).sessionId;
           const sessionId = typeof maybeSessionId === 'string' ? maybeSessionId : 'unknown';
@@ -431,7 +431,7 @@ export class DaemonServer {
             chunkReceivedAtMs,
             parsedAtMs,
             parseDurationMs,
-            messageBytes: Buffer.byteLength(JSON.stringify(msg), 'utf8'),
+            messageBytes: rawByteLength,
           }, 'IPC_METRIC cu_observation_parse');
         }
         const result = validateClientMessage(msg);


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on PR #2576: the `messageBytes` metric was calling `JSON.stringify(msg)` on every parsed `cu_observation`, adding a redundant full serialization pass on the socket hot path. This is wasteful for multi-megabyte payloads (inline screenshots).

**Changes:**
- Added `feedRaw()` method to `createMessageParser` that returns `{ msg, rawByteLength }` tuples, computing `Buffer.byteLength` on the raw trimmed line during parsing
- Updated `server.ts` to use `feedRaw()` and surface the pre-computed `rawByteLength` in the `IPC_METRIC` log instead of re-encoding via `JSON.stringify(msg)`
- Existing `feed()` method is unchanged for backward compatibility

**Files modified:**
- `assistant/src/daemon/ipc-protocol.ts`
- `assistant/src/daemon/server.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
