### PR TITLE
fix: preserve schema budget in additional pages branch

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -130,10 +130,10 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
         additionalSize += filename.length + content.length + 30;
         additionalPageBlocks.push(`--- ${filename} ---`, content);
       }
-      if (additionalSize + primaryHtml.length > MAX_CONTEXT_LENGTH) {
+      if (additionalSize + primaryHtml.length > MAX_CONTEXT_LENGTH - schemaSize) {
         additionalPageBlocks.length = 0;
       } else {
-        mainBudget = MAX_CONTEXT_LENGTH - additionalSize;
+        mainBudget = MAX_CONTEXT_LENGTH - schemaSize - additionalSize;
       }
     }
 


### PR DESCRIPTION
## Summary
Addresses review feedback from #2789:

- **Schema budget preservation**: The additional pages code path was reassigning `mainBudget = MAX_CONTEXT_LENGTH - additionalSize`, dropping the `schemaSize` deduction. Now correctly subtracts both `schemaSize` and `additionalSize` from `MAX_CONTEXT_LENGTH`.
- **Overflow check consistency**: The overflow guard now also accounts for `schemaSize`, preventing the total context from exceeding the budget when both schema and additional pages are present.

## Test plan
- [ ] Verify context injection stays within MAX_CONTEXT_LENGTH when schema + additional pages are both present
- [ ] Verify additional pages are still included when they fit within the adjusted budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
