### PR TITLE
fix: keep ChatViewModel alive until session ID arrives for archived threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -104,14 +104,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
 
         chatViewModels[id]?.stopGenerating()
-        chatViewModels.removeValue(forKey: id)
         threads[index].isArchived = true
 
         if let sessionId = threads[index].sessionId {
             var archived = archivedSessionIds
             archived.insert(sessionId)
             archivedSessionIds = archived
+            // Session ID already known — safe to release the view model.
+            chatViewModels.removeValue(forKey: id)
         }
+        // When sessionId is nil, keep the ChatViewModel alive so the
+        // onSessionCreated callback can still fire and persist the archive state
+        // via backfillSessionId. The view model is cleaned up there.
 
         // If the archived thread was active, select an adjacent visible thread
         // or create a new one if none remain.
@@ -335,11 +339,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
               threads[index].sessionId == nil else { return }
         threads[index].sessionId = sessionId
         // If the thread was archived before the session ID arrived,
-        // persist the archive state now that we have a session ID.
+        // persist the archive state now that we have a session ID and
+        // release the view model that was kept alive for this callback.
         if threads[index].isArchived {
             var archived = archivedSessionIds
             archived.insert(sessionId)
             archivedSessionIds = archived
+            chatViewModels.removeValue(forKey: threadId)
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses reviewer feedback from PR #2701. The archive-persistence code in `backfillSessionId` was unreachable because:

1. `archiveThread()` removed the ChatViewModel from `chatViewModels` immediately (line 107)
2. The `onSessionCreated` callback held a `[weak viewModel]` reference, which became nil after removal
3. Even if it survived, `backfillSessionId` looked up the VM by identity in `chatViewModels`, which would fail

**Fix:** Only remove the ChatViewModel when the session ID is already known. When `sessionId` is nil, keep the VM alive so `onSessionCreated` can fire, persist the archive state to `archivedSessionIds`, and then clean up the VM.

## Changes

- `archiveThread()`: Conditionally remove ChatViewModel — only when sessionId is already available
- `backfillSessionId()`: Clean up the ChatViewModel after persisting archive state for archived threads

## Test plan

- [ ] Archive a thread before the daemon assigns a session ID (e.g., archive immediately after creating)
- [ ] Verify the thread does not reappear as visible after app restart
- [ ] Verify archiving a thread with an existing session ID still works as before
- [ ] Verify unarchiving a thread that was archived before session ID assignment works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
