### PR TITLE
feat: replace bordered cards with timeline layout in ActivityPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -7,9 +7,24 @@ struct ActivityPanel: View {
 
     var body: some View {
         VSidePanel(title: "Activity", onClose: onClose) {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                ForEach(toolCalls) { toolCall in
-                    ActivityStepView(toolCall: toolCall)
+            ZStack(alignment: .leading) {
+                // Vertical timeline line aligned with center of status circles
+                Rectangle()
+                    .fill(VColor.surfaceBorder)
+                    .frame(width: 1)
+                    .padding(.leading, 11) // center of 24pt circle
+
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
+                        ActivityStepView(toolCall: toolCall)
+                            .padding(.vertical, VSpacing.sm)
+
+                        if index < toolCalls.count - 1 {
+                            Divider()
+                                .background(VColor.surfaceBorder)
+                                .padding(.leading, 32)
+                        }
+                    }
                 }
             }
         }
@@ -118,15 +133,6 @@ struct ActivityStepView: View {
                 .padding(.leading, 32)
             }
         }
-        .padding(VSpacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(toolCall.isError ? VColor.error.opacity(0.05) : VColor.surface)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
     }
 
     private var statusColor: Color {


### PR DESCRIPTION
## Summary
- Remove card backgrounds and border strokes from individual activity steps
- Add a vertical timeline line connecting status circles on the left edge
- Separate steps with subtle dividers instead of card borders
- Part 2 of 6 in the Activity panel restyle plan

## Test plan
- [x] `./build.sh` compiles successfully
- [ ] Open Activity panel and verify steps are connected by a vertical line
- [ ] Verify error steps still have distinct visual treatment on the result block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
