### PR TITLE
fix: reset publishedUrl on navigation to prevent stale state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -60,6 +60,7 @@ struct MainWindowView: View {
 
     private func publishPage(html: String, title: String?) {
         guard !isPublishing else { return }
+        publishedUrl = nil
         isPublishing = true
 
         Task { @MainActor in
@@ -592,6 +593,7 @@ struct MainWindowView: View {
                     // "< Chat" pill button — single exit action
                     Button(action: {
                         showSharePicker = false
+                        publishedUrl = nil
                         windowState.closeDynamicPanel()
                     }) {
                         HStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
## Summary
- Resets `publishedUrl = nil` in the "< Chat" back button action so navigating away clears any published URL state
- Resets `publishedUrl = nil` at the start of `publishPage()` so re-publishing a different page clears the stale URL immediately

Addresses feedback from PR #2823: after publishing a page, the checkmark icon and URL pill would incorrectly persist when viewing a different static page.

## Test plan
- [ ] Publish a static page, verify URL pill appears
- [ ] Click "< Chat" to go back, open a different static page — verify globe icon (not checkmark) is shown
- [ ] Publish page A, then immediately publish page B — verify page B's URL appears (not page A's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
