### PR TITLE
feat: contextual workspace composer placeholder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -15,7 +15,7 @@ struct ComposerView: View {
     let onRemoveAttachment: (String) -> Void
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
-
+    var placeholderText: String = "What would you like to do?"
     /// Bound to ChatView's state so it can compute composerReservedHeight for safe area insets.
     @Binding var editorContentHeight: CGFloat
 
@@ -138,7 +138,7 @@ struct ComposerView: View {
         ScrollView(.vertical, showsIndicators: false) {
             ZStack(alignment: .leading) {
                 TextField(
-                    ghostSuffix != nil ? "" : "What would you like to do?",
+                    ghostSuffix != nil ? "" : placeholderText,
                     text: $inputText,
                     axis: .vertical
                 )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -714,6 +714,9 @@ struct MainWindowView: View {
 
                 // Floating composer — fade is handled inside the WebView via CSS
                 if let viewModel = threadManager.activeViewModel {
+                    let placeholder = data.appId != nil
+                        ? "Describe changes to \(surface.title ?? "this app")..."
+                        : "Describe changes to this page..."
                     ComposerView(
                         inputText: Binding(
                             get: { viewModel.inputText },
@@ -731,6 +734,7 @@ struct MainWindowView: View {
                         onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
                         onPaste: { viewModel.addAttachmentFromPasteboard() },
                         onMicrophoneToggle: onMicrophoneToggle,
+                        placeholderText: placeholder,
                         editorContentHeight: $workspaceEditorContentHeight,
                         isComposerExpanded: $windowState.workspaceComposerExpanded
                     )


### PR DESCRIPTION
## Summary
- Add `placeholderText` parameter to ComposerView with default "What would you like to do?"
- In workspace mode, show "Describe changes to {appName}..." for app-backed surfaces
- Show "Describe changes to this page..." for ephemeral surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
