### PR TITLE
fix(ui): consistent width for inline widget cards

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -43,6 +43,7 @@ public struct InlineSurfaceRouter: View {
                 actionButtons
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .inlineWidgetCard()
         .overlay(alignment: .topTrailing) {
             if isDynamicPreview {
@@ -68,9 +69,8 @@ public struct InlineSurfaceRouter: View {
                 .padding(VSpacing.sm)
             }
         }
-        // Dynamic page previews should be compact, not stretch to fill.
-        // Use maxWidth instead of fixedSize so narrow parent views still constrain the card.
-        .frame(maxWidth: isDynamicPreview ? 350 : .infinity, alignment: .leading)
+        // Consistent width for all widget cards; dynamic page previews are more compact.
+        .frame(maxWidth: isDynamicPreview ? 350 : 540, alignment: .leading)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Set a fixed `maxWidth: 540` for all inline widget cards so weather, flights, and other widgets render at the same width
- Added `.frame(maxWidth: .infinity)` before card chrome so fixed-column widgets (weather) stretch to fill the available width instead of shrinking to content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
