### PR TITLE
feat: reusable migration move helper

### DIFF
--- a/assistant/src/__tests__/platform-move-helper.test.ts
+++ b/assistant/src/__tests__/platform-move-helper.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+import { migratePath } from '../util/platform.js';
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `move-helper-test-${randomBytes(4).toString('hex')}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('migratePath', () => {
+  test('no-op when source does not exist', () => {
+    const tmp = makeTmpDir();
+    const src = join(tmp, 'missing');
+    const dst = join(tmp, 'dest');
+
+    migratePath(src, dst);
+
+    expect(existsSync(dst)).toBe(false);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('moves source file to destination', () => {
+    const tmp = makeTmpDir();
+    const src = join(tmp, 'source.txt');
+    const dst = join(tmp, 'dest.txt');
+    writeFileSync(src, 'hello');
+
+    migratePath(src, dst);
+
+    expect(existsSync(src)).toBe(false);
+    expect(existsSync(dst)).toBe(true);
+    expect(readFileSync(dst, 'utf-8')).toBe('hello');
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('moves source directory to destination', () => {
+    const tmp = makeTmpDir();
+    const src = join(tmp, 'srcdir');
+    mkdirSync(src);
+    writeFileSync(join(src, 'file.txt'), 'content');
+    const dst = join(tmp, 'dstdir');
+
+    migratePath(src, dst);
+
+    expect(existsSync(src)).toBe(false);
+    expect(existsSync(join(dst, 'file.txt'))).toBe(true);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('no-op when destination already exists', () => {
+    const tmp = makeTmpDir();
+    const src = join(tmp, 'source.txt');
+    const dst = join(tmp, 'dest.txt');
+    writeFileSync(src, 'source-content');
+    writeFileSync(dst, 'existing-content');
+
+    migratePath(src, dst);
+
+    // Source should remain untouched
+    expect(existsSync(src)).toBe(true);
+    expect(readFileSync(src, 'utf-8')).toBe('source-content');
+    // Destination should keep its original content
+    expect(readFileSync(dst, 'utf-8')).toBe('existing-content');
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('creates destination parent directories', () => {
+    const tmp = makeTmpDir();
+    const src = join(tmp, 'source.txt');
+    const dst = join(tmp, 'nested', 'deep', 'dest.txt');
+    writeFileSync(src, 'hello');
+
+    migratePath(src, dst);
+
+    expect(existsSync(dst)).toBe(true);
+    expect(readFileSync(dst, 'utf-8')).toBe('hello');
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('idempotent: second call is no-op after successful move', () => {
+    const tmp = makeTmpDir();
+    const src = join(tmp, 'source.txt');
+    const dst = join(tmp, 'dest.txt');
+    writeFileSync(src, 'hello');
+
+    migratePath(src, dst);
+    // Source is gone, so second call is a no-op
+    migratePath(src, dst);
+
+    expect(existsSync(src)).toBe(false);
+    expect(readFileSync(dst, 'utf-8')).toBe('hello');
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -159,6 +159,36 @@ export function getWorkspacePromptPath(file: string): string {
   return join(getWorkspaceDir(), file);
 }
 
+/**
+ * Idempotent move: relocates source to destination for migration.
+ * - No-op if source is missing (already migrated or never existed).
+ * - No-op if destination already exists (avoids clobbering).
+ * - Creates destination parent directories as needed.
+ * - Logs warning on failure instead of throwing.
+ *
+ * Exported for testing; not intended for general use outside migrations.
+ */
+export function migratePath(source: string, destination: string): void {
+  if (!existsSync(source)) return;
+  if (existsSync(destination)) {
+    log.warn(
+      { source, destination },
+      'Migration skipped: destination already exists',
+    );
+    return;
+  }
+  const destDir = dirname(destination);
+  if (!existsSync(destDir)) {
+    mkdirSync(destDir, { recursive: true });
+  }
+  try {
+    renameSync(source, destination);
+    log.info({ from: source, to: destination }, 'Migrated path');
+  } catch (err) {
+    log.warn({ err, from: source, to: destination }, 'Failed to migrate path');
+  }
+}
+
 export function ensureDataDir(): void {
   const root = getRootDir();
   const data = getDataDir();


### PR DESCRIPTION
## Summary
- Extracts idempotent `migratePath()` helper from inline `migrateItem` (PR 3 of workspace migration plan)
- Handles: missing source (no-op), existing destination (no-op + warn), parent dir creation, rename failure logging
- 6 test cases covering all edge cases

## Test plan
- [x] `bun test src/__tests__/platform-move-helper.test.ts` — 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
