### PR TITLE
Archive threads instead of deleting them

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -105,10 +105,10 @@ struct MainWindowView: View {
                     VStack(spacing: 0) {
                         // Row 1 — thread tab bar
                         ThreadTabBar(
-                            threads: threadManager.threads,
+                            threads: threadManager.visibleThreads,
                             activeThreadId: threadManager.activeThreadId,
                             onSelect: { threadManager.selectThread(id: $0) },
-                            onClose: { threadManager.closeThread(id: $0) },
+                            onClose: { threadManager.archiveThread(id: $0) },
                             onCreate: { threadManager.createThread() },
                             activePanel: $windowState.activePanel
                         )
@@ -224,8 +224,8 @@ struct MainWindowView: View {
                     .font(VFont.body)
                     .foregroundColor(thread.id == threadManager.activeThreadId ? VColor.accent : VColor.textPrimary)
                 Spacer()
-                // Reserve space for close button
-                if threadManager.threads.count > 1 {
+                // Reserve space for archive button
+                if threadManager.visibleThreads.count > 1 {
                     Spacer().frame(width: 16)
                 }
             }
@@ -235,8 +235,8 @@ struct MainWindowView: View {
         }
         .buttonStyle(.plain)
         .overlay(alignment: .trailing) {
-            if threadManager.threads.count > 1 {
-                Button(action: { threadManager.closeThread(id: thread.id) }) {
+            if threadManager.visibleThreads.count > 1 {
+                Button(action: { threadManager.archiveThread(id: thread.id) }) {
                     Image(systemName: "archivebox")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundColor(VColor.textMuted)
@@ -270,7 +270,7 @@ struct MainWindowView: View {
 
             ScrollView {
                 VStack(spacing: VSpacing.xs) {
-                    ForEach(threadManager.threads) { thread in
+                    ForEach(threadManager.visibleThreads) { thread in
                         threadItem(thread)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -27,6 +27,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Called when an inline confirmation response should dismiss the floating panel.
     var confirmationDismissHandler: ((String) -> Void)?
 
+    /// Threads that are not archived — used by the UI to populate the sidebar/tab bar.
+    var visibleThreads: [ThreadModel] {
+        threads.filter { !$0.isArchived }
+    }
+
     var activeViewModel: ChatViewModel? {
         guard let activeThreadId else { return nil }
         return chatViewModels[activeThreadId]
@@ -74,6 +79,25 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
 
         log.info("Closed thread \(id)")
+    }
+
+    func archiveThread(id: UUID) {
+        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+
+        chatViewModels[id]?.stopGenerating()
+        threads[index].isArchived = true
+
+        // If the archived thread was active, switch to the nearest visible thread
+        // or create a new one if none remain.
+        if activeThreadId == id {
+            if let next = visibleThreads.first {
+                activeThreadId = next.id
+            } else {
+                createThread()
+            }
+        }
+
+        log.info("Archived thread \(id)")
     }
 
     /// Clear the `activeSurfaceId` on a specific thread's ChatViewModel.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -6,11 +6,13 @@ struct ThreadModel: Identifiable, Hashable {
     let createdAt: Date
     /// Daemon conversation ID for restored threads. Nil for new, unsaved threads.
     let sessionId: String?
+    var isArchived: Bool
 
-    init(id: UUID = UUID(), title: String = "New Thread", createdAt: Date = Date(), sessionId: String? = nil) {
+    init(id: UUID = UUID(), title: String = "New Thread", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
         self.sessionId = sessionId
+        self.isArchived = isArchived
     }
 }


### PR DESCRIPTION
## Summary
- Added `isArchived` property to `ThreadModel`
- Added `archiveThread(id:)` to `ThreadManager` that marks threads as archived instead of removing them, and switches to the next visible thread (or creates a new one)
- Updated drawer and tab bar to use `visibleThreads` (filters out archived) so archived threads no longer appear in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
