### PR TITLE
fix: filter empty text blocks & update stale Haiku model ID

### DIFF
--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -191,7 +191,7 @@ async function classifyRelationship(
 
   const response = await Promise.race([
     client.messages.create({
-      model: 'claude-haiku-4-20250414',
+      model: 'claude-haiku-4-5-20251001',
       max_tokens: 256,
       system: CONTRADICTION_SYSTEM_PROMPT,
       tools: [{

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -32,7 +32,9 @@ export class AnthropicProvider implements Provider {
         max_tokens: 64000,
         messages: messages.map((m) => ({
           role: m.role,
-          content: m.content.map((block) => this.toAnthropicBlock(block)),
+          content: m.content
+            .map((block) => this.toAnthropicBlock(block))
+            .filter((block) => !(block.type === 'text' && !(block as { text?: string }).text?.trim())),
         })),
         ...config,
       };


### PR DESCRIPTION
## Summary
- Filter empty text content blocks before sending to the Anthropic API, preventing 400 errors from persisted conversation history
- Update contradiction checker model ID from non-existent `claude-haiku-4-20250414` to `claude-haiku-4-5-20251001`

## Test plan
- [x] TypeScript type-check passes
- [x] Existing tests pass (no regressions)
- [x] Haiku model ID matches all other references in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
