### PR TITLE
feat: redact sensitive fields in permission prompt payloads

### DIFF
--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -5,6 +5,7 @@ import type { ExecutionTarget } from '../tools/types.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { AssistantError, ErrorCode } from '../util/errors.js';
+import { redactSensitiveFields } from '../security/redaction.js';
 
 const log = getLogger('permission-prompter');
 
@@ -53,7 +54,7 @@ export class PermissionPrompter {
         type: 'confirmation_request',
         requestId,
         toolName,
-        input,
+        input: redactSensitiveFields(input),
         riskLevel,
         allowlistOptions: allowlistOptions.map((o) => ({ label: o.label, description: o.description, pattern: o.pattern })),
         scopeOptions: scopeOptions.map((o) => ({ label: o.label, scope: o.scope })),


### PR DESCRIPTION
## Summary
- Apply `redactSensitiveFields` to tool input in `confirmation_request` messages
- Sensitive values (passwords, tokens, api keys) never reach the UI or client-side logs in plaintext
- Allow/deny logic unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
