### PR TITLE
feat: tool policy matcher for credential enforcement

### DIFF
--- a/assistant/src/__tests__/tool-policy.test.ts
+++ b/assistant/src/__tests__/tool-policy.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from 'bun:test';
+import { isToolAllowed } from '../tools/credentials/tool-policy.js';
+
+describe('isToolAllowed', () => {
+  // ── Allow cases ─────────────────────────────────────────────────────
+
+  test('allows tool listed in allowedTools', () => {
+    expect(isToolAllowed('browser_fill_credential', ['browser_fill_credential'])).toBe(true);
+  });
+
+  test('allows tool when multiple tools are listed', () => {
+    expect(isToolAllowed('bash', ['browser_fill_credential', 'bash', 'web_fetch'])).toBe(true);
+  });
+
+  // ── Deny cases ──────────────────────────────────────────────────────
+
+  test('denies tool not in allowedTools', () => {
+    expect(isToolAllowed('bash', ['browser_fill_credential'])).toBe(false);
+  });
+
+  test('denies when allowedTools is empty', () => {
+    expect(isToolAllowed('browser_fill_credential', [])).toBe(false);
+  });
+
+  test('denies when allowedTools is undefined', () => {
+    expect(isToolAllowed('browser_fill_credential', undefined as unknown as string[])).toBe(false);
+  });
+
+  test('denies when toolName is empty', () => {
+    expect(isToolAllowed('', ['browser_fill_credential'])).toBe(false);
+  });
+
+  test('denies when toolName is not a string', () => {
+    expect(isToolAllowed(null as unknown as string, ['browser_fill_credential'])).toBe(false);
+  });
+
+  // ── Exact match (no wildcards) ──────────────────────────────────────
+
+  test('requires exact match — no prefix matching', () => {
+    expect(isToolAllowed('browser_fill', ['browser_fill_credential'])).toBe(false);
+  });
+
+  test('requires exact match — no suffix matching', () => {
+    expect(isToolAllowed('browser_fill_credential_v2', ['browser_fill_credential'])).toBe(false);
+  });
+
+  test('match is case-sensitive', () => {
+    expect(isToolAllowed('Browser_Fill_Credential', ['browser_fill_credential'])).toBe(false);
+  });
+});

--- a/assistant/src/tools/credentials/tool-policy.ts
+++ b/assistant/src/tools/credentials/tool-policy.ts
@@ -1,0 +1,25 @@
+/**
+ * Tool policy matcher for credential usage enforcement.
+ *
+ * Determines whether a requesting tool is allowed to use a credential
+ * based on the credential's allowed tools list.
+ */
+
+/**
+ * Check whether a tool is allowed to use a credential.
+ *
+ * @param toolName - The name of the tool requesting credential use
+ * @param allowedTools - The credential's allowed tools list
+ * @returns true if the tool is explicitly listed in allowedTools
+ *
+ * Semantics:
+ * 1. Explicit allowlist — tool must be listed by exact name
+ * 2. No wildcard support in v1
+ * 3. Fail-closed on empty or missing list
+ */
+export function isToolAllowed(toolName: string, allowedTools: string[]): boolean {
+  if (!allowedTools || allowedTools.length === 0) return false;
+  if (!toolName || typeof toolName !== 'string') return false;
+
+  return allowedTools.includes(toolName);
+}


### PR DESCRIPTION
## Summary
- Add `isToolAllowed(toolName, allowedTools)` with explicit allowlist semantics
- Exact name match, no wildcards in v1, case-sensitive
- Fail-closed on empty or missing list

## Test plan
- [x] `bun test tool-policy.test.ts` — 10 pass

PR 6/30 of CREDENTIAL_STORAGE plan (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
