### PR TITLE
Add activity panel for tool call progress tracking

### DIFF
--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -33,9 +33,7 @@ struct MessageBubbleView: View {
                     // Pre-text tool calls render above the bubble
                     let preTextCalls = message.toolCalls.filter { $0.arrivedBeforeText }
                     if !preTextCalls.isEmpty {
-                        ForEach(preTextCalls) { toolCall in
-                            ToolCallChip(toolCall: toolCall)
-                        }
+                        ToolCallProgressBar(toolCalls: preTextCalls)
                     }
 
                     // Message text (only shown for non-confirmation messages)
@@ -55,9 +53,7 @@ struct MessageBubbleView: View {
                     // Post-text tool calls render below the bubble
                     let postTextCalls = message.toolCalls.filter { !$0.arrivedBeforeText }
                     if !postTextCalls.isEmpty {
-                        ForEach(postTextCalls) { toolCall in
-                            ToolCallChip(toolCall: toolCall)
-                        }
+                        ToolCallProgressBar(toolCalls: postTextCalls)
                     }
 
                     // Inline surfaces (cards, tables, interactive widgets)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -35,6 +35,8 @@ struct ChatView: View {
     let onCopyDebugInfo: () -> Void
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
+    let onOpenActivity: ([ToolCallData]) -> Void
+    let isActivityPanelOpen: Bool
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
@@ -291,7 +293,9 @@ struct ChatView: View {
                             ChatBubble(
                                 message: message,
                                 hideToolCalls: nextAssistantHasSurfaces(after: index),
-                                onSurfaceAction: onSurfaceAction
+                                onSurfaceAction: onSurfaceAction,
+                                onOpenActivity: onOpenActivity,
+                                isActivityPanelOpen: isActivityPanelOpen
                             )
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -548,6 +552,8 @@ private struct ChatBubble: View {
     /// When true, tool call chips are suppressed because a nearby message has inline surfaces.
     let hideToolCalls: Bool
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
+    let onOpenActivity: ([ToolCallData]) -> Void
+    let isActivityPanelOpen: Bool
 
     private var isUser: Bool { message.role == .user }
 
@@ -655,15 +661,13 @@ private struct ChatBubble: View {
         }
     }
 
-    /// Tool call chips rendered outside the bubble.
+    /// Current step indicator rendered outside the bubble.
     /// Hidden for user messages, when there are no tool calls, or when inline surfaces are present.
     @ViewBuilder
     private func toolCallChips(_ calls: [ToolCallData]) -> some View {
         if !isUser && !calls.isEmpty && message.inlineSurfaces.isEmpty && !hideToolCalls {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                ForEach(calls) { toolCall in
-                    ToolCallChip(toolCall: toolCall)
-                }
+            CurrentStepIndicator(toolCalls: calls, isActivityPanelOpen: isActivityPanelOpen) {
+                onOpenActivity(calls)
             }
             .frame(maxWidth: 520, alignment: .leading)
         }
@@ -987,7 +991,9 @@ private struct ChatViewPreviewWrapper: View {
                 onDismissSessionError: {},
                 onCopyDebugInfo: {},
                 watchSession: nil,
-                onStopWatch: {}
+                onStopWatch: {},
+                onOpenActivity: { _ in },
+                isActivityPanelOpen: false
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -11,9 +11,21 @@ final class MainWindowState: ObservableObject {
     @Published var activeDynamicParsedSurface: Surface?
     @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
+    @Published var activityToolCalls: [ToolCallData] = []
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey
+    }
+
+    func toggleActivityPanel(with toolCalls: [ToolCallData]) {
+        if activePanel == .activity {
+            // Close if already open
+            activePanel = nil
+        } else {
+            // Open with new tool calls
+            self.activityToolCalls = toolCalls
+            self.activePanel = .activity
+        }
     }
 
     func togglePanel(_ panel: SidePanelType) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -381,7 +381,13 @@ struct MainWindowView: View {
                         onDismissSessionError: { viewModel.dismissSessionError() },
                         onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
                         watchSession: ambientAgent.activeWatchSession,
-                        onStopWatch: { viewModel.stopWatchSession() }
+                        onStopWatch: { viewModel.stopWatchSession() },
+                        onOpenActivity: { toolCalls in
+                            print("DEBUG: onOpenActivity called with \(toolCalls.count) tool calls")
+                            windowState.toggleActivityPanel(with: toolCalls)
+                            print("DEBUG: activePanel is now \(String(describing: windowState.activePanel))")
+                        },
+                        isActivityPanelOpen: windowState.activePanel == .activity
                     )
                 }
             }, panel: {
@@ -612,6 +618,11 @@ struct MainWindowView: View {
                 )
             case .doctor:
                 DoctorPanel(onClose: { windowState.activePanel = nil })
+            case .activity:
+                ActivityPanel(
+                    toolCalls: windowState.activityToolCalls,
+                    onClose: { windowState.activePanel = nil }
+                )
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct ActivityPanel: View {
+    let toolCalls: [ToolCallData]
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Activity")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+
+                Spacer()
+
+                Button {
+                    onClose()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(VSpacing.lg)
+            .background(VColor.chatBackground)
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Activity timeline
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    ForEach(toolCalls) { toolCall in
+                        ActivityStepView(toolCall: toolCall)
+                    }
+                }
+                .padding(VSpacing.lg)
+            }
+        }
+        .frame(width: 400)
+        .background(VColor.background)
+    }
+}
+
+struct ActivityStepView: View {
+    let toolCall: ToolCallData
+    @State private var isResultExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Step header with icon
+            HStack(spacing: VSpacing.sm) {
+                // Status icon
+                ZStack {
+                    Circle()
+                        .fill(statusColor.opacity(0.15))
+                        .frame(width: 24, height: 24)
+
+                    if toolCall.isComplete {
+                        if toolCall.isError {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundColor(VColor.error)
+                        } else {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundColor(VColor.accent)
+                        }
+                    } else {
+                        ProgressView()
+                            .scaleEffect(0.5)
+                            .tint(VColor.accent)
+                    }
+                }
+
+                // Step name
+                Text(toolCall.toolName)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                Spacer()
+            }
+
+            // Input summary
+            if !toolCall.inputSummary.isEmpty {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 11))
+                        .foregroundColor(VColor.textMuted)
+
+                    Text(toolCall.inputSummary)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(2)
+                }
+                .padding(.leading, 32) // Align with text after icon
+            }
+
+            // Screenshot
+            if let cachedImage = toolCall.cachedImage {
+                Image(nsImage: cachedImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    .padding(.leading, 32)
+            }
+
+            // Result
+            if let result = toolCall.result, !result.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(result)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(toolCall.isError ? VColor.error : VColor.textSecondary)
+                        .lineLimit(isResultExpanded ? nil : 6)
+                        .textSelection(.enabled)
+
+                    // Show more/less button if text is long
+                    if result.count > 200 || result.split(separator: "\n").count > 6 {
+                        Button(action: {
+                            withAnimation(VAnimation.fast) {
+                                isResultExpanded.toggle()
+                            }
+                        }) {
+                            HStack(spacing: VSpacing.xxs) {
+                                Text(isResultExpanded ? "Show less" : "Show more")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.accent)
+                                Image(systemName: isResultExpanded ? "chevron.up" : "chevron.down")
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundColor(VColor.accent)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.top, VSpacing.xxs)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(VSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.surface)
+                )
+                .padding(.leading, 32)
+            }
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(toolCall.isError ? VColor.error.opacity(0.05) : VColor.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private var statusColor: Color {
+        if toolCall.isError {
+            return VColor.error
+        } else if toolCall.isComplete {
+            return VColor.accent
+        } else {
+            return VColor.accent
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct ActivityPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        ActivityPanel(
+            toolCalls: [
+                ToolCallData(
+                    toolName: "Web Search",
+                    inputSummary: "flights from New York to London next week",
+                    result: "Found 5 search results",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Navigate",
+                    inputSummary: "https://www.google.com/travel/flights",
+                    result: "Navigated successfully",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Screenshot",
+                    inputSummary: "",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Click",
+                    inputSummary: "[aria-label=\"Departure\"]",
+                    isComplete: false
+                )
+            ],
+            onClose: {}
+        )
+        .frame(height: 600)
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -5,4 +5,5 @@ enum SidePanelType: Hashable, CaseIterable {
     case directory
     case debug
     case doctor
+    case activity
 }

--- a/clients/shared/Features/Chat/CurrentStepIndicator.swift
+++ b/clients/shared/Features/Chat/CurrentStepIndicator.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+/// A simple indicator showing the current step being executed.
+/// Clicking it opens the Activity sidebar with all step details.
+public struct CurrentStepIndicator: View {
+    public let toolCalls: [ToolCallData]
+    public let isActivityPanelOpen: Bool
+    public let onTap: () -> Void
+
+    public init(toolCalls: [ToolCallData], isActivityPanelOpen: Bool = false, onTap: @escaping () -> Void) {
+        self.toolCalls = toolCalls
+        self.isActivityPanelOpen = isActivityPanelOpen
+        self.onTap = onTap
+    }
+
+    private var currentStep: ToolCallData? {
+        // Find the first incomplete step, or the last step if all are complete
+        toolCalls.first(where: { !$0.isComplete }) ?? toolCalls.last
+    }
+
+    private var completedCount: Int {
+        toolCalls.filter { $0.isComplete }.count
+    }
+
+    private var totalCount: Int {
+        toolCalls.count
+    }
+
+    @State private var isHovered = false
+
+    public var body: some View {
+        if let current = currentStep {
+            HStack(spacing: VSpacing.sm) {
+                // Spinner or checkmark
+                if current.isComplete {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 14))
+                        .foregroundColor(VColor.accent)
+                } else {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .frame(width: 14, height: 14)
+                }
+
+                // Current step text
+                Text(current.toolName)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                // Progress counter
+                if totalCount > 1 {
+                    Text("(\(completedCount)/\(totalCount))")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Spacer()
+
+                // Chevron to indicate it's clickable
+                Image(systemName: isActivityPanelOpen ? "chevron.left" : "chevron.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(VColor.textMuted)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isHovered ? VColor.surfaceBorder.opacity(0.5) : VColor.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+            .onHover { hovering in
+                withAnimation(VAnimation.fast) {
+                    isHovered = hovering
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                print("DEBUG: CurrentStepIndicator tapped")
+                onTap()
+            }
+            .padding(.top, VSpacing.md)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("CurrentStepIndicator") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+
+        VStack(spacing: VSpacing.xl) {
+            // In progress
+            CurrentStepIndicator(
+                toolCalls: [
+                    ToolCallData(
+                        toolName: "Web Search",
+                        inputSummary: "flights from New York to London",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Navigate",
+                        inputSummary: "https://google.com/flights",
+                        isComplete: false
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Click",
+                        inputSummary: "Departure field",
+                        isComplete: false
+                    )
+                ],
+                onTap: {}
+            )
+
+            // Single step
+            CurrentStepIndicator(
+                toolCalls: [
+                    ToolCallData(
+                        toolName: "Checking Navitime schedule for specific date",
+                        inputSummary: "",
+                        isComplete: false
+                    )
+                ],
+                onTap: {}
+            )
+
+            // Completed
+            CurrentStepIndicator(
+                toolCalls: [
+                    ToolCallData(
+                        toolName: "Web Search",
+                        inputSummary: "flights",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Navigate",
+                        inputSummary: "url",
+                        isComplete: true
+                    )
+                ],
+                onTap: {}
+            )
+        }
+        .padding(VSpacing.xl)
+        .frame(width: 500)
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -1,0 +1,326 @@
+import SwiftUI
+
+/// A horizontal progress bar that displays tool calls as clickable steps.
+/// Each step can be expanded to show details like results and screenshots.
+public struct ToolCallProgressBar: View {
+    public let toolCalls: [ToolCallData]
+    @State private var expandedStepId: UUID?
+
+    public init(toolCalls: [ToolCallData]) {
+        self.toolCalls = toolCalls
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Progress bar with steps
+            VStack(spacing: VSpacing.xs) {
+                // Icons and lines row
+                HStack(spacing: 0) {
+                    ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
+                        // Step circle
+                        stepCircle(for: toolCall, index: index)
+
+                        // Connector line (skip for last item)
+                        if index < toolCalls.count - 1 {
+                            connectorLine(isComplete: toolCall.isComplete)
+                        }
+                    }
+                }
+
+                // Labels row (only show when 4 or fewer steps)
+                if toolCalls.count <= 4 {
+                    HStack(spacing: 0) {
+                        ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
+                            // Step label
+                            stepLabel(for: toolCall)
+                                .frame(width: labelWidth(index: index))
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, VSpacing.md)
+
+            // Expanded details (shown when a step is clicked)
+            if let expandedId = expandedStepId,
+               let expandedCall = toolCalls.first(where: { $0.id == expandedId }) {
+                expandedDetails(for: expandedCall)
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.95).combined(with: .opacity),
+                        removal: .opacity
+                    ))
+            }
+        }
+    }
+
+    // MARK: - Step Circle
+
+    @ViewBuilder
+    private func stepCircle(for toolCall: ToolCallData, index: Int) -> some View {
+        Button {
+            withAnimation(VAnimation.fast) {
+                // Toggle expansion when clicked
+                if expandedStepId == toolCall.id {
+                    expandedStepId = nil
+                } else if toolCall.isComplete {
+                    expandedStepId = toolCall.id
+                }
+            }
+        } label: {
+            ZStack {
+                if toolCall.isComplete {
+                    // Filled circle for completed steps
+                    Circle()
+                        .fill(toolCall.isError ? VColor.error : VColor.accent)
+                        .frame(width: 20, height: 20)
+
+                    if toolCall.isError {
+                        // Error icon
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundColor(.white)
+                    } else {
+                        // Checkmark
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+                } else {
+                    // Outlined circle for in-progress
+                    Circle()
+                        .strokeBorder(VColor.accent, lineWidth: 2)
+                        .frame(width: 20, height: 20)
+
+                    // Loading spinner inside
+                    ProgressView()
+                        .scaleEffect(0.35)
+                        .tint(VColor.accent)
+                        .frame(width: 20, height: 20)
+                }
+            }
+            .frame(width: 20, height: 20)
+        }
+        .buttonStyle(.plain)
+        .disabled(!toolCall.isComplete)
+    }
+
+    // MARK: - Step Label
+
+    @ViewBuilder
+    private func stepLabel(for toolCall: ToolCallData) -> some View {
+        Text(toolCall.toolName)
+            .font(VFont.small)
+            .foregroundColor(stepTextColor(for: toolCall))
+            .lineLimit(1)
+            .multilineTextAlignment(.center)
+    }
+
+    // Calculate label width to align with circles and lines
+    private func labelWidth(index: Int) -> CGFloat {
+        let circleWidth: CGFloat = 20
+        let lineWidth: CGFloat = 32
+
+        if index == toolCalls.count - 1 {
+            // Last item: just the circle
+            return circleWidth
+        } else {
+            // Circle + line
+            return circleWidth + lineWidth
+        }
+    }
+
+    // MARK: - Connector Line
+
+    private func connectorLine(isComplete: Bool) -> some View {
+        Rectangle()
+            .fill(VColor.surfaceBorder)
+            .frame(width: 32, height: 2)
+    }
+
+    // MARK: - Expanded Details
+
+    @ViewBuilder
+    private func expandedDetails(for toolCall: ToolCallData) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Header
+            HStack {
+                Image(systemName: "terminal")
+                    .font(.system(size: 12))
+                    .foregroundColor(toolCall.isError ? VColor.error : VColor.accent)
+
+                Text(toolCall.toolName)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                Spacer()
+
+                Button {
+                    withAnimation(VAnimation.fast) {
+                        expandedStepId = nil
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+            }
+
+            // Input summary
+            if !toolCall.inputSummary.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text("Input")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textMuted)
+
+                    Text(toolCall.inputSummary)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                        .textSelection(.enabled)
+                }
+            }
+
+            // Screenshot
+            if let cachedImage = toolCall.cachedImage {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text("Screenshot")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textMuted)
+
+                    #if os(macOS)
+                    Image(nsImage: cachedImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    #elseif os(iOS)
+                    Image(uiImage: cachedImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    #endif
+                }
+            }
+
+            // Result
+            if let result = toolCall.result {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text("Result")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textMuted)
+
+                    ScrollView {
+                        Text(result)
+                            .font(VFont.monoSmall)
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                    }
+                    .frame(maxHeight: 200)
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Colors
+
+    private func stepBackgroundColor(for toolCall: ToolCallData) -> Color {
+        if toolCall.isError {
+            return VColor.error
+        } else if !toolCall.isComplete {
+            return VColor.accent
+        } else {
+            return VColor.accent
+        }
+    }
+
+    private func stepBorderColor(for toolCall: ToolCallData) -> Color {
+        if toolCall.isError {
+            return VColor.error
+        } else if !toolCall.isComplete {
+            return VColor.accent.opacity(0.5)
+        } else {
+            return VColor.accent.opacity(0.8)
+        }
+    }
+
+    private func stepTextColor(for toolCall: ToolCallData) -> Color {
+        if toolCall.isError {
+            return VColor.error
+        } else if !toolCall.isComplete {
+            return VColor.textSecondary
+        } else {
+            return VColor.textPrimary
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("ToolCallProgressBar") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+
+        VStack(spacing: VSpacing.xl) {
+            // In progress example
+            ToolCallProgressBar(toolCalls: [
+                ToolCallData(
+                    toolName: "Web Search",
+                    inputSummary: "flights from New York to London next week",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Navigate",
+                    inputSummary: "https://www.google.com/travel/flights",
+                    result: "Navigated to Google Flights",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Screenshot",
+                    inputSummary: "",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Click",
+                    inputSummary: "[aria-label=\"Departure\"]",
+                    isComplete: false
+                )
+            ])
+
+            // Completed with error
+            ToolCallProgressBar(toolCalls: [
+                ToolCallData(
+                    toolName: "Web Search",
+                    inputSummary: "flights NYC to London",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Navigate",
+                    inputSummary: "https://www.google.com/travel/flights",
+                    isComplete: true
+                ),
+                ToolCallData(
+                    toolName: "Browser Click",
+                    inputSummary: "invalid selector",
+                    result: "Element not found",
+                    isError: true,
+                    isComplete: true
+                )
+            ])
+        }
+        .padding(VSpacing.xl)
+    }
+    .frame(width: 600, height: 500)
+}
+#endif


### PR DESCRIPTION
## Summary
- Introduces a new Activity side panel that shows detailed tool execution history
- Replaces individual tool call chips with CurrentStepIndicator showing current step with progress counter (X/Y)
- Adds ToolCallProgressBar for horizontal progress visualization with expandable step details
- Activity panel displays full timeline with status icons, input summaries, screenshots, and results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
