### PR TITLE
fix: drop messages with empty content arrays after block stripping

### DIFF
--- a/assistant/src/daemon/session-dynamic-profile.ts
+++ b/assistant/src/daemon/session-dynamic-profile.ts
@@ -50,6 +50,11 @@ export function stripDynamicProfileMessages(messages: Message[], profileText: st
     return stripped.length > 0 ? { ...block, text: stripped } : null;
   }).filter((block): block is NonNullable<typeof block> => block !== null);
   if (!changed) return messages;
+  // If stripping removed all content blocks, drop the message entirely
+  // to avoid sending an empty content array to the provider.
+  if (nextContent.length === 0) {
+    return [...messages.slice(0, lastUserIdx), ...messages.slice(lastUserIdx + 1)];
+  }
   return [
     ...messages.slice(0, lastUserIdx),
     { ...message, content: nextContent },

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -71,8 +71,9 @@ export function stripActiveSurfaceContext(messages: Message[]): Message[] {
       return !block.text.startsWith('<active_dynamic_page>');
     });
     if (nextContent.length === message.content.length) return message;
+    if (nextContent.length === 0) return null;
     return { ...message, content: nextContent };
-  });
+  }).filter((message): message is NonNullable<typeof message> => message !== null);
 }
 
 /**

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -35,7 +35,7 @@ export class AnthropicProvider implements Provider {
           content: m.content
             .map((block) => this.toAnthropicBlock(block))
             .filter((block) => !(block.type === 'text' && !(block as { text?: string }).text?.trim())),
-        })),
+        })).filter((m) => m.content.length > 0),
         ...config,
       };
 


### PR DESCRIPTION
## Summary
- `stripDynamicProfileMessages` and `stripActiveSurfaceContext` can remove all content blocks from a message, producing `content: []` which the Anthropic API rejects with a 400 error ("text content blocks must be non-empty")
- Both stripping functions now drop messages that end up with zero content blocks
- Added a safety filter in the Anthropic provider to also drop messages with empty content arrays as a last line of defense

## Test plan
- [x] TypeScript type-check passes
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
