### PR TITLE
feat: add publish button for static pages in macOS client

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -13,6 +13,8 @@ struct MainWindowView: View {
     @State private var showSharePicker = false
     @State private var isBundling = false
     @State private var shareFileURL: URL?
+    @State private var isPublishing = false
+    @State private var publishedUrl: String?
     @State private var isHoveredThread: UUID?
     @State private var threadMenuOpenId: UUID?
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
@@ -54,6 +56,28 @@ struct MainWindowView: View {
     private func pageURL(for appId: String) -> URL? {
         guard let port = daemonClient.httpPort else { return nil }
         return URL(string: "http://localhost:\(port)/pages/\(appId)")
+    }
+
+    private func publishPage(html: String, title: String?) {
+        guard !isPublishing else { return }
+        isPublishing = true
+
+        Task { @MainActor in
+            daemonClient.onPublishPageResponse = { response in
+                isPublishing = false
+                if response.success, let url = response.publicUrl {
+                    publishedUrl = url
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(url, forType: .string)
+                }
+            }
+
+            do {
+                try daemonClient.sendPublishPage(html: html, title: title)
+            } catch {
+                isPublishing = false
+            }
+        }
     }
 
     private func bundleAndShare(appId: String) {
@@ -651,6 +675,63 @@ struct MainWindowView: View {
                             )
                             .frame(width: 1, height: 1)
                         )
+                    } else {
+                        // Publish button for static pages
+                        Button(action: {
+                            publishPage(html: data.html, title: data.preview?.title)
+                        }) {
+                            Group {
+                                if isPublishing {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .scaleEffect(0.7)
+                                } else if publishedUrl != nil {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .font(.system(size: 12, weight: .medium))
+                                } else {
+                                    Image(systemName: "globe")
+                                        .font(.system(size: 12, weight: .medium))
+                                }
+                            }
+                            .foregroundColor(publishedUrl != nil ? VColor.success : VColor.textPrimary)
+                            .frame(width: 32, height: 32)
+                            .background(
+                                Circle()
+                                    .fill(VColor.surface.opacity(0.85))
+                                    .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isPublishing)
+                        .accessibilityLabel(publishedUrl != nil ? "Published" : "Publish")
+
+                        // Show URL pill after publishing
+                        if let url = publishedUrl {
+                            Button(action: {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(url, forType: .string)
+                            }) {
+                                HStack(spacing: VSpacing.xs) {
+                                    Image(systemName: "doc.on.doc")
+                                        .font(.system(size: 10, weight: .medium))
+                                    Text(url)
+                                        .font(VFont.caption)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                                .foregroundColor(VColor.textSecondary)
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, VSpacing.xs)
+                                .background(
+                                    Capsule()
+                                        .fill(VColor.surface.opacity(0.85))
+                                        .overlay(Capsule().stroke(VColor.surfaceBorder, lineWidth: 1))
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Copy published URL")
+                            .frame(maxWidth: 200)
+                        }
                     }
                 }
                 .padding(.horizontal, VSpacing.xl)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -152,6 +152,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `slack_webhook_config_response` message.
     public var onSlackWebhookConfigResponse: ((SlackWebhookConfigResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `publish_page_response` message.
+    public var onPublishPageResponse: ((PublishPageResponseMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -687,6 +690,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(SlackWebhookConfigRequestMessage(action: action, webhookUrl: webhookUrl))
     }
 
+    /// Publish a static page to Vercel.
+    public func sendPublishPage(html: String, title: String? = nil) throws {
+        try send(PublishPageRequestMessage(html: html, title: title))
+    }
+
+    /// Unpublish a page and delete its Vercel deployment.
+    public func sendUnpublishPage(deploymentId: String) throws {
+        try send(UnpublishPageRequestMessage(deploymentId: deploymentId))
+    }
+
     // MARK: - Signing Identity (macOS only)
 
     #if os(macOS)
@@ -906,6 +919,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onShareToSlackResponse?(msg)
         case .slackWebhookConfigResponse(let msg):
             onSlackWebhookConfigResponse?(msg)
+        case .publishPageResponse(let msg):
+            onPublishPageResponse?(msg)
+        case .unpublishPageResponse:
+            break // Handled via specific callback if needed
         case .memoryStatus(let msg):
             latestMemoryStatus = msg
         case .traceEvent(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1266,6 +1266,36 @@ extension IPCOpenBundleResponseManifest {
 }
 
 
+// MARK: - Publish / Unpublish Page Messages
+
+/// Sent to publish a static page via Vercel.
+/// Backed by generated `IPCPublishPageRequest`.
+public typealias PublishPageRequestMessage = IPCPublishPageRequest
+
+extension IPCPublishPageRequest {
+    public init(html: String, title: String? = nil) {
+        self.init(type: "publish_page", html: html, title: title)
+    }
+}
+
+/// Response from publishing a static page.
+/// Backed by generated `IPCPublishPageResponse`.
+public typealias PublishPageResponseMessage = IPCPublishPageResponse
+
+/// Sent to unpublish a page and delete its Vercel deployment.
+/// Backed by generated `IPCUnpublishPageRequest`.
+public typealias UnpublishPageRequestMessage = IPCUnpublishPageRequest
+
+extension IPCUnpublishPageRequest {
+    public init(deploymentId: String) {
+        self.init(type: "unpublish_page", deploymentId: deploymentId)
+    }
+}
+
+/// Response from unpublishing a page.
+/// Backed by generated `IPCUnpublishPageResponse`.
+public typealias UnpublishPageResponseMessage = IPCUnpublishPageResponse
+
 // MARK: - Slack Webhook Messages (Manual)
 
 public struct ShareToSlackRequestMessage: Encodable, Sendable {
@@ -1355,6 +1385,8 @@ public enum ServerMessage: Decodable, Sendable {
     case signBundlePayload(SignBundlePayloadMessage)
     case shareToSlackResponse(ShareToSlackResponseMessage)
     case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
+    case publishPageResponse(PublishPageResponseMessage)
+    case unpublishPageResponse(UnpublishPageResponseMessage)
     case uiSurfaceUndoResult(UiSurfaceUndoResultMessage)
     case ipcBlobProbeResult(IpcBlobProbeResultMessage)
     case daemonStatus(DaemonStatusMessage)
@@ -1535,6 +1567,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "daemon_status":
             let message = try DaemonStatusMessage(from: decoder)
             self = .daemonStatus(message)
+        case "publish_page_response":
+            let message = try PublishPageResponseMessage(from: decoder)
+            self = .publishPageResponse(message)
+        case "unpublish_page_response":
+            let message = try UnpublishPageResponseMessage(from: decoder)
+            self = .unpublishPageResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add IPC message typealiases and convenience inits for `PublishPageRequest/Response` and `UnpublishPageRequest/Response` in `IPCMessages.swift`, wired into the `ServerMessage` enum decoder
- Add `onPublishPageResponse` callback, `sendPublishPage`, and `sendUnpublishPage` methods to `DaemonClient`
- Add a globe publish button in `MainWindowView` for non-app surfaces that publishes static HTML to Vercel, shows a checkmark on success, and copies the public URL to clipboard with a URL pill for re-copying

Part of #2804

## Test plan
- [ ] Verify publish button appears for surfaces without an `appId`
- [ ] Verify clicking publish sends `publish_page` IPC message and shows spinner
- [ ] Verify successful response shows checkmark icon and copies URL to clipboard
- [ ] Verify URL pill appears and allows re-copying
- [ ] Verify existing share button still works for app-based surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
