### PR TITLE
fix: add log hygiene guarantees to secret prompt flow

### DIFF
--- a/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
+++ b/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+// Capture all logger calls so we can verify secret values never appear
+const logCalls: Array<{ level: string; args: unknown[] }> = [];
+function capture(level: string) {
+  return (...args: unknown[]) => { logCalls.push({ level, args }); };
+}
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: capture('info'),
+    warn: capture('warn'),
+    error: capture('error'),
+    debug: capture('debug'),
+    trace: capture('trace'),
+    fatal: capture('fatal'),
+    child: () => ({
+      info: capture('info'),
+      warn: capture('warn'),
+      error: capture('error'),
+      debug: capture('debug'),
+    }),
+  }),
+}));
+
+// Import after mock so SecretPrompter picks up the captured logger
+const { SecretPrompter } = await import('../permissions/secret-prompter.js');
+
+/** Recursively check if a secret value appears anywhere in logged args. */
+function logContainsValue(secret: string): boolean {
+  return logCalls.some((call) => JSON.stringify(call.args).includes(secret));
+}
+
+describe('secret prompt log hygiene', () => {
+  let prompter: InstanceType<typeof SecretPrompter>;
+  let sentMessages: ServerMessage[];
+
+  beforeEach(() => {
+    logCalls.length = 0;
+    sentMessages = [];
+    prompter = new SecretPrompter((msg) => { sentMessages.push(msg); });
+  });
+
+  test('resolveSecret never logs the secret value', async () => {
+    const secret = 'sv42';
+    const promise = prompter.prompt('myservice', 'apikey', 'API Key');
+    const requestId = (sentMessages[0] as any).requestId;
+    prompter.resolveSecret(requestId, secret, 'store');
+    const result = await promise;
+
+    // Value is returned correctly
+    expect(result.value).toBe(secret);
+    // But never appears in any log call
+    expect(logContainsValue(secret)).toBe(false);
+  });
+
+  test('resolveSecret for unknown requestId logs only requestId, not value', () => {
+    const secret = 'lk99';
+    prompter.resolveSecret('no-such-id', secret, 'store');
+
+    // There should be a warn log for the unknown requestId
+    expect(logCalls.some((c) => c.level === 'warn')).toBe(true);
+    // The secret value must not appear
+    expect(logContainsValue(secret)).toBe(false);
+  });
+
+  test('prompt timeout logs only metadata, not the secret value', async () => {
+    const promise = prompter.prompt('svc', 'key', 'Label');
+    const requestId = (sentMessages[0] as any).requestId;
+
+    // Simulate a normal resolve (timeout would also log metadata only)
+    prompter.resolveSecret(requestId, undefined);
+    await promise;
+
+    // Verify no log contains any value-like content beyond metadata
+    for (const call of logCalls) {
+      const serialized = JSON.stringify(call.args);
+      // Metadata fields are fine
+      expect(serialized).not.toContain('"value"');
+    }
+  });
+
+  test('sent IPC message contains value=undefined (value flows through IPC, not logs)', async () => {
+    const promise = prompter.prompt('svc', 'tok', 'Token');
+    const msg = sentMessages[0] as any;
+    // The IPC message should NOT contain a value field
+    expect(msg.value).toBeUndefined();
+    prompter.resolveSecret(msg.requestId, undefined);
+    await promise;
+  });
+});

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -31,6 +31,13 @@ export class SecretPrompter {
     this.sendToClient = sendToClient;
   }
 
+  /**
+   * Send a secret_request to the client and wait for the response.
+   *
+   * SECURITY: Logs only metadata (requestId, service, field) — never the
+   * returned secret value. The timeout path also returns a null value
+   * without logging anything sensitive.
+   */
   async prompt(
     service: string,
     field: string,
@@ -64,6 +71,13 @@ export class SecretPrompter {
     });
   }
 
+  /**
+   * Resolve a pending secret prompt with the user-supplied value.
+   *
+   * SECURITY: This method intentionally never logs `value`. All log
+   * statements must use metadata-only fields (requestId, service, field).
+   * Any future change that adds logging here must be audited for leaks.
+   */
   resolveSecret(requestId: string, value?: string, delivery?: SecretDelivery): void {
     const pending = this.pending.get(requestId);
     if (!pending) {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -98,6 +98,11 @@ final class SecretPromptManager {
         panels.removeAll()
     }
 
+    /// Forward the user's response to the daemon via `onResponse`.
+    ///
+    /// **Security invariant**: This method intentionally never logs `value`.
+    /// All logging in this class uses metadata-only fields (requestId, service, field).
+    /// Any future change that adds logging here must be audited for secret leaks.
     private func respond(requestId: String, value: String?, delivery: String? = nil) -> Bool {
         let success = onResponse?(requestId, value, delivery) ?? true
         if success && value == nil {


### PR DESCRIPTION
## Summary
- Add security-invariant doc comments to `SecretPrompter.resolveSecret()` and `SecretPromptManager.respond()` documenting that secret values must never be logged
- Add `secret-prompt-log-hygiene.test.ts` that captures logger output and verifies secret values never appear in any log call
- Existing behavior unchanged — both sides already correctly avoid logging values

Part of credential storage security hardening plan (PR 25/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
