### PR TITLE
feat: add publish/unpublish page IPC contract and daemon handlers

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -313,6 +313,14 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     sessionId: 'sess-001',
     surfaceId: 'surface-001',
   },
+  publish_page: {
+    type: 'publish_page',
+    html: '<html><body>Hello</body></html>',
+  },
+  unpublish_page: {
+    type: 'unpublish_page',
+    deploymentId: 'dpl-001',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -874,6 +882,16 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     surfaceId: 'surface-001',
     success: true,
     remainingUndos: 3,
+  },
+  publish_page_response: {
+    type: 'publish_page_response',
+    success: true,
+    publicUrl: 'https://example.vercel.app',
+    deploymentId: 'dpl-001',
+  },
+  unpublish_page_response: {
+    type: 'unpublish_page_response',
+    success: true,
   },
 };
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -55,6 +55,8 @@ import type {
   ShareToSlackRequest,
   SlackWebhookConfigRequest,
   AppUpdatePreviewRequest,
+  PublishPageRequest,
+  UnpublishPageRequest,
 } from './ipc-protocol.js';
 import { postToSlackWebhook } from '../slack/slack-webhook.js';
 import { createHash } from 'node:crypto';
@@ -81,6 +83,9 @@ import { packageApp } from '../bundler/app-bundler.js';
 import { createSharedAppLink } from '../memory/shared-app-links-store.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
+import { deployHtmlToVercel, deleteVercelDeployment } from '../services/vercel-deploy.js';
+import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedPageByDeploymentId } from '../memory/published-pages-store.js';
+import { getSecureKey } from '../security/secure-keys.js';
 import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId, validateBlobKindEncoding } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
