### PR TITLE
feat: update macOS identity, profile, and UI paths to workspace layout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -9,10 +9,10 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate")
 
-/// Writes `~/.vellum/IDENTITY.md` with the assistant's chosen name so the
+/// Writes `~/.vellum/workspace/IDENTITY.md` with the assistant's chosen name so the
 /// daemon's system prompt includes the correct identity.
 func writeVellumIdentityFile(name: String) {
-    let vellumDir = NSHomeDirectory() + "/.vellum"
+    let vellumDir = NSHomeDirectory() + "/.vellum/workspace"
     let identityPath = vellumDir + "/IDENTITY.md"
     let content = """
     # IDENTITY
@@ -839,7 +839,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         onboardingWindow = onboarding
     }
 
-    /// Writes (or updates) `~/.vellum/IDENTITY.md` with the user-chosen assistant name.
+    /// Writes (or updates) `~/.vellum/workspace/IDENTITY.md` with the user-chosen assistant name.
     ///
     /// If the file already exists, only the `- **Name:** …` line is replaced so that
     /// user customizations (extra persona instructions, changed role/tone, etc.) are preserved.
@@ -848,7 +848,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
 
-        let vellumDir = NSHomeDirectory() + "/.vellum"
+        let vellumDir = NSHomeDirectory() + "/.vellum/workspace"
         let identityPath = vellumDir + "/IDENTITY.md"
 
         do {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -52,7 +52,7 @@ struct AgentPanel: View {
             }
         } message: {
             if let skill = skillToDelete {
-                Text("Are you sure you want to delete \"\(skill.name)\"? This will remove it from ~/.vellum/skills/.")
+                Text("Are you sure you want to delete \"\(skill.name)\"? This will remove it from ~/.vellum/workspace/skills/.")
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
@@ -32,7 +32,7 @@ private struct ExtractionResponse: Codable {
 
 /// Extracts a structured user profile from an interview transcript by sending
 /// the conversation to a new daemon session with a profile-extraction system prompt.
-/// Merges `personality` and `userBehavior` into `~/.vellum/SOUL.md` and stores the
+/// Merges `personality` and `userBehavior` into `~/.vellum/workspace/SOUL.md` and stores the
 /// profile in UserDefaults for client-side use.
 ///
 /// Designed to run in the background after onboarding completes. Fails silently
@@ -221,7 +221,7 @@ final class ProfileExtractor {
         return jsonString.data(using: .utf8)
     }
 
-    /// Writes the assistant's name to `~/.vellum/IDENTITY.md` so the daemon
+    /// Writes the assistant's name to `~/.vellum/workspace/IDENTITY.md` so the daemon
     /// knows who it is when building the system prompt.
     private func writeIdentityFile(_ name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -232,7 +232,7 @@ final class ProfileExtractor {
         writeVellumIdentityFile(name: trimmed)
     }
 
-    /// Updates `~/.vellum/SOUL.md` by merging personality and user-behavior
+    /// Updates `~/.vellum/workspace/SOUL.md` by merging personality and user-behavior
     /// content into the existing file's `## Personality` and `## User-Specific Behavior`
     /// sections rather than overwriting the whole file (which would nuke Core Principles,
     /// Boundaries, Evolution guardrails, etc.).
@@ -240,7 +240,7 @@ final class ProfileExtractor {
     /// If SOUL.md doesn't exist yet, writes a minimal file with just these two sections;
     /// the daemon's `ensurePromptFiles()` will seed the full template on next startup.
     private func updateSoulFile(personality: String, userBehavior: String) {
-        let vellumDir = NSHomeDirectory() + "/.vellum"
+        let vellumDir = NSHomeDirectory() + "/.vellum/workspace"
         let soulPath = vellumDir + "/SOUL.md"
 
         do {

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -316,7 +316,7 @@ struct SkillsSettingsView: View {
             }
         } message: {
             if let skill = skillToDelete {
-                Text("Are you sure you want to delete \"\(skill.name)\"? This will remove it from ~/.vellum/skills/.")
+                Text("Are you sure you want to delete \"\(skill.name)\"? This will remove it from ~/.vellum/workspace/skills/.")
             }
         }
         .sheet(item: $inspectingSkill) { skill in


### PR DESCRIPTION
## Summary
- Updates hardcoded `~/.vellum/` paths in the macOS client to use the new `~/.vellum/workspace/` layout
- **AppDelegate**: identity file writes now target `~/.vellum/workspace/`
- **ProfileExtractor**: SOUL/IDENTITY file paths updated to workspace dir
- **SkillsSettingsView & AgentPanel**: UI text references updated from `~/.vellum/skills/` to `~/.vellum/workspace/skills/`

Part of the workspace migration plan (PRs 15-17 combined).

## Test plan
- [ ] Verify macOS app builds successfully
- [ ] Verify identity files are written to `~/.vellum/workspace/` on launch
- [ ] Verify UI text shows correct workspace paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
