### PR TITLE
fix: guard missing allowedTools in credential broker deny messages

### DIFF
--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -43,12 +43,13 @@ export class CredentialBroker {
 
     // Tool policy enforcement — deny if tool is not in the credential's allowed list
     if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
+      const tools = metadata.allowedTools ?? [];
       return {
         authorized: false,
         reason: `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
-          (metadata.allowedTools.length === 0
+          (tools.length === 0
             ? 'No tools are currently allowed — update the credential with allowed_tools via credential_store.'
-            : `Allowed tools: ${metadata.allowedTools.join(', ')}.`),
+            : `Allowed tools: ${tools.join(', ')}.`),
       };
     }
 
@@ -128,12 +129,13 @@ export class CredentialBroker {
 
     // Tool policy enforcement — deny if tool is not in the credential's allowed list
     if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
+      const tools = metadata.allowedTools ?? [];
       return {
         success: false,
         reason: `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
-          (metadata.allowedTools.length === 0
+          (tools.length === 0
             ? 'No tools are currently allowed — update the credential with allowed_tools via credential_store.'
-            : `Allowed tools: ${metadata.allowedTools.join(', ')}.`),
+            : `Allowed tools: ${tools.join(', ')}.`),
       };
     }
 


### PR DESCRIPTION
Address reviewer feedback from PR #2733.

Null-check `allowedTools` via `?? []` before formatting deny messages in both `authorize()` and `browserFill()` to prevent `TypeError` on legacy or partially-written metadata records where `allowedTools` may be `undefined`.

**Changes:**
- `authorize()`: normalize `metadata.allowedTools` to `[]` before accessing `.length`/`.join()`
- `browserFill()`: same guard in the duplicated deny branch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
