### PR TITLE
feat: enforce tool policy in credential broker

### DIFF
--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -67,7 +67,7 @@ describe('CredentialBroker.browserFill', () => {
   });
 
   test('fills successfully when credential exists', async () => {
-    upsertCredentialMetadata('github', 'token');
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
     setSecureKey('credential:github:token', 'ghp_secret123');
 
     let filledValue: string | undefined;
@@ -85,7 +85,7 @@ describe('CredentialBroker.browserFill', () => {
   });
 
   test('returns metadata-only result (no plaintext in return value)', async () => {
-    upsertCredentialMetadata('github', 'token');
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
     setSecureKey('credential:github:token', 'ghp_secret123');
 
     const result = await broker.browserFill({
@@ -115,7 +115,7 @@ describe('CredentialBroker.browserFill', () => {
   });
 
   test('fails when metadata exists but no stored secret value', async () => {
-    upsertCredentialMetadata('github', 'token');
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
     // No setSecureKey call — metadata exists but value doesn't
 
     const result = await broker.browserFill({
@@ -130,7 +130,7 @@ describe('CredentialBroker.browserFill', () => {
   });
 
   test('returns failure when fill callback throws', async () => {
-    upsertCredentialMetadata('github', 'token');
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
     setSecureKey('credential:github:token', 'ghp_secret123');
 
     const result = await broker.browserFill({
@@ -146,8 +146,8 @@ describe('CredentialBroker.browserFill', () => {
   });
 
   test('handles multiple fills with different credentials', async () => {
-    upsertCredentialMetadata('github', 'username');
-    upsertCredentialMetadata('github', 'password');
+    upsertCredentialMetadata('github', 'username', { allowedTools: ['browser_fill_credential'] });
+    upsertCredentialMetadata('github', 'password', { allowedTools: ['browser_fill_credential'] });
     setSecureKey('credential:github:username', 'octocat');
     setSecureKey('credential:github:password', 'hunter2');
 
@@ -174,7 +174,7 @@ describe('CredentialBroker.browserFill', () => {
   });
 
   test('accepts optional domain parameter', async () => {
-    upsertCredentialMetadata('github', 'token');
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
     setSecureKey('credential:github:token', 'ghp_secret123');
 
     const result = await broker.browserFill({
@@ -189,8 +189,42 @@ describe('CredentialBroker.browserFill', () => {
     expect(result.success).toBe(true);
   });
 
+  test('denies fill when tool is not in allowedTools', async () => {
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['other_tool'] });
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    let fillCalled = false;
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => { fillCalled = true; },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('not allowed');
+    expect(result.reason).toContain('browser_fill_credential');
+    // Fill callback must not be invoked when policy denies
+    expect(fillCalled).toBe(false);
+  });
+
+  test('denies fill when allowedTools is empty (fail-closed)', async () => {
+    upsertCredentialMetadata('github', 'token', { allowedTools: [] });
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('No tools are currently allowed');
+  });
+
   test('fill callback error does not leak plaintext in result', async () => {
-    upsertCredentialMetadata('github', 'token');
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
     setSecureKey('credential:github:token', 'ghp_supersecret');
 
     const result = await broker.browserFill({

--- a/assistant/src/__tests__/credential-broker.test.ts
+++ b/assistant/src/__tests__/credential-broker.test.ts
@@ -33,8 +33,8 @@ describe('CredentialBroker', () => {
       }
     });
 
-    test('authorizes when credential metadata exists', () => {
-      upsertCredentialMetadata('github', 'token');
+    test('authorizes when tool is in allowedTools', () => {
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
       const result = broker.authorize({
         service: 'github',
         field: 'token',
@@ -50,8 +50,38 @@ describe('CredentialBroker', () => {
       }
     });
 
-    test('issues unique token IDs', () => {
+    test('denies when tool is not in allowedTools', () => {
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['other_tool'] });
+      const result = broker.authorize({
+        service: 'github',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+      });
+      expect(result.authorized).toBe(false);
+      if (!result.authorized) {
+        expect(result.reason).toContain('not allowed');
+        expect(result.reason).toContain('browser_fill_credential');
+        expect(result.reason).toContain('Allowed tools: other_tool');
+      }
+    });
+
+    test('denies when allowedTools is empty (fail-closed)', () => {
       upsertCredentialMetadata('github', 'token');
+      const result = broker.authorize({
+        service: 'github',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+      });
+      expect(result.authorized).toBe(false);
+      if (!result.authorized) {
+        expect(result.reason).toContain('not allowed');
+        expect(result.reason).toContain('No tools are currently allowed');
+        expect(result.reason).toContain('credential_store');
+      }
+    });
+
+    test('issues unique token IDs', () => {
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['tool1', 'tool2'] });
       const r1 = broker.authorize({ service: 'github', field: 'token', toolName: 'tool1' });
       const r2 = broker.authorize({ service: 'github', field: 'token', toolName: 'tool2' });
       expect(r1.authorized).toBe(true);
@@ -64,7 +94,7 @@ describe('CredentialBroker', () => {
 
   describe('consume', () => {
     test('returns storage key on first consumption', () => {
-      upsertCredentialMetadata('github', 'token');
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
       const auth = broker.authorize({ service: 'github', field: 'token', toolName: 'browser_fill_credential' });
       expect(auth.authorized).toBe(true);
       if (!auth.authorized) return;
@@ -75,7 +105,7 @@ describe('CredentialBroker', () => {
     });
 
     test('rejects double consumption', () => {
-      upsertCredentialMetadata('github', 'token');
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
       const auth = broker.authorize({ service: 'github', field: 'token', toolName: 'browser_fill_credential' });
       if (!auth.authorized) return;
 
@@ -94,7 +124,7 @@ describe('CredentialBroker', () => {
 
   describe('revoke', () => {
     test('revokes existing token', () => {
-      upsertCredentialMetadata('github', 'token');
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
       const auth = broker.authorize({ service: 'github', field: 'token', toolName: 'browser_fill_credential' });
       if (!auth.authorized) return;
 
@@ -111,7 +141,7 @@ describe('CredentialBroker', () => {
 
   describe('revokeAll', () => {
     test('clears all active tokens', () => {
-      upsertCredentialMetadata('github', 'token');
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['tool1', 'tool2'] });
       broker.authorize({ service: 'github', field: 'token', toolName: 'tool1' });
       broker.authorize({ service: 'github', field: 'token', toolName: 'tool2' });
       expect(broker.activeTokenCount).toBe(2);
@@ -123,7 +153,7 @@ describe('CredentialBroker', () => {
 
   describe('activeTokenCount', () => {
     test('counts only unconsumed tokens', () => {
-      upsertCredentialMetadata('github', 'token');
+      upsertCredentialMetadata('github', 'token', { allowedTools: ['tool1', 'tool2'] });
       const auth1 = broker.authorize({ service: 'github', field: 'token', toolName: 'tool1' });
       broker.authorize({ service: 'github', field: 'token', toolName: 'tool2' });
       expect(broker.activeTokenCount).toBe(2);

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -8,6 +8,7 @@ import type {
   UsageToken,
 } from './broker-types.js';
 import { getCredentialMetadata } from './metadata-store.js';
+import { isToolAllowed } from './tool-policy.js';
 import { getSecureKey } from '../../security/secure-keys.js';
 import { getLogger } from '../../util/logger.js';
 
@@ -21,7 +22,7 @@ const log = getLogger('credential-broker');
  * 2. Issues a single-use token for the authorized usage
  * 3. On consumption, returns the storage key so the caller can read the secret internally
  *
- * Policy checks (tool policy, domain policy) are stubs in this PR — full enforcement comes later.
+ * Tool policy is enforced at authorize/fill time; domain policy enforcement comes in PR 20.
  */
 export class CredentialBroker {
   private tokens = new Map<string, UsageToken>();
@@ -39,8 +40,16 @@ export class CredentialBroker {
       };
     }
 
-    // Policy check stubs — full enforcement in PRs 19-20
-    // For now, always authorize if metadata exists.
+    // Tool policy enforcement — deny if tool is not in the credential's allowed list
+    if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
+      return {
+        authorized: false,
+        reason: `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
+          (metadata.allowedTools.length === 0
+            ? 'No tools are currently allowed — update the credential with allowed_tools via credential_store.'
+            : `Allowed tools: ${metadata.allowedTools.join(', ')}.`),
+      };
+    }
 
     const token: UsageToken = {
       tokenId: uuid(),
@@ -116,8 +125,16 @@ export class CredentialBroker {
       };
     }
 
-    // Policy check stubs — full enforcement in PRs 19-20
-    // For now, always allow if metadata exists.
+    // Tool policy enforcement — deny if tool is not in the credential's allowed list
+    if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
+      return {
+        success: false,
+        reason: `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
+          (metadata.allowedTools.length === 0
+            ? 'No tools are currently allowed — update the credential with allowed_tools via credential_store.'
+            : `Allowed tools: ${metadata.allowedTools.join(', ')}.`),
+      };
+    }
 
     const value = getSecureKey(`credential:${request.service}:${request.field}`);
     if (!value) {


### PR DESCRIPTION
## Summary
- Broker now checks `allowedTools` before any secret operation (`authorize` and `browserFill`)
- Fail-closed enforcement: empty or missing `allowedTools` denies all access with actionable error
- Existing tests updated to include `allowedTools` policy; new tests for denial and fail-closed behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
