### PR TITLE
fix: strengthen credential path test to check source imports

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   contextInjectionCases,
   directReadCases,
@@ -79,12 +82,16 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
     });
   }
 
-  test('browser_fill_credential does not import getCredentialValue', async () => {
-    // After PR 16+17, the browser tool uses CredentialBroker instead
-    // of importing getCredentialValue directly.
-    const browserModule = await import('../tools/browser/headless-browser.js');
-    // The module itself should not re-export getCredentialValue
-    expect('getCredentialValue' in browserModule).toBe(false);
+  test('browser_fill_credential does not import getCredentialValue', () => {
+    // Static source check: if headless-browser ever re-introduces an import
+    // of getCredentialValue, the plaintext-read regression would return even
+    // though the module doesn't re-export it.
+    const thisDir = dirname(fileURLToPath(import.meta.url));
+    const browserSrc = readFileSync(
+      resolve(thisDir, '../tools/browser/headless-browser.ts'),
+      'utf-8',
+    );
+    expect(browserSrc).not.toContain('getCredentialValue');
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses feedback from PR #2731 (codex bot review).

The previous test for `browser_fill_credential does not import getCredentialValue` only checked the module's **exports** (`'getCredentialValue' in browserModule`). This is weak because if headless-browser re-introduced a direct `import { getCredentialValue }` internally without re-exporting it, the test would still pass and the plaintext-read regression would go undetected.

**Fix:** Replace the export-based check with a static source scan that reads `headless-browser.ts` and asserts `getCredentialValue` does not appear anywhere in the source. This catches both import statements and any other reference to the forbidden API.

## Changes
- `assistant/src/__tests__/credential-security-invariants.test.ts`: Replace dynamic import + `in` check with `readFileSync` source scan

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] `credential-security-invariants.test.ts` — 5 pass, 16 skip, 0 fail
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
