### PR TITLE
Add /plan-html slash command for plan markdown + friendly HTML

### DIFF
--- a/.claude/commands/plan-html.md
+++ b/.claude/commands/plan-html.md
@@ -1,0 +1,82 @@
+Create or refresh a rollout plan and a companion friendly HTML view.
+
+The user passed: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, stop and ask for a plan name/topic. Example:
+`/plan-html dashboard onboarding`.
+
+## Goal
+
+Produce plan artifacts in `.private/plans/` that are easy to execute and easy to review:
+
+1. A canonical markdown plan (`.md`) for implementation workflows.
+2. A self-contained, polished HTML plan (`.html`) for human-friendly review.
+
+## Steps
+
+### 1. Resolve plan filename
+
+Convert `$ARGUMENTS` into a stable filename slug:
+- Upper snake case with `.md` / `.html` suffix.
+- Example: `dashboard onboarding` -> `DASHBOARD_ONBOARDING.md` and `DASHBOARD_ONBOARDING.html`.
+
+If the user explicitly provides a filename, honor it.
+
+### 2. Load existing context first
+
+- If `.private/plans/<name>.md` exists, read it and update in place.
+- If `.private/plans/<name>.html` exists, read it and refresh it to match the markdown plan.
+- Keep existing product decisions unless the user asked to change them.
+
+### 3. Write the markdown plan
+
+Create/update `.private/plans/<name>.md` with:
+- Objective and primary outcomes.
+- Product requirements.
+- Scope decisions and guardrails.
+- PR sequence overview table.
+- Detailed PR sections (branch, title, scope, files, steps, validation, acceptance).
+- Final acceptance checklist.
+
+Keep PRs small and sequenced with clear ownership boundaries.
+
+### 4. Write the friendly HTML view
+
+Create/update `.private/plans/<name>.html` as a self-contained file (no external assets) with:
+- A strong hero summary.
+- Quick nav anchors.
+- Outcome cards.
+- Task chips / key highlights.
+- Roadmap table.
+- Expandable PR detail cards.
+- For each PR detail card, include a clear **Files to modify** section (paths listed explicitly).
+- Final acceptance checklist.
+- Responsive layout for desktop and mobile.
+
+Design guidance:
+- Intentional typography and spacing hierarchy.
+- Distinct visual direction (not plain markdown render).
+- Meaningful color system and card structure.
+- Keep content faithfully aligned with the markdown source.
+
+### 5. Validate parity
+
+Before finishing:
+- Confirm all PRs and acceptance criteria in HTML match markdown.
+- Confirm each HTML PR card includes the corresponding “Files to modify” list.
+- Confirm no stale sections from older versions remain.
+
+### 6. Open the HTML for review
+
+Run:
+`open .private/plans/<name>.html`
+
+Then report:
+- The two file paths created/updated.
+- A concise summary of what changed.
+
+## Important
+
+- The markdown plan is source-of-truth for execution workflows.
+- The HTML plan must remain content-equivalent and review-friendly.
+- `.private/` is gitignored; this command focuses on planning artifacts, not committed source changes.

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 | `/safe-blitz <feature>` | End-to-end feature delivery on a feature branch — plans, creates issues, swarm-executes in parallel, sweeps for review feedback. All milestone PRs merge into a feature branch (not main). Creates a final PR for manual review. Does not switch your working tree. Supports `--auto`, `--workers N`, `--skip-plan`, `--branch NAME`. |
 | `/safe-blitz-done [PR\|branch]` | Finalize a safe-blitz — squash-merges the feature branch PR into main, sets the project issue to Done, closes the issue, and deletes the local branch. Auto-detects the PR from current branch, open `feature/*` PRs, or project board "In Review" items. |
 | `/execute-plan <file>` | Sequential multi-PR rollout — reads a plan file from `.private/plans/`, executes each PR in order, mainlining each before moving to the next. |
+| `/check-reviews-and-swarm` | Combined review sweep + execution pass — runs review checks, then swarms on actionable feedback items. |
 
 ### Human-in-the-loop plan execution
 
@@ -314,6 +315,8 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 
 | Command | Purpose |
 |---------|---------|
+| `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
+| `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
 | `/scrub` | Kill the running Vellum app (non-fatal if not running), wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
 
 ### Review


### PR DESCRIPTION
## Summary
- add new slash command `/plan-html` in `.claude/commands/plan-html.md`
- instruct it to create/update both markdown plan and companion friendly HTML view
- require per-PR **Files to modify** sections in the HTML cards
- update README `Slash Commands` tables to include `/plan-html`
- sync README command listings with existing command files by adding `/release` and `/check-reviews-and-swarm` entries

## Why
This captures the new planning workflow where plans are reviewed in a richer HTML format while keeping markdown as the execution source of truth.
