### PR TITLE
feat: cut over skills to workspace/skills path

### DIFF
--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -8,6 +8,7 @@ let TEST_DIR = '';
 
 mock.module('../util/platform.js', () => ({
   getRootDir: () => TEST_DIR,
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
 }));
 
 mock.module('../util/logger.js', () => ({

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -25,6 +25,7 @@ const mockConfig = {
 
 mock.module('../util/platform.js', () => ({
   getRootDir: () => TEST_DIR,
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
   getDataDir: () => TEST_DIR,
   ensureDataDir: () => {},
   getSocketPath: () => join(TEST_DIR, 'vellum.sock'),

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -9,6 +9,7 @@ let TEST_DIR = '';
 
 mock.module('../util/platform.js', () => ({
   getRootDir: () => TEST_DIR,
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
 }));
 
 mock.module('../util/logger.js', () => ({

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync, realpathSync, statSync, writeFil
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import Anthropic from '@anthropic-ai/sdk';
 import { getConfig } from './loader.js';
-import { getRootDir } from '../util/platform.js';
+import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { stripCommentLines } from './system-prompt.js';
 
@@ -148,7 +148,7 @@ export function checkSkillRequirements(
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 export function getSkillsDir(): string {
-  return join(getRootDir(), 'skills');
+  return getWorkspaceSkillsDir();
 }
 
 export function getBundledSkillsDir(): string {

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -73,7 +73,7 @@ import { handleWatchObservation } from './watch-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp, createApp, updateApp } from '../memory/app-store.js';
 import { defaultGallery } from '../gallery/default-gallery.js';
-import { getRootDir } from '../util/platform.js';
+import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 import { parseSlashCandidate } from '../skills/slash-commands.js';
 import { removeSkillsIndexEntry, deleteManagedSkill, validateManagedSkillId } from '../skills/managed-store.js';
@@ -1180,7 +1180,7 @@ async function handleSkillsUninstall(
       }
     } else {
       // Namespaced slug (org/name) — direct filesystem removal
-      const skillDir = join(getRootDir(), 'skills', msg.name);
+      const skillDir = join(getWorkspaceSkillsDir(), msg.name);
       if (!existsSync(skillDir)) {
         ctx.send(socket, {
           type: 'skills_operation_response',

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 import { existsSync, chmodSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
-import { getSocketPath, getRootDir, getWorkspaceDir, getSandboxWorkingDir, removeSocketFile } from '../util/platform.js';
+import { getSocketPath, getRootDir, getWorkspaceDir, getWorkspaceSkillsDir, getSandboxWorkingDir, removeSocketFile } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -303,7 +303,7 @@ export class DaemonServer {
   }
 
   private startSkillsWatchers(evictSessions: () => void): void {
-    const skillsDir = join(getRootDir(), 'skills');
+    const skillsDir = getWorkspaceSkillsDir();
     if (!existsSync(skillsDir)) return;
 
     const scheduleSkillsReload = (file: string): void => {

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -1,12 +1,11 @@
 import { getLogger } from '../util/logger.js';
-import { getRootDir } from '../util/platform.js';
-import { join } from 'node:path';
+import { getWorkspaceSkillsDir } from '../util/platform.js';
 
 const log = getLogger('clawhub');
 
 // Managed skills directory
 function getManagedSkillsDir(): string {
-  return join(getRootDir(), 'skills');
+  return getWorkspaceSkillsDir();
 }
 
 // Validate slug format (alphanumeric, hyphens, dots, underscores; optional namespace with single slash)

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, renameSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { getRootDir } from '../util/platform.js';
+import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('managed-store');
@@ -24,7 +24,7 @@ export function validateManagedSkillId(id: string): string | null {
 // ─── Path helpers ────────────────────────────────────────────────────────────
 
 export function getManagedSkillsDir(): string {
-  return join(getRootDir(), 'skills');
+  return getWorkspaceSkillsDir();
 }
 
 export function getManagedSkillDir(id: string): string {


### PR DESCRIPTION
## Summary
- All managed-skill paths use `getWorkspaceSkillsDir()` (PR 13 of workspace migration plan)
- Updated skills.ts, managed-store.ts, clawhub.ts, server.ts, handlers.ts
- Phase 1 complete — all core paths now workspace-backed

## Test plan
- [x] Skills tests pass (managed-store, lifecycle, delete-managed-skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
