### PR TITLE
fix(ui): use Color.clear instead of EmptyView for reliable onAppear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -580,7 +580,7 @@ struct MainWindowView: View {
         if let panel = windowState.activePanel {
             switch panel {
             case .generated:
-                EmptyView()
+                Color.clear.frame(width: 0, height: 0)
                     .onAppear { windowState.activePanel = nil }
             case .agent:
                 AgentPanel(onClose: { windowState.activePanel = nil }, onInvokeSkill: { skill in


### PR DESCRIPTION
## Summary
- Replace `EmptyView()` with `Color.clear.frame(width: 0, height: 0)` in the `.generated` panel case
- `EmptyView` can be optimized out of the view hierarchy by SwiftUI, meaning `.onAppear` may never fire
- `Color.clear` is guaranteed to remain in the hierarchy and trigger `.onAppear` reliably

Addresses review feedback on #2666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
