### PR TITLE
feat: wire workspace migration into startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -9,6 +9,7 @@ import {
   getPidPath,
   ensureDataDir,
   migrateToDataLayout,
+  migrateToWorkspaceLayout,
   removeSocketFile,
 } from '../util/platform.js';
 import { initializeDb } from '../memory/db.js';
@@ -175,7 +176,11 @@ export async function ensureDaemonRunning(): Promise<void> {
 
 // Entry point for the daemon process itself
 export async function runDaemon(): Promise<void> {
+  // Migration order matters: first move legacy flat files into the data dir
+  // structure, then relocate the data dir into the active workspace, and
+  // finally create any directories that don't yet exist.
   migrateToDataLayout();
+  migrateToWorkspaceLayout();
   ensureDataDir();
 
   const seedDir = process.env.INTERFACES_SEED_DIR?.trim();


### PR DESCRIPTION
## Summary
- Calls `migrateToWorkspaceLayout()` during daemon startup (PR 5 of workspace migration plan)
- Migration order: `migrateToDataLayout()` → `migrateToWorkspaceLayout()` → `ensureDataDir()`
- Single line change in `lifecycle.ts`

## Test plan
- [x] `bun test src/__tests__/platform-workspace-migration.test.ts` — 4 tests pass
- [x] `bun test src/__tests__/daemon-server-session-init.test.ts` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
