### PR TITLE
fix: persist pomodoro timer to DB before scheduling in memory

### DIFF
--- a/assistant/src/tools/timer/pomodoro.ts
+++ b/assistant/src/tools/timer/pomodoro.ts
@@ -165,11 +165,8 @@ function startAction(input: Record<string, unknown>, sessionId: string): ToolExe
     status: 'running',
   };
 
-  scheduleCompletion(timer, sessionId, durationMs);
-
-  const sessionTimers = getOrCreateSessionTimers(sessionId);
-  sessionTimers.set(id, timer);
-
+  // Persist to DB before scheduling in memory so a failed insert
+  // doesn't leave a live in-memory timer with no DB row (split-brain).
   insertTimer({
     id,
     sessionId,
@@ -182,6 +179,11 @@ function startAction(input: Record<string, unknown>, sessionId: string): ToolExe
     createdAt: now,
     updatedAt: now,
   });
+
+  scheduleCompletion(timer, sessionId, durationMs);
+
+  const sessionTimers = getOrCreateSessionTimers(sessionId);
+  sessionTimers.set(id, timer);
 
   log.info({ id, label, durationMinutes, sessionId }, 'Pomodoro timer started');
 


### PR DESCRIPTION
Addresses reviewer feedback from PR #2729 (Codex P2).

## Problem
`startAction` scheduled the in-memory timer and stored it in the session map **before** calling `insertTimer`. If the DB insert failed (e.g. primary-key collision, SQLite error), a live in-memory timer would keep running with no backing database row — split-brain state.

## Fix
Reorder `startAction` to persist the timer row first, then schedule the `setTimeout` and add to the in-memory map. If `insertTimer` throws, neither the timeout nor the map entry are created.

## Test plan
- Existing pomodoro tests pass (no behavior change on the happy path)
- Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
