### PR TITLE
docs: reconcile credential storage docs with implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1619,7 +1619,7 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 | Component | Location | What it stores |
 |-----------|----------|----------------|
 | Secret values | macOS Keychain | Encrypted credential values keyed as `credential:{service}:{field}` |
-| Credential metadata | `~/.vellum/data/db/assistant.db` | Service, field, label, policy (allowedTools, allowedDomains), timestamps |
+| Credential metadata | `~/.vellum/data/credentials/metadata.json` | Service, field, label, policy (allowedTools, allowedDomains), timestamps |
 | Config | `~/.vellum/config.*` | `secretDetection` settings: enabled, action, entropyThreshold, allowOneTimeSend |
 
 ### Key Files
@@ -1628,7 +1628,8 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 |------|------|
 | `assistant/src/tools/credentials/vault.ts` | `credential_store` tool — store, list, delete, prompt actions |
 | `assistant/src/security/secure-keys.ts` | Keychain read/write via `/usr/bin/security` CLI |
-| `assistant/src/tools/credentials/metadata-store.ts` | SQLite metadata CRUD for credential records |
+| `assistant/src/tools/credentials/metadata-store.ts` | JSON file metadata CRUD for credential records |
+| `assistant/src/tools/credentials/broker.ts` | Brokered credential access with policy enforcement and transient send |
 | `assistant/src/tools/credentials/policy-validate.ts` | Policy input validation (allowedTools, allowedDomains) |
 | `assistant/src/permissions/secret-prompter.ts` | IPC secret_request/secret_response flow |
 | `assistant/src/security/secret-scanner.ts` | Regex + entropy-based secret detection |
@@ -1643,7 +1644,7 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 |------|-------|--------|-----------|-----------|
 | API key | macOS Keychain | Encrypted binary | `/usr/bin/security` CLI | Permanent |
 | Credential secrets | macOS Keychain | Encrypted binary | `secure-keys.ts` wrapper | Permanent (until deleted via tool) |
-| Credential metadata | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent (until deleted via tool) |
+| Credential metadata | `~/.vellum/data/credentials/metadata.json` | JSON | Atomic file write | Permanent (until deleted via tool) |
 | User preferences | UserDefaults | plist | Foundation | Permanent |
 | Ambient observations | `~/Library/.../knowledge.json` | JSON array | Swift Codable | Max 500 entries, FIFO |
 | Ambient insights | `~/Library/.../insights.json` | JSON array | Swift Codable | Max 50 entries, FIFO |

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Run `vellum doctor` for a full diagnostic check including sandbox backend status
 
 The assistant can store and use credentials (API keys, tokens, passwords) without exposing secret values to the LLM or logs.
 
-- **Storage**: Secret values are stored in the macOS Keychain via `secure-keys.ts`. Metadata (service, field, label, usage policy) is stored in SQLite.
+- **Storage**: Secret values are stored in the macOS Keychain via `secure-keys.ts`. Metadata (service, field, label, usage policy) is stored in a JSON file at `~/.vellum/data/credentials/metadata.json`.
 - **Secret prompt**: When a credential is needed, a floating `SecretPromptView` panel appears. The user enters the value in a `SecureField` — the LLM never sees it.
 - **Ingress blocking**: Inbound user messages are scanned for secrets (regex + entropy). If `secretDetection.action` is `block` (the default), messages containing secrets are rejected with a notice to use the secure prompt instead.
 - **Usage policy**: Each credential can specify `allowedTools` and `allowedDomains`. The `CredentialBroker` enforces these policies at use time.

--- a/docs/security/credential-storage.md
+++ b/docs/security/credential-storage.md
@@ -39,7 +39,7 @@ The `CredentialBroker` enforces these policies at use time. Requests outside the
 | Component | Location | Contents |
 |-----------|----------|----------|
 | Secret values | macOS Keychain | Encrypted values keyed as `credential:{service}:{field}` |
-| Credential metadata | SQLite (`~/.vellum/data/db/assistant.db`) | Service, field, label, usage policy, timestamps |
+| Credential metadata | JSON file (`~/.vellum/data/credentials/metadata.json`) | Service, field, label, usage policy, timestamps |
 | Config | `~/.vellum/config.*` | `secretDetection` settings |
 
 This split means the daemon process can enumerate credentials and check policies without ever loading plaintext secrets into memory. Secrets are fetched from the Keychain only at the point of use, by the broker.
@@ -51,7 +51,7 @@ This split means the daemon process can enumerate credentials and check policies
 3. The macOS client shows a floating `SecretPromptView` panel with a `SecureField`.
 4. The user enters the value and clicks "Save" (or "Send Once" if enabled).
 5. The client sends `secret_response` back via IPC.
-6. The vault tool stores the value in the Keychain (for "store" delivery) or forwards it for immediate use (for "transient_send" delivery).
+6. The vault tool stores the value in the Keychain (for "store" delivery) or injects it into the `CredentialBroker` for immediate one-time use (for "transient_send" delivery). The broker holds the value in memory and discards it after the next `consume` or `browserFill` call.
 7. The tool returns a metadata-only confirmation to the model.
 
 ### Secret ingress blocking
@@ -102,7 +102,11 @@ All credential security settings live under `secretDetection` in the assistant c
 |------|------|
 | `assistant/src/tools/credentials/vault.ts` | `credential_store` tool implementation |
 | `assistant/src/security/secure-keys.ts` | Keychain read/write wrapper |
-| `assistant/src/tools/credentials/metadata-store.ts` | SQLite metadata CRUD |
+| `assistant/src/tools/credentials/metadata-store.ts` | JSON file metadata CRUD |
+| `assistant/src/tools/credentials/broker.ts` | Brokered credential access with policy enforcement |
+| `assistant/src/tools/credentials/tool-policy.ts` | Tool allowlist matching |
+| `assistant/src/tools/credentials/domain-policy.ts` | Registrable-domain matching |
+| `assistant/src/security/redaction.ts` | Recursive field-level redaction for sensitive keys |
 | `assistant/src/tools/credentials/policy-validate.ts` | Policy input validation |
 | `assistant/src/tools/credentials/policy-types.ts` | Policy type definitions |
 | `assistant/src/permissions/secret-prompter.ts` | IPC secret request/response flow |


### PR DESCRIPTION
## Summary
- Fix metadata storage location across 3 files: JSON file at `~/.vellum/data/credentials/metadata.json`, not SQLite
- Clarify one-time send (`transient_send`) flow: vault injects value into `CredentialBroker` for immediate consumption, then discards
- Add missing key files to tables: `broker.ts`, `tool-policy.ts`, `domain-policy.ts`, `redaction.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
