### PR TITLE
fix: guard page-tracking edge cases from PR #2798 feedback

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -112,7 +112,7 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
 
     // Build additional page content (all pages except the primary one)
     const otherPages: Record<string, string> = {};
-    if (viewingPage) {
+    if (viewingPage && primaryLabel !== 'index.html') {
       // Show index.html as additional context
       otherPages['index.html'] = ctx.html;
     }


### PR DESCRIPTION
## Summary
- **Fix duplicate index.html injection**: When `viewingPage` is set but not found in `appPages`, the fallback keeps `primaryLabel = 'index.html'`. Previously, the `otherPages` block unconditionally added `index.html` as additional context whenever `viewingPage` was truthy, causing index.html to appear as both the primary page and in additional context. Added a `primaryLabel !== 'index.html'` guard to prevent this duplication.

Addresses Devin reviewer feedback on PR #2798.

**Note:** The Codex feedback regarding the `onPageChanged` closure in `MainWindowView.swift` (capturing `threadManager.activeViewModel` at closure creation time to prevent stale writes) could not be applied due to sandbox file permission restrictions on the `Features/MainWindow/` directory. That fix still needs to be applied separately:
```swift
// In dynamicWorkspaceView, before ZStack:
let currentViewModel = threadManager.activeViewModel
// Then in the closure:
onPageChanged: { [weak currentViewModel] page in
    currentViewModel?.currentPage = page
},
```

## Test plan
- [ ] Verify that when `currentPage` is set to a non-existent page name, `index.html` only appears once in context (as the primary page, not duplicated in additional pages)
- [ ] Verify that when `currentPage` points to a valid additional page, `index.html` correctly appears in additional context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
