### PR TITLE
fix: restore previous threads on app reload by default

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -8,7 +8,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 @MainActor
 final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
-    @AppStorage("restoreRecentThreads") private(set) var restoreRecentThreads = false
+    @AppStorage("restoreRecentThreads") private(set) var restoreRecentThreads = true
     @Published var threads: [ThreadModel] = []
     @Published var activeThreadId: UUID? {
         didSet {


### PR DESCRIPTION
## Summary
- The `restoreRecentThreads` AppStorage setting defaulted to `false`, so previous threads were never loaded from the daemon when the desktop app started up
- Flipped the default to `true` so the 5 most recent conversations automatically appear in the tab bar on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
