### PR TITLE
Fix wasCancelled detection after race condition fix

### DIFF
--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -151,7 +151,7 @@ async function generateSummary(session: WatchSession): Promise<void> {
       (Date.now() - session.startedAt) / 60_000,
     );
     const expectedMinutes = Math.round(session.durationSeconds / 60);
-    const wasCancelled = session.status === 'completing' && elapsedMinutes < expectedMinutes - 1;
+    const wasCancelled = elapsedMinutes < expectedMinutes - 1;
 
     const userContent = [
       `Focus area: ${session.focusArea}`,


### PR DESCRIPTION
Addresses feedback on #2632. The race condition fix set `session.status = 'completed'` before calling `generateSummary`, which broke the `wasCancelled` check (it compared against `'completing'`, now always false). Since `generateSummary` is only called from the `completing` block, simplify to check elapsed time directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
