### PR TITLE
feat: add Vercel deploy service and published pages DB store

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -295,6 +295,18 @@ export function initializeDb(): void {
   `);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS published_pages (
+      id TEXT PRIMARY KEY,
+      deployment_id TEXT NOT NULL UNIQUE,
+      public_url TEXT NOT NULL,
+      page_title TEXT,
+      html_hash TEXT NOT NULL,
+      published_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active'
+    )
+  `);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS shared_app_links (
       id TEXT PRIMARY KEY,
       share_token TEXT NOT NULL UNIQUE,
@@ -487,6 +499,9 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_actor ON llm_usage_events(actor)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_shared_app_links_share_token ON shared_app_links(share_token)`);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_published_pages_html_hash ON published_pages(html_hash)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_published_pages_status ON published_pages(status)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entities_name ON memory_entities(name)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entities_type ON memory_entities(type)`);

--- a/assistant/src/memory/published-pages-store.ts
+++ b/assistant/src/memory/published-pages-store.ts
@@ -1,0 +1,99 @@
+/**
+ * Store for published page records.
+ *
+ * Tracks HTML pages deployed to Vercel, keyed by deployment ID and content hash
+ * for deduplication.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import { getDb } from './db.js';
+import { publishedPages } from './schema.js';
+
+export interface PublishedPageRecord {
+  id: string;
+  deploymentId: string;
+  publicUrl: string;
+  pageTitle: string | null;
+  htmlHash: string;
+  publishedAt: number;
+  status: string;
+}
+
+export function createPublishedPage(record: {
+  id: string;
+  deploymentId: string;
+  publicUrl: string;
+  pageTitle?: string;
+  htmlHash: string;
+}): void {
+  const db = getDb();
+  db.insert(publishedPages)
+    .values({
+      id: record.id,
+      deploymentId: record.deploymentId,
+      publicUrl: record.publicUrl,
+      pageTitle: record.pageTitle ?? null,
+      htmlHash: record.htmlHash,
+      publishedAt: Date.now(),
+      status: 'active',
+    })
+    .run();
+}
+
+export function getPublishedPageByDeploymentId(
+  deploymentId: string,
+): PublishedPageRecord | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(publishedPages)
+    .where(eq(publishedPages.deploymentId, deploymentId))
+    .get();
+
+  return row ?? null;
+}
+
+export function getPublishedPageByHash(
+  hash: string,
+): PublishedPageRecord | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(publishedPages)
+    .where(
+      and(
+        eq(publishedPages.htmlHash, hash),
+        eq(publishedPages.status, 'active'),
+      ),
+    )
+    .get();
+
+  return row ?? null;
+}
+
+export function listPublishedPages(): PublishedPageRecord[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(publishedPages)
+    .where(eq(publishedPages.status, 'active'))
+    .all();
+}
+
+export function markDeleted(id: string): boolean {
+  const db = getDb();
+  const existing = db
+    .select({ id: publishedPages.id })
+    .from(publishedPages)
+    .where(eq(publishedPages.id, id))
+    .get();
+
+  if (!existing) return false;
+
+  db.update(publishedPages)
+    .set({ status: 'deleted' })
+    .where(eq(publishedPages.id, id))
+    .run();
+
+  return true;
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -319,6 +319,16 @@ export const sharedAppLinks = sqliteTable('shared_app_links', {
   expiresAt: integer('expires_at'),
 });
 
+export const publishedPages = sqliteTable('published_pages', {
+  id: text('id').primaryKey(),
+  deploymentId: text('deployment_id').notNull().unique(),
+  publicUrl: text('public_url').notNull(),
+  pageTitle: text('page_title'),
+  htmlHash: text('html_hash').notNull(),
+  publishedAt: integer('published_at').notNull(),
+  status: text('status').notNull().default('active'),
+});
+
 export const llmUsageEvents = sqliteTable('llm_usage_events', {
   id: text('id').primaryKey(),
   createdAt: integer('created_at').notNull(),

--- a/assistant/src/services/vercel-deploy.ts
+++ b/assistant/src/services/vercel-deploy.ts
@@ -1,0 +1,72 @@
+/**
+ * Thin wrapper around the Vercel REST API for deploying static HTML pages.
+ */
+
+export async function deployHtmlToVercel(opts: {
+  html: string;
+  name: string;
+  token: string;
+}): Promise<{ url: string; deploymentId: string }> {
+  const slug = opts.name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const body = {
+    name: slug,
+    files: [
+      {
+        file: 'index.html',
+        data: Buffer.from(opts.html).toString('base64'),
+      },
+    ],
+    projectSettings: { framework: null },
+    target: 'production',
+  };
+
+  const response = await fetch('https://api.vercel.com/v13/deployments', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${opts.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Vercel deploy failed (${response.status}): ${text}`);
+  }
+
+  const data = (await response.json()) as { url: string; id: string };
+
+  let publicUrl = data.url;
+  if (!publicUrl.startsWith('https://')) {
+    publicUrl = `https://${publicUrl}`;
+  }
+
+  return { url: publicUrl, deploymentId: data.id };
+}
+
+export async function deleteVercelDeployment(
+  deploymentId: string,
+  token: string,
+): Promise<void> {
+  const response = await fetch(
+    `https://api.vercel.com/v13/deployments/${deploymentId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Vercel delete deployment failed (${response.status}): ${text}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `assistant/src/services/vercel-deploy.ts`: thin wrapper around Vercel REST API (`deployHtmlToVercel`, `deleteVercelDeployment`) using `fetch` with base64-encoded HTML file uploads
- Add `published_pages` table to drizzle schema and SQLite DDL with indexes on `html_hash` and `status`
- Add `assistant/src/memory/published-pages-store.ts`: CRUD store with hash-based dedup lookup, following the same pattern as `shared-app-links-store.ts`

Part of #2802.

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed)
- [ ] Integration test: call `deployHtmlToVercel` with a valid Vercel token and confirm a deployment URL is returned
- [ ] Unit test: exercise published-pages-store CRUD against an in-memory SQLite DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
