### PR TITLE
feat: wire onLinkOpen through SurfaceContainerView and MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -581,6 +581,9 @@ struct MainWindowView: View {
                     guard let appId = data.appId else { return }
                     try? daemonClient?.sendAppUpdatePreview(appId: appId, preview: base64)
                 } : nil,
+                onLinkOpen: { url, metadata in
+                    surfaceManager.onLinkOpen?(url, metadata)
+                },
                 topContentInset: 56,
                 bottomContentInset: workspaceComposerReservedHeight
             )

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -78,7 +78,8 @@ struct SurfaceContainerView: View {
                     appId: viewModel.appId,
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
-                    sandboxMode: viewModel.sandboxMode
+                    sandboxMode: viewModel.sandboxMode,
+                    onLinkOpen: viewModel.onLinkOpen
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):


### PR DESCRIPTION
Part of #2826. Passes onLinkOpen callback from SurfaceViewModel through to DynamicPageSurfaceView in both the floating panel path (SurfaceContainerView) and the workspace path (MainWindowView).

## Summary
- **SurfaceContainerView**: Added `onLinkOpen: viewModel.onLinkOpen` parameter to `DynamicPageSurfaceView` instantiation in the `.dynamicPage` case
- **MainWindowView**: Added `onLinkOpen` closure to `DynamicPageSurfaceView` instantiation in `dynamicWorkspaceView()`, forwarding to `surfaceManager.onLinkOpen`

## Test plan
- [ ] Verify floating panel surfaces can open external links via onLinkOpen
- [ ] Verify workspace mode surfaces can open external links via onLinkOpen
- [ ] Confirm no regressions in existing surface rendering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
