### PR TITLE
fix: restrict frontmatter unescaping to double-quoted values

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -169,6 +169,25 @@ describe('buildSkillMarkdown', () => {
     expect(skill).toBeDefined();
     expect(skill!.name).toBe('path\\name');
   });
+
+  test('single-quoted frontmatter preserves backslashes literally', () => {
+    // Single-quoted YAML values treat backslashes as literal characters.
+    // Manually write a SKILL.md with single-quoted frontmatter to simulate
+    // a hand-authored skill file.
+    const skillDir = join(TEST_DIR, 'skills', 'single-quote-test');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      "---\nname: 'path\\\\name'\ndescription: 'has \\n in it'\n---\n\nBody.\n",
+    );
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, 'skills')]);
+    const skill = catalog.find((s) => s.id === 'single-quote-test');
+    expect(skill).toBeDefined();
+    // Backslashes should be preserved literally, not interpreted as escape sequences
+    expect(skill!.name).toBe('path\\\\name');
+    expect(skill!.description).toBe('has \\n in it');
+  });
 });
 
 describe('SKILLS.md index management', () => {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -188,18 +188,20 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
 
     const key = trimmed.slice(0, separatorIndex).trim();
     let value = trimmed.slice(separatorIndex + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith('\'') && value.endsWith('\''))
-    ) {
+    const isDoubleQuoted = value.startsWith('"') && value.endsWith('"');
+    const isSingleQuoted = value.startsWith('\'') && value.endsWith('\'');
+    if (isDoubleQuoted || isSingleQuoted) {
       value = value.slice(1, -1);
-      // Unescape sequences produced by buildSkillMarkdown's esc().
-      // Single-pass to avoid misinterpreting \\n (escaped backslash + n) as a newline.
-      value = value.replace(/\\(["\\nr])/g, (_, ch) => {
-        if (ch === 'n') return '\n';
-        if (ch === 'r') return '\r';
-        return ch; // handles \\ → \ and \" → "
-      });
+      if (isDoubleQuoted) {
+        // Unescape sequences produced by buildSkillMarkdown's esc().
+        // Only for double-quoted values — single-quoted YAML treats backslashes literally.
+        // Single-pass to avoid misinterpreting \\n (escaped backslash + n) as a newline.
+        value = value.replace(/\\(["\\nr])/g, (_, ch) => {
+          if (ch === 'n') return '\n';
+          if (ch === 'r') return '\r';
+          return ch; // handles \\ → \ and \" → "
+        });
+      }
     }
     fields[key] = value;
   }


### PR DESCRIPTION
## Summary
- Restricts the frontmatter unescape logic in `parseFrontmatter` to only apply to double-quoted values, not single-quoted ones
- Single-quoted YAML values treat backslashes literally, so unescaping them would silently corrupt data (e.g. `\n` becoming a newline)
- Adds a test verifying single-quoted frontmatter preserves backslashes as-is

## Context
Addresses review feedback from Codex on PR #2572, which identified that the unescape pass incorrectly ran for both double- and single-quoted values.

## Test plan
- [x] All 39 managed-store tests pass (including new single-quote test)
- [x] TypeScript type-check passes
- [x] Existing round-trip tests still pass (they use double-quoted values via buildSkillMarkdown)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
