### PR TITLE
fix: scope onPageChanged callback to originating surface view model

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -550,8 +550,8 @@ struct MainWindowView: View {
                 onCoordinatorReady: data.appId != nil ? { coordinator in
                     surfaceManager.surfaceCoordinators[surface.id] = coordinator
                 } : nil,
-                onPageChanged: { page in
-                    threadManager.activeViewModel?.currentPage = page
+                onPageChanged: { [weak viewModel = threadManager.activeViewModel] page in
+                    viewModel?.currentPage = page
                 },
                 onSnapshotCaptured: data.appId != nil ? { [weak daemonClient] base64 in
                     guard let appId = data.appId else { return }


### PR DESCRIPTION
## Summary
- Captures `threadManager.activeViewModel` at closure creation time via `[weak viewModel = ...]` instead of reading it at callback time
- WKNavigationDelegate page-change callbacks fire asynchronously; if the user switches surfaces/threads before the callback fires, the stale closure would write `currentPage` to the wrong ChatViewModel
- Completes the fix from PR #2821 which addressed the TypeScript half of PR #2798 feedback

Addresses Codex feedback on #2798.

## Test plan
- [ ] Open a multi-page app, navigate to a different page, then quickly switch threads before the navigation completes — verify `currentPage` is set on the correct thread's view model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
