### PR TITLE
feat: wire reminders into the scheduler tick

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -217,9 +217,19 @@ export async function runDaemon(): Promise<void> {
   const server = new DaemonServer();
   await server.start();
   const memoryWorker = startMemoryJobsWorker();
-  const scheduler = startScheduler(async (conversationId, message) => {
-    await server.processMessage('schedule', conversationId, message);
-  });
+  const scheduler = startScheduler(
+    async (conversationId, message) => {
+      await server.processMessage('schedule', conversationId, message);
+    },
+    (reminder) => {
+      server.broadcast({
+        type: 'reminder_fired',
+        reminderId: reminder.id,
+        label: reminder.label,
+        message: reminder.message,
+      });
+    },
+  );
 
   rehydrateTimers();
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -483,7 +483,7 @@ export class DaemonServer {
     }
   }
 
-  private broadcast(msg: ServerMessage): void {
+  broadcast(msg: ServerMessage): void {
     for (const socket of this.connectedSockets) {
       this.send(socket, msg);
     }

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -5,6 +5,7 @@ import {
   createScheduleRun,
   completeScheduleRun,
 } from './schedule-store.js';
+import { claimDueReminders, setReminderConversationId } from '../tools/reminder/reminder-store.js';
 
 const log = getLogger('scheduler');
 
@@ -13,6 +14,8 @@ export type ScheduleMessageProcessor = (
   message: string,
 ) => Promise<unknown>;
 
+export type ReminderNotifier = (reminder: { id: string; label: string; message: string }) => void;
+
 export interface SchedulerHandle {
   runOnce(): Promise<number>;
   stop(): void;
@@ -20,7 +23,10 @@ export interface SchedulerHandle {
 
 const TICK_INTERVAL_MS = 15_000;
 
-export function startScheduler(processMessage: ScheduleMessageProcessor): SchedulerHandle {
+export function startScheduler(
+  processMessage: ScheduleMessageProcessor,
+  notifyReminder: ReminderNotifier,
+): SchedulerHandle {
   let stopped = false;
   let tickRunning = false;
 
@@ -28,7 +34,7 @@ export function startScheduler(processMessage: ScheduleMessageProcessor): Schedu
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
-      await runScheduleOnce(processMessage);
+      await runScheduleOnce(processMessage, notifyReminder);
     } catch (err) {
       log.error({ err }, 'Schedule tick failed');
     } finally {
@@ -42,7 +48,7 @@ export function startScheduler(processMessage: ScheduleMessageProcessor): Schedu
 
   return {
     async runOnce(): Promise<number> {
-      return runScheduleOnce(processMessage);
+      return runScheduleOnce(processMessage, notifyReminder);
     },
     stop(): void {
       stopped = true;
@@ -51,12 +57,15 @@ export function startScheduler(processMessage: ScheduleMessageProcessor): Schedu
   };
 }
 
-async function runScheduleOnce(processMessage: ScheduleMessageProcessor): Promise<number> {
+async function runScheduleOnce(
+  processMessage: ScheduleMessageProcessor,
+  notifyReminder: ReminderNotifier,
+): Promise<number> {
   const now = Date.now();
-  const jobs = claimDueSchedules(now);
-  if (jobs.length === 0) return 0;
-
   let processed = 0;
+
+  // ── Cron jobs ───────────────────────────────────────────────────────
+  const jobs = claimDueSchedules(now);
   for (const job of jobs) {
     const conversation = createConversation(`Schedule: ${job.name}`);
     const runId = createScheduleRun(job.id, conversation.id);
@@ -73,6 +82,27 @@ async function runScheduleOnce(processMessage: ScheduleMessageProcessor): Promis
     }
   }
 
-  log.info({ processed, total: jobs.length }, 'Schedule tick complete');
+  // ── One-shot reminders ──────────────────────────────────────────────
+  const dueReminders = claimDueReminders(now);
+  for (const reminder of dueReminders) {
+    if (reminder.mode === 'execute') {
+      const conversation = createConversation(`Reminder: ${reminder.label}`);
+      setReminderConversationId(reminder.id, conversation.id);
+      try {
+        log.info({ reminderId: reminder.id, label: reminder.label, conversationId: conversation.id }, 'Executing reminder');
+        await processMessage(conversation.id, reminder.message);
+      } catch (err) {
+        log.warn({ err, reminderId: reminder.id }, 'Reminder execution failed');
+      }
+    } else {
+      log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
+      notifyReminder({ id: reminder.id, label: reminder.label, message: reminder.message });
+    }
+    processed += 1;
+  }
+
+  if (processed > 0) {
+    log.info({ processed }, 'Schedule tick complete');
+  }
   return processed;
 }


### PR DESCRIPTION
## Summary
- Extend `startScheduler` with a `ReminderNotifier` callback param
- In `runScheduleOnce`, after cron jobs, claim due reminders and dispatch by mode (execute → create conversation + processMessage, notify → broadcast ReminderFired)
- Make `DaemonServer.broadcast()` public so lifecycle can pass it to the scheduler
- Wire the notify callback in `lifecycle.ts`

PR 4 of 6 in the deferred reminder system plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
