### PR TITLE
fix: correct Swift codegen type mapping and IPC struct references

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -179,6 +179,7 @@ const INT_PATTERNS = [
   /[Ll]ength$/,
   /[Ii]ndex$/,
   /[Ee]xpected$/,
+  /[Uu]ndos$/,
 ];
 
 function shouldBeInt(propName: string): boolean {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1239,7 +1239,7 @@ public struct IPCUiSurfaceUndoResult: Codable, Sendable {
     public let surfaceId: String
     public let success: Bool
     /// Number of remaining undo entries after this undo.
-    public let remainingUndos: Double
+    public let remainingUndos: Int
 }
 
 public struct IPCUiSurfaceUpdate: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -274,10 +274,10 @@ extension IPCUiSurfaceAction {
 }
 
 /// Sent when user requests undo on a workspace surface.
-/// Backed by generated `IPCUiSurfaceUndo`.
-public typealias UiSurfaceUndoMessage = IPCUiSurfaceUndo
+/// Backed by generated `IPCUiSurfaceUndoRequest`.
+public typealias UiSurfaceUndoMessage = IPCUiSurfaceUndoRequest
 
-extension IPCUiSurfaceUndo {
+extension IPCUiSurfaceUndoRequest {
     public init(sessionId: String, surfaceId: String) {
         self.init(type: "ui_surface_undo", sessionId: sessionId, surfaceId: surfaceId)
     }


### PR DESCRIPTION
## Summary
- Adds `/[Uu]ndos$/` to `INT_PATTERNS` in `generate-swift.ts` so `remainingUndos` is generated as `Int` instead of `Double`, matching the `surfaceUndoCount: Int` property in `ChatViewModel.swift`
- Regenerates `IPCContractGenerated.swift` with the corrected type
- Updates 3 references in `IPCMessages.swift` from the old `IPCUiSurfaceUndo` name to `IPCUiSurfaceUndoRequest` to match the renamed generated struct

## Test plan
- [ ] Verify `IPCContractGenerated.swift` has `remainingUndos: Int`
- [ ] Verify `IPCMessages.swift` references `IPCUiSurfaceUndoRequest` consistently
- [ ] Run `bun run generate:ipc -- --check` to confirm codegen is up to date
- [ ] Build macOS client to confirm no type mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
