### PR TITLE
fix: enforce 5-word limit on autogenerated thread names at runtime

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1949,6 +1949,8 @@ export class Session {
     const textBlock = response.content.find((b) => b.type === 'text');
     if (textBlock && textBlock.type === 'text') {
       let title = textBlock.text.trim().replace(/^["']|["']$/g, '');
+      const words = title.split(/\s+/);
+      if (words.length > 5) title = words.slice(0, 5).join(' ');
       if (title.length > 40) title = title.slice(0, 40).trimEnd();
       conversationStore.updateConversationTitle(this.conversationId, title);
       log.info({ conversationId: this.conversationId, title }, 'Auto-generated conversation title');


### PR DESCRIPTION
Address reviewer feedback from PR #2705.

The existing runtime safeguard only truncates by character length (40 chars), so a model response with more than 5 short words (and <=40 chars) would be stored unchanged. This adds word-count enforcement: split by whitespace, keep only the first 5 words, then apply character-length truncation.

**Changes:**
- `assistant/src/daemon/session.ts`: Added `split(/\s+/)` + `slice(0, 5).join(' ')` before the existing char-length guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
