### PR TITLE
fix: even out gaps between sidebar, chat, and side panel

### DIFF
--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -25,8 +25,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .padding([.bottom, .leading], VSpacing.sm)
-                    .padding(.trailing, showPanel && panel != nil ? 0 : VSpacing.sm)
+                    .padding([.bottom, .leading, .trailing], VSpacing.sm)
 
                 // Panel slides in from right, pushing content
                 if showPanel, let panel = panel {


### PR DESCRIPTION
## Summary
- The main chat content had `0` trailing padding when a side panel was open, making the gap between chat and panel (8pt) half the gap between the thread drawer and chat (16pt)
- Changed to always apply `VSpacing.sm` trailing padding so both inter-panel gaps are a consistent 16pt (8pt padding + 8pt drag divider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
