### PR TITLE
feat: credential_store writes metadata on store/prompt/delete

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -8,6 +8,7 @@ import {
   listSecureKeys,
   getBackendType,
 } from '../../security/secure-keys.js';
+import { upsertCredentialMetadata, deleteCredentialMetadata } from './metadata-store.js';
 
 /**
  * Retrieve the actual secret value for a credential.
@@ -89,6 +90,7 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
+        upsertCredentialMetadata(service, field);
         return { content: `Stored credential for ${service}/${field}.`, isError: false };
       }
 
@@ -130,6 +132,7 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: `Error: credential ${service}/${field} not found`, isError: true };
         }
+        deleteCredentialMetadata(service, field);
         return { content: `Deleted credential for ${service}/${field}.`, isError: false };
       }
 
@@ -162,6 +165,7 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
+        upsertCredentialMetadata(service, field);
         return { content: `Credential stored for ${service}/${field}.`, isError: false };
       }
 


### PR DESCRIPTION
## Summary
- On `store` and `prompt` actions, write/update metadata records
- On `delete` action, clean up corresponding metadata
- Output strings and API contract unchanged

## Test plan
- [x] `bun test credential-vault.test.ts` — 21 pass (all existing tests)

PR 8/30 of CREDENTIAL_STORAGE plan (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
