### PR TITLE
fix: route Vercel credential reads through broker

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -85,7 +85,7 @@ import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { deployHtmlToVercel, deleteVercelDeployment } from '../services/vercel-deploy.js';
 import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedPageByDeploymentId } from '../memory/published-pages-store.js';
-import { getSecureKey } from '../security/secure-keys.js';
+import { credentialBroker } from '../tools/credentials/broker.js';
 import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId, validateBlobKindEncoding } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
@@ -2100,60 +2100,58 @@ async function handlePublishPage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  try {
-    const token = getSecureKey('credential:vercel:api_token');
-    if (!token) {
-      ctx.send(socket, {
-        type: 'publish_page_response',
-        success: false,
-        error: 'No Vercel API token configured. Use the credential store to add one (service: vercel, field: api_token).',
-      });
-      return;
-    }
+  // Hash the HTML for dedup — can be done before credential check
+  const htmlHash = createHash('sha256').update(msg.html).digest('hex');
 
-    // Hash the HTML for dedup
-    const htmlHash = createHash('sha256').update(msg.html).digest('hex');
-
-    // Check if already published
-    const existing = getPublishedPageByHash(htmlHash);
-    if (existing) {
-      ctx.send(socket, {
-        type: 'publish_page_response',
-        success: true,
-        publicUrl: existing.publicUrl,
-        deploymentId: existing.deploymentId,
-      });
-      return;
-    }
-
-    const name = msg.title
-      ? msg.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50)
-      : `vellum-page-${Date.now()}`;
-
-    const result = await deployHtmlToVercel({ html: msg.html, name, token });
-
-    const id = uuid();
-    createPublishedPage({
-      id,
-      deploymentId: result.deploymentId,
-      publicUrl: result.url,
-      pageTitle: msg.title,
-      htmlHash,
-    });
-
+  // Check if already published (no credential needed)
+  const existing = getPublishedPageByHash(htmlHash);
+  if (existing) {
     ctx.send(socket, {
       type: 'publish_page_response',
       success: true,
-      publicUrl: result.url,
-      deploymentId: result.deploymentId,
+      publicUrl: existing.publicUrl,
+      deploymentId: existing.deploymentId,
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, 'Failed to publish page');
+    return;
+  }
+
+  const useResult = await credentialBroker.serverUse({
+    service: 'vercel',
+    field: 'api_token',
+    toolName: 'publish_page',
+    execute: async (token) => {
+      const name = msg.title
+        ? msg.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50)
+        : `vellum-page-${Date.now()}`;
+
+      const result = await deployHtmlToVercel({ html: msg.html, name, token });
+
+      const id = uuid();
+      createPublishedPage({
+        id,
+        deploymentId: result.deploymentId,
+        publicUrl: result.url,
+        pageTitle: msg.title,
+        htmlHash,
+      });
+
+      return { url: result.url, deploymentId: result.deploymentId };
+    },
+  });
+
+  if (useResult.success && useResult.result) {
+    ctx.send(socket, {
+      type: 'publish_page_response',
+      success: true,
+      publicUrl: useResult.result.url,
+      deploymentId: useResult.result.deploymentId,
+    });
+  } else {
+    log.error({ reason: useResult.reason }, 'Failed to publish page');
     ctx.send(socket, {
       type: 'publish_page_response',
       success: false,
-      error: message,
+      error: useResult.reason ?? 'Failed to publish page',
     });
   }
 }
@@ -2163,35 +2161,31 @@ async function handleUnpublishPage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  try {
-    const token = getSecureKey('credential:vercel:api_token');
-    if (!token) {
-      ctx.send(socket, {
-        type: 'unpublish_page_response',
-        success: false,
-        error: 'No Vercel API token configured.',
-      });
-      return;
-    }
+  const useResult = await credentialBroker.serverUse({
+    service: 'vercel',
+    field: 'api_token',
+    toolName: 'unpublish_page',
+    execute: async (token) => {
+      await deleteVercelDeployment(msg.deploymentId, token);
 
-    await deleteVercelDeployment(msg.deploymentId, token);
+      const record = getPublishedPageByDeploymentId(msg.deploymentId);
+      if (record) {
+        markDeleted(record.id);
+      }
+    },
+  });
 
-    const record = getPublishedPageByDeploymentId(msg.deploymentId);
-    if (record) {
-      markDeleted(record.id);
-    }
-
+  if (useResult.success) {
     ctx.send(socket, {
       type: 'unpublish_page_response',
       success: true,
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err, deploymentId: msg.deploymentId }, 'Failed to unpublish page');
+  } else {
+    log.error({ reason: useResult.reason, deploymentId: msg.deploymentId }, 'Failed to unpublish page');
     ctx.send(socket, {
       type: 'unpublish_page_response',
       success: false,
-      error: message,
+      error: useResult.reason ?? 'Failed to unpublish page',
     });
   }
 }

