### PR TITLE
fix: use components(separatedBy:) for Show more line count in ActivityPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -137,7 +137,7 @@ struct ActivityStepView: View {
                         .textSelection(.enabled)
 
                     // Show more/less button if text is long
-                    if result.count > 120 || result.split(separator: "\n").count > 3 {
+                    if result.count > 80 || result.components(separatedBy: "\n").count > 3 {
                         Button(action: {
                             withAnimation(VAnimation.fast) {
                                 isResultExpanded.toggle()


### PR DESCRIPTION
Addresses review feedback on #2684:

- Use `components(separatedBy: "\n")` instead of `split(separator: "\n")` to correctly count empty lines for Show more visibility. Swift's `split(separator:)` defaults to `omittingEmptySubsequences: true`, which skips blank lines and undercounts visual lines.
- Lower character threshold from 120 to 80 to better handle narrow panel widths where long lines wrap past 3 visual lines.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
