### PR TITLE
fix(ui): switch chat bubbles and thread drawer to SF Pro for better readability

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -709,7 +709,7 @@ private struct ChatBubble: View {
 
             if hasText {
                 Text(markdownText)
-                    .font(VFont.body)
+                    .font(.system(size: 13))
                     .foregroundColor(isUser ? .white : VColor.textPrimary)
                     .tint(isUser ? .white : VColor.accent)
                     .textSelection(.enabled)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -239,7 +239,7 @@ struct MainWindowView: View {
                 threadManager.selectThread(id: thread.id)
             }) {
                 Text(thread.title)
-                    .font(.custom("Inter", size: 13))
+                    .font(.system(size: 13))
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -294,7 +294,7 @@ struct MainWindowView: View {
                 .padding(.bottom, VSpacing.xl)
 
             Text("Recents")
-                .font(.custom("Inter", size: 11))
+                .font(.system(size: 11))
                 .foregroundColor(VColor.textMuted)
                 .padding(.bottom, VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -731,7 +731,7 @@ private struct NewConversationButton: View {
                             .stroke(isHovered ? VColor.textMuted : VColor.textMuted.opacity(0.5), lineWidth: 1)
                     )
                 Text("New conversation")
-                    .font(.custom("Inter-Medium", size: 13))
+                    .font(.system(size: 13, weight: .medium))
             }
             .foregroundColor(VColor.textPrimary)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -771,14 +771,14 @@ private struct ParentalControlsMenuButton: View {
         } label: {
             HStack(spacing: VSpacing.md) {
                 Text("P")
-                    .font(.custom("Inter-SemiBold", size: 13))
+                    .font(.system(size: 13, weight: .semibold))
                     .foregroundColor(.white)
                     .frame(width: 32, height: 32)
                     .background(VColor.textMuted)
                     .clipShape(Circle())
 
                 Text("Parental Controls")
-                    .font(.custom("Inter-Medium", size: 13))
+                    .font(.system(size: 13, weight: .medium))
                     .foregroundColor(VColor.textPrimary)
 
                 Spacer()

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -53,18 +53,18 @@ public enum VFont {
     public static let title      = Font.custom("Silkscreen-Bold", size: 22)
     public static let headline   = Font.custom("Silkscreen-Bold", size: 13)
 
-    // MARK: - Body / UI (DM Mono)
+    // MARK: - Body / UI (Inter)
 
-    public static let body       = dmMono("DMMono-Regular", size: 13)
-    public static let bodyMedium = dmMono("DMMono-Medium", size: 13)
-    public static let bodyBold   = dmMono("DMMono-Medium", size: 13)
-    public static let caption    = dmMono("DMMono-Regular", size: 11)
-    public static let captionMedium = dmMono("DMMono-Medium", size: 11)
-    public static let small      = dmMono("DMMono-Regular", size: 10)
+    public static let body       = Font.custom("Inter", size: 13)
+    public static let bodyMedium = Font.custom("Inter-Medium", size: 13)
+    public static let bodyBold   = Font.custom("Inter-SemiBold", size: 13)
+    public static let caption    = Font.custom("Inter", size: 11)
+    public static let captionMedium = Font.custom("Inter-Medium", size: 11)
+    public static let small      = Font.custom("Inter", size: 10)
 
     // MARK: - Specialized
 
-    public static let cardTitle  = dmMono("DMMono-Medium", size: 17)
+    public static let cardTitle  = Font.custom("Inter-Medium", size: 17)
     public static let cardEmoji  = Font.system(size: 32)
     public static let mono       = dmMono("DMMono-Regular", size: 13)
     public static let monoSmall  = dmMono("DMMono-Regular", size: 11)


### PR DESCRIPTION
## Summary
- Switch chat bubble text from Inter to SF Pro (system font) for better letter spacing and readability
- Switch all thread drawer text (thread titles, "Recents", "New conversation", "Parental Controls") from Inter to SF Pro
- Update VFont body/UI tokens from DM Mono back to Inter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