--- a/assistant/src/tools/credentials/broker-types.ts
+++ b/assistant/src/tools/credentials/broker-types.ts
@@ -61,3 +61,22 @@ export interface BrowserFillResult {
   success: boolean;
   reason?: string;
 }
+
+/** Request for the broker to use a credential server-side without exposing plaintext. */
+export interface ServerUseRequest<T> {
+  service: string;
+  field: string;
+  toolName: string;
+  /**
+   * Opaque callback — the broker calls this with the plaintext value internally.
+   * The caller provides the function but never receives the secret value directly.
+   */
+  execute: (value: string) => Promise<T>;
+}
+
+/** Result of a broker-mediated server-side credential use — contains the callback result, never plaintext. */
+export interface ServerUseResult<T> {
+  success: boolean;
+  result?: T;
+  reason?: string;
+}

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -5,6 +5,8 @@ import type {
   BrowserFillRequest,
   BrowserFillResult,
   ConsumeResult,
+  ServerUseRequest,
+  ServerUseResult,
   UsageToken,
 } from './broker-types.js';
 import { getCredentialMetadata } from './metadata-store.js';
@@ -206,6 +208,62 @@ export class CredentialBroker {
         'Browser fill failed',
       );
       return { success: false, reason: 'Fill operation failed' };
+    }
+  }
+
+  /**
+   * Use a credential server-side without exposing plaintext to the caller.
+   *
+   * Like browserFill, the broker reads the secret internally and passes it
+   * to the provided callback. The return value contains only the callback's
+   * result — the plaintext never leaves this method's scope.
+   */
+  async serverUse<T>(request: ServerUseRequest<T>): Promise<ServerUseResult<T>> {
+    const metadata = getCredentialMetadata(request.service, request.field);
+    if (!metadata) {
+      return {
+        success: false,
+        reason: `No credential found for ${request.service}/${request.field}`,
+      };
+    }
+
+    if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
+      const tools = metadata.allowedTools ?? [];
+      return {
+        success: false,
+        reason: `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
+          (tools.length === 0
+            ? 'No tools are currently allowed — update the credential with allowed_tools via credential_store.'
+            : `Allowed tools: ${tools.join(', ')}.`),
+      };
+    }
+
+    const storageKey = `credential:${request.service}:${request.field}`;
+    const transient = this.transientValues.get(storageKey);
+    const value = transient ?? getSecureKey(storageKey);
+    if (transient !== undefined) {
+      this.transientValues.delete(storageKey);
+    }
+    if (!value) {
+      return {
+        success: false,
+        reason: `Credential metadata exists but no stored value for ${request.service}/${request.field}`,
+      };
+    }
+
+    try {
+      const result = await request.execute(value);
+      log.info(
+        { service: request.service, field: request.field, tool: request.toolName },
+        'Server-side credential use completed',
+      );
+      return { success: true, result };
+    } catch (err) {
+      log.error(
+        { err, service: request.service, field: request.field },
+        'Server-side credential use failed',
+      );
+      return { success: false, reason: 'Credential use failed' };
     }
   }
 


### PR DESCRIPTION
## Summary
- `handlers.ts` was importing `getSecureKey` directly to read the Vercel API token for publish/unpublish — violating the `getSecureKey` import allowlist invariant test
- Added `serverUse()` method to `CredentialBroker` — same callback pattern as `browserFill` where the secret stays inside the broker's scope and is never returned to the caller
- Refactored `handlePublishPage` and `handleUnpublishPage` to use `credentialBroker.serverUse()` instead of direct `getSecureKey` reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
