### PR TITLE
fix(skills): update SKILL.md preview docs and null-safe showView()

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -808,7 +808,7 @@ function showView(name) {
   document.querySelectorAll('.view').forEach(v => v.hidden = true);
   document.getElementById('view-' + name).hidden = false;
   document.querySelectorAll('.nav-link').forEach(btn => btn.classList.remove('active'));
-  document.querySelector(`[onclick="showView('${name}')"]`).classList.add('active');
+  document.querySelector(`[onclick="showView('${name}')"]`)?.classList.add('active');
 }
 ```
 
@@ -822,13 +822,15 @@ Call `app_create` with:
 - `schema_json`: JSON schema as string
 - `html`: Complete HTML document as string
 - `auto_open`: (optional, defaults to `true`) Opens the app immediately
+- `preview`: (optional) Inline preview card — see below
 
 Since `auto_open` defaults to `true`, you don't need to call `app_open` separately after `app_create`.
 
-#### Preview metadata (ui_show only)
+#### Preview metadata
 
-When calling `ui_show` with `surface_type: "dynamic_page"`, include a `preview` object for an inline chat preview card:
+Both `ui_show` and `app_create` support a `preview` object for an inline chat preview card. Always include it so the user sees a compact summary without opening the app.
 
+**With `ui_show`:**
 ```json
 {
   "surface_type": "dynamic_page",
@@ -848,7 +850,24 @@ When calling `ui_show` with `surface_type: "dynamic_page"`, include a `preview` 
 }
 ```
 
-Preview fields: `title` (required), `subtitle`, `description`, `icon` (emoji), `metrics` (up to 3 key-value pills). Note: `preview` applies to `ui_show` only, not `app_create` or `app_open`.
+**With `app_create`:**
+```json
+{
+  "name": "Expense Tracker",
+  "schema_json": "{}",
+  "html": "...",
+  "preview": {
+    "title": "Expense Tracker",
+    "icon": "💰",
+    "metrics": [
+      { "label": "Records", "value": "24" },
+      { "label": "Categories", "value": "8" }
+    ]
+  }
+}
+```
+
+Preview fields: `title` (required), `subtitle`, `description`, `icon` (emoji), `metrics` (up to 3 key-value pills). When `app_create` is called with `auto_open: true` (the default), the preview is forwarded through `app_open` automatically.
 
 ### 6. Handle Iteration
 


### PR DESCRIPTION
## Summary
- Update App Builder SKILL.md preview metadata section to document that `preview` works with both `ui_show` and `app_create` (not just `ui_show`). Adds `app_create` example and lists `preview` in the `app_create` parameter docs.
- Add optional chaining (`?.`) to `showView()` querySelector so it doesn't throw when called for detail views that lack a nav button.

Addresses Codex feedback on PR #2692 and PR #2698.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
