### PR TITLE
feat: opaque credential IDs and resolver helpers

### DIFF
--- a/assistant/src/__tests__/credential-resolve.test.ts
+++ b/assistant/src/__tests__/credential-resolve.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  upsertCredentialMetadata,
+  _setMetadataPath,
+} from '../tools/credentials/metadata-store.js';
+import {
+  resolveByServiceField,
+  resolveById,
+} from '../tools/credentials/resolve.js';
+
+const TEST_DIR = join(tmpdir(), `vellum-credresolve-test-${randomBytes(4).toString('hex')}`);
+const META_PATH = join(TEST_DIR, 'metadata.json');
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  mkdirSync(TEST_DIR, { recursive: true });
+  _setMetadataPath(META_PATH);
+});
+
+afterAll(() => {
+  _setMetadataPath(null);
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+});
+
+describe('credential resolver', () => {
+  describe('resolveByServiceField', () => {
+    test('resolves existing credential', () => {
+      const created = upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['browser_fill_credential'],
+      });
+
+      const result = resolveByServiceField('github', 'token');
+      expect(result).toBeDefined();
+      expect(result!.credentialId).toBe(created.credentialId);
+      expect(result!.service).toBe('github');
+      expect(result!.field).toBe('token');
+      expect(result!.storageKey).toBe('credential:github:token');
+      expect(result!.metadata.allowedTools).toEqual(['browser_fill_credential']);
+    });
+
+    test('returns undefined for non-existent credential', () => {
+      expect(resolveByServiceField('nonexistent', 'field')).toBeUndefined();
+    });
+  });
+
+  describe('resolveById', () => {
+    test('resolves existing credential by ID', () => {
+      const created = upsertCredentialMetadata('gmail', 'password');
+
+      const result = resolveById(created.credentialId);
+      expect(result).toBeDefined();
+      expect(result!.credentialId).toBe(created.credentialId);
+      expect(result!.service).toBe('gmail');
+      expect(result!.field).toBe('password');
+      expect(result!.storageKey).toBe('credential:gmail:password');
+    });
+
+    test('returns undefined for non-existent ID', () => {
+      expect(resolveById('non-existent-id')).toBeUndefined();
+    });
+  });
+
+  describe('cross-resolution', () => {
+    test('service/field and ID resolve to same credential', () => {
+      const created = upsertCredentialMetadata('github', 'token');
+
+      const byServiceField = resolveByServiceField('github', 'token');
+      const byId = resolveById(created.credentialId);
+
+      expect(byServiceField).toBeDefined();
+      expect(byId).toBeDefined();
+      expect(byServiceField!.credentialId).toBe(byId!.credentialId);
+      expect(byServiceField!.storageKey).toBe(byId!.storageKey);
+    });
+  });
+
+  describe('storage key format', () => {
+    test('storage key follows credential:{service}:{field} format', () => {
+      upsertCredentialMetadata('my-service', 'api-key');
+      const result = resolveByServiceField('my-service', 'api-key');
+      expect(result!.storageKey).toBe('credential:my-service:api-key');
+    });
+  });
+});

--- a/assistant/src/tools/credentials/resolve.ts
+++ b/assistant/src/tools/credentials/resolve.ts
@@ -1,0 +1,61 @@
+/**
+ * Credential resolver — maps between opaque IDs, service/field pairs,
+ * and storage locators.
+ *
+ * This decouples external credential references from the underlying
+ * secure key naming convention.
+ */
+
+import {
+  getCredentialMetadata,
+  getCredentialMetadataById,
+  type CredentialMetadata,
+} from './metadata-store.js';
+
+export interface ResolvedCredential {
+  credentialId: string;
+  service: string;
+  field: string;
+  /** The key used in the secure key backend. */
+  storageKey: string;
+  metadata: CredentialMetadata;
+}
+
+/**
+ * Resolve a credential by service and field.
+ * Returns the resolved credential or undefined if not found.
+ */
+export function resolveByServiceField(
+  service: string,
+  field: string,
+): ResolvedCredential | undefined {
+  const metadata = getCredentialMetadata(service, field);
+  if (!metadata) return undefined;
+
+  return {
+    credentialId: metadata.credentialId,
+    service: metadata.service,
+    field: metadata.field,
+    storageKey: `credential:${metadata.service}:${metadata.field}`,
+    metadata,
+  };
+}
+
+/**
+ * Resolve a credential by its opaque ID.
+ * Returns the resolved credential or undefined if not found.
+ */
+export function resolveById(
+  credentialId: string,
+): ResolvedCredential | undefined {
+  const metadata = getCredentialMetadataById(credentialId);
+  if (!metadata) return undefined;
+
+  return {
+    credentialId: metadata.credentialId,
+    service: metadata.service,
+    field: metadata.field,
+    storageKey: `credential:${metadata.service}:${metadata.field}`,
+    metadata,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `resolveByServiceField` and `resolveById` resolver functions
- Decouple external credential references from storage key names
- Backward-compatible storage key format preserved

## Test plan
- [x] `bun test credential-resolve.test.ts` — 6 pass

PR 9/30 of CREDENTIAL_STORAGE plan (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
