### PR TITLE
chore: remove remaining pomodoro references

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -446,7 +446,7 @@ exports[`IPC message snapshots ClientMessage types gallery_list serializes to ex
 
 exports[`IPC message snapshots ClientMessage types gallery_install serializes to expected JSON 1`] = `
 {
-  "galleryAppId": "gallery-pomodoro-timer",
+  "galleryAppId": "gallery-focus-timer",
   "type": "gallery_install",
 }
 `;
@@ -1319,7 +1319,7 @@ exports[`IPC message snapshots ServerMessage types gallery_list_response seriali
 exports[`IPC message snapshots ServerMessage types gallery_install_response serializes to expected JSON 1`] = `
 {
   "appId": "app-new-001",
-  "name": "Pomodoro Timer",
+  "name": "Focus Timer",
   "success": true,
   "type": "gallery_install_response",
 }

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -289,7 +289,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   },
   gallery_install: {
     type: 'gallery_install',
-    galleryAppId: 'gallery-pomodoro-timer',
+    galleryAppId: 'gallery-focus-timer',
   },
   app_update_preview: {
     type: 'app_update_preview',
@@ -846,7 +846,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'gallery_install_response',
     success: true,
     appId: 'app-new-001',
-    name: 'Pomodoro Timer',
+    name: 'Focus Timer',
   },
   share_app_cloud_response: {
     type: 'share_app_cloud_response',

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -963,7 +963,7 @@ These are the apps you should be building — not just functional, but ones that
 - **Kanban board** — draggable cards across columns with CSS transitions on reorder, color-coded priority borders, glassmorphism column headers, card lift-and-shadow on drag, animated checkmark on task completion
 - **Habit tracker** — contribution-graph heatmap with `color-mix()` intensity scaling, streak counter with animated fire emoji, staggered card reveal on page load, mesh gradient background, progress rings for weekly goals
 - **Expense dashboard** — metric cards with sparkline trends, animated bar chart for category breakdown, gradient accent on the hero total, data table with inline status badges, skeleton shimmer while loading
-- **Pomodoro timer** — SVG circular countdown with animated progress ring, session history timeline, pulsing glow effect during focus mode, satisfying checkmark animation on completion
+- **Focus timer** — SVG circular countdown with animated progress ring, session history timeline, pulsing glow effect during focus mode, satisfying checkmark animation on completion
 - **Writing journal** — rich textarea with word count, mood-colored entry cards using palette scales, calendar heatmap for writing streaks, pullquote widget for favorite passages, dot-grid page background
 - **Flashcard app** — CSS 3D card flip with `transform: rotateY()`, spaced repetition progress bar, staggered deck reveal, success/fail color feedback, progress ring for mastery percentage
 - **Recipe book** — beautiful card grid with hover lift, ingredient scaling with live calculation, step-by-step mode with progress indicator, category-colored gradient headers

--- a/assistant/src/gallery/default-gallery.ts
+++ b/assistant/src/gallery/default-gallery.ts
@@ -1,11 +1,11 @@
 import type { GalleryManifest } from './gallery-manifest.js';
 
-const pomodoroTimerHtml = `<!DOCTYPE html>
+const focusTimerHtml = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Pomodoro Timer</title>
+<title>Focus Timer</title>
 <style>
   :root {
     --bg: #1a1a2e;
@@ -103,7 +103,7 @@ const pomodoroTimerHtml = `<!DOCTYPE html>
 </head>
 <body>
 <div class="container">
-  <h1>Pomodoro Timer</h1>
+  <h1>Focus Timer</h1>
   <div class="mode-label" id="modeLabel">Work Session</div>
   <div class="timer-display" id="timerDisplay">25:00</div>
   <div class="controls">
@@ -739,8 +739,8 @@ export const defaultGallery: GalleryManifest = {
   ],
   apps: [
     {
-      id: 'gallery-pomodoro-timer',
-      name: 'Pomodoro Timer',
+      id: 'gallery-focus-timer',
+      name: 'Focus Timer',
       description: 'A clean countdown timer with 25-minute work sessions and 5-minute breaks. Track your completed sessions and total focus time.',
       icon: '\u{1F345}',
       category: 'productivity',
@@ -751,7 +751,7 @@ export const defaultGallery: GalleryManifest = {
         properties: {},
         additionalProperties: false,
       }),
-      htmlDefinition: pomodoroTimerHtml,
+      htmlDefinition: focusTimerHtml,
     },
     {
       id: 'gallery-habit-tracker',


### PR DESCRIPTION
## Summary
- Rename the gallery app from "Pomodoro Timer" to "Focus Timer" (`gallery-focus-timer` ID, updated HTML title/heading, variable name)
- Update test fixtures (`ipc-snapshot.test.ts`) and snapshot file to use the new name
- Update app-builder skill doc (`SKILL.md`) example from "Pomodoro timer" to "Focus timer"

Zero pomodoro references remain in `assistant/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
