### PR TITLE
fix: redact sensitive keys with object/array values in tool input sanitizer

### DIFF
--- a/assistant/src/__tests__/tool-executor-redaction.test.ts
+++ b/assistant/src/__tests__/tool-executor-redaction.test.ts
@@ -111,4 +111,26 @@ describe('redactSensitiveFields', () => {
     expect(result.credentials).toBe('<redacted />');
     expect(result.apikey).toBe('<redacted />');
   });
+
+  test('redacts sensitive keys with object values', () => {
+    const input = { value: { raw: 'secret-data' }, name: 'test' };
+    const result = redactSensitiveFields(input);
+    expect(result.value).toBe('<redacted />');
+    expect(result.name).toBe('test');
+  });
+
+  test('redacts sensitive keys with array values', () => {
+    const input = { token: ['secret1', 'secret2'], name: 'test' };
+    const result = redactSensitiveFields(input);
+    expect(result.token).toBe('<redacted />');
+    expect(result.name).toBe('test');
+  });
+
+  test('redacts sensitive keys with deeply nested object values', () => {
+    const input = {
+      credentials: { user: 'admin', pass: 'hunter2', nested: { deep: true } },
+    };
+    const result = redactSensitiveFields(input);
+    expect(result.credentials).toBe('<redacted />');
+  });
 });

--- a/assistant/src/security/redaction.ts
+++ b/assistant/src/security/redaction.ts
@@ -26,7 +26,7 @@ function isSensitiveKey(key: string): boolean {
 /**
  * Recursively redact sensitive fields from an object.
  *
- * - Replaces string/number/boolean values of sensitive keys with `<redacted />`
+ * - Replaces values of sensitive keys with `<redacted />` regardless of type
  * - Recurses into nested objects and arrays
  * - Returns a shallow copy — never mutates the original
  */
@@ -36,7 +36,7 @@ export function redactSensitiveFields(
   const result: Record<string, unknown> = {};
 
   for (const [key, val] of Object.entries(obj)) {
-    if (isSensitiveKey(key) && val != null && typeof val !== 'object') {
+    if (isSensitiveKey(key) && val != null) {
       result[key] = REDACTION_PLACEHOLDER;
     } else if (Array.isArray(val)) {
       result[key] = val.map((item) =>


### PR DESCRIPTION
Addresses reviewer feedback from PR #2737 (Codex P1 + Devin).

**Problem:** `redactSensitiveFields` only masked sensitive keys when the value was a primitive (`typeof val !== 'object'`). Object and array values bypassed redaction — the code recursed into them instead, potentially leaking secrets like `{ value: { raw: 'secret' } }` or `{ token: ['secret'] }` in audit logs and hook payloads.

**Fix:** When a sensitive key is found, redact the entire value immediately with `<redacted />` regardless of type. No recursion into sensitive key values.

**Tests:** Added 3 new test cases covering object values, array values, and deeply nested object values on sensitive keys.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
