### PR TITLE
fix: add base64 encoding field to Vercel deployment file upload

### DIFF
--- a/assistant/src/services/vercel-deploy.ts
+++ b/assistant/src/services/vercel-deploy.ts
@@ -19,6 +19,7 @@ export async function deployHtmlToVercel(opts: {
       {
         file: 'index.html',
         data: Buffer.from(opts.html).toString('base64'),
+        encoding: 'base64',
       },
     ],
     projectSettings: { framework: null },


### PR DESCRIPTION
## Summary
- Adds the missing `encoding: 'base64'` field to the file object sent to the Vercel v13 deployments API
- Without this field, deployed pages render raw base64 text instead of HTML

Addresses review feedback on #2807.

## Test plan
- [ ] Verify type-check passes
- [ ] Deploy a test HTML page via the share flow and confirm it renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
