### PR TITLE
fix: compute IPC byte length lazily for cu_observation only

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -20,7 +20,12 @@ export function serialize(msg: ClientMessage | ServerMessage): string {
 
 export interface ParsedMessage<T = ClientMessage | ServerMessage> {
   msg: T;
-  rawByteLength: number;
+  /** Raw trimmed line; use rawByteLength() to get UTF-8 byte count on demand. */
+  rawLine: string;
+}
+
+export function rawByteLength(pm: ParsedMessage): number {
+  return Buffer.byteLength(pm.rawLine, 'utf8');
 }
 
 export function createMessageParser(options?: { maxLineSize?: number }) {
@@ -38,7 +43,7 @@ export function createMessageParser(options?: { maxLineSize?: number }) {
         try {
           results.push({
             msg: JSON.parse(trimmed),
-            rawByteLength: Buffer.byteLength(trimmed, 'utf8'),
+            rawLine: trimmed,
           });
         } catch {
           // Skip malformed messages

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -16,6 +16,7 @@ import { ComputerUseSession } from './computer-use-session.js';
 import {
   serialize,
   createMessageParser,
+  rawByteLength,
   MAX_LINE_SIZE,
   type ClientMessage,
   type ServerMessage,
@@ -418,7 +419,8 @@ export class DaemonServer {
       }
       const parsedAtMs = Date.now();
       const parseDurationMs = Number(process.hrtime.bigint() - parseStartNs) / 1_000_000;
-      for (const { msg, rawByteLength } of parsed) {
+      for (const entry of parsed) {
+        const msg = entry.msg;
         if (typeof msg === 'object' && msg !== null && (msg as { type?: unknown }).type === 'cu_observation') {
           const maybeSessionId = (msg as { sessionId?: unknown }).sessionId;
           const sessionId = typeof maybeSessionId === 'string' ? maybeSessionId : 'unknown';
@@ -431,7 +433,7 @@ export class DaemonServer {
             chunkReceivedAtMs,
             parsedAtMs,
             parseDurationMs,
-            messageBytes: rawByteLength,
+            messageBytes: rawByteLength(entry),
           }, 'IPC_METRIC cu_observation_parse');
         }
         const result = validateClientMessage(msg);


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on PR #2639: `Buffer.byteLength()` was being called eagerly for every parsed IPC message in `parseLines()`, but it's only needed for `cu_observation` metrics logging. This added an unnecessary full-string scan on large non-`cu_observation` payloads (e.g. `user_message` with inline attachments), partially reintroducing the hot-path overhead #2639 was meant to remove.

**Changes:**
- Replaced the eagerly-computed `rawByteLength: number` field on `ParsedMessage` with a `rawLine: string` reference
- Added an exported `rawByteLength(pm)` helper that computes `Buffer.byteLength` on demand
- `server.ts` now only calls `rawByteLength()` inside the `cu_observation` branch

**Files modified:**
- `assistant/src/daemon/ipc-protocol.ts`
- `assistant/src/daemon/server.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
