### PR TITLE
fix: persist archive state in backfillSessionId for pre-archived threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -334,6 +334,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
               let index = threads.firstIndex(where: { $0.id == threadId }),
               threads[index].sessionId == nil else { return }
         threads[index].sessionId = sessionId
+        // If the thread was archived before the session ID arrived,
+        // persist the archive state now that we have a session ID.
+        if threads[index].isArchived {
+            var archived = archivedSessionIds
+            archived.insert(sessionId)
+            archivedSessionIds = archived
+        }
     }
 
     private var archivedSessionIds: Set<String> {


### PR DESCRIPTION
## Summary
- When a thread is archived before the daemon responds with `session_info`, `backfillSessionId` now also persists the sessionId to `archivedSessionIds` in UserDefaults
- Prevents archived threads from silently reappearing as visible after app restart

Addresses review feedback on #2679.

## Test plan
- [ ] Archive a new thread before the daemon assigns a session ID
- [ ] Verify the thread stays archived after app restart
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
