### PR TITLE
feat: animate step entries and auto-scroll in activity panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -7,22 +7,37 @@ struct ActivityPanel: View {
 
     var body: some View {
         VSidePanel(title: "Activity", onClose: onClose) {
-            ZStack(alignment: .leading) {
-                // Vertical timeline line aligned with center of status circles
-                Rectangle()
-                    .fill(VColor.surfaceBorder)
-                    .frame(width: 1)
-                    .padding(.leading, 11) // center of 24pt circle
+            ScrollViewReader { proxy in
+                ZStack(alignment: .leading) {
+                    // Vertical timeline line aligned with center of status circles
+                    Rectangle()
+                        .fill(VColor.surfaceBorder)
+                        .frame(width: 1)
+                        .padding(.leading, 11) // center of 24pt circle
 
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
-                        ActivityStepView(toolCall: toolCall)
-                            .padding(.vertical, VSpacing.sm)
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
+                            ActivityStepView(toolCall: toolCall)
+                                .id(toolCall.id)
+                                .padding(.vertical, VSpacing.sm)
+                                .transition(.asymmetric(
+                                    insertion: .move(edge: .top).combined(with: .opacity),
+                                    removal: .opacity
+                                ))
 
-                        if index < toolCalls.count - 1 {
-                            Divider()
-                                .background(VColor.surfaceBorder)
-                                .padding(.leading, 32)
+                            if index < toolCalls.count - 1 {
+                                Divider()
+                                    .background(VColor.surfaceBorder)
+                                    .padding(.leading, 32)
+                            }
+                        }
+                    }
+                    .animation(VAnimation.standard, value: toolCalls.count)
+                }
+                .onChange(of: toolCalls.count) {
+                    if let lastId = toolCalls.last?.id {
+                        withAnimation(VAnimation.standard) {
+                            proxy.scrollTo(lastId, anchor: .bottom)
                         }
                     }
                 }
@@ -151,8 +166,10 @@ struct ActivityStepView: View {
                 }
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
                 .padding(.leading, 32)
+                .transition(.opacity)
             }
         }
+        .animation(VAnimation.fast, value: toolCall.isComplete)
     }
 
     private var toolIcon: String {


### PR DESCRIPTION
## Summary
- Add slide-in transitions for new steps (move from top + opacity fade)
- Auto-scroll to the latest step when new ones appear via `ScrollViewReader`
- Add opacity transition on result blocks when tool calls complete
- Animation driven by `toolCalls.count` changes
- Part 6 of 6 (final) in the Activity panel restyle plan

## Test plan
- [x] `./build.sh` compiles successfully
- [ ] Verify new steps animate in smoothly (slide + fade)
- [ ] Verify panel auto-scrolls to show the latest step
- [ ] Verify result blocks fade in when tool call completes
- [ ] Verify no layout jank or jumps during animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
