### PR TITLE
fix: guard stale scroll restore and complete JS string escaping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -358,11 +358,17 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 // First load — no scroll to preserve
                 webView.loadHTMLString(data.html, baseURL: URL(string: origin))
             } else {
-                // Subsequent update — save scroll, reload, restore scroll after load
+                // Subsequent update — save scroll, reload, restore scroll after load.
+                // Capture the HTML we intend to load so we can detect staleness.
+                let htmlToLoad = data.html
                 webView.evaluateJavaScript("JSON.stringify({x: window.scrollX, y: window.scrollY})") { result, _ in
+                    // If another update arrived while we were waiting for the scroll
+                    // position, currentHTML will have moved on. Skip this stale load
+                    // so we don't overwrite the newer render.
+                    guard htmlToLoad == context.coordinator.currentHTML else { return }
                     let scrollState = result as? String
                     context.coordinator.pendingScrollRestore = scrollState
-                    webView.loadHTMLString(data.html, baseURL: URL(string: origin))
+                    webView.loadHTMLString(htmlToLoad, baseURL: URL(string: origin))
                 }
             }
         }
@@ -624,10 +630,15 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             // Restore scroll position if this load was a refinement update.
             if let scrollJSON = pendingScrollRestore {
                 pendingScrollRestore = nil
+                let safeScrollJSON = scrollJSON
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "'", with: "\\'")
+                    .replacingOccurrences(of: "\n", with: "\\n")
+                    .replacingOccurrences(of: "\r", with: "\\r")
                 let js = """
                     (function() {
                         try {
-                            var s = JSON.parse('\(scrollJSON.replacingOccurrences(of: "'", with: "\\'"))');
+                            var s = JSON.parse('\(safeScrollJSON)');
                             window.scrollTo(s.x || 0, s.y || 0);
                         } catch(e) {}
                     })();


### PR DESCRIPTION
## Summary
Addresses review feedback from #2784:

- **Stale HTML guard**: Before loading HTML in the evaluateJavaScript completion block, verify that the HTML still matches `currentHTML` to prevent race conditions with rapid updates. If another update arrived while waiting for scroll position, the stale load is skipped.
- **Complete JS escaping**: Apply the full escaping pattern (backslash, single quote, newline, carriage return) to `scrollJSON` interpolation, matching the established convention elsewhere in the file (lines ~494-498, ~531-534).

## Test plan
- [ ] Verify scroll position is preserved during surface updates
- [ ] Verify rapid successive updates don't cause stale HTML rendering
- [ ] Verify special characters in scroll JSON don't break JS evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
