### PR TITLE
fix: account for all padding in VSplitView resize constraint

### DIFF
--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -97,7 +97,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
         // Calculate constraints
         let minPanelWidth: CGFloat = 300
         let minMainContentWidth: CGFloat = 300
-        let dividerAndPadding = VSpacing.xs + (VSpacing.xs * 2)
+        // main leading + main trailing + divider + panel trailing
+        let dividerAndPadding = VSpacing.xs * 4
         let maxAllowed = initialAvailableWidth - minMainContentWidth - dividerAndPadding
 
         // Update width without animation to prevent jitter


### PR DESCRIPTION
Address reviewer feedback from PR #2726.

The `dividerAndPadding` calculation only counted 3 of 4 horizontal padding areas (main leading + divider + panel trailing), missing the main trailing padding. This allowed the panel to grow large enough to push main content below `minMainContentWidth`.

Updated from `VSpacing.xs * 3` to `VSpacing.xs * 4` to include all four: main leading, main trailing, divider, and panel trailing.

Fixes feedback from Codex and Devin on #2726.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
