### PR TITLE
fix: validate delivery enum in secret_response IPC validator

### DIFF
--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -107,6 +107,12 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     if (obj.value !== undefined && typeof obj.value !== 'string') {
       return 'secret_response "value" must be a string when present';
     }
+    if (obj.delivery !== undefined) {
+      const validDeliveries = ['store', 'transient_send'];
+      if (typeof obj.delivery !== 'string' || !validDeliveries.includes(obj.delivery)) {
+        return `secret_response "delivery" must be one of: ${validDeliveries.join(', ')}`;
+      }
+    }
     return null;
   },
 


### PR DESCRIPTION
Address reviewer feedback from PRs #2720 and #2722.

The `delivery` field on `SecretResponse` is typed as `'store' | 'transient_send'` but `validateClientMessage` in `ipc-validate.ts` didn't validate it at runtime, allowing malformed values to pass through silently.

This adds validation following the existing pattern for `confirmation_response` `decision` validation: when `delivery` is present, it must be one of the allowed enum values.

Closes feedback on #2720 and #2722.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
