### PR TITLE
fix: correct violation field for allowed-access test case

### DIFF
--- a/assistant/src/__tests__/fixtures/credential-security-fixtures.ts
+++ b/assistant/src/__tests__/fixtures/credential-security-fixtures.ts
@@ -117,7 +117,7 @@ export const logLeakageCases: LogLeakageCase[] = [
 export interface PolicyMisuseCase {
   label: string;
   /** Type of policy violation */
-  violation: 'wrong_tool' | 'wrong_domain' | 'missing_policy' | 'empty_allowlist';
+  violation: 'none' | 'wrong_tool' | 'wrong_domain' | 'missing_policy' | 'empty_allowlist';
   credentialId: string;
   requestingTool: string;
   requestDomain?: string;
@@ -170,7 +170,7 @@ export const policyMisuseCases: PolicyMisuseCase[] = [
   },
   {
     label: 'browser_fill_credential allowed when tool and domain match',
-    violation: 'wrong_tool',
+    violation: 'none',
     credentialId: 'cred-005',
     requestingTool: 'browser_fill_credential',
     requestDomain: 'login.example.com',


### PR DESCRIPTION
Address reviewer feedback from PR #2708.

## Changes
- Add `'none'` to the `PolicyMisuseCase` type's `violation` union for cases where no policy violation occurs
- Fix cred-005 fixture which incorrectly had `violation: 'wrong_tool'` despite being an allowed-access case (`expectedDenied: false`)

## Context
The last entry in `policyMisuseCases` represents a successful access scenario (tool and domain both match the credential policy). Using `violation: 'wrong_tool'` was semantically incorrect since there is no violation. The new `'none'` member makes the intent explicit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
