### PR TITLE
fix: show globe icon for web_fetch tool in ActivityPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -175,7 +175,7 @@ struct ActivityStepView: View {
     private var toolIcon: String {
         let name = toolCall.toolName.lowercased()
         if name.contains("search") { return "magnifyingglass" }
-        if name.contains("navigate") { return "globe" }
+        if name.contains("navigate") || name.contains("fetch") { return "globe" }
         if name.contains("screenshot") { return "camera.viewfinder" }
         if name.contains("click") { return "cursorarrow.click.2" }
         if name.contains("read") || name.contains("edit") || name.contains("write") { return "doc.text" }


### PR DESCRIPTION
Addresses review feedback on #2685: add 'fetch' to the globe icon case in toolIcon so web_fetch ('Fetch URL') shows a globe instead of terminal icon.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
