### PR TITLE
fix: set completedAt on all tool call completion paths

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1132,6 +1132,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
                 for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
                     messages[index].toolCalls[j].isComplete = true
+                    messages[index].toolCalls[j].completedAt = Date()
                 }
             }
             currentAssistantMessageId = nil
@@ -1167,6 +1168,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
                 for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
                     messages[index].toolCalls[j].isComplete = true
+                    messages[index].toolCalls[j].completedAt = Date()
                 }
             }
             currentAssistantMessageId = nil
@@ -1201,6 +1203,7 @@ public final class ChatViewModel: ObservableObject {
             messages[index].isStreaming = false
             for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
                 messages[index].toolCalls[j].isComplete = true
+                messages[index].toolCalls[j].completedAt = Date()
             }
         }
 


### PR DESCRIPTION
Addresses review feedback on #2686: set `completedAt = Date()` in `stopGenerating()` fallback loops so canceled/force-finished steps show duration in the activity panel.

## Changes

In `ChatViewModel.swift`, three fallback loops in `stopGenerating()` set `isComplete = true` without setting `completedAt`. This meant canceled or force-finished tool call steps appeared complete but showed no duration. Added `completedAt = Date()` alongside each `isComplete = true` in all three locations:

1. **No active session guard** (line ~1134) — early return when there's no active session
2. **Cancel send failure** (line ~1170) — `catch` block when sending the cancel message fails  
3. **Normal cancel path** (line ~1205) — main cancel flow before the safety timeout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
