### PR TITLE
feat: restyle result blocks with left accent border

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -97,15 +97,17 @@ struct ActivityStepView: View {
 
             // Result
             if let result = toolCall.result, !result.isEmpty {
+                let accentColor = toolCall.isError ? VColor.error : VColor.accent
+
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text(result)
                         .font(VFont.monoSmall)
                         .foregroundColor(toolCall.isError ? VColor.error : VColor.textSecondary)
-                        .lineLimit(isResultExpanded ? nil : 6)
+                        .lineLimit(isResultExpanded ? nil : 3)
                         .textSelection(.enabled)
 
                     // Show more/less button if text is long
-                    if result.count > 200 || result.split(separator: "\n").count > 6 {
+                    if result.count > 120 || result.split(separator: "\n").count > 3 {
                         Button(action: {
                             withAnimation(VAnimation.fast) {
                                 isResultExpanded.toggle()
@@ -126,10 +128,13 @@ struct ActivityStepView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.sm)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(VColor.surface)
-                )
+                .background(Slate._900)
+                .overlay(alignment: .leading) {
+                    Rectangle()
+                        .fill(accentColor)
+                        .frame(width: 2)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
                 .padding(.leading, 32)
             }
         }


### PR DESCRIPTION
## Summary
- Replace full rounded-rect background on result blocks with a 2pt left accent border
- Purple accent for success results, red for error results, on `Slate._900` background
- Reduce default line limit from 6 to 3 for more compact initial display
- Part 3 of 6 in the Activity panel restyle plan

## Test plan
- [x] `./build.sh` compiles successfully
- [ ] Verify result blocks show colored left border (purple for success, red for errors)
- [ ] Verify "Show more" toggle still works correctly with the new 3-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
