### PR TITLE
feat: enforce domain policy in credential broker

### DIFF
--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -173,8 +173,11 @@ describe('CredentialBroker.browserFill', () => {
     expect(filled.password).toBe('hunter2');
   });
 
-  test('accepts optional domain parameter', async () => {
-    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
+  test('allows fill when domain matches allowedDomains', async () => {
+    upsertCredentialMetadata('github', 'token', {
+      allowedTools: ['browser_fill_credential'],
+      allowedDomains: ['github.com'],
+    });
     setSecureKey('credential:github:token', 'ghp_secret123');
 
     const result = await broker.browserFill({
@@ -185,7 +188,78 @@ describe('CredentialBroker.browserFill', () => {
       fill: async () => {},
     });
 
-    // Domain policy enforcement is a stub — should still succeed
+    expect(result.success).toBe(true);
+  });
+
+  test('allows fill on subdomain when registrable domain matches', async () => {
+    upsertCredentialMetadata('github', 'token', {
+      allowedTools: ['browser_fill_credential'],
+      allowedDomains: ['github.com'],
+    });
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      domain: 'login.github.com',
+      fill: async () => {},
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('denies fill when domain does not match allowedDomains', async () => {
+    upsertCredentialMetadata('github', 'token', {
+      allowedTools: ['browser_fill_credential'],
+      allowedDomains: ['github.com'],
+    });
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      domain: 'evil.com',
+      fill: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('not allowed');
+    expect(result.reason).toContain('evil.com');
+    expect(result.reason).toContain('github.com');
+  });
+
+  test('denies fill when domain policy exists but no domain provided', async () => {
+    upsertCredentialMetadata('github', 'token', {
+      allowedTools: ['browser_fill_credential'],
+      allowedDomains: ['github.com'],
+    });
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('no page domain was provided');
+  });
+
+  test('skips domain check when allowedDomains is empty', async () => {
+    upsertCredentialMetadata('github', 'token', { allowedTools: ['browser_fill_credential'] });
+    setSecureKey('credential:github:token', 'ghp_secret123');
+
+    // No domain provided and no allowedDomains policy — should succeed
+    const result = await broker.browserFill({
+      service: 'github',
+      field: 'token',
+      toolName: 'browser_fill_credential',
+      fill: async () => {},
+    });
+
     expect(result.success).toBe(true);
   });
 

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -9,6 +9,7 @@ import type {
 } from './broker-types.js';
 import { getCredentialMetadata } from './metadata-store.js';
 import { isToolAllowed } from './tool-policy.js';
+import { isDomainAllowed } from './domain-policy.js';
 import { getSecureKey } from '../../security/secure-keys.js';
 import { getLogger } from '../../util/logger.js';
 
@@ -22,7 +23,7 @@ const log = getLogger('credential-broker');
  * 2. Issues a single-use token for the authorized usage
  * 3. On consumption, returns the storage key so the caller can read the secret internally
  *
- * Tool policy is enforced at authorize/fill time; domain policy enforcement comes in PR 20.
+ * Tool policy is enforced at authorize/fill time; domain policy is enforced at fill time.
  */
 export class CredentialBroker {
   private tokens = new Map<string, UsageToken>();
@@ -134,6 +135,24 @@ export class CredentialBroker {
             ? 'No tools are currently allowed — update the credential with allowed_tools via credential_store.'
             : `Allowed tools: ${metadata.allowedTools.join(', ')}.`),
       };
+    }
+
+    // Domain policy enforcement — deny if the page domain is not in the credential's allowed list
+    if (metadata.allowedDomains.length > 0) {
+      if (!request.domain) {
+        return {
+          success: false,
+          reason: `Credential ${request.service}/${request.field} has a domain policy but no page domain was provided. ` +
+            `Allowed domains: ${metadata.allowedDomains.join(', ')}.`,
+        };
+      }
+      if (!isDomainAllowed(request.domain, metadata.allowedDomains)) {
+        return {
+          success: false,
+          reason: `Domain "${request.domain}" is not allowed for credential ${request.service}/${request.field}. ` +
+            `Allowed domains: ${metadata.allowedDomains.join(', ')}.`,
+        };
+      }
     }
 
     const value = getSecureKey(`credential:${request.service}:${request.field}`);


### PR DESCRIPTION
## Summary
- Broker `browserFill` now checks `allowedDomains` using registrable-domain matching before filling
- Denies fill when domain doesn't match, is missing (but policy exists), or is invalid
- Empty `allowedDomains` skips the check (no domain restriction configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
