### PR TITLE
Add archived threads list in settings with unarchive action

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -606,7 +606,7 @@ struct MainWindowView: View {
                     }
                 }, daemonClient: daemonClient)
             case .settings:
-                SettingsPanel(onClose: { windowState.activePanel = nil }, store: settingsStore, daemonClient: daemonClient)
+                SettingsPanel(onClose: { windowState.activePanel = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
             case .directory:
                 DirectoryPanel(onClose: { windowState.activePanel = nil })
             case .debug:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -6,6 +6,7 @@ struct SettingsPanel: View {
     var onClose: () -> Void
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
+    @ObservedObject var threadManager: ThreadManager
 
     @State private var apiKeyText: String = ""
     @State private var braveKeyText: String = ""
@@ -185,6 +186,35 @@ struct SettingsPanel: View {
                 .padding(VSpacing.lg)
                 .vCard(background: Slate._900)
 
+                // ARCHIVED THREADS section
+                if !threadManager.archivedThreads.isEmpty {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("ARCHIVED THREADS")
+                            .font(VFont.sectionTitle)
+                            .foregroundColor(VColor.textPrimary)
+
+                        ForEach(threadManager.archivedThreads) { thread in
+                            HStack {
+                                Text(thread.title)
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textSecondary)
+                                    .lineLimit(1)
+                                Spacer()
+                                Button(action: { threadManager.unarchiveThread(id: thread.id) }) {
+                                    Text("Unarchive")
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.accent)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Unarchive \(thread.title)")
+                            }
+                            .padding(.vertical, VSpacing.xs)
+                        }
+                    }
+                    .padding(VSpacing.lg)
+                    .vCard(background: Slate._900)
+                }
+
                 // PERMISSIONS section
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     Text("PERMISSIONS")
@@ -308,9 +338,10 @@ struct SettingsPanel: View {
 
 #Preview("SettingsPanel") {
     let agent = AmbientAgent()
+    let dc = DaemonClient()
     ZStack {
         VColor.background.ignoresSafeArea()
-        SettingsPanel(onClose: {}, store: SettingsStore(ambientAgent: agent))
+        SettingsPanel(onClose: {}, store: SettingsStore(ambientAgent: agent), threadManager: ThreadManager(daemonClient: dc))
     }
     .frame(width: 600, height: 700)
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -33,6 +33,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads.filter { !$0.isArchived }
     }
 
+    var archivedThreads: [ThreadModel] {
+        threads.filter { $0.isArchived }
+    }
+
     var activeViewModel: ChatViewModel? {
         guard let activeThreadId else { return nil }
         return chatViewModels[activeThreadId]
@@ -105,6 +109,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
 
         log.info("Archived thread \(id)")
+    }
+
+    func unarchiveThread(id: UUID) {
+        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+
+        threads[index].isArchived = false
+
+        if let sessionId = threads[index].sessionId {
+            var archived = archivedSessionIds
+            archived.remove(sessionId)
+            archivedSessionIds = archived
+        }
+
+        log.info("Unarchived thread \(id)")
     }
 
     func isSessionArchived(_ sessionId: String) -> Bool {


### PR DESCRIPTION
## Summary
- Added `unarchiveThread(id:)` to `ThreadManager` that restores a thread to the sidebar and removes its session ID from the persisted archive set
- Added `archivedThreads` computed property to `ThreadManager`
- Added "ARCHIVED THREADS" section to `SettingsPanel` (between Display and Permissions) that lists archived threads with an "Unarchive" button for each; section only appears when there are archived threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