@@ -443,6 +448,8 @@ const handlers: DispatchMap = {
   gallery_install: handleGalleryInstall,
   share_to_slack: handleShareToSlack,
   slack_webhook_config: handleSlackWebhookConfig,
+  publish_page: handlePublishPage,
+  unpublish_page: handleUnpublishPage,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ipc_blob_probe: handleIpcBlobProbe,
   ui_surface_action: (msg, _socket, ctx) => {
@@ -2080,6 +2087,109 @@ async function handleShareAppCloud(
     log.error({ err, appId: msg.appId }, 'Failed to share app to cloud');
     ctx.send(socket, {
       type: 'share_app_cloud_response',
+      success: false,
+      error: message,
+    });
+  }
+}
+
+// ─── Publish page handlers ──────────────────────────────────────────────────
+
+async function handlePublishPage(
+  msg: PublishPageRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    const token = getSecureKey('credential:vercel:api_token');
+    if (!token) {
+      ctx.send(socket, {
+        type: 'publish_page_response',
+        success: false,
+        error: 'No Vercel API token configured. Use the credential store to add one (service: vercel, field: api_token).',
+      });
+      return;
+    }
+
+    // Hash the HTML for dedup
+    const htmlHash = createHash('sha256').update(msg.html).digest('hex');
+
+    // Check if already published
+    const existing = getPublishedPageByHash(htmlHash);
+    if (existing) {
+      ctx.send(socket, {
+        type: 'publish_page_response',
+        success: true,
+        publicUrl: existing.publicUrl,
+        deploymentId: existing.deploymentId,
+      });
+      return;
+    }
+
+    const name = msg.title
+      ? msg.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50)
+      : `vellum-page-${Date.now()}`;
+
+    const result = await deployHtmlToVercel({ html: msg.html, name, token });
+
+    const id = uuid();
+    createPublishedPage({
+      id,
+      deploymentId: result.deploymentId,
+      publicUrl: result.url,
+      pageTitle: msg.title,
+      htmlHash,
+    });
+
+    ctx.send(socket, {
+      type: 'publish_page_response',
+      success: true,
+      publicUrl: result.url,
+      deploymentId: result.deploymentId,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to publish page');
+    ctx.send(socket, {
+      type: 'publish_page_response',
+      success: false,
+      error: message,
+    });
+  }
+}
+
+async function handleUnpublishPage(
+  msg: UnpublishPageRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    const token = getSecureKey('credential:vercel:api_token');
+    if (!token) {
+      ctx.send(socket, {
+        type: 'unpublish_page_response',
+        success: false,
+        error: 'No Vercel API token configured.',
+      });
+      return;
+    }
+
+    await deleteVercelDeployment(msg.deploymentId, token);
+
+    const record = getPublishedPageByDeploymentId(msg.deploymentId);
+    if (record) {
+      markDeleted(record.id);
+    }
+
+    ctx.send(socket, {
+      type: 'unpublish_page_response',
+      success: true,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, deploymentId: msg.deploymentId }, 'Failed to unpublish page');
+    ctx.send(socket, {
+      type: 'unpublish_page_response',
       success: false,
       error: message,
     });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -520,6 +520,31 @@ export interface UiSurfaceUndoRequest {
   surfaceId: string;
 }
 
+export interface PublishPageRequest {
+  type: 'publish_page';
+  html: string;
+  title?: string;
+}
+
+export interface PublishPageResponse {
+  type: 'publish_page_response';
+  success: boolean;
+  publicUrl?: string;
+  deploymentId?: string;
+  error?: string;
+}
+
+export interface UnpublishPageRequest {
+  type: 'unpublish_page';
+  deploymentId: string;
+}
+
+export interface UnpublishPageResponse {
+  type: 'unpublish_page_response';
+  success: boolean;
+  error?: string;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -582,7 +607,9 @@ export type ClientMessage =
   | SessionsClearRequest
   | GalleryListRequest
   | GalleryInstallRequest
-  | AppUpdatePreviewRequest;
+  | AppUpdatePreviewRequest
+  | PublishPageRequest
+  | UnpublishPageRequest;
 
 // === Server → Client messages ===
 
@@ -1347,7 +1374,9 @@ export type ServerMessage =
   | GalleryInstallResponse
   | ShareToSlackResponse
   | SlackWebhookConfigResponse
-  | AppUpdatePreviewResponse;
+  | AppUpdatePreviewResponse
+  | PublishPageResponse
+  | UnpublishPageResponse;
 
 // === Contract schema ===
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -604,6 +604,20 @@ public struct IPCPongMessage: Codable, Sendable {
     public let type: String
 }
 
+public struct IPCPublishPageRequest: Codable, Sendable {
+    public let type: String
+    public let html: String
+    public let title: String?
+}
+
+public struct IPCPublishPageResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let publicUrl: String?
+    public let deploymentId: String?
+    public let error: String?
+}
+
 public struct IPCRegenerateRequest: Codable, Sendable {
     public let type: String
     public let sessionId: String
@@ -1213,7 +1227,7 @@ public struct IPCUiSurfaceShowTable: Codable, Sendable {
     public let display: String?
 }
 
-public struct IPCUiSurfaceUndo: Codable, Sendable {
+public struct IPCUiSurfaceUndoRequest: Codable, Sendable {
     public let type: String
     public let sessionId: String
     public let surfaceId: String
@@ -1224,7 +1238,8 @@ public struct IPCUiSurfaceUndoResult: Codable, Sendable {
     public let sessionId: String
     public let surfaceId: String
     public let success: Bool
-    public let remainingUndos: Int
+    /// Number of remaining undo entries after this undo.
+    public let remainingUndos: Double
 }
 
 public struct IPCUiSurfaceUpdate: Codable, Sendable {
@@ -1243,6 +1258,17 @@ public struct IPCUndoComplete: Codable, Sendable {
 public struct IPCUndoRequest: Codable, Sendable {
     public let type: String
     public let sessionId: String
+}
+
+public struct IPCUnpublishPageRequest: Codable, Sendable {
+    public let type: String
+    public let deploymentId: String
+}
+
+public struct IPCUnpublishPageResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let error: String?
 }
 
 public struct IPCUpdateTrustRule: Codable, Sendable {
@@ -1290,6 +1316,7 @@ public struct IPCUserMessage: Codable, Sendable {
     public let content: String?
     public let attachments: [IPCUserMessageAttachment]?
     public let activeSurfaceId: String?
+    /// The page currently displayed in the WebView (e.g. "settings.html").
     public let currentPage: String?
 }
 


### PR DESCRIPTION
## Summary
- Add `PublishPageRequest`/`PublishPageResponse` and `UnpublishPageRequest`/`UnpublishPageResponse` IPC contract types
- Add daemon handlers that deploy HTML pages to Vercel with SHA-256 content-hash deduplication
- Regenerate Swift IPC contract bindings
- Update IPC snapshot tests with new message types

Part of #2803

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] Swift codegen regenerated successfully
- [x] IPC snapshot test updated with new message type entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
