### PR TITLE
feat: cut over IPC blob dir to workspace/data path

### DIFF
--- a/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
@@ -111,31 +111,30 @@ final class IpcBlobStoreTests: XCTestCase {
     }
 
     // MARK: - resolveBlobDir
-    // Baseline: blob dir currently resolves under ~/.vellum/data/ipc-blobs.
-    // WILL MOVE to ~/.vellum/workspace/data/ipc-blobs after workspace migration.
+    // Blob dir resolves under ~/.vellum/workspace/data/ipc-blobs (workspace-backed).
 
     func testResolveBlobDirDefaultsToHomeDotVellum() {
         let resolved = resolveBlobDir(environment: [:])
         let home = NSHomeDirectory()
-        XCTAssertEqual(resolved, home + "/.vellum/data/ipc-blobs")
+        XCTAssertEqual(resolved, home + "/.vellum/workspace/data/ipc-blobs")
     }
 
     func testResolveBlobDirHonorsBaseDataDir() {
         let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "/tmp/custom-root"])
-        XCTAssertEqual(resolved, "/tmp/custom-root/.vellum/data/ipc-blobs")
+        XCTAssertEqual(resolved, "/tmp/custom-root/.vellum/workspace/data/ipc-blobs")
     }
 
     func testResolveBlobDirIgnoresEmptyBaseDataDir() {
         let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "  "])
         let home = NSHomeDirectory()
-        XCTAssertEqual(resolved, home + "/.vellum/data/ipc-blobs")
+        XCTAssertEqual(resolved, home + "/.vellum/workspace/data/ipc-blobs")
     }
 
     func testResolveBlobDirDoesNotExpandTildeInBaseDataDir() {
         // The daemon's getRootDir() keeps BASE_DATA_DIR literal via path.join(),
         // so the Swift client must NOT expand "~/" either.
         let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "~/custom"])
-        XCTAssertEqual(resolved, "~/custom/.vellum/data/ipc-blobs")
+        XCTAssertEqual(resolved, "~/custom/.vellum/workspace/data/ipc-blobs")
         XCTAssertFalse(resolved.contains(NSHomeDirectory()), "home dir should NOT appear in path")
     }
 

--- a/clients/shared/IPC/IpcBlobStore.swift
+++ b/clients/shared/IPC/IpcBlobStore.swift
@@ -8,7 +8,7 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Ip
 /// The daemon derives its blob dir from `BASE_DATA_DIR` (or `$HOME`), so the
 /// client must use the same root to ensure probe files land in the same directory.
 ///
-/// Resolution: `(BASE_DATA_DIR || $HOME) / .vellum / data / ipc-blobs`
+/// Resolution: `(BASE_DATA_DIR || $HOME) / .vellum / workspace / data / ipc-blobs`
 ///
 /// Returns a plain string path rather than a URL to avoid Foundation's URL
 /// layer normalizing or expanding tildes (both `URL(fileURLWithPath:)` and
@@ -22,7 +22,7 @@ func resolveBlobDir(environment: [String: String]? = nil) -> String {
     } else {
         root = NSHomeDirectory()
     }
-    return root + "/.vellum/data/ipc-blobs"
+    return root + "/.vellum/workspace/data/ipc-blobs"
 }
 
 /// Manages local blob files for zero-copy IPC transport.


### PR DESCRIPTION
## Summary
- Updates Swift `resolveBlobDir()` to `~/.vellum/workspace/data/ipc-blobs` (PR 14 of workspace migration plan)
- Updates 4 Swift test assertions
- TS ipc-blob-store tests unaffected (use mock)

## Test plan
- [x] `bun test src/__tests__/ipc-blob-store.test.ts` — 24 tests pass
- [x] Swift `IpcBlobStore.swift` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
