### PR TITLE
feat: persist pomodoro timers across daemon restarts

### DIFF
--- a/assistant/src/__tests__/pomodoro.test.ts
+++ b/assistant/src/__tests__/pomodoro.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { executePomodoro, timers, MAX_DURATION_MINUTES } from '../tools/timer/pomodoro.js';
+import { executePomodoro, timers, rehydrateTimers, MAX_DURATION_MINUTES } from '../tools/timer/pomodoro.js';
+import { initializeDb } from '../memory/db.js';
+import { getDb } from '../memory/db.js';
+import { pomodoroTimers } from '../memory/schema.js';
+import { eq } from 'drizzle-orm';
+
+initializeDb();
 
 const SESSION_A = 'session-a';
 const SESSION_B = 'session-b';
@@ -11,9 +17,16 @@ function getSessionTimers(sessionId: string) {
   return timers.get(sessionId) ?? new Map();
 }
 
+/** Clear all timer rows from the database. */
+function clearTimerDb() {
+  const db = getDb();
+  db.delete(pomodoroTimers).run();
+}
+
 describe('pomodoro tool', () => {
   beforeEach(() => {
     timers.clear();
+    clearTimerDb();
   });
 
   afterEach(() => {
@@ -26,6 +39,7 @@ describe('pomodoro tool', () => {
       }
     }
     timers.clear();
+    clearTimerDb();
   });
 
   // ── action validation ────────────────────────────────────────────
@@ -86,6 +100,18 @@ describe('pomodoro tool', () => {
     expect(sessionTimers.size).toBe(2);
     const ids = Array.from(sessionTimers.keys());
     expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  test('start persists timer to database', () => {
+    executePomodoro({ action: 'start', label: 'Persisted' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+
+    const db = getDb();
+    const row = db.select().from(pomodoroTimers).where(eq(pomodoroTimers.id, id)).get();
+    expect(row).toBeDefined();
+    expect(row!.label).toBe('Persisted');
+    expect(row!.status).toBe('running');
+    expect(row!.sessionId).toBe(SESSION_A);
   });
 
   // ── duration overflow ─────────────────────────────────────────────
@@ -187,6 +213,17 @@ describe('pomodoro tool', () => {
     expect(timer.timeoutHandle).toBeUndefined();
   });
 
+  test('pause persists status to database', () => {
+    executePomodoro({ action: 'start', label: 'PauseMe' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id }, ctxA);
+
+    const db = getDb();
+    const row = db.select().from(pomodoroTimers).where(eq(pomodoroTimers.id, id)).get();
+    expect(row!.status).toBe('paused');
+    expect(row!.remainingMs).toBeGreaterThan(0);
+  });
+
   test('pause rejects already paused timer', () => {
     executePomodoro({ action: 'start' }, ctxA);
     const id = getSessionTimers(SESSION_A).keys().next().value!;
@@ -269,6 +306,16 @@ describe('pomodoro tool', () => {
     const result = executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('cancelled');
+  });
+
+  test('cancel persists status to database', () => {
+    executePomodoro({ action: 'start', label: 'CancelMe' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
+
+    const db = getDb();
+    const row = db.select().from(pomodoroTimers).where(eq(pomodoroTimers.id, id)).get();
+    expect(row!.status).toBe('cancelled');
   });
 
   test('cancel rejects already cancelled timer', () => {
@@ -367,6 +414,12 @@ describe('pomodoro tool', () => {
     expect(timer.completedAt).toBeDefined();
     expect(timer.remainingMs).toBe(0);
     expect(timer.timeoutHandle).toBeUndefined();
+
+    // Verify completion was persisted
+    const db = getDb();
+    const row = db.select().from(pomodoroTimers).where(eq(pomodoroTimers.id, id)).get();
+    expect(row!.status).toBe('completed');
+    expect(row!.completedAt).toBeDefined();
   });
 
   test('completed timer shows 100% progress', async () => {
@@ -434,5 +487,117 @@ describe('pomodoro tool', () => {
     const result = executePomodoro({ action: 'start', duration_minutes: 30 }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Expected end:');
+  });
+
+  // ── rehydration ──────────────────────────────────────────────────
+
+  test('rehydrateTimers restores paused timers from database', () => {
+    // Create and pause a timer
+    executePomodoro({ action: 'start', label: 'Paused Across Restart', duration_minutes: 10 }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id }, ctxA);
+
+    // Simulate daemon restart: clear in-memory state
+    for (const sessionMap of timers.values()) {
+      for (const timer of sessionMap.values()) {
+        if (timer.timeoutHandle) clearTimeout(timer.timeoutHandle);
+      }
+    }
+    timers.clear();
+    expect(getSessionTimers(SESSION_A).size).toBe(0);
+
+    // Rehydrate
+    const count = rehydrateTimers();
+    expect(count).toBe(1);
+
+    // Timer should be back in memory
+    const rehydrated = getSessionTimers(SESSION_A).get(id);
+    expect(rehydrated).toBeDefined();
+    expect(rehydrated!.status).toBe('paused');
+    expect(rehydrated!.label).toBe('Paused Across Restart');
+    expect(rehydrated!.timeoutHandle).toBeUndefined();
+  });
+
+  test('rehydrateTimers marks expired running timers as completed', () => {
+    // Insert a timer directly into DB that should have already expired
+    const db = getDb();
+    const now = Date.now();
+    const expiredId = 'expired1';
+    db.insert(pomodoroTimers).values({
+      id: expiredId,
+      sessionId: SESSION_A,
+      label: 'Already Expired',
+      durationMinutes: 1,
+      startedAt: now - 120_000, // started 2 min ago (1-min timer)
+      remainingMs: 60_000,
+      status: 'running',
+      completedAt: null,
+      createdAt: now - 120_000,
+      updatedAt: now - 120_000,
+    }).run();
+
+    const count = rehydrateTimers();
+    expect(count).toBe(1);
+
+    const timer = getSessionTimers(SESSION_A).get(expiredId);
+    expect(timer).toBeDefined();
+    expect(timer!.status).toBe('completed');
+    expect(timer!.completedAt).toBeDefined();
+    expect(timer!.remainingMs).toBe(0);
+
+    // DB should also reflect completion
+    const row = db.select().from(pomodoroTimers).where(eq(pomodoroTimers.id, expiredId)).get();
+    expect(row!.status).toBe('completed');
+  });
+
+  test('rehydrateTimers resumes running timers with remaining time', () => {
+    // Insert a timer directly into DB that still has time left
+    const db = getDb();
+    const now = Date.now();
+    const activeId = 'active1';
+    db.insert(pomodoroTimers).values({
+      id: activeId,
+      sessionId: SESSION_A,
+      label: 'Still Running',
+      durationMinutes: 10,
+      startedAt: now - 60_000, // started 1 min ago (10-min timer)
+      remainingMs: 600_000,
+      status: 'running',
+      completedAt: null,
+      createdAt: now - 60_000,
+      updatedAt: now - 60_000,
+    }).run();
+
+    const count = rehydrateTimers();
+    expect(count).toBe(1);
+
+    const timer = getSessionTimers(SESSION_A).get(activeId);
+    expect(timer).toBeDefined();
+    expect(timer!.status).toBe('running');
+    expect(timer!.timeoutHandle).toBeDefined();
+    // Should have ~9 min remaining
+    expect(timer!.remainingMs).toBeGreaterThan(500_000);
+    expect(timer!.remainingMs).toBeLessThanOrEqual(540_000);
+  });
+
+  test('rehydrateTimers skips completed/cancelled timers', () => {
+    const db = getDb();
+    const now = Date.now();
+    db.insert(pomodoroTimers).values({
+      id: 'done1',
+      sessionId: SESSION_A,
+      label: 'Done',
+      durationMinutes: 5,
+      startedAt: now - 300_000,
+      remainingMs: 0,
+      status: 'completed',
+      completedAt: now,
+      createdAt: now - 300_000,
+      updatedAt: now,
+    }).run();
+
+    const count = rehydrateTimers();
+    expect(count).toBe(0);
+    expect(getSessionTimers(SESSION_A).size).toBe(0);
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -24,6 +24,7 @@ import { startMemoryJobsWorker } from '../memory/jobs-worker.js';
 import { QdrantManager } from '../memory/qdrant-manager.js';
 import { initQdrantClient } from '../memory/qdrant-client.js';
 import { startScheduler } from '../schedule/scheduler.js';
+import { rehydrateTimers } from '../tools/timer/pomodoro.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { getHookManager } from '../hooks/manager.js';
@@ -219,6 +220,8 @@ export async function runDaemon(): Promise<void> {
   const scheduler = startScheduler(async (conversationId, message) => {
     await server.processMessage('schedule', conversationId, message);
   });
+
+  rehydrateTimers();
 
   // Start optional runtime HTTP server when RUNTIME_HTTP_PORT is set
   let runtimeHttp: RuntimeHttpServer | null = null;

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -232,6 +232,21 @@ export function initializeDb(): void {
   `);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS pomodoro_timers (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      label TEXT NOT NULL,
+      duration_minutes REAL NOT NULL,
+      started_at INTEGER NOT NULL,
+      remaining_ms INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      completed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS cron_jobs (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -456,6 +471,8 @@ export function initializeDb(): void {
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_assistant_status ON message_runs(assistant_id, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_conversation ON message_runs(conversation_id)`);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_pomodoro_timers_session_status ON pomodoro_timers(session_id, status)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled_next_run ON cron_jobs(enabled, next_run_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_runs_job_id ON cron_runs(job_id)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -217,6 +217,21 @@ export const memoryCheckpoints = sqliteTable('memory_checkpoints', {
   updatedAt: integer('updated_at').notNull(),
 });
 
+// ── Pomodoro Timers ──────────────────────────────────────────────────
+
+export const pomodoroTimers = sqliteTable('pomodoro_timers', {
+  id: text('id').primaryKey(),
+  sessionId: text('session_id').notNull(),
+  label: text('label').notNull(),
+  durationMinutes: real('duration_minutes').notNull(),
+  startedAt: integer('started_at').notNull(),
+  remainingMs: integer('remaining_ms').notNull(),
+  status: text('status').notNull(),         // running | paused | completed | cancelled
+  completedAt: integer('completed_at'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 // ── Cron / Deferred Tasks ────────────────────────────────────────────
 
 export const cronJobs = sqliteTable('cron_jobs', {

--- a/assistant/src/tools/timer/pomodoro.ts
+++ b/assistant/src/tools/timer/pomodoro.ts
@@ -3,6 +3,12 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getLogger } from '../../util/logger.js';
+import {
+  insertTimer,
+  updateTimerStatus,
+  listActiveTimers,
+  pruneTimerRows,
+} from './timer-store.js';
 
 const log = getLogger('pomodoro');
 
@@ -17,19 +23,21 @@ export function unregisterTimerCompletionNotifier(sessionId: string): void {
   completionNotifiers.delete(sessionId);
 }
 
-/** Remove completed/cancelled timers for a session to prevent unbounded map growth. */
+/** Remove completed/cancelled timers for a session (in-memory + db). */
 export function pruneSessionTimers(sessionId: string): void {
   const session = timers.get(sessionId);
-  if (!session) return;
-  for (const [id, timer] of session) {
-    if (timer.status === 'completed' || timer.status === 'cancelled') {
-      if (timer.timeoutHandle) clearTimeout(timer.timeoutHandle);
-      session.delete(id);
+  if (session) {
+    for (const [id, timer] of session) {
+      if (timer.status === 'completed' || timer.status === 'cancelled') {
+        if (timer.timeoutHandle) clearTimeout(timer.timeoutHandle);
+        session.delete(id);
+      }
+    }
+    if (session.size === 0) {
+      timers.delete(sessionId);
     }
   }
-  if (session.size === 0) {
-    timers.delete(sessionId);
-  }
+  pruneTimerRows(sessionId);
 }
 
 export interface PomodoroTimer {
@@ -49,7 +57,6 @@ export const MAX_DURATION_MINUTES = 1440;
 /** Module-level map of active timers keyed by sessionId -> timerId. */
 export const timers = new Map<string, Map<string, PomodoroTimer>>();
 
-/** Returns the per-session timer map, creating it if it doesn't exist. Use only in write paths (start). */
 function getOrCreateSessionTimers(sessionId: string): Map<string, PomodoroTimer> {
   let session = timers.get(sessionId);
   if (!session) {
@@ -59,7 +66,6 @@ function getOrCreateSessionTimers(sessionId: string): Map<string, PomodoroTimer>
   return session;
 }
 
-/** Returns the per-session timer map without creating one. Returns undefined when the session has no timers. */
 function findSessionTimers(sessionId: string): Map<string, PomodoroTimer> | undefined {
   return timers.get(sessionId);
 }
@@ -94,9 +100,6 @@ function formatTimerStatus(timer: PomodoroTimer): string {
     const now = Date.now();
     elapsedMs = now - timer.startedAt;
     remainingMs = Math.max(0, totalMs - elapsedMs);
-    // Correct for resumed timers: remainingMs was set at resume time
-    // and startedAt was adjusted, so elapsed = now - startedAt
-    // This is correct because startedAt is adjusted on resume.
   }
 
   const percentage = totalMs > 0 ? Math.min(100, Math.round((elapsedMs / totalMs) * 100)) : 100;
@@ -115,6 +118,23 @@ function formatTimerStatus(timer: PomodoroTimer): string {
   }
 
   return lines.join('\n');
+}
+
+/** Schedule a setTimeout that fires the completion callback and persists the status. */
+function scheduleCompletion(timer: PomodoroTimer, sessionId: string, delayMs: number): void {
+  timer.timeoutHandle = setTimeout(() => {
+    timer.status = 'completed';
+    timer.completedAt = Date.now();
+    timer.remainingMs = 0;
+    timer.timeoutHandle = undefined;
+    log.info({ id: timer.id, label: timer.label }, 'Pomodoro timer completed');
+    updateTimerStatus(timer.id, {
+      status: 'completed',
+      remainingMs: 0,
+      completedAt: timer.completedAt,
+    });
+    completionNotifiers.get(sessionId)?.(timer);
+  }, delayMs);
 }
 
 function startAction(input: Record<string, unknown>, sessionId: string): ToolExecutionResult {
@@ -145,17 +165,24 @@ function startAction(input: Record<string, unknown>, sessionId: string): ToolExe
     status: 'running',
   };
 
-  timer.timeoutHandle = setTimeout(() => {
-    timer.status = 'completed';
-    timer.completedAt = Date.now();
-    timer.remainingMs = 0;
-    timer.timeoutHandle = undefined;
-    log.info({ id: timer.id, label: timer.label }, 'Pomodoro timer completed');
-    completionNotifiers.get(sessionId)?.(timer);
-  }, durationMs);
+  scheduleCompletion(timer, sessionId, durationMs);
 
   const sessionTimers = getOrCreateSessionTimers(sessionId);
   sessionTimers.set(id, timer);
+
+  insertTimer({
+    id,
+    sessionId,
+    label,
+    durationMinutes,
+    startedAt: now,
+    remainingMs: durationMs,
+    status: 'running',
+    completedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
   log.info({ id, label, durationMinutes, sessionId }, 'Pomodoro timer started');
 
   const endTime = new Date(now + durationMs).toISOString();
@@ -196,6 +223,11 @@ function pauseAction(input: Record<string, unknown>, sessionId: string): ToolExe
     timer.timeoutHandle = undefined;
   }
 
+  updateTimerStatus(timerId, {
+    status: 'paused',
+    remainingMs: timer.remainingMs,
+  });
+
   log.info({ id: timerId, remainingMs: timer.remainingMs }, 'Pomodoro timer paused');
 
   return {
@@ -221,19 +253,17 @@ function resumeAction(input: Record<string, unknown>, sessionId: string): ToolEx
   }
 
   const now = Date.now();
-  // Adjust startedAt so that elapsed calculations remain correct.
   const totalMs = timer.durationMinutes * 60 * 1000;
   timer.startedAt = now - (totalMs - timer.remainingMs);
   timer.status = 'running';
 
-  timer.timeoutHandle = setTimeout(() => {
-    timer.status = 'completed';
-    timer.completedAt = Date.now();
-    timer.remainingMs = 0;
-    timer.timeoutHandle = undefined;
-    log.info({ id: timer.id, label: timer.label }, 'Pomodoro timer completed');
-    completionNotifiers.get(sessionId)?.(timer);
-  }, timer.remainingMs);
+  scheduleCompletion(timer, sessionId, timer.remainingMs);
+
+  updateTimerStatus(timerId, {
+    status: 'running',
+    startedAt: timer.startedAt,
+    remainingMs: timer.remainingMs,
+  });
 
   log.info({ id: timerId, remainingMs: timer.remainingMs }, 'Pomodoro timer resumed');
 
@@ -264,7 +294,6 @@ function cancelAction(input: Record<string, unknown>, sessionId: string): ToolEx
     timer.timeoutHandle = undefined;
   }
 
-  // Preserve remaining time at time of cancellation
   if (timer.status === 'running') {
     const now = Date.now();
     const elapsed = now - timer.startedAt;
@@ -273,6 +302,12 @@ function cancelAction(input: Record<string, unknown>, sessionId: string): ToolEx
   }
 
   timer.status = 'cancelled';
+
+  updateTimerStatus(timerId, {
+    status: 'cancelled',
+    remainingMs: timer.remainingMs,
+  });
+
   log.info({ id: timerId }, 'Pomodoro timer cancelled');
 
   return {
@@ -342,9 +377,64 @@ export function executePomodoro(
   }
 }
 
+/**
+ * Rehydrate timers from the database after a daemon restart.
+ * Running timers that haven't expired are resumed with adjusted timeouts.
+ * Running timers that have already expired are marked completed.
+ * Paused timers are restored as-is.
+ */
+export function rehydrateTimers(): number {
+  const rows = listActiveTimers();
+  if (rows.length === 0) return 0;
+
+  const now = Date.now();
+  let rehydrated = 0;
+
+  for (const row of rows) {
+    const timer: PomodoroTimer = {
+      id: row.id,
+      label: row.label,
+      durationMinutes: row.durationMinutes,
+      startedAt: row.startedAt,
+      remainingMs: row.remainingMs,
+      status: row.status as PomodoroTimer['status'],
+      completedAt: row.completedAt ?? undefined,
+    };
+
+    if (row.status === 'running') {
+      const totalMs = row.durationMinutes * 60 * 1000;
+      const elapsed = now - row.startedAt;
+      const remaining = Math.max(0, totalMs - elapsed);
+
+      if (remaining <= 0) {
+        // Timer expired while daemon was down
+        timer.status = 'completed';
+        timer.completedAt = row.startedAt + totalMs;
+        timer.remainingMs = 0;
+        updateTimerStatus(row.id, {
+          status: 'completed',
+          remainingMs: 0,
+          completedAt: timer.completedAt,
+        });
+      } else {
+        timer.remainingMs = remaining;
+        scheduleCompletion(timer, row.sessionId, remaining);
+      }
+    }
+    // Paused timers need no timeout — just restore them
+
+    const sessionTimers = getOrCreateSessionTimers(row.sessionId);
+    sessionTimers.set(row.id, timer);
+    rehydrated += 1;
+  }
+
+  log.info({ rehydrated }, 'Rehydrated pomodoro timers from database');
+  return rehydrated;
+}
+
 class PomodoroTool implements Tool {
   name = 'pomodoro';
-  description = 'Manage focus timers. Start, pause, resume, cancel, or check status of pomodoro timers.';
+  description = 'Manage focus timers. Start, pause, resume, cancel, or check status of pomodoro timers. Timers persist across daemon restarts.';
   category = 'timer';
   defaultRiskLevel = RiskLevel.Low;
 

--- a/assistant/src/tools/timer/timer-store.ts
+++ b/assistant/src/tools/timer/timer-store.ts
@@ -1,0 +1,78 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { getDb } from '../../memory/db.js';
+import { pomodoroTimers } from '../../memory/schema.js';
+
+export interface TimerRow {
+  id: string;
+  sessionId: string;
+  label: string;
+  durationMinutes: number;
+  startedAt: number;
+  remainingMs: number;
+  status: string;
+  completedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export function insertTimer(row: TimerRow): void {
+  const db = getDb();
+  db.insert(pomodoroTimers).values(row).run();
+}
+
+export function updateTimerStatus(
+  id: string,
+  updates: {
+    status: string;
+    remainingMs?: number;
+    startedAt?: number;
+    completedAt?: number | null;
+  },
+): void {
+  const db = getDb();
+  const set: Record<string, unknown> = {
+    status: updates.status,
+    updatedAt: Date.now(),
+  };
+  if (updates.remainingMs !== undefined) set.remainingMs = updates.remainingMs;
+  if (updates.startedAt !== undefined) set.startedAt = updates.startedAt;
+  if (updates.completedAt !== undefined) set.completedAt = updates.completedAt;
+  db.update(pomodoroTimers).set(set).where(eq(pomodoroTimers.id, id)).run();
+}
+
+export function deleteTimer(id: string): void {
+  const db = getDb();
+  db.delete(pomodoroTimers).where(eq(pomodoroTimers.id, id)).run();
+}
+
+export function listTimersBySession(sessionId: string): TimerRow[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(pomodoroTimers)
+    .where(eq(pomodoroTimers.sessionId, sessionId))
+    .all();
+}
+
+/** Load all running or paused timers (for rehydration after daemon restart). */
+export function listActiveTimers(): TimerRow[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(pomodoroTimers)
+    .where(inArray(pomodoroTimers.status, ['running', 'paused']))
+    .all();
+}
+
+/** Delete completed/cancelled timers for a session. */
+export function pruneTimerRows(sessionId: string): void {
+  const db = getDb();
+  db.delete(pomodoroTimers)
+    .where(
+      and(
+        eq(pomodoroTimers.sessionId, sessionId),
+        inArray(pomodoroTimers.status, ['completed', 'cancelled']),
+      ),
+    )
+    .run();
+}


### PR DESCRIPTION
## Summary
- Added `pomodoro_timers` SQLite table and `timer-store.ts` persistence layer to back pomodoro timers with durable storage
- All timer mutations (start, pause, resume, cancel, complete) are now persisted to the database
- On daemon startup, `rehydrateTimers()` restores active timers: running timers get new timeouts (or are marked completed if expired), paused timers are restored as-is
- Added rehydration and persistence tests alongside existing test suite (44 tests, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
