### PR TITLE
feat: switch default secret detection from warn to block

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -141,7 +141,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   secretDetection: {
     enabled: true,
-    action: 'warn',
+    action: 'block',
     entropyThreshold: 4.0,
   },
   auditLog: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -94,7 +94,7 @@ export const SecretDetectionConfigSchema = z.object({
     .enum(VALID_SECRET_ACTIONS, {
       error: `secretDetection.action must be one of: ${VALID_SECRET_ACTIONS.join(', ')}`,
     })
-    .default('warn'),
+    .default('block'),
   entropyThreshold: z
     .number({ error: 'secretDetection.entropyThreshold must be a number' })
     .finite('secretDetection.entropyThreshold must be finite')
@@ -818,7 +818,7 @@ export const AssistantConfigSchema = z.object({
   }),
   secretDetection: SecretDetectionConfigSchema.default({
     enabled: true,
-    action: 'warn',
+    action: 'block',
     entropyThreshold: 4.0,
   }),
   auditLog: AuditLogConfigSchema.default({


### PR DESCRIPTION
## Summary
- Change `secretDetection.action` default from `warn` to `block`
- Secrets detected in tool output are now blocked by default instead of just warned about
- Users can still configure `warn` or `redact` via `config.json`

Part of credential storage security hardening plan (PR 26/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
