### PR TITLE
Replace X with archive icon on thread close buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -237,14 +237,14 @@ struct MainWindowView: View {
         .overlay(alignment: .trailing) {
             if threadManager.threads.count > 1 {
                 Button(action: { threadManager.closeThread(id: thread.id) }) {
-                    Image(systemName: "xmark")
+                    Image(systemName: "archivebox")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundColor(VColor.textMuted)
                         .frame(width: 16, height: 16)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Close \(thread.title)")
+                .accessibilityLabel("Archive \(thread.title)")
                 .padding(.trailing, VSpacing.lg)
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
@@ -37,14 +37,14 @@ struct ThreadTab: View {
         .overlay(alignment: .trailing) {
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
-                    Image(systemName: "xmark")
+                    Image(systemName: "archivebox")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundColor(VColor.textMuted)
                         .frame(width: 16, height: 16)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Close \(label)")
+                .accessibilityLabel("Archive \(label)")
                 .padding(.trailing, VSpacing.sm)
             }
         }


### PR DESCRIPTION
## Summary
- Changed thread close button icon from `xmark` to `archivebox` SF Symbol in both the thread drawer (`MainWindowView`) and the thread tab bar (`ThreadTab`)
- Updated accessibility labels from "Close" to "Archive" to match the new icon semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
