### PR TITLE
fix: wire ingress redirect through real secret lifecycle

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -199,19 +199,32 @@ describe('Invariant 3: secrets never logged in plaintext', () => {
         expect((redacted.nested as Record<string, unknown>).safe).toBe('this is fine');
       });
     } else if (tc.component === 'ipc_decode') {
-      // PR 24 — Swift-side decode log hygiene (cannot test in TS unit tests)
+      // PR 24 — IPC decode log hygiene: the TS daemon's IPC parser must not
+      // log raw line content (which could contain secrets in malformed messages)
       test(`${tc.label}`, () => {
-        // Swift IPC decode logging is verified by manual audit and Swift tests.
-        // The TS daemon never logs raw IPC line content — it only processes
-        // parsed JSON messages after successful decode.
-        expect(true).toBe(true);
+        const thisDir = dirname(fileURLToPath(import.meta.url));
+        const ipcSrc = readFileSync(
+          resolve(thisDir, '../daemon/ipc-protocol.ts'),
+          'utf-8',
+        );
+        // The parser should not log raw line/chunk/buffer content
+        // (log.info/warn/error with the raw data would leak secrets)
+        const logCalls = ipcSrc.match(/log\.\w+\(.*?(line|chunk|raw|buffer)\b/g) ?? [];
+        expect(logCalls).toEqual([]);
       });
     } else {
-      // PR 25 — secret prompter log hygiene
+      // PR 25 — secret prompter log hygiene: the prompter must never log
+      // the resolved secret value
       test(`${tc.label}`, () => {
-        // The secret prompter (secret-prompter.ts) only logs requestId and
-        // service/field — never the resolved secret value. Verified by source audit.
-        expect(true).toBe(true);
+        const thisDir = dirname(fileURLToPath(import.meta.url));
+        const prompterSrc = readFileSync(
+          resolve(thisDir, '../permissions/secret-prompter.ts'),
+          'utf-8',
+        );
+        // The prompter must not log the 'value' parameter
+        // Look for log calls that reference 'value' as a logged field
+        const valueLogCalls = prompterSrc.match(/log\.\w+\(\{[^}]*\bvalue\b/g) ?? [];
+        expect(valueLogCalls).toEqual([]);
       });
     }
   }

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1445,15 +1445,11 @@ async function handleTaskSubmit(
         type: 'error',
         message: taskIngressCheck.userNotice!,
       });
-      // Redirect: send a secret_request directly (no session exists yet)
-      ctx.send(socket, {
-        type: 'secret_request',
-        requestId,
-        service: 'detected',
-        field: taskIngressCheck.detectedTypes.join(','),
-        label: 'Secure Credential Entry',
-        description: 'Your message contained a secret. Please enter it here instead — it will be stored securely and never sent to the AI.',
-      });
+      // Create a session so the secret_response lifecycle works end-to-end
+      const conversation = conversationStore.createConversation('(blocked — secret detected)');
+      ctx.socketToSession.set(socket, conversation.id);
+      const session = await ctx.getOrCreateSession(conversation.id, socket, true);
+      session.redirectToSecurePrompt(taskIngressCheck.detectedTypes);
       return;
     }
 
@@ -2399,7 +2395,7 @@ function handleCuSessionCreate(
   }
   sessionIds.add(msg.sessionId);
 
-  log.info({ sessionId: msg.sessionId, task: msg.task }, 'Computer-use session created');
+  log.info({ sessionId: msg.sessionId, taskLength: msg.task.length }, 'Computer-use session created');
 }
 
 function handleCuSessionAbort(

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -374,15 +374,35 @@ export class Session {
 
   /**
    * Redirect the user to the secure credential prompt after an ingress block.
-   * The prompt result is fire-and-forget — timeout/cancel is acceptable.
+   * If the user enters a value, it is stored in the vault (or injected as
+   * transient) so the credential is available for later tool use.
    */
   redirectToSecurePrompt(detectedTypes: string[]): void {
+    const service = 'detected';
+    const field = detectedTypes.join(',');
     this.secretPrompter.prompt(
-      'detected', detectedTypes.join(','),
+      service, field,
       'Secure Credential Entry',
       'Your message contained a secret. Please enter it here instead — it will be stored securely and never sent to the AI.',
       undefined, this.conversationId,
-    ).catch(() => { /* prompt timeout or cancel is fine */ });
+    ).then((result) => {
+      if (!result.value) return; // user cancelled or timed out
+
+      const { setSecureKey } = require('../security/secure-keys.js');
+      const { upsertCredentialMetadata } = require('../tools/credentials/metadata-store.js');
+
+      if (result.delivery === 'transient_send') {
+        const { credentialBroker } = require('../tools/credentials/broker.js');
+        credentialBroker.injectTransient(service, field, result.value);
+        try { upsertCredentialMetadata(service, field, {}); } catch {}
+        log.info({ service, field, delivery: 'transient_send' }, 'Ingress redirect: transient credential injected');
+      } else {
+        const key = `credential:${service}:${field}`;
+        setSecureKey(key, result.value);
+        try { upsertCredentialMetadata(service, field, {}); } catch {}
+        log.info({ service, field }, 'Ingress redirect: credential stored');
+      }
+    }).catch(() => { /* prompt timeout or cancel is fine */ });
   }
 
   isProcessing(): boolean {


### PR DESCRIPTION
## Summary
- **[P1]** Wire `redirectToSecurePrompt` in session.ts to store/inject the returned secret value instead of fire-and-forget — persists to keychain (store) or injects into broker (transient_send)
- **[P1]** Wire task_submit ingress redirect through a real session so `handleSecretResponse` can resolve the prompt — the raw `secret_request` was orphaned without a session
- **[P2]** Replace remaining plaintext task logging in CU session creation (`task: msg.task` → `taskLength: msg.task.length`)
- **[P3]** Replace `expect(true).toBe(true)` placeholder invariant tests with source-scanning assertions verifying IPC parser and secret prompter don't log sensitive content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
