### PR TITLE
feat: redirect to secure prompt on secret ingress block

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -504,7 +504,7 @@ async function handleUserMessage(
 
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
 
-    // Block inbound messages that contain secrets before they enter model context
+    // Block inbound messages that contain secrets and redirect to secure prompt
     const ingressCheck = checkIngressForSecrets(msg.content ?? '');
     if (ingressCheck.blocked) {
       rlog.warn({ detectedTypes: ingressCheck.detectedTypes }, 'Blocked user message containing secrets');
@@ -512,6 +512,8 @@ async function handleUserMessage(
         type: 'error',
         message: ingressCheck.userNotice!,
       });
+      // Redirect: trigger a secure prompt so the user can enter the secret safely
+      session.redirectToSecurePrompt(ingressCheck.detectedTypes);
       return;
     }
 
@@ -1435,13 +1437,22 @@ async function handleTaskSubmit(
   const rlog = log.child({ requestId });
 
   try {
-    // Block inbound tasks that contain secrets before they enter model context
+    // Block inbound tasks that contain secrets and redirect to secure prompt
     const taskIngressCheck = checkIngressForSecrets(msg.task);
     if (taskIngressCheck.blocked) {
       rlog.warn({ detectedTypes: taskIngressCheck.detectedTypes }, 'Blocked task_submit containing secrets');
       ctx.send(socket, {
         type: 'error',
         message: taskIngressCheck.userNotice!,
+      });
+      // Redirect: send a secret_request directly (no session exists yet)
+      ctx.send(socket, {
+        type: 'secret_request',
+        requestId,
+        service: 'detected',
+        field: taskIngressCheck.detectedTypes.join(','),
+        label: 'Secure Credential Entry',
+        description: 'Your message contained a secret. Please enter it here instead — it will be stored securely and never sent to the AI.',
       });
       return;
     }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -371,6 +371,19 @@ export class Session {
     return this.onEscalateToComputerUse !== undefined;
   }
 
+  /**
+   * Redirect the user to the secure credential prompt after an ingress block.
+   * The prompt result is fire-and-forget — timeout/cancel is acceptable.
+   */
+  redirectToSecurePrompt(detectedTypes: string[]): void {
+    this.secretPrompter.prompt(
+      'detected', detectedTypes.join(','),
+      'Secure Credential Entry',
+      'Your message contained a secret. Please enter it here instead — it will be stored securely and never sent to the AI.',
+      undefined, this.conversationId,
+    ).catch(() => { /* prompt timeout or cancel is fine */ });
+  }
+
   isProcessing(): boolean {
     return this.processing;
   }


### PR DESCRIPTION
## Summary
- On ingress block in `handleUserMessage`, sends a `secret_request` via `session.redirectToSecurePrompt()` so the user can re-enter the value through the SecureField UI
- On ingress block in `handleTaskSubmit`, sends a `secret_request` directly via IPC (no session exists yet at that point)
- Both paths still send the error notice first, then follow up with the redirect prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
