### PR TITLE
feat: show AI response when workspace refinement produces no surface update

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -654,6 +654,42 @@ struct MainWindowView: View {
                     .animation(VAnimation.standard, value: viewModel.isWorkspaceRefinementInFlight)
                 }
 
+                // Refinement failure toast — shown when the AI responded with text
+                // but didn't actually update the surface
+                if let viewModel = threadManager.activeViewModel,
+                   let failureText = viewModel.refinementFailureText {
+                    HStack(alignment: .top, spacing: VSpacing.sm) {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 13, weight: .medium))
+                            .padding(.top, 1)
+                        Text(failureText)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(4)
+                            .multilineTextAlignment(.leading)
+                        Spacer(minLength: 0)
+                        Button {
+                            viewModel.refinementFailureText = nil
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.md)
+                    .frame(maxWidth: 480)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(VColor.surface.opacity(0.95))
+                            .overlay(RoundedRectangle(cornerRadius: VRadius.lg).stroke(VColor.surfaceBorder, lineWidth: 1))
+                    )
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    .animation(VAnimation.standard, value: viewModel.refinementFailureText != nil)
+                }
+
                 // Floating composer — fade is handled inside the WebView via CSS
                 if let viewModel = threadManager.activeViewModel {
                     ComposerView(

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -111,6 +111,14 @@ public final class ChatViewModel: ObservableObject {
     /// Used by `messageComplete` to correctly suppress refinement side-effects
     /// even though `isWorkspaceRefinementInFlight` is cleared immediately for UI.
     private var cancelledDuringRefinement: Bool = false
+    /// Text buffered during a workspace refinement (normally suppressed from chat).
+    /// Surfaced to the user if the refinement completes without a surface update.
+    private var refinementTextBuffer: String = ""
+    private var refinementReceivedSurfaceUpdate: Bool = false
+    /// When non-nil, displays a toast in the workspace with the AI's response
+    /// after a refinement that produced no surface update.
+    @Published public var refinementFailureText: String?
+    private var refinementFailureDismissTask: Task<Void, Never>?
     @Published public var pendingSkillInvocation: SkillInvocationData?
     @Published public var isWatchSessionActive: Bool = false
 
@@ -449,6 +457,10 @@ public final class ChatViewModel: ObservableObject {
             }
         } else {
             isWorkspaceRefinementInFlight = true
+            refinementTextBuffer = ""
+            refinementReceivedSurfaceUpdate = false
+            refinementFailureText = nil
+            refinementFailureDismissTask?.cancel()
         }
         pendingSkillInvocation = nil
         inputText = ""
@@ -682,7 +694,10 @@ public final class ChatViewModel: ObservableObject {
         case .assistantTextDelta(let delta):
             guard belongsToSession(delta.sessionId) else { return }
             guard !isCancelling else { return }
-            guard !isWorkspaceRefinementInFlight else { return }
+            if isWorkspaceRefinementInFlight {
+                refinementTextBuffer += delta.text
+                return
+            }
             isThinking = false
             currentAssistantHasText = true
             if let existingId = currentAssistantMessageId,
@@ -714,6 +729,23 @@ public final class ChatViewModel: ObservableObject {
             // Only clear isSending if no messages are still queued
             if pendingQueuedCount == 0 {
                 isSending = false
+            }
+            // Surface the AI's text response when a refinement produced no update
+            if wasRefinement {
+                if !refinementReceivedSurfaceUpdate && !refinementTextBuffer.isEmpty {
+                    let text = refinementTextBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !text.isEmpty {
+                        refinementFailureText = text
+                        refinementFailureDismissTask?.cancel()
+                        refinementFailureDismissTask = Task { [weak self] in
+                            try? await Task.sleep(nanoseconds: 8_000_000_000)
+                            guard let self, !Task.isCancelled else { return }
+                            self.refinementFailureText = nil
+                        }
+                    }
+                }
+                refinementTextBuffer = ""
+                refinementReceivedSurfaceUpdate = false
             }
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             if !wasRefinement {
@@ -1002,6 +1034,9 @@ public final class ChatViewModel: ObservableObject {
 
         case .uiSurfaceUpdate(let msg):
             guard belongsToSession(msg.sessionId) else { return }
+            if isWorkspaceRefinementInFlight {
+                refinementReceivedSurfaceUpdate = true
+            }
             // Find the inline surface across all messages and update its data
             for msgIndex in messages.indices {
                 if let surfaceIndex = messages[msgIndex].inlineSurfaces.firstIndex(where: { $0.id == msg.surfaceId }) {


### PR DESCRIPTION
## Summary
- When a workspace refinement completes without the AI calling `app_update`/`ui_update`, the AI's text response is now shown as a dismissible toast overlay in the workspace instead of being silently discarded
- Text deltas are buffered during refinement; on success (surface updated) the buffer is discarded, on failure it's surfaced to the user
- Toast auto-dismisses after 8 seconds and is cleared when the user starts a new refinement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
