### PR TITLE
feat: implement true transient one-time send via credential broker

### DIFF
--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -14,10 +14,9 @@ import { browserManager } from './browser-manager.js';
 import type { RouteHandler } from './browser-manager.js';
 import { detectCaptcha } from './captcha-detector.js';
 import { detectAuthChallenge, formatAuthChallenge } from './auth-detector.js';
-import { CredentialBroker } from '../credentials/broker.js';
+import { credentialBroker } from '../credentials/broker.js';
 
 const log = getLogger('headless-browser');
-const credentialBroker = new CredentialBroker();
 
 const NAVIGATE_TIMEOUT_MS = 30_000;
 

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -27,6 +27,18 @@ const log = getLogger('credential-broker');
  */
 export class CredentialBroker {
   private tokens = new Map<string, UsageToken>();
+  /** Transient values for one-time send: consumed on first read, never persisted. */
+  private transientValues = new Map<string, string>();
+
+  /**
+   * Inject a value for one-time use. The value is consumed on the next
+   * browserFill or consume call for this service/field pair, then discarded.
+   */
+  injectTransient(service: string, field: string, value: string): void {
+    const key = `credential:${service}:${field}`;
+    this.transientValues.set(key, value);
+    log.info({ service, field }, 'Transient credential injected for one-time use');
+  }
 
   /**
    * Authorize the use of a credential for a specific tool and optional domain.
@@ -85,7 +97,14 @@ export class CredentialBroker {
 
     token.consumed = true;
     const storageKey = `credential:${token.service}:${token.field}`;
-    log.info({ tokenId, storageKey }, 'Usage token consumed');
+    // Check for transient value first (one-time send) — consume and discard
+    const transient = this.transientValues.get(storageKey);
+    if (transient !== undefined) {
+      this.transientValues.delete(storageKey);
+      log.info({ tokenId, storageKey, transient: true }, 'Usage token consumed (transient)');
+    } else {
+      log.info({ tokenId, storageKey }, 'Usage token consumed');
+    }
 
     return { success: true, storageKey };
   }
@@ -157,7 +176,13 @@ export class CredentialBroker {
       }
     }
 
-    const value = getSecureKey(`credential:${request.service}:${request.field}`);
+    const storageKey = `credential:${request.service}:${request.field}`;
+    // Check transient values first (one-time send), then fall back to keychain
+    const transient = this.transientValues.get(storageKey);
+    const value = transient ?? getSecureKey(storageKey);
+    if (transient !== undefined) {
+      this.transientValues.delete(storageKey);
+    }
     if (!value) {
       return {
         success: false,
@@ -193,3 +218,6 @@ export class CredentialBroker {
     return count;
   }
 }
+
+/** Shared singleton broker instance used by vault and browser tools. */
+export const credentialBroker = new CredentialBroker();

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -11,6 +11,7 @@ import {
 import { upsertCredentialMetadata, deleteCredentialMetadata } from './metadata-store.js';
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput } from './policy-types.js';
+import { credentialBroker } from './broker.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 
@@ -229,10 +230,21 @@ class CredentialStoreTool implements Tool {
               isError: true,
             };
           }
-          // SECURITY: value is used for the immediate action only, never stored or logged
+          // Inject into broker for one-time use by the next tool call, then discard
+          credentialBroker.injectTransient(service, field, result.value);
+          // Also upsert metadata so broker policy checks can find the credential
+          try {
+            upsertCredentialMetadata(service, field, {
+              allowedTools: promptPolicy.allowedTools,
+              allowedDomains: promptPolicy.allowedDomains,
+              usageDescription: promptPolicy.usageDescription,
+            });
+          } catch (err) {
+            log.warn({ service, field, err }, 'metadata write failed for transient credential');
+          }
           log.info({ service, field, delivery: 'transient_send' }, 'One-time secret delivery used');
           return {
-            content: `One-time credential provided for ${service}/${field}. The value was NOT saved to the vault.`,
+            content: `One-time credential provided for ${service}/${field}. The value was NOT saved to the vault and will be consumed by the next operation.`,
             isError: false,
           };
         }


### PR DESCRIPTION
## Summary
- Wire `transient_send` delivery through the shared `CredentialBroker` singleton so one-time credentials are actually consumed by the next tool call
- Add `transientValues` map with `injectTransient()` to broker; update `consume()` and `browserFill()` to check transient values before keychain
- Export shared singleton from `broker.ts` and use it in `headless-browser.ts` (instead of creating a separate instance)
- Vault upserts metadata for transient credentials so broker policy checks work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
