### PR TITLE
docs: update secondary docs paths for workspace layout

### DIFF
--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -1,16 +1,16 @@
-# Skills Support (`~/.vellum/skills`)
+# Skills Support (`~/.vellum/workspace/skills`)
 
 Vellum Assistant supports a skills catalog at:
 
-- `~/.vellum/skills/SKILLS.md`
+- `~/.vellum/workspace/skills/SKILLS.md`
 
 Each skill lives in its own directory:
 
-- `~/.vellum/skills/<skill-id>/SKILL.md`
+- `~/.vellum/workspace/skills/<skill-id>/SKILL.md`
 
 ## `SKILLS.md` Format
 
-`SKILLS.md` is a Markdown list of paths, one skill per list item, resolved relative to `~/.vellum/skills/`.
+`SKILLS.md` is a Markdown list of paths, one skill per list item, resolved relative to `~/.vellum/workspace/skills/`.
 
 Supported entry forms:
 
@@ -21,10 +21,10 @@ Supported entry forms:
 Notes:
 
 - Absolute paths are ignored.
-- Paths resolving outside `~/.vellum/skills/` are ignored.
+- Paths resolving outside `~/.vellum/workspace/skills/` are ignored.
 - Duplicate entries are deduplicated (first entry wins).
 - If `SKILLS.md` exists, it is authoritative for which skills are exposed.
-- If `SKILLS.md` is missing, skills are auto-discovered from `~/.vellum/skills/*/SKILL.md`.
+- If `SKILLS.md` is missing, skills are auto-discovered from `~/.vellum/workspace/skills/*/SKILL.md`.
 
 ## `SKILL.md` Requirements
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -334,7 +334,7 @@ The app supports connecting to a remote daemon via SSH socket forwarding. Set `V
 
 ### Zero-Copy Blob Transport
 
-On local macOS connections, large CU observation payloads (screenshots, AX trees) are offloaded to file-based blobs at `~/.vellum/data/ipc-blobs/` instead of inline base64/text. On every macOS socket connect, the client runs a blob probe: writes a random nonce to the blob directory and sends its SHA-256 to the daemon. If the daemon reads the file and the hashes match, `isBlobTransportAvailable` is set to `true` and subsequent observations use blob references. Over SSH-forwarded sockets, the probe fails automatically (no shared filesystem) and the client falls back to inline payloads. On iOS, the probe is compiled out via `#if os(macOS)`.
+On local macOS connections, large CU observation payloads (screenshots, AX trees) are offloaded to file-based blobs at `~/.vellum/workspace/data/ipc-blobs/` instead of inline base64/text. On every macOS socket connect, the client runs a blob probe: writes a random nonce to the blob directory and sends its SHA-256 to the daemon. If the daemon reads the file and the hashes match, `isBlobTransportAvailable` is set to `true` and subsequent observations use blob references. Over SSH-forwarded sockets, the probe fails automatically (no shared filesystem) and the client falls back to inline payloads. On iOS, the probe is compiled out via `#if os(macOS)`.
 
 ## Safety
 


### PR DESCRIPTION
## Summary
- Update `assistant/docs/skills.md` — 6 skills path references to workspace layout
- Update `clients/macos/README.md` — IPC blob path to workspace layout
- Socket paths in client docs correctly left at root

Part of the workspace migration plan (PR 23).

## Test plan
- [ ] Manual read-through for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
