### PR TITLE
fix(ipc): avoid retaining raw line string on non-metric messages

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -20,12 +20,8 @@ export function serialize(msg: ClientMessage | ServerMessage): string {
 
 export interface ParsedMessage<T = ClientMessage | ServerMessage> {
   msg: T;
-  /** Raw trimmed line; use rawByteLength() to get UTF-8 byte count on demand. */
-  rawLine: string;
-}
-
-export function rawByteLength(pm: ParsedMessage): number {
-  return Buffer.byteLength(pm.rawLine, 'utf8');
+  /** UTF-8 byte length of the raw line, populated only for cu_observation messages. */
+  rawByteLength?: number;
 }
 
 export function createMessageParser(options?: { maxLineSize?: number }) {
@@ -41,10 +37,12 @@ export function createMessageParser(options?: { maxLineSize?: number }) {
       const trimmed = line.trim();
       if (trimmed) {
         try {
-          results.push({
-            msg: JSON.parse(trimmed),
-            rawLine: trimmed,
-          });
+          const msg = JSON.parse(trimmed);
+          const entry: ParsedMessage = { msg };
+          if (typeof msg === 'object' && msg !== null && msg.type === 'cu_observation') {
+            entry.rawByteLength = Buffer.byteLength(trimmed, 'utf8');
+          }
+          results.push(entry);
         } catch {
           // Skip malformed messages
         }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -16,7 +16,6 @@ import { ComputerUseSession } from './computer-use-session.js';
 import {
   serialize,
   createMessageParser,
-  rawByteLength,
   MAX_LINE_SIZE,
   type ClientMessage,
   type ServerMessage,
@@ -433,7 +432,7 @@ export class DaemonServer {
             chunkReceivedAtMs,
             parsedAtMs,
             parseDurationMs,
-            messageBytes: rawByteLength(entry),
+            messageBytes: entry.rawByteLength,
           }, 'IPC_METRIC cu_observation_parse');
         }
         const result = validateClientMessage(msg);


### PR DESCRIPTION
Addresses review feedback on #2650. ParsedMessage no longer stores rawLine on every message — byte length is computed eagerly but only for cu_observation messages, preventing unnecessary heap retention of large JSON payloads.

### Changes

- **`ipc-protocol.ts`**: Replaced `rawLine: string` with `rawByteLength?: number` on `ParsedMessage`. Moved byte-length computation into `parseLines()`, gated on `msg.type === 'cu_observation'`. Removed the standalone `rawByteLength()` function.
- **`server.ts`**: Reads `entry.rawByteLength` directly instead of calling the removed function. Removed the `rawByteLength` import.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
