### PR TITLE
fix: resolve 20 eslint errors across 6 files

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -126,6 +126,7 @@ describe('Invariant 1: secrets never enter LLM context', () => {
     }));
 
     // Re-import to pick up the mock
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { checkIngressForSecrets } = require('../security/secret-ingress.js');
 
     // Build a fake AWS key at runtime to avoid pre-commit hook
@@ -175,6 +176,7 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
 
     const thisDir = dirname(fileURLToPath(import.meta.url));
     const srcDir = resolve(thisDir, '..');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { readdirSync, statSync } = require('node:fs');
 
     // Recursively collect all .ts files in src/ (excluding __tests__)
@@ -393,11 +395,13 @@ describe('One-time send override', () => {
   });
 
   test('allowOneTimeSend defaults to false in config', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { DEFAULT_CONFIG } = require('../config/defaults.js');
     expect(DEFAULT_CONFIG.secretDetection.allowOneTimeSend).toBe(false);
   });
 
   test('default secretDetection.action is block', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { DEFAULT_CONFIG } = require('../config/defaults.js');
     expect(DEFAULT_CONFIG.secretDetection.action).toBe('block');
   });

--- a/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
+++ b/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import type { ServerMessage, SecretRequest } from '../daemon/ipc-contract.js';
 
 // Capture all logger calls so we can verify secret values never appear
 const logCalls: Array<{ level: string; args: unknown[] }> = [];
