### PR TITLE
fix: sanitize tool_use IDs for Anthropic API compatibility

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -9,6 +9,14 @@ import type {
 } from "../types.js";
 import { ProviderError } from "../../util/errors.js";
 
+const TOOL_ID_RE = /[^a-zA-Z0-9_-]/g;
+
+/** Anthropic requires tool_use IDs to match ^[a-zA-Z0-9_-]+$ */
+function sanitizeToolId(id: string): string {
+  const sanitized = id.replace(TOOL_ID_RE, '_');
+  return sanitized || `fallback_${Date.now()}`;
+}
+
 export class AnthropicProvider implements Provider {
   public readonly name = "anthropic";
   private client: Anthropic;
@@ -137,11 +145,12 @@ export class AnthropicProvider implements Provider {
       case "tool_use":
         return {
           type: "tool_use",
-          id: block.id,
+          id: sanitizeToolId(block.id),
           name: block.name,
           input: block.input,
         };
       case "tool_result": {
+        const toolUseId = sanitizeToolId(block.tool_use_id);
         if (block.contentBlocks && block.contentBlocks.length > 0) {
           // Build rich content array: text + images for Anthropic's native multi-part tool results
           const parts: Anthropic.ToolResultBlockParam['content'] = [
@@ -163,14 +172,14 @@ export class AnthropicProvider implements Provider {
           }
           return {
             type: "tool_result",
-            tool_use_id: block.tool_use_id,
+            tool_use_id: toolUseId,
             content: parts,
             is_error: block.is_error,
           };
         }
         return {
           type: "tool_result",
-          tool_use_id: block.tool_use_id,
+          tool_use_id: toolUseId,
           content: block.content,
           is_error: block.is_error,
         };


### PR DESCRIPTION
## Summary
- Sanitize tool_use IDs in the Anthropic provider's `toAnthropicBlock` method to ensure they match the required `^[a-zA-Z0-9_-]+$` pattern
- Fixes 400 errors when conversation history contains tool_use IDs from non-Anthropic providers (e.g. OpenAI-compatible local models) that may contain invalid characters
- Applied consistently to both `tool_use.id` and `tool_result.tool_use_id` so paired blocks stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
