### PR TITLE
feat: add workspace context renderer

### DIFF
--- a/assistant/src/__tests__/top-level-renderer.test.ts
+++ b/assistant/src/__tests__/top-level-renderer.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from 'bun:test';
+import { renderWorkspaceTopLevelContext } from '../workspace/top-level-renderer.js';
+import type { TopLevelSnapshot } from '../workspace/top-level-scanner.js';
+
+describe('renderWorkspaceTopLevelContext', () => {
+  test('renders basic snapshot with directories', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/sandbox',
+      directories: ['lib', 'src', 'tests'],
+      truncated: false,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot);
+    expect(result).toBe([
+      '<workspace_top_level>',
+      'Root: /sandbox',
+      'Directories: lib, src, tests',
+      '</workspace_top_level>',
+    ].join('\n'));
+  });
+
+  test('includes truncation note when truncated', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/sandbox',
+      directories: ['a', 'b'],
+      truncated: true,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot);
+    expect(result).toContain('(list truncated — more directories exist)');
+    expect(result).toContain('Directories: a, b');
+  });
+
+  test('does not include truncation note when not truncated', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/sandbox',
+      directories: ['src'],
+      truncated: false,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot);
+    expect(result).not.toContain('truncated');
+  });
+
+  test('renders empty directory list', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/empty',
+      directories: [],
+      truncated: false,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot);
+    expect(result).toBe([
+      '<workspace_top_level>',
+      'Root: /empty',
+      'Directories: ',
+      '</workspace_top_level>',
+    ].join('\n'));
+  });
+
+  test('produces stable output for equal input', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/sandbox',
+      directories: ['alpha', 'beta', 'gamma'],
+      truncated: false,
+    };
+
+    const r1 = renderWorkspaceTopLevelContext(snapshot);
+    const r2 = renderWorkspaceTopLevelContext(snapshot);
+    expect(r1).toBe(r2);
+  });
+
+  test('starts with opening tag and ends with closing tag', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/test',
+      directories: ['src'],
+      truncated: false,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot);
+    expect(result.startsWith('<workspace_top_level>')).toBe(true);
+    expect(result.endsWith('</workspace_top_level>')).toBe(true);
+  });
+
+  test('includes hidden directories', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/project',
+      directories: ['.git', '.vscode', 'src'],
+      truncated: false,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot);
+    expect(result).toContain('.git');
+    expect(result).toContain('.vscode');
+    expect(result).toContain('src');
+  });
+});

--- a/assistant/src/workspace/top-level-renderer.ts
+++ b/assistant/src/workspace/top-level-renderer.ts
@@ -1,0 +1,18 @@
+import type { TopLevelSnapshot } from './top-level-scanner.js';
+
+/**
+ * Render a workspace top-level snapshot into a compact XML-like block
+ * suitable for injection into user messages.
+ *
+ * Output is stable for equal input and kept concise to minimize token cost.
+ */
+export function renderWorkspaceTopLevelContext(snapshot: TopLevelSnapshot): string {
+  const lines: string[] = ['<workspace_top_level>'];
+  lines.push(`Root: ${snapshot.rootPath}`);
+  lines.push(`Directories: ${snapshot.directories.join(', ')}`);
+  if (snapshot.truncated) {
+    lines.push('(list truncated — more directories exist)');
+  }
+  lines.push('</workspace_top_level>');
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Adds `workspace/top-level-renderer.ts` with `renderWorkspaceTopLevelContext()`
- Converts scanner snapshot to compact XML-like block for prompt injection
- Stable output, truncation note support, concise formatting

## Test plan
- [x] `bun test src/__tests__/top-level-renderer.test.ts` — 7 tests pass

Part 4/14 of workspace-files rollout plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
