### PR TITLE
feat: allow archiving the last remaining thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -225,9 +225,7 @@ struct MainWindowView: View {
                     .foregroundColor(thread.id == threadManager.activeThreadId ? VColor.accent : VColor.textPrimary)
                 Spacer()
                 // Reserve space for archive button
-                if threadManager.visibleThreads.count > 1 {
-                    Spacer().frame(width: 16)
-                }
+                Spacer().frame(width: 16)
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.xs)
@@ -235,18 +233,16 @@ struct MainWindowView: View {
         }
         .buttonStyle(.plain)
         .overlay(alignment: .trailing) {
-            if threadManager.visibleThreads.count > 1 {
-                Button(action: { threadManager.archiveThread(id: thread.id) }) {
-                    Image(systemName: "archivebox")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Archive \(thread.title)")
-                .padding(.trailing, VSpacing.lg)
+            Button(action: { threadManager.archiveThread(id: thread.id) }) {
+                Image(systemName: "archivebox")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Archive \(thread.title)")
+            .padding(.trailing, VSpacing.lg)
         }
         .background(thread.id == threadManager.activeThreadId ? VColor.surface : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -23,7 +23,7 @@ struct ThreadTabBar: View {
                         label: thread.title,
                         icon: "flame",
                         isSelected: thread.id == activeThreadId,
-                        isCloseable: threads.count > 1,
+                        isCloseable: true,
                         onSelect: { onSelect(thread.id) },
                         onClose: { onClose(thread.id) }
                     )


### PR DESCRIPTION
## Summary
- Remove `visibleThreads.count > 1` guards that blocked archiving when only one thread remained
- Archive button now always appears in both tab mode and drawer mode
- When the last visible thread is archived, a new blank thread is created automatically (existing ThreadManager behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
