### PR TITLE
docs: update command docs paths for workspace layout

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -21,8 +21,8 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 3. Remove the daemon database (conversations, messages, etc.), including legacy paths that the migration would otherwise re-populate:
    ```bash
-   rm -f ~/.vellum/data/db/assistant.db ~/.vellum/data/db/assistant.db-shm ~/.vellum/data/db/assistant.db-wal
-   rm -f ~/.vellum/data/assistant.db ~/.vellum/data/assistant.db-shm ~/.vellum/data/assistant.db-wal
+   rm -f ~/.vellum/workspace/data/db/assistant.db ~/.vellum/workspace/data/db/assistant.db-shm ~/.vellum/workspace/data/db/assistant.db-wal
+   rm -f ~/.vellum/workspace/data/assistant.db ~/.vellum/workspace/data/assistant.db-shm ~/.vellum/workspace/data/assistant.db-wal
    ```
 
 4. Remove caches:


### PR DESCRIPTION
## Summary
- Update `scrub.md` database removal paths from `~/.vellum/data/` to `~/.vellum/workspace/data/`
- No other command docs contained old path references

Part of the workspace migration plan (PR 24).

## Test plan
- [ ] Manual read-through of scrub.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
