### PR TITLE
feat: improve window sizing and add post-onboarding greeting

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -826,6 +826,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.setupAutoUpdate()
 
             self?.showMainWindow()
+
+            // Send an automatic greeting after onboarding completes
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                if let viewModel = self?.mainWindow?.activeViewModel {
+                    viewModel.inputText = "Wake up, my friend"
+                    viewModel.sendMessage()
+                }
+            }
         }
         onboarding.show()
         onboardingWindow = onboarding

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -83,9 +83,17 @@ final class MainWindow {
         let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let windowWidth = min(screenFrame.width * 0.8, 1200)
+        let windowHeight = min(screenFrame.height * 0.85, 900)
+        let windowRect = NSRect(
+            x: screenFrame.midX - windowWidth / 2,
+            y: screenFrame.midY - windowHeight / 2,
+            width: windowWidth,
+            height: windowHeight
+        )
 
         let window = NSWindow(
-            contentRect: screenFrame,
+            contentRect: windowRect,
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -97,7 +105,7 @@ final class MainWindow {
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
-        window.setFrame(screenFrame, display: false)
+        window.setFrame(windowRect, display: false)
 
         configureTrafficLightPadding(window)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -55,15 +55,14 @@ final class OnboardingWindow {
 
         window.contentMinSize = NSSize(width: 800, height: 600)
 
+        let startWidth: CGFloat = 800
+        let startHeight: CGFloat = 680
         if let visibleFrame = Self.visibleScreenFrame() {
-            // Start at minimum width, full height — centered on screen
-            let startWidth = window.contentMinSize.width
-            let startHeight = visibleFrame.height
             let x = visibleFrame.midX - startWidth / 2
-            let y = visibleFrame.origin.y
+            let y = visibleFrame.midY - startHeight / 2
             window.setFrame(NSRect(x: x, y: y, width: startWidth, height: startHeight), display: true)
         } else {
-            window.setContentSize(window.contentMinSize)
+            window.setContentSize(NSSize(width: startWidth, height: startHeight))
             window.center()
         }
 


### PR DESCRIPTION
## Summary
- Onboarding window is now 800x680 and centered on screen instead of stretching full height
- Main chat window opens at ~80% of screen size (max 1200x900), centered, instead of filling the entire screen
- After onboarding completes, automatically sends "Wake up, my friend" to kick off the first conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
