### PR TITLE
fix: wire policy context through requestSecret chain and redact task logs

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1451,7 +1451,7 @@ async function handleTaskSubmit(
     const interactionType = slashCandidate.kind === 'candidate'
       ? 'text_qa' as const
       : await classifyInteraction(msg.task, msg.source);
-    rlog.info({ interactionType, slashBypass: slashCandidate.kind === 'candidate', task: msg.task }, 'Task classified');
+    rlog.info({ interactionType, slashBypass: slashCandidate.kind === 'candidate', taskLength: msg.task.length }, 'Task classified');
 
     if (interactionType === 'computer_use') {
       // Create CU session (reuse handleCuSessionCreate logic)

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -228,6 +228,7 @@ export class Session {
             params.service, params.field, params.label,
             params.description, params.placeholder,
             this.conversationId,
+            params.purpose, params.allowedTools, params.allowedDomains,
           );
         },
         requestConfirmation: async (req) => {

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -47,6 +47,9 @@ export class SecretPrompter {
     description?: string,
     placeholder?: string,
     sessionId?: string,
+    purpose?: string,
+    allowedTools?: string[],
+    allowedDomains?: string[],
   ): Promise<SecretPromptResult> {
     const requestId = uuid();
 
@@ -70,6 +73,9 @@ export class SecretPrompter {
         description,
         placeholder,
         sessionId,
+        purpose,
+        allowedTools,
+        allowedDomains,
         allowOneTimeSend: config.secretDetection.allowOneTimeSend,
       };
       this.sendToClient(msg);

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -209,7 +209,12 @@ class CredentialStoreTool implements Tool {
         }
         const promptPolicy = toPolicyFromInput(promptPolicyInput);
 
-        const result = await context.requestSecret({ service, field, label, description, placeholder });
+        const result = await context.requestSecret({
+          service, field, label, description, placeholder,
+          purpose: promptPolicy.usageDescription,
+          allowedTools: promptPolicy.allowedTools.length > 0 ? promptPolicy.allowedTools : undefined,
+          allowedDomains: promptPolicy.allowedDomains.length > 0 ? promptPolicy.allowedDomains : undefined,
+        });
         if (!result.value) {
           return { content: 'User cancelled the credential prompt.', isError: false };
         }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -108,6 +108,9 @@ export interface ToolContext {
     label: string;
     description?: string;
     placeholder?: string;
+    purpose?: string;
+    allowedTools?: string[];
+    allowedDomains?: string[];
   }) => Promise<SecretPromptResult>;
 }
 


### PR DESCRIPTION
## Summary
- Extends `requestSecret` params to carry `purpose`, `allowedTools`, `allowedDomains` end-to-end from vault tool → session → SecretPrompter → IPC → Swift UI
- Vault prompt action now forwards policy context from the LLM-provided input to the secure prompt UI
- Replaces raw `msg.task` in handleTaskSubmit log line with `taskLength` to prevent secret leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
