### PR TITLE
feat: credential policy types and validators

### DIFF
--- a/assistant/src/__tests__/credential-policy-validate.test.ts
+++ b/assistant/src/__tests__/credential-policy-validate.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  validatePolicyInput,
+  toPolicyFromInput,
+  createStrictDefaultPolicy,
+} from '../tools/credentials/policy-validate.js';
+import type { CredentialPolicyInput } from '../tools/credentials/policy-types.js';
+
+describe('validatePolicyInput', () => {
+  test('valid input with all fields', () => {
+    const input: CredentialPolicyInput = {
+      allowed_tools: ['browser_fill_credential'],
+      allowed_domains: ['example.com', 'login.example.com'],
+      usage_description: 'Login to example.com',
+    };
+    const result = validatePolicyInput(input);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('valid input with no fields (all optional)', () => {
+    const result = validatePolicyInput({});
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('valid input with only allowed_tools', () => {
+    const result = validatePolicyInput({ allowed_tools: ['bash'] });
+    expect(result.valid).toBe(true);
+  });
+
+  test('valid input with only allowed_domains', () => {
+    const result = validatePolicyInput({ allowed_domains: ['example.com'] });
+    expect(result.valid).toBe(true);
+  });
+
+  test('invalid: allowed_tools not an array', () => {
+    const result = validatePolicyInput({ allowed_tools: 'browser_fill_credential' as unknown as string[] });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('allowed_tools must be an array of strings');
+  });
+
+  test('invalid: allowed_tools contains empty string', () => {
+    const result = validatePolicyInput({ allowed_tools: ['browser_fill_credential', ''] });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('allowed_tools[1]');
+  });
+
+  test('invalid: allowed_tools contains non-string', () => {
+    const result = validatePolicyInput({ allowed_tools: ['browser_fill_credential', 42 as unknown as string] });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('allowed_tools[1]');
+  });
+
+  test('invalid: allowed_domains not an array', () => {
+    const result = validatePolicyInput({ allowed_domains: 'example.com' as unknown as string[] });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('allowed_domains must be an array of strings');
+  });
+
+  test('invalid: allowed_domains contains empty string', () => {
+    const result = validatePolicyInput({ allowed_domains: ['example.com', '  '] });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('allowed_domains[1]');
+  });
+
+  test('invalid: usage_description not a string', () => {
+    const result = validatePolicyInput({ usage_description: 123 as unknown as string });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('usage_description must be a string');
+  });
+
+  test('multiple errors reported at once', () => {
+    const result = validatePolicyInput({
+      allowed_tools: 'bad' as unknown as string[],
+      allowed_domains: 42 as unknown as string[],
+      usage_description: true as unknown as string,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(3);
+  });
+});
+
+describe('toPolicyFromInput', () => {
+  test('converts full input to policy', () => {
+    const policy = toPolicyFromInput({
+      allowed_tools: ['browser_fill_credential'],
+      allowed_domains: ['example.com'],
+      usage_description: 'Login credentials',
+    });
+    expect(policy.allowedTools).toEqual(['browser_fill_credential']);
+    expect(policy.allowedDomains).toEqual(['example.com']);
+    expect(policy.usageDescription).toBe('Login credentials');
+  });
+
+  test('defaults missing arrays to empty (deny all)', () => {
+    const policy = toPolicyFromInput({});
+    expect(policy.allowedTools).toEqual([]);
+    expect(policy.allowedDomains).toEqual([]);
+    expect(policy.usageDescription).toBeUndefined();
+  });
+
+  test('preserves provided empty arrays', () => {
+    const policy = toPolicyFromInput({
+      allowed_tools: [],
+      allowed_domains: [],
+    });
+    expect(policy.allowedTools).toEqual([]);
+    expect(policy.allowedDomains).toEqual([]);
+  });
+});
+
+describe('createStrictDefaultPolicy', () => {
+  test('returns deny-all policy', () => {
+    const policy = createStrictDefaultPolicy();
+    expect(policy.allowedTools).toEqual([]);
+    expect(policy.allowedDomains).toEqual([]);
+    expect(policy.usageDescription).toBeUndefined();
+    expect(policy.createdByFlow).toBeUndefined();
+  });
+});

--- a/assistant/src/tools/credentials/policy-types.ts
+++ b/assistant/src/tools/credentials/policy-types.ts
@@ -1,0 +1,32 @@
+/**
+ * Credential usage policy types.
+ *
+ * These types define the constraints placed on how a stored credential
+ * may be used. Policies are attached at credential creation time and
+ * enforced by the CredentialBroker before any secret operation.
+ */
+
+/** How a credential was originally captured. */
+export type CredentialCreationFlow = 'secure_prompt' | 'tool_store' | 'migration';
+
+/** Policy that governs how a credential may be used. */
+export interface CredentialPolicy {
+  /** Tools allowed to consume this credential (fail-closed if empty). */
+  allowedTools: string[];
+
+  /** Registrable domains where this credential may be used (fail-closed if empty). */
+  allowedDomains: string[];
+
+  /** Human-readable description of intended usage. */
+  usageDescription?: string;
+
+  /** How the credential was originally captured. */
+  createdByFlow?: CredentialCreationFlow;
+}
+
+/** Input fields for specifying policy when storing a credential. */
+export interface CredentialPolicyInput {
+  allowed_tools?: string[];
+  allowed_domains?: string[];
+  usage_description?: string;
+}

--- a/assistant/src/tools/credentials/policy-validate.ts
+++ b/assistant/src/tools/credentials/policy-validate.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure validation helpers for credential policies.
+ *
+ * These functions validate policy input without side effects.
+ * They are used during credential creation and update to ensure
+ * policy data is well-formed before persistence.
+ */
+
+import type { CredentialPolicy, CredentialPolicyInput } from './policy-types.js';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate a credential policy input.
+ * Returns a result with `valid: true` if the input is well-formed,
+ * or `valid: false` with a list of error messages.
+ */
+export function validatePolicyInput(input: CredentialPolicyInput): ValidationResult {
+  const errors: string[] = [];
+
+  if (input.allowed_tools !== undefined) {
+    if (!Array.isArray(input.allowed_tools)) {
+      errors.push('allowed_tools must be an array of strings');
+    } else {
+      for (let i = 0; i < input.allowed_tools.length; i++) {
+        const tool = input.allowed_tools[i];
+        if (typeof tool !== 'string' || tool.trim().length === 0) {
+          errors.push(`allowed_tools[${i}] must be a non-empty string`);
+        }
+      }
+    }
+  }
+
+  if (input.allowed_domains !== undefined) {
+    if (!Array.isArray(input.allowed_domains)) {
+      errors.push('allowed_domains must be an array of strings');
+    } else {
+      for (let i = 0; i < input.allowed_domains.length; i++) {
+        const domain = input.allowed_domains[i];
+        if (typeof domain !== 'string' || domain.trim().length === 0) {
+          errors.push(`allowed_domains[${i}] must be a non-empty string`);
+        }
+      }
+    }
+  }
+
+  if (input.usage_description !== undefined) {
+    if (typeof input.usage_description !== 'string') {
+      errors.push('usage_description must be a string');
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Convert validated policy input into a CredentialPolicy.
+ * Applies strict defaults: empty allowed lists = deny all.
+ */
+export function toPolicyFromInput(input: CredentialPolicyInput): CredentialPolicy {
+  return {
+    allowedTools: input.allowed_tools ?? [],
+    allowedDomains: input.allowed_domains ?? [],
+    usageDescription: input.usage_description,
+  };
+}
+
+/**
+ * Create a strict default policy (deny all usage).
+ * Used when a credential is stored without explicit policy.
+ */
+export function createStrictDefaultPolicy(): CredentialPolicy {
+  return {
+    allowedTools: [],
+    allowedDomains: [],
+  };
+}


### PR DESCRIPTION
## Summary
- Add `CredentialPolicy` and `CredentialPolicyInput` types
- Add pure validation helpers with strict defaults (empty = deny all)
- No runtime behavior changes

## Test plan
- [x] `bun test credential-policy-validate.test.ts` — 15 pass

PR 3/30 of CREDENTIAL_STORAGE plan (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
