### PR TITLE
feat(weather): add °F/°C toggle to HTML weather page

### DIFF
--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -142,34 +142,67 @@ interface WeatherPageInput {
   speedUnit: string;
   todayHigh: number;
   todayLow: number;
-  hourly: Array<{ time: string; temp: number; code: number }>;
-  forecast: Array<{ day: string; low: number; high: number; precip: number | null; code: number }>;
+  hourly: Array<{ time: string; temp: number; tempAlt: number; code: number }>;
+  forecast: Array<{ day: string; low: number; high: number; lowAlt: number; highAlt: number; precip: number | null; code: number }>;
+  // Alternate-unit values for the °F/°C toggle
+  unitAlt: string;
+  speedUnitAlt: string;
+  currentTempAlt: number;
+  feelsLikeAlt: number;
+  todayHighAlt: number;
+  todayLowAlt: number;
+  windSpeedAlt: number;
 }
 
 /**
  * Builds a self-contained HTML weather page using the Vellum design system tokens.
  * This renders in the workspace when the user clicks "View Output" on the preview card.
+ * Includes a segmented °F/°C toggle that swaps all temperatures and wind speeds inline.
  */
 function buildWeatherPageHtml(d: WeatherPageInput): string {
   const condEmoji = weatherCodeToEmoji(d.conditionCode);
+  const isF = d.unit === 'F';
+
+  // Map primary/alt values to explicit F and C for data attributes
+  const tempF = isF ? d.currentTemp : d.currentTempAlt;
+  const tempC = isF ? d.currentTempAlt : d.currentTemp;
+  const feelsF = isF ? d.feelsLike : d.feelsLikeAlt;
+  const feelsC = isF ? d.feelsLikeAlt : d.feelsLike;
+  const highF = isF ? d.todayHigh : d.todayHighAlt;
+  const highC = isF ? d.todayHighAlt : d.todayHigh;
+  const lowF = isF ? d.todayLow : d.todayLowAlt;
+  const lowC = isF ? d.todayLowAlt : d.todayLow;
+  const windMph = isF ? d.windSpeed : d.windSpeedAlt;
+  const windKph = isF ? d.windSpeedAlt : d.windSpeed;
 
   const hourlyHtml = d.hourly.slice(0, 24).map(h => {
     const e = weatherCodeToEmoji(h.code);
+    const hf = isF ? h.temp : h.tempAlt;
+    const hc = isF ? h.tempAlt : h.temp;
     return `<div style="display:flex;flex-direction:column;align-items:center;gap:4px;min-width:56px">` +
       `<div style="font-size:13px;color:var(--v-text-secondary)">${escapeHtml(h.time)}</div>` +
       `<div style="font-size:20px">${e}</div>` +
-      `<div style="font-size:14px;font-weight:500">${h.temp}°${d.unit}</div></div>`;
+      `<span data-temp-f="${hf}" data-temp-c="${hc}" style="font-size:14px;font-weight:500">${h.temp}°${d.unit}</span></div>`;
   }).join('');
 
-  const allTemps = d.forecast.flatMap(f => [f.low, f.high]);
-  const globalMin = Math.min(...allTemps);
-  const globalMax = Math.max(...allTemps);
-  const range = globalMax - globalMin || 1;
+  // Precompute bar positions for both unit systems so the toggle can update them
+  const dailyF = d.forecast.map(f => ({ low: isF ? f.low : f.lowAlt, high: isF ? f.high : f.highAlt }));
+  const dailyC = d.forecast.map(f => ({ low: isF ? f.lowAlt : f.low, high: isF ? f.highAlt : f.high }));
+  const allF = dailyF.flatMap(f => [f.low, f.high]);
+  const fMin = Math.min(...allF), fMax = Math.max(...allF), fRange = fMax - fMin || 1;
+  const allC = dailyC.flatMap(f => [f.low, f.high]);
+  const cMin = Math.min(...allC), cMax = Math.max(...allC), cRange = cMax - cMin || 1;
 
-  const dailyHtml = d.forecast.map(f => {
+  const dailyHtml = d.forecast.map((f, i) => {
     const e = weatherCodeToEmoji(f.code);
-    const leftPct = ((f.low - globalMin) / range) * 100;
-    const widthPct = Math.max(((f.high - f.low) / range) * 100, 3);
+    const lf = dailyF[i].low, hf = dailyF[i].high;
+    const lc = dailyC[i].low, hc = dailyC[i].high;
+    const leftPctF = ((lf - fMin) / fRange) * 100;
+    const widthPctF = Math.max(((hf - lf) / fRange) * 100, 3);
+    const leftPctC = ((lc - cMin) / cRange) * 100;
+    const widthPctC = Math.max(((hc - lc) / cRange) * 100, 3);
+    const leftPct = isF ? leftPctF : leftPctC;
+    const widthPct = isF ? widthPctF : widthPctC;
     const precipCell = f.precip !== null && f.precip > 0
       ? `<span style="font-size:12px;color:var(--v-accent);width:36px;text-align:right">${f.precip}%</span>`
       : `<span style="width:36px"></span>`;
@@ -177,25 +210,32 @@ function buildWeatherPageHtml(d: WeatherPageInput): string {
       `<span style="width:44px;font-size:14px;font-weight:500">${escapeHtml(f.day)}</span>` +
       `<span style="font-size:18px;width:28px;text-align:center">${e}</span>` +
       `${precipCell}` +
-      `<span style="font-size:14px;color:var(--v-text-muted);width:36px;text-align:right">${f.low}°${d.unit}</span>` +
+      `<span data-temp-f="${lf}" data-temp-c="${lc}" style="font-size:14px;color:var(--v-text-muted);width:36px;text-align:right">${f.low}°${d.unit}</span>` +
       `<div style="flex:1;height:6px;background:var(--v-surface);border-radius:3px;position:relative;overflow:hidden;min-width:80px">` +
-      `<div style="position:absolute;left:${leftPct}%;width:${widthPct}%;height:100%;border-radius:3px;background:linear-gradient(to right,var(--v-emerald-400),var(--v-amber-400))"></div></div>` +
-      `<span style="font-size:14px;font-weight:500;width:36px">${f.high}°${d.unit}</span></div>`;
+      `<div data-bar data-left-f="${leftPctF}" data-width-f="${widthPctF}" data-left-c="${leftPctC}" data-width-c="${widthPctC}" style="position:absolute;left:${leftPct}%;width:${widthPct}%;height:100%;border-radius:3px;background:linear-gradient(to right,var(--v-emerald-400),var(--v-amber-400))"></div></div>` +
+      `<span data-temp-f="${hf}" data-temp-c="${hc}" style="font-size:14px;font-weight:500;width:36px">${f.high}°${d.unit}</span></div>`;
   }).join('');
 
+  // Toggle button styles — active gets a visible fill, inactive stays ghost
+  const activeBg = 'rgba(255,255,255,0.15)';
+  const inactiveBg = 'transparent';
+  const activeColor = 'var(--v-text)';
+  const inactiveColor = 'var(--v-text-muted)';
+  const btnBase = 'border:none;cursor:pointer;padding:5px 12px;font-size:13px;line-height:1;transition:background 0.15s,color 0.15s,font-weight 0.15s';
+
   return [
-    `<div style="max-width:520px;margin:0 auto;padding:24px">`,
+    `<div data-unit="${d.unit}" style="max-width:520px;margin:0 auto;padding:24px">`,
     // Hero
     `<div style="text-align:center;margin-bottom:24px">`,
     `<div style="font-size:13px;text-transform:uppercase;letter-spacing:2px;color:var(--v-text-secondary);font-weight:600;margin-bottom:16px">${escapeHtml(d.location)}</div>`,
     `<div style="display:flex;align-items:center;justify-content:center;gap:16px">`,
-    `<span style="font-size:72px;font-weight:200;line-height:1;color:var(--v-text)">${d.currentTemp}°${d.unit}</span>`,
+    `<span data-temp-f="${tempF}" data-temp-c="${tempC}" style="font-size:72px;font-weight:200;line-height:1;color:var(--v-text)">${d.currentTemp}°${d.unit}</span>`,
     `<div style="text-align:left">`,
     `<div style="font-size:32px;line-height:1.2">${condEmoji}</div>`,
     `<div style="font-size:15px;color:var(--v-text);font-weight:500">${escapeHtml(d.condition)}</div>`,
     `</div></div>`,
-    `<div style="font-size:14px;color:var(--v-text-muted);margin-top:8px">Feels like ${d.feelsLike}°${d.unit} &middot; H:${d.todayHigh}°${d.unit} L:${d.todayLow}°${d.unit}</div>`,
-    `<div style="font-size:13px;color:var(--v-text-muted);margin-top:4px">💨 ${d.windSpeed} ${escapeHtml(d.speedUnit)} ${escapeHtml(d.windDirection)} &middot; 💧 ${d.humidity}%</div>`,
+    `<div style="font-size:14px;color:var(--v-text-muted);margin-top:8px">Feels like <span data-temp-f="${feelsF}" data-temp-c="${feelsC}">${d.feelsLike}°${d.unit}</span> &middot; H:<span data-temp-f="${highF}" data-temp-c="${highC}">${d.todayHigh}°${d.unit}</span> L:<span data-temp-f="${lowF}" data-temp-c="${lowC}">${d.todayLow}°${d.unit}</span></div>`,
+    `<div style="font-size:13px;color:var(--v-text-muted);margin-top:4px">💨 <span data-wind-mph="${windMph}" data-wind-kph="${windKph}">${d.windSpeed} ${escapeHtml(d.speedUnit)}</span> ${escapeHtml(d.windDirection)} &middot; 💧 ${d.humidity}%</div>`,
     `</div>`,
     // Hourly
     `<div style="border-top:1px solid var(--v-surface-border);padding-top:16px;margin-bottom:16px">`,
@@ -204,9 +244,42 @@ function buildWeatherPageHtml(d: WeatherPageInput): string {
     `</div>`,
     // Daily
     `<div style="border-top:1px solid var(--v-surface-border);padding-top:16px">`,
-    `<div style="font-size:12px;text-transform:uppercase;letter-spacing:1px;color:var(--v-text-muted);margin-bottom:8px">${d.forecast.length}-Day Forecast</div>`,
-    dailyHtml,
+    `<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">`,
+    `<div style="font-size:12px;text-transform:uppercase;letter-spacing:1px;color:var(--v-text-muted)">${d.forecast.length}-Day Forecast</div>`,
+    `<div style="display:inline-flex;border-radius:8px;overflow:hidden;border:1px solid rgba(255,255,255,0.12)">`,
+    `<button data-unit-btn="F" style="${btnBase};border-radius:7px 0 0 7px;background:${isF ? activeBg : inactiveBg};color:${isF ? activeColor : inactiveColor};font-weight:${isF ? '600' : '400'}">°F</button>`,
+    `<button data-unit-btn="C" style="${btnBase};border-radius:0 7px 7px 0;background:${isF ? inactiveBg : activeBg};color:${isF ? inactiveColor : activeColor};font-weight:${isF ? '400' : '600'}">°C</button>`,
     `</div></div>`,
+    dailyHtml,
+    `</div>`,
+    // Toggle script
+    `<script>(function(){`,
+    `var r=document.querySelector('[data-unit]');if(!r)return;`,
+    `r.addEventListener('click',function(e){`,
+    `var b=e.target.closest('[data-unit-btn]');if(!b)return;`,
+    `var u=b.getAttribute('data-unit-btn');`,
+    `if(r.getAttribute('data-unit')===u)return;`,
+    `r.setAttribute('data-unit',u);`,
+    `var f=u==='F',s=f?'\\u00B0F':'\\u00B0C';`,
+    `r.querySelectorAll('[data-temp-f]').forEach(function(el){`,
+    `el.textContent=(f?el.getAttribute('data-temp-f'):el.getAttribute('data-temp-c'))+s;`,
+    `});`,
+    `r.querySelectorAll('[data-wind-mph]').forEach(function(el){`,
+    `el.textContent=f?el.getAttribute('data-wind-mph')+' mph':el.getAttribute('data-wind-kph')+' km/h';`,
+    `});`,
+    `r.querySelectorAll('[data-bar]').forEach(function(el){`,
+    `el.style.left=(f?el.getAttribute('data-left-f'):el.getAttribute('data-left-c'))+'%';`,
+    `el.style.width=(f?el.getAttribute('data-width-f'):el.getAttribute('data-width-c'))+'%';`,
+    `});`,
+    `r.querySelectorAll('[data-unit-btn]').forEach(function(bt){`,
+    `var on=bt.getAttribute('data-unit-btn')===u;`,
+    `bt.style.background=on?'rgba(255,255,255,0.15)':'transparent';`,
+    `bt.style.color=on?'var(--v-text)':'var(--v-text-muted)';`,
+    `bt.style.fontWeight=on?'600':'400';`,
+    `});`,
+    `});`,
+    `})()</script>`,
+    `</div>`,
   ].join('');
 }
 
@@ -298,9 +371,20 @@ export async function executeGetWeather(
   const tempUnit = useFahrenheit ? 'F' : 'C';
   const speedUnit = useFahrenheit ? 'mph' : 'km/h';
 
-  const currentTemp = useFahrenheit ? celsiusToFahrenheit(current.temperature_2m) : Math.round(current.temperature_2m);
-  const currentFeelsLike = useFahrenheit ? celsiusToFahrenheit(current.apparent_temperature) : Math.round(current.apparent_temperature);
-  const currentWind = useFahrenheit ? kphToMph(current.wind_speed_10m) : Math.round(current.wind_speed_10m);
+  const tempC = Math.round(current.temperature_2m);
+  const tempF = celsiusToFahrenheit(current.temperature_2m);
+  const currentTemp = useFahrenheit ? tempF : tempC;
+  const currentTempAlt = useFahrenheit ? tempC : tempF;
+
+  const feelsC = Math.round(current.apparent_temperature);
+  const feelsF = celsiusToFahrenheit(current.apparent_temperature);
+  const currentFeelsLike = useFahrenheit ? feelsF : feelsC;
+  const currentFeelsLikeAlt = useFahrenheit ? feelsC : feelsF;
+
+  const windKph = Math.round(current.wind_speed_10m);
+  const windMph = kphToMph(current.wind_speed_10m);
+  const currentWind = useFahrenheit ? windMph : windKph;
+  const currentWindAlt = useFahrenheit ? windKph : windMph;
   const windDir = windDirectionToCompass(current.wind_direction_10m);
   const currentDescription = weatherCodeToDescription(current.weather_code);
 
@@ -324,6 +408,8 @@ export async function executeGetWeather(
     icon: string;
     low: number;
     high: number;
+    lowAlt: number;
+    highAlt: number;
     precip: number | null;
     condition: string;
     code: number;
@@ -335,8 +421,14 @@ export async function executeGetWeather(
 
   for (let i = 0; i < daily.time.length; i++) {
     const date = daily.time[i];
-    const high = useFahrenheit ? celsiusToFahrenheit(daily.temperature_2m_max[i]) : Math.round(daily.temperature_2m_max[i]);
-    const low = useFahrenheit ? celsiusToFahrenheit(daily.temperature_2m_min[i]) : Math.round(daily.temperature_2m_min[i]);
+    const highC = Math.round(daily.temperature_2m_max[i]);
+    const highF = celsiusToFahrenheit(daily.temperature_2m_max[i]);
+    const high = useFahrenheit ? highF : highC;
+    const highAlt = useFahrenheit ? highC : highF;
+    const lowC = Math.round(daily.temperature_2m_min[i]);
+    const lowF = celsiusToFahrenheit(daily.temperature_2m_min[i]);
+    const low = useFahrenheit ? lowF : lowC;
+    const lowAlt = useFahrenheit ? lowC : lowF;
     const precip = daily.precipitation_probability_max[i];
     const desc = weatherCodeToDescription(daily.weather_code[i]);
     const icon = weatherCodeToSFSymbol(daily.weather_code[i]);
@@ -352,13 +444,13 @@ export async function executeGetWeather(
 
     lines.push(`${date}: High ${high}\u00B0${tempUnit}, Low ${low}\u00B0${tempUnit}, Precip ${precip}%, ${desc}`);
 
-    forecastItems.push({ day: dayLabel, icon, low, high, precip: precip > 0 ? precip : null, condition: desc, code: daily.weather_code[i] });
+    forecastItems.push({ day: dayLabel, icon, low, high, lowAlt, highAlt, precip: precip > 0 ? precip : null, condition: desc, code: daily.weather_code[i] });
   }
 
   // Process hourly data: next 24 hours from the current hour.
   // Use the current time from the API response (which is in the location's local
   // timezone, thanks to timezone=auto) to find the correct starting index.
-  const hourlyItems: Array<{ time: string; icon: string; temp: number; code: number }> = [];
+  const hourlyItems: Array<{ time: string; icon: string; temp: number; tempAlt: number; code: number }> = [];
   if (forecast.hourly?.time) {
     const currentTimeLocal = forecast.current.time; // e.g. "2026-02-12T22:00"
     const currentHourPrefix = currentTimeLocal.slice(0, 13); // e.g. "2026-02-12T22"
@@ -368,9 +460,10 @@ export async function executeGetWeather(
     const count = Math.min(24, forecast.hourly.time.length - startIndex);
     for (let i = 0; i < count; i++) {
       const idx = startIndex + i;
-      const hourTemp = useFahrenheit
-        ? celsiusToFahrenheit(forecast.hourly.temperature_2m[idx])
-        : Math.round(forecast.hourly.temperature_2m[idx]);
+      const hourTempC = Math.round(forecast.hourly.temperature_2m[idx]);
+      const hourTempF = celsiusToFahrenheit(forecast.hourly.temperature_2m[idx]);
+      const hourTemp = useFahrenheit ? hourTempF : hourTempC;
+      const hourTempAlt = useFahrenheit ? hourTempC : hourTempF;
       const isDay = forecast.hourly.is_day[idx] === 1;
       const icon = weatherCodeToSFSymbol(forecast.hourly.weather_code[idx], isDay);
 
@@ -386,13 +479,15 @@ export async function executeGetWeather(
         timeLabel = `${displayHour}${suffix}`;
       }
 
-      hourlyItems.push({ time: timeLabel, icon, temp: hourTemp, code: forecast.hourly.weather_code[idx] });
+      hourlyItems.push({ time: timeLabel, icon, temp: hourTemp, tempAlt: hourTempAlt, code: forecast.hourly.weather_code[idx] });
     }
   }
 
   // Build dynamic page HTML + preview for compact inline card with "View Output"
   const todayHigh = forecastItems.length > 0 ? forecastItems[0].high : currentTemp;
   const todayLow = forecastItems.length > 0 ? forecastItems[0].low : currentTemp;
+  const todayHighAlt = forecastItems.length > 0 ? forecastItems[0].highAlt : currentTempAlt;
+  const todayLowAlt = forecastItems.length > 0 ? forecastItems[0].lowAlt : currentTempAlt;
 
   const weatherHtml = buildWeatherPageHtml({
     location: locationDisplay,
@@ -407,8 +502,15 @@ export async function executeGetWeather(
     speedUnit,
     todayHigh,
     todayLow,
-    hourly: hourlyItems.map(h => ({ time: h.time, temp: h.temp, code: h.code })),
-    forecast: forecastItems.map(f => ({ day: f.day, low: f.low, high: f.high, precip: f.precip, code: f.code })),
+    hourly: hourlyItems.map(h => ({ time: h.time, temp: h.temp, tempAlt: h.tempAlt, code: h.code })),
+    forecast: forecastItems.map(f => ({ day: f.day, low: f.low, high: f.high, lowAlt: f.lowAlt, highAlt: f.highAlt, precip: f.precip, code: f.code })),
+    unitAlt: useFahrenheit ? 'C' : 'F',
+    speedUnitAlt: useFahrenheit ? 'km/h' : 'mph',
+    currentTempAlt,
+    feelsLikeAlt: currentFeelsLikeAlt,
+    todayHighAlt,
+    todayLowAlt,
+    windSpeedAlt: currentWindAlt,
   });
 
   const uiShowData = {


### PR DESCRIPTION
## Summary
- Add a segmented °F/°C toggle button to the HTML weather page, placed on the 10-Day Forecast header line
- Precompute both Fahrenheit and Celsius values (plus mph/km·h⁻¹) from raw API data and embed as `data-temp-f`/`data-temp-c` attributes on all temperature elements
- Inline script swaps all tagged values, wind speeds, and forecast bar positions on toggle — no network round-trip needed

## Test plan
- [x] All 25 existing weather tests pass (`bun test get-weather.test.ts`)
- [ ] Manual: trigger weather query → click "View Output" → verify toggle appears on the 10-Day Forecast line
- [ ] Manual: click °C → all temps switch to Celsius, wind to km/h, bars reposition; click °F → reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
