### PR TITLE
feat: update remaining hardcoded path strings to workspace layout

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -76,7 +76,7 @@ describe('skills catalog loading', () => {
     expect(catalog.map((skill) => skill.id)).toEqual(['lint', 'test']);
   });
 
-  test('rejects SKILLS.md entries that resolve outside ~/.vellum/skills', () => {
+  test('rejects SKILLS.md entries that resolve outside ~/.vellum/workspace/skills', () => {
     writeSkill('safe', 'Safe Skill', 'Safe skill');
     writeFileSync(
       join(TEST_DIR, 'skills', 'SKILLS.md'),
@@ -87,7 +87,7 @@ describe('skills catalog loading', () => {
     expect(catalog.map((skill) => skill.id)).toEqual(['safe']);
   });
 
-  test('rejects symlinked SKILLS.md entries that point outside ~/.vellum/skills', () => {
+  test('rejects symlinked SKILLS.md entries that point outside ~/.vellum/workspace/skills', () => {
     const externalSkillDir = join(TEST_DIR, 'outside', 'external-skill');
     mkdirSync(externalSkillDir, { recursive: true });
     writeFileSync(
@@ -102,7 +102,7 @@ describe('skills catalog loading', () => {
     expect(catalog).toHaveLength(0);
   });
 
-  test('rejects symlinked SKILL.md files that point outside ~/.vellum/skills', () => {
+  test('rejects symlinked SKILL.md files that point outside ~/.vellum/workspace/skills', () => {
     const linkedSkillDir = join(TEST_DIR, 'skills', 'linked-file-skill');
     mkdirSync(linkedSkillDir, { recursive: true });
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -273,7 +273,7 @@ function readSkillFromDirectory(directoryPath: string, skillsDir: string, source
 
   try {
     if (isOutsideSkillsRoot(skillsDir, directoryPath)) {
-      log.warn({ directoryPath }, 'Skipping skill directory that resolves outside ~/.vellum/skills');
+      log.warn({ directoryPath }, 'Skipping skill directory that resolves outside ~/.vellum/workspace/skills');
       return null;
     }
 
@@ -284,7 +284,7 @@ function readSkillFromDirectory(directoryPath: string, skillsDir: string, source
     }
 
     if (isOutsideSkillsRoot(skillsDir, skillFilePath)) {
-      log.warn({ skillFilePath }, 'Skipping SKILL.md that resolves outside ~/.vellum/skills');
+      log.warn({ skillFilePath }, 'Skipping SKILL.md that resolves outside ~/.vellum/workspace/skills');
       return null;
     }
 
@@ -440,7 +440,7 @@ function resolveIndexEntryToDirectory(skillsDir: string, entry: string): string 
   if (isOutsideSkillsRoot(skillsDir, resolvedDirectory)) {
     log.warn(
       { entry, resolvedDirectory: getCanonicalPath(resolvedDirectory) },
-      'Skipping SKILLS.md entry that resolves outside ~/.vellum/skills',
+      'Skipping SKILLS.md entry that resolves outside ~/.vellum/workspace/skills',
     );
     return null;
   }
@@ -665,7 +665,7 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   if (skill.bundled) {
     loaded = readBundledSkillFromDirectory(skill.directoryPath);
   } else if (skill.source === 'workspace') {
-    // Workspace skills live outside ~/.vellum/skills, so use their parent
+    // Workspace skills live outside ~/.vellum/workspace/skills, so use their parent
     // directory as the root to avoid the isOutsideSkillsRoot rejection.
     loaded = readSkillFromDirectory(skill.directoryPath, dirname(skill.directoryPath), skill.source);
   } else {
@@ -687,7 +687,7 @@ export function resolveSkillSelector(selector: string, workspaceSkillsDir?: stri
 
   const catalog = loadSkillCatalog(workspaceSkillsDir);
   if (catalog.length === 0) {
-    return { error: 'No skills are available. Configure ~/.vellum/skills/SKILLS.md or add skill directories.' };
+    return { error: 'No skills are available. Configure ~/.vellum/workspace/skills/SKILLS.md or add skill directories.' };
   }
 
   const exactIdMatch = catalog.find((skill) => skill.id === needle);

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -40,7 +40,7 @@ export function ensurePromptFiles(): void {
  * Composition:
  *   1. Base prompt: IDENTITY.md + SOUL.md (guaranteed to exist after ensurePromptFiles)
  *   2. Append USER.md (user profile)
- *   3. Append skills catalog from ~/.vellum/skills
+ *   3. Append skills catalog from ~/.vellum/workspace/skills
  */
 export function buildSystemPrompt(): string {
   const soulPath = getWorkspacePromptPath('SOUL.md');
@@ -246,7 +246,7 @@ function buildDynamicSkillWorkflowSection(): string {
     '1. **Validate the gap.** Confirm no existing tool or installed skill covers the need.',
     '2. **Draft a TypeScript snippet.** Write a self-contained snippet that exports a `default` or `run` function with signature `(input: unknown) => unknown | Promise<unknown>`.',
     '3. **Test with `evaluate_typescript_code`.** Call the tool to run the snippet in a sandbox. Iterate until it passes.',
-    '4. **Persist with `scaffold_managed_skill`.** Only after successful evaluation and explicit user consent, call `scaffold_managed_skill` to write the skill to `~/.vellum/skills/<id>/`.',
+    '4. **Persist with `scaffold_managed_skill`.** Only after successful evaluation and explicit user consent, call `scaffold_managed_skill` to write the skill to `~/.vellum/workspace/skills/<id>/`.',
     '5. **Load and use.** Call `skill_load` with the new skill ID before invoking the skill-driven flow.',
     '',
     'Important constraints:',

--- a/assistant/src/hooks/templates.ts
+++ b/assistant/src/hooks/templates.ts
@@ -9,7 +9,7 @@ const log = getLogger('hooks-templates');
 
 /**
  * Install bundled hook templates into the user's hooks directory.
- * Templates are copied from `assistant/hook-templates/` to `~/.vellum/hooks/`.
+ * Templates are copied from `assistant/hook-templates/` to `~/.vellum/workspace/hooks/`.
  * - Never overwrites existing hooks (user modifications are preserved).
  * - Newly installed hooks are disabled by default.
  */

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -82,7 +82,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 1000,
   }));
 
-  // Managed skill authoring tools — scaffold and delete modify ~/.vellum/skills/
+  // Managed skill authoring tools — scaffold and delete modify ~/.vellum/workspace/skills/
   // and should require explicit user approval.
   const MANAGED_SKILL_TOOLS = ['scaffold_managed_skill', 'delete_managed_skill'] as const;
   const managedSkillRules = MANAGED_SKILL_TOOLS.map((tool) => ({

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -6,7 +6,7 @@ import { deleteManagedSkill } from '../../skills/managed-store.js';
 
 export class DeleteManagedSkillTool implements Tool {
   name = 'delete_managed_skill';
-  description = 'Delete a managed skill from ~/.vellum/skills and remove it from the SKILLS.md index.';
+  description = 'Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index.';
   category = 'skills';
   defaultRiskLevel = RiskLevel.High;
 

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -6,7 +6,7 @@ import { loadSkillBySelector } from '../../config/skills.js';
 
 export class SkillLoadTool implements Tool {
   name = 'skill_load';
-  description = 'Load full instructions for a configured skill from ~/.vellum/skills.';
+  description = 'Load full instructions for a configured skill from ~/.vellum/workspace/skills.';
   category = 'skills';
   defaultRiskLevel = RiskLevel.Low;
 

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -11,7 +11,7 @@ function sanitizeFrontmatterValue(value: string): string {
 
 export class ScaffoldManagedSkillTool implements Tool {
   name = 'scaffold_managed_skill';
-  description = 'Create or update a managed skill in ~/.vellum/skills. The skill becomes available for skill_load immediately.';
+  description = 'Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately.';
   category = 'skills';
   defaultRiskLevel = RiskLevel.High;
 


### PR DESCRIPTION
## Summary
- Update user-facing path strings in skill tools (`load`, `scaffold-managed`, `delete-managed`)
- Update system prompt skill references and hook template paths
- Update permissions defaults comments and skills config log messages
- Update test descriptions for consistency

Part of the workspace migration plan (PR 20).

## Test plan
- [ ] `bun test src/__tests__/system-prompt.test.ts` — 33 tests pass
- [ ] `bun test src/__tests__/dynamic-skill-workflow-prompt.test.ts` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
