### PR TITLE
fix(chat): reset cancelledDuringRefinement in stopGenerating error paths

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1106,6 +1106,7 @@ public final class ChatViewModel: ObservableObject {
         guard daemonClient.isConnected else {
             log.warning("Cannot send cancel: daemon not connected")
             isWorkspaceRefinementInFlight = false
+            cancelledDuringRefinement = false
             isSending = false
             isThinking = false
             isCancelling = false
@@ -1139,6 +1140,7 @@ public final class ChatViewModel: ObservableObject {
             // messageComplete event will arrive from the daemon. Reset
             // all transient state now to avoid stuck UI.
             isWorkspaceRefinementInFlight = false
+            cancelledDuringRefinement = false
             isSending = false
             isThinking = false
             isCancelling = false


### PR DESCRIPTION
## Summary
- Reset `cancelledDuringRefinement` in two additional error paths in `stopGenerating()` that were missed by #2665
- The daemon-disconnected early return path now resets the flag
- The send-failed catch block now resets the flag

This prevents `cancelledDuringRefinement` from getting stuck as `true`, which would cause the next `messageComplete` handler to incorrectly treat a normal response as a refinement (skipping `ingestAssistantAttachments` and `fetchSuggestion`).

Addresses review feedback on #2665.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
