### PR TITLE
feat: add reminder tool with create/list/cancel actions

### DIFF
--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -1,0 +1,224 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { initializeDb } from '../memory/db.js';
+import { getDb } from '../memory/db.js';
+import { reminders } from '../memory/schema.js';
+import { reminderTool } from '../tools/reminder/reminder.js';
+import { claimDueReminders } from '../tools/reminder/reminder-store.js';
+
+initializeDb();
+
+const dummyContext = {
+  workingDir: '/tmp',
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+};
+
+function clearReminders() {
+  getDb().delete(reminders).run();
+}
+
+describe('reminder tool', () => {
+  beforeEach(() => {
+    clearReminders();
+  });
+
+  // ── action validation ───────────────────────────────────────────────
+
+  test('rejects missing action', async () => {
+    const result = await reminderTool.execute({}, dummyContext);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('action is required');
+  });
+
+  test('rejects unknown action', async () => {
+    const result = await reminderTool.execute({ action: 'explode' }, dummyContext);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown action');
+  });
+
+  // ── create ──────────────────────────────────────────────────────────
+
+  test('create with valid future ISO timestamp succeeds', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      label: 'Call Sidd',
+      message: 'Remember to call Sidd',
+    }, dummyContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Reminder created');
+    expect(result.content).toContain('Call Sidd');
+    expect(result.content).toContain('notify');
+  });
+
+  test('create with past timestamp returns error', async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: past,
+      label: 'Too late',
+      message: 'This is in the past',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('must be in the future');
+  });
+
+  test('create with invalid timestamp string returns error', async () => {
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: 'not-a-date',
+      label: 'Bad date',
+      message: 'This has a bad date',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid timestamp');
+  });
+
+  test('create defaults mode to notify', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      label: 'Default mode',
+      message: 'Should be notify',
+    }, dummyContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Mode: notify');
+  });
+
+  test('create with mode execute sets mode correctly', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      label: 'Execute mode',
+      message: 'Should be execute',
+      mode: 'execute',
+    }, dummyContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Mode: execute');
+  });
+
+  test('create requires fire_at', async () => {
+    const result = await reminderTool.execute({
+      action: 'create',
+      label: 'No fire_at',
+      message: 'Missing fire_at',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('fire_at is required');
+  });
+
+  test('create requires label', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      message: 'Missing label',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('label is required');
+  });
+
+  test('create requires message', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      label: 'No message',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('message is required');
+  });
+
+  // ── list ────────────────────────────────────────────────────────────
+
+  test('list returns "No reminders found" when empty', async () => {
+    const result = await reminderTool.execute({ action: 'list' }, dummyContext);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No reminders found');
+  });
+
+  test('list returns formatted reminders', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      label: 'Test reminder',
+      message: 'Test message',
+    }, dummyContext);
+
+    const result = await reminderTool.execute({ action: 'list' }, dummyContext);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Test reminder');
+    expect(result.content).toContain('pending');
+  });
+
+  // ── cancel ──────────────────────────────────────────────────────────
+
+  test('cancel with valid pending reminder succeeds', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const createResult = await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      label: 'Cancel me',
+      message: 'To be cancelled',
+    }, dummyContext);
+
+    // Extract ID from the create result
+    const idMatch = createResult.content.match(/ID: (.+)/);
+    expect(idMatch).not.toBeNull();
+    const id = idMatch![1].trim();
+
+    const result = await reminderTool.execute({
+      action: 'cancel',
+      reminder_id: id,
+    }, dummyContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('cancelled');
+  });
+
+  test('cancel with nonexistent ID returns error', async () => {
+    const result = await reminderTool.execute({
+      action: 'cancel',
+      reminder_id: 'nonexistent',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  test('cancel with already-fired reminder returns error', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const createResult = await reminderTool.execute({
+      action: 'create',
+      fire_at: future,
+      label: 'Fire then cancel',
+      message: 'x',
+    }, dummyContext);
+
+    const idMatch = createResult.content.match(/ID: (.+)/);
+    const id = idMatch![1].trim();
+
+    // Force-fire by claiming with a future timestamp
+    claimDueReminders(Date.now() + 120_000);
+
+    const result = await reminderTool.execute({
+      action: 'cancel',
+      reminder_id: id,
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found or already fired');
+  });
+});

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -1,0 +1,147 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { formatLocalDate } from '../../schedule/schedule-store.js';
+import {
+  insertReminder,
+  listReminders,
+  cancelReminder,
+} from './reminder-store.js';
+
+function executeReminder(input: Record<string, unknown>): ToolExecutionResult {
+  const action = input.action as string | undefined;
+  if (!action) {
+    return { content: 'Error: action is required', isError: true };
+  }
+
+  switch (action) {
+    case 'create':
+      return createAction(input);
+    case 'list':
+      return listAction();
+    case 'cancel':
+      return cancelAction(input);
+    default:
+      return {
+        content: `Error: Unknown action "${action}". Valid actions: create, list, cancel`,
+        isError: true,
+      };
+  }
+}
+
+function createAction(input: Record<string, unknown>): ToolExecutionResult {
+  const fireAtStr = input.fire_at as string | undefined;
+  const label = input.label as string | undefined;
+  const message = input.message as string | undefined;
+  const mode = (input.mode as string | undefined) ?? 'notify';
+
+  if (!fireAtStr) {
+    return { content: 'Error: fire_at is required for create', isError: true };
+  }
+  if (!label) {
+    return { content: 'Error: label is required for create', isError: true };
+  }
+  if (!message) {
+    return { content: 'Error: message is required for create', isError: true };
+  }
+  if (mode !== 'notify' && mode !== 'execute') {
+    return { content: 'Error: mode must be "notify" or "execute"', isError: true };
+  }
+
+  const fireAt = new Date(fireAtStr).getTime();
+  if (isNaN(fireAt)) {
+    return { content: `Error: Invalid timestamp "${fireAtStr}". Use ISO 8601 format (e.g. "2025-03-15T09:00:00Z").`, isError: true };
+  }
+  if (fireAt <= Date.now()) {
+    return { content: 'Error: fire_at must be in the future', isError: true };
+  }
+
+  const reminder = insertReminder({ label, message, fireAt, mode });
+
+  return {
+    content: `Reminder created.\n  ID: ${reminder.id}\n  Label: ${reminder.label}\n  Fires at: ${formatLocalDate(reminder.fireAt)}\n  Mode: ${reminder.mode}`,
+    isError: false,
+  };
+}
+
+function listAction(): ToolExecutionResult {
+  const all = listReminders();
+  if (all.length === 0) {
+    return { content: 'No reminders found.', isError: false };
+  }
+
+  const lines = all.map((r) => {
+    const status = r.status === 'fired'
+      ? `fired at ${formatLocalDate(r.firedAt!)}`
+      : r.status;
+    return `  - [${r.id}] "${r.label}" — ${formatLocalDate(r.fireAt)} (${r.mode}, ${status})`;
+  });
+
+  return { content: `Reminders:\n${lines.join('\n')}`, isError: false };
+}
+
+function cancelAction(input: Record<string, unknown>): ToolExecutionResult {
+  const reminderId = input.reminder_id as string | undefined;
+  if (!reminderId) {
+    return { content: 'Error: reminder_id is required for cancel', isError: true };
+  }
+
+  const ok = cancelReminder(reminderId);
+  if (!ok) {
+    return { content: `Error: Reminder "${reminderId}" not found or already fired/cancelled.`, isError: true };
+  }
+
+  return { content: `Reminder "${reminderId}" cancelled.`, isError: false };
+}
+
+class ReminderTool implements Tool {
+  name = 'reminder';
+  description = 'Create, list, or cancel one-time reminders. Reminders fire at a specific time and either notify the user or execute a message through the assistant.';
+  category = 'reminder';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['create', 'list', 'cancel'],
+            description: 'Reminder action',
+          },
+          fire_at: {
+            type: 'string',
+            description: 'ISO 8601 timestamp for when the reminder should fire (required for create)',
+          },
+          label: {
+            type: 'string',
+            description: 'Human-readable label (required for create)',
+          },
+          message: {
+            type: 'string',
+            description: 'Content shown in notification (notify) or sent to agent (execute). Required for create.',
+          },
+          mode: {
+            type: 'string',
+            enum: ['notify', 'execute'],
+            description: 'How the reminder fires. Defaults to notify.',
+          },
+          reminder_id: {
+            type: 'string',
+            description: 'Reminder ID (required for cancel)',
+          },
+        },
+        required: ['action'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    return executeReminder(input);
+  }
+}
+
+export const reminderTool = new ReminderTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -13,6 +13,7 @@ import { memorySearchTool, memorySaveTool, memoryUpdateTool } from './memory/reg
 import { credentialStoreTool } from './credentials/vault.js';
 import { accountManageTool } from './credentials/account-registry.js';
 import { pomodoroTool } from './timer/pomodoro.js';
+import { reminderTool } from './reminder/reminder.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
@@ -47,6 +48,7 @@ export const explicitTools: Tool[] = [
   credentialStoreTool,
   accountManageTool,
   pomodoroTool,
+  reminderTool,
   screenWatchTool,
 ];
 


### PR DESCRIPTION
## Summary
- Create `ReminderTool` implementing the `Tool` interface with create, list, and cancel actions
- Create action validates ISO 8601 timestamps, rejects past timestamps, defaults to notify mode
- Register `reminderTool` in tool manifest alongside existing tools
- Add 15 tests covering validation, all actions, and edge cases

PR 2 of 6 in the deferred reminder system plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
