### PR TITLE
feat: update ensureDataDir() to create workspace tree

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -70,6 +70,8 @@ describe('baseline path characterization (pre-migration)', () => {
     const base = join(tmpdir(), `platform-test-${randomBytes(4).toString('hex')}`);
     process.env.BASE_DATA_DIR = base;
     const rootDir = getRootDir();
+    const ws = getWorkspaceDir();
+    const wsData = join(ws, 'data');
 
     if (existsSync(rootDir)) {
       rmSync(rootDir, { recursive: true, force: true });
@@ -77,23 +79,30 @@ describe('baseline path characterization (pre-migration)', () => {
 
     ensureDataDir();
 
-    // Root-level dirs
+    // Root-level dirs (runtime / protected)
     expect(existsSync(getRootDir())).toBe(true);
-    expect(existsSync(join(getRootDir(), 'skills'))).toBe(true);
-    expect(existsSync(join(getRootDir(), 'hooks'))).toBe(true);
     expect(existsSync(join(getRootDir(), 'protected'))).toBe(true);
 
-    // Data sub-dirs
-    expect(existsSync(getDataDir())).toBe(true);
-    expect(existsSync(join(getDataDir(), 'db'))).toBe(true);
-    expect(existsSync(join(getDataDir(), 'qdrant'))).toBe(true);
-    expect(existsSync(join(getDataDir(), 'logs'))).toBe(true);
-    expect(existsSync(join(getDataDir(), 'memory'))).toBe(true);
-    expect(existsSync(join(getDataDir(), 'memory', 'knowledge'))).toBe(true);
-    expect(existsSync(join(getDataDir(), 'apps'))).toBe(true);
-    expect(existsSync(getSandboxRootDir())).toBe(true);
-    expect(existsSync(getSandboxWorkingDir())).toBe(true);
-    expect(existsSync(getInterfacesDir())).toBe(true);
+    // Workspace dirs
+    expect(existsSync(ws)).toBe(true);
+    expect(existsSync(join(ws, 'hooks'))).toBe(true);
+    expect(existsSync(join(ws, 'skills'))).toBe(true);
+
+    // Data sub-dirs under workspace
+    expect(existsSync(wsData)).toBe(true);
+    expect(existsSync(join(wsData, 'db'))).toBe(true);
+    expect(existsSync(join(wsData, 'qdrant'))).toBe(true);
+    expect(existsSync(join(wsData, 'logs'))).toBe(true);
+    expect(existsSync(join(wsData, 'memory'))).toBe(true);
+    expect(existsSync(join(wsData, 'memory', 'knowledge'))).toBe(true);
+    expect(existsSync(join(wsData, 'apps'))).toBe(true);
+    expect(existsSync(join(wsData, 'interfaces'))).toBe(true);
+
+    // Legacy dirs should NOT be created
+    expect(existsSync(join(getRootDir(), 'skills'))).toBe(false);
+    expect(existsSync(join(getRootDir(), 'hooks'))).toBe(false);
+    expect(existsSync(join(getRootDir(), 'data', 'sandbox'))).toBe(false);
+    expect(existsSync(join(getRootDir(), 'data', 'sandbox', 'fs'))).toBe(false);
 
     rmSync(rootDir, { recursive: true, force: true });
   });

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -231,22 +231,25 @@ export function migrateToWorkspaceLayout(): void {
 
 export function ensureDataDir(): void {
   const root = getRootDir();
-  const data = getDataDir();
+  const workspace = getWorkspaceDir();
+  const wsData = join(workspace, 'data');
   const dirs = [
+    // Root-level dirs (runtime / protected)
     root,
-    join(root, 'skills'),
-    join(root, 'hooks'),
     join(root, 'protected'),
-    data,
-    join(data, 'db'),
-    join(data, 'qdrant'),
-    join(data, 'logs'),
-    join(data, 'memory'),
-    join(data, 'memory', 'knowledge'),
-    join(data, 'apps'),
-    join(data, 'sandbox'),
-    join(data, 'sandbox', 'fs'),
-    join(data, 'interfaces'),
+    // Workspace dirs
+    workspace,
+    join(workspace, 'hooks'),
+    join(workspace, 'skills'),
+    // Data sub-dirs under workspace
+    wsData,
+    join(wsData, 'db'),
+    join(wsData, 'qdrant'),
+    join(wsData, 'logs'),
+    join(wsData, 'memory'),
+    join(wsData, 'memory', 'knowledge'),
+    join(wsData, 'apps'),
+    join(wsData, 'interfaces'),
   ];
   for (const dir of dirs) {
     if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary
- Updates `ensureDataDir()` to create post-migration workspace directory structure (PR 6 of workspace migration plan)
- Creates `workspace/`, `workspace/data/*`, `workspace/hooks`, `workspace/skills`
- Removes legacy `root/skills`, `root/hooks`, `data/sandbox`, `data/sandbox/fs`

## Test plan
- [x] `bun test src/__tests__/platform.test.ts` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
