### PR TITLE
refactor: migrate ActivityPanel to VSidePanel component

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -6,44 +6,13 @@ struct ActivityPanel: View {
     let onClose: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Header
-            HStack {
-                Text("Activity")
-                    .font(VFont.headline)
-                    .foregroundColor(VColor.textPrimary)
-
-                Spacer()
-
-                Button {
-                    onClose()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 32, height: 32)
-                        .contentShape(Rectangle())
+        VSidePanel(title: "Activity", onClose: onClose) {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                ForEach(toolCalls) { toolCall in
+                    ActivityStepView(toolCall: toolCall)
                 }
-                .buttonStyle(.plain)
-            }
-            .padding(VSpacing.lg)
-            .background(VColor.chatBackground)
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
-            // Activity timeline
-            ScrollView {
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    ForEach(toolCalls) { toolCall in
-                        ActivityStepView(toolCall: toolCall)
-                    }
-                }
-                .padding(VSpacing.lg)
             }
         }
-        .frame(width: 400)
-        .background(VColor.background)
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the hand-rolled header/scroll/background in ActivityPanel with the shared `VSidePanel` component
- Activity panel now uses `VFont.panelTitle` (24pt Silkscreen, uppercased) matching Agent/Debug/Settings panels
- Consistent padding (`VSpacing.xl`) and background (`VColor.backgroundSubtle`) inherited from VSidePanel

## Test plan
- [x] `./build.sh` compiles successfully
- [ ] Open Activity panel and verify header matches other panels visually
- [ ] Verify scrolling, close button, and content padding work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
