### PR TITLE
feat: add timestamp metadata to activity panel steps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -68,6 +68,21 @@ struct ActivityStepView: View {
                     .foregroundColor(VColor.textPrimary)
 
                 Spacer()
+
+                // Duration
+                if toolCall.isComplete, let started = toolCall.startedAt, let completed = toolCall.completedAt {
+                    let duration = completed.timeIntervalSince(started)
+                    Text(formatDuration(duration))
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                } else if !toolCall.isComplete, let started = toolCall.startedAt {
+                    TimelineView(.animation(minimumInterval: 0.5)) { context in
+                        let elapsed = context.date.timeIntervalSince(started)
+                        Text(formatDuration(elapsed))
+                            .font(VFont.small)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                }
             }
 
             // Input summary
@@ -149,6 +164,15 @@ struct ActivityStepView: View {
         if name.contains("read") || name.contains("edit") || name.contains("write") { return "doc.text" }
         if name.contains("command") || name.contains("bash") || name.contains("shell") { return "terminal" }
         return "terminal"
+    }
+
+    private func formatDuration(_ seconds: TimeInterval) -> String {
+        if seconds < 60 {
+            return String(format: "%.1fs", seconds)
+        }
+        let mins = Int(seconds) / 60
+        let secs = Int(seconds) % 60
+        return "\(mins)m \(secs)s"
     }
 
     private var statusColor: Color {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -94,6 +94,8 @@ public struct ToolCallData: Identifiable, Equatable {
     /// Whether this tool call arrived before any text content in the message.
     /// Used to render pre-text tool calls above and post-text tool calls below the bubble.
     public var arrivedBeforeText: Bool
+    public var startedAt: Date?
+    public var completedAt: Date?
     /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
     public var imageData: String?
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
@@ -116,7 +118,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.imageData == rhs.imageData
     }
 
-    public init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil) {
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
@@ -126,6 +128,8 @@ public struct ToolCallData: Identifiable, Equatable {
         self.arrivedBeforeText = arrivedBeforeText
         self.imageData = imageData
         self.cachedImage = Self.decodeImage(from: imageData)
+        self.startedAt = startedAt
+        self.completedAt = completedAt
     }
 
     /// Decode base64 image data into a platform image. Returns nil if data is absent or invalid.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -926,7 +926,8 @@ public final class ChatViewModel: ObservableObject {
             let toolCall = ToolCallData(
                 toolName: toolDisplayName(msg.toolName),
                 inputSummary: summarizeToolInput(msg.input),
-                arrivedBeforeText: !currentAssistantHasText
+                arrivedBeforeText: !currentAssistantHasText,
+                startedAt: Date()
             )
             // Add to existing assistant message or create one
             if let existingId = currentAssistantMessageId,
@@ -954,6 +955,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[msgIndex].toolCalls[tcIndex].result = truncatedResult
                 messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true
+                messages[msgIndex].toolCalls[tcIndex].completedAt = Date()
                 messages[msgIndex].toolCalls[tcIndex].imageData = msg.imageData
                 messages[msgIndex].toolCalls[tcIndex].cachedImage = ToolCallData.decodeImage(from: msg.imageData)
             }


### PR DESCRIPTION
## Summary
- Add `startedAt` and `completedAt` fields to `ToolCallData` (backward-compatible, default nil)
- Populate `startedAt` when tool calls are created, `completedAt` when results arrive
- Display duration for completed steps (e.g. "1.2s") aligned to trailing edge
- Show live elapsed timer for in-progress steps via `TimelineView`
- Part 5 of 6 in the Activity panel restyle plan

## Test plan
- [x] `./build.sh` compiles successfully
- [ ] Verify completed steps show duration (e.g. "1.2s")
- [ ] Verify in-progress steps show a live ticking timer
- [ ] Verify steps from history (without timestamps) show nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