@@ -45,7 +45,7 @@ describe('secret prompt log hygiene', () => {
   test('resolveSecret never logs the secret value', async () => {
     const secret = 'sv42';
     const promise = prompter.prompt('myservice', 'apikey', 'API Key');
-    const requestId = (sentMessages[0] as any).requestId;
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
     prompter.resolveSecret(requestId, secret, 'store');
     const result = await promise;
 
@@ -67,7 +67,7 @@ describe('secret prompt log hygiene', () => {
 
   test('prompt timeout logs only metadata, not the secret value', async () => {
     const promise = prompter.prompt('svc', 'key', 'Label');
-    const requestId = (sentMessages[0] as any).requestId;
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
 
     // Simulate a normal resolve (timeout would also log metadata only)
     prompter.resolveSecret(requestId, undefined);
@@ -83,7 +83,7 @@ describe('secret prompt log hygiene', () => {
 
   test('sent IPC message contains value=undefined (value flows through IPC, not logs)', async () => {
     const promise = prompter.prompt('svc', 'tok', 'Token');
-    const msg = sentMessages[0] as any;
+    const msg = sentMessages[0] as SecretRequest & { value?: unknown };
     // The IPC message should NOT contain a value field
     expect(msg.value).toBeUndefined();
     prompter.resolveSecret(msg.requestId, undefined);

--- a/assistant/src/__tests__/secret-response-routing.test.ts
+++ b/assistant/src/__tests__/secret-response-routing.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach } from 'bun:test';
 import { SecretPrompter } from '../permissions/secret-prompter.js';
 import type { SecretPromptResult } from '../permissions/secret-prompter.js';
-import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import type { ServerMessage, SecretRequest } from '../daemon/ipc-contract.js';
 
 describe('secret response routing', () => {
   let prompter: SecretPrompter;
@@ -14,7 +14,7 @@ describe('secret response routing', () => {
 
   test('resolveSecret defaults delivery to store when omitted', async () => {
     const promise = prompter.prompt('github', 'token', 'GitHub Token');
-    const requestId = (sentMessages[0] as any).requestId;
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
     prompter.resolveSecret(requestId, 'test-value');
     const result: SecretPromptResult = await promise;
     expect(result.value).toBe('test-value');
@@ -23,7 +23,7 @@ describe('secret response routing', () => {
 
   test('resolveSecret passes store delivery', async () => {
     const promise = prompter.prompt('github', 'token', 'GitHub Token');
-    const requestId = (sentMessages[0] as any).requestId;
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
     prompter.resolveSecret(requestId, 'test-value', 'store');
     const result = await promise;
     expect(result.value).toBe('test-value');
@@ -32,7 +32,7 @@ describe('secret response routing', () => {
 
   test('resolveSecret passes transient_send delivery', async () => {
     const promise = prompter.prompt('github', 'token', 'GitHub Token');
-    const requestId = (sentMessages[0] as any).requestId;
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
     prompter.resolveSecret(requestId, 'one-time-value', 'transient_send');
     const result = await promise;
     expect(result.value).toBe('one-time-value');
@@ -41,7 +41,7 @@ describe('secret response routing', () => {
 
   test('resolveSecret with cancelled value defaults delivery to store', async () => {
     const promise = prompter.prompt('github', 'token', 'GitHub Token');
-    const requestId = (sentMessages[0] as any).requestId;
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
     prompter.resolveSecret(requestId, undefined);
     const result = await promise;
     expect(result.value).toBeNull();
@@ -52,7 +52,7 @@ describe('secret response routing', () => {
     // We can't easily test the full timeout, but we verify the structure
     // by resolving immediately (the timeout path also returns { value: null, delivery: 'store' })
     const promise = prompter.prompt('github', 'token', 'GitHub Token');
-    const requestId = (sentMessages[0] as any).requestId;
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
     prompter.resolveSecret(requestId, undefined, undefined);
     const result = await promise;
     expect(result.value).toBeNull();
@@ -62,7 +62,7 @@ describe('secret response routing', () => {
   test('sent message is a secret_request with correct fields', async () => {
     const promise = prompter.prompt('github', 'token', 'GitHub Token', 'desc', 'placeholder', 'session-1');
     expect(sentMessages.length).toBe(1);
-    const msg = sentMessages[0] as any;
+    const msg = sentMessages[0] as SecretRequest;
     expect(msg.type).toBe('secret_request');
     expect(msg.service).toBe('github');
     expect(msg.field).toBe('token');
@@ -86,8 +86,8 @@ describe('secret response routing', () => {
     try {
       await promise;
       expect(true).toBe(false); // should not reach here
-    } catch (e: any) {
-      expect(e.message).toBe('Prompter disposed');
+    } catch (e: unknown) {
+      expect((e as Error).message).toBe('Prompter disposed');
     }
   });
 });

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -62,7 +62,7 @@ import { postToSlackWebhook } from '../slack/slack-webhook.js';
 import { createHash } from 'node:crypto';
 import { computeContentId } from '../util/content-id.js';
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, rmSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { addRule, removeRule, updateRule, getAllRules } from '../permissions/trust-store.js';

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -385,14 +385,14 @@ export class Session {
       'Secure Credential Entry',
       'Your message contained a secret. Please enter it here instead — it will be stored securely and never sent to the AI.',
       undefined, this.conversationId,
-    ).then((result) => {
+    ).then(async (result) => {
       if (!result.value) return; // user cancelled or timed out
 
-      const { setSecureKey } = require('../security/secure-keys.js');
-      const { upsertCredentialMetadata } = require('../tools/credentials/metadata-store.js');
+      const { setSecureKey } = await import('../security/secure-keys.js');
+      const { upsertCredentialMetadata } = await import('../tools/credentials/metadata-store.js');
 
       if (result.delivery === 'transient_send') {
-        const { credentialBroker } = require('../tools/credentials/broker.js');
+        const { credentialBroker } = await import('../tools/credentials/broker.js');
         credentialBroker.injectTransient(service, field, result.value);
         try { upsertCredentialMetadata(service, field, {}); } catch {}
         log.info({ service, field, delivery: 'transient_send' }, 'Ingress redirect: transient credential injected');

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -2,7 +2,6 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import {
-  getSecureKey,
   setSecureKey,
   deleteSecureKey,
   listSecureKeys,
@@ -16,14 +15,6 @@ import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('credential-vault');
-
-/**
- * Retrieve the actual secret value for a credential.
- * Internal to vault — callers must go through the CredentialBroker.
- */
-function getCredentialValue(service: string, field: string): string | undefined {
-  return getSecureKey(`credential:${service}:${field}`);
-}
 
 class CredentialStoreTool implements Tool {
   name = 'credential_store';


### PR DESCRIPTION
## Summary
- Remove unused imports (`mkdirSync`, `writeFileSync`) from handlers.ts and dead `getCredentialValue` function from vault.ts
- Replace `as any` casts with proper `SecretRequest` types in test files
- Convert `require()` to `await import()` in session.ts and add eslint-disable for intentional test requires
- Fix `catch (e: any)` to `catch (e: unknown)` in secret-response-routing test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
