### PR TITLE
fix: handle schedule-list IPC failures to prevent infinite loading state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
@@ -7,6 +7,7 @@ struct ScheduledTasksView: View {
 
     @State private var schedules: [ScheduleItem] = []
     @State private var isLoading = true
+    @State private var errorMessage: String? = nil
     @State private var scheduleToDelete: ScheduleItem? = nil
 
     var body: some View {
@@ -26,6 +27,21 @@ struct ScheduledTasksView: View {
             if isLoading {
                 Spacer()
                 ProgressView()
+                Spacer()
+            } else if let errorMessage {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text("Failed to load schedules")
+                        .foregroundStyle(.secondary)
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                    Button("Retry") { loadSchedules() }
+                        .padding(.top, 4)
+                }
                 Spacer()
             } else if schedules.isEmpty {
                 Spacer()
@@ -83,7 +99,13 @@ struct ScheduledTasksView: View {
 
     @MainActor private func loadSchedules() {
         isLoading = true
-        try? daemonClient.sendListSchedules()
+        errorMessage = nil
+        do {
+            try daemonClient.sendListSchedules()
+        } catch {
+            isLoading = false
+            errorMessage = error.localizedDescription
+        }
     }
 
     @MainActor private func toggleSchedule(id: String, enabled: Bool) {


### PR DESCRIPTION
## Summary
- Address reviewer feedback from PR #2735 (Codex P2)
- If `sendListSchedules()` throws (e.g. daemon socket disconnected), `isLoading` was left as `true`, causing an infinite spinner with no way to recover
- Replace `try?` with `do/catch` to clear loading state on failure, display an error message with a Retry button

## Changes
- `ScheduledTasksView.swift`: Added `errorMessage` state, error view with retry button, proper `do/catch` in `loadSchedules()`

## Test plan
- [ ] Disconnect daemon and open Scheduled Tasks sheet -- should show error state with message and Retry button
- [ ] Click Retry after reconnecting daemon -- should reload schedules successfully
- [ ] Normal flow with daemon connected still works as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
