### PR TITLE
fix(ui): auto-dismiss empty generated panel to prevent dead-end state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -581,6 +581,7 @@ struct MainWindowView: View {
             switch panel {
             case .generated:
                 EmptyView()
+                    .onAppear { windowState.activePanel = nil }
             case .agent:
                 AgentPanel(onClose: { windowState.activePanel = nil }, onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {


### PR DESCRIPTION
## Summary
- Add `.onAppear { windowState.activePanel = nil }` to the `.generated` case in `panelContent` so it immediately dismisses itself when rendered as `EmptyView()` in the side panel
- Prevents an empty, unclosable 400px side panel when `activePanel == .generated` but `isDynamicExpanded` is false

## Context
PR #2663 replaced the `.generated` case in `panelContent` with `EmptyView()` but this creates a dead-end state. Both Codex and Devin reviewers identified the issue: when `.openDynamicWorkspace` notification sets `activePanel` to `.generated`, the `VSplitView` renders with `showPanel: true` but the panel content is just an empty view with no way to close it.

## Test plan
- [ ] Trigger `.openDynamicWorkspace` notification with `isDynamicExpanded` set to false
- [ ] Verify the side panel does not remain stuck open with empty content
- [ ] Verify normal panel switching (agent, debug, etc.) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
