### PR TITLE
feat: add reminders table and store layer

### DIFF
--- a/assistant/src/__tests__/reminder-store.test.ts
+++ b/assistant/src/__tests__/reminder-store.test.ts
@@ -1,0 +1,175 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { initializeDb } from '../memory/db.js';
+import { getDb } from '../memory/db.js';
+import { reminders } from '../memory/schema.js';
+import {
+  insertReminder,
+  getReminder,
+  listReminders,
+  cancelReminder,
+  claimDueReminders,
+  setReminderConversationId,
+} from '../tools/reminder/reminder-store.js';
+
+initializeDb();
+
+function clearReminders() {
+  getDb().delete(reminders).run();
+}
+
+describe('reminder-store', () => {
+  beforeEach(() => {
+    clearReminders();
+  });
+
+  // ── insertReminder ──────────────────────────────────────────────────
+
+  test('insertReminder creates a row and returns it with correct fields', () => {
+    const r = insertReminder({
+      label: 'Call Sidd',
+      message: 'Remember to call Sidd about the project',
+      fireAt: Date.now() + 60_000,
+      mode: 'notify',
+    });
+
+    expect(r.id).toBeTruthy();
+    expect(r.label).toBe('Call Sidd');
+    expect(r.message).toBe('Remember to call Sidd about the project');
+    expect(r.mode).toBe('notify');
+    expect(r.status).toBe('pending');
+    expect(r.firedAt).toBeNull();
+    expect(r.conversationId).toBeNull();
+    expect(r.createdAt).toBeGreaterThan(0);
+    expect(r.updatedAt).toBeGreaterThan(0);
+  });
+
+  // ── getReminder ─────────────────────────────────────────────────────
+
+  test('getReminder returns null for nonexistent ID', () => {
+    expect(getReminder('nonexistent')).toBeNull();
+  });
+
+  test('getReminder returns the inserted reminder', () => {
+    const r = insertReminder({
+      label: 'Test',
+      message: 'Test message',
+      fireAt: Date.now() + 60_000,
+      mode: 'execute',
+    });
+
+    const fetched = getReminder(r.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(r.id);
+    expect(fetched!.mode).toBe('execute');
+  });
+
+  // ── listReminders ──────────────────────────────────────────────────
+
+  test('listReminders returns all reminders', () => {
+    insertReminder({ label: 'A', message: 'a', fireAt: Date.now() + 60_000, mode: 'notify' });
+    insertReminder({ label: 'B', message: 'b', fireAt: Date.now() + 120_000, mode: 'execute' });
+
+    const all = listReminders();
+    expect(all).toHaveLength(2);
+  });
+
+  test('listReminders with pendingOnly filters to pending only', () => {
+    const r = insertReminder({ label: 'A', message: 'a', fireAt: Date.now() + 60_000, mode: 'notify' });
+    insertReminder({ label: 'B', message: 'b', fireAt: Date.now() + 120_000, mode: 'notify' });
+
+    // Cancel one
+    cancelReminder(r.id);
+
+    const pending = listReminders({ pendingOnly: true });
+    expect(pending).toHaveLength(1);
+    expect(pending[0].label).toBe('B');
+
+    const all = listReminders();
+    expect(all).toHaveLength(2);
+  });
+
+  // ── cancelReminder ──────────────────────────────────────────────────
+
+  test('cancelReminder sets status to cancelled and returns true', () => {
+    const r = insertReminder({ label: 'Cancel me', message: 'x', fireAt: Date.now() + 60_000, mode: 'notify' });
+    expect(cancelReminder(r.id)).toBe(true);
+
+    const fetched = getReminder(r.id);
+    expect(fetched!.status).toBe('cancelled');
+  });
+
+  test('cancelReminder returns false for nonexistent ID', () => {
+    expect(cancelReminder('nonexistent')).toBe(false);
+  });
+
+  test('cancelReminder returns false for already-fired reminder', () => {
+    const r = insertReminder({ label: 'Fire me', message: 'x', fireAt: Date.now() - 1000, mode: 'notify' });
+
+    // Fire it first
+    claimDueReminders(Date.now());
+
+    expect(cancelReminder(r.id)).toBe(false);
+  });
+
+  // ── claimDueReminders ──────────────────────────────────────────────
+
+  test('claimDueReminders claims reminders where fireAt <= now', () => {
+    const now = Date.now();
+    insertReminder({ label: 'Past', message: 'x', fireAt: now - 5000, mode: 'notify' });
+    insertReminder({ label: 'Future', message: 'y', fireAt: now + 60_000, mode: 'notify' });
+
+    const claimed = claimDueReminders(now);
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0].label).toBe('Past');
+    expect(claimed[0].status).toBe('fired');
+    expect(claimed[0].firedAt).toBe(now);
+  });
+
+  test('claimDueReminders skips already-fired reminders', () => {
+    const now = Date.now();
+    insertReminder({ label: 'Past', message: 'x', fireAt: now - 5000, mode: 'notify' });
+
+    // Claim once
+    const first = claimDueReminders(now);
+    expect(first).toHaveLength(1);
+
+    // Claim again — should get nothing
+    const second = claimDueReminders(now);
+    expect(second).toHaveLength(0);
+  });
+
+  test('claimDueReminders skips cancelled reminders', () => {
+    const now = Date.now();
+    const r = insertReminder({ label: 'Cancel me', message: 'x', fireAt: now - 5000, mode: 'notify' });
+    cancelReminder(r.id);
+
+    const claimed = claimDueReminders(now);
+    expect(claimed).toHaveLength(0);
+  });
+
+  test('claimDueReminders optimistic locking prevents double-claiming', () => {
+    const now = Date.now();
+    insertReminder({ label: 'Once only', message: 'x', fireAt: now - 1000, mode: 'notify' });
+
+    // Two simultaneous claims
+    const first = claimDueReminders(now);
+    const second = claimDueReminders(now);
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(0);
+  });
+
+  // ── setReminderConversationId ──────────────────────────────────────
+
+  test('setReminderConversationId updates the conversation ID on a fired reminder', () => {
+    const now = Date.now();
+    const r = insertReminder({ label: 'Exec me', message: 'x', fireAt: now - 1000, mode: 'execute' });
+
+    claimDueReminders(now);
+
+    setReminderConversationId(r.id, 'conv-123');
+
+    const fetched = getReminder(r.id);
+    expect(fetched!.conversationId).toBe('conv-123');
+  });
+});

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -247,6 +247,21 @@ export function initializeDb(): void {
   `);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS reminders (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      message TEXT NOT NULL,
+      fire_at INTEGER NOT NULL,
+      mode TEXT NOT NULL,
+      status TEXT NOT NULL,
+      fired_at INTEGER,
+      conversation_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS cron_jobs (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -473,6 +488,8 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_conversation ON message_runs(conversation_id)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_pomodoro_timers_session_status ON pomodoro_timers(session_id, status)`);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_reminders_status_fire_at ON reminders(status, fire_at)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled_next_run ON cron_jobs(enabled, next_run_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_runs_job_id ON cron_runs(job_id)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -232,6 +232,21 @@ export const pomodoroTimers = sqliteTable('pomodoro_timers', {
   updatedAt: integer('updated_at').notNull(),
 });
 
+// ── Reminders ────────────────────────────────────────────────────────
+
+export const reminders = sqliteTable('reminders', {
+  id: text('id').primaryKey(),
+  label: text('label').notNull(),
+  message: text('message').notNull(),
+  fireAt: integer('fire_at').notNull(),           // epoch ms, absolute timestamp
+  mode: text('mode').notNull(),                   // 'notify' | 'execute'
+  status: text('status').notNull(),               // 'pending' | 'fired' | 'cancelled'
+  firedAt: integer('fired_at'),
+  conversationId: text('conversation_id'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 // ── Cron / Deferred Tasks ────────────────────────────────────────────
 
 export const cronJobs = sqliteTable('cron_jobs', {

--- a/assistant/src/tools/reminder/reminder-store.ts
+++ b/assistant/src/tools/reminder/reminder-store.ts
@@ -1,0 +1,129 @@
+import { and, asc, eq, lte } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from '../../memory/db.js';
+import { reminders } from '../../memory/schema.js';
+
+export interface ReminderRow {
+  id: string;
+  label: string;
+  message: string;
+  fireAt: number;
+  mode: 'notify' | 'execute';
+  status: 'pending' | 'fired' | 'cancelled';
+  firedAt: number | null;
+  conversationId: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export function insertReminder(params: {
+  label: string;
+  message: string;
+  fireAt: number;
+  mode: 'notify' | 'execute';
+}): ReminderRow {
+  const db = getDb();
+  const id = uuid();
+  const now = Date.now();
+  const row: ReminderRow = {
+    id,
+    label: params.label,
+    message: params.message,
+    fireAt: params.fireAt,
+    mode: params.mode,
+    status: 'pending',
+    firedAt: null,
+    conversationId: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(reminders).values(row).run();
+  return row;
+}
+
+export function getReminder(id: string): ReminderRow | null {
+  const db = getDb();
+  const row = db.select().from(reminders).where(eq(reminders.id, id)).get();
+  if (!row) return null;
+  return parseRow(row);
+}
+
+export function listReminders(options?: { pendingOnly?: boolean }): ReminderRow[] {
+  const db = getDb();
+  const conditions = options?.pendingOnly ? eq(reminders.status, 'pending') : undefined;
+  const rows = db
+    .select()
+    .from(reminders)
+    .where(conditions)
+    .orderBy(asc(reminders.fireAt))
+    .all();
+  return rows.map(parseRow);
+}
+
+export function cancelReminder(id: string): boolean {
+  const db = getDb();
+  const now = Date.now();
+  const result = db
+    .update(reminders)
+    .set({ status: 'cancelled', updatedAt: now })
+    .where(and(eq(reminders.id, id), eq(reminders.status, 'pending')))
+    .run() as unknown as { changes?: number };
+  return (result.changes ?? 0) > 0;
+}
+
+/**
+ * Claim all pending reminders where fire_at <= now.
+ * Uses optimistic locking: UPDATE ... SET status='fired' WHERE status='pending' AND id=?
+ * Same pattern as claimDueSchedules in schedule-store.ts.
+ */
+export function claimDueReminders(now: number): ReminderRow[] {
+  const db = getDb();
+  const candidates = db
+    .select()
+    .from(reminders)
+    .where(and(eq(reminders.status, 'pending'), lte(reminders.fireAt, now)))
+    .orderBy(asc(reminders.fireAt))
+    .all();
+
+  const claimed: ReminderRow[] = [];
+  for (const row of candidates) {
+    const result = db
+      .update(reminders)
+      .set({ status: 'fired', firedAt: now, updatedAt: now })
+      .where(and(eq(reminders.id, row.id), eq(reminders.status, 'pending')))
+      .run() as unknown as { changes?: number };
+
+    if ((result.changes ?? 0) === 0) continue;
+
+    claimed.push(parseRow({
+      ...row,
+      status: 'fired',
+      firedAt: now,
+      updatedAt: now,
+    }));
+  }
+  return claimed;
+}
+
+export function setReminderConversationId(id: string, conversationId: string): void {
+  const db = getDb();
+  db.update(reminders)
+    .set({ conversationId, updatedAt: Date.now() })
+    .where(eq(reminders.id, id))
+    .run();
+}
+
+function parseRow(row: typeof reminders.$inferSelect): ReminderRow {
+  return {
+    id: row.id,
+    label: row.label,
+    message: row.message,
+    fireAt: row.fireAt,
+    mode: row.mode as ReminderRow['mode'],
+    status: row.status as ReminderRow['status'],
+    firedAt: row.firedAt,
+    conversationId: row.conversationId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `reminders` table to schema and DB init (with `idx_reminders_status_fire_at` index)
- Create `reminder-store.ts` with insert, get, list, cancel, claimDue (optimistic locking), and setConversationId functions
- Add comprehensive tests covering all store operations including optimistic locking

PR 1 of 6 in the deferred reminder system plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
