### PR TITLE
fix: guard metadata writes in vault.ts with try-catch

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -121,11 +121,15 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field, {
-          allowedTools: policy.allowedTools,
-          allowedDomains: policy.allowedDomains,
-          usageDescription: policy.usageDescription,
-        });
+        try {
+          upsertCredentialMetadata(service, field, {
+            allowedTools: policy.allowedTools,
+            allowedDomains: policy.allowedDomains,
+            usageDescription: policy.usageDescription,
+          });
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata write failed after storing credential');
+        }
         return { content: `Stored credential for ${service}/${field}.`, isError: false };
       }
 
@@ -167,7 +171,11 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: `Error: credential ${service}/${field} not found`, isError: true };
         }
-        deleteCredentialMetadata(service, field);
+        try {
+          deleteCredentialMetadata(service, field);
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata cleanup failed after deleting credential');
+        }
         return { content: `Deleted credential for ${service}/${field}.`, isError: false };
       }
 
@@ -230,11 +238,15 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field, {
-          allowedTools: promptPolicy.allowedTools,
-          allowedDomains: promptPolicy.allowedDomains,
-          usageDescription: promptPolicy.usageDescription,
-        });
+        try {
+          upsertCredentialMetadata(service, field, {
+            allowedTools: promptPolicy.allowedTools,
+            allowedDomains: promptPolicy.allowedDomains,
+            usageDescription: promptPolicy.usageDescription,
+          });
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata write failed after storing credential');
+        }
         return { content: `Credential stored for ${service}/${field}.`, isError: false };
       }
 


### PR DESCRIPTION
## Summary

Wraps the three metadata write call sites in `vault.ts` (`upsertCredentialMetadata` and `deleteCredentialMetadata`) in try-catch blocks so that filesystem errors (disk full, permission denied, unrecognized metadata file version) don't propagate as unhandled exceptions after the primary credential operation has already succeeded.

- **store** action (line 124): `upsertCredentialMetadata` wrapped in try-catch
- **delete** action (line 170): `deleteCredentialMetadata` wrapped in try-catch  
- **prompt** action (line 233): `upsertCredentialMetadata` wrapped in try-catch

Failures are logged as warnings using the existing `credential-vault` logger. The metadata writes are best-effort — a failure should not prevent the tool from returning a success result.

Addresses feedback from PR #2715.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
