### PR TITLE
Fix sidebar resize jitter and drag lag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -20,6 +20,7 @@ struct MainWindowView: View {
     @State private var drawerDragStartWidth: Double?
     @State private var drawerDragStartAvailableWidth: CGFloat?
     @State private var isDrawerDragging: Bool = false
+    private let drawerDragCoordinateSpaceName = "MainWindowDrawerDragCoordinateSpace"
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
@@ -111,6 +112,7 @@ struct MainWindowView: View {
                             // Center: Chat + right panel
                             chatContentView(geometry: geometry)
                         }
+                        .coordinateSpace(name: drawerDragCoordinateSpaceName)
                         .animation(isDrawerDragging ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: columnVisibility)
                     }
                 } else {
@@ -341,7 +343,7 @@ struct MainWindowView: View {
                 }
             }
             .gesture(
-                DragGesture(minimumDistance: 0)
+                DragGesture(minimumDistance: 0, coordinateSpace: .named(drawerDragCoordinateSpaceName))
                     .onChanged { value in
                         // Capture initial state on first drag event
                         if drawerDragStartWidth == nil {
@@ -355,7 +357,10 @@ struct MainWindowView: View {
                             return
                         }
 
-                        let newWidth = initialWidth + value.translation.width
+                        // Use a stable parent coordinate space so divider movement
+                        // does not feed back into gesture translation while dragging.
+                        let deltaX = value.location.x - value.startLocation.x
+                        let newWidth = initialWidth + Double(deltaX)
                         let minMainContent: CGFloat = 300
                         let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.sm - (VSpacing.sm * 2)
 

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -13,6 +13,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
     @State private var dragStartWidth: Double?
     @State private var dragStartAvailableWidth: CGFloat?
     @State private var isDragging: Bool = false
+    private let dragCoordinateSpaceName = "VSplitViewDragCoordinateSpace"
 
     // MARK: - Body
 
@@ -41,6 +42,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                         .transition(.move(edge: .trailing))
                 }
             }
+            .coordinateSpace(name: dragCoordinateSpaceName)
             .animation(isDragging ? nil : VAnimation.standard, value: showPanel)
         }
     }
@@ -60,7 +62,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
             }
             #endif
             .gesture(
-                DragGesture(minimumDistance: 0)
+                DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
                     .onChanged { value in
                         self.handleDragChanged(value, availableWidth: availableWidth)
                     }
@@ -88,8 +90,10 @@ public struct VSplitView<Main: View, Panel: View>: View {
             return
         }
 
-        // Calculate new width (dragging left increases, right decreases)
-        let newWidth = initialWidth - value.translation.width
+        // Measure drag in a stable parent coordinate space so the divider moving
+        // during resize does not change the gesture's reference frame.
+        let deltaX = value.location.x - value.startLocation.x
+        let newWidth = initialWidth - Double(deltaX)
 
         // Calculate constraints
         let minPanelWidth: CGFloat = 300


### PR DESCRIPTION
## Summary
- use stable named coordinate spaces for both left drawer and right panel resize gestures
- compute drag deltas from `startLocation`/`location` to prevent feedback as the divider moves
- keep existing width constraints and no-animation resize updates intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
