### PR TITLE
feat: cut over getDataDir() to workspace/data

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -42,15 +42,15 @@ describe('baseline path characterization (pre-migration)', () => {
     const base = join(tmpdir(), `platform-test-${randomBytes(4).toString('hex')}`);
     process.env.BASE_DATA_DIR = base;
     const root = join(base, '.vellum');
-    const data = join(root, 'data');
+    const data = join(root, 'workspace', 'data');
 
     // Root dir — stays as anchor for all paths
     expect(getRootDir()).toBe(root);
 
-    // WILL MOVE to ~/.vellum/workspace/data
-    expect(getDataDir()).toBe(join(root, 'data'));
+    // Now resolves under workspace/data
+    expect(getDataDir()).toBe(join(root, 'workspace', 'data'));
 
-    // WILL MOVE (under workspace/data)
+    // Sub-paths under workspace/data
     expect(getDbPath()).toBe(join(data, 'db', 'assistant.db'));
     expect(getLogPath()).toBe(join(data, 'logs', 'vellum.log'));
     expect(getHistoryPath()).toBe(join(data, 'history'));

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -45,11 +45,11 @@ export function getRootDir(): string {
 }
 
 /**
- * Returns the internal data directory (~/.vellum/data). Runtime databases,
- * logs, memory indices, and other internal state live here.
+ * Returns the internal data directory (~/.vellum/workspace/data). Runtime
+ * databases, logs, memory indices, and other internal state live here.
  */
 export function getDataDir(): string {
-  return join(getRootDir(), 'data');
+  return join(getWorkspaceDir(), 'data');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Changes `getDataDir()` to `join(getWorkspaceDir(), 'data')` (PR 7 of workspace migration plan)
- All sub-paths (db, logs, ipc-blobs, interfaces, etc.) follow automatically
- Single-line implementation change with test updates

## Test plan
- [x] `bun test src/__tests__/platform.test.ts` — passes
- [x] `bun test src/__tests__/config-schema.test.ts` — passes (uses mock, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
