### PR TITLE
fix(widgets): normalize internal padding for consistent left alignment

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -55,7 +55,6 @@ public struct InlineDynamicPagePreview: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .frame(maxWidth: 350)
         .onHover { hovering in
             #if os(macOS)
             if hovering { NSCursor.pointingHand.set() }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineListWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineListWidget.swift
@@ -53,7 +53,6 @@ public struct InlineListWidget: View {
                     .foregroundColor(isSelected ? VColor.accent : VColor.textMuted)
             }
         }
-        .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)
         .background(
             RoundedRectangle(cornerRadius: VRadius.sm)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -28,7 +28,6 @@ public struct InlineTableWidget: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .padding(.horizontal, VSpacing.sm)
             .padding(.bottom, VSpacing.xxs)
 
             Divider()
@@ -78,7 +77,6 @@ public struct InlineTableWidget: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .background(
             RoundedRectangle(cornerRadius: VRadius.sm)


### PR DESCRIPTION
## Summary
- Remove extra `.padding(.horizontal, VSpacing.sm)` from `InlineTableWidget` headers/rows and `InlineListWidget` rows so all widget types share the same 16pt content padding from `.inlineWidgetCard()`
- Remove redundant `.frame(maxWidth: 350)` from `InlineDynamicPagePreview` — already applied by `InlineSurfaceRouter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
