### PR TITLE
feat: wire end-to-end link opening in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -178,6 +178,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.refreshSkillsCache()
         }
 
+        // Open URL: daemon -> Swift -> interstitial -> browser
+        daemonClient.onOpenUrl = { msg in
+            guard let url = URL(string: msg.url) else { return }
+            let alert = NSAlert()
+            alert.messageText = "Open External Link?"
+            alert.informativeText = msg.url
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Open in Browser")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() == .alertFirstButtonReturn {
+                NSWorkspace.shared.open(url)
+            }
+        }
+
         // Handle escalation: text_qa -> computer_use via request_computer_control
         daemonClient.onTaskRouted = { [weak self] routed in
             guard let self else { return }
@@ -283,6 +297,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // Data response: daemon -> Swift -> JS
         daemonClient.onAppDataResponse = { [weak self] msg in
             self?.surfaceManager.resolveDataResponse(surfaceId: msg.surfaceId, response: msg)
+        }
+
+        // Link open: JS -> Swift -> daemon
+        surfaceManager.onLinkOpen = { [weak self] url, metadata in
+            let codableMetadata = metadata?.mapValues { AnyCodable($0) }
+            try? self?.daemonClient.sendLinkOpenRequest(url: url, metadata: codableMetadata)
         }
 
         // Route dynamic pages to workspace


### PR DESCRIPTION
Part of #2826. Final wiring that connects SurfaceManager.onLinkOpen → DaemonClient.sendLinkOpenRequest → DaemonClient.onOpenUrl → NSAlert confirmation → NSWorkspace.open. Completes the vellum.openLink feature.

## Changes

In `AppDelegate.setupSurfaceManager()`:
- Wire `surfaceManager.onLinkOpen` to forward link open requests from JS surfaces to the daemon via `daemonClient.sendLinkOpenRequest`

In `AppDelegate.setupDaemonClient()`:
- Wire `daemonClient.onOpenUrl` to show a confirmation dialog (NSAlert) before opening external URLs in the default browser via `NSWorkspace.shared.open`

## Test plan
- [ ] Trigger `vellum.openLink` from a dynamic page surface and verify the confirmation dialog appears
- [ ] Confirm clicking "Open in Browser" opens the URL in the default browser
- [ ] Confirm clicking "Cancel" dismisses the dialog without opening anything
- [ ] Verify invalid URLs are silently ignored (guard on URL parsing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
