### PR TITLE
feat: add one-time send delivery field to secret response contract

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -383,6 +383,7 @@ exports[`IPC message snapshots ClientMessage types get_signing_identity_response
 
 exports[`IPC message snapshots ClientMessage types secret_response serializes to expected JSON 1`] = `
 {
+  "delivery": "store",
   "requestId": "req-secret-001",
   "type": "secret_response",
   "value": "ghp_test_token_value",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -255,6 +255,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'secret_response',
     requestId: 'req-secret-001',
     value: 'ghp_test_token_value',
+    delivery: 'store',
   },
   sessions_clear: {
     type: 'sessions_clear',
@@ -872,11 +873,11 @@ describe('IPC message snapshots', () => {
     });
 
     test('secret_response has no audit or provenance fields', () => {
-      // The current secret_response includes: type, requestId, value?.
+      // The current secret_response includes: type, requestId, value?, delivery?.
       // It has NO provenance, audit-id, or encrypted-handle fields.
       const resp = clientMessages.secret_response;
       const keys = Object.keys(resp).sort();
-      expect(keys).toEqual(['requestId', 'type', 'value']);
+      expect(keys).toEqual(['delivery', 'requestId', 'type', 'value']);
     });
 
     test('secret_request round-trips with all optional fields populated', () => {
@@ -902,6 +903,7 @@ describe('IPC message snapshots', () => {
       const cancelled: typeof clientMessages.secret_response = {
         type: 'secret_response',
         requestId: 'req-cancel-001',
+        delivery: 'store',
         // value intentionally omitted — user cancelled the prompt
       };
       const serialized = serialize(cancelled);

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -46,6 +46,8 @@ export interface SecretResponse {
   type: 'secret_response';
   requestId: string;
   value?: string;    // undefined = user cancelled
+  /** How the secret should be delivered: 'store' persists to keychain (default), 'transient_send' for one-time use without persisting. */
+  delivery?: 'store' | 'transient_send';
 }
 
 export interface SessionListRequest {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -347,10 +347,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         daemonClient.onSecretRequest = { [weak self] msg in
             self?.secretPromptManager.showPrompt(msg)
         }
-        secretPromptManager.onResponse = { [weak self] requestId, value in
+        secretPromptManager.onResponse = { [weak self] requestId, value, delivery in
             guard let self else { return false }
             do {
-                try self.daemonClient.sendSecretResponse(requestId: requestId, value: value)
+                try self.daemonClient.sendSecretResponse(requestId: requestId, value: value, delivery: delivery)
                 return true
             } catch {
                 log.error("Failed to send secret response: \(error.localizedDescription)")

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -17,9 +17,10 @@ final class SecretPromptManager {
     private let panelWidth: CGFloat = 400
 
     /// Called when the user responds to a secret prompt.
-    /// Parameters: (requestId, value?) — value is nil if user cancelled.
+    /// Parameters: (requestId, value?, delivery?) — value is nil if user cancelled.
+    /// `delivery` is "store" (default) or "transient_send" for one-time use.
     /// Returns `true` if the IPC send succeeded.
-    var onResponse: ((String, String?) -> Bool)?
+    var onResponse: ((String, String?, String?) -> Bool)?
 
     func showPrompt(_ message: SecretRequestMessage) {
         // Dismiss existing panel for same request, if any
@@ -32,8 +33,9 @@ final class SecretPromptManager {
             purpose: message.purpose,
             allowedTools: message.allowedTools,
             allowedDomains: message.allowedDomains,
+            allowOneTimeSend: message.allowOneTimeSend ?? false,
             onSave: { [weak self] value in
-                self?.respond(requestId: message.requestId, value: value) ?? false
+                self?.respond(requestId: message.requestId, value: value, delivery: "store") ?? false
             },
             onCancel: { [weak self] in
                 _ = self?.respond(requestId: message.requestId, value: nil)
@@ -91,13 +93,13 @@ final class SecretPromptManager {
     func dismissAll() {
         for (requestId, panel) in panels {
             panel.close()
-            _ = onResponse?(requestId, nil)
+            _ = onResponse?(requestId, nil, nil)
         }
         panels.removeAll()
     }
 
-    private func respond(requestId: String, value: String?) -> Bool {
-        let success = onResponse?(requestId, value) ?? true
+    private func respond(requestId: String, value: String?, delivery: String? = nil) -> Bool {
+        let success = onResponse?(requestId, value, delivery) ?? true
         if success && value == nil {
             // Cancel: dismiss immediately
             dismissPrompt(requestId: requestId)
@@ -120,6 +122,7 @@ struct SecretPromptView: View {
     let purpose: String?
     let allowedTools: [String]?
     let allowedDomains: [String]?
+    let allowOneTimeSend: Bool
     let onSave: (String) -> Bool
     let onCancel: () -> Void
 
@@ -203,6 +206,18 @@ struct SecretPromptView: View {
                         }
                     }
                     .disabled(secretValue.isEmpty)
+                }
+
+                if allowOneTimeSend {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10))
+                            .foregroundColor(VColor.textMuted)
+                        Text("One-time send available (not yet enabled)")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .opacity(0.6)
                 }
             }
         }

--- a/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
@@ -6,14 +6,14 @@ import XCTest
 final class SecretPromptManagerTests: XCTestCase {
 
     private var manager: SecretPromptManager!
-    private var responses: [(requestId: String, value: String?)] = []
+    private var responses: [(requestId: String, value: String?, delivery: String?)] = []
 
     override func setUp() {
         super.setUp()
         manager = SecretPromptManager()
         responses = []
-        manager.onResponse = { [unowned self] requestId, value in
-            self.responses.append((requestId: requestId, value: value))
+        manager.onResponse = { [unowned self] requestId, value, delivery in
+            self.responses.append((requestId: requestId, value: value, delivery: delivery))
             return true
         }
     }
@@ -114,5 +114,17 @@ final class SecretPromptManagerTests: XCTestCase {
         let panel2 = manager.panelForRequest("r1")
         XCTAssertNotNil(panel2)
         XCTAssertTrue(panel1 !== panel2, "Should create a new panel, not reuse the old one")
+    }
+
+    // MARK: - One-time send affordance
+
+    func testPanelCreatedWithOneTimeSendEnabled() {
+        manager.showPrompt(makeRequest(allowOneTimeSend: true))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
+    }
+
+    func testPanelCreatedWithOneTimeSendDisabled() {
+        manager.showPrompt(makeRequest(allowOneTimeSend: false))
+        XCTAssertNotNil(manager.panelForRequest("r1"))
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -474,8 +474,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Secret Response
 
     /// Send a secret response for a credential prompt request.
-    public func sendSecretResponse(requestId: String, value: String?) throws {
-        try send(SecretResponseMessage(requestId: requestId, value: value))
+    public func sendSecretResponse(requestId: String, value: String?, delivery: String? = nil) throws {
+        try send(SecretResponseMessage(requestId: requestId, value: value, delivery: delivery))
     }
 
     // MARK: - Trust Rule Addition

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -641,6 +641,8 @@ public struct IPCSecretResponse: Codable, Sendable {
     public let type: String
     public let requestId: String
     public let value: String?
+    /// How the secret should be delivered: 'store' persists to keychain (default), 'transient_send' for one-time use without persisting.
+    public let delivery: String?
 }
 
 public struct IPCSessionCreateRequest: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1101,8 +1101,8 @@ extension IPCConfirmationResponse {
 public typealias SecretResponseMessage = IPCSecretResponse
 
 extension IPCSecretResponse {
-    public init(requestId: String, value: String?) {
-        self.init(type: "secret_response", requestId: requestId, value: value)
+    public init(requestId: String, value: String?, delivery: String? = nil) {
+        self.init(type: "secret_response", requestId: requestId, value: value, delivery: delivery)
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds optional `delivery` field (`store` | `transient_send`) to `SecretResponse` IPC contract
- Regenerates Swift IPC models and updates `sendSecretResponse` to accept delivery
- Adds disabled one-time-send affordance text in secret prompt UI when `allowOneTimeSend` is true
- Updates IPC snapshot tests for new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
