### PR TITLE
test: baseline characterization tests for credential paths

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -176,4 +176,48 @@ describe('executeBrowserFillCredential', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('field is required');
   });
+
+  // -----------------------------------------------------------------------
+  // Baseline characterization — freeze current contract before hardening
+  // -----------------------------------------------------------------------
+  describe('baseline characterization', () => {
+    test('fill succeeds with no domain or tool-policy checks', async () => {
+      // Currently browser_fill_credential does not validate the page URL
+      // against any allowed-domains policy on the credential. It fills
+      // unconditionally as long as the credential exists and the element
+      // resolves. Future PRs will add domain-scoped credential policies.
+      snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+      const result = await executeBrowserFillCredential(
+        {
+          service: 'gmail',
+          field: 'password',
+          element_id: 'e1',
+          // No domain or policy fields exist on the input schema today
+        },
+        ctx,
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('Filled password for gmail');
+      // The secret value must not appear in the output
+      expect(result.content).not.toContain('super-secret-password');
+    });
+
+    test('context has no credential access audit trail', async () => {
+      // The ToolContext passed to browser_fill_credential does not include
+      // any audit or logging callback for credential access. Calls to
+      // getCredentialValue are not tracked. Future PRs will add an audit
+      // hook on the context.
+      snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+      await executeBrowserFillCredential(
+        { service: 'gmail', field: 'password', element_id: 'e1' },
+        ctx,
+      );
+      // Verify getCredentialValue was called with bare service/field and
+      // no additional context (no domain, no session provenance).
+      expect(mockGetCredentialValue).toHaveBeenCalledTimes(1);
+      expect(mockGetCredentialValue).toHaveBeenCalledWith('gmail', 'password');
+      // Only 2 arguments — no audit context parameter
+      expect(mockGetCredentialValue.mock.calls[0]).toHaveLength(2);
+    });
+  });
 });

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -351,6 +351,60 @@ describe('credential_store tool', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Baseline characterization — freeze current contract before hardening
+  // -----------------------------------------------------------------------
+  describe('baseline characterization', () => {
+    test('getCredentialValue is a public export that returns plaintext directly', () => {
+      // This documents that getCredentialValue returns the raw secret as a
+      // plain string with no wrapper, scope check, or access policy.
+      // PR 17 will change this to return an opaque handle instead.
+      setSecureKey('credential:acme:api_key', 'sk-live-abc123');
+      const result = getCredentialValue('acme', 'api_key');
+      expect(typeof result).toBe('string');
+      expect(result).toBe('sk-live-abc123');
+    });
+
+    test('credential_store input schema has no policy or domain fields', () => {
+      // The current tool accepts only: action, service, field, value,
+      // label, description, placeholder. There are no access-policy,
+      // allowed-domains, or expiry fields. Future PRs will add these.
+      const knownProperties = ['action', 'service', 'field', 'value', 'label', 'description', 'placeholder'];
+      // Verify the execute wrapper accepts arbitrary inputs without error
+      // (unknown keys are silently ignored, not validated against a policy schema)
+      const storeResult = executeVault({
+        action: 'store',
+        service: 'test-svc',
+        field: 'token',
+        value: 'val',
+        allowedDomains: ['example.com'],   // not part of current schema
+        expiresAt: '2026-12-31',           // not part of current schema
+        accessPolicy: 'browser_fill_only', // not part of current schema
+      });
+      // Store succeeds — extra fields are silently ignored
+      return storeResult.then((r) => {
+        expect(r.isError).toBe(false);
+        expect(r.content).toBe('Stored credential for test-svc/token.');
+      });
+    });
+
+    test('list action entries contain only service and field (no policy metadata)', () => {
+      setSecureKey('credential:myservice:myfield', 'secret-val');
+
+      return executeVault({ action: 'list' }).then((result) => {
+        const entries = JSON.parse(result.content);
+        const entry = entries.find(
+          (e: { service: string; field: string }) => e.service === 'myservice' && e.field === 'myfield',
+        );
+        expect(entry).toBeDefined();
+        // Current list entries expose exactly {service, field} — no policy
+        // metadata like allowedDomains, createdAt, or accessPolicy.
+        const keys = Object.keys(entry!).sort();
+        expect(keys).toEqual(['field', 'service']);
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Namespace isolation
   // -----------------------------------------------------------------------
   describe('namespace isolation', () => {

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -842,6 +842,70 @@ describe('IPC message snapshots', () => {
     }
   });
 
+  // -----------------------------------------------------------------------
+  // Baseline characterization — freeze credential IPC contract before hardening
+  // -----------------------------------------------------------------------
+  describe('credential IPC baselines', () => {
+    test('secret_request has no policy context fields', () => {
+      // The current secret_request includes: type, requestId, service,
+      // field, label, description?, placeholder?, sessionId?.
+      // It has NO access-policy, allowed-domains, or credential-scope
+      // fields. Future PRs will add policy context to the IPC contract.
+      const req = serverMessages.secret_request;
+      const keys = Object.keys(req).sort();
+      expect(keys).toEqual([
+        'description',
+        'field',
+        'label',
+        'placeholder',
+        'requestId',
+        'service',
+        'sessionId',
+        'type',
+      ]);
+    });
+
+    test('secret_response has no audit or provenance fields', () => {
+      // The current secret_response includes: type, requestId, value?.
+      // It has NO provenance, audit-id, or encrypted-handle fields.
+      const resp = clientMessages.secret_response;
+      const keys = Object.keys(resp).sort();
+      expect(keys).toEqual(['requestId', 'type', 'value']);
+    });
+
+    test('secret_request round-trips with all optional fields populated', () => {
+      const req = serverMessages.secret_request;
+      const serialized = serialize(req);
+      const parsed = JSON.parse(serialized.trimEnd());
+      expect(parsed).toEqual(req);
+      // Verify the optional fields are present in the fixture
+      expect(parsed.description).toBeDefined();
+      expect(parsed.placeholder).toBeDefined();
+      expect(parsed.sessionId).toBeDefined();
+    });
+
+    test('secret_response round-trips with value present', () => {
+      const resp = clientMessages.secret_response;
+      const serialized = serialize(resp);
+      const parsed = JSON.parse(serialized.trimEnd());
+      expect(parsed).toEqual(resp);
+      expect(parsed.value).toBe('ghp_test_token_value');
+    });
+
+    test('secret_response round-trips with value absent (user cancelled)', () => {
+      const cancelled: typeof clientMessages.secret_response = {
+        type: 'secret_response',
+        requestId: 'req-cancel-001',
+        // value intentionally omitted — user cancelled the prompt
+      };
+      const serialized = serialize(cancelled);
+      const parsed = JSON.parse(serialized.trimEnd());
+      expect(parsed.type).toBe('secret_response');
+      expect(parsed.requestId).toBe('req-cancel-001');
+      expect(parsed.value).toBeUndefined();
+    });
+  });
+
   // Baseline assertions for error-related message contracts.
   // These document the current shape before error handling modernization.
   describe('error message baselines', () => {


### PR DESCRIPTION
## Summary
- Add 10 baseline characterization tests that freeze current credential behavior before security hardening
- Document `getCredentialValue` public API contract, credential_store schema boundaries, browser_fill_credential unchecked flow, and IPC field sets
- No runtime behavior changes — tests only

## Test plan
- [x] `bun test credential-vault.test.ts` — 160 pass
- [x] `bun test browser-fill-credential.test.ts` — pass
- [x] `bun test ipc-snapshot.test.ts` — pass

PR 1/30 of CREDENTIAL_STORAGE plan (Phase 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
