### PR TITLE
feat: refactor browser_fill_credential to use credential broker

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -54,9 +54,18 @@ mock.module('../tools/network/url-safety.js', () => ({
 }));
 
 let mockGetCredentialValue: ReturnType<typeof mock>;
+let mockGetCredentialMetadata: ReturnType<typeof mock>;
 
 mock.module('../tools/credentials/vault.js', () => ({
   getCredentialValue: (...args: unknown[]) => mockGetCredentialValue(...args),
+}));
+
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: (...args: unknown[]) => mockGetCredentialMetadata(...args),
+  getCredentialMetadataById: () => undefined,
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+  _setMetadataPath: () => {},
 }));
 
 import { executeBrowserFillCredential } from '../tools/browser/headless-browser.js';
@@ -82,6 +91,10 @@ function resetMockPage() {
   };
 }
 
+function defaultMetadata(service: string, field: string) {
+  return { credentialId: `${service}:${field}`, service, field, createdAt: Date.now() };
+}
+
 // ── browser_fill_credential ──────────────────────────────────────────
 
 describe('executeBrowserFillCredential', () => {
@@ -89,6 +102,7 @@ describe('executeBrowserFillCredential', () => {
     resetMockPage();
     snapshotMaps.clear();
     mockGetCredentialValue = mock(() => 'super-secret-password');
+    mockGetCredentialMetadata = mock((service: string, field: string) => defaultMetadata(service, field));
   });
 
   test('fills credential into element by element_id', async () => {
@@ -114,6 +128,19 @@ describe('executeBrowserFillCredential', () => {
   });
 
   test('returns error when credential not found', async () => {
+    mockGetCredentialMetadata = mock(() => undefined);
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserFillCredential(
+      { service: 'slack', field: 'api_key', element_id: 'e1' },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No credential stored for slack/api_key');
+    expect(result.content).toContain('credential_store');
+    expect(mockPage.fill).not.toHaveBeenCalled();
+  });
+
+  test('returns error when metadata exists but no stored value', async () => {
     mockGetCredentialValue = mock(() => undefined);
     snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
     const result = await executeBrowserFillCredential(
@@ -178,46 +205,29 @@ describe('executeBrowserFillCredential', () => {
   });
 
   // -----------------------------------------------------------------------
-  // Baseline characterization — freeze current contract before hardening
+  // Broker-mediated credential access — verify broker path is used
   // -----------------------------------------------------------------------
-  describe('baseline characterization', () => {
+  describe('broker integration', () => {
     test('fill succeeds with no domain or tool-policy checks', async () => {
-      // Currently browser_fill_credential does not validate the page URL
-      // against any allowed-domains policy on the credential. It fills
-      // unconditionally as long as the credential exists and the element
-      // resolves. Future PRs will add domain-scoped credential policies.
       snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
       const result = await executeBrowserFillCredential(
-        {
-          service: 'gmail',
-          field: 'password',
-          element_id: 'e1',
-          // No domain or policy fields exist on the input schema today
-        },
+        { service: 'gmail', field: 'password', element_id: 'e1' },
         ctx,
       );
       expect(result.isError).toBe(false);
       expect(result.content).toContain('Filled password for gmail');
-      // The secret value must not appear in the output
       expect(result.content).not.toContain('super-secret-password');
     });
 
-    test('context has no credential access audit trail', async () => {
-      // The ToolContext passed to browser_fill_credential does not include
-      // any audit or logging callback for credential access. Calls to
-      // getCredentialValue are not tracked. Future PRs will add an audit
-      // hook on the context.
+    test('credential access goes through broker (metadata + value checked)', async () => {
       snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
       await executeBrowserFillCredential(
         { service: 'gmail', field: 'password', element_id: 'e1' },
         ctx,
       );
-      // Verify getCredentialValue was called with bare service/field and
-      // no additional context (no domain, no session provenance).
-      expect(mockGetCredentialValue).toHaveBeenCalledTimes(1);
+      // Broker checks metadata first, then reads the value
+      expect(mockGetCredentialMetadata).toHaveBeenCalledWith('gmail', 'password');
       expect(mockGetCredentialValue).toHaveBeenCalledWith('gmail', 'password');
-      // Only 2 arguments — no audit context parameter
-      expect(mockGetCredentialValue.mock.calls[0]).toHaveLength(2);
     });
   });
 });

--- a/assistant/src/__tests__/signup-e2e.test.ts
+++ b/assistant/src/__tests__/signup-e2e.test.ts
@@ -59,6 +59,7 @@ import {
   listSecureKeys,
 } from '../security/secure-keys.js';
 import { getCredentialValue } from '../tools/credentials/vault.js';
+import { upsertCredentialMetadata, _setMetadataPath } from '../tools/credentials/metadata-store.js';
 import {
   executeBrowserNavigate,
   executeBrowserClick,
@@ -90,6 +91,7 @@ beforeAll(async () => {
   _resetBackend();
   mkdirSync(join(testDir, 'browser-profile'), { recursive: true });
   _setStorePath(STORE_PATH);
+  _setMetadataPath(join(testDir, 'metadata.json'));
 
   server = createMockSignupServer();
   ({ url } = await server.start());
@@ -98,6 +100,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await executeBrowserClose({ close_all_pages: true }, ctx);
   await server.stop();
+  _setMetadataPath(null);
   _setStorePath(null);
   _resetBackend();
   _resetDeps();
@@ -123,9 +126,10 @@ beforeEach(() => {
 
 describe('end-to-end signup flow', () => {
   test('happy path: full signup with credential fill', async () => {
-    // Store credential in vault
+    // Store credential in vault with metadata (broker requires metadata)
     const storeOk = setSecureKey(`credential:mockservice:password`, TEST_PASSWORD);
     expect(storeOk).toBe(true);
+    upsertCredentialMetadata('mockservice', 'password');
     expect(getCredentialValue('mockservice', 'password')).toBe(TEST_PASSWORD);
 
     // Navigate to signup
@@ -232,6 +236,7 @@ describe('end-to-end signup flow', () => {
   test('taken username shows validation error', async () => {
     // Store credential so fill works
     setSecureKey(`credential:mockservice:password`, TEST_PASSWORD);
+    upsertCredentialMetadata('mockservice', 'password');
 
     await executeBrowserNavigate(
       { url: `${url}/signup`, allow_private_network: true },
@@ -272,6 +277,7 @@ describe('end-to-end signup flow', () => {
   test('wrong verification code shows error', async () => {
     // Store credential so fill works
     setSecureKey(`credential:mockservice:password`, TEST_PASSWORD);
+    upsertCredentialMetadata('mockservice', 'password');
 
     await executeBrowserNavigate(
       { url: `${url}/signup`, allow_private_network: true },
@@ -319,6 +325,7 @@ describe('end-to-end signup flow', () => {
   test('credential value never leaks into any tool output', async () => {
     const secret = ['MyS3cret', '!Value', '42'].join('');
     setSecureKey(`credential:leak-test:password`, secret);
+    upsertCredentialMetadata('leak-test', 'password');
 
     await executeBrowserNavigate(
       { url: `${url}/signup`, allow_private_network: true },

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -14,9 +14,10 @@ import { browserManager } from './browser-manager.js';
 import type { RouteHandler } from './browser-manager.js';
 import { detectCaptcha } from './captcha-detector.js';
 import { detectAuthChallenge, formatAuthChallenge } from './auth-detector.js';
-import { getCredentialValue } from '../credentials/vault.js';
+import { CredentialBroker } from '../credentials/broker.js';
 
 const log = getLogger('headless-browser');
+const credentialBroker = new CredentialBroker();
 
 const NAVIGATE_TIMEOUT_MS = 30_000;
 
@@ -908,30 +909,35 @@ async function executeBrowserFillCredential(
   const { selector, error } = resolveSelector(context.sessionId, input);
   if (error) return { content: error, isError: true };
 
-  const value = getCredentialValue(service, field);
-  if (!value) {
-    return {
-      content: `No credential stored for ${service}/${field}. Use credential_store to save it first.`,
-      isError: true,
-    };
-  }
-
   const pressEnter = input.press_enter === true;
+  const page = await browserManager.getOrCreateSessionPage(context.sessionId);
 
-  try {
-    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
-    await page.fill(selector!, value);
+  const result = await credentialBroker.browserFill({
+    service,
+    field,
+    toolName: 'browser_fill_credential',
+    fill: async (value) => {
+      await page.fill(selector!, value);
+    },
+  });
 
-    if (pressEnter) {
-      await page.press(selector!, 'Enter');
+  if (!result.success) {
+    const reason = result.reason ?? 'unknown error';
+    if (reason.includes('No credential found') || reason.includes('no stored value')) {
+      return {
+        content: `No credential stored for ${service}/${field}. Use credential_store to save it first.`,
+        isError: true,
+      };
     }
-
-    return { content: `Filled ${field} for ${service} into the target element.`, isError: false };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err, selector }, 'Fill credential failed');
-    return { content: `Error: Fill credential failed: ${msg}`, isError: true };
+    log.error({ selector, reason }, 'Fill credential failed');
+    return { content: `Error: Fill credential failed: ${reason}`, isError: true };
   }
+
+  if (pressEnter) {
+    await page.press(selector!, 'Enter');
+  }
+
+  return { content: `Filled ${field} for ${service} into the target element.`, isError: false };
 }
 
 class BrowserFillCredentialTool implements Tool {


### PR DESCRIPTION
## Summary
- Replace direct `getCredentialValue()` call in `executeBrowserFillCredential` with `credentialBroker.browserFill()`, removing the browser tool's direct access to plaintext secrets
- Update browser fill tests to mock both metadata-store and vault (broker checks metadata before reading secret)
- Update signup e2e tests to call `upsertCredentialMetadata()` alongside `setSecureKey()` so the broker path works end-to-end

PR 16 of the credential storage hardening plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
