### PR TITLE
fix: even out side panel section gaps

### DIFF
--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -33,7 +33,7 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
                     .accessibilityLabel("Close \(title)")
                 }
             }
-            .padding(.horizontal, VSpacing.xl)
+            .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.lg)
 
             Divider()
@@ -46,7 +46,8 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
             // own ScrollView (e.g. TraceTimelineView) isn't starved.
             ScrollView {
                 content()
-                    .padding(VSpacing.xl)
+                    .padding(VSpacing.lg)
+                    .frame(maxWidth: .infinity, alignment: .top)
             }
             .layoutPriority(-1)
         }


### PR DESCRIPTION
## Summary
- Reduced VSidePanel horizontal padding from `VSpacing.xl` (24pt) to `VSpacing.lg` (16pt) for both the header and scroll content
- Added `.frame(maxWidth: .infinity, alignment: .top)` on scroll content to ensure sections fill the full panel width, eliminating the left-right gap asymmetry visible in the settings panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
