### PR TITLE
fix: strip port from bare hostnames before IPv6 check in domain normalizer

### DIFF
--- a/assistant/src/__tests__/domain-normalize.test.ts
+++ b/assistant/src/__tests__/domain-normalize.test.ts
@@ -40,6 +40,13 @@ describe('normalizeDomain', () => {
     expect(result!.hostname).toBe('example.com');
   });
 
+  test('strips port from bare hostname', () => {
+    const result = normalizeDomain('example.com:8080');
+    expect(result).not.toBeNull();
+    expect(result!.hostname).toBe('example.com');
+    expect(result!.registrableDomain).toBe('example.com');
+  });
+
   // ── Normalization ───────────────────────────────────────────────────
 
   test('lowercases hostname', () => {

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -44,6 +44,12 @@ export function normalizeDomain(input: string): DomainInfo | null {
     hostname = input;
   }
 
+  // Strip trailing port from bare hostnames (no scheme).
+  // Without this, "example.com:8080" is misidentified as IPv6 by isIPAddress.
+  if (!input.includes('://')) {
+    hostname = hostname.replace(/:\d+$/, '');
+  }
+
   // Normalize: lowercase, strip trailing dot
   hostname = hostname.toLowerCase().replace(/\.$/, '');
 


### PR DESCRIPTION
Addresses reviewer feedback from PR #2711.

Bare `host:port` strings like `example.com:8080` were incorrectly rejected as IPv6 addresses because the port separator colon matched the `hostname.includes(':')` check in `isIPAddress`.

**Fix:** Strip trailing `:port` from bare hostnames (when no `://` scheme is present) before IP address detection.

**Test:** Added test case for `example.com:8080` — verifies it parses correctly instead of returning `null`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
