### PR TITLE
fix(conflicts): handle Unicode smart apostrophes in question-word gate

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -609,6 +609,14 @@ describe('looksLikeClarificationReply', () => {
     expect(looksLikeClarificationReply('where is the new config')).toBe(false);
   });
 
+  test('rejects questions with Unicode smart/curly apostrophes', () => {
+    // U+2019 RIGHT SINGLE QUOTATION MARK (common on macOS/iOS keyboards)
+    expect(looksLikeClarificationReply("what\u2019s new in Bun")).toBe(false);
+    expect(looksLikeClarificationReply("where\u2019s the new config")).toBe(false);
+    // U+2018 LEFT SINGLE QUOTATION MARK
+    expect(looksLikeClarificationReply("who\u2018s option")).toBe(false);
+  });
+
   test('accepts words that share a question-word prefix but are not questions', () => {
     // "whichever" starts with "which", "however" starts with "how", etc.
     // These should NOT be rejected by the question-word gate.

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -206,7 +206,7 @@ export function looksLikeClarificationReply(userMessage: string): boolean {
   const firstWord = words[0];
   const firstNorm = normalized[0];
   for (const qw of QUESTION_WORD_PREFIXES) {
-    if (firstNorm === qw || (firstWord.startsWith(qw) && firstWord[qw.length] === "'")) return false;
+    if (firstNorm === qw || (firstWord.startsWith(qw) && "'\u2018\u2019".includes(firstWord[qw.length]))) return false;
   }
 
   const hasAction = normalized.some((w) => ACTION_CUES.has(w));


### PR DESCRIPTION
Addresses review feedback from PR #2637.

The contraction check in `looksLikeClarificationReply()` only matched ASCII apostrophe (`U+0027`), so inputs with curly/smart quotes like `"what's new in Bun"` (common on macOS/iOS keyboards) bypassed the question-word gate and could be misclassified as clarification replies, triggering unintended conflict resolution.

Now also matches `U+2018` (LEFT SINGLE QUOTATION MARK) and `U+2019` (RIGHT SINGLE QUOTATION MARK).

**Changes:**
- `session-conflict-gate.ts`: Updated apostrophe check to include Unicode smart quotes
- `session-conflict-gate.test.ts`: Added 3 test cases for Unicode apostrophe rejection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
