### PR TITLE
feat: add tool-specific icons to activity panel steps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -51,7 +51,7 @@ struct ActivityStepView: View {
                                 .font(.system(size: 10, weight: .bold))
                                 .foregroundColor(VColor.error)
                         } else {
-                            Image(systemName: "checkmark")
+                            Image(systemName: toolIcon)
                                 .font(.system(size: 10, weight: .bold))
                                 .foregroundColor(VColor.accent)
                         }
@@ -73,7 +73,7 @@ struct ActivityStepView: View {
             // Input summary
             if !toolCall.inputSummary.isEmpty {
                 HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "terminal")
+                    Image(systemName: toolIcon)
                         .font(.system(size: 11))
                         .foregroundColor(VColor.textMuted)
 
@@ -138,6 +138,17 @@ struct ActivityStepView: View {
                 .padding(.leading, 32)
             }
         }
+    }
+
+    private var toolIcon: String {
+        let name = toolCall.toolName.lowercased()
+        if name.contains("search") { return "magnifyingglass" }
+        if name.contains("navigate") { return "globe" }
+        if name.contains("screenshot") { return "camera.viewfinder" }
+        if name.contains("click") { return "cursorarrow.click.2" }
+        if name.contains("read") || name.contains("edit") || name.contains("write") { return "doc.text" }
+        if name.contains("command") || name.contains("bash") || name.contains("shell") { return "terminal" }
+        return "terminal"
     }
 
     private var statusColor: Color {


### PR DESCRIPTION
## Summary
- Add `toolIcon` computed property mapping tool names to SF Symbols (magnifyingglass, globe, camera.viewfinder, etc.)
- Use tool-specific icon in the input summary row instead of generic terminal icon
- Show tool icon in the status circle on completion instead of generic checkmark
- Unknown tools fall back to terminal icon
- Part 4 of 6 in the Activity panel restyle plan

## Test plan
- [x] `./build.sh` compiles successfully
- [ ] Verify different tool types show distinct icons in the activity panel
- [ ] Verify unknown tools still show terminal icon as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
