### PR TITLE
fix: limit autogenerated thread names to 5 words / 40 chars

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1939,16 +1939,17 @@ export class Session {
     const client = new Anthropic({ apiKey });
     const response = await client.messages.create({
       model: 'claude-haiku-4-5-20251001',
-      max_tokens: 30,
+      max_tokens: 20,
       messages: [{
         role: 'user',
-        content: `Generate a short title (3-6 words, no quotes) for this conversation:\n\nUser: ${userMessage.slice(0, 200)}\nAssistant: ${assistantResponse.slice(0, 200)}`,
+        content: `Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.\n\nUser: ${userMessage.slice(0, 200)}\nAssistant: ${assistantResponse.slice(0, 200)}`,
       }],
     });
 
     const textBlock = response.content.find((b) => b.type === 'text');
     if (textBlock && textBlock.type === 'text') {
-      const title = textBlock.text.trim().replace(/^["']|["']$/g, '');
+      let title = textBlock.text.trim().replace(/^["']|["']$/g, '');
+      if (title.length > 40) title = title.slice(0, 40).trimEnd();
       conversationStore.updateConversationTitle(this.conversationId, title);
       log.info({ conversationId: this.conversationId, title }, 'Auto-generated conversation title');
     }


### PR DESCRIPTION
## Summary
- Updated the LLM prompt for thread title generation to enforce a maximum of 5 words and 40 characters
- Reduced max_tokens from 30 to 20 to match the shorter output
- Added a hard truncation safeguard at 40 characters in case the LLM exceeds the limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
