### PR TITLE
refactor(widgets): extract InlineWidgetCard modifier for consistent card chrome

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// Standard card chrome for inline chat widgets.
+/// Applies consistent padding, background, border, corner radius, and shadow
+/// so all widget types (card, dynamic page, table, list) share the same visual treatment.
+public struct InlineWidgetCardModifier: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .padding(VSpacing.lg)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(VColor.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
+            )
+            .vShadow(VShadow.sm)
+    }
+}
+
+public extension View {
+    func inlineWidgetCard() -> some View {
+        modifier(InlineWidgetCardModifier())
+    }
+}
+
+#if DEBUG
+#Preview("InlineWidgetCard") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: VSpacing.lg) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Widget Title")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Some body content for the widget card.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .inlineWidgetCard()
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Another Widget")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Both cards share the same chrome.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .inlineWidgetCard()
+        }
+        .padding()
+    }
+    .frame(width: 450, height: 300)
+}
+#endif

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -43,15 +43,7 @@ public struct InlineSurfaceRouter: View {
                 actionButtons
             }
         }
-        .padding(VSpacing.lg)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.surface)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
-        )
+        .inlineWidgetCard()
         .overlay(alignment: .topTrailing) {
             if isDynamicPreview {
                 Button {
@@ -76,7 +68,6 @@ public struct InlineSurfaceRouter: View {
                 .padding(VSpacing.sm)
             }
         }
-        .vShadow(VShadow.sm)
         // Dynamic page previews should be compact, not stretch to fill.
         // Use maxWidth instead of fixedSize so narrow parent views still constrain the card.
         .frame(maxWidth: isDynamicPreview ? 350 : .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Extracts shared card styling (padding, background, border, radius, shadow) from `InlineSurfaceRouter` into a new reusable `.inlineWidgetCard()` view modifier in `DesignSystem/Modifiers/`
- Refactors `InlineSurfaceRouter` to use the new modifier, reducing inline styling duplication
- Creates a single source of truth for inline widget card chrome so all widget types (card, dynamic page, table, list) share consistent visual treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
