### PR TITLE
fix: return immutable token copy from credential broker authorize

### DIFF
--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -66,7 +66,7 @@ export class CredentialBroker {
     log.info({ tokenId: token.tokenId, service: request.service, field: request.field, tool: request.toolName },
       'Usage token issued');
 
-    return { authorized: true, token };
+    return { authorized: true, token: { ...token } };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Return a shallow copy of the `UsageToken` (`{ ...token }`) from `authorize()` instead of a mutable reference to the broker's internal state
- Prevents callers from bypassing the single-use token guarantee by mutating `consumed` back to `false`
- Prevents retargeting `service`/`field` fields to access different credentials

Addresses reviewer feedback from PR #2724 (Codex P1, Devin critical).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
