### PR TITLE
feat: add DaemonClient onOpenUrl callback and sendLinkOpenRequest

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -155,6 +155,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `publish_page_response` message.
     public var onPublishPageResponse: ((PublishPageResponseMessage) -> Void)?
 
+    /// Called when the daemon sends an `open_url` message.
+    public var onOpenUrl: ((OpenUrlMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -700,6 +703,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(UnpublishPageRequestMessage(deploymentId: deploymentId))
     }
 
+    // MARK: - Link Open
+
+    /// Send a link_open_request to the daemon, requesting it open a URL externally.
+    public func sendLinkOpenRequest(url: String, metadata: [String: AnyCodable]?) throws {
+        try send(LinkOpenRequestMessage(url: url, metadata: metadata))
+    }
+
     // MARK: - Signing Identity (macOS only)
 
     #if os(macOS)
@@ -921,6 +931,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSlackWebhookConfigResponse?(msg)
         case .publishPageResponse(let msg):
             onPublishPageResponse?(msg)
+        case .openUrl(let msg):
+            onOpenUrl?(msg)
         case .unpublishPageResponse:
             break // Handled via specific callback if needed
         case .memoryStatus(let msg):


### PR DESCRIPTION
## Summary
- Adds `onOpenUrl` callback property to `DaemonClient` for routing `open_url` server messages
- Adds `case .openUrl` routing in `handleServerMessage()` switch to forward to the callback
- Adds `sendLinkOpenRequest(url:metadata:)` convenience method for sending `link_open_request` messages to the daemon

Part of #2826.

## Test plan
- [ ] Verify `onOpenUrl` callback fires when daemon sends an `open_url` message
- [ ] Verify `sendLinkOpenRequest` correctly encodes and sends a `link_open_request` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
