### PR TITLE
feat: block inbound user messages containing secrets

### DIFF
--- a/assistant/src/__tests__/secret-ingress-handler.test.ts
+++ b/assistant/src/__tests__/secret-ingress-handler.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+const mockConfig = {
+  secretDetection: {
+    enabled: true,
+    action: 'block' as 'redact' | 'warn' | 'block',
+    entropyThreshold: 4.0,
+  },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+const { checkIngressForSecrets } = await import('../security/secret-ingress.js');
+
+// Build test fixtures at runtime to avoid tripping the pre-commit secret hook.
+// These are well-known fake AWS/GitHub patterns used across the test suite.
+const AWS_KEY = ['AKIA', 'IOSFODNN7', 'REALKEY'].join('');
+const GH_TOKEN = ['ghp_', 'ABCDEFghijklMN01234567', '89abcdefghijkl'].join('');
+
+describe('secret ingress handler', () => {
+  beforeEach(() => {
+    mockConfig.secretDetection = { enabled: true, action: 'block', entropyThreshold: 4.0 };
+  });
+
+  test('blocks message containing an AWS key', () => {
+    const result = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain('AWS Access Key');
+    expect(result.userNotice).toBeDefined();
+    expect(result.userNotice).not.toContain(AWS_KEY);
+  });
+
+  test('allows normal text through', () => {
+    const result = checkIngressForSecrets('Hello, can you help me write a function?');
+    expect(result.blocked).toBe(false);
+    expect(result.detectedTypes).toHaveLength(0);
+    expect(result.userNotice).toBeUndefined();
+  });
+
+  test('does not block when detection is disabled', () => {
+    mockConfig.secretDetection.enabled = false;
+    const result = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
+    expect(result.blocked).toBe(false);
+  });
+
+  test('does not block in warn mode (warn only applies to tool output)', () => {
+    mockConfig.secretDetection.action = 'warn';
+    const result = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
+    expect(result.blocked).toBe(false);
+  });
+
+  test('does not block in redact mode', () => {
+    mockConfig.secretDetection.action = 'redact';
+    const result = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
+    expect(result.blocked).toBe(false);
+  });
+
+  test('user notice never contains the secret value', () => {
+    const result = checkIngressForSecrets(`Use this: ${AWS_KEY}`);
+    expect(result.blocked).toBe(true);
+    expect(result.userNotice).not.toContain(AWS_KEY);
+  });
+
+  test('detects multiple secret types', () => {
+    const msg = `AWS: ${AWS_KEY} and GH: ${GH_TOKEN}`;
+    const result = checkIngressForSecrets(msg);
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('empty content passes through', () => {
+    const result = checkIngressForSecrets('');
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -77,6 +77,7 @@ import { removeSkillsIndexEntry, deleteManagedSkill, validateManagedSkillId } fr
 import { packageApp } from '../bundler/app-bundler.js';
 import { createSharedAppLink } from '../memory/shared-app-links-store.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
+import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId, validateBlobKindEncoding } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
@@ -488,6 +489,17 @@ async function handleUserMessage(
     }
 
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+
+    // Block inbound messages that contain secrets before they enter model context
+    const ingressCheck = checkIngressForSecrets(msg.content ?? '');
+    if (ingressCheck.blocked) {
+      rlog.warn({ detectedTypes: ingressCheck.detectedTypes }, 'Blocked user message containing secrets');
+      ctx.send(socket, {
+        type: 'error',
+        message: ingressCheck.userNotice!,
+      });
+      return;
+    }
 
     session.traceEmitter.emit('request_received', 'User message received', {
       requestId,
@@ -1409,6 +1421,17 @@ async function handleTaskSubmit(
   const rlog = log.child({ requestId });
 
   try {
+    // Block inbound tasks that contain secrets before they enter model context
+    const taskIngressCheck = checkIngressForSecrets(msg.task);
+    if (taskIngressCheck.blocked) {
+      rlog.warn({ detectedTypes: taskIngressCheck.detectedTypes }, 'Blocked task_submit containing secrets');
+      ctx.send(socket, {
+        type: 'error',
+        message: taskIngressCheck.userNotice!,
+      });
+      return;
+    }
+
     // Slash candidates always route to text_qa — bypass classifier
     const slashCandidate = parseSlashCandidate(msg.task);
     const interactionType = slashCandidate.kind === 'candidate'

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -1,0 +1,56 @@
+import { getConfig } from '../config/loader.js';
+import { scanText } from './secret-scanner.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('secret-ingress');
+
+export interface IngressCheckResult {
+  /** Whether the message should be blocked from entering the model context. */
+  blocked: boolean;
+  /** Secret types detected (empty if none). */
+  detectedTypes: string[];
+  /**
+   * User-facing notice explaining why the message was blocked.
+   * Does NOT echo the secret value — only describes what was found.
+   */
+  userNotice?: string;
+}
+
+/**
+ * Scan inbound user text for secrets before it enters model context.
+ *
+ * When `secretDetection.action` is `block` (default), any message containing
+ * a detected secret is rejected with a safe notice. The raw message content
+ * is never logged or persisted.
+ *
+ * SECURITY: This function intentionally never logs the message content.
+ */
+export function checkIngressForSecrets(content: string): IngressCheckResult {
+  const config = getConfig();
+  if (!config.secretDetection.enabled) {
+    return { blocked: false, detectedTypes: [] };
+  }
+
+  // Only block in 'block' mode; 'warn' and 'redact' apply to tool output, not user input
+  if (config.secretDetection.action !== 'block') {
+    return { blocked: false, detectedTypes: [] };
+  }
+
+  const matches = scanText(content);
+
+  if (matches.length === 0) {
+    return { blocked: false, detectedTypes: [] };
+  }
+
+  const detectedTypes = [...new Set(matches.map((m) => m.type))];
+  log.warn({ detectedTypes, matchCount: matches.length }, 'Blocked inbound message containing secrets');
+
+  return {
+    blocked: true,
+    detectedTypes,
+    userNotice:
+      `Your message appears to contain sensitive information (${detectedTypes.join(', ')}). ` +
+      `For security, it was not sent to the AI. ` +
+      `Please use the secure credential prompt instead — the assistant will ask for secrets when it needs them.`,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `secret-ingress.ts` guard that scans `user_message` and `task_submit` content before it enters model context
- In block mode (default), messages containing detected secrets are rejected with a safe user notice
- Blocked content is never persisted to conversation history or sent to the model
- User notice describes what was detected without echoing the secret value

Part of credential storage security hardening plan (PR 27/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
