### PR TITLE
feat: add activity completion notifications for computer-use sessions

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -199,6 +199,22 @@ export function initializeDb(): void {
   `);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS message_surfaces (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      surface_id TEXT NOT NULL,
+      surface_type TEXT NOT NULL,
+      title TEXT,
+      data TEXT NOT NULL,
+      actions TEXT,
+      surface_message TEXT,
+      display TEXT,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS channel_inbound_events (
       id TEXT PRIMARY KEY,
       assistant_id TEXT NOT NULL,

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -210,7 +210,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             daemonClient: self.daemonClient,
             maxSteps: maxSteps,
             sessionId: routed.sessionId,
-            skipSessionCreate: true
+            skipSessionCreate: true,
+            notificationService: self.services.activityNotificationService
         )
         self.currentSession = session
 
@@ -1062,7 +1063,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     maxSteps: maxSteps,
                     attachments: submission.attachments,
                     sessionId: routed.sessionId,
-                    skipSessionCreate: true
+                    skipSessionCreate: true,
+                    notificationService: self.services.activityNotificationService
                 )
                 self.currentSession = session
                 let overlay = SessionOverlayWindow(session: session)
@@ -1146,7 +1148,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             actions: [approveAction, dismissAction],
             intentIdentifiers: []
         )
-        center.setNotificationCategories([automationCategory])
+
+        let viewAction = UNNotificationAction(
+            identifier: "VIEW_ACTIVITY",
+            title: "View Results",
+            options: .foreground
+        )
+        let activityCategory = UNNotificationCategory(
+            identifier: "ACTIVITY_COMPLETE",
+            actions: [viewAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([automationCategory, activityCategory])
     }
 
     private func registerBundledFonts() {
@@ -1351,7 +1366,24 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse
     ) async {
         let userInfo = response.notification.request.content.userInfo
-        guard response.notification.request.content.categoryIdentifier == "AUTOMATION_INSIGHT",
+        let categoryId = response.notification.request.content.categoryIdentifier
+
+        // Handle activity completion notifications
+        if categoryId == "ACTIVITY_COMPLETE" {
+            await MainActor.run {
+                // Show main window
+                self.showMainWindow()
+
+                // Optional: Navigate to the completed session/thread
+                // if let sessionId = userInfo["sessionId"] as? String {
+                //     // Navigate to thread containing this session
+                // }
+            }
+            return
+        }
+
+        // Handle automation insight notifications
+        guard categoryId == "AUTOMATION_INSIGHT",
               let insightId = userInfo["insightId"] as? String,
               let insightTitle = userInfo["insightTitle"] as? String,
               let description = userInfo["insightDescription"] as? String else {

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -17,4 +17,10 @@ public final class AppServices {
         ambientAgent: ambientAgent,
         daemonClient: daemonClient
     )
+
+    /// Activity notification service for sending push notifications on task completion.
+    /// Lazy because it needs `settingsStore` which is set above.
+    public lazy var activityNotificationService: ActivityNotificationService = ActivityNotificationService(
+        settingsStore: settingsStore
+    )
 }

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -31,6 +31,10 @@ final class ComputerUseSession: ObservableObject {
     private let maxSteps: Int
     private let interactionType: InteractionType
     private let skipSessionCreate: Bool
+    private let notificationService: ActivityNotificationServiceProtocol?
+
+    /// Weak reference to the chat view model for extracting tool calls for notifications.
+    weak var relatedViewModel: ChatViewModel?
 
     private var isCancelled = false
     private var isPaused = false
@@ -68,7 +72,8 @@ final class ComputerUseSession: ObservableObject {
         initialDelayMs: UInt64 = 300,
         adaptiveDelay: Bool = true,
         sessionId: String? = nil,
-        skipSessionCreate: Bool = false
+        skipSessionCreate: Bool = false,
+        notificationService: ActivityNotificationServiceProtocol? = nil
     ) {
         self.id = sessionId ?? UUID().uuidString
         self.task = task
@@ -82,6 +87,7 @@ final class ComputerUseSession: ObservableObject {
         self.initialDelayMs = initialDelayMs
         self.adaptiveDelayEnabled = adaptiveDelay
         self.skipSessionCreate = skipSessionCreate
+        self.notificationService = notificationService
         self.verifier = ActionVerifier(maxSteps: maxSteps)
         self.logger = SessionLogger(task: task, attachments: attachments)
     }
@@ -172,6 +178,24 @@ final class ComputerUseSession: ObservableObject {
                         self.state = .completed(summary: complete.summary, steps: complete.stepCount)
                     }
                     self.logger.finishSession(result: "completed: \(complete.summary)")
+                    log.info("Session completed, notificationService present: \(self.notificationService != nil)")
+
+                    // Send notification if service is available
+                    if let notificationService = self.notificationService {
+                        log.info("Calling notificationService.notifySessionComplete")
+                        let toolCalls = self.extractToolCalls()
+                        Task {
+                            await notificationService.notifySessionComplete(
+                                summary: complete.summary,
+                                steps: complete.stepCount,
+                                toolCalls: toolCalls,
+                                sessionId: self.id
+                            )
+                        }
+                    } else {
+                        log.warning("notificationService is nil, cannot send notification")
+                    }
+
                     return
 
                 case .cuError(let error) where error.sessionId == self.id:
@@ -825,6 +849,18 @@ final class ComputerUseSession: ObservableObject {
         if interactiveCount < 3 { return true }
         if consecutiveUnchangedSteps >= 2 { return true }
         return false
+    }
+
+    // MARK: - Helper Methods
+
+    /// Extracts all tool calls from the related ChatViewModel for notification purposes.
+    private func extractToolCalls() -> [ToolCallData] {
+        guard let viewModel = relatedViewModel else { return [] }
+
+        // Collect tool calls from all assistant messages
+        return viewModel.messages
+            .filter { $0.role == .assistant }
+            .flatMap { $0.toolCalls }
     }
 
     // MARK: - Control

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -250,17 +250,6 @@ struct ChatView: View {
 
     // MARK: - Message List
 
-    /// Check if the next assistant message after `index` has inline surfaces,
-    /// meaning tool call chips at `index` should be hidden.
-    private func nextAssistantHasSurfaces(after index: Int) -> Bool {
-        for i in (index + 1)..<messages.count {
-            let m = messages[i]
-            if m.role == .user { break }
-            if !m.inlineSurfaces.isEmpty { return true }
-        }
-        return false
-    }
-
     private func shouldShowTimestamp(at index: Int) -> Bool {
         if index == 0 { return true }
         let current = messages[index].timestamp
@@ -292,7 +281,7 @@ struct ChatView: View {
                         } else {
                             ChatBubble(
                                 message: message,
-                                hideToolCalls: nextAssistantHasSurfaces(after: index),
+                                hideToolCalls: false,
                                 onSurfaceAction: onSurfaceAction,
                                 onOpenActivity: onOpenActivity,
                                 isActivityPanelOpen: isActivityPanelOpen
@@ -618,30 +607,18 @@ private struct ChatBubble: View {
         return hasText || !message.attachments.isEmpty
     }
 
-    /// Tool calls that arrived before any text content in the message.
-    private var toolCallsBeforeText: [ToolCallData] {
-        message.toolCalls.filter { $0.arrivedBeforeText }
-    }
-
-    /// Tool calls that arrived after text content started streaming.
-    private var toolCallsAfterText: [ToolCallData] {
-        message.toolCalls.filter { !$0.arrivedBeforeText }
-    }
 
     var body: some View {
         HStack {
             if isUser { Spacer(minLength: 0) }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
-                // Pre-text tool calls render above the bubble
-                toolCallChips(toolCallsBeforeText)
-
                 if shouldShowBubble {
                     bubbleContent
                 }
 
-                // Post-text tool calls render below the bubble
-                toolCallChips(toolCallsAfterText)
+                // Consolidated tool indicator showing all tool calls
+                toolCallChips(message.toolCalls)
 
                 // Inline surfaces render below the bubble as full-width cards
                 if !message.inlineSurfaces.isEmpty {
@@ -662,11 +639,15 @@ private struct ChatBubble: View {
     }
 
     /// Current step indicator rendered outside the bubble.
-    /// Hidden for user messages, when there are no tool calls, or when inline surfaces are present.
+    /// Shows when message is streaming or has tool calls.
     @ViewBuilder
     private func toolCallChips(_ calls: [ToolCallData]) -> some View {
-        if !isUser && !calls.isEmpty && message.inlineSurfaces.isEmpty && !hideToolCalls {
-            CurrentStepIndicator(toolCalls: calls, isActivityPanelOpen: isActivityPanelOpen) {
+        if !isUser && (message.isStreaming || !calls.isEmpty) {
+            CurrentStepIndicator(
+                toolCalls: calls,
+                isActivityPanelOpen: isActivityPanelOpen,
+                isStreaming: message.isStreaming
+            ) {
                 onOpenActivity(calls)
             }
             .frame(maxWidth: 520, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -37,7 +37,10 @@ final class MainWindow {
 
     init(services: AppServices) {
         self.services = services
-        self.threadManager = ThreadManager(daemonClient: services.daemonClient)
+        self.threadManager = ThreadManager(
+            daemonClient: services.daemonClient,
+            activityNotificationService: services.activityNotificationService
+        )
         self.threadManager.ambientAgent = services.ambientAgent
         services.daemonClient.onTraceEvent = { [weak self] msg in
             Task { @MainActor in

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -24,6 +24,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private let daemonClient: DaemonClient
     private var viewModelCancellable: AnyCancellable?
     private let sessionRestorer: ThreadSessionRestorer
+    private let activityNotificationService: ActivityNotificationService?
 
     /// Called when an inline confirmation response should dismiss the floating panel.
     var confirmationDismissHandler: ((String) -> Void)?
@@ -38,12 +39,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     var activeViewModel: ChatViewModel? {
-        guard let activeThreadId else { return nil }
+        guard let activeThreadId else { return nil}
         return chatViewModels[activeThreadId]
     }
 
-    init(daemonClient: DaemonClient) {
+    init(daemonClient: DaemonClient, activityNotificationService: ActivityNotificationService? = nil) {
         self.daemonClient = daemonClient
+        self.activityNotificationService = activityNotificationService
         self.sessionRestorer = ThreadSessionRestorer(daemonClient: daemonClient)
         // Create one default thread so the window is never empty
         createThread()
@@ -230,7 +232,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func makeViewModel() -> ChatViewModel {
-        let viewModel = ChatViewModel(daemonClient: daemonClient)
+        let viewModel = ChatViewModel(daemonClient: daemonClient, onToolCallsComplete: { [weak self] toolCalls in
+            guard let self, let service = self.activityNotificationService else { return }
+            // Send notification when tool calls complete
+            Task { @MainActor in
+                await service.notifySessionComplete(
+                    summary: "Tool execution completed",
+                    steps: toolCalls.count,
+                    toolCalls: toolCalls,
+                    sessionId: "" // Session ID not needed for chat-based notifications
+                )
+            }
+        })
         viewModel.onInlineConfirmationResponse = { [weak self] requestId in
             self?.confirmationDismissHandler?(requestId)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -28,6 +28,11 @@ public final class SettingsStore: ObservableObject {
             ambientAgent?.captureIntervalSeconds = ambientInterval
         }
     }
+    @Published var activityNotificationsEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(activityNotificationsEnabled, forKey: "activityNotificationsEnabled")
+        }
+    }
 
     // MARK: - Trust Rules Coordination
 
@@ -55,6 +60,9 @@ public final class SettingsStore: ObservableObject {
 
         let storedInterval = UserDefaults.standard.double(forKey: "ambientCaptureInterval")
         self.ambientInterval = storedInterval == 0 ? 30 : storedInterval
+
+        // Default to enabled for notifications
+        self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true
 
         // React to Keychain changes from other surfaces
         NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -114,6 +114,14 @@ public struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Notifications") {
+                Toggle("Notify when tasks complete", isOn: $store.activityNotificationsEnabled)
+
+                Text("Get notified when computer-use sessions finish so you don't need to watch progress.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Ambient Agent") {
                 Toggle("Enable ambient screen watching", isOn: $store.ambientEnabled)
 

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -1,0 +1,123 @@
+import Foundation
+import UserNotifications
+import AppKit
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ActivityNotificationService")
+
+/// Protocol for sending activity completion notifications.
+public protocol ActivityNotificationServiceProtocol {
+    func notifySessionComplete(
+        summary: String,
+        steps: Int,
+        toolCalls: [ToolCallData],
+        sessionId: String
+    ) async
+}
+
+/// Service for sending push notifications when computer-use sessions complete.
+@MainActor
+public final class ActivityNotificationService: ActivityNotificationServiceProtocol {
+    private let settingsStore: SettingsStore
+
+    public init(settingsStore: SettingsStore) {
+        self.settingsStore = settingsStore
+    }
+
+    /// Sends a notification when a session completes.
+    /// - Only sends if notifications are enabled in settings
+    /// - Only sends if app is in background
+    /// - Only sends if notification permissions are granted
+    public func notifySessionComplete(
+        summary: String,
+        steps: Int,
+        toolCalls: [ToolCallData],
+        sessionId: String
+    ) async {
+        log.info("notifySessionComplete called for session \(sessionId, privacy: .public)")
+
+        // Check if notifications enabled in settings
+        guard settingsStore.activityNotificationsEnabled else {
+            log.info("Notifications disabled in settings")
+            return
+        }
+
+        // Check if app is in background
+        let isActive = NSApp.isActive
+        log.info("App isActive: \(isActive)")
+        guard !isActive else {
+            log.info("App is in foreground, skipping notification")
+            return
+        }
+
+        // Check notification permissions
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        log.info("Notification authorization status: \(settings.authorizationStatus.rawValue)")
+        guard settings.authorizationStatus == .authorized else {
+            log.warning("Notification permission not granted")
+            return
+        }
+
+        // Format notification content
+        let content = UNMutableNotificationContent()
+        content.title = formatTitle(summary: summary, steps: steps)
+        content.body = formatBody(toolCalls: toolCalls)
+        content.categoryIdentifier = "ACTIVITY_COMPLETE"
+        content.sound = .default
+        content.userInfo = ["sessionId": sessionId, "type": "activity_complete"]
+
+        log.info("Sending notification: \(content.title, privacy: .public)")
+
+        // Send notification
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+
+        do {
+            try await center.add(request)
+            log.info("Notification sent successfully")
+        } catch {
+            log.error("Failed to send notification: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func formatTitle(summary: String, steps: Int) -> String {
+        let stepWord = steps == 1 ? "step" : "steps"
+        return "Task completed (\(steps) \(stepWord))"
+    }
+
+    private func formatBody(toolCalls: [ToolCallData]) -> String {
+        // If no tool calls, show summary
+        guard !toolCalls.isEmpty else {
+            return "Your task has completed successfully."
+        }
+
+        // Show first few tool names with summaries
+        // Example: "Web Search: flights NYC to London, Browser Navigate, Screenshot"
+        let toolDescriptions = toolCalls.prefix(3).compactMap { tc -> String? in
+            // Skip tools without meaningful summaries
+            if tc.inputSummary.isEmpty {
+                return tc.toolName
+            } else {
+                return "\(tc.toolName): \(tc.inputSummary)"
+            }
+        }
+
+        // Build final body
+        var body = toolDescriptions.joined(separator: ", ")
+
+        if toolCalls.count > 3 {
+            let remainingCount = toolCalls.count - 3
+            let toolWord = remainingCount == 1 ? "tool" : "tools"
+            body += ", and \(remainingCount) more \(toolWord)"
+        }
+
+        return body.isEmpty ? "Your task has completed successfully." : body
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -132,6 +132,8 @@ public final class ChatViewModel: ObservableObject {
     private let daemonClient: DaemonClient
     public var sessionId: String?
     private var pendingUserMessage: String?
+    /// Optional callback for sending notifications when tool-use messages complete
+    public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
     private var pendingUserAttachments: [IPCAttachment]?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
@@ -209,8 +211,9 @@ public final class ChatViewModel: ObservableObject {
     /// Set via the onPageChanged callback when the user navigates within a multi-page app.
     public var currentPage: String?
 
-    public init(daemonClient: DaemonClient) {
+    public init(daemonClient: DaemonClient, onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
         self.daemonClient = daemonClient
+        self.onToolCallsComplete = onToolCallsComplete
     }
 
     // MARK: - Attachments
@@ -766,9 +769,15 @@ public final class ChatViewModel: ObservableObject {
             if !wasRefinement {
                 ingestAssistantAttachments(complete.attachments)
             }
+            var completedToolCalls: [ToolCallData]?
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                // Check if this message has completed tool calls
+                let toolCalls = messages[index].toolCalls
+                if !toolCalls.isEmpty && toolCalls.allSatisfy({ $0.isComplete }) {
+                    completedToolCalls = toolCalls
+                }
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
@@ -781,6 +790,10 @@ public final class ChatViewModel: ObservableObject {
             // Skip follow-up suggestions for workspace refinements
             if !isSending && !wasRefinement {
                 fetchSuggestion()
+            }
+            // Notify about completed tool calls
+            if let toolCalls = completedToolCalls, let callback = onToolCallsComplete {
+                callback(toolCalls)
             }
 
         case .undoComplete(let undoMsg):

--- a/clients/shared/Features/Chat/CurrentStepIndicator.swift
+++ b/clients/shared/Features/Chat/CurrentStepIndicator.swift
@@ -5,11 +5,13 @@ import SwiftUI
 public struct CurrentStepIndicator: View {
     public let toolCalls: [ToolCallData]
     public let isActivityPanelOpen: Bool
+    public let isStreaming: Bool
     public let onTap: () -> Void
 
-    public init(toolCalls: [ToolCallData], isActivityPanelOpen: Bool = false, onTap: @escaping () -> Void) {
+    public init(toolCalls: [ToolCallData], isActivityPanelOpen: Bool = false, isStreaming: Bool = false, onTap: @escaping () -> Void) {
         self.toolCalls = toolCalls
         self.isActivityPanelOpen = isActivityPanelOpen
+        self.isStreaming = isStreaming
         self.onTap = onTap
     }
 
@@ -27,31 +29,53 @@ public struct CurrentStepIndicator: View {
     }
 
     @State private var isHovered = false
+    @State private var pulseOpacity: Double = 1.0
+
+    private var isLoading: Bool {
+        // Show loading state if streaming OR if there are incomplete tools
+        isStreaming || !toolCalls.allSatisfy { $0.isComplete }
+    }
 
     public var body: some View {
-        if let current = currentStep {
+        // Show indicator when streaming OR when there are tool calls
+        if isStreaming || currentStep != nil {
+            let current = currentStep
+
             HStack(spacing: VSpacing.sm) {
                 // Spinner or checkmark
-                if current.isComplete {
+                if let current = current, current.isComplete {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 14))
                         .foregroundColor(VColor.accent)
                 } else {
                     ProgressView()
-                        .scaleEffect(0.6)
-                        .frame(width: 14, height: 14)
+                        .scaleEffect(0.7)
+                        .frame(width: 16, height: 16)
+                        .tint(VColor.accent)
                 }
 
-                // Current step text
-                Text(current.toolName)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
+                // Current step text with loading indicator
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    HStack(spacing: VSpacing.xs) {
+                        // Show tool name if available, otherwise show generic "Thinking..."
+                        Text(current?.toolName ?? "Thinking...")
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.textPrimary)
 
-                // Progress counter
-                if totalCount > 1 {
-                    Text("(\(completedCount)/\(totalCount))")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                        // Progress counter inline with title
+                        if totalCount > 1 {
+                            Text("(\(completedCount)/\(totalCount))")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+
+                    if isLoading {
+                        Text("Working...")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.accent)
+                            .opacity(pulseOpacity)
+                    }
                 }
 
                 Spacer()
@@ -69,7 +93,7 @@ public struct CurrentStepIndicator: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    .stroke(isLoading ? VColor.accent.opacity(0.5) : VColor.surfaceBorder, lineWidth: isLoading ? 1.5 : 1)
             )
             .onHover { hovering in
                 withAnimation(VAnimation.fast) {
@@ -82,6 +106,22 @@ public struct CurrentStepIndicator: View {
                 onTap()
             }
             .padding(.top, VSpacing.md)
+            .onAppear {
+                if isLoading {
+                    startPulseAnimation()
+                }
+            }
+            .onChange(of: isLoading) { _, newValue in
+                if newValue {
+                    startPulseAnimation()
+                }
+            }
+        }
+    }
+
+    private func startPulseAnimation() {
+        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+            pulseOpacity = 0.4
         }
     }
 }
@@ -113,6 +153,7 @@ public struct CurrentStepIndicator: View {
                         isComplete: false
                     )
                 ],
+                isStreaming: true,
                 onTap: {}
             )
 
@@ -125,6 +166,7 @@ public struct CurrentStepIndicator: View {
                         isComplete: false
                     )
                 ],
+                isStreaming: true,
                 onTap: {}
             )
 
@@ -142,6 +184,7 @@ public struct CurrentStepIndicator: View {
                         isComplete: true
                     )
                 ],
+                isStreaming: false,
                 onTap: {}
             )
         }


### PR DESCRIPTION
## Summary

- Add push notifications when computer-use sessions and tool executions complete
- Create ActivityNotificationService for managing notification delivery
- Improve CurrentStepIndicator UI with better loading states and pulsing animations
- Add settings toggle to enable/disable notifications (default: enabled)
- Support "View Results" action on notification tap to open main window

Users no longer need to watch sessions actively - they'll be notified when tasks complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
