### PR TITLE
feat: harden browser tool error semantics for policy denials

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -98,7 +98,15 @@ function resetMockPage() {
 }
 
 function defaultMetadata(service: string, field: string) {
-  return { credentialId: `${service}:${field}`, service, field, createdAt: Date.now() };
+  return {
+    credentialId: `${service}:${field}`,
+    service,
+    field,
+    allowedTools: ['browser_fill_credential'],
+    allowedDomains: [] as string[],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
 }
 
 // ── browser_fill_credential ──────────────────────────────────────────
@@ -234,6 +242,68 @@ describe('executeBrowserFillCredential', () => {
       // Broker checks metadata first, then reads the value
       expect(mockGetCredentialMetadata).toHaveBeenCalledWith('gmail', 'password');
       expect(mockGetSecureKey).toHaveBeenCalledWith('credential:gmail:password');
+    });
+
+    test('returns tool policy denial with actionable message', async () => {
+      mockGetCredentialMetadata = mock((service: string, field: string) => ({
+        ...defaultMetadata(service, field),
+        allowedTools: ['some_other_tool'],
+      }));
+      snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+      const result = await executeBrowserFillCredential(
+        { service: 'gmail', field: 'password', element_id: 'e1' },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Policy denied');
+      expect(result.content).toContain('not allowed to use credential');
+      expect(result.content).toContain('credential_store');
+      expect(mockPage.fill).not.toHaveBeenCalled();
+    });
+
+    test('returns domain policy denial with actionable message', async () => {
+      mockGetCredentialMetadata = mock((service: string, field: string) => ({
+        ...defaultMetadata(service, field),
+        allowedDomains: ['other-site.com'],
+      }));
+      snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+      const result = await executeBrowserFillCredential(
+        { service: 'gmail', field: 'password', element_id: 'e1' },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Domain policy denied');
+      expect(result.content).toContain('Navigate to an allowed domain');
+      expect(mockPage.fill).not.toHaveBeenCalled();
+    });
+
+    test('passes current page domain to broker', async () => {
+      mockGetCredentialMetadata = mock((service: string, field: string) => ({
+        ...defaultMetadata(service, field),
+        allowedDomains: ['example.com'],
+      }));
+      snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+      const result = await executeBrowserFillCredential(
+        { service: 'gmail', field: 'password', element_id: 'e1' },
+        ctx,
+      );
+      // Page URL is https://example.com/ which matches allowedDomains
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('Filled password for gmail');
+    });
+
+    test('policy denial errors never contain credential values', async () => {
+      mockGetCredentialMetadata = mock((service: string, field: string) => ({
+        ...defaultMetadata(service, field),
+        allowedTools: ['other_tool'],
+      }));
+      snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+      const result = await executeBrowserFillCredential(
+        { service: 'gmail', field: 'password', element_id: 'e1' },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).not.toContain('super-secret-password');
     });
   });
 });

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -912,10 +912,23 @@ async function executeBrowserFillCredential(
   const pressEnter = input.press_enter === true;
   const page = await browserManager.getOrCreateSessionPage(context.sessionId);
 
+  // Extract domain from the current page for domain policy enforcement
+  let pageDomain: string | undefined;
+  try {
+    const pageUrl = page.url();
+    if (pageUrl && pageUrl !== 'about:blank') {
+      const parsed = new URL(pageUrl);
+      pageDomain = parsed.hostname;
+    }
+  } catch {
+    // Invalid URL — pageDomain stays undefined, broker will deny if domain policy exists
+  }
+
   const result = await credentialBroker.browserFill({
     service,
     field,
     toolName: 'browser_fill_credential',
+    domain: pageDomain,
     fill: async (value) => {
       await page.fill(selector!, value);
     },
@@ -926,6 +939,18 @@ async function executeBrowserFillCredential(
     if (reason.includes('No credential found') || reason.includes('no stored value')) {
       return {
         content: `No credential stored for ${service}/${field}. Use credential_store to save it first.`,
+        isError: true,
+      };
+    }
+    if (reason.includes('not allowed to use credential')) {
+      return {
+        content: `Policy denied: ${reason} Update the credential's allowed_tools via credential_store if this tool should have access.`,
+        isError: true,
+      };
+    }
+    if (reason.includes('not allowed for credential') || reason.includes('no page domain was provided')) {
+      return {
+        content: `Domain policy denied: ${reason} Navigate to an allowed domain before filling this credential.`,
         isError: true,
       };
     }


### PR DESCRIPTION
## Summary
- Distinguish tool-policy and domain-policy denials from missing credentials in `browser_fill_credential`
- Extract page domain from current URL and pass to broker for domain policy enforcement
- Error messages are actionable (suggest updating `credential_store` or navigating to an allowed domain) and never contain credential values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
