### PR TITLE
Persist archived thread state across app restarts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -5,6 +5,7 @@ import Foundation
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadManager")
+private let archivedSessionsKey = "archivedSessionIds"
 
 @MainActor
 final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
@@ -87,6 +88,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         chatViewModels[id]?.stopGenerating()
         threads[index].isArchived = true
 
+        if let sessionId = threads[index].sessionId {
+            var archived = archivedSessionIds
+            archived.insert(sessionId)
+            archivedSessionIds = archived
+        }
+
         // If the archived thread was active, switch to the nearest visible thread
         // or create a new one if none remain.
         if activeThreadId == id {
@@ -98,6 +105,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
 
         log.info("Archived thread \(id)")
+    }
+
+    func isSessionArchived(_ sessionId: String) -> Bool {
+        archivedSessionIds.contains(sessionId)
     }
 
     /// Clear the `activeSurfaceId` on a specific thread's ChatViewModel.
@@ -189,6 +200,15 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     // MARK: - Private
+
+    private var archivedSessionIds: Set<String> {
+        get {
+            Set(UserDefaults.standard.stringArray(forKey: archivedSessionsKey) ?? [])
+        }
+        set {
+            UserDefaults.standard.set(Array(newValue), forKey: archivedSessionsKey)
+        }
+    }
 
     /// Subscribe to the active ChatViewModel's objectWillChange so that
     /// SwiftUI re-evaluates views when the nested view model publishes

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -16,6 +16,7 @@ protocol ThreadRestorerDelegate: AnyObject {
     func removeChatViewModel(for threadId: UUID)
     func makeViewModel() -> ChatViewModel
     func activateThread(_ id: UUID)
+    func isSessionArchived(_ sessionId: String) -> Bool
 }
 
 /// Handles daemon session restoration: fetching the session list on connect,
@@ -88,7 +89,8 @@ final class ThreadSessionRestorer {
             let thread = ThreadModel(
                 title: session.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
-                sessionId: session.id
+                sessionId: session.id,
+                isArchived: delegate.isSessionArchived(session.id)
             )
             let viewModel = delegate.makeViewModel()
             viewModel.sessionId = session.id
@@ -105,8 +107,8 @@ final class ThreadSessionRestorer {
             delegate.threads = restoredThreads + delegate.threads
         }
 
-        if let firstThread = restoredThreads.first {
-            delegate.activateThread(firstThread.id)
+        if let firstVisible = restoredThreads.first(where: { !$0.isArchived }) {
+            delegate.activateThread(firstVisible.id)
         }
 
         log.info("Restored \(restoredThreads.count) threads from daemon")


### PR DESCRIPTION
## Summary
- Store archived session IDs in `UserDefaults` so threads stay archived after app relaunch
- `ThreadSessionRestorer` checks the persisted set when restoring threads and marks them as archived, skipping activation of archived threads
- Added `isSessionArchived(_:)` to `ThreadRestorerDelegate` protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
