### PR TITLE
feat: add browser fill operation to credential broker

### DIFF
--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Use encrypted backend (no keychain) with a temp store path
+// ---------------------------------------------------------------------------
+
+import { _overrideDeps, _resetDeps } from '../security/keychain.js';
+
+_overrideDeps({
+  isMacOS: () => false,
+  isLinux: () => false,
+  execFileSync: (() => '') as unknown as typeof import('node:child_process').execFileSync,
+});
+
+import { _resetBackend } from '../security/secure-keys.js';
+import { _setStorePath } from '../security/encrypted-store.js';
+
+const TEST_DIR = join(tmpdir(), `vellum-broker-fill-test-${randomBytes(4).toString('hex')}`);
+const STORE_PATH = join(TEST_DIR, 'keys.enc');
+
+// ---------------------------------------------------------------------------
+// Mock registry to avoid double-registration
+// ---------------------------------------------------------------------------
+
+mock.module('../tools/registry.js', () => ({
+  registerTool: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test
+// ---------------------------------------------------------------------------
+
+import { CredentialBroker } from '../tools/credentials/broker.js';
+import { upsertCredentialMetadata, _setMetadataPath } from '../tools/credentials/metadata-store.js';
+import { setSecureKey } from '../security/secure-keys.js';
+
+describe('CredentialBroker.browserFill', () => {
+  let broker: CredentialBroker;
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+    _resetBackend();
+    _setMetadataPath(join(TEST_DIR, 'metadata.json'));
+    broker = new CredentialBroker();
+  });
+
+  afterEach(() => {
+    _setMetadataPath(null);
+    _setStorePath(null);
+    _resetBackend();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  test('fills successfully when credential exists', async () => {
+    upsertCredentialMetadata('github', 'token');
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    let filledValue: string | undefined;
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async (value) => { filledValue = value; },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.reason).toBeUndefined();
+    // The fill callback received the plaintext
+    expect(filledValue).toBe('ghp_secret123');
+  });
+
+  test('returns metadata-only result (no plaintext in return value)', async () => {
+    upsertCredentialMetadata('github', 'token');
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => {},
+    });
+
+    // Result has no plaintext value — only success/failure metadata
+    expect(result).toEqual({ success: true });
+    expect('value' in result).toBe(false);
+    expect('storageKey' in result).toBe(false);
+  });
+
+  test('fails when no credential metadata exists', async () => {
+    const result = await broker.browserFill({
+      service: 'nonexistent',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('No credential found');
+    expect(result.reason).toContain('nonexistent/token');
+  });
+
+  test('fails when metadata exists but no stored secret value', async () => {
+    upsertCredentialMetadata('github', 'token');
+    // No setSecureKey call — metadata exists but value doesn't
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('no stored value');
+  });
+
+  test('returns failure when fill callback throws', async () => {
+    upsertCredentialMetadata('github', 'token');
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => { throw new Error('Element not found'); },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('Fill operation failed');
+    expect(result.reason).toContain('Element not found');
+  });
+
+  test('handles multiple fills with different credentials', async () => {
+    upsertCredentialMetadata('github', 'username');
+    upsertCredentialMetadata('github', 'password');
+    setSecureKey('credential:github:username', 'octocat');
+    setSecureKey('credential:github:password', 'hunter2');
+
+    const filled: Record<string, string> = {};
+
+    const r1 = await broker.browserFill({
+      service: 'github',
+      field: 'username',
+      toolName: 'browser_fill_credential',
+      fill: async (v) => { filled.username = v; },
+    });
+
+    const r2 = await broker.browserFill({
+      service: 'github',
+      field: 'password',
+      toolName: 'browser_fill_credential',
+      fill: async (v) => { filled.password = v; },
+    });
+
+    expect(r1.success).toBe(true);
+    expect(r2.success).toBe(true);
+    expect(filled.username).toBe('octocat');
+    expect(filled.password).toBe('hunter2');
+  });
+
+  test('accepts optional domain parameter', async () => {
+    upsertCredentialMetadata('github', 'token');
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      domain: 'github.com',
+      fill: async () => {},
+    });
+
+    // Domain policy enforcement is a stub — should still succeed
+    expect(result.success).toBe(true);
+  });
+
+  test('fill callback error does not leak plaintext in result', async () => {
+    upsertCredentialMetadata('github', 'token');
+    setSecureKey('credential:github:token', 'ghp_supersecret');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => { throw new Error('timeout'); },
+    });
+
+    expect(result.success).toBe(false);
+    // Ensure the secret value doesn't appear in the error result
+    expect(JSON.stringify(result)).not.toContain('ghp_supersecret');
+  });
+});

--- a/assistant/src/tools/credentials/broker-types.ts
+++ b/assistant/src/tools/credentials/broker-types.ts
@@ -42,3 +42,22 @@ export interface ConsumeResult {
   /** Error reason if consumption failed. */
   reason?: string;
 }
+
+/** Request for the broker to fill a browser field without exposing plaintext. */
+export interface BrowserFillRequest {
+  service: string;
+  field: string;
+  toolName: string;
+  domain?: string;
+  /**
+   * Opaque fill callback — the broker calls this with the plaintext value internally.
+   * The caller provides the fill function but never receives the secret value.
+   */
+  fill: (value: string) => Promise<void>;
+}
+
+/** Result of a broker-mediated browser fill — contains only metadata, never plaintext. */
+export interface BrowserFillResult {
+  success: boolean;
+  reason?: string;
+}

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -2,10 +2,13 @@ import { v4 as uuid } from 'uuid';
 import type {
   AuthorizeRequest,
   AuthorizeResult,
+  BrowserFillRequest,
+  BrowserFillResult,
   ConsumeResult,
   UsageToken,
 } from './broker-types.js';
 import { getCredentialMetadata } from './metadata-store.js';
+import { getCredentialValue } from './vault.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('credential-broker');
@@ -94,6 +97,50 @@ export class CredentialBroker {
     this.tokens.clear();
     if (count > 0) {
       log.info({ count }, 'All usage tokens revoked');
+    }
+  }
+
+  /**
+   * Fill a browser field using a credential without exposing plaintext to the caller.
+   *
+   * The broker resolves the credential, reads the secret internally, and passes it
+   * to the provided fill callback. The return value contains only metadata — the
+   * plaintext never leaves this method's scope.
+   */
+  async browserFill(request: BrowserFillRequest): Promise<BrowserFillResult> {
+    const metadata = getCredentialMetadata(request.service, request.field);
+    if (!metadata) {
+      return {
+        success: false,
+        reason: `No credential found for ${request.service}/${request.field}`,
+      };
+    }
+
+    // Policy check stubs — full enforcement in PRs 19-20
+    // For now, always allow if metadata exists.
+
+    const value = getCredentialValue(request.service, request.field);
+    if (!value) {
+      return {
+        success: false,
+        reason: `Credential metadata exists but no stored value for ${request.service}/${request.field}`,
+      };
+    }
+
+    try {
+      await request.fill(value);
+      log.info(
+        { service: request.service, field: request.field, tool: request.toolName },
+        'Browser fill completed',
+      );
+      return { success: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, service: request.service, field: request.field },
+        'Browser fill failed',
+      );
+      return { success: false, reason: `Fill operation failed: ${msg}` };
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `browserFill()` method to `CredentialBroker` that fills browser fields without exposing plaintext to the caller
- Broker accepts a fill callback, reads the secret internally, and returns only success/failure metadata
- Add `BrowserFillRequest` and `BrowserFillResult` types to broker-types
- 8 tests covering successful fill, missing credentials, fill errors, and plaintext leak prevention

PR 15 of the credential storage hardening plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
