### PR TITLE
feat: cut over hooks path to workspace/hooks

### DIFF
--- a/assistant/src/__tests__/hooks-blocking.test.ts
+++ b/assistant/src/__tests__/hooks-blocking.test.ts
@@ -39,7 +39,7 @@ describe('Blocking Hooks', () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, '.vellum', 'hooks');
+    hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
     resetHookManager();
   });

--- a/assistant/src/__tests__/hooks-config.test.ts
+++ b/assistant/src/__tests__/hooks-config.test.ts
@@ -11,7 +11,7 @@ import { loadHooksConfig, saveHooksConfig, isHookEnabled, setHookEnabled, ensure
 
 describe('Hooks Config', () => {
   beforeEach(() => {
-    const hooksDir = join(testDir, '.vellum', 'hooks');
+    const hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
   });
 
@@ -26,7 +26,7 @@ describe('Hooks Config', () => {
   });
 
   test('loadHooksConfig reads existing config', () => {
-    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    const configPath = join(testDir, '.vellum', 'workspace', 'hooks', 'config.json');
     writeFileSync(configPath, JSON.stringify({
       version: 1,
       hooks: { 'my-hook': { enabled: true } },
@@ -37,7 +37,7 @@ describe('Hooks Config', () => {
   });
 
   test('loadHooksConfig returns defaults for invalid JSON', () => {
-    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    const configPath = join(testDir, '.vellum', 'workspace', 'hooks', 'config.json');
     writeFileSync(configPath, 'NOT VALID JSON {{{');
 
     const config = loadHooksConfig();
@@ -46,7 +46,7 @@ describe('Hooks Config', () => {
   });
 
   test('loadHooksConfig returns defaults for invalid structure', () => {
-    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    const configPath = join(testDir, '.vellum', 'workspace', 'hooks', 'config.json');
     writeFileSync(configPath, JSON.stringify({ foo: 'bar' }));
 
     const config = loadHooksConfig();
@@ -58,7 +58,7 @@ describe('Hooks Config', () => {
     const config = { version: 1, hooks: { 'test-hook': { enabled: true } } };
     saveHooksConfig(config);
 
-    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    const configPath = join(testDir, '.vellum', 'workspace', 'hooks', 'config.json');
     expect(existsSync(configPath)).toBe(true);
     const read = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(read.hooks['test-hook'].enabled).toBe(true);

--- a/assistant/src/__tests__/hooks-discovery.test.ts
+++ b/assistant/src/__tests__/hooks-discovery.test.ts
@@ -23,7 +23,7 @@ describe('Hooks Discovery', () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, '.vellum', 'hooks');
+    hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/hooks-integration.test.ts
+++ b/assistant/src/__tests__/hooks-integration.test.ts
@@ -37,7 +37,7 @@ describe('Hooks Integration', () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, '.vellum', 'hooks');
+    hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
     resetHookManager();
   });

--- a/assistant/src/__tests__/hooks-manager.test.ts
+++ b/assistant/src/__tests__/hooks-manager.test.ts
@@ -37,7 +37,7 @@ describe('HookManager', () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, '.vellum', 'hooks');
+    hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
     resetHookManager();
   });

--- a/assistant/src/__tests__/hooks-runner.test.ts
+++ b/assistant/src/__tests__/hooks-runner.test.ts
@@ -36,7 +36,7 @@ describe('Hook Runner', () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, '.vellum', 'hooks');
+    hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/hooks-settings.test.ts
+++ b/assistant/src/__tests__/hooks-settings.test.ts
@@ -16,7 +16,7 @@ describe('Hook Settings', () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, '.vellum', 'hooks');
+    hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/hooks-templates.test.ts
+++ b/assistant/src/__tests__/hooks-templates.test.ts
@@ -26,7 +26,7 @@ describe('Hook Templates', () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, '.vellum', 'hooks');
+    hooksDir = join(testDir, '.vellum', 'workspace', 'hooks');
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -59,8 +59,8 @@ describe('baseline path characterization (pre-migration)', () => {
     expect(getSandboxRootDir()).toBe(join(data, 'sandbox'));
     expect(getSandboxWorkingDir()).toBe(join(root, 'workspace'));
 
-    // WILL MOVE to ~/.vellum/workspace/hooks
-    expect(getHooksDir()).toBe(join(root, 'hooks'));
+    // Now resolves under workspace/hooks
+    expect(getHooksDir()).toBe(join(root, 'workspace', 'hooks'));
 
     // STAYS ROOT — runtime files remain at ~/.vellum/
     expect(getPidPath()).toBe(join(root, 'vellum.pid'));

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -128,7 +128,7 @@ export function getHistoryPath(): string {
 }
 
 export function getHooksDir(): string {
-  return join(getRootDir(), 'hooks');
+  return getWorkspaceHooksDir();
 }
 
 // --- Workspace path primitives ---


### PR DESCRIPTION
## Summary
- Switches `getHooksDir()` to workspace hooks dir (PR 9 of workspace migration plan)
- Updates 8 hook test files with new path expectations
- No hooks source code changes needed — all use the helper

## Test plan
- [x] All hook tests pass (hooks-config, discovery, manager, runner, settings, templates, integration, blocking)
- [x] `bun test src/__tests__/platform.test.ts` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
