### PR TITLE
feat: add deterministic top-level directory scanner

### DIFF
--- a/assistant/src/__tests__/top-level-scanner.test.ts
+++ b/assistant/src/__tests__/top-level-scanner.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { scanTopLevelDirectories, MAX_TOP_LEVEL_ENTRIES } from '../workspace/top-level-scanner.js';
+
+describe('scanTopLevelDirectories', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'scanner-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('returns empty array for empty directory', () => {
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.rootPath).toBe(tempDir);
+    expect(result.directories).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+
+  test('returns only directories, not files', () => {
+    mkdirSync(join(tempDir, 'src'));
+    mkdirSync(join(tempDir, 'lib'));
+    writeFileSync(join(tempDir, 'README.md'), 'hello');
+    writeFileSync(join(tempDir, 'package.json'), '{}');
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.directories).toEqual(['lib', 'src']);
+    expect(result.truncated).toBe(false);
+  });
+
+  test('sorts directories lexicographically', () => {
+    mkdirSync(join(tempDir, 'zebra'));
+    mkdirSync(join(tempDir, 'alpha'));
+    mkdirSync(join(tempDir, 'middle'));
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.directories).toEqual(['alpha', 'middle', 'zebra']);
+  });
+
+  test('includes hidden directories', () => {
+    mkdirSync(join(tempDir, '.git'));
+    mkdirSync(join(tempDir, '.vscode'));
+    mkdirSync(join(tempDir, 'src'));
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.directories).toEqual(['.git', '.vscode', 'src']);
+  });
+
+  test('is non-recursive — does not descend into subdirectories', () => {
+    mkdirSync(join(tempDir, 'src'));
+    mkdirSync(join(tempDir, 'src', 'nested'));
+    mkdirSync(join(tempDir, 'src', 'nested', 'deep'));
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.directories).toEqual(['src']);
+  });
+
+  test('is deterministic — same input produces same output', () => {
+    mkdirSync(join(tempDir, 'b'));
+    mkdirSync(join(tempDir, 'a'));
+    mkdirSync(join(tempDir, 'c'));
+
+    const r1 = scanTopLevelDirectories(tempDir);
+    const r2 = scanTopLevelDirectories(tempDir);
+    expect(r1).toEqual(r2);
+  });
+
+  test('returns truncated=true when exceeding MAX_TOP_LEVEL_ENTRIES', () => {
+    for (let i = 0; i < MAX_TOP_LEVEL_ENTRIES + 5; i++) {
+      mkdirSync(join(tempDir, `dir-${String(i).padStart(4, '0')}`));
+    }
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.truncated).toBe(true);
+    expect(result.directories).toHaveLength(MAX_TOP_LEVEL_ENTRIES);
+  });
+
+  test('returns truncated=false at exactly MAX_TOP_LEVEL_ENTRIES', () => {
+    for (let i = 0; i < MAX_TOP_LEVEL_ENTRIES; i++) {
+      mkdirSync(join(tempDir, `dir-${String(i).padStart(4, '0')}`));
+    }
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.truncated).toBe(false);
+    expect(result.directories).toHaveLength(MAX_TOP_LEVEL_ENTRIES);
+  });
+
+  test('handles non-existent rootPath gracefully', () => {
+    const result = scanTopLevelDirectories('/tmp/non-existent-path-abc123');
+    expect(result.rootPath).toBe('/tmp/non-existent-path-abc123');
+    expect(result.directories).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+});

--- a/assistant/src/workspace/top-level-scanner.ts
+++ b/assistant/src/workspace/top-level-scanner.ts
@@ -1,0 +1,34 @@
+import { readdirSync } from 'node:fs';
+
+/** Hard cap on returned entries to keep context bounded. */
+export const MAX_TOP_LEVEL_ENTRIES = 120;
+
+export interface TopLevelSnapshot {
+  rootPath: string;
+  directories: string[];
+  truncated: boolean;
+}
+
+/**
+ * Return a deterministic, bounded list of top-level directories
+ * under `rootPath`.  Hidden directories are included.  The result
+ * is sorted lexicographically.
+ */
+export function scanTopLevelDirectories(rootPath: string): TopLevelSnapshot {
+  let entries: string[];
+  try {
+    entries = readdirSync(rootPath, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+  } catch {
+    return { rootPath, directories: [], truncated: false };
+  }
+
+  const truncated = entries.length > MAX_TOP_LEVEL_ENTRIES;
+  return {
+    rootPath,
+    directories: truncated ? entries.slice(0, MAX_TOP_LEVEL_ENTRIES) : entries,
+    truncated,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `workspace/top-level-scanner.ts` with `scanTopLevelDirectories()` 
- Returns sorted, non-recursive, bounded directory listing (cap: 120)
- Includes hidden directories, handles non-existent paths gracefully

## Test plan
- [x] `bun test src/__tests__/top-level-scanner.test.ts` — 9 tests pass

Part 3/14 of workspace-files rollout plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
