### PR TITLE
fix: reject invalid request hosts in domain policy matcher

### DIFF
--- a/assistant/src/__tests__/domain-policy.test.ts
+++ b/assistant/src/__tests__/domain-policy.test.ts
@@ -56,6 +56,10 @@ describe('isDomainAllowed', () => {
     expect(isDomainAllowed('not a valid host!!!', ['example.com'])).toBe(false);
   });
 
+  test('denies malformed host even when same string is in allowed list', () => {
+    expect(isDomainAllowed('not a valid host!!!', ['not a valid host!!!'])).toBe(false);
+  });
+
   test('denies IP addresses', () => {
     expect(isDomainAllowed('192.168.1.1', ['192.168.1.1'])).toBe(false);
   });

--- a/assistant/src/tools/credentials/domain-policy.ts
+++ b/assistant/src/tools/credentials/domain-policy.ts
@@ -27,6 +27,10 @@ export function isDomainAllowed(requestHost: string, allowedDomains: string[]): 
   const requestInfo = normalizeDomain(requestHost);
   if (!requestInfo) return false;
 
+  // Require a valid registrable domain — rejects malformed hostnames that
+  // normalizeDomain doesn't explicitly filter (e.g. strings with spaces/symbols).
+  if (!requestInfo.registrableDomain) return false;
+
   for (const allowed of allowedDomains) {
     const allowedInfo = normalizeDomain(allowed);
     if (!allowedInfo) continue;


### PR DESCRIPTION
## Summary
- Require a valid registrable domain on the request host before allowing exact-match in `isDomainAllowed`
- Previously, `normalizeDomain` could return a `DomainInfo` with a `hostname` but `null` registrable domain for malformed inputs (e.g. strings with spaces/symbols), so `isDomainAllowed('invalid!!!', ['invalid!!!'])` would incorrectly return `true`
- Adds test case covering the exact scenario described in the review feedback

Addresses reviewer feedback from PR #2712.

## Test plan
- [x] New test: `denies malformed host even when same string is in allowed list`
- [x] All 21 domain-policy tests pass
- [x] Type-check clean (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
