### PR TITLE
fix: reduce inter-panel gaps for tighter layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -326,14 +326,14 @@ struct MainWindowView: View {
         .frame(width: threadDrawerWidth)
         .background(VColor.backgroundSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .padding(.bottom, VSpacing.sm)
-        .padding(.leading, VSpacing.sm)
+        .padding(.bottom, VSpacing.xs)
+        .padding(.leading, VSpacing.xs)
     }
 
     private func drawerDragDivider(availableWidth: CGFloat) -> some View {
         Rectangle()
             .fill(Color.clear)
-            .frame(width: VSpacing.sm)
+            .frame(width: VSpacing.xs)
             .contentShape(Rectangle())
             .onHover { hovering in
                 if hovering {
@@ -362,7 +362,7 @@ struct MainWindowView: View {
                         let deltaX = value.location.x - value.startLocation.x
                         let newWidth = initialWidth + Double(deltaX)
                         let minMainContent: CGFloat = 300
-                        let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.sm - (VSpacing.sm * 2)
+                        let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.xs - (VSpacing.xs * 2)
 
                         // Update width without animation to prevent jitter
                         var transaction = Transaction()

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -25,7 +25,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .padding([.bottom, .leading, .trailing], VSpacing.sm)
+                    .padding([.bottom, .leading, .trailing], VSpacing.xs)
 
                 // Panel slides in from right, pushing content
                 if showPanel, let panel = panel {
@@ -37,7 +37,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                         .animation(nil, value: panelWidth)  // Disable animation on width changes
                         .background(VColor.backgroundSubtle)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                        .padding([.bottom, .trailing], VSpacing.sm)
+                        .padding([.bottom, .trailing], VSpacing.xs)
                         .transition(.move(edge: .trailing))
                 }
             }
@@ -49,7 +49,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
     private func dragDivider(availableWidth: CGFloat) -> some View {
         Rectangle()
             .fill(Color.clear)
-            .frame(width: VSpacing.sm)
+            .frame(width: VSpacing.xs)
             .contentShape(Rectangle())
             #if os(macOS)
             .onHover { hovering in
@@ -97,7 +97,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
         // Calculate constraints
         let minPanelWidth: CGFloat = 300
         let minMainContentWidth: CGFloat = 300
-        let dividerAndPadding = VSpacing.sm + (VSpacing.sm * 2)
+        let dividerAndPadding = VSpacing.xs + (VSpacing.xs * 2)
         let maxAllowed = initialAvailableWidth - minMainContentWidth - dividerAndPadding
 
         // Update width without animation to prevent jitter


### PR DESCRIPTION
## Summary
- Changed all panel padding and drag divider widths from `VSpacing.sm` (8pt) to `VSpacing.xs` (4pt) in both `VSplitView` and `MainWindowView`
- Halves the total inter-panel gaps from 16pt to 8pt (4pt padding + 4pt divider) for a more compact layout
- Updated the drag constraint calculations to match the new spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
