### PR TITLE
fix: use zoom-adjusted width and account for side panel in drawer clamp

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -106,7 +106,7 @@ struct MainWindowView: View {
                                     .animation(nil, value: threadDrawerWidth)  // Disable animation on width changes
                                     .transition(.move(edge: .leading))
 
-                                drawerDragDivider(availableWidth: geometry.size.width)
+                                drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
                             }
 
                             // Center: Chat + right panel
@@ -362,7 +362,8 @@ struct MainWindowView: View {
                         let deltaX = value.location.x - value.startLocation.x
                         let newWidth = initialWidth + Double(deltaX)
                         let minMainContent: CGFloat = 300
-                        let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.xs - (VSpacing.xs * 2)
+                        let activePanelWidth: CGFloat = windowState.activePanel != nil ? sidePanelWidth : 0
+                        let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.xs - (VSpacing.xs * 2) - activePanelWidth
 
                         // Update width without animation to prevent jitter
                         var transaction = Transaction()


### PR DESCRIPTION
Address reviewer feedback from PR #2699.

- Pass `geometry.size.width / zoomManager.zoomLevel` to `drawerDragDivider` so the max allowed drawer width is computed against the effective layout width rather than the raw window width. When zoom > 1, the layout is scaled down, so the raw width overstates available space.
- Subtract `sidePanelWidth` from `maxAllowed` when a right panel is active, preventing the drawer from consuming space needed by the side panel and pushing chat content offscreen.

Fixes:
1. **Codex P1**: Account for open right panel in drawer width clamp
2. **Codex P2 + Devin**: Clamp drawer width using zoom-adjusted layout width
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
