### PR TITLE
fix: remove explicit return in @ViewBuilder function

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -224,7 +224,7 @@ struct MainWindowView: View {
     @ViewBuilder
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected = thread.id == threadManager.activeThreadId
-        return HStack(spacing: 0) {
+        HStack(spacing: 0) {
             Button(action: { threadManager.selectThread(id: thread.id) }) {
                 Text(thread.title)
                     .font(.custom("Inter", size: 13))


### PR DESCRIPTION
## Summary
- Remove explicit `return` keyword in `threadItem()` `@ViewBuilder` function that was disabling the result builder and producing repeated compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
