### PR TITLE
fix: use deterministic fallback for empty sanitized tool IDs

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -14,7 +14,7 @@ const TOOL_ID_RE = /[^a-zA-Z0-9_-]/g;
 /** Anthropic requires tool_use IDs to match ^[a-zA-Z0-9_-]+$ */
 function sanitizeToolId(id: string): string {
   const sanitized = id.replace(TOOL_ID_RE, '_');
-  return sanitized || `fallback_${Date.now()}`;
+  return sanitized || 'fallback_empty_id';
 }
 
 export class AnthropicProvider implements Provider {


### PR DESCRIPTION
## Summary
- Replace `Date.now()`-based fallback with deterministic `'fallback_empty_id'` in `sanitizeToolId`
- Fixes potential tool_use/tool_result ID mismatch when an ID sanitizes to empty

## Context
Addresses reviewer feedback from PR #2721. Both Codex and Devin identified that `sanitizeToolId` generates `fallback_${Date.now()}` when an ID sanitizes to empty. Since `tool_use.id` and `tool_result.tool_use_id` are sanitized in separate calls, they could get different timestamps, producing mismatched IDs that Anthropic rejects.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
