### PR TITLE
fix: correct watch paths and detect xcassets/deletion changes in build script

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -351,26 +351,59 @@ if [ "$CMD" = "run" ]; then
     # Watch for file changes and auto-rebuild+relaunch (skip in nested invocations)
     if [ -z "${VELLUM_NO_WATCH:-}" ]; then
         WATCH_MARKER=$(mktemp)
+        WATCH_MANIFEST=$(mktemp)
         touch "$WATCH_MARKER"
-        trap 'rm -f "$WATCH_MARKER"' EXIT
+        trap 'rm -f "$WATCH_MARKER" "$WATCH_MANIFEST"' EXIT
+
+        WATCH_DIRS=("$SCRIPT_DIR/vellum-assistant" "$SCRIPT_DIR/vellum-assistant-app")
+        WATCH_FILES=("$SCRIPT_DIR/../Package.swift")
+
+        # Snapshot current watched files so we can detect deletions
+        snapshot_watched_files() {
+            find "${WATCH_DIRS[@]}" "${WATCH_FILES[@]}" \
+                -not -path '*/.build/*' \
+                -not -path '*/dist/*' \
+                \( -name "*.swift" -o -name "*.xcassets" -o -path "*.xcassets/*" \) \
+                2>/dev/null | sort > "$WATCH_MANIFEST"
+        }
+        snapshot_watched_files
 
         echo ""
         echo "Watching for changes... (Ctrl+C to stop)"
         while true; do
             sleep 2
-            # Look for any .swift or Package.swift changes (stop at first match for speed)
-            CHANGED=$(find "$SCRIPT_DIR/vellum-assistant" "$SCRIPT_DIR/vellum-assistant-app" "$SCRIPT_DIR/Package.swift" \
+
+            CHANGED=""
+
+            # Detect modifications: .swift files, .xcassets dirs, or files inside .xcassets
+            CHANGED=$(find "${WATCH_DIRS[@]}" "${WATCH_FILES[@]}" \
                 -not -path '*/.build/*' \
                 -not -path '*/dist/*' \
-                \( -name "*.swift" -o -name "*.xcassets" \) \
+                \( -name "*.swift" -o -name "*.xcassets" -o -path "*.xcassets/*" \) \
                 -newer "$WATCH_MARKER" \
                 -print -quit 2>/dev/null || true)
+
+            # Detect deletions: compare current file list against previous snapshot
+            if [ -z "$CHANGED" ]; then
+                CURRENT_MANIFEST=$(mktemp)
+                find "${WATCH_DIRS[@]}" "${WATCH_FILES[@]}" \
+                    -not -path '*/.build/*' \
+                    -not -path '*/dist/*' \
+                    \( -name "*.swift" -o -name "*.xcassets" -o -path "*.xcassets/*" \) \
+                    2>/dev/null | sort > "$CURRENT_MANIFEST"
+                if ! diff -q "$WATCH_MANIFEST" "$CURRENT_MANIFEST" > /dev/null 2>&1; then
+                    CHANGED="(file added or removed)"
+                fi
+                rm -f "$CURRENT_MANIFEST"
+            fi
+
             if [ -n "$CHANGED" ]; then
                 echo ""
                 echo "───────────────────────────────────"
                 echo "Change detected, rebuilding..."
                 echo "───────────────────────────────────"
                 touch "$WATCH_MARKER"
+                snapshot_watched_files
                 if VELLUM_NO_WATCH=1 "$0" run; then
                     echo "✓ Rebuilt and relaunched"
                 else


### PR DESCRIPTION
## Summary

Addresses reviewer feedback from PR #2702:

- **Fix Package.swift path** (Devin feedback): `$SCRIPT_DIR/Package.swift` resolved to `clients/macos/Package.swift` which doesn't exist. Changed to `$SCRIPT_DIR/../Package.swift` to correctly point at `clients/Package.swift`.
- **Detect changes inside .xcassets bundles** (Codex P1): Added `-path "*.xcassets/*"` to the find pattern so edits to files within existing asset catalogs (Contents.json, image files under .appiconset) trigger hot reload.
- **Detect file deletions** (Codex P2): Added manifest-based snapshot diffing — each poll cycle compares the current file list against the previous snapshot. If any file was added or removed, it triggers a rebuild.

## Test plan

- [ ] Run `./build.sh run`, edit a `.swift` file — verify rebuild triggers
- [ ] Edit a file inside `.xcassets` (e.g., Contents.json) — verify rebuild triggers
- [ ] Delete a watched `.swift` file — verify rebuild triggers
- [ ] Add a new `.swift` file — verify rebuild triggers
- [ ] Verify Package.swift path resolves correctly (no `find` errors in output)

Follows up on #2702.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
