### PR TITLE
feat: preserve scroll position during surface updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -346,9 +346,21 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
         // Reload if the HTML content has changed.
         if data.html != context.coordinator.currentHTML {
+            let previousHTML = context.coordinator.currentHTML
             context.coordinator.currentHTML = data.html
             let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
-            webView.loadHTMLString(data.html, baseURL: URL(string: origin))
+
+            if previousHTML.isEmpty {
+                // First load — no scroll to preserve
+                webView.loadHTMLString(data.html, baseURL: URL(string: origin))
+            } else {
+                // Subsequent update — save scroll, reload, restore scroll after load
+                webView.evaluateJavaScript("JSON.stringify({x: window.scrollX, y: window.scrollY})") { result, _ in
+                    let scrollState = result as? String
+                    context.coordinator.pendingScrollRestore = scrollState
+                    webView.loadHTMLString(data.html, baseURL: URL(string: origin))
+                }
+            }
         }
 
         // Re-apply content insets and fade overlay when they change (e.g. composer expands).
@@ -390,6 +402,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var lastBottomInset: Int = 0
         var desiredTopInset: Int = 0
         var desiredBottomInset: Int = 0
+        /// JSON string with {x, y} scroll position to restore after the next page load.
+        var pendingScrollRestore: String?
         private var hasCapturedSnapshot = false
 
         init(
@@ -588,6 +602,20 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            // Restore scroll position if this load was a refinement update.
+            if let scrollJSON = pendingScrollRestore {
+                pendingScrollRestore = nil
+                let js = """
+                    (function() {
+                        try {
+                            var s = JSON.parse('\(scrollJSON.replacingOccurrences(of: "'", with: "\\'"))');
+                            window.scrollTo(s.x || 0, s.y || 0);
+                        } catch(e) {}
+                    })();
+                    """
+                webView.evaluateJavaScript(js, completionHandler: nil)
+            }
+
             // Re-inject content insets after page load completes. The WKUserScript from
             // makeNSView has creation-time values baked in, which may be stale if insets
             // changed since then (e.g. composer expanded). Apply the current desired values.


### PR DESCRIPTION
## Summary
- Save scroll position (scrollX/scrollY) before reloading HTML during refinement updates
- Restore scroll position after the page finishes loading via `webView(_:didFinish:)`
- First loads still use plain `loadHTMLString` without scroll save/restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
