### PR TITLE
fix: add missing getWorkspaceSkillsDir mock to checker test

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -9,6 +9,7 @@ const checkerTestDir = mkdtempSync(join(tmpdir(), 'checker-test-'));
 mock.module('../util/platform.js', () => ({
   getRootDir: () => checkerTestDir,
   getDataDir: () => join(checkerTestDir, 'data'),
+  getWorkspaceSkillsDir: () => join(checkerTestDir, 'skills'),
   isMacOS: () => process.platform === 'darwin',
   isLinux: () => process.platform === 'linux',
   isWindows: () => process.platform === 'win32',


### PR DESCRIPTION
## Summary
- The `skill_load deny rule blocks aliases that resolve to the same skill id` test was failing because the platform module mock in `checker.test.ts` didn't include `getWorkspaceSkillsDir`
- Without this mock, `loadSkillCatalog()` couldn't discover skills created by `writeSkill()`, so alias-to-ID resolution always failed and deny rules weren't matched
- Added `getWorkspaceSkillsDir: () => join(checkerTestDir, 'skills')` to the platform mock, aligning it with the directory where `writeSkill()` creates test skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
