### PR TITLE
feat: handle reminder_fired in Swift client

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -167,6 +167,25 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // Show macOS notification when a reminder fires
+        daemonClient.onReminderFired = { msg in
+            let content = UNMutableNotificationContent()
+            content.title = "Reminder: \(msg.label)"
+            content.body = msg.message
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: "reminder-\(msg.reminderId)",
+                content: content,
+                trigger: nil
+            )
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error {
+                    log.error("Failed to post reminder notification: \(error.localizedDescription)")
+                }
+            }
+        }
+
         // Handle open_bundle_response from the daemon
         daemonClient.onOpenBundleResponse = { [weak self] response in
             guard let self else { return }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -101,6 +101,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when a pomodoro timer completes.
     public var onTimerCompleted: ((TimerCompletedMessage) -> Void)?
 
+    /// Called when a reminder fires.
+    public var onReminderFired: ((ReminderFiredMessage) -> Void)?
+
     /// Called when the daemon sends a `trust_rules_list_response` message.
     public var onTrustRulesListResponse: (([TrustRuleItem]) -> Void)?
 
@@ -844,6 +847,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onTaskRouted?(msg)
         case .timerCompleted(let msg):
             onTimerCompleted?(msg)
+        case .reminderFired(let msg):
+            onReminderFired?(msg)
         case .trustRulesListResponse(let msg):
             onTrustRulesListResponse?(msg.rules)
         case .schedulesListResponse(let msg):


### PR DESCRIPTION
## Summary
- Add `onReminderFired` callback to `DaemonClient` with dispatch case
- Wire notification handler in `AppDelegate` to show macOS notification with reminder label and message

PR 5 of 6 in the deferred reminder system plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
