### PR TITLE
feat: cut over config path to workspace/config.json

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -9,11 +9,13 @@ import { randomBytes } from 'node:crypto';
 // ---------------------------------------------------------------------------
 
 const TEST_DIR = join(tmpdir(), `vellum-schema-test-${randomBytes(4).toString('hex')}`);
-const CONFIG_PATH = join(TEST_DIR, 'config.json');
+const WORKSPACE_DIR = join(TEST_DIR, 'workspace');
+const CONFIG_PATH = join(WORKSPACE_DIR, 'config.json');
 
 function ensureTestDir(): void {
   const dirs = [
     TEST_DIR,
+    WORKSPACE_DIR,
     join(TEST_DIR, 'data'),
     join(TEST_DIR, 'memory'),
     join(TEST_DIR, 'memory', 'knowledge'),
@@ -32,6 +34,8 @@ mock.module('../util/logger.js', () => ({
 
 mock.module('../util/platform.js', () => ({
   getRootDir: () => TEST_DIR,
+  getWorkspaceDir: () => WORKSPACE_DIR,
+  getWorkspaceConfigPath: () => CONFIG_PATH,
   getDataDir: () => join(TEST_DIR, 'data'),
   getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
   ensureDataDir: () => ensureTestDir(),
@@ -470,7 +474,7 @@ describe('loadConfig with schema validation', () => {
     // Keep TEST_DIR and logs in place to avoid racing async logger stream init.
     ensureTestDir();
     const resetPaths = [
-      join(TEST_DIR, 'config.json'),
+      CONFIG_PATH,
       join(TEST_DIR, 'keys.enc'),
       join(TEST_DIR, 'data'),
       join(TEST_DIR, 'memory'),

--- a/assistant/src/__tests__/key-migration.test.ts
+++ b/assistant/src/__tests__/key-migration.test.ts
@@ -9,6 +9,8 @@ import { randomBytes } from 'node:crypto';
 // ---------------------------------------------------------------------------
 
 const TEST_DIR = join(tmpdir(), `vellum-migration-test-${randomBytes(4).toString('hex')}`);
+const WORKSPACE_DIR = join(TEST_DIR, 'workspace');
+const CONFIG_PATH = join(WORKSPACE_DIR, 'config.json');
 const STORE_PATH = join(TEST_DIR, 'keys.enc');
 
 mock.module('../util/logger.js', () => ({
@@ -19,10 +21,13 @@ mock.module('../util/logger.js', () => ({
 
 mock.module('../util/platform.js', () => ({
   getRootDir: () => TEST_DIR,
+  getWorkspaceDir: () => WORKSPACE_DIR,
+  getWorkspaceConfigPath: () => CONFIG_PATH,
   getDataDir: () => join(TEST_DIR, 'data'),
   getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
   ensureDataDir: () => {
     if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    if (!existsSync(WORKSPACE_DIR)) mkdirSync(WORKSPACE_DIR, { recursive: true });
     const logsDir = join(TEST_DIR, 'logs');
     if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
   },
@@ -46,6 +51,7 @@ describe('key migration', () => {
       rmSync(TEST_DIR, { recursive: true, force: true });
     }
     mkdirSync(TEST_DIR, { recursive: true });
+    mkdirSync(WORKSPACE_DIR, { recursive: true });
     mkdirSync(join(TEST_DIR, 'logs'), { recursive: true });
     _setStorePath(STORE_PATH);
     _setBackend('encrypted');
@@ -59,7 +65,7 @@ describe('key migration', () => {
   });
 
   test('[experimental] migrates plaintext apiKeys from config.json to secure storage', () => {
-    const configPath = join(TEST_DIR, 'config.json');
+    const configPath = CONFIG_PATH;
     writeFileSync(configPath, JSON.stringify({
       provider: 'anthropic',
       apiKeys: {
@@ -86,7 +92,7 @@ describe('key migration', () => {
   });
 
   test('does not migrate when no apiKeys in config.json', () => {
-    const configPath = join(TEST_DIR, 'config.json');
+    const configPath = CONFIG_PATH;
     writeFileSync(configPath, JSON.stringify({
       provider: 'anthropic',
       model: 'claude-sonnet-4-5-20250929',
@@ -102,7 +108,7 @@ describe('key migration', () => {
   });
 
   test('does not migrate empty apiKeys object', () => {
-    const configPath = join(TEST_DIR, 'config.json');
+    const configPath = CONFIG_PATH;
     writeFileSync(configPath, JSON.stringify({
       provider: 'anthropic',
       apiKeys: {},
@@ -116,7 +122,7 @@ describe('key migration', () => {
   });
 
   test('preserves other config fields during migration', () => {
-    const configPath = join(TEST_DIR, 'config.json');
+    const configPath = CONFIG_PATH;
     writeFileSync(configPath, JSON.stringify({
       provider: 'openai',
       model: 'gpt-4',
@@ -136,7 +142,7 @@ describe('key migration', () => {
   });
 
   test('[experimental] migration only happens once (idempotent)', () => {
-    const configPath = join(TEST_DIR, 'config.json');
+    const configPath = CONFIG_PATH;
     writeFileSync(configPath, JSON.stringify({
       provider: 'anthropic',
       apiKeys: { anthropic: 'sk-ant-test-key' },
@@ -157,7 +163,7 @@ describe('key migration', () => {
   });
 
   test('skips non-string values in apiKeys during migration', () => {
-    const configPath = join(TEST_DIR, 'config.json');
+    const configPath = CONFIG_PATH;
     writeFileSync(configPath, JSON.stringify({
       provider: 'anthropic',
       apiKeys: {

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1,6 +1,5 @@
 import { readFileSync, writeFileSync, existsSync, statSync } from 'node:fs';
-import { join } from 'node:path';
-import { getRootDir, ensureDataDir } from '../util/platform.js';
+import { ensureDataDir, getWorkspaceConfigPath } from '../util/platform.js';
 import { ConfigError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { DEFAULT_CONFIG } from './defaults.js';
@@ -17,7 +16,7 @@ let cached: AssistantConfig | null = null;
 let loading = false;
 
 function getConfigPath(): string {
-  return join(getRootDir(), 'config.json');
+  return getWorkspaceConfigPath();
 }
 
 function cloneDefaultConfig(): AssistantConfig {


### PR DESCRIPTION
## Summary
- Config loader uses `getWorkspaceConfigPath()` (PR 10 of workspace migration plan)
- Updated config-schema and key-migration test mocks and assertions

## Test plan
- [x] `bun test src/__tests__/config-schema.test.ts src/__tests__/key-migration.test.ts` — 61 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
