### PR TITLE
feat: add workspace surface undo for refinement changes

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -338,6 +338,19 @@ exports[`IPC message snapshots ClientMessage types schedule_remove serializes to
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types reminders_list serializes to expected JSON 1`] = `
+{
+  "type": "reminders_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types reminder_cancel serializes to expected JSON 1`] = `
+{
+  "id": "rem-001",
+  "type": "reminder_cancel",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types bundle_app serializes to expected JSON 1`] = `
 {
   "appId": "app-001",
@@ -438,6 +451,14 @@ exports[`IPC message snapshots ClientMessage types gallery_install serializes to
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types app_update_preview serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "preview": "base64-png-data",
+  "type": "app_update_preview",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types share_app_cloud serializes to expected JSON 1`] = `
 {
   "appId": "app-001",
@@ -456,6 +477,14 @@ exports[`IPC message snapshots ClientMessage types slack_webhook_config serializ
 {
   "action": "get",
   "type": "slack_webhook_config",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types ui_surface_undo serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_undo",
 }
 `;
 
@@ -1094,6 +1123,24 @@ exports[`IPC message snapshots ServerMessage types schedules_list_response seria
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types reminders_list_response serializes to expected JSON 1`] = `
+{
+  "reminders": [
+    {
+      "createdAt": 1700000000000,
+      "fireAt": 1700100000000,
+      "firedAt": null,
+      "id": "rem-001",
+      "label": "Call Sidd",
+      "message": "Remember to call Sidd about the project",
+      "mode": "notify",
+      "status": "pending",
+    },
+  ],
+  "type": "reminders_list_response",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types bundle_app_response serializes to expected JSON 1`] = `
 {
   "bundlePath": "/tmp/My_App-abc12345.vellumapp",
@@ -1302,49 +1349,20 @@ exports[`IPC message snapshots ServerMessage types slack_webhook_config_response
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types reminders_list serializes to expected JSON 1`] = `
-{
-  "type": "reminders_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types reminder_cancel serializes to expected JSON 1`] = `
-{
-  "id": "rem-001",
-  "type": "reminder_cancel",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types reminders_list_response serializes to expected JSON 1`] = `
-{
-  "reminders": [
-    {
-      "createdAt": 1700000000000,
-      "fireAt": 1700100000000,
-      "firedAt": null,
-      "id": "rem-001",
-      "label": "Call Sidd",
-      "message": "Remember to call Sidd about the project",
-      "mode": "notify",
-      "status": "pending",
-    },
-  ],
-  "type": "reminders_list_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_update_preview serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "preview": "base64-png-data",
-  "type": "app_update_preview",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types app_update_preview_response serializes to expected JSON 1`] = `
 {
   "appId": "app-001",
   "success": true,
   "type": "app_update_preview_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_undo_result serializes to expected JSON 1`] = `
+{
+  "remainingUndos": 3,
+  "sessionId": "sess-001",
+  "success": true,
+  "surfaceId": "surface-001",
+  "type": "ui_surface_undo_result",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -308,6 +308,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'slack_webhook_config',
     action: 'get',
   },
+  ui_surface_undo: {
+    type: 'ui_surface_undo',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -862,6 +867,13 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'app_update_preview_response',
     success: true,
     appId: 'app-001',
+  },
+  ui_surface_undo_result: {
+    type: 'ui_surface_undo_result',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
+    success: true,
+    remainingUndos: 3,
   },
 };
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -458,6 +458,14 @@ const handlers: DispatchMap = {
     }
     log.warn({ sessionId: msg.sessionId, surfaceId: msg.surfaceId }, 'No session found for surface action');
   },
+  ui_surface_undo: (msg, _socket, ctx) => {
+    const session = ctx.sessions.get(msg.sessionId);
+    if (session) {
+      session.handleSurfaceUndo(msg.surfaceId);
+      return;
+    }
+    log.warn({ sessionId: msg.sessionId, surfaceId: msg.surfaceId }, 'No session found for surface undo');
+  },
 };
 
 export function handleMessage(

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -512,6 +512,12 @@ export interface UiSurfaceAction {
   data?: Record<string, unknown>;
 }
 
+export interface UiSurfaceUndoRequest {
+  type: 'ui_surface_undo';
+  sessionId: string;
+  surfaceId: string;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -535,6 +541,7 @@ export type ClientMessage =
   | WatchObservation
   | TaskSubmit
   | UiSurfaceAction
+  | UiSurfaceUndoRequest
   | AppDataRequest
   | SkillsListRequest
   | SkillDetailRequest
@@ -1263,6 +1270,15 @@ export interface UiSurfaceDismiss {
   surfaceId: string;
 }
 
+export interface UiSurfaceUndoResult {
+  type: 'ui_surface_undo_result';
+  sessionId: string;
+  surfaceId: string;
+  success: boolean;
+  /** Number of remaining undo entries after this undo. */
+  remainingUndos: number;
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | AssistantThinkingDelta
@@ -1298,6 +1314,7 @@ export type ServerMessage =
   | UiSurfaceShow
   | UiSurfaceUpdate
   | UiSurfaceDismiss
+  | UiSurfaceUndoResult
   | AppDataResponse
   | SkillsListResponse
   | SkillDetailResponse

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -61,7 +61,7 @@ import {
 import { buildMemoryQuery } from '../memory/query-builder.js';
 import { computeRecallBudget } from '../memory/retrieval-budget.js';
 import { recordUsageEvent } from '../memory/llm-usage-store.js';
-import { getApp } from '../memory/app-store.js';
+import { getApp, updateApp } from '../memory/app-store.js';
 import { compileDynamicProfile } from '../memory/profile-compiler.js';
 import { getMemoryConflictAndCleanupStats } from '../memory/admin.js';
 import { ConflictGate } from './session-conflict-gate.js';
@@ -124,6 +124,9 @@ export class Session {
     surfaceType: SurfaceType;
   }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
+  /** Per-surface undo stack: stores previous HTML strings for workspace refinement undo. */
+  private surfaceUndoStacks = new Map<string, string[]>();
+  private static readonly MAX_UNDO_DEPTH = 10;
   private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => boolean;
   public readonly traceEmitter: TraceEmitter;
 
@@ -1725,6 +1728,9 @@ export class Session {
       const data = stored.data as DynamicPageSurfaceData;
       if (data.appId !== appId) continue;
 
+      // Push current HTML onto the undo stack before overwriting
+      this.pushUndoState(surfaceId, data.html);
+
       // Update in-memory surface state so the next refinement gets fresh HTML
       const updatedData: DynamicPageSurfaceData = { ...data, html: app.htmlDefinition };
       stored.data = updatedData;
@@ -1739,6 +1745,78 @@ export class Session {
 
       log.info({ conversationId: this.conversationId, surfaceId, appId }, 'Auto-refreshed surface after app_update');
     }
+  }
+
+  private pushUndoState(surfaceId: string, html: string): void {
+    let stack = this.surfaceUndoStacks.get(surfaceId);
+    if (!stack) {
+      stack = [];
+      this.surfaceUndoStacks.set(surfaceId, stack);
+    }
+    stack.push(html);
+    if (stack.length > Session.MAX_UNDO_DEPTH) {
+      stack.shift();
+    }
+  }
+
+  handleSurfaceUndo(surfaceId: string): void {
+    const stack = this.surfaceUndoStacks.get(surfaceId);
+    if (!stack || stack.length === 0) {
+      this.sendToClient({
+        type: 'ui_surface_undo_result',
+        sessionId: this.conversationId,
+        surfaceId,
+        success: false,
+        remainingUndos: 0,
+      });
+      return;
+    }
+
+    const previousHtml = stack.pop()!;
+    const stored = this.surfaceState.get(surfaceId);
+    if (!stored || stored.surfaceType !== 'dynamic_page') {
+      this.sendToClient({
+        type: 'ui_surface_undo_result',
+        sessionId: this.conversationId,
+        surfaceId,
+        success: false,
+        remainingUndos: stack.length,
+      });
+      return;
+    }
+
+    const data = stored.data as DynamicPageSurfaceData;
+
+    // If app-backed, also revert the persisted app
+    if (data.appId) {
+      try {
+        updateApp(data.appId, { htmlDefinition: previousHtml });
+      } catch (err) {
+        log.error({ appId: data.appId, err }, 'Failed to revert app during undo');
+      }
+    }
+
+    // Update in-memory state
+    const revertedData: DynamicPageSurfaceData = { ...data, html: previousHtml };
+    stored.data = revertedData;
+
+    // Push reverted HTML to the client
+    this.sendToClient({
+      type: 'ui_surface_update',
+      sessionId: this.conversationId,
+      surfaceId,
+      data: revertedData,
+    });
+
+    this.sendToClient({
+      type: 'ui_surface_undo_result',
+      sessionId: this.conversationId,
+      surfaceId,
+      success: true,
+      remainingUndos: stack.length,
+    });
+
+    log.info({ conversationId: this.conversationId, surfaceId, remaining: stack.length }, 'Surface undo applied');
   }
 
   private async surfaceProxyResolver(
@@ -1836,6 +1914,11 @@ export class Session {
       const stored = this.surfaceState.get(surfaceId);
       let mergedData: SurfaceData;
       if (stored) {
+        // Push current HTML to undo stack for dynamic pages
+        if (stored.surfaceType === 'dynamic_page') {
+          const currentHtml = (stored.data as DynamicPageSurfaceData).html;
+          this.pushUndoState(surfaceId, currentHtml);
+        }
         mergedData = { ...stored.data, ...patch } as SurfaceData;
         stored.data = mergedData;
       } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -587,6 +587,28 @@ struct MainWindowView: View {
 
                     Spacer()
 
+                    // Undo button — revert the last refinement on this surface
+                    if let viewModel = threadManager.activeViewModel,
+                       viewModel.surfaceUndoCount > 0 {
+                        Button(action: {
+                            viewModel.undoSurfaceRefinement()
+                        }) {
+                            Image(systemName: "arrow.uturn.backward")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(VColor.textPrimary)
+                                .frame(width: 32, height: 32)
+                                .background(
+                                    Circle()
+                                        .fill(VColor.surface.opacity(0.85))
+                                        .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Undo")
+                        .transition(.opacity)
+                        .animation(VAnimation.standard, value: viewModel.surfaceUndoCount)
+                    }
+
                     // Share button — bundle app and share via system share sheet
                     if let appId = data.appId {
                         Button(action: {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -119,6 +119,8 @@ public final class ChatViewModel: ObservableObject {
     /// after a refinement that produced no surface update.
     @Published public var refinementFailureText: String?
     private var refinementFailureDismissTask: Task<Void, Never>?
+    /// Number of undo steps available for the active workspace surface.
+    @Published public var surfaceUndoCount: Int = 0
     @Published public var pendingSkillInvocation: SkillInvocationData?
     @Published public var isWatchSessionActive: Bool = false
 
@@ -194,7 +196,9 @@ public final class ChatViewModel: ObservableObject {
 
     /// Surface the user is currently viewing in workspace mode.
     /// Set by MainWindowView when the dynamic workspace is expanded.
-    public var activeSurfaceId: String?
+    public var activeSurfaceId: String? {
+        didSet { surfaceUndoCount = 0 }
+    }
 
     public init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -1032,10 +1036,17 @@ public final class ChatViewModel: ObservableObject {
                 messages.append(newMsg)
             }
 
+        case .uiSurfaceUndoResult(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            surfaceUndoCount = msg.remainingUndos
+
         case .uiSurfaceUpdate(let msg):
             guard belongsToSession(msg.sessionId) else { return }
             if isWorkspaceRefinementInFlight {
                 refinementReceivedSurfaceUpdate = true
+            }
+            if msg.surfaceId == activeSurfaceId {
+                surfaceUndoCount += 1
             }
             // Find the inline surface across all messages and update its data
             for msgIndex in messages.indices {
@@ -1299,6 +1310,17 @@ public final class ChatViewModel: ObservableObject {
             isSending = false
             isThinking = false
             errorText = "Failed to regenerate message."
+        }
+    }
+
+    /// Revert the last refinement on the active workspace surface.
+    public func undoSurfaceRefinement() {
+        guard let sessionId, let surfaceId = activeSurfaceId else { return }
+        guard surfaceUndoCount > 0 else { return }
+        do {
+            try daemonClient.sendSurfaceUndo(sessionId: sessionId, surfaceId: surfaceId)
+        } catch {
+            log.error("Failed to send surface undo: \(error.localizedDescription)")
         }
     }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -460,6 +460,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(message)
     }
 
+    // MARK: - Surface Undo
+
+    /// Send a surface undo request to revert the last refinement on a workspace surface.
+    public func sendSurfaceUndo(sessionId: String, surfaceId: String) throws {
+        let message = UiSurfaceUndoMessage(sessionId: sessionId, surfaceId: surfaceId)
+        try send(message)
+    }
+
     // MARK: - Confirmation Response
 
     /// Send a confirmation response for a tool permission request.

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1213,6 +1213,20 @@ public struct IPCUiSurfaceShowTable: Codable, Sendable {
     public let display: String?
 }
 
+public struct IPCUiSurfaceUndo: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+}
+
+public struct IPCUiSurfaceUndoResult: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let success: Bool
+    public let remainingUndos: Int
+}
+
 public struct IPCUiSurfaceUpdate: Codable, Sendable {
     public let type: String
     public let sessionId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -273,6 +273,20 @@ extension IPCUiSurfaceAction {
     }
 }
 
+/// Sent when user requests undo on a workspace surface.
+/// Backed by generated `IPCUiSurfaceUndo`.
+public typealias UiSurfaceUndoMessage = IPCUiSurfaceUndo
+
+extension IPCUiSurfaceUndo {
+    public init(sessionId: String, surfaceId: String) {
+        self.init(type: "ui_surface_undo", sessionId: sessionId, surfaceId: surfaceId)
+    }
+}
+
+/// Result of a surface undo operation.
+/// Backed by generated `IPCUiSurfaceUndoResult`.
+public typealias UiSurfaceUndoResultMessage = IPCUiSurfaceUndoResult
+
 /// Sent when a persistent app's JS makes a data request via the RPC bridge.
 /// Backed by generated `IPCAppDataRequest`.
 public typealias AppDataRequestMessage = IPCAppDataRequest
@@ -1341,6 +1355,7 @@ public enum ServerMessage: Decodable, Sendable {
     case signBundlePayload(SignBundlePayloadMessage)
     case shareToSlackResponse(ShareToSlackResponseMessage)
     case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
+    case uiSurfaceUndoResult(UiSurfaceUndoResultMessage)
     case ipcBlobProbeResult(IpcBlobProbeResultMessage)
     case daemonStatus(DaemonStatusMessage)
     case getSigningIdentity
@@ -1509,6 +1524,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)
+        case "ui_surface_undo_result":
+            let message = try UiSurfaceUndoResultMessage(from: decoder)
+            self = .uiSurfaceUndoResult(message)
         case "ipc_blob_probe_result":
             let message = try IpcBlobProbeResultMessage(from: decoder)
             self = .ipcBlobProbeResult(message)


### PR DESCRIPTION
## Summary
- Add per-surface undo stack (up to 10 states) in the daemon session, supporting both ephemeral surfaces and persisted app-backed surfaces
- Add `ui_surface_undo` / `ui_surface_undo_result` IPC messages with full client-server round-trip
- Show an undo button in the workspace top bar when undo history is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
