### PR TITLE
feat: registrable-domain normalization utility

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -22,6 +22,7 @@
         "pino-pretty": "^13.1.3",
         "playwright": "^1.58.2",
         "postgres": "^3.4.8",
+        "tldts": "^7.0.23",
         "tree-sitter-bash": "0.25.1",
         "uuid": "^11.1.0",
         "web-tree-sitter": "0.26.5",
@@ -985,6 +986,10 @@
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tldts": ["tldts@7.0.23", "", { "dependencies": { "tldts-core": "^7.0.23" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw=="],
+
+    "tldts-core": ["tldts-core@7.0.23", "", {}, "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -38,6 +38,7 @@
     "pino-pretty": "^13.1.3",
     "playwright": "^1.58.2",
     "postgres": "^3.4.8",
+    "tldts": "^7.0.23",
     "tree-sitter-bash": "0.25.1",
     "uuid": "^11.1.0",
     "web-tree-sitter": "0.26.5",

--- a/assistant/src/__tests__/domain-normalize.test.ts
+++ b/assistant/src/__tests__/domain-normalize.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from 'bun:test';
+import { normalizeDomain } from '../tools/network/domain-normalize.js';
+
+describe('normalizeDomain', () => {
+  // ── Basic hostname parsing ──────────────────────────────────────────
+
+  test('parses simple hostname', () => {
+    const result = normalizeDomain('example.com');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('example.com');
+    expect(result!.registrableDomain).toBe('example.com');
+  });
+
+  test('parses subdomain', () => {
+    const result = normalizeDomain('login.example.com');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('login.example.com');
+    expect(result!.registrableDomain).toBe('example.com');
+  });
+
+  test('parses deep subdomain', () => {
+    const result = normalizeDomain('foo.bar.example.co.uk');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('foo.bar.example.co.uk');
+    expect(result!.registrableDomain).toBe('example.co.uk');
+  });
+
+  // ── URL extraction ──────────────────────────────────────────────────
+
+  test('extracts hostname from full URL', () => {
+    const result = normalizeDomain('https://login.example.com/path?q=1');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('login.example.com');
+    expect(result!.registrableDomain).toBe('example.com');
+  });
+
+  test('extracts hostname from URL with port', () => {
+    const result = normalizeDomain('https://example.com:8443/api');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('example.com');
+  });
+
+  // ── Normalization ───────────────────────────────────────────────────
+
+  test('lowercases hostname', () => {
+    const result = normalizeDomain('Login.EXAMPLE.Com');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('login.example.com');
+    expect(result!.registrableDomain).toBe('example.com');
+  });
+
+  test('strips trailing dot', () => {
+    const result = normalizeDomain('example.com.');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('example.com');
+    expect(result!.registrableDomain).toBe('example.com');
+  });
+
+  // ── Punycode / IDN ──────────────────────────────────────────────────
+
+  test('handles punycode domain', () => {
+    const result = normalizeDomain('xn--nxasmq6b.example.com');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('xn--nxasmq6b.example.com');
+    expect(result!.registrableDomain).toBe('example.com');
+  });
+
+  // ── Rejection cases ─────────────────────────────────────────────────
+
+  test('returns null for IPv4 address', () => {
+    expect(normalizeDomain('192.168.1.1')).toBeNull();
+  });
+
+  test('returns null for IPv6 address', () => {
+    expect(normalizeDomain('[::1]')).toBeNull();
+    expect(normalizeDomain('::1')).toBeNull();
+  });
+
+  test('returns null for localhost', () => {
+    expect(normalizeDomain('localhost')).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(normalizeDomain('')).toBeNull();
+  });
+
+  test('returns null for null-like input', () => {
+    expect(normalizeDomain(null as unknown as string)).toBeNull();
+    expect(normalizeDomain(undefined as unknown as string)).toBeNull();
+  });
+
+  // ── Co.uk / multi-part TLD ──────────────────────────────────────────
+
+  test('handles co.uk correctly', () => {
+    const result = normalizeDomain('www.bbc.co.uk');
+    expect(result).not.toBeNull();
+    expect(result!.registrableDomain).toBe('bbc.co.uk');
+  });
+
+  test('handles com.au correctly', () => {
+    const result = normalizeDomain('shop.example.com.au');
+    expect(result).not.toBeNull();
+    expect(result!.registrableDomain).toBe('example.com.au');
+  });
+});

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -1,0 +1,72 @@
+/**
+ * Registrable domain normalization utility.
+ *
+ * Wraps `tldts` to provide deterministic domain parsing used by
+ * credential domain policy enforcement.
+ */
+
+import { parse } from 'tldts';
+
+export interface DomainInfo {
+  /** Original hostname, lowercased and stripped of trailing dot. */
+  hostname: string;
+  /** Registrable domain (eTLD+1), e.g. "example.co.uk" for "foo.bar.example.co.uk". */
+  registrableDomain: string | null;
+}
+
+/**
+ * Parse and normalize a hostname or URL into its domain components.
+ *
+ * Handles:
+ * - Full URLs (extracts hostname)
+ * - Bare hostnames
+ * - Trailing dots
+ * - Mixed case
+ * - Punycode/IDN domains
+ *
+ * Returns `null` for inputs that cannot be parsed into a valid hostname
+ * (e.g. IP addresses, localhost, empty strings).
+ */
+export function normalizeDomain(input: string): DomainInfo | null {
+  if (!input || typeof input !== 'string') return null;
+
+  let hostname: string;
+
+  // If input looks like a URL, extract the hostname
+  try {
+    if (input.includes('://')) {
+      const url = new URL(input);
+      hostname = url.hostname;
+    } else {
+      hostname = input;
+    }
+  } catch {
+    hostname = input;
+  }
+
+  // Normalize: lowercase, strip trailing dot
+  hostname = hostname.toLowerCase().replace(/\.$/, '');
+
+  if (!hostname) return null;
+
+  // Reject IP addresses and localhost — they don't have registrable domains
+  if (isIPAddress(hostname) || hostname === 'localhost') {
+    return null;
+  }
+
+  const result = parse(hostname);
+  const registrableDomain = result.domain || null;
+
+  return {
+    hostname,
+    registrableDomain,
+  };
+}
+
+function isIPAddress(hostname: string): boolean {
+  // IPv4
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return true;
+  // IPv6 (bracketed or bare)
+  if (hostname.startsWith('[') || hostname.includes(':')) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- Add `tldts` dependency for registrable domain parsing
- Create `domain-normalize.ts` wrapper with hostname extraction, case normalization, trailing dot removal
- Handle multi-part TLDs (co.uk, com.au), punycode, IP/localhost rejection

## Test plan
- [x] `bun test domain-normalize.test.ts` — 15 pass

PR 4/30 of CREDENTIAL_STORAGE plan (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
