### PR TITLE
fix(composer): handle text selection and stale refocus on Shift+Enter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -211,23 +211,36 @@ struct ComposerView: View {
         }
         .onKeyPress(.return, phases: .down) { keyPress in
             if keyPress.modifiers == .shift {
-                let cursorLoc: Int
+                let cursorRange: NSRange
                 if let textView = NSApp.keyWindow?.firstResponder as? NSTextView {
-                    cursorLoc = textView.selectedRange().location
+                    cursorRange = textView.selectedRange()
                 } else {
-                    cursorLoc = (inputText as NSString).length
+                    let len = (inputText as NSString).length
+                    cursorRange = NSRange(location: len, length: 0)
                 }
                 // Insert through the binding so SwiftUI stays in sync.
+                // Use the full selection range so that selected text is
+                // replaced by the newline instead of inserting alongside it.
                 let ns = inputText as NSString
-                let loc = min(cursorLoc, ns.length)
+                let loc = min(cursorRange.location, ns.length)
+                let selLen = min(cursorRange.length, ns.length - loc)
                 inputText = ns.replacingCharacters(
-                    in: NSRange(location: loc, length: 0),
+                    in: NSRange(location: loc, length: selLen),
                     with: "\n"
                 ) as String
                 // If the text mutation causes a focus loss, the onChange
                 // handler will re-focus and place the cursor here.
                 shouldRefocus = true
                 pendingCursorPosition = loc + 1
+                // Clear the flag on the next run-loop tick if focus was
+                // never actually lost, preventing a stale refocus request
+                // from stealing first responder later.
+                DispatchQueue.main.async {
+                    if isComposerFocused {
+                        shouldRefocus = false
+                        pendingCursorPosition = nil
+                    }
+                }
                 return .handled
             }
             guard keyPress.modifiers.isEmpty else { return .ignored }


### PR DESCRIPTION
## Summary
- **Shift+Enter now correctly replaces selected text** with a newline instead of inserting at the cursor position with `length: 0`. The full `selectedRange()` (both location and length) is captured and used in `replacingCharacters(in:with:)`.
- **Stale `shouldRefocus` flag is cleared** on the next run-loop tick if focus was never actually lost. This prevents the flag from stealing first responder when the user clicks another control (e.g. a side-panel input).

Follow-up to #2658, addressing review feedback from Codex and Devin.

## Test plan
- [ ] Select text in the composer, press Shift+Enter — selected text should be replaced with a newline
- [ ] Press Shift+Enter without a selection — newline should be inserted at cursor position as before
- [ ] After pressing Shift+Enter, click on a side-panel input — focus should NOT be stolen back to the composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
