### PR TITLE
feat: add onLinkOpen wiring to SurfaceViewModel and SurfaceManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -15,6 +15,7 @@ final class SurfaceViewModel: ObservableObject {
     let appId: String?
     let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
     let onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)?
+    let onLinkOpen: ((String, [String: Any]?) -> Void)?
     let sandboxMode: Bool
 
     init(
@@ -24,6 +25,7 @@ final class SurfaceViewModel: ObservableObject {
         appId: String? = nil,
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
         onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)? = nil,
+        onLinkOpen: ((String, [String: Any]?) -> Void)? = nil,
         sandboxMode: Bool = false
     ) {
         self.surface = surface
@@ -32,6 +34,7 @@ final class SurfaceViewModel: ObservableObject {
         self.appId = appId
         self.onDataRequest = onDataRequest
         self.onCoordinatorReady = onCoordinatorReady
+        self.onLinkOpen = onLinkOpen
         self.sandboxMode = sandboxMode
     }
 }
@@ -88,6 +91,10 @@ final class SurfaceManager: ObservableObject {
     /// When set, dynamic pages with `display != "inline"` route to the full-window
     /// workspace instead of opening as floating NSPanels.
     var onDynamicPageShow: ((UiSurfaceShowMessage) -> Void)?
+
+    /// Called when a dynamic page requests opening an external link.
+    /// Parameters: url string, optional metadata dictionary.
+    var onLinkOpen: ((String, [String: Any]?) -> Void)?
 
     // MARK: - Show
 
@@ -153,6 +160,9 @@ final class SurfaceManager: ObservableObject {
             onCoordinatorReady: appId != nil ? { [weak self] coordinator in
                 self?.surfaceCoordinators[surface.id] = coordinator
             } : nil,
+            onLinkOpen: { [weak self] url, metadata in
+                self?.onLinkOpen?(url, metadata)
+            },
             sandboxMode: isSandboxed
         )
         viewModels[surface.id] = viewModel


### PR DESCRIPTION
Part of #2826. Adds onLinkOpen callback to SurfaceViewModel and SurfaceManager so link open requests from DynamicPageSurfaceView can propagate up to AppDelegate.

## Changes
- Added `onLinkOpen: ((String, [String: Any]?) -> Void)?` property to `SurfaceViewModel`
- Added corresponding `onLinkOpen` callback property to `SurfaceManager`
- Wired `onLinkOpen` through in `showSurface()` without the `respondedSurfaces` guard (links should not block other actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
