### PR TITLE
fix: sanitize callback errors in credential broker browserFill

### DIFF
--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -171,12 +171,14 @@ export class CredentialBroker {
       );
       return { success: true };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      // Log the raw error for debugging but never return it — the callback
+      // error text may embed the credential value, leaking plaintext outside
+      // the broker's trust boundary.
       log.error(
         { err, service: request.service, field: request.field },
         'Browser fill failed',
       );
-      return { success: false, reason: `Fill operation failed: ${msg}` };
+      return { success: false, reason: 'Fill operation failed' };
     }
   }
 


### PR DESCRIPTION
Address Codex P1 feedback from PR #2727.

When `request.fill()` throws, the raw error message could contain the credential value (e.g. a wrapper that embeds the attempted input in its error text), leaking plaintext outside the broker's trust boundary.

**Fix**: Return a generic `"Fill operation failed"` reason instead of interpolating the callback error message. The raw error is still logged for debugging.

**File modified**: `assistant/src/tools/credentials/broker.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
