### PR TITLE
feat: domain policy matcher for credential enforcement

### DIFF
--- a/assistant/src/__tests__/domain-policy.test.ts
+++ b/assistant/src/__tests__/domain-policy.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'bun:test';
+import { isDomainAllowed } from '../tools/credentials/domain-policy.js';
+
+describe('isDomainAllowed', () => {
+  // ── Exact host match ────────────────────────────────────────────────
+
+  test('allows exact hostname match', () => {
+    expect(isDomainAllowed('example.com', ['example.com'])).toBe(true);
+  });
+
+  test('allows exact hostname match (case insensitive)', () => {
+    expect(isDomainAllowed('Example.COM', ['example.com'])).toBe(true);
+  });
+
+  // ── Registrable-domain + subdomain ──────────────────────────────────
+
+  test('allows subdomain when registrable domain matches', () => {
+    expect(isDomainAllowed('login.example.com', ['example.com'])).toBe(true);
+  });
+
+  test('allows deep subdomain when registrable domain matches', () => {
+    expect(isDomainAllowed('a.b.c.example.com', ['example.com'])).toBe(true);
+  });
+
+  test('allows subdomain of co.uk domain', () => {
+    expect(isDomainAllowed('login.bbc.co.uk', ['bbc.co.uk'])).toBe(true);
+  });
+
+  // ── Deny cases ──────────────────────────────────────────────────────
+
+  test('denies unrelated domain', () => {
+    expect(isDomainAllowed('evil.com', ['example.com'])).toBe(false);
+  });
+
+  test('denies domain that looks similar but differs', () => {
+    expect(isDomainAllowed('notexample.com', ['example.com'])).toBe(false);
+  });
+
+  test('denies different TLD', () => {
+    expect(isDomainAllowed('example.org', ['example.com'])).toBe(false);
+  });
+
+  test('denies when allowed list is empty', () => {
+    expect(isDomainAllowed('example.com', [])).toBe(false);
+  });
+
+  test('denies when allowed list is undefined-like', () => {
+    expect(isDomainAllowed('example.com', undefined as unknown as string[])).toBe(false);
+  });
+
+  test('denies when request host is empty', () => {
+    expect(isDomainAllowed('', ['example.com'])).toBe(false);
+  });
+
+  test('denies when request host is invalid', () => {
+    expect(isDomainAllowed('not a valid host!!!', ['example.com'])).toBe(false);
+  });
+
+  test('denies IP addresses', () => {
+    expect(isDomainAllowed('192.168.1.1', ['192.168.1.1'])).toBe(false);
+  });
+
+  test('denies localhost', () => {
+    expect(isDomainAllowed('localhost', ['localhost'])).toBe(false);
+  });
+
+  // ── URL extraction ──────────────────────────────────────────────────
+
+  test('extracts hostname from full URL', () => {
+    expect(isDomainAllowed('https://login.example.com/path', ['example.com'])).toBe(true);
+  });
+
+  test('denies URL with wrong domain', () => {
+    expect(isDomainAllowed('https://evil.com/path', ['example.com'])).toBe(false);
+  });
+
+  // ── Subdomain in allowed list ──────────────────────────────────────
+
+  test('allows exact subdomain match when subdomain is in allowed list', () => {
+    expect(isDomainAllowed('login.example.com', ['login.example.com'])).toBe(true);
+  });
+
+  test('denies different subdomain when only specific subdomain is allowed', () => {
+    // When allowed is a subdomain (not the registrable domain itself),
+    // only exact matches should work
+    expect(isDomainAllowed('other.example.com', ['login.example.com'])).toBe(false);
+  });
+
+  // ── Multiple allowed domains ────────────────────────────────────────
+
+  test('matches against any domain in the allowed list', () => {
+    expect(isDomainAllowed('login.github.com', ['example.com', 'github.com'])).toBe(true);
+  });
+
+  test('denies when none of the allowed domains match', () => {
+    expect(isDomainAllowed('evil.com', ['example.com', 'github.com'])).toBe(false);
+  });
+});

--- a/assistant/src/tools/credentials/domain-policy.ts
+++ b/assistant/src/tools/credentials/domain-policy.ts
@@ -1,0 +1,51 @@
+/**
+ * Domain policy matcher for credential usage enforcement.
+ *
+ * Uses registrable-domain semantics: a credential allowed for "example.com"
+ * can be used on "login.example.com" or "app.example.com", but not on
+ * "notexample.com" or "example.co.uk".
+ */
+
+import { normalizeDomain } from '../network/domain-normalize.js';
+
+/**
+ * Check whether a request host is allowed by the credential's domain policy.
+ *
+ * @param requestHost - The hostname or URL of the current request/page
+ * @param allowedDomains - The credential's allowed domain list
+ * @returns true if the request host matches an allowed domain
+ *
+ * Matching rules:
+ * 1. Exact hostname match (case-insensitive)
+ * 2. Registrable-domain match with subdomain allowance
+ * 3. Deny if requestHost is missing, invalid, IP, or localhost
+ * 4. Deny if allowedDomains is empty or undefined (fail-closed)
+ */
+export function isDomainAllowed(requestHost: string, allowedDomains: string[]): boolean {
+  if (!allowedDomains || allowedDomains.length === 0) return false;
+
+  const requestInfo = normalizeDomain(requestHost);
+  if (!requestInfo) return false;
+
+  for (const allowed of allowedDomains) {
+    const allowedInfo = normalizeDomain(allowed);
+    if (!allowedInfo) continue;
+
+    // Exact hostname match
+    if (requestInfo.hostname === allowedInfo.hostname) return true;
+
+    // Registrable-domain match: request's registrable domain must equal
+    // the allowed entry's registrable domain, and the allowed entry
+    // must itself be a registrable domain (not a subdomain).
+    if (
+      requestInfo.registrableDomain &&
+      allowedInfo.registrableDomain &&
+      requestInfo.registrableDomain === allowedInfo.registrableDomain &&
+      allowedInfo.hostname === allowedInfo.registrableDomain
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- Add `isDomainAllowed(requestHost, allowedDomains)` with registrable-domain semantics
- Subdomain allowance: `login.example.com` matches policy `example.com`
- Fail-closed on empty list, invalid host, IP, localhost

## Test plan
- [x] `bun test domain-policy.test.ts` — 20 pass

PR 5/30 of CREDENTIAL_STORAGE plan (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
