### PR TITLE
feat(onboarding): add API key entry step after naming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -1,0 +1,122 @@
+import VellumAssistantShared
+import SwiftUI
+
+@MainActor
+struct APIKeyStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var apiKey: String = ""
+    @State private var showContent = false
+    @State private var alreadyConfigured = false
+    @FocusState private var keyFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: VSpacing.xxl) {
+            VStack(spacing: VSpacing.md) {
+                Text("Connect to Claude")
+                    .font(VFont.onboardingTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("Enter your Anthropic API key to get started.")
+                    .font(VFont.onboardingSubtitle)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 400)
+            }
+            .opacity(showContent ? 1 : 0)
+
+            if alreadyConfigured {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                    Text("API key already configured")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .opacity(showContent ? 1 : 0)
+
+                OnboardingButton(title: "Continue", style: .primary) {
+                    state.advance()
+                }
+                .opacity(showContent ? 1 : 0)
+            } else {
+                SecureField("sk-ant-\u{2026}", text: $apiKey)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 18, weight: .medium, design: .monospaced))
+                    .foregroundColor(VColor.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, VSpacing.lg)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .fill(VColor.surface.opacity(0.5))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+                    )
+                    .frame(maxWidth: 360)
+                    .focused($keyFieldFocused)
+                    .opacity(showContent ? 1 : 0)
+                    .onSubmit {
+                        saveAndContinue()
+                    }
+
+                OnboardingButton(
+                    title: "Save & Continue",
+                    style: .primary,
+                    disabled: apiKey.trimmingCharacters(in: .whitespaces).isEmpty
+                ) {
+                    saveAndContinue()
+                }
+                .opacity(showContent ? 1 : 0)
+
+                Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
+                    Text("Get your API key at console.anthropic.com")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.accent)
+                }
+                .opacity(showContent ? 1 : 0)
+
+                OnboardingButton(title: "Skip", style: .ghost) {
+                    state.advance()
+                }
+                .opacity(showContent ? 1 : 0)
+            }
+        }
+        .onAppear {
+            if APIKeyManager.getKey() != nil {
+                alreadyConfigured = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showContent = true
+                }
+                if !alreadyConfigured {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        keyFieldFocused = true
+                    }
+                }
+            }
+        }
+    }
+
+    private func saveAndContinue() {
+        let trimmed = apiKey.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setKey(trimmed)
+        state.advance()
+    }
+}
+
+#Preview {
+    ZStack {
+        VColor.background
+        APIKeyStepView(state: {
+            let s = OnboardingState()
+            s.currentStep = 2
+            return s
+        }())
+    }
+    .frame(width: 520, height: 400)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EggSceneView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EggSceneView.swift
@@ -20,8 +20,8 @@ struct EggSceneView: View {
                 if progress > 0 {
                     scene.setCrackProgress(progress, animated: false)
                 }
-                // Resume full hatch if restored at step 6
-                if state.currentStep == 6 {
+                // Resume full hatch if restored at step 7 (Alive)
+                if state.currentStep == 7 {
                     scene.triggerFullHatch()
                 }
             }
@@ -29,9 +29,9 @@ struct EggSceneView: View {
                 scene.setCrackProgress(newValue, animated: true)
             }
             .onChange(of: state.currentStep) { old, new in
-                if (3...5).contains(new) && new > old {
+                if (4...6).contains(new) && new > old {
                     scene.triggerDramaticCrack(for: new)
-                } else if new == 6 {
+                } else if new == 7 {
                     scene.triggerFullHatch()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -14,14 +14,14 @@ struct OnboardingStageImage: View {
     @State private var displayedStage: Int = 1
     @State private var isTransitioning = false
 
-    /// Maps onboarding step (0-6) to stage image number (1-5).
+    /// Maps onboarding step (0-7) to stage image number (1-5).
     private var stageNumber: Int {
         switch currentStep {
-        case 0, 1: return 1
-        case 2:    return 2
-        case 3, 4: return 3
-        case 5:    return 4
-        default:   return 5
+        case 0, 1, 2: return 1
+        case 3:       return 2
+        case 4, 5:    return 3
+        case 6:       return 4
+        default:      return 5
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -23,8 +23,8 @@ struct OnboardingFlowView: View {
                 .opacity(0.25)
                 .allowsHitTesting(false)
 
-                if state.currentStep <= 6 {
-                    // Vertical card layout (steps 0-6)
+                if state.currentStep <= 7 {
+                    // Vertical card layout (steps 0-7)
                     VStack(spacing: 0) {
                         // TOP: Meadow background + stage image
                         ZStack {
@@ -46,14 +46,16 @@ struct OnboardingFlowView: View {
                                 case 1:
                                     NamingStepView(state: state)
                                 case 2:
-                                    FnKeyStepView(state: state)
+                                    APIKeyStepView(state: state)
                                 case 3:
-                                    SpeechPermissionStepView(state: state)
+                                    FnKeyStepView(state: state)
                                 case 4:
-                                    AccessibilityPermissionStepView(state: state)
+                                    SpeechPermissionStepView(state: state)
                                 case 5:
-                                    ScreenPermissionStepView(state: state)
+                                    AccessibilityPermissionStepView(state: state)
                                 case 6:
+                                    ScreenPermissionStepView(state: state)
+                                case 7:
                                     AliveStepView(
                                         state: state,
                                         onComplete: onComplete,
@@ -96,7 +98,7 @@ struct OnboardingFlowView: View {
                     .shadow(color: .black.opacity(0.4), radius: 24, y: 12)
                     .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
                 } else {
-                    // Step 7: Interview — manages its own layout
+                    // Step 8: Interview — manages its own layout
                     InterviewStepView(
                         state: state,
                         daemonClient: daemonClient,

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingProgressDots.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingProgressDots.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// Five cumulative progress dots for the onboarding flow.
 ///
-/// By default maps 7 steps (0-6) to 5 dots. Pass a custom `totalSteps`
+/// By default maps 8 steps (0-7) to 5 dots. Pass a custom `totalSteps`
 /// for flows with a different number of steps (e.g. `totalSteps: 5` for
 /// the first-meeting flow).
 struct OnboardingProgressDots: View {
@@ -12,7 +12,7 @@ struct OnboardingProgressDots: View {
 
     private let totalDots = 5
 
-    init(currentStep: Int, totalSteps: Int = 7) {
+    init(currentStep: Int, totalSteps: Int = 8) {
         self.currentStep = currentStep
         self.totalSteps = totalSteps
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -54,12 +54,13 @@ final class OnboardingState {
         }
         switch currentStep {
         case 0: return hasHatched ? 0.15 : 0.0
-        case 1: return 0.25
-        case 2: return 0.35
-        case 3: return speechGranted ? 0.55 : 0.40
-        case 4: return accessibilityGranted ? 0.75 : 0.60
-        case 5: return screenGranted ? 0.95 : 0.80
-        case 6: return 1.0
+        case 1: return 0.20
+        case 2: return 0.30
+        case 3: return 0.40
+        case 4: return speechGranted ? 0.55 : 0.45
+        case 5: return accessibilityGranted ? 0.75 : 0.60
+        case 6: return screenGranted ? 0.95 : 0.80
+        case 7: return 1.0
         default: return 1.0
         }
     }
@@ -85,9 +86,9 @@ final class OnboardingState {
         firstMeetingCrackProgress = CGFloat(UserDefaults.standard.double(forKey: "onboarding.firstMeetingCrackProgress"))
 
         // Clamp restored step to the variant's maximum to prevent out-of-range
-        // rendering (e.g. a step saved from the 7-step default flow would be
+        // rendering (e.g. a step saved from the 8-step default flow would be
         // invalid for the 5-step first-meeting flow).
-        let maxStep = onboardingVariant == .firstMeeting ? 4 : 6
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : 7
         if currentStep > maxStep {
             currentStep = maxStep
         }


### PR DESCRIPTION
## Summary
- Add API key entry as step 2 in onboarding (after naming, before Fn key setup)
- SecureField input with Save & Continue, Skip, and link to console.anthropic.com
- Auto-detects existing keys (survives `/scrub` via Keychain) and shows "Already configured"
- Shifts all subsequent steps by +1 and updates egg hatch animations, stage images, crack progress, and progress dots accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
