### PR TITLE
fix(ui): remove Dynamic panel button and side drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -64,9 +64,6 @@ struct MainWindowView: View {
 
                                 // Panel toggle buttons
                                 HStack(spacing: VSpacing.sm) {
-                                    VIconButton(label: "Dynamic", icon: "wand.and.stars", isActive: windowState.activePanel == .generated, iconOnly: true) {
-                                        windowState.togglePanel(.generated)
-                                    }
                                     VIconButton(label: "Skills", icon: "exclamationmark.triangle", isActive: windowState.activePanel == .agent, iconOnly: true) {
                                         windowState.togglePanel(.agent)
                                     }
@@ -583,7 +580,7 @@ struct MainWindowView: View {
         if let panel = windowState.activePanel {
             switch panel {
             case .generated:
-                GeneratedPanel(onClose: { showSharePicker = false; windowState.closeDynamicPanel() }, isExpanded: $windowState.isDynamicExpanded, daemonClient: daemonClient)
+                EmptyView()
             case .agent:
                 AgentPanel(onClose: { windowState.activePanel = nil }, onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -10,9 +10,6 @@ struct NavigationToolbar: View {
                 Spacer()
 
                 // Right group — labeled buttons
-                VIconButton(label: "Dynamic", icon: "wand.and.stars", isActive: activePanel == .generated) {
-                    togglePanel(.generated)
-                }
                 VIconButton(label: "Agent", icon: "exclamationmark.triangle", isActive: activePanel == .agent) {
                     togglePanel(.agent)
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -42,9 +42,6 @@ struct ThreadTabBar: View {
 
                 // Panel toggle buttons
                 HStack(spacing: VSpacing.sm) {
-                    VIconButton(label: "Dynamic", icon: "wand.and.stars", isActive: activePanel == .generated) {
-                        togglePanel(.generated)
-                    }
                     VIconButton(label: "Skills", icon: "exclamationmark.triangle", isActive: activePanel == .agent) {
                         togglePanel(.agent)
                     }


### PR DESCRIPTION
## Summary
- Removed the "Dynamic" toolbar button from all three toolbar locations (drawer mode, tab bar, and NavigationToolbar)
- Replaced the `.generated` panel content with `EmptyView()` so dynamic workspaces opened from inline chat previews still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
