### PR TITLE
feat: add Swift IPC types for link_open_request and open_url

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -466,6 +466,12 @@ public struct IPCIpcBlobRef: Codable, Sendable {
     public let sha256: String?
 }
 
+public struct IPCLinkOpenRequest: Codable, Sendable {
+    public let type: String
+    public let url: String
+    public let metadata: [String: AnyCodable]?
+}
+
 public struct IPCListItem: Codable, Sendable {
     public let id: String
     public let title: String
@@ -594,6 +600,12 @@ public struct IPCOpenBundleResponseSignatureResult: Codable, Sendable {
     public let signerKeyId: String?
     public let signerDisplayName: String?
     public let signerAccount: String?
+}
+
+public struct IPCOpenUrl: Codable, Sendable {
+    public let type: String
+    public let url: String
+    public let title: String?
 }
 
 public struct IPCPingMessage: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -297,6 +297,16 @@ extension IPCAppDataRequest {
     }
 }
 
+/// Sent to request opening a URL in the user's browser.
+/// Backed by generated `IPCLinkOpenRequest`.
+public typealias LinkOpenRequestMessage = IPCLinkOpenRequest
+
+extension IPCLinkOpenRequest {
+    public init(url: String, metadata: [String: AnyCodable]?) {
+        self.init(type: "link_open_request", url: url, metadata: metadata)
+    }
+}
+
 /// Sent to request opening an app by ID.
 /// Backed by generated `IPCAppOpenRequest`.
 public typealias AppOpenRequestMessage = IPCAppOpenRequest
@@ -672,6 +682,10 @@ public typealias TaskRoutedMessage = IPCTaskRouted
 
 /// Result from ambient observation analysis.
 public typealias AmbientResultMessage = IPCAmbientResult
+
+/// Instructs the client to open a URL in the browser.
+/// Backed by generated `IPCOpenUrl`.
+public typealias OpenUrlMessage = IPCOpenUrl
 
 /// Daemon status sent on connect — includes runtime HTTP port when available.
 public typealias DaemonStatusMessage = IPCDaemonStatusMessage
@@ -1390,6 +1404,7 @@ public enum ServerMessage: Decodable, Sendable {
     case uiSurfaceUndoResult(UiSurfaceUndoResultMessage)
     case ipcBlobProbeResult(IpcBlobProbeResultMessage)
     case daemonStatus(DaemonStatusMessage)
+    case openUrl(OpenUrlMessage)
     case getSigningIdentity
     case pong
     case unknown(String)
@@ -1562,6 +1577,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "ipc_blob_probe_result":
             let message = try IpcBlobProbeResultMessage(from: decoder)
             self = .ipcBlobProbeResult(message)
+        case "open_url":
+            let message = try OpenUrlMessage(from: decoder)
+            self = .openUrl(message)
         case "get_signing_identity":
             self = .getSigningIdentity
         case "daemon_status":


### PR DESCRIPTION
Part of #2826. Regenerates Swift DTOs from the updated TS contract and adds hand-maintained typealiases, convenience inits, and ServerMessage decoder case for the new link open IPC types.

## Changes
- **`clients/shared/IPC/Generated/IPCContractGenerated.swift`** — regenerated to include `IPCLinkOpenRequest` and `IPCOpenUrl` structs
- **`clients/shared/IPC/IPCMessages.swift`** — added:
  - `LinkOpenRequestMessage` typealias + convenience init (client → server)
  - `OpenUrlMessage` typealias (server → client)
  - `case openUrl(OpenUrlMessage)` in `ServerMessage` enum
  - `"open_url"` decoder case in `ServerMessage.init(from:)`

## Test plan
- [x] `bun run generate:ipc` succeeds and produces `IPCLinkOpenRequest` / `IPCOpenUrl`
- [x] Swift decoder drift check passes (`check-swift-decoder-drift.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
