### PR TITLE
fix(chat): reset cancelledDuringRefinement in error handlers

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -819,6 +819,7 @@ public final class ChatViewModel: ObservableObject {
         case .error(let err):
             log.error("Server error: \(err.message)")
             isWorkspaceRefinementInFlight = false
+            cancelledDuringRefinement = false
             isThinking = false
             let wasCancelling = isCancelling
             isCancelling = false
@@ -1017,6 +1018,7 @@ public final class ChatViewModel: ObservableObject {
             guard sessionId != nil, belongsToSession(msg.sessionId) else { return }
             log.error("Session error [\(msg.code.rawValue)]: \(msg.userMessage)")
             isWorkspaceRefinementInFlight = false
+            cancelledDuringRefinement = false
             isThinking = false
             let wasCancelling = isCancelling
             isCancelling = false


### PR DESCRIPTION
## Summary
- Reset the `cancelledDuringRefinement` flag in `.error` and `.sessionError` handlers in `ChatViewModel.swift`
- Prevents stale state from corrupting subsequent normal message completions when a cancel during refinement is acknowledged via an error path

## Context
PR #2659 introduced the `cancelledDuringRefinement` flag to preserve refinement context for `messageComplete` after cancel. Both Codex and Devin reviewers identified that the flag was not reset in `.error` and `.sessionError` handlers, which could leave it stuck as `true` and corrupt subsequent message completions.

The flag was already correctly reset in `.messageComplete`, `.generationCancelled`, and the cancel timeout — but the error paths were missed.

## Test plan
- [x] Verify `cancelledDuringRefinement` is reset in all terminal event handlers
- [ ] Cancel a workspace refinement, trigger a server error, then send a new message — should complete normally without refinement context bleeding through

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
