### PR TITLE
fix: set sessionId on unarchived thread's ChatViewModel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -144,7 +144,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         // Re-create the ChatViewModel since it was removed on archive.
         if chatViewModels[id] == nil {
-            chatViewModels[id] = makeViewModel()
+            let viewModel = makeViewModel()
+            viewModel.sessionId = threads[index].sessionId
+            chatViewModels[id] = viewModel
         }
 
         if let sessionId = threads[index].sessionId {


### PR DESCRIPTION
Addresses review feedback on #2677: when `unarchiveThread()` recreates a `ChatViewModel` via `makeViewModel()`, the new VM's `sessionId` was left nil. This caused unarchived threads to bootstrap a fresh daemon session instead of continuing the thread's existing conversation.

The fix sets `viewModel.sessionId = threads[index].sessionId` on the newly created VM, preserving session continuity.

Flagged by both Codex and Devin on #2677.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
