### PR TITLE
feat: remember main window size and position across launches

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -106,6 +106,7 @@ final class MainWindow {
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
         window.setFrame(windowRect, display: false)
+        window.setFrameAutosaveName("MainWindow")
 
         configureTrafficLightPadding(window)
 


### PR DESCRIPTION
## Summary
- Use AppKit's `setFrameAutosaveName("MainWindow")` to automatically persist and restore the main window's size and position via UserDefaults
- On first launch, the default calculated size (80% screen width, 85% height) is used; subsequent launches restore the user's last window frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
