### PR TITLE
fix: remove overly broad body > * width cap from design system

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -182,10 +182,6 @@ body {
   justify-content: center;
   -webkit-font-smoothing: antialiased;
 }
-body > * {
-  width: 100%;
-  max-width: 900px;
-}
 
 @media (prefers-color-scheme: dark) {
   body {


### PR DESCRIPTION
## Summary
- Removes the `body > *` CSS rule that applied `max-width: 900px` to every direct body child
- This rule (added in #2800) over-constrained runtime overlays like `#vellum-bottom-fade` that need full viewport width
- Content centering is already handled by `.v-page { max-width: 900px }`

Addresses feedback from Codex on #2800.

## Test plan
- [ ] Verify apps still center correctly (`.v-page` handles max-width)
- [ ] Verify bottom fade overlay spans full viewport width on wide webviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
