### PR TITLE
feat: cut over sandbox working dir to workspace root

### DIFF
--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -14,7 +14,7 @@ mock.module('../util/platform.js', () => ({
   getRootDir: () => '/tmp',
   getDataDir: () => '/tmp/data',
   getSandboxRootDir: () => '/tmp/sandbox',
-  getSandboxWorkingDir: () => '/tmp/sandbox/fs',
+  getSandboxWorkingDir: () => '/tmp/workspace',
   getPlatformName: () => 'linux',
   getClipboardCommand: () => null,
   getSocketPath: () => '/tmp/test.sock',
@@ -103,6 +103,6 @@ describe('ComputerUseSession working directory', () => {
 
     await session.handleObservation(observation);
 
-    expect(capturedWorkingDir).toBe('/tmp/sandbox/fs');
+    expect(capturedWorkingDir).toBe('/tmp/workspace');
   });
 });

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -73,7 +73,7 @@ mock.module('../util/logger.js', () => ({
 mock.module('../util/platform.js', () => ({
   getSocketPath: () => '/tmp/test.sock',
   getDataDir: () => '/tmp',
-  getSandboxWorkingDir: () => '/tmp/sandbox/fs',
+  getSandboxWorkingDir: () => '/tmp/workspace',
 }));
 
 mock.module('../providers/registry.js', () => ({
@@ -210,7 +210,7 @@ describe('DaemonServer initial session hydration', () => {
 
     await internal.sendInitialSession(socket);
 
-    expect(lastCreatedWorkingDir).toBe('/tmp/sandbox/fs');
+    expect(lastCreatedWorkingDir).toBe('/tmp/workspace');
   });
 
   test('ignores deprecated sandbox_set runtime override messages', async () => {

--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -57,7 +57,7 @@ describe('baseline path characterization (pre-migration)', () => {
     expect(getIpcBlobDir()).toBe(join(data, 'ipc-blobs'));
     expect(getInterfacesDir()).toBe(join(data, 'interfaces'));
     expect(getSandboxRootDir()).toBe(join(data, 'sandbox'));
-    expect(getSandboxWorkingDir()).toBe(join(data, 'sandbox', 'fs'));
+    expect(getSandboxWorkingDir()).toBe(join(root, 'workspace'));
 
     // WILL MOVE to ~/.vellum/workspace/hooks
     expect(getHooksDir()).toBe(join(root, 'hooks'));

--- a/assistant/src/__tests__/sandbox-diagnostics.test.ts
+++ b/assistant/src/__tests__/sandbox-diagnostics.test.ts
@@ -25,7 +25,7 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => '/tmp/vellum-test/data/db/assistant.db',
   getLogPath: () => '/tmp/vellum-test/data/logs/daemon.log',
   getSandboxRootDir: () => '/tmp/vellum-test/sandbox',
-  getSandboxWorkingDir: () => '/tmp/vellum-test/sandbox/workspace',
+  getSandboxWorkingDir: () => '/tmp/vellum-test/workspace',
   ensureDataDir: () => {},
   getHistoryPath: () => '/tmp/vellum-test/data/history',
   getHooksDir: () => '/tmp/vellum-test/hooks',
@@ -330,7 +330,7 @@ describe('runSandboxDiagnostics — Docker mount writable check', () => {
     expect(args).toContain('alpine:3.19');
     // Mount source should be the sandbox working dir (getSandboxWorkingDir)
     const mountArg = args.find((a: string) => a.startsWith('type=bind'));
-    expect(mountArg).toContain('/tmp/vellum-test/sandbox/workspace');
+    expect(mountArg).toContain('/tmp/vellum-test/workspace');
     // Probe command should be 'test -w /workspace' matching runtime preflight
     expect(args).toContain('test');
     expect(args).toContain('-w');

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -69,11 +69,12 @@ export function getSandboxRootDir(): string {
 }
 
 /**
- * Returns the default sandbox working directory (~/.vellum/data/sandbox/fs).
- * Tool working directories should use this path unless explicitly overridden.
+ * Returns the default sandbox working directory (~/.vellum/workspace).
+ * This is the workspace root — tool working directories should use this
+ * path unless explicitly overridden.
  */
 export function getSandboxWorkingDir(): string {
-  return join(getSandboxRootDir(), 'fs');
+  return getWorkspaceDir();
 }
 
 export function getInterfacesDir(): string {


### PR DESCRIPTION
## Summary
- `getSandboxWorkingDir()` now returns `getWorkspaceDir()` (PR 8 of workspace migration plan)
- Docker bind mount semantics unchanged, only host source path changes
- Updated 4 test files with new path expectations

## Test plan
- [x] `bun test src/__tests__/platform.test.ts` — passes
- [x] `bun test src/__tests__/daemon-server-session-init.test.ts` — passes
- [x] `bun test src/__tests__/computer-use-session-working-dir.test.ts` — passes
- [x] `bun test src/__tests__/sandbox-diagnostics.test.ts` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
