### PR TITLE
feat: WebView page tracking for multi-page app context

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -523,7 +523,7 @@ async function handleUserMessage(
       attributes: { source: 'user_message' },
     });
 
-    const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId);
+    const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId, msg.currentPage);
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
       session.traceEmitter.emit('request_error', 'Message rejected — queue is full', {
@@ -560,7 +560,7 @@ async function handleUserMessage(
     // Fire-and-forget: don't block the IPC handler so the connection can
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).
-    session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId).catch((err) => {
+    session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId, msg.currentPage).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
       ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -24,6 +24,8 @@ export interface UserMessage {
   content?: string;
   attachments?: UserMessageAttachment[];
   activeSurfaceId?: string;
+  /** The page currently displayed in the WebView (e.g. "settings.html"). */
+  currentPage?: string;
 }
 
 export interface UserMessageAttachment {

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -13,6 +13,7 @@ export interface QueuedMessage {
   requestId: string;
   onEvent: (msg: ServerMessage) => void;
   activeSurfaceId?: string;
+  currentPage?: string;
 }
 
 export const MAX_QUEUE_DEPTH = 10;

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -17,6 +17,8 @@ export interface ActiveSurfaceContext {
   appSchemaJson?: string;
   /** Additional pages keyed by filename (e.g. "settings.html" → HTML content). */
   appPages?: Record<string, string>;
+  /** The page currently displayed in the WebView (e.g. "settings.html"). */
+  currentPage?: string;
 }
 
 /**
@@ -70,7 +72,12 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
     // App structure metadata
     lines.push('', 'App structure:');
     const pageNames = ctx.appPages ? Object.keys(ctx.appPages) : [];
-    lines.push(`- Main page (index.html): shown below`);
+    const viewingPage = ctx.currentPage && ctx.currentPage !== 'index.html' ? ctx.currentPage : null;
+
+    if (viewingPage) {
+      lines.push(`- Currently viewing: ${viewingPage}`);
+    }
+    lines.push(`- Main page (index.html)${viewingPage ? '' : ': shown below'}`);
     if (pageNames.length > 0) {
       lines.push(`- Additional pages: ${pageNames.join(', ')}`);
       lines.push('  To modify additional pages, include the `pages` parameter in `app_update`.');
@@ -90,27 +97,47 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
       lines.push('- Data schema: none (display-only)');
     }
 
-    // Main page HTML — reserve budget for additional pages (and schema)
+    // Determine which HTML to show as primary based on the currently viewed page
+    let primaryLabel = 'index.html';
+    let primaryHtml = ctx.html;
+    if (viewingPage && ctx.appPages?.[viewingPage]) {
+      primaryLabel = viewingPage;
+      primaryHtml = ctx.appPages[viewingPage];
+    }
+
+    // Primary page HTML — reserve budget for additional pages (and schema)
     const schemaSize = schema ? Math.min(schema.length, MAX_SCHEMA_LENGTH) : 0;
     let mainBudget = MAX_CONTEXT_LENGTH - schemaSize;
     const additionalPageBlocks: string[] = [];
 
-    if (ctx.appPages && pageNames.length > 0) {
-      // Try to include additional page content if total fits
-      let additionalSize = 0;
+    // Build additional page content (all pages except the primary one)
+    const otherPages: Record<string, string> = {};
+    if (viewingPage) {
+      // Show index.html as additional context
+      otherPages['index.html'] = ctx.html;
+    }
+    if (ctx.appPages) {
       for (const [filename, content] of Object.entries(ctx.appPages)) {
-        additionalSize += filename.length + content.length + 30; // overhead for delimiters
+        if (filename !== primaryLabel) {
+          otherPages[filename] = content;
+        }
+      }
+    }
+
+    if (Object.keys(otherPages).length > 0) {
+      let additionalSize = 0;
+      for (const [filename, content] of Object.entries(otherPages)) {
+        additionalSize += filename.length + content.length + 30;
         additionalPageBlocks.push(`--- ${filename} ---`, content);
       }
-      if (additionalSize + ctx.html.length > MAX_CONTEXT_LENGTH) {
-        // Too large — omit page content, just list names (already done above)
+      if (additionalSize + primaryHtml.length > MAX_CONTEXT_LENGTH) {
         additionalPageBlocks.length = 0;
       } else {
         mainBudget = MAX_CONTEXT_LENGTH - additionalSize;
       }
     }
 
-    lines.push('', 'Current HTML (index.html):', truncateHtml(ctx.html, mainBudget));
+    lines.push('', `Current HTML (${primaryLabel}):`, truncateHtml(primaryHtml, mainBudget));
 
     if (additionalPageBlocks.length > 0) {
       lines.push('', 'Additional page content:', ...additionalPageBlocks);

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -120,6 +120,7 @@ export class Session {
   private hasNoClient = false;
   private readonly queue = new MessageQueue();
   private currentActiveSurfaceId?: string;
+  private currentPage?: string;
   private pendingSurfaceActions = new Map<string, {
     surfaceType: SurfaceType;
   }>();
@@ -440,12 +441,13 @@ export class Session {
     onEvent: (msg: ServerMessage) => void,
     requestId: string,
     activeSurfaceId?: string,
+    currentPage?: string,
   ): { queued: boolean; rejected?: boolean; requestId: string } {
     if (!this.processing) {
       return { queued: false, requestId };
     }
 
-    const pushed = this.queue.push({ content, attachments, requestId, onEvent, activeSurfaceId });
+    const pushed = this.queue.push({ content, attachments, requestId, onEvent, activeSurfaceId, currentPage });
     if (!pushed) {
       return { queued: false, rejected: true, requestId };
     }
@@ -825,6 +827,7 @@ export class Session {
           activeSurface = {
             surfaceId: this.currentActiveSurfaceId,
             html: data.html,
+            currentPage: this.currentPage,
           };
           // Enrich with app context when the surface is backed by a persisted app
           if (data.appId) {
@@ -1362,6 +1365,7 @@ export class Session {
 
     // Set the active surface for the dequeued message so runAgentLoop can inject context
     this.currentActiveSurfaceId = next.activeSurfaceId;
+    this.currentPage = next.currentPage;
 
     // Fire-and-forget: persistUserMessage set this.processing = true
     // so subsequent messages will still be enqueued. runAgentLoop's
@@ -1383,8 +1387,10 @@ export class Session {
     onEvent: (msg: ServerMessage) => void,
     requestId?: string,
     activeSurfaceId?: string,
+    currentPage?: string,
   ): Promise<string> {
     this.currentActiveSurfaceId = activeSurfaceId;
+    this.currentPage = currentPage;
 
     // Resolve slash commands before persistence
     const slashResult = this.resolveSlash(content);

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -550,6 +550,9 @@ struct MainWindowView: View {
                 onCoordinatorReady: data.appId != nil ? { coordinator in
                     surfaceManager.surfaceCoordinators[surface.id] = coordinator
                 } : nil,
+                onPageChanged: { page in
+                    threadManager.activeViewModel?.currentPage = page
+                },
                 onSnapshotCaptured: data.appId != nil ? { [weak daemonClient] base64 in
                     guard let appId = data.appId else { return }
                     try? daemonClient?.sendAppUpdatePreview(appId: appId, preview: base64)

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -41,6 +41,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     let appId: String?
     let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
     let onCoordinatorReady: ((Coordinator) -> Void)?
+    /// Called when the user navigates to a different page in a multi-page app.
+    let onPageChanged: ((String) -> Void)?
     /// Called with a base64-encoded PNG screenshot after the page finishes loading.
     let onSnapshotCaptured: ((String) -> Void)?
     /// When true, blocks all network requests to external origins and restricts navigation.
@@ -54,6 +56,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         appId: String? = nil,
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
         onCoordinatorReady: ((Coordinator) -> Void)? = nil,
+        onPageChanged: ((String) -> Void)? = nil,
         onSnapshotCaptured: ((String) -> Void)? = nil,
         sandboxMode: Bool = false,
         topContentInset: CGFloat = 0,
@@ -64,6 +67,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         self.appId = appId
         self.onDataRequest = onDataRequest
         self.onCoordinatorReady = onCoordinatorReady
+        self.onPageChanged = onPageChanged
         self.onSnapshotCaptured = onSnapshotCaptured
         self.sandboxMode = sandboxMode
         self.topContentInset = topContentInset
@@ -71,7 +75,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
+        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -394,8 +398,11 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
         var onAction: (String, Any?) -> Void
         var onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
+        var onPageChanged: ((String) -> Void)?
         var onSnapshotCaptured: ((String) -> Void)?
         var currentHTML: String
+        /// The page currently displayed in a multi-page app (e.g. "settings.html").
+        var currentPage: String = "index.html"
         let sandboxMode: Bool
         weak var webView: WKWebView?
         var lastTopInset: Int = 0
@@ -409,12 +416,14 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         init(
             onAction: @escaping (String, Any?) -> Void,
             onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,
+            onPageChanged: ((String) -> Void)?,
             onSnapshotCaptured: ((String) -> Void)?,
             currentHTML: String,
             sandboxMode: Bool = false
         ) {
             self.onAction = onAction
             self.onDataRequest = onDataRequest
+            self.onPageChanged = onPageChanged
             self.onSnapshotCaptured = onSnapshotCaptured
             self.currentHTML = currentHTML
             self.sandboxMode = sandboxMode
@@ -501,6 +510,16 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     if let error {
                         log.error("confirm: JS eval error: \(error.localizedDescription, privacy: .public)")
                     }
+                }
+                return
+            }
+
+            // Handle page_changed messages from navigation tracking.
+            if let type = body["type"] as? String, type == "page_changed" {
+                if let page = body["page"] as? String, page != currentPage {
+                    currentPage = page
+                    log.info("[WebView] Page changed to: \(page, privacy: .public)")
+                    onPageChanged?(page)
                 }
                 return
             }
@@ -639,6 +658,23 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     })();
                     """
                 webView.evaluateJavaScript(js, completionHandler: nil)
+            }
+
+            // Detect page changes from URL-based navigation (e.g. <a href="settings.html">).
+            if let url = webView.url {
+                let path = url.path
+                let pageName: String
+                if path == "/" || path.isEmpty {
+                    pageName = "index.html"
+                } else {
+                    // Extract filename from path (e.g. "/settings.html" → "settings.html")
+                    pageName = String(path.dropFirst()) // remove leading "/"
+                }
+                if !pageName.isEmpty && pageName != currentPage {
+                    currentPage = pageName
+                    log.info("[WebView] Page detected from URL: \(pageName, privacy: .public)")
+                    onPageChanged?(pageName)
+                }
             }
 
             // Capture a preview screenshot after the page has rendered (once per load).

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -200,9 +200,14 @@ public final class ChatViewModel: ObservableObject {
         didSet {
             if oldValue != activeSurfaceId {
                 surfaceUndoCount = 0
+                currentPage = nil
             }
         }
     }
+
+    /// The page currently displayed in the workspace WebView (e.g. "settings.html").
+    /// Set via the onPageChanged callback when the user navigates within a multi-page app.
+    public var currentPage: String?
 
     public init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -561,7 +566,8 @@ public final class ChatViewModel: ObservableObject {
                 sessionId: sessionId,
                 content: text,
                 attachments: attachments,
-                activeSurfaceId: activeSurfaceId
+                activeSurfaceId: activeSurfaceId,
+                currentPage: activeSurfaceId != nil ? currentPage : nil
             ))
         } catch {
             log.error("Failed to send user_message: \(error.localizedDescription)")
@@ -684,7 +690,8 @@ public final class ChatViewModel: ObservableObject {
                             sessionId: info.sessionId,
                             content: pending,
                             attachments: attachments,
-                            activeSurfaceId: activeSurfaceId
+                            activeSurfaceId: activeSurfaceId,
+                            currentPage: activeSurfaceId != nil ? currentPage : nil
                         ))
                     } catch {
                         log.error("Failed to send queued user_message: \(error.localizedDescription)")

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1290,6 +1290,7 @@ public struct IPCUserMessage: Codable, Sendable {
     public let content: String?
     public let attachments: [IPCUserMessageAttachment]?
     public let activeSurfaceId: String?
+    public let currentPage: String?
 }
 
 public struct IPCUserMessageAttachment: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -218,8 +218,8 @@ extension IPCSessionCreateRequest {
 public typealias UserMessageMessage = IPCUserMessage
 
 extension IPCUserMessage {
-    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil) {
-        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId)
+    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil) {
+        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage)
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `currentPage` field to IPC `UserMessage` so the daemon knows which page the user is viewing in a multi-page app
- Threads `currentPage` through handlers, session queue, and session to the runtime injection layer
- Rewrites `injectActiveSurfaceContext` to show the currently viewed page as primary content (with other pages as secondary context)
- Swift: adds page detection via bridge messages and URL-based fallback in `DynamicPageSurfaceView`, wires `onPageChanged` callback through `MainWindowView` to `ChatViewModel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
