### PR TITLE
feat: implement migrateToWorkspaceLayout()

### DIFF
--- a/assistant/src/__tests__/platform-workspace-migration.test.ts
+++ b/assistant/src/__tests__/platform-workspace-migration.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+import { migrateToWorkspaceLayout } from '../util/platform.js';
+
+const originalBaseDataDir = process.env.BASE_DATA_DIR;
+
+function makeTmpBase(): string {
+  const base = join(
+    tmpdir(),
+    `ws-migration-test-${randomBytes(4).toString('hex')}`,
+  );
+  mkdirSync(base, { recursive: true });
+  return base;
+}
+
+afterEach(() => {
+  if (originalBaseDataDir == null) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = originalBaseDataDir;
+  }
+});
+
+/**
+ * Populate a fake ~/.vellum directory with all legacy items that the
+ * migration is expected to relocate.
+ */
+function populateLegacyLayout(root: string): void {
+  mkdirSync(root, { recursive: true });
+
+  // data dir with sandbox/fs content
+  const dataDir = join(root, 'data');
+  mkdirSync(join(dataDir, 'sandbox', 'fs', 'project'), { recursive: true });
+  writeFileSync(join(dataDir, 'sandbox', 'fs', 'hello.txt'), 'sandbox-file');
+  writeFileSync(
+    join(dataDir, 'sandbox', 'fs', 'project', 'main.ts'),
+    'project-code',
+  );
+  mkdirSync(join(dataDir, 'db'), { recursive: true });
+  writeFileSync(join(dataDir, 'db', 'assistant.db'), 'db-content');
+  mkdirSync(join(dataDir, 'logs'), { recursive: true });
+  writeFileSync(join(dataDir, 'logs', 'vellum.log'), 'log-content');
+
+  // config.json
+  writeFileSync(join(root, 'config.json'), '{"theme":"dark"}');
+
+  // hooks
+  mkdirSync(join(root, 'hooks'), { recursive: true });
+  writeFileSync(join(root, 'hooks', 'on-start.sh'), '#!/bin/bash');
+
+  // prompt files
+  writeFileSync(join(root, 'IDENTITY.md'), '# Identity');
+  writeFileSync(join(root, 'SOUL.md'), '# Soul');
+  writeFileSync(join(root, 'USER.md'), '# User');
+
+  // skills
+  mkdirSync(join(root, 'skills'), { recursive: true });
+  writeFileSync(join(root, 'skills', 'search.json'), '{}');
+
+  // runtime files that should NOT move
+  writeFileSync(join(root, 'vellum.sock'), 'socket-placeholder');
+  writeFileSync(join(root, 'vellum.pid'), '12345');
+}
+
+describe('migrateToWorkspaceLayout', () => {
+  test('full legacy migration moves all items into workspace/', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    populateLegacyLayout(root);
+
+    migrateToWorkspaceLayout();
+
+    // (a) sandbox/fs content was extracted to become workspace root
+    expect(existsSync(ws)).toBe(true);
+    expect(readFileSync(join(ws, 'hello.txt'), 'utf-8')).toBe('sandbox-file');
+    expect(readFileSync(join(ws, 'project', 'main.ts'), 'utf-8')).toBe(
+      'project-code',
+    );
+    // Original sandbox/fs should be gone (renamed)
+    expect(existsSync(join(root, 'data', 'sandbox', 'fs'))).toBe(false);
+
+    // (b) config.json moved
+    expect(existsSync(join(root, 'config.json'))).toBe(false);
+    expect(readFileSync(join(ws, 'config.json'), 'utf-8')).toBe(
+      '{"theme":"dark"}',
+    );
+
+    // (c) data dir moved
+    expect(existsSync(join(root, 'data'))).toBe(false);
+    expect(
+      readFileSync(join(ws, 'data', 'db', 'assistant.db'), 'utf-8'),
+    ).toBe('db-content');
+    expect(
+      readFileSync(join(ws, 'data', 'logs', 'vellum.log'), 'utf-8'),
+    ).toBe('log-content');
+
+    // (d) hooks moved
+    expect(existsSync(join(root, 'hooks'))).toBe(false);
+    expect(readFileSync(join(ws, 'hooks', 'on-start.sh'), 'utf-8')).toBe(
+      '#!/bin/bash',
+    );
+
+    // (e) IDENTITY.md moved
+    expect(existsSync(join(root, 'IDENTITY.md'))).toBe(false);
+    expect(readFileSync(join(ws, 'IDENTITY.md'), 'utf-8')).toBe('# Identity');
+
+    // (f) skills moved
+    expect(existsSync(join(root, 'skills'))).toBe(false);
+    expect(readFileSync(join(ws, 'skills', 'search.json'), 'utf-8')).toBe(
+      '{}',
+    );
+
+    // (g) SOUL.md moved
+    expect(existsSync(join(root, 'SOUL.md'))).toBe(false);
+    expect(readFileSync(join(ws, 'SOUL.md'), 'utf-8')).toBe('# Soul');
+
+    // (h) USER.md moved
+    expect(existsSync(join(root, 'USER.md'))).toBe(false);
+    expect(readFileSync(join(ws, 'USER.md'), 'utf-8')).toBe('# User');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('idempotent: second run is a no-op', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    populateLegacyLayout(root);
+
+    // First run
+    migrateToWorkspaceLayout();
+
+    // Snapshot workspace state after first run
+    const configAfterFirst = readFileSync(join(ws, 'config.json'), 'utf-8');
+    const identityAfterFirst = readFileSync(join(ws, 'IDENTITY.md'), 'utf-8');
+
+    // Second run — should not throw and should not change anything
+    migrateToWorkspaceLayout();
+
+    expect(readFileSync(join(ws, 'config.json'), 'utf-8')).toBe(
+      configAfterFirst,
+    );
+    expect(readFileSync(join(ws, 'IDENTITY.md'), 'utf-8')).toBe(
+      identityAfterFirst,
+    );
+    expect(existsSync(join(ws, 'data', 'db', 'assistant.db'))).toBe(true);
+    expect(existsSync(join(ws, 'hooks', 'on-start.sh'))).toBe(true);
+    expect(existsSync(join(ws, 'skills', 'search.json'))).toBe(true);
+    expect(readFileSync(join(ws, 'SOUL.md'), 'utf-8')).toBe('# Soul');
+    expect(readFileSync(join(ws, 'USER.md'), 'utf-8')).toBe('# User');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('destination conflict leaves source intact', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    // Create workspace dir with conflicting content already in place
+    mkdirSync(ws, { recursive: true });
+    writeFileSync(join(ws, 'config.json'), 'existing-config');
+    writeFileSync(join(ws, 'IDENTITY.md'), 'existing-identity');
+
+    // Create legacy items that should NOT overwrite existing workspace items
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'config.json'), 'legacy-config');
+    writeFileSync(join(root, 'IDENTITY.md'), 'legacy-identity');
+
+    migrateToWorkspaceLayout();
+
+    // Workspace content should be unchanged (not overwritten)
+    expect(readFileSync(join(ws, 'config.json'), 'utf-8')).toBe(
+      'existing-config',
+    );
+    expect(readFileSync(join(ws, 'IDENTITY.md'), 'utf-8')).toBe(
+      'existing-identity',
+    );
+
+    // Source files should still exist (not moved because destination existed)
+    expect(existsSync(join(root, 'config.json'))).toBe(true);
+    expect(readFileSync(join(root, 'config.json'), 'utf-8')).toBe(
+      'legacy-config',
+    );
+    expect(existsSync(join(root, 'IDENTITY.md'))).toBe(true);
+    expect(readFileSync(join(root, 'IDENTITY.md'), 'utf-8')).toBe(
+      'legacy-identity',
+    );
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('root runtime files (vellum.sock, vellum.pid) are unaffected', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+
+    populateLegacyLayout(root);
+
+    migrateToWorkspaceLayout();
+
+    // Runtime files should remain at root level
+    expect(existsSync(join(root, 'vellum.sock'))).toBe(true);
+    expect(readFileSync(join(root, 'vellum.sock'), 'utf-8')).toBe(
+      'socket-placeholder',
+    );
+    expect(existsSync(join(root, 'vellum.pid'))).toBe(true);
+    expect(readFileSync(join(root, 'vellum.pid'), 'utf-8')).toBe('12345');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+});

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -189,6 +189,46 @@ export function migratePath(source: string, destination: string): void {
   }
 }
 
+/**
+ * Migrate from the flat ~/.vellum layout to the workspace-based layout.
+ *
+ * Step (a) is special: if the workspace dir doesn't exist yet but the old
+ * sandbox working dir (data/sandbox/fs) does, its contents are "extracted"
+ * to become the new workspace root via rename. All subsequent moves then
+ * land inside that workspace directory.
+ *
+ * Idempotent: safe to call on every startup — already-migrated items are
+ * skipped, and a second run is a no-op.
+ */
+export function migrateToWorkspaceLayout(): void {
+  const root = getRootDir();
+  if (!existsSync(root)) return;
+
+  const ws = getWorkspaceDir();
+
+  // (a) Extract data/sandbox/fs -> workspace (only when workspace doesn't exist yet)
+  if (!existsSync(ws)) {
+    const sandboxFs = join(root, 'data', 'sandbox', 'fs');
+    if (existsSync(sandboxFs)) {
+      try {
+        renameSync(sandboxFs, ws);
+        log.info({ from: sandboxFs, to: ws }, 'Extracted sandbox/fs as workspace root');
+      } catch (err) {
+        log.warn({ err, from: sandboxFs, to: ws }, 'Failed to extract sandbox/fs');
+      }
+    }
+  }
+
+  // (b)-(h) Move legacy root-level items into workspace
+  migratePath(join(root, 'config.json'), join(ws, 'config.json'));
+  migratePath(join(root, 'data'), join(ws, 'data'));
+  migratePath(join(root, 'hooks'), join(ws, 'hooks'));
+  migratePath(join(root, 'IDENTITY.md'), join(ws, 'IDENTITY.md'));
+  migratePath(join(root, 'skills'), join(ws, 'skills'));
+  migratePath(join(root, 'SOUL.md'), join(ws, 'SOUL.md'));
+  migratePath(join(root, 'USER.md'), join(ws, 'USER.md'));
+}
+
 export function ensureDataDir(): void {
   const root = getRootDir();
   const data = getDataDir();


### PR DESCRIPTION
## Summary
- Implements complete `migrateToWorkspaceLayout()` function (PR 4 of workspace migration plan)
- Extracts `data/sandbox/fs` as workspace root, then moves config, data, hooks, prompt files, and skills
- Deterministic migration order, idempotent, conflict-safe (leaves source in place if destination exists)
- Not yet wired into startup — that's PR 5

## Test plan
- [x] `bun test src/__tests__/platform-workspace-migration.test.ts` — 4 tests, 36 assertions pass
  - Full legacy migration
  - Idempotent second run
  - Destination conflict handling
  - Root runtime files unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
