### PR TITLE
feat: add CredentialBroker interface with in-memory token map

### DIFF
--- a/assistant/src/__tests__/credential-broker.test.ts
+++ b/assistant/src/__tests__/credential-broker.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { CredentialBroker } from '../tools/credentials/broker.js';
+import { upsertCredentialMetadata, _setMetadataPath } from '../tools/credentials/metadata-store.js';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('CredentialBroker', () => {
+  let broker: CredentialBroker;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'broker-test-'));
+    _setMetadataPath(join(tmpDir, 'metadata.json'));
+    broker = new CredentialBroker();
+  });
+
+  afterEach(() => {
+    _setMetadataPath(null);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('authorize', () => {
+    test('denies when no credential metadata exists', () => {
+      const result = broker.authorize({
+        service: 'github',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+      });
+      expect(result.authorized).toBe(false);
+      if (!result.authorized) {
+        expect(result.reason).toContain('No credential found');
+      }
+    });
+
+    test('authorizes when credential metadata exists', () => {
+      upsertCredentialMetadata('github', 'token');
+      const result = broker.authorize({
+        service: 'github',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+      });
+      expect(result.authorized).toBe(true);
+      if (result.authorized) {
+        expect(result.token.service).toBe('github');
+        expect(result.token.field).toBe('token');
+        expect(result.token.toolName).toBe('browser_fill_credential');
+        expect(result.token.consumed).toBe(false);
+        expect(result.token.tokenId).toBeTruthy();
+      }
+    });
+
+    test('issues unique token IDs', () => {
+      upsertCredentialMetadata('github', 'token');
+      const r1 = broker.authorize({ service: 'github', field: 'token', toolName: 'tool1' });
+      const r2 = broker.authorize({ service: 'github', field: 'token', toolName: 'tool2' });
+      expect(r1.authorized).toBe(true);
+      expect(r2.authorized).toBe(true);
+      if (r1.authorized && r2.authorized) {
+        expect(r1.token.tokenId).not.toBe(r2.token.tokenId);
+      }
+    });
+  });
+
+  describe('consume', () => {
+    test('returns storage key on first consumption', () => {
+      upsertCredentialMetadata('github', 'token');
+      const auth = broker.authorize({ service: 'github', field: 'token', toolName: 'browser_fill_credential' });
+      expect(auth.authorized).toBe(true);
+      if (!auth.authorized) return;
+
+      const result = broker.consume(auth.token.tokenId);
+      expect(result.success).toBe(true);
+      expect(result.storageKey).toBe('credential:github:token');
+    });
+
+    test('rejects double consumption', () => {
+      upsertCredentialMetadata('github', 'token');
+      const auth = broker.authorize({ service: 'github', field: 'token', toolName: 'browser_fill_credential' });
+      if (!auth.authorized) return;
+
+      broker.consume(auth.token.tokenId);
+      const result = broker.consume(auth.token.tokenId);
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('already consumed');
+    });
+
+    test('rejects unknown token ID', () => {
+      const result = broker.consume('nonexistent-token');
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('not found');
+    });
+  });
+
+  describe('revoke', () => {
+    test('revokes existing token', () => {
+      upsertCredentialMetadata('github', 'token');
+      const auth = broker.authorize({ service: 'github', field: 'token', toolName: 'browser_fill_credential' });
+      if (!auth.authorized) return;
+
+      expect(broker.revoke(auth.token.tokenId)).toBe(true);
+      // After revocation, consume should fail
+      const result = broker.consume(auth.token.tokenId);
+      expect(result.success).toBe(false);
+    });
+
+    test('returns false for unknown token', () => {
+      expect(broker.revoke('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('revokeAll', () => {
+    test('clears all active tokens', () => {
+      upsertCredentialMetadata('github', 'token');
+      broker.authorize({ service: 'github', field: 'token', toolName: 'tool1' });
+      broker.authorize({ service: 'github', field: 'token', toolName: 'tool2' });
+      expect(broker.activeTokenCount).toBe(2);
+
+      broker.revokeAll();
+      expect(broker.activeTokenCount).toBe(0);
+    });
+  });
+
+  describe('activeTokenCount', () => {
+    test('counts only unconsumed tokens', () => {
+      upsertCredentialMetadata('github', 'token');
+      const auth1 = broker.authorize({ service: 'github', field: 'token', toolName: 'tool1' });
+      broker.authorize({ service: 'github', field: 'token', toolName: 'tool2' });
+      expect(broker.activeTokenCount).toBe(2);
+
+      if (auth1.authorized) {
+        broker.consume(auth1.token.tokenId);
+      }
+      expect(broker.activeTokenCount).toBe(1);
+    });
+  });
+});

--- a/assistant/src/tools/credentials/broker-types.ts
+++ b/assistant/src/tools/credentials/broker-types.ts
@@ -1,0 +1,44 @@
+/** Opaque token representing a policy-checked authorization to use a credential. */
+export interface UsageToken {
+  tokenId: string;
+  credentialId: string;
+  service: string;
+  field: string;
+  toolName: string;
+  /** Timestamp (epoch ms) when this token was created. */
+  createdAt: number;
+  /** Whether this token has been consumed (single-use). */
+  consumed: boolean;
+}
+
+/** Request to authorize the use of a credential. */
+export interface AuthorizeRequest {
+  service: string;
+  field: string;
+  toolName: string;
+  /** Optional domain for domain-policy checking (used by browser tools). */
+  domain?: string;
+}
+
+/** Successful authorization result. */
+export interface AuthorizeSuccess {
+  authorized: true;
+  token: UsageToken;
+}
+
+/** Denied authorization result. */
+export interface AuthorizeDenied {
+  authorized: false;
+  reason: string;
+}
+
+export type AuthorizeResult = AuthorizeSuccess | AuthorizeDenied;
+
+/** Result of consuming a token. */
+export interface ConsumeResult {
+  success: boolean;
+  /** The storage key to read the secret from (only present on success). */
+  storageKey?: string;
+  /** Error reason if consumption failed. */
+  reason?: string;
+}

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -1,0 +1,108 @@
+import { v4 as uuid } from 'uuid';
+import type {
+  AuthorizeRequest,
+  AuthorizeResult,
+  ConsumeResult,
+  UsageToken,
+} from './broker-types.js';
+import { getCredentialMetadata } from './metadata-store.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('credential-broker');
+
+/**
+ * Credential broker that issues single-use tokens for policy-checked credential access.
+ *
+ * The broker never exposes plaintext secret values. Instead, it:
+ * 1. Checks that a credential exists and has metadata
+ * 2. Issues a single-use token for the authorized usage
+ * 3. On consumption, returns the storage key so the caller can read the secret internally
+ *
+ * Policy checks (tool policy, domain policy) are stubs in this PR — full enforcement comes later.
+ */
+export class CredentialBroker {
+  private tokens = new Map<string, UsageToken>();
+
+  /**
+   * Authorize the use of a credential for a specific tool and optional domain.
+   * Returns a single-use token on success, or a denial reason on failure.
+   */
+  authorize(request: AuthorizeRequest): AuthorizeResult {
+    const metadata = getCredentialMetadata(request.service, request.field);
+    if (!metadata) {
+      return {
+        authorized: false,
+        reason: `No credential found for ${request.service}/${request.field}`,
+      };
+    }
+
+    // Policy check stubs — full enforcement in PRs 19-20
+    // For now, always authorize if metadata exists.
+
+    const token: UsageToken = {
+      tokenId: uuid(),
+      credentialId: metadata.credentialId,
+      service: request.service,
+      field: request.field,
+      toolName: request.toolName,
+      createdAt: Date.now(),
+      consumed: false,
+    };
+
+    this.tokens.set(token.tokenId, token);
+    log.info({ tokenId: token.tokenId, service: request.service, field: request.field, tool: request.toolName },
+      'Usage token issued');
+
+    return { authorized: true, token };
+  }
+
+  /**
+   * Consume a previously issued token. Returns the storage key on success.
+   * Each token can only be consumed once.
+   */
+  consume(tokenId: string): ConsumeResult {
+    const token = this.tokens.get(tokenId);
+    if (!token) {
+      return { success: false, reason: 'Token not found or already revoked' };
+    }
+    if (token.consumed) {
+      return { success: false, reason: 'Token already consumed' };
+    }
+
+    token.consumed = true;
+    const storageKey = `credential:${token.service}:${token.field}`;
+    log.info({ tokenId, storageKey }, 'Usage token consumed');
+
+    return { success: true, storageKey };
+  }
+
+  /**
+   * Revoke a token, removing it from the active set.
+   * Returns true if the token existed and was revoked.
+   */
+  revoke(tokenId: string): boolean {
+    const existed = this.tokens.delete(tokenId);
+    if (existed) {
+      log.info({ tokenId }, 'Usage token revoked');
+    }
+    return existed;
+  }
+
+  /** Revoke all tokens (e.g. on session teardown). */
+  revokeAll(): void {
+    const count = this.tokens.size;
+    this.tokens.clear();
+    if (count > 0) {
+      log.info({ count }, 'All usage tokens revoked');
+    }
+  }
+
+  /** Return the number of active (non-consumed, non-revoked) tokens. */
+  get activeTokenCount(): number {
+    let count = 0;
+    for (const token of this.tokens.values()) {
+      if (!token.consumed) count++;
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `CredentialBroker` class with authorize/consume/revoke token lifecycle
- Introduces `broker-types.ts` with `UsageToken`, `AuthorizeRequest/Result`, `ConsumeResult` types
- Policy checks are stubbed (always authorize if metadata exists) — enforcement in PRs 19-20
- Adds 10 tests covering full token lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
