### PR TITLE
fix: sync sibling surface undo stacks after broadcast undo

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1829,6 +1829,23 @@ export class Session {
           data: revertedData,
         });
       }
+
+      // Sync sibling undo stacks: pop the top entry if it matches the HTML we
+      // just reverted to, preventing phantom no-op undo steps on siblings.
+      for (const [sid, s] of this.surfaceState.entries()) {
+        if (sid === surfaceId) continue;
+        if (s.surfaceType !== 'dynamic_page') continue;
+        const sData = s.data as DynamicPageSurfaceData;
+        if (sData.appId !== data.appId) continue;
+
+        const siblingStack = this.surfaceUndoStacks.get(sid);
+        if (siblingStack && siblingStack.length > 0) {
+          const top = siblingStack[siblingStack.length - 1];
+          if (top === previousHtml) {
+            siblingStack.pop();
+          }
+        }
+      }
     } else {
       // Ephemeral surface — update only the requesting surface
       const revertedData: DynamicPageSurfaceData = { ...data, html: previousHtml };


### PR DESCRIPTION
## Summary
Addresses review feedback from #2790:

- **Sibling undo stack sync**: When an undo is broadcast to all surfaces sharing the same appId, sibling surfaces' undo stacks are now trimmed to match. The top entry is popped from each sibling's stack if it matches the HTML that was just reverted to, preventing phantom no-op undo steps.

## Test plan
- [ ] Verify undo on one surface correctly updates all sibling surfaces
- [ ] Verify sibling surfaces don't have stale undo entries after broadcast
- [ ] Verify remainingUndos count stays accurate across surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
