### PR TITLE
feat: credential metadata store (non-secret data only)

### DIFF
--- a/assistant/src/__tests__/credential-metadata-store.test.ts
+++ b/assistant/src/__tests__/credential-metadata-store.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  upsertCredentialMetadata,
+  getCredentialMetadata,
+  getCredentialMetadataById,
+  listCredentialMetadata,
+  deleteCredentialMetadata,
+  _setMetadataPath,
+} from '../tools/credentials/metadata-store.js';
+
+const TEST_DIR = join(tmpdir(), `vellum-credmeta-test-${randomBytes(4).toString('hex')}`);
+const META_PATH = join(TEST_DIR, 'metadata.json');
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  mkdirSync(TEST_DIR, { recursive: true });
+  _setMetadataPath(META_PATH);
+});
+
+afterAll(() => {
+  _setMetadataPath(null);
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+});
+
+describe('credential metadata store', () => {
+  // ── Create ──────────────────────────────────────────────────────────
+
+  describe('upsertCredentialMetadata', () => {
+    test('creates new record with generated ID', () => {
+      const record = upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['browser_fill_credential'],
+        allowedDomains: ['github.com'],
+        usageDescription: 'GitHub login',
+      });
+
+      expect(record.credentialId).toBeTruthy();
+      expect(record.service).toBe('github');
+      expect(record.field).toBe('token');
+      expect(record.allowedTools).toEqual(['browser_fill_credential']);
+      expect(record.allowedDomains).toEqual(['github.com']);
+      expect(record.usageDescription).toBe('GitHub login');
+      expect(record.createdAt).toBeGreaterThan(0);
+      expect(record.updatedAt).toBe(record.createdAt);
+    });
+
+    test('defaults policy arrays to empty', () => {
+      const record = upsertCredentialMetadata('gmail', 'password');
+      expect(record.allowedTools).toEqual([]);
+      expect(record.allowedDomains).toEqual([]);
+      expect(record.usageDescription).toBeUndefined();
+    });
+
+    test('updates existing record by service+field', () => {
+      const created = upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['browser_fill_credential'],
+      });
+
+      const updated = upsertCredentialMetadata('github', 'token', {
+        allowedDomains: ['github.com'],
+        usageDescription: 'Updated purpose',
+      });
+
+      expect(updated.credentialId).toBe(created.credentialId);
+      expect(updated.allowedTools).toEqual(['browser_fill_credential']);
+      expect(updated.allowedDomains).toEqual(['github.com']);
+      expect(updated.usageDescription).toBe('Updated purpose');
+      expect(updated.updatedAt).toBeGreaterThanOrEqual(created.createdAt);
+    });
+  });
+
+  // ── Read ────────────────────────────────────────────────────────────
+
+  describe('getCredentialMetadata', () => {
+    test('returns metadata by service+field', () => {
+      upsertCredentialMetadata('github', 'token');
+      const result = getCredentialMetadata('github', 'token');
+      expect(result).toBeDefined();
+      expect(result!.service).toBe('github');
+    });
+
+    test('returns undefined for non-existent credential', () => {
+      expect(getCredentialMetadata('nonexistent', 'field')).toBeUndefined();
+    });
+  });
+
+  describe('getCredentialMetadataById', () => {
+    test('returns metadata by credentialId', () => {
+      const created = upsertCredentialMetadata('github', 'token');
+      const result = getCredentialMetadataById(created.credentialId);
+      expect(result).toBeDefined();
+      expect(result!.service).toBe('github');
+    });
+
+    test('returns undefined for non-existent ID', () => {
+      expect(getCredentialMetadataById('non-existent-id')).toBeUndefined();
+    });
+  });
+
+  // ── List ────────────────────────────────────────────────────────────
+
+  describe('listCredentialMetadata', () => {
+    test('returns all credentials', () => {
+      upsertCredentialMetadata('github', 'token');
+      upsertCredentialMetadata('gmail', 'password');
+      const list = listCredentialMetadata();
+      expect(list).toHaveLength(2);
+    });
+
+    test('returns empty array when no credentials exist', () => {
+      expect(listCredentialMetadata()).toEqual([]);
+    });
+  });
+
+  // ── Delete ──────────────────────────────────────────────────────────
+
+  describe('deleteCredentialMetadata', () => {
+    test('deletes existing metadata', () => {
+      upsertCredentialMetadata('github', 'token');
+      expect(deleteCredentialMetadata('github', 'token')).toBe(true);
+      expect(getCredentialMetadata('github', 'token')).toBeUndefined();
+    });
+
+    test('returns false for non-existent credential', () => {
+      expect(deleteCredentialMetadata('nonexistent', 'field')).toBe(false);
+    });
+  });
+
+  // ── Persistence ─────────────────────────────────────────────────────
+
+  describe('persistence', () => {
+    test('metadata survives across calls (file-backed)', () => {
+      upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['browser_fill_credential'],
+      });
+
+      // Read again (simulates new process reading same file)
+      const result = getCredentialMetadata('github', 'token');
+      expect(result).toBeDefined();
+      expect(result!.allowedTools).toEqual(['browser_fill_credential']);
+    });
+  });
+
+  // ── No secret values ───────────────────────────────────────────────
+
+  describe('security', () => {
+    test('metadata records never contain secret values', () => {
+      const record = upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['browser_fill_credential'],
+      });
+
+      const keys = Object.keys(record);
+      expect(keys).not.toContain('value');
+      expect(keys).not.toContain('password');
+      expect(JSON.stringify(record)).not.toContain('secret');
+    });
+  });
+});

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -1,0 +1,159 @@
+/**
+ * Credential metadata store.
+ *
+ * Persists non-secret metadata about credentials (policy, timestamps, IDs)
+ * in a versioned JSON file under protected storage. Secret values remain
+ * in the secure key backend only.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { getDataDir } from '../../util/platform.js';
+import { randomUUID } from 'node:crypto';
+
+export interface CredentialMetadata {
+  credentialId: string;
+  service: string;
+  field: string;
+  allowedTools: string[];
+  allowedDomains: string[];
+  usageDescription?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface MetadataFile {
+  version: 1;
+  credentials: CredentialMetadata[];
+}
+
+let overridePath: string | null = null;
+
+function getMetadataPath(): string {
+  if (overridePath) return overridePath;
+  return join(getDataDir(), 'credentials', 'metadata.json');
+}
+
+function loadFile(): MetadataFile {
+  const path = getMetadataPath();
+  if (!existsSync(path)) {
+    return { version: 1, credentials: [] };
+  }
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const data = JSON.parse(raw) as MetadataFile;
+    if (data.version !== 1) {
+      return { version: 1, credentials: [] };
+    }
+    return data;
+  } catch {
+    return { version: 1, credentials: [] };
+  }
+}
+
+function saveFile(data: MetadataFile): void {
+  const path = getMetadataPath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(path, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+/**
+ * Create or update a credential metadata record.
+ * If a record with the same service+field exists, it is updated.
+ */
+export function upsertCredentialMetadata(
+  service: string,
+  field: string,
+  policy?: {
+    allowedTools?: string[];
+    allowedDomains?: string[];
+    usageDescription?: string;
+  },
+): CredentialMetadata {
+  const data = loadFile();
+  const now = Date.now();
+
+  const existing = data.credentials.find(
+    (c) => c.service === service && c.field === field,
+  );
+
+  if (existing) {
+    if (policy?.allowedTools !== undefined) existing.allowedTools = policy.allowedTools;
+    if (policy?.allowedDomains !== undefined) existing.allowedDomains = policy.allowedDomains;
+    if (policy?.usageDescription !== undefined) existing.usageDescription = policy.usageDescription;
+    existing.updatedAt = now;
+    saveFile(data);
+    return existing;
+  }
+
+  const record: CredentialMetadata = {
+    credentialId: randomUUID(),
+    service,
+    field,
+    allowedTools: policy?.allowedTools ?? [],
+    allowedDomains: policy?.allowedDomains ?? [],
+    usageDescription: policy?.usageDescription,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  data.credentials.push(record);
+  saveFile(data);
+  return record;
+}
+
+/**
+ * Get metadata for a credential by service and field.
+ */
+export function getCredentialMetadata(
+  service: string,
+  field: string,
+): CredentialMetadata | undefined {
+  const data = loadFile();
+  return data.credentials.find(
+    (c) => c.service === service && c.field === field,
+  );
+}
+
+/**
+ * Get metadata for a credential by its opaque ID.
+ */
+export function getCredentialMetadataById(
+  credentialId: string,
+): CredentialMetadata | undefined {
+  const data = loadFile();
+  return data.credentials.find((c) => c.credentialId === credentialId);
+}
+
+/**
+ * List all credential metadata records.
+ */
+export function listCredentialMetadata(): CredentialMetadata[] {
+  const data = loadFile();
+  return data.credentials;
+}
+
+/**
+ * Delete metadata for a credential.
+ */
+export function deleteCredentialMetadata(
+  service: string,
+  field: string,
+): boolean {
+  const data = loadFile();
+  const idx = data.credentials.findIndex(
+    (c) => c.service === service && c.field === field,
+  );
+  if (idx === -1) return false;
+  data.credentials.splice(idx, 1);
+  saveFile(data);
+  return true;
+}
+
+/** @internal Test-only: override the metadata file path. */
+export function _setMetadataPath(path: string | null): void {
+  overridePath = path;
+}


### PR DESCRIPTION
## Summary
- Add versioned JSON metadata store for credential policy data
- Store credentialId, service, field, allowedTools, allowedDomains, timestamps
- Secret values remain in secure key backend only
- CRUD with upsert semantics

## Test plan
- [x] `bun test credential-metadata-store.test.ts` — 13 pass

PR 7/30 of CREDENTIAL_STORAGE plan (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
