### PR TITLE
feat: add daemon handler for link_open_request

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -57,6 +57,7 @@ import type {
   AppUpdatePreviewRequest,
   PublishPageRequest,
   UnpublishPageRequest,
+  LinkOpenRequest,
 } from './ipc-protocol.js';
 import { postToSlackWebhook } from '../slack/slack-webhook.js';
 import { createHash } from 'node:crypto';
@@ -451,9 +452,7 @@ const handlers: DispatchMap = {
   publish_page: handlePublishPage,
   unpublish_page: handleUnpublishPage,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
-  link_open_request: (_msg, _socket, _ctx) => {
-    // Handled in M2
-  },
+  link_open_request: handleLinkOpenRequest,
   ipc_blob_probe: handleIpcBlobProbe,
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -2573,4 +2572,24 @@ async function handleCuObservation(
   session.handleObservation(msg).catch((err) => {
     log.error({ err, sessionId: msg.sessionId }, 'Error handling CU observation');
   });
+}
+
+function handleLinkOpenRequest(
+  msg: LinkOpenRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const parsed = new URL(msg.url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      log.warn({ url: msg.url }, 'link_open_request: blocked non-http URL');
+      return;
+    }
+  } catch {
+    log.warn({ url: msg.url }, 'link_open_request: invalid URL');
+    return;
+  }
+  // V1: passthrough. Future: affiliate param injection based on metadata
+  const finalUrl = msg.url;
+  ctx.send(socket, { type: 'open_url', url: finalUrl });
 }


### PR DESCRIPTION
## Summary
- Implements the `link_open_request` handler in `assistant/src/daemon/handlers.ts`
- Validates URLs are http/https only, blocking other protocols with a warning log
- Responds with `open_url` message containing the validated URL
- V1 is a passthrough; future versions will support affiliate param injection based on metadata

Part of #2826.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Send a `link_open_request` with a valid https URL and confirm `open_url` response
- [ ] Send a `link_open_request` with `file://` URL and confirm it is blocked
- [ ] Send a `link_open_request` with an invalid URL string and confirm it is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
