### PR TITLE
feat: add VELLUM_WORKSPACE_DIR env var to hook runtime contract

### DIFF
--- a/assistant/src/__tests__/hooks-runner.test.ts
+++ b/assistant/src/__tests__/hooks-runner.test.ts
@@ -105,6 +105,35 @@ describe('Hook Runner', () => {
     expect(result.stdout.trim()).toContain('.vellum');
   });
 
+  test('sets VELLUM_WORKSPACE_DIR environment variable', async () => {
+    const hook = createTestHook(hooksDir, 'wsdir-hook', '#!/bin/bash\necho "$VELLUM_WORKSPACE_DIR"');
+    const eventData: HookEventData = { event: 'daemon-start' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    const wsDir = result.stdout.trim();
+    expect(wsDir).toContain('.vellum');
+    expect(wsDir).toEndWith('workspace');
+  });
+
+  test('sets both VELLUM_ROOT_DIR and VELLUM_WORKSPACE_DIR', async () => {
+    const hook = createTestHook(
+      hooksDir,
+      'both-dirs-hook',
+      '#!/bin/bash\necho "$VELLUM_ROOT_DIR|$VELLUM_WORKSPACE_DIR"',
+    );
+    const eventData: HookEventData = { event: 'pre-tool-execute' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    const [rootDir, wsDir] = result.stdout.trim().split('|');
+    expect(rootDir).toContain('.vellum');
+    expect(wsDir).toContain('.vellum');
+    expect(wsDir).toEndWith('workspace');
+    // workspace dir should be a subdirectory of root dir
+    expect(wsDir).toStartWith(rootDir);
+  });
+
   test('[experimental] times out after specified duration', async () => {
     const hook = createTestHook(hooksDir, 'slow-hook', '#!/bin/bash\nsleep 10');
     const eventData: HookEventData = { event: 'pre-tool-execute' };

--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { basename, extname, join } from 'node:path';
 import { homedir } from 'node:os';
-import { getRootDir } from '../util/platform.js';
+import { getRootDir, getWorkspaceDir } from '../util/platform.js';
 import { getHookSettings } from './config.js';
 import type { DiscoveredHook, HookEventData } from './types.js';
 
@@ -69,6 +69,7 @@ export async function runHookScript(
         VELLUM_HOOK_EVENT: eventData.event,
         VELLUM_HOOK_NAME: hook.name,
         VELLUM_ROOT_DIR: getRootDir(),
+        VELLUM_WORKSPACE_DIR: getWorkspaceDir(),
         VELLUM_HOOK_SETTINGS: JSON.stringify(getHookSettings(hook.name, hook.manifest)),
       },
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- Add `VELLUM_WORKSPACE_DIR` env var pointing to `~/.vellum/workspace` in hook process environment
- Keep `VELLUM_ROOT_DIR` as `~/.vellum` for backward compatibility
- Add tests verifying both env vars are present and workspace dir is a subdirectory of root dir

Part of the workspace migration plan (PR 19).

## Test plan
- [ ] Run `bun test src/__tests__/hooks-runner.test.ts` — all tests pass
- [ ] Verify hooks can access both `VELLUM_ROOT_DIR` and `VELLUM_WORKSPACE_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
