### PR TITLE
feat: generalize tool input redaction in executor

### DIFF
--- a/assistant/src/__tests__/tool-executor-redaction.test.ts
+++ b/assistant/src/__tests__/tool-executor-redaction.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from 'bun:test';
+import { redactSensitiveFields } from '../security/redaction.js';
+
+describe('redactSensitiveFields', () => {
+  test('redacts known sensitive keys', () => {
+    const input = {
+      service: 'github',
+      field: 'token',
+      value: 'v1',
+      password: 'p1',
+      api_key: 'k1',
+      authorization: 'a1',
+    };
+    const result = redactSensitiveFields(input);
+    expect(result.service).toBe('github');
+    expect(result.field).toBe('token');
+    expect(result.value).toBe('<redacted />');
+    expect(result.password).toBe('<redacted />');
+    expect(result.api_key).toBe('<redacted />');
+    expect(result.authorization).toBe('<redacted />');
+  });
+
+  test('is case-insensitive for key matching', () => {
+    const input = { Password: 'p1', API_KEY: 'k1', Token: 't1' };
+    const result = redactSensitiveFields(input);
+    expect(result.Password).toBe('<redacted />');
+    expect(result.API_KEY).toBe('<redacted />');
+    expect(result.Token).toBe('<redacted />');
+  });
+
+  test('recurses into nested objects', () => {
+    const input = {
+      name: 'test',
+      config: {
+        secret: 'nested',
+        endpoint: 'https://api.example.com',
+      },
+    };
+    const result = redactSensitiveFields(input);
+    expect(result.name).toBe('test');
+    const config = result.config as Record<string, unknown>;
+    expect(config.secret).toBe('<redacted />');
+    expect(config.endpoint).toBe('https://api.example.com');
+  });
+
+  test('recurses into arrays of objects', () => {
+    const input = {
+      items: [
+        { name: 'a', password: 'pa' },
+        { name: 'b', password: 'pb' },
+      ],
+    };
+    const result = redactSensitiveFields(input);
+    const items = result.items as Array<Record<string, unknown>>;
+    expect(items[0].name).toBe('a');
+    expect(items[0].password).toBe('<redacted />');
+    expect(items[1].name).toBe('b');
+    expect(items[1].password).toBe('<redacted />');
+  });
+
+  test('preserves primitive arrays', () => {
+    const input = { tags: ['public', 'v1'], token: 'tk' };
+    const result = redactSensitiveFields(input);
+    expect(result.tags).toEqual(['public', 'v1']);
+    expect(result.token).toBe('<redacted />');
+  });
+
+  test('does not mutate the original input', () => {
+    const input = { value: 'x1', nested: { password: 'y1' } };
+    const result = redactSensitiveFields(input);
+    expect(input.value).toBe('x1');
+    expect((input.nested as Record<string, unknown>).password).toBe('y1');
+    expect(result.value).toBe('<redacted />');
+  });
+
+  test('handles null and undefined values gracefully', () => {
+    const input = { value: null, password: undefined, name: 'test' };
+    const result = redactSensitiveFields(input);
+    expect(result.value).toBeNull();
+    expect(result.password).toBeUndefined();
+    expect(result.name).toBe('test');
+  });
+
+  test('handles empty objects', () => {
+    const result = redactSensitiveFields({});
+    expect(result).toEqual({});
+  });
+
+  test('redacts numeric and boolean sensitive values', () => {
+    const input = { token: 12345, secret: true, name: 'test' };
+    const result = redactSensitiveFields(input);
+    expect(result.token).toBe('<redacted />');
+    expect(result.secret).toBe('<redacted />');
+    expect(result.name).toBe('test');
+  });
+
+  test('preserves non-sensitive keys completely', () => {
+    const input = {
+      service: 'gmail',
+      field: 'password',
+      action: 'store',
+      selector: 'input[type=password]',
+    };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual(input);
+  });
+
+  test('redacts credentials and apikey variants', () => {
+    const input = { credentials: 'c1', apikey: 'k1' };
+    const result = redactSensitiveFields(input);
+    expect(result.credentials).toBe('<redacted />');
+    expect(result.apikey).toBe('<redacted />');
+  });
+});

--- a/assistant/src/security/redaction.ts
+++ b/assistant/src/security/redaction.ts
@@ -1,0 +1,55 @@
+/**
+ * Recursive field-level redaction for tool inputs and lifecycle payloads.
+ *
+ * Replaces values of known-sensitive keys with a redaction placeholder,
+ * preserving the overall structure for debugging and audit.
+ */
+
+const REDACTION_PLACEHOLDER = '<redacted />';
+
+/** Keys whose values are always redacted (case-insensitive match). */
+const SENSITIVE_KEYS = new Set([
+  'value',
+  'password',
+  'token',
+  'api_key',
+  'apikey',
+  'authorization',
+  'secret',
+  'credentials',
+]);
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(key.toLowerCase());
+}
+
+/**
+ * Recursively redact sensitive fields from an object.
+ *
+ * - Replaces string/number/boolean values of sensitive keys with `<redacted />`
+ * - Recurses into nested objects and arrays
+ * - Returns a shallow copy — never mutates the original
+ */
+export function redactSensitiveFields(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, val] of Object.entries(obj)) {
+    if (isSensitiveKey(key) && val != null && typeof val !== 'object') {
+      result[key] = REDACTION_PLACEHOLDER;
+    } else if (Array.isArray(val)) {
+      result[key] = val.map((item) =>
+        item != null && typeof item === 'object' && !Array.isArray(item)
+          ? redactSensitiveFields(item as Record<string, unknown>)
+          : item,
+      );
+    } else if (val != null && typeof val === 'object') {
+      result[key] = redactSensitiveFields(val as Record<string, unknown>);
+    } else {
+      result[key] = val;
+    }
+  }
+
+  return result;
+}

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -13,6 +13,7 @@ import { applyEdit } from './shared/filesystem/edit-engine.js';
 import { wrapCommand } from './terminal/sandbox.js';
 import { getConfig } from '../config/loader.js';
 import { scanText, redactSecrets } from '../security/secret-scanner.js';
+import { redactSensitiveFields } from '../security/redaction.js';
 import { getHookManager } from '../hooks/manager.js';
 
 const log = getLogger('tool-executor');
@@ -418,16 +419,11 @@ function resolveExecutionTarget(toolName: string): ExecutionTarget {
 }
 
 /**
- * Sanitize tool inputs before they are emitted in lifecycle events.
- * This prevents plaintext secrets (e.g. credential_store `value`) from
- * being persisted in audit logs.
+ * Sanitize tool inputs before they are emitted in lifecycle events and hooks.
+ * Applies recursive field-level redaction for known-sensitive keys.
  */
-function sanitizeToolInput(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
-  if (toolName === 'credential_store' && 'value' in input) {
-    const { value: _redacted, ...rest } = input;
-    return { ...rest, value: '<redacted />' };
-  }
-  return input;
+function sanitizeToolInput(_toolName: string, input: Record<string, unknown>): Record<string, unknown> {
+  return redactSensitiveFields(input);
 }
 
 function emitLifecycleEvent(context: ToolContext, event: ToolLifecycleEvent): void {


### PR DESCRIPTION
## Summary
- New `redactSensitiveFields()` helper recursively masks values of sensitive keys (value, password, token, api_key, authorization, secret, credentials)
- Replaces old credential_store-specific `sanitizeToolInput` with general-purpose field-level redactor
- Applied to all lifecycle events and hook payloads in the tool executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
