### PR TITLE
fix: handle all-archived restore and persist archive for new threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -210,6 +210,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             self?.ambientAgent?.activeWatchSession?.stop()
             self?.ambientAgent?.activeWatchSession = nil
         }
+        viewModel.onSessionCreated = { [weak self, weak viewModel] sessionId in
+            guard let self, let viewModel else { return }
+            self.backfillSessionId(sessionId, for: viewModel)
+        }
         return viewModel
     }
 
@@ -218,6 +222,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     // MARK: - Private
+
+    /// Backfill ThreadModel.sessionId when the daemon assigns a session to a new thread.
+    private func backfillSessionId(_ sessionId: String, for viewModel: ChatViewModel) {
+        guard let threadId = chatViewModels.first(where: { $0.value === viewModel })?.key,
+              let index = threads.firstIndex(where: { $0.id == threadId }),
+              threads[index].sessionId == nil else { return }
+        threads[index].sessionId = sessionId
+    }
 
     private var archivedSessionIds: Set<String> {
         get {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -5,7 +5,8 @@ struct ThreadModel: Identifiable, Hashable {
     let title: String
     let createdAt: Date
     /// Daemon conversation ID for restored threads. Nil for new, unsaved threads.
-    let sessionId: String?
+    /// Mutable so it can be backfilled when the daemon assigns a session to a new thread.
+    var sessionId: String?
     var isArchived: Bool
 
     init(id: UUID = UUID(), title: String = "New Thread", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -16,6 +16,7 @@ protocol ThreadRestorerDelegate: AnyObject {
     func removeChatViewModel(for threadId: UUID)
     func makeViewModel() -> ChatViewModel
     func activateThread(_ id: UUID)
+    func createThread()
     func isSessionArchived(_ sessionId: String) -> Bool
 }
 
@@ -109,6 +110,10 @@ final class ThreadSessionRestorer {
 
         if let firstVisible = restoredThreads.first(where: { !$0.isArchived }) {
             delegate.activateThread(firstVisible.id)
+        } else if defaultThreadIsEmpty {
+            // All restored threads are archived and the default thread was removed,
+            // so create a new empty thread to avoid a blank window.
+            delegate.createThread()
         }
 
         log.info("Restored \(restoredThreads.count) threads from daemon")

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -11,6 +11,8 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
     var restoreRecentThreads: Bool = true
     var viewModels: [UUID: ChatViewModel] = [:]
     var activatedThreadId: UUID?
+    var createThreadCallCount = 0
+    var archivedSessionIds: Set<String> = []
     private let daemonClient: DaemonClient
 
     init(daemonClient: DaemonClient) {
@@ -35,6 +37,19 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
 
     func activateThread(_ id: UUID) {
         activatedThreadId = id
+    }
+
+    func createThread() {
+        createThreadCallCount += 1
+        let thread = ThreadModel()
+        let vm = makeViewModel()
+        threads.insert(thread, at: 0)
+        viewModels[thread.id] = vm
+        activatedThreadId = thread.id
+    }
+
+    func isSessionArchived(_ sessionId: String) -> Bool {
+        archivedSessionIds.contains(sessionId)
     }
 }
 
@@ -274,5 +289,64 @@ struct ThreadSessionRestorerTests {
 
         // Only 5 sessions should be restored
         #expect(delegate.threads.count == 5)
+    }
+
+    // MARK: - All-Archived Restore
+
+    @Test @MainActor
+    func allArchivedSessionsCreatesNewThread() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        // Mark all sessions as archived
+        delegate.archivedSessionIds = ["s1", "s2"]
+
+        // Start with one empty default thread
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Chat 1", updatedAt: 3000),
+            (id: "s2", title: "Chat 2", updatedAt: 2000),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        // Default thread replaced, restored threads are archived, new thread created
+        #expect(delegate.createThreadCallCount == 1)
+        // 2 archived threads + 1 new thread
+        #expect(delegate.threads.count == 3)
+        // The new thread should be active
+        #expect(delegate.activatedThreadId != nil)
+        #expect(delegate.threads.first(where: { $0.id == delegate.activatedThreadId })?.isArchived == false)
+    }
+
+    @Test @MainActor
+    func allArchivedWithNonEmptyDefaultDoesNotCreateThread() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        delegate.archivedSessionIds = ["s1"]
+
+        // Default thread has an active session (not empty)
+        let activeThread = ThreadModel(title: "Active")
+        let activeVm = delegate.makeViewModel()
+        activeVm.sessionId = "active-session"
+        delegate.threads = [activeThread]
+        delegate.viewModels[activeThread.id] = activeVm
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Archived Chat", updatedAt: 1000),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        // Default thread preserved, no new thread created
+        #expect(delegate.createThreadCallCount == 0)
+        #expect(delegate.threads.count == 2)
+        #expect(delegate.threads.contains(where: { $0.id == activeThread.id }))
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -173,6 +173,10 @@ public final class ChatViewModel: ObservableObject {
     /// The macOS layer should cancel the WatchSession and send a cancel to the daemon.
     public var onStopWatch: (() -> Void)?
 
+    /// Called when the daemon assigns a session ID to this chat (via session_info).
+    /// Used by ThreadManager to backfill ThreadModel.sessionId for new threads.
+    public var onSessionCreated: ((String) -> Void)?
+
     /// Whether this view model has had its history loaded from the daemon.
     public var isHistoryLoaded: Bool = false
 
@@ -637,6 +641,7 @@ public final class ChatViewModel: ObservableObject {
 
                 sessionId = info.sessionId
                 bootstrapCorrelationId = nil
+                onSessionCreated?(info.sessionId)
                 log.info("Chat session created: \(info.sessionId)")
 
                 // Send the queued user message


### PR DESCRIPTION
Addresses review feedback on #2673:

- Create a fallback thread when all restored sessions are archived (prevents blank window on launch)
- Make sessionId mutable so archive state can be persisted for threads created during the current session
- Add onSessionCreated callback to backfill ThreadModel.sessionId when the daemon assigns a session to a new thread
- Add createThread() to ThreadRestorerDelegate protocol for fallback thread creation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
