### PR TITLE
feat: make thread sidebar resizable

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -14,7 +14,9 @@ struct MainWindowView: View {
     @State private var isHoveredThread: UUID?
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
     @AppStorage("sidebarOpen") private var sidebarOpen: Bool = false
+    @AppStorage("threadDrawerWidth") private var threadDrawerWidth: Double = 240
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
+    @GestureState private var drawerDragStartWidth: Double? = nil
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
@@ -98,6 +100,8 @@ struct MainWindowView: View {
                             if columnVisibility != .detailOnly {
                                 threadDrawerView
                                     .transition(.move(edge: .leading))
+
+                                drawerDragDivider(availableWidth: geometry.size.width)
                             }
 
                             // Center: Chat + right panel
@@ -286,11 +290,40 @@ struct MainWindowView: View {
                 onSwitchToTabs: { useThreadDrawer = false }
             )
         }
-        .frame(width: 240)
+        .frame(width: threadDrawerWidth)
         .background(VColor.backgroundSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .padding(.bottom, VSpacing.sm)
         .padding(.leading, VSpacing.sm)
+    }
+
+    private func drawerDragDivider(availableWidth: CGFloat) -> some View {
+        Rectangle()
+            .fill(Color.clear)
+            .frame(width: VSpacing.sm)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.set()
+                } else {
+                    NSCursor.arrow.set()
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .updating($drawerDragStartWidth) { _, state, _ in
+                        if state == nil {
+                            state = threadDrawerWidth
+                        }
+                    }
+                    .onChanged { value in
+                        let initialWidth = drawerDragStartWidth ?? threadDrawerWidth
+                        let newWidth = initialWidth + value.translation.width
+                        let minMainContent: CGFloat = 300
+                        let maxAllowed = availableWidth - minMainContent - VSpacing.sm - (VSpacing.sm * 2)
+                        threadDrawerWidth = min(max(newWidth, 180), maxAllowed)
+                    }
+            )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Adds a drag divider on the right edge of the thread drawer, matching the existing right panel resize pattern from VSplitView
- Width is persisted via `@AppStorage("threadDrawerWidth")` (defaults to 240pt, min 180pt)
- Cursor changes to resize indicator on hover for discoverability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
