### PR TITLE
feat: add prompt cache breakpoints on conversation messages

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -68,6 +68,20 @@ export class AnthropicProvider implements Provider {
         }));
       }
 
+      // Place cache breakpoints on the last two user turns so the
+      // conversation prefix is cached between agent-loop iterations.
+      const userIndices: number[] = [];
+      for (let i = 0; i < params.messages.length; i++) {
+        if (params.messages[i].role === 'user') userIndices.push(i);
+      }
+      for (const idx of userIndices.slice(-2)) {
+        const content = params.messages[idx].content;
+        if (Array.isArray(content) && content.length > 0) {
+          (content[content.length - 1] as unknown as { cache_control?: { type: string } })
+            .cache_control = { type: 'ephemeral' };
+        }
+      }
+
       const stream = this.client.messages.stream(params, { signal });
 
       stream.on("text", (text) => {


### PR DESCRIPTION
## Summary
- Add `cache_control: { type: 'ephemeral' }` to the last content block of the last two user messages sent to the Anthropic API
- Previously only the system prompt and tool definitions were cached, leaving the entire growing conversation history as uncached input on every agent-loop turn
- Uses 4 of 4 available cache breakpoints (system, tools, penultimate user turn, last user turn) for maximum cache hit rates in multi-turn tool-use loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
