### PR TITLE
fix: exclude unused bg.png from SPM target to silence build warning

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
             name: "VellumAssistantLib",
             dependencies: ["VellumAssistantShared", "HotKey", "Sparkle"],
             path: "macos/vellum-assistant",
-            exclude: ["Resources/Info.plist"],
+            exclude: ["Resources/Info.plist", "Resources/bg.png"],
             resources: [
                 .process("Resources/Assets.xcassets"),
                 .process("Resources/meadow.svg"),


### PR DESCRIPTION
## Summary
- Adds `Resources/bg.png` to the `exclude` list in `Package.swift` for the `VellumAssistantLib` target
- The file isn't referenced anywhere in code and was causing SPM to emit `found 1 file(s) which are unhandled` during builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
