### PR TITLE
feat: display credential usage context in secret prompt UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -29,6 +29,9 @@ final class SecretPromptManager {
             label: message.label,
             description: message.description,
             placeholder: message.placeholder ?? "",
+            purpose: message.purpose,
+            allowedTools: message.allowedTools,
+            allowedDomains: message.allowedDomains,
             onSave: { [weak self] value in
                 self?.respond(requestId: message.requestId, value: value) ?? false
             },
@@ -40,7 +43,11 @@ final class SecretPromptManager {
         let hostingController = NSHostingController(rootView: view)
         hostingController.sizingOptions = .preferredContentSize
 
-        let panelHeight: CGFloat = message.description != nil ? 270 : 230
+        let hasContext = message.purpose != nil
+            || !(message.allowedTools ?? []).isEmpty
+            || !(message.allowedDomains ?? []).isEmpty
+        let baseHeight: CGFloat = message.description != nil ? 270 : 230
+        let panelHeight: CGFloat = hasContext ? baseHeight + 100 : baseHeight
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
             styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
@@ -69,6 +76,11 @@ final class SecretPromptManager {
         panel.orderFront(nil)
 
         log.info("Showing secret prompt: requestId=\(message.requestId), service=\(message.service), field=\(message.field)")
+    }
+
+    /// Test-only accessor for the panel backing a given request.
+    func panelForRequest(_ requestId: String) -> NSPanel? {
+        panels[requestId]
     }
 
     func dismissPrompt(requestId: String) {
@@ -105,11 +117,20 @@ struct SecretPromptView: View {
     let label: String
     let description: String?
     let placeholder: String
+    let purpose: String?
+    let allowedTools: [String]?
+    let allowedDomains: [String]?
     let onSave: (String) -> Bool
     let onCancel: () -> Void
 
     @State private var secretValue: String = ""
     @State private var saved = false
+
+    private var hasContext: Bool {
+        purpose != nil
+            || !(allowedTools ?? []).isEmpty
+            || !(allowedDomains ?? []).isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -136,6 +157,11 @@ struct SecretPromptView: View {
                 Text(description)
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
+            }
+
+            // Usage context
+            if hasContext {
+                usageContextSection
             }
 
             // Secure input
@@ -183,6 +209,42 @@ struct SecretPromptView: View {
         .padding(VSpacing.xl)
         .frame(width: 400)
         .vPanelBackground()
+    }
+
+    @ViewBuilder
+    private var usageContextSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Usage Scope")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+
+            if let purpose = purpose {
+                contextBullet(icon: "info.circle.fill", label: "Purpose", value: purpose)
+            }
+
+            if let tools = allowedTools, !tools.isEmpty {
+                contextBullet(icon: "wrench.fill", label: "Tools", value: tools.joined(separator: ", "))
+            }
+
+            if let domains = allowedDomains, !domains.isEmpty {
+                contextBullet(icon: "globe", label: "Domains", value: domains.joined(separator: ", "))
+            }
+        }
+        .padding(VSpacing.sm)
+        .background(VColor.surface.opacity(0.5))
+        .cornerRadius(6)
+    }
+
+    private func contextBullet(icon: String, label: String, value: String) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+                .foregroundColor(VColor.accent)
+                .frame(width: 14, alignment: .center)
+            Text("\(label): \(value)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
     }
 
     private func safetyBullet(icon: String, text: String) -> some View {

--- a/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class SecretPromptManagerTests: XCTestCase {
+
+    private var manager: SecretPromptManager!
+    private var responses: [(requestId: String, value: String?)] = []
+
+    override func setUp() {
+        super.setUp()
+        manager = SecretPromptManager()
+        responses = []
+        manager.onResponse = { [unowned self] requestId, value in
+            self.responses.append((requestId: requestId, value: value))
+            return true
+        }
+    }
+
+    override func tearDown() {
+        manager.dismissAll()
+        manager = nil
+        responses = []
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeRequest(
+        requestId: String = "r1",
+        description: String? = nil,
+        purpose: String? = nil,
+        allowedTools: [String]? = nil,
+        allowedDomains: [String]? = nil,
+        allowOneTimeSend: Bool? = nil
+    ) -> IPCSecretRequest {
+        IPCSecretRequest(
+            type: "secret_request",
+            requestId: requestId,
+            service: "github",
+            field: "token",
+            label: "GitHub Token",
+            description: description,
+            placeholder: nil,
+            sessionId: nil,
+            purpose: purpose,
+            allowedTools: allowedTools,
+            allowedDomains: allowedDomains,
+            allowOneTimeSend: allowOneTimeSend
+        )
+    }
+
+    // MARK: - Panel creation with context variations
+
+    func testPanelCreatedWithNoContext() {
+        manager.showPrompt(makeRequest())
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+    }
+
+    func testPanelCreatedWithPurposeOnly() {
+        manager.showPrompt(makeRequest(purpose: "Sign in to GitHub"))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+    }
+
+    func testPanelCreatedWithToolsOnly() {
+        manager.showPrompt(makeRequest(allowedTools: ["browser_fill_credential"]))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+    }
+
+    func testPanelCreatedWithDomainsOnly() {
+        manager.showPrompt(makeRequest(allowedDomains: ["github.com", "api.github.com"]))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+    }
+
+    func testPanelCreatedWithFullContext() {
+        manager.showPrompt(makeRequest(
+            description: "Enter your GitHub token",
+            purpose: "Authenticate with GitHub API",
+            allowedTools: ["browser_fill_credential"],
+            allowedDomains: ["github.com"]
+        ))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+    }
+
+    func testPanelCreatedWithEmptyArrayContext() {
+        manager.showPrompt(makeRequest(allowedTools: [], allowedDomains: []))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+    }
+
+    // MARK: - Existing behavior preserved
+
+    func testDismissRemovesPanel() {
+        manager.showPrompt(makeRequest())
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+        manager.dismissPrompt(requestId: "r1")
+        XCTAssertNil(manager.panelForRequest("r1"))
+    }
+
+    func testDismissAllClearsAllPanels() {
+        manager.showPrompt(makeRequest(requestId: "r1"))
+        manager.showPrompt(makeRequest(requestId: "r2", purpose: "Test"))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+        XCTAssertNotNil(manager.panelForRequest("r2"))
+        manager.dismissAll()
+        XCTAssertNil(manager.panelForRequest("r1"))
+        XCTAssertNil(manager.panelForRequest("r2"))
+    }
+
+    func testShowPromptReplacesExistingPanel() {
+        manager.showPrompt(makeRequest())
+        let panel1 = manager.panelForRequest("r1")
+        manager.showPrompt(makeRequest(purpose: "Updated"))
+        let panel2 = manager.panelForRequest("r1")
+        XCTAssertNotNil(panel2)
+        XCTAssertTrue(panel1 !== panel2, "Should create a new panel, not reuse the old one")
+    }
+}


### PR DESCRIPTION
## Summary
- Shows purpose, allowed tools, and allowed domains in the macOS secret prompt panel before credential save
- Adds "Usage Scope" section with contextual bullets when context fields are populated
- Adds 9 SecretPromptManagerTests covering all context variations and existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
