### PR TITLE
fix(codegen): skip generic type defs that produce invalid Swift names

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -125,7 +125,10 @@ function generateSchemas(): Record<string, SchemaDef> {
   for (const schema of Object.values(result)) {
     if (!schema.definitions) continue;
     for (const [defName, defSchema] of Object.entries(schema.definitions)) {
-      if (!result[defName] && !SKIP_TYPES.has(defName)) {
+      // Skip generic type references (e.g. Partial<CardSurfaceData>, Record<string,unknown>)
+      // — these produce invalid Swift struct names and are already handled as
+      // [String: AnyCodable] in schemaToSwiftType via the startsWith checks.
+      if (!result[defName] && !SKIP_TYPES.has(defName) && !defName.includes('<')) {
         result[defName] = defSchema;
       }
     }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -583,63 +583,6 @@ public struct IPCOpenBundleResponseSignatureResult: Codable, Sendable {
     public let signerAccount: String?
 }
 
-public struct IPCPartial<CardSurfaceData>: Codable, Sendable {
-    public let title: String?
-    public let subtitle: String?
-    public let body: String?
-    public let metadata: [IPCPartial<CardSurfaceData>Metadata]?
-    /// Optional template name for specialized rendering (e.g. "weather_forecast").
-    public let template: String?
-    /// Arbitrary data consumed by the template renderer. Shape depends on template.
-    public let templateData: [String: AnyCodable]?
-}
-
-public struct IPCPartial<CardSurfaceData>Metadata: Codable, Sendable {
-    public let label: String
-    public let value: String
-}
-
-public struct IPCPartial<ConfirmationSurfaceData>: Codable, Sendable {
-    public let message: String?
-    public let detail: String?
-    public let confirmLabel: String?
-    public let cancelLabel: String?
-    public let destructive: Bool?
-}
-
-public struct IPCPartial<DynamicPageSurfaceData>: Codable, Sendable {
-    public let html: String?
-    public let width: Int?
-    public let height: Int?
-    public let appId: String?
-    public let preview: IPCDynamicPagePreview?
-}
-
-public struct IPCPartial<FileUploadSurfaceData>: Codable, Sendable {
-    public let prompt: String?
-    public let acceptedTypes: [String]?
-    public let maxFiles: Int?
-    public let maxSizeBytes: Int?
-}
-
-public struct IPCPartial<FormSurfaceData>: Codable, Sendable {
-    public let description: String?
-    public let fields: [IPCFormField]?
-    public let submitLabel: String?
-}
-
-public struct IPCPartial<ListSurfaceData>: Codable, Sendable {
-    public let items: [IPCListItem]?
-    public let selectionMode: String?
-}
-
-public struct IPCPartial<TableSurfaceData>: Codable, Sendable {
-    public let columns: [IPCTableColumn]?
-    public let rows: [IPCTableRow]?
-    public let selectionMode: String?
-    public let caption: String?
-}
-
 public struct IPCPingMessage: Codable, Sendable {
     public let type: String
 }


### PR DESCRIPTION
## Summary
- The nested schema extraction added in #2645 was pulling in `Partial<...>` type definitions, producing struct names like `IPCPartial<CardSurfaceData>` which are invalid Swift identifiers and break compilation
- Added a check to skip definition names containing `<` during extraction — these generic types are already handled as `[String: AnyCodable]` in property resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
