### PR TITLE
fix: bound workspace context size and clarify pages replacement semantics

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -74,19 +74,25 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
     if (pageNames.length > 0) {
       lines.push(`- Additional pages: ${pageNames.join(', ')}`);
       lines.push('  To modify additional pages, include the `pages` parameter in `app_update`.');
-      lines.push('  To add a new page, include it in `pages` with its HTML content.');
+      lines.push('  IMPORTANT: The `pages` parameter is a full replacement — always include ALL');
+      lines.push('  existing pages (with their current content) alongside any modified or new pages.');
     } else {
       lines.push('- Additional pages: none');
     }
     const schema = ctx.appSchemaJson;
+    const MAX_SCHEMA_LENGTH = 10_000;
     if (schema && schema !== '"{}"' && schema !== '{}') {
-      lines.push(`- Data schema: ${schema}`);
+      const truncatedSchema = schema.length > MAX_SCHEMA_LENGTH
+        ? schema.slice(0, MAX_SCHEMA_LENGTH) + '… (truncated)'
+        : schema;
+      lines.push(`- Data schema: ${truncatedSchema}`);
     } else {
       lines.push('- Data schema: none (display-only)');
     }
 
-    // Main page HTML — reserve budget for additional pages
-    let mainBudget = MAX_CONTEXT_LENGTH;
+    // Main page HTML — reserve budget for additional pages (and schema)
+    const schemaSize = schema ? Math.min(schema.length, MAX_SCHEMA_LENGTH) : 0;
+    let mainBudget = MAX_CONTEXT_LENGTH - schemaSize;
     const additionalPageBlocks: string[] = [];
 
     if (ctx.appPages && pageNames.length > 0) {


### PR DESCRIPTION
## Summary
Addresses review feedback from #2776:

- **Pages replacement semantics**: Updated workspace prompt to instruct the model that the `pages` parameter is a full replacement — all existing pages must be included alongside changes. Prevents silent data loss when a refinement sends only one changed page.
- **Schema size cap**: Added truncation for `appSchemaJson` (max 10k chars) to prevent unbounded prompt inflation. Schema size now reduces the available budget for HTML content.

## Test plan
- [ ] Verify workspace refinement prompt includes the pages replacement warning
- [ ] Verify large schemas get truncated in the injected context
- [ ] Confirm type-check passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
