### PR TITLE
feat: extend secret prompt IPC with usage context

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -491,10 +491,18 @@ exports[`IPC message snapshots ServerMessage types tool_result serializes to exp
 
 exports[`IPC message snapshots ServerMessage types secret_request serializes to expected JSON 1`] = `
 {
+  "allowOneTimeSend": false,
+  "allowedDomains": [
+    "github.com",
+  ],
+  "allowedTools": [
+    "browser_fill_credential",
+  ],
   "description": "Needed to push changes",
   "field": "token",
   "label": "GitHub Personal Access Token",
   "placeholder": "ghp_xxxxxxxxxxxx",
+  "purpose": "Push code changes to GitHub",
   "requestId": "req-secret-001",
   "service": "github",
   "sessionId": "sess-001",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -331,6 +331,10 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     description: 'Needed to push changes',
     placeholder: 'ghp_xxxxxxxxxxxx',
     sessionId: 'sess-001',
+    purpose: 'Push code changes to GitHub',
+    allowedTools: ['browser_fill_credential'],
+    allowedDomains: ['github.com'],
+    allowOneTimeSend: false,
   },
   confirmation_request: {
     type: 'confirmation_request',
@@ -846,18 +850,20 @@ describe('IPC message snapshots', () => {
   // Baseline characterization — freeze credential IPC contract before hardening
   // -----------------------------------------------------------------------
   describe('credential IPC baselines', () => {
-    test('secret_request has no policy context fields', () => {
-      // The current secret_request includes: type, requestId, service,
-      // field, label, description?, placeholder?, sessionId?.
-      // It has NO access-policy, allowed-domains, or credential-scope
-      // fields. Future PRs will add policy context to the IPC contract.
+    test('secret_request includes policy context fields', () => {
+      // After PR 10: secret_request now includes policy context fields
+      // for purpose, allowedTools, allowedDomains, and allowOneTimeSend.
       const req = serverMessages.secret_request;
       const keys = Object.keys(req).sort();
       expect(keys).toEqual([
+        'allowOneTimeSend',
+        'allowedDomains',
+        'allowedTools',
         'description',
         'field',
         'label',
         'placeholder',
+        'purpose',
         'requestId',
         'service',
         'sessionId',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -590,6 +590,14 @@ export interface SecretRequest {
   description?: string;
   placeholder?: string;
   sessionId?: string;
+  /** Intended purpose of the credential (displayed to user). */
+  purpose?: string;
+  /** Tools allowed to use this credential. */
+  allowedTools?: string[];
+  /** Domains where this credential may be used. */
+  allowedDomains?: string[];
+  /** Whether one-time send override is available. */
+  allowOneTimeSend?: boolean;
 }
 
 export interface MessageComplete {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -627,6 +627,14 @@ public struct IPCSecretRequest: Codable, Sendable {
     public let description: String?
     public let placeholder: String?
     public let sessionId: String?
+    /// Intended purpose of the credential (displayed to user).
+    public let purpose: String?
+    /// Tools allowed to use this credential.
+    public let allowedTools: [String]?
+    /// Domains where this credential may be used.
+    public let allowedDomains: [String]?
+    /// Whether one-time send override is available.
+    public let allowOneTimeSend: Bool?
 }
 
 public struct IPCSecretResponse: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Adds `purpose`, `allowedTools`, `allowedDomains`, and `allowOneTimeSend` optional fields to `SecretRequest` IPC message
- Regenerates Swift IPC models to match
- Updates IPC snapshot tests for new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
