### PR TITLE
feat: add policy fields to credential_store input schema

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -47,7 +47,6 @@ mock.module('../tools/registry.js', () => ({
 
 // getCredentialValue is no longer exported (sealed in PR 17) — use getSecureKey directly
 
-// We need to construct the tool directly for testing execute()
 import type { ToolContext } from '../tools/types.js';
 import {
   setSecureKey,
@@ -55,6 +54,8 @@ import {
   listSecureKeys,
   deleteSecureKey,
 } from '../security/secure-keys.js';
+import { getCredentialMetadata, _setMetadataPath } from '../tools/credentials/metadata-store.js';
+import { credentialStoreTool } from '../tools/credentials/vault.js';
 
 // Create a minimal context for tool execution
 const _ctx: ToolContext = {
@@ -157,9 +158,11 @@ describe('credential_store tool', () => {
     }
     mkdirSync(TEST_DIR, { recursive: true });
     _setStorePath(STORE_PATH);
+    _setMetadataPath(join(TEST_DIR, 'metadata.json'));
   });
 
   afterEach(() => {
+    _setMetadataPath(null);
     _setStorePath(null);
     _resetBackend();
   });
@@ -358,27 +361,48 @@ describe('credential_store tool', () => {
       expect('getCredentialValue' in vaultModule).toBe(false);
     });
 
-    test('credential_store input schema has no policy or domain fields', () => {
-      // The current tool accepts only: action, service, field, value,
-      // label, description, placeholder. There are no access-policy,
-      // allowed-domains, or expiry fields. Future PRs will add these.
-      const knownProperties = ['action', 'service', 'field', 'value', 'label', 'description', 'placeholder'];
-      // Verify the execute wrapper accepts arbitrary inputs without error
-      // (unknown keys are silently ignored, not validated against a policy schema)
-      const storeResult = executeVault({
+    test('store with policy fields persists metadata', async () => {
+      const result = await credentialStoreTool.execute({
         action: 'store',
-        service: 'test-svc',
+        service: 'github',
+        field: 'token',
+        value: 'ghp_secret',
+        allowed_tools: ['browser_fill_credential'],
+        allowed_domains: ['github.com'],
+        usage_description: 'GitHub login',
+      }, _ctx);
+      expect(result.isError).toBe(false);
+      const metadata = getCredentialMetadata('github', 'token');
+      expect(metadata).toBeDefined();
+      expect(metadata!.allowedTools).toEqual(['browser_fill_credential']);
+      expect(metadata!.allowedDomains).toEqual(['github.com']);
+      expect(metadata!.usageDescription).toBe('GitHub login');
+    });
+
+    test('store without policy fields defaults to empty arrays', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'slack',
+        field: 'token',
+        value: 'xoxb-secret',
+      }, _ctx);
+      expect(result.isError).toBe(false);
+      const metadata = getCredentialMetadata('slack', 'token');
+      expect(metadata).toBeDefined();
+      expect(metadata!.allowedTools).toEqual([]);
+      expect(metadata!.allowedDomains).toEqual([]);
+    });
+
+    test('store rejects invalid policy input', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'test',
         field: 'token',
         value: 'val',
-        allowedDomains: ['example.com'],   // not part of current schema
-        expiresAt: '2026-12-31',           // not part of current schema
-        accessPolicy: 'browser_fill_only', // not part of current schema
-      });
-      // Store succeeds — extra fields are silently ignored
-      return storeResult.then((r) => {
-        expect(r.isError).toBe(false);
-        expect(r.content).toBe('Stored credential for test-svc/token.');
-      });
+        allowed_tools: 'not-an-array',
+      }, _ctx);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('allowed_tools must be an array');
     });
 
     test('list action entries contain only service and field (no policy metadata)', () => {

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -9,6 +9,8 @@ import {
   getBackendType,
 } from '../../security/secure-keys.js';
 import { upsertCredentialMetadata, deleteCredentialMetadata } from './metadata-store.js';
+import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
+import type { CredentialPolicyInput } from './policy-types.js';
 
 /**
  * Retrieve the actual secret value for a credential.
@@ -60,6 +62,20 @@ class CredentialStoreTool implements Tool {
             type: 'string',
             description: 'Placeholder text for the input field (only for prompt action), e.g. "ghp_xxxxxxxxxxxx"',
           },
+          allowed_tools: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Tools allowed to use this credential (for store/prompt actions), e.g. ["browser_fill_credential"]. Empty = deny all.',
+          },
+          allowed_domains: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Domains where this credential may be used (for store/prompt actions), e.g. ["github.com"]. Empty = deny all.',
+          },
+          usage_description: {
+            type: 'string',
+            description: 'Human-readable description of intended usage (for store/prompt actions), e.g. "GitHub login for pushing changes"',
+          },
         },
         required: ['action'],
       },
@@ -85,12 +101,27 @@ class CredentialStoreTool implements Tool {
           return { content: 'Error: value is required for store action', isError: true };
         }
 
+        const policyInput: CredentialPolicyInput = {
+          allowed_tools: input.allowed_tools as string[] | undefined,
+          allowed_domains: input.allowed_domains as string[] | undefined,
+          usage_description: input.usage_description as string | undefined,
+        };
+        const policyResult = validatePolicyInput(policyInput);
+        if (!policyResult.valid) {
+          return { content: `Error: ${policyResult.errors.join('; ')}`, isError: true };
+        }
+        const policy = toPolicyFromInput(policyInput);
+
         const key = `credential:${service}:${field}`;
         const ok = setSecureKey(key, value);
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field);
+        upsertCredentialMetadata(service, field, {
+          allowedTools: policy.allowedTools,
+          allowedDomains: policy.allowedDomains,
+          usageDescription: policy.usageDescription,
+        });
         return { content: `Stored credential for ${service}/${field}.`, isError: false };
       }
 
@@ -155,6 +186,17 @@ class CredentialStoreTool implements Tool {
         const description = input.description as string | undefined;
         const placeholder = input.placeholder as string | undefined;
 
+        const promptPolicyInput: CredentialPolicyInput = {
+          allowed_tools: input.allowed_tools as string[] | undefined,
+          allowed_domains: input.allowed_domains as string[] | undefined,
+          usage_description: input.usage_description as string | undefined,
+        };
+        const promptPolicyResult = validatePolicyInput(promptPolicyInput);
+        if (!promptPolicyResult.valid) {
+          return { content: `Error: ${promptPolicyResult.errors.join('; ')}`, isError: true };
+        }
+        const promptPolicy = toPolicyFromInput(promptPolicyInput);
+
         const result = await context.requestSecret({ service, field, label, description, placeholder });
         if (!result.value) {
           return { content: 'User cancelled the credential prompt.', isError: false };
@@ -166,7 +208,11 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field);
+        upsertCredentialMetadata(service, field, {
+          allowedTools: promptPolicy.allowedTools,
+          allowedDomains: promptPolicy.allowedDomains,
+          usageDescription: promptPolicy.usageDescription,
+        });
         return { content: `Credential stored for ${service}/${field}.`, isError: false };
       }
 


### PR DESCRIPTION
## Summary
- Add `allowed_tools`, `allowed_domains`, and `usage_description` to the `credential_store` tool input schema for both `store` and `prompt` actions
- Policy input is validated via `policy-validate.ts` and persisted in credential metadata
- Credentials stored without policy fields default to empty arrays (deny-all)
- 3 new tests verifying policy persistence, defaults, and validation errors

PR 18 of the credential storage hardening plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
