### PR TITLE
feat: persist sidebar open/close state across app restarts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -7,11 +7,12 @@ struct MainWindowView: View {
     var zoomManager: ZoomManager
     @ObservedObject var traceStore: TraceStore
     @ObservedObject var windowState: MainWindowState
-    @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
+    @State private var columnVisibility: NavigationSplitViewVisibility
     @State private var selectedThreadId: UUID?
     @State private var workspaceEditorContentHeight: CGFloat = 20
     @State private var showSharePicker = false
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
+    @AppStorage("sidebarOpen") private var sidebarOpen: Bool = false
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
@@ -29,6 +30,8 @@ struct MainWindowView: View {
         self.settingsStore = settingsStore
         self.windowState = windowState
         self.onMicrophoneToggle = onMicrophoneToggle
+        let savedSidebarOpen = UserDefaults.standard.bool(forKey: "sidebarOpen")
+        _columnVisibility = State(initialValue: savedSidebarOpen ? .all : .detailOnly)
     }
 
     // MARK: - Layout Constants
@@ -57,6 +60,7 @@ struct MainWindowView: View {
                                 VIconButton(label: "Threads", icon: "sidebar.left", isActive: columnVisibility != .detailOnly, iconOnly: true) {
                                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                                         columnVisibility = (columnVisibility == .detailOnly) ? .all : .detailOnly
+                                        sidebarOpen = (columnVisibility != .detailOnly)
                                     }
                                 }
 


### PR DESCRIPTION
## Summary
- Saves the threads/conversations sidebar open/close state to UserDefaults via `@AppStorage("sidebarOpen")`
- Restores the saved state when the app launches by reading UserDefaults in the view's init
- Defaults to closed (matching existing behavior) when no saved state exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
