### PR TITLE
feat: add app directory view with preview snapshots

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1332,3 +1332,19 @@ exports[`IPC message snapshots ServerMessage types reminders_list_response seria
   "type": "reminders_list_response",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types app_update_preview serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "preview": "base64-png-data",
+  "type": "app_update_preview",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_update_preview_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "success": true,
+  "type": "app_update_preview_response",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -291,6 +291,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'gallery_install',
     galleryAppId: 'gallery-pomodoro-timer',
   },
+  app_update_preview: {
+    type: 'app_update_preview',
+    appId: 'app-001',
+    preview: 'base64-png-data',
+  },
   share_app_cloud: {
     type: 'share_app_cloud',
     appId: 'app-001',
@@ -852,6 +857,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'slack_webhook_config_response',
     webhookUrl: 'https://hooks.slack.com/services/T00/B00/xxx',
     success: true,
+  },
+  app_update_preview_response: {
+    type: 'app_update_preview_response',
+    success: true,
+    appId: 'app-001',
   },
 };
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -54,6 +54,7 @@ import type {
   GalleryInstallRequest,
   ShareToSlackRequest,
   SlackWebhookConfigRequest,
+  AppUpdatePreviewRequest,
 } from './ipc-protocol.js';
 import { postToSlackWebhook } from '../slack/slack-webhook.js';
 import { createHash } from 'node:crypto';
@@ -70,7 +71,7 @@ import { resolveSkillStates } from '../config/skill-state.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { handleWatchObservation } from './watch-handler.js';
 import { classifyInteraction } from './classifier.js';
-import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp, createApp } from '../memory/app-store.js';
+import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp, createApp, updateApp } from '../memory/app-store.js';
 import { defaultGallery } from '../gallery/default-gallery.js';
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
@@ -423,6 +424,7 @@ const handlers: DispatchMap = {
   bundle_app: handleBundleApp,
   open_bundle: handleOpenBundle,
   app_open_request: (msg, socket, ctx) => handleAppOpenRequest(msg, socket, ctx),
+  app_update_preview: handleAppUpdatePreview,
   apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
   shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
   shared_app_delete: handleSharedAppDelete,
@@ -1779,6 +1781,19 @@ function handleAppOpenRequest(msg: { appId: string }, socket: net.Socket, ctx: H
     data: { html: app.htmlDefinition, appId: app.id },
     display: 'panel',
   } as UiSurfaceShow);
+}
+
+// ─── App update preview handler ─────────────────────────────────────────────
+
+function handleAppUpdatePreview(msg: AppUpdatePreviewRequest, socket: net.Socket, ctx: HandlerContext): void {
+  try {
+    updateApp(msg.appId, { preview: msg.preview });
+    ctx.send(socket, { type: 'app_update_preview_response', success: true, appId: msg.appId });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to update app preview');
+    ctx.send(socket, { type: 'error', message: `Failed to update app preview: ${message}` });
+  }
 }
 
 // ─── Apps list handler ──────────────────────────────────────────────────────

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -4,6 +4,7 @@
     "AmbientObservation",
     "AppDataRequest",
     "AppOpenRequest",
+    "AppUpdatePreviewRequest",
     "AppsListRequest",
     "BundleAppRequest",
     "CancelRequest",
@@ -64,6 +65,7 @@
   "serverMessageTypes": [
     "AmbientResult",
     "AppDataResponse",
+    "AppUpdatePreviewResponse",
     "AppsListResponse",
     "AssistantTextDelta",
     "AssistantThinkingDelta",
@@ -132,6 +134,7 @@
     "ambient_observation",
     "app_data_request",
     "app_open_request",
+    "app_update_preview",
     "apps_list",
     "bundle_app",
     "cancel",
@@ -192,6 +195,7 @@
   "serverWireTypes": [
     "ambient_result",
     "app_data_response",
+    "app_update_preview_response",
     "apps_list_response",
     "assistant_text_delta",
     "assistant_thinking_delta",

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -337,6 +337,19 @@ export interface BundleAppRequest {
   appId: string;
 }
 
+export interface AppUpdatePreviewRequest {
+  type: 'app_update_preview';
+  appId: string;
+  /** Base64-encoded PNG screenshot thumbnail. */
+  preview: string;
+}
+
+export interface AppUpdatePreviewResponse {
+  type: 'app_update_preview_response';
+  success: boolean;
+  appId: string;
+}
+
 export interface OpenBundleRequest {
   type: 'open_bundle';
   filePath: string;
@@ -559,7 +572,8 @@ export type ClientMessage =
   | SlackWebhookConfigRequest
   | SessionsClearRequest
   | GalleryListRequest
-  | GalleryInstallRequest;
+  | GalleryInstallRequest
+  | AppUpdatePreviewRequest;
 
 // === Server → Client messages ===
 
@@ -1313,7 +1327,8 @@ export type ServerMessage =
   | GalleryListResponse
   | GalleryInstallResponse
   | ShareToSlackResponse
-  | SlackWebhookConfigResponse;
+  | SlackWebhookConfigResponse
+  | AppUpdatePreviewResponse;
 
 // === Contract schema ===
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -93,25 +93,6 @@ struct MainWindowView: View {
                                 }
 
                                 Spacer()
-
-                                // Panel toggle buttons
-                                HStack(spacing: VSpacing.sm) {
-                                    VIconButton(label: "Skills", icon: "exclamationmark.triangle", isActive: windowState.activePanel == .agent, iconOnly: true) {
-                                        windowState.togglePanel(.agent)
-                                    }
-                                    VIconButton(label: "Settings", icon: "gearshape", isActive: windowState.activePanel == .settings, iconOnly: true) {
-                                        windowState.togglePanel(.settings)
-                                    }
-                                    VIconButton(label: "Directory", icon: "doc.text", isActive: windowState.activePanel == .directory, iconOnly: true) {
-                                        windowState.togglePanel(.directory)
-                                    }
-                                    VIconButton(label: "Debug", icon: "ant", isActive: windowState.activePanel == .debug, iconOnly: true) {
-                                        windowState.togglePanel(.debug)
-                                    }
-                                    VIconButton(label: "Doctor", icon: "stethoscope", isActive: windowState.activePanel == .doctor, iconOnly: true) {
-                                        windowState.togglePanel(.doctor)
-                                    }
-                                }
                             }
                             .padding(.leading, trafficLightPadding)
                             .padding(.trailing, VSpacing.lg)
@@ -260,6 +241,9 @@ struct MainWindowView: View {
             Button(action: {
                 threadMenuOpenId = nil
                 threadManager.selectThread(id: thread.id)
+                if windowState.activePanel == .directory {
+                    windowState.activePanel = nil
+                }
             }) {
                 Text(thread.title)
                     .font(.system(size: 13))
@@ -311,7 +295,7 @@ struct MainWindowView: View {
     @ViewBuilder
     private var threadDrawerView: some View {
         VStack(spacing: 0) {
-            NewConversationButton(action: { threadMenuOpenId = nil; threadManager.createThread() })
+            NewConversationButton(action: { threadMenuOpenId = nil; windowState.activePanel = nil; threadManager.createThread() })
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.top, VSpacing.md)
                 .padding(.bottom, VSpacing.xl)
@@ -340,6 +324,7 @@ struct MainWindowView: View {
             ParentalControlsMenuButton(
                 onSettings: { windowState.togglePanel(.settings) },
                 onSkills: { windowState.togglePanel(.agent) },
+                onDirectory: { windowState.togglePanel(.directory) },
                 onDebug: { windowState.togglePanel(.debug) },
                 onDoctor: { windowState.togglePanel(.doctor) }
             )
@@ -408,7 +393,18 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private func chatContentView(geometry: GeometryProxy) -> some View {
-        if windowState.isDynamicExpanded && windowState.activePanel == .generated {
+        if windowState.activePanel == .directory {
+            AppDirectoryView(
+                daemonClient: daemonClient,
+                onBack: { windowState.activePanel = nil },
+                onOpenApp: { surfaceMsg in
+                    windowState.activeDynamicSurface = surfaceMsg
+                    windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
+                    windowState.activePanel = .generated
+                    windowState.isDynamicExpanded = true
+                }
+            )
+        } else if windowState.isDynamicExpanded && windowState.activePanel == .generated {
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
                 // Workspace mode: full-window dynamic page
@@ -553,6 +549,10 @@ struct MainWindowView: View {
                 } : nil,
                 onCoordinatorReady: data.appId != nil ? { coordinator in
                     surfaceManager.surfaceCoordinators[surface.id] = coordinator
+                } : nil,
+                onSnapshotCaptured: data.appId != nil ? { [weak daemonClient] base64 in
+                    guard let appId = data.appId else { return }
+                    try? daemonClient?.sendAppUpdatePreview(appId: appId, preview: base64)
                 } : nil,
                 topContentInset: 56,
                 bottomContentInset: workspaceComposerReservedHeight
@@ -744,7 +744,8 @@ struct MainWindowView: View {
             case .settings:
                 SettingsPanel(onClose: { windowState.activePanel = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
             case .directory:
-                DirectoryPanel(onClose: { windowState.activePanel = nil })
+                Color.clear.frame(width: 0, height: 0)
+                    .onAppear { /* handled full-screen in chatContentView */ }
             case .debug:
                 DebugPanel(
                     traceStore: traceStore,
@@ -825,6 +826,7 @@ private struct NewConversationButton: View {
 private struct ParentalControlsMenuButton: View {
     let onSettings: () -> Void
     let onSkills: () -> Void
+    let onDirectory: () -> Void
     let onDebug: () -> Void
     let onDoctor: () -> Void
     @State private var isHovered = false
@@ -869,6 +871,7 @@ private struct ParentalControlsMenuButton: View {
                 DrawerMenuView(
                     onSettings: { showDrawer = false; onSettings() },
                     onSkills: { showDrawer = false; onSkills() },
+                    onDirectory: { showDrawer = false; onDirectory() },
                     onDebug: { showDrawer = false; onDebug() },
                     onDoctor: { showDrawer = false; onDoctor() }
                 )
@@ -882,6 +885,7 @@ private struct ParentalControlsMenuButton: View {
 private struct DrawerMenuView: View {
     let onSettings: () -> Void
     let onSkills: () -> Void
+    let onDirectory: () -> Void
     let onDebug: () -> Void
     let onDoctor: () -> Void
 
@@ -889,6 +893,7 @@ private struct DrawerMenuView: View {
         VStack(alignment: .leading, spacing: 0) {
             DrawerMenuItem(icon: "gearshape", label: "Settings", action: onSettings)
             DrawerMenuItem(icon: "wand.and.stars", label: "Skills", action: onSkills)
+            DrawerMenuItem(icon: "doc.text", label: "Directory", action: onDirectory)
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -1,0 +1,422 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Full-screen app directory view showing all local and shared apps as a card grid.
+struct AppDirectoryView: View {
+    let daemonClient: DaemonClient
+    let onBack: () -> Void
+    let onOpenApp: (UiSurfaceShowMessage) -> Void
+
+    @State private var searchText = ""
+    @State private var isSearchExpanded = false
+    @State private var displayItems: [DirectoryAppItem] = []
+    @State private var isLoading = false
+    @State private var hoveredAppId: String?
+
+    @State private var localApps: [AppItem] = []
+    @State private var sharedApps: [SharedAppItem] = []
+    @State private var pendingResponses = 0
+
+    private let columns = [
+        GridItem(.flexible(), spacing: VSpacing.lg),
+        GridItem(.flexible(), spacing: VSpacing.lg),
+        GridItem(.flexible(), spacing: VSpacing.lg),
+    ]
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // Top bar
+                HStack {
+                    backButton
+
+                    Spacer()
+
+                    Text("App Directory")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(VColor.textPrimary)
+
+                    Spacer()
+
+                    // Collapsible search
+                    if !displayItems.isEmpty || !searchText.isEmpty {
+                        HStack(spacing: VSpacing.sm) {
+                            if isSearchExpanded {
+                                TextField("Search apps...", text: $searchText)
+                                    .textFieldStyle(.plain)
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textPrimary)
+                                    .frame(width: 160)
+
+                                if !searchText.isEmpty {
+                                    Button(action: { searchText = "" }) {
+                                        Image(systemName: "xmark.circle.fill")
+                                            .font(.system(size: 12))
+                                            .foregroundColor(VColor.textMuted)
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+
+                            Button(action: {
+                                withAnimation(VAnimation.fast) {
+                                    isSearchExpanded.toggle()
+                                    if !isSearchExpanded {
+                                        searchText = ""
+                                    }
+                                }
+                            }) {
+                                Image(systemName: "magnifyingglass")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(VColor.textSecondary)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.horizontal, isSearchExpanded ? VSpacing.md : VSpacing.sm)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(
+                            isSearchExpanded
+                                ? AnyShapeStyle(VColor.surface)
+                                : AnyShapeStyle(.clear)
+                        )
+                        .clipShape(Capsule())
+                        .overlay(
+                            isSearchExpanded
+                                ? Capsule().stroke(VColor.surfaceBorder, lineWidth: 1)
+                                : nil
+                        )
+                    } else {
+                        // Balance the back button width when no search
+                        Color.clear.frame(width: 80, height: 1)
+                    }
+                }
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.top, VSpacing.md)
+                .padding(.bottom, VSpacing.lg)
+
+                // Content
+                ScrollView {
+                    if isLoading {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .controlSize(.regular)
+                            Spacer()
+                        }
+                        .frame(height: 300)
+                    } else if displayItems.isEmpty {
+                        VEmptyState(
+                            title: "No apps yet",
+                            subtitle: "Apps built with your assistant will appear here",
+                            icon: "square.grid.2x2"
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, VSpacing.xxxl)
+                    } else if filteredItems.isEmpty {
+                        VEmptyState(
+                            title: "No results",
+                            subtitle: "No apps matched \"\(searchText)\"",
+                            icon: "magnifyingglass"
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, VSpacing.xxxl)
+                    } else {
+                        LazyVGrid(columns: columns, spacing: VSpacing.lg) {
+                            ForEach(filteredItems) { item in
+                                appCard(item)
+                            }
+                        }
+                        .padding(.horizontal, VSpacing.xl)
+                        .padding(.bottom, VSpacing.xl)
+                    }
+                }
+            }
+        }
+        .onAppear { fetchApps() }
+    }
+
+    // MARK: - Back Button
+
+    private var backButton: some View {
+        Button(action: onBack) {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("Chat")
+                    .font(VFont.bodyMedium)
+            }
+            .foregroundColor(VColor.textPrimary)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                Capsule()
+                    .fill(VColor.surface.opacity(0.85))
+                    .overlay(Capsule().stroke(VColor.surfaceBorder, lineWidth: 1))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Back to chat")
+    }
+
+    // MARK: - App Card
+
+    private func appCard(_ item: DirectoryAppItem) -> some View {
+        let isHovered = hoveredAppId == item.id
+
+        return VStack(alignment: .leading, spacing: 0) {
+            // Preview thumbnail or placeholder
+            Group {
+                if let preview = item.preview,
+                   let data = Data(base64Encoded: preview),
+                   let nsImage = NSImage(data: data) {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(height: 160)
+                        .clipped()
+                } else {
+                    ZStack {
+                        VColor.backgroundSubtle
+
+                        Text(item.icon ?? "\u{1F4F1}")
+                            .font(.system(size: 40))
+                    }
+                    .frame(height: 160)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .clipShape(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: VRadius.lg,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: VRadius.lg
+                )
+            )
+
+            // Info section
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(spacing: VSpacing.xs) {
+                    Text(item.name)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
+
+                    if item.isShared {
+                        HStack(spacing: 2) {
+                            Image(systemName: "person.2.fill")
+                                .font(.system(size: 8))
+                            Text("Shared")
+                                .font(VFont.small)
+                        }
+                        .foregroundColor(Violet._400)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Violet._900.opacity(0.5))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                }
+
+                Text(item.dateLabel)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+            }
+            .padding(VSpacing.md)
+        }
+        .background(isHovered ? Slate._800 : VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(isHovered ? VColor.surfaceBorder.opacity(0.8) : VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
+        )
+        .scaleEffect(isHovered ? 1.02 : 1.0)
+        .animation(VAnimation.fast, value: isHovered)
+        .contentShape(Rectangle())
+        .onTapGesture { openApp(item) }
+        .onHover { hovering in
+            withAnimation(VAnimation.fast) {
+                hoveredAppId = hovering ? item.id : nil
+            }
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    // MARK: - Filtering
+
+    private var filteredItems: [DirectoryAppItem] {
+        guard !searchText.isEmpty else { return displayItems }
+        return displayItems.filter {
+            $0.name.localizedCaseInsensitiveContains(searchText) ||
+            ($0.description?.localizedCaseInsensitiveContains(searchText) ?? false)
+        }
+    }
+
+    // MARK: - Data Fetching
+
+    private func fetchApps() {
+        isLoading = true
+        pendingResponses = 2
+
+        Task { @MainActor in
+            daemonClient.onAppsListResponse = { response in
+                self.localApps = response.apps
+                self.pendingResponses -= 1
+                if self.pendingResponses <= 0 {
+                    self.buildDisplayItems()
+                    self.isLoading = false
+                }
+            }
+
+            daemonClient.onSharedAppsListResponse = { response in
+                self.sharedApps = response.apps
+                self.pendingResponses -= 1
+                if self.pendingResponses <= 0 {
+                    self.buildDisplayItems()
+                    self.isLoading = false
+                }
+            }
+
+            daemonClient.onError = { _ in
+                if self.isLoading {
+                    self.pendingResponses -= 1
+                    if self.pendingResponses <= 0 {
+                        self.buildDisplayItems()
+                        self.isLoading = false
+                    }
+                }
+            }
+
+            do {
+                try daemonClient.sendAppsList()
+            } catch {
+                pendingResponses -= 1
+            }
+
+            do {
+                try daemonClient.sendSharedAppsList()
+            } catch {
+                pendingResponses -= 1
+            }
+
+            if pendingResponses <= 0 {
+                buildDisplayItems()
+                isLoading = false
+            }
+        }
+    }
+
+    private func buildDisplayItems() {
+        var items: [DirectoryAppItem] = []
+
+        for app in localApps {
+            items.append(DirectoryAppItem(
+                id: "local-\(app.id)",
+                name: app.name,
+                description: app.description,
+                icon: app.icon,
+                preview: app.preview,
+                dateLabel: formatDate(app.createdAt),
+                isShared: false,
+                localAppId: app.id,
+                sharedUUID: nil
+            ))
+        }
+
+        for app in sharedApps {
+            items.append(DirectoryAppItem(
+                id: "shared-\(app.uuid)",
+                name: app.name,
+                description: app.description,
+                icon: app.icon,
+                preview: app.preview,
+                dateLabel: formatISO(app.installedAt),
+                isShared: true,
+                localAppId: nil,
+                sharedUUID: app.uuid
+            ))
+        }
+
+        displayItems = items
+    }
+
+    // MARK: - Open App
+
+    private func openApp(_ item: DirectoryAppItem) {
+        if let localId = item.localAppId {
+            try? daemonClient.sendAppOpen(appId: localId)
+        } else if let uuid = item.sharedUUID {
+            let safeName = htmlEscape(item.name)
+            let sanitizedUUID = uuid
+                .replacingOccurrences(of: "\\", with: "")
+                .replacingOccurrences(of: "'", with: "")
+            let entryURL = "\(VellumAppSchemeHandler.scheme)://\(sanitizedUUID)/index.html"
+            let html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta charset="utf-8"><title>\(safeName)</title></head>
+            <body><script>window.location.href = '\(entryURL)';</script></body>
+            </html>
+            """
+            let surfaceMsg = UiSurfaceShowMessage(
+                sessionId: "shared-app",
+                surfaceId: "shared-app-\(uuid)",
+                surfaceType: "dynamic_page",
+                title: item.name,
+                data: AnyCodable(["html": html]),
+                actions: nil,
+                display: "panel"
+            )
+            onOpenApp(surfaceMsg)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatDate(_ epochMs: Int) -> String {
+        let date = Date(timeIntervalSince1970: Double(epochMs) / 1000)
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func formatISO(_ isoString: String) -> String {
+        let isoFormatter = ISO8601DateFormatter()
+        guard let date = isoFormatter.date(from: isoString) else { return isoString }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func htmlEscape(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}
+
+/// Display model for directory app items.
+private struct DirectoryAppItem: Identifiable {
+    let id: String
+    let name: String
+    let description: String?
+    let icon: String?
+    let preview: String?
+    let dateLabel: String
+    let isShared: Bool
+    let localAppId: String?
+    let sharedUUID: String?
+}
+
+#Preview {
+    AppDirectoryView(
+        daemonClient: DaemonClient(),
+        onBack: {},
+        onOpenApp: { _ in }
+    )
+    .frame(width: 900, height: 600)
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -41,6 +41,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     let appId: String?
     let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
     let onCoordinatorReady: ((Coordinator) -> Void)?
+    /// Called with a base64-encoded PNG screenshot after the page finishes loading.
+    let onSnapshotCaptured: ((String) -> Void)?
     /// When true, blocks all network requests to external origins and restricts navigation.
     let sandboxMode: Bool
     let topContentInset: CGFloat
@@ -52,6 +54,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         appId: String? = nil,
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
         onCoordinatorReady: ((Coordinator) -> Void)? = nil,
+        onSnapshotCaptured: ((String) -> Void)? = nil,
         sandboxMode: Bool = false,
         topContentInset: CGFloat = 0,
         bottomContentInset: CGFloat = 0
@@ -61,13 +64,14 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         self.appId = appId
         self.onDataRequest = onDataRequest
         self.onCoordinatorReady = onCoordinatorReady
+        self.onSnapshotCaptured = onSnapshotCaptured
         self.sandboxMode = sandboxMode
         self.topContentInset = topContentInset
         self.bottomContentInset = bottomContentInset
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, currentHTML: data.html, sandboxMode: sandboxMode)
+        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -378,6 +382,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
         var onAction: (String, Any?) -> Void
         var onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
+        var onSnapshotCaptured: ((String) -> Void)?
         var currentHTML: String
         let sandboxMode: Bool
         weak var webView: WKWebView?
@@ -385,15 +390,18 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var lastBottomInset: Int = 0
         var desiredTopInset: Int = 0
         var desiredBottomInset: Int = 0
+        private var hasCapturedSnapshot = false
 
         init(
             onAction: @escaping (String, Any?) -> Void,
             onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,
+            onSnapshotCaptured: ((String) -> Void)?,
             currentHTML: String,
             sandboxMode: Bool = false
         ) {
             self.onAction = onAction
             self.onDataRequest = onDataRequest
+            self.onSnapshotCaptured = onSnapshotCaptured
             self.currentHTML = currentHTML
             self.sandboxMode = sandboxMode
         }
@@ -535,30 +543,87 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             }
         }
 
+        /// Captures a screenshot of the current WebView content as a base64-encoded PNG.
+        func captureSnapshot(completion: @escaping (String?) -> Void) {
+            guard let webView = webView else {
+                completion(nil)
+                return
+            }
+            let config = WKSnapshotConfiguration()
+            config.afterScreenUpdates = true
+            webView.takeSnapshot(with: config) { image, error in
+                if let error = error {
+                    log.error("Snapshot capture failed: \(error.localizedDescription, privacy: .public)")
+                    completion(nil)
+                    return
+                }
+                guard let image = image,
+                      let tiff = image.tiffRepresentation,
+                      let bitmap = NSBitmapImageRep(data: tiff) else {
+                    completion(nil)
+                    return
+                }
+                // Resize to a reasonable thumbnail (max 400px wide) to keep payload small
+                let maxWidth: CGFloat = 400
+                let scale = min(1.0, maxWidth / image.size.width)
+                let targetSize = NSSize(
+                    width: image.size.width * scale,
+                    height: image.size.height * scale
+                )
+                let resized = NSImage(size: targetSize)
+                resized.lockFocus()
+                image.draw(in: NSRect(origin: .zero, size: targetSize),
+                           from: NSRect(origin: .zero, size: image.size),
+                           operation: .copy,
+                           fraction: 1.0)
+                resized.unlockFocus()
+                guard let resizedTiff = resized.tiffRepresentation,
+                      let resizedBitmap = NSBitmapImageRep(data: resizedTiff),
+                      let pngData = resizedBitmap.representation(using: .png, properties: [.compressionFactor: 0.8]) else {
+                    completion(nil)
+                    return
+                }
+                completion(pngData.base64EncodedString())
+            }
+        }
+
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             // Re-inject content insets after page load completes. The WKUserScript from
             // makeNSView has creation-time values baked in, which may be stale if insets
             // changed since then (e.g. composer expanded). Apply the current desired values.
             let top = desiredTopInset
             let bottom = desiredBottomInset
-            guard top > 0 || bottom > 0 || lastTopInset > 0 || lastBottomInset > 0 else { return }
-            lastTopInset = top
-            lastBottomInset = bottom
-            let fadeHeight = bottom + 32
-            let js = """
-                (function() {
-                    var el = document.getElementById('vellum-content-insets');
-                    if (!el) { el = document.createElement('style'); el.id = 'vellum-content-insets'; (document.head || document.documentElement).appendChild(el); }
-                    el.textContent = 'body { padding-top: \(top)px; padding-bottom: \(bottom)px; }';
-                    var fade = document.getElementById('vellum-bottom-fade');
-                    if (fade) {
-                        fade.style.height = '\(fadeHeight)px';
-                        var bg = getComputedStyle(document.body).backgroundColor || 'rgba(0,0,0,0)';
-                        fade.style.background = 'linear-gradient(to bottom, transparent 0%, ' + bg + ' 100%)';
+            if top > 0 || bottom > 0 || lastTopInset > 0 || lastBottomInset > 0 {
+                lastTopInset = top
+                lastBottomInset = bottom
+                let fadeHeight = bottom + 32
+                let js = """
+                    (function() {
+                        var el = document.getElementById('vellum-content-insets');
+                        if (!el) { el = document.createElement('style'); el.id = 'vellum-content-insets'; (document.head || document.documentElement).appendChild(el); }
+                        el.textContent = 'body { padding-top: \(top)px; padding-bottom: \(bottom)px; }';
+                        var fade = document.getElementById('vellum-bottom-fade');
+                        if (fade) {
+                            fade.style.height = '\(fadeHeight)px';
+                            var bg = getComputedStyle(document.body).backgroundColor || 'rgba(0,0,0,0)';
+                            fade.style.background = 'linear-gradient(to bottom, transparent 0%, ' + bg + ' 100%)';
+                        }
+                    })();
+                    """
+                webView.evaluateJavaScript(js, completionHandler: nil)
+            }
+
+            // Capture a preview screenshot after the page has rendered (once per load).
+            if !hasCapturedSnapshot, let onSnapshotCaptured {
+                hasCapturedSnapshot = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+                    self?.captureSnapshot { base64 in
+                        if let base64 {
+                            onSnapshotCaptured(base64)
+                        }
                     }
-                })();
-                """
-            webView.evaluateJavaScript(js, completionHandler: nil)
+                }
+            }
         }
 
         func webView(

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -634,6 +634,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(AppOpenRequestMessage(appId: appId))
     }
 
+    /// Send a preview screenshot for an app.
+    public func sendAppUpdatePreview(appId: String, preview: String) throws {
+        try send(AppUpdatePreviewRequestMessage(appId: appId, preview: preview))
+    }
+
     /// Request the list of all apps from the daemon.
     public func sendAppsList() throws {
         try send(AppsListRequestMessage())
@@ -873,6 +878,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSkillsInspectResponse?(msg)
         case .appsListResponse(let msg):
             onAppsListResponse?(msg)
+        case .appUpdatePreviewResponse:
+            break // Fire-and-forget; no callback needed
         case .sharedAppsListResponse(let msg):
             onSharedAppsListResponse?(msg)
         case .sharedAppDeleteResponse(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -79,6 +79,19 @@ public struct IPCAppsListResponseApp: Codable, Sendable {
     public let contentId: String?
 }
 
+public struct IPCAppUpdatePreviewRequest: Codable, Sendable {
+    public let type: String
+    public let appId: String
+    /// Base64-encoded PNG screenshot thumbnail.
+    public let preview: String
+}
+
+public struct IPCAppUpdatePreviewResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let appId: String
+}
+
 public struct IPCAssistantTextDelta: Codable, Sendable {
     public let type: String
     public let text: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -293,6 +293,20 @@ extension IPCAppOpenRequest {
     }
 }
 
+/// Sent to update an app's preview screenshot.
+/// Backed by generated `IPCAppUpdatePreviewRequest`.
+public typealias AppUpdatePreviewRequestMessage = IPCAppUpdatePreviewRequest
+
+extension IPCAppUpdatePreviewRequest {
+    public init(appId: String, preview: String) {
+        self.init(type: "app_update_preview", appId: appId, preview: preview)
+    }
+}
+
+/// Response from updating an app's preview screenshot.
+/// Backed by generated `IPCAppUpdatePreviewResponse`.
+public typealias AppUpdatePreviewResponseMessage = IPCAppUpdatePreviewResponse
+
 /// Sent to request the list of all apps.
 /// Backed by generated `IPCAppsListRequest`.
 public typealias AppsListRequestMessage = IPCAppsListRequest
@@ -1318,6 +1332,7 @@ public enum ServerMessage: Decodable, Sendable {
     case remindersListResponse(RemindersListResponseMessage)
     case schedulesListResponse(SchedulesListResponseMessage)
     case appsListResponse(AppsListResponseMessage)
+    case appUpdatePreviewResponse(AppUpdatePreviewResponseMessage)
     case sharedAppsListResponse(SharedAppsListResponseMessage)
     case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
     case forkSharedAppResponse(ForkSharedAppResponseMessage)
@@ -1464,6 +1479,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "apps_list_response":
             let message = try AppsListResponseMessage(from: decoder)
             self = .appsListResponse(message)
+        case "app_update_preview_response":
+            let message = try AppUpdatePreviewResponseMessage(from: decoder)
+            self = .appUpdatePreviewResponse(message)
         case "shared_apps_list_response":
             let message = try SharedAppsListResponseMessage(from: decoder)
             self = .sharedAppsListResponse(message)


### PR DESCRIPTION
## Summary
- Add full-screen app directory view with card grid showing local and shared apps, collapsible search, and SF font title
- Auto-capture preview screenshots of apps via WKWebView snapshots and persist via new `app_update_preview` IPC message
- Clicking a sidebar thread while viewing the directory navigates back to chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
