### PR TITLE
fix(composer): restore focus and cursor after Shift-Enter newline

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -204,8 +204,23 @@ struct ComposerView: View {
         }
         .onKeyPress(.return, phases: .down) { keyPress in
             if keyPress.modifiers == .shift {
-                if let textView = NSApp.keyWindow?.firstResponder as? NSTextView {
+                if let textView = NSApp.keyWindow?.firstResponder as? NSTextView,
+                   let window = NSApp.keyWindow {
                     textView.insertNewlineIgnoringFieldEditor(nil)
+                    // Restore focus at the AppKit level if SwiftUI's re-render
+                    // resigns first responder. Using makeFirstResponder instead
+                    // of @FocusState avoids the select-all that SwiftUI applies
+                    // when re-focusing a TextField.
+                    let savedRange = textView.selectedRange()
+                    DispatchQueue.main.async {
+                        if !(window.firstResponder is NSTextView) {
+                            window.makeFirstResponder(textView)
+                        }
+                        if let tv = window.firstResponder as? NSTextView,
+                           tv.selectedRange() != savedRange {
+                            tv.setSelectedRange(savedRange)
+                        }
+                    }
                 } else {
                     inputText += "\n"
                 }


### PR DESCRIPTION
## Summary
- Fix Shift-Enter in the composer losing focus or selecting all text after inserting a newline
- SwiftUI's re-render can resign first responder after `insertNewlineIgnoringFieldEditor`; save and restore both first responder and cursor position on the next run loop tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
