### PR TITLE
assistant: add onboarding memory schema for locale, color, and trust stage

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -45,7 +45,7 @@ mock.module('../util/logger.js', () => ({
 }));
 
 // Import after mock
-const { buildSystemPrompt, ensurePromptFiles, stripCommentLines } = await import('../config/system-prompt.js');
+const { buildSystemPrompt, ensurePromptFiles, stripCommentLines, buildOnboardingGuidanceSection } = await import('../config/system-prompt.js');
 
 /** Strip the Configuration and Skills sections so base-prompt tests stay focused. */
 function basePrompt(result: string): string {
@@ -152,6 +152,20 @@ describe('buildSystemPrompt', () => {
     const result = buildSystemPrompt();
     expect(result).toContain('## Parallel Task Orchestration');
     expect(result).toContain('swarm_delegate');
+  });
+
+  test('includes onboarding guidance section', () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain('## Onboarding State Management');
+  });
+
+  test('onboarding guidance appears before swarm guidance', () => {
+    const result = buildSystemPrompt();
+    const onboardingIdx = result.indexOf('## Onboarding State Management');
+    const swarmIdx = result.indexOf('## Parallel Task Orchestration');
+    expect(onboardingIdx).toBeGreaterThan(-1);
+    expect(swarmIdx).toBeGreaterThan(-1);
+    expect(onboardingIdx).toBeLessThan(swarmIdx);
   });
 
   test('omits user skills from catalog when none are configured', () => {
@@ -369,5 +383,58 @@ describe('ensurePromptFiles', () => {
     // doesn't crash. A true "missing template" scenario would require
     // mocking the filesystem, but the important contract is: no throw.
     expect(() => ensurePromptFiles()).not.toThrow();
+  });
+});
+
+describe('buildOnboardingGuidanceSection', () => {
+  test('includes locale guidance', () => {
+    const section = buildOnboardingGuidanceSection();
+    expect(section).toContain('### Locale');
+    expect(section).toContain('city');
+    expect(section).toContain('region');
+    expect(section).toContain('country');
+    expect(section).toContain('timezone');
+    expect(section).toContain('localeId');
+    expect(section).toContain('confidence');
+  });
+
+  test('includes dashboard color preference guidance', () => {
+    const section = buildOnboardingGuidanceSection();
+    expect(section).toContain('### Dashboard Color Preference');
+    expect(section).toContain('label');
+    expect(section).toContain('hex');
+    expect(section).toContain('source');
+    expect(section).toContain('applied');
+  });
+
+  test('includes onboarding tasks guidance with valid states', () => {
+    const section = buildOnboardingGuidanceSection();
+    expect(section).toContain('### Onboarding Tasks');
+    expect(section).toContain('pending');
+    expect(section).toContain('in_progress');
+    expect(section).toContain('done');
+    expect(section).toContain('deferred_to_dashboard');
+  });
+
+  test('includes trust stage guidance with milestones', () => {
+    const section = buildOnboardingGuidanceSection();
+    expect(section).toContain('### Trust Stage');
+    expect(section).toContain('hatched');
+    expect(section).toContain('firstConversationComplete');
+    expect(section).toContain('permissionsUnlocked');
+  });
+
+  test('includes trust-gated permission guidance', () => {
+    const section = buildOnboardingGuidanceSection();
+    expect(section).toContain('Gate permission requests based on trust stage');
+    expect(section).toContain('firstConversationComplete');
+  });
+
+  test('does not contain platform-specific logic', () => {
+    const section = buildOnboardingGuidanceSection();
+    expect(section).not.toContain('macOS');
+    expect(section).not.toContain('darwin');
+    expect(section).not.toContain('Windows');
+    expect(section).not.toContain('Linux');
   });
 });

--- a/assistant/src/__tests__/user-template.test.ts
+++ b/assistant/src/__tests__/user-template.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+const { stripCommentLines } = await import('../config/system-prompt.js');
+
+const TEMPLATE_PATH = join(import.meta.dirname ?? __dirname, '..', 'config', 'templates', 'USER.md');
+const raw = readFileSync(TEMPLATE_PATH, 'utf-8');
+const rendered = stripCommentLines(raw);
+
+describe('USER.md template shape', () => {
+  test('contains the top-level USER heading', () => {
+    expect(rendered).toContain('# USER');
+  });
+
+  test('contains basic profile fields', () => {
+    expect(rendered).toContain('**Name:**');
+    expect(rendered).toContain('**Pronouns:**');
+    expect(rendered).toContain('**What to call you:**');
+  });
+
+  test('contains Context section', () => {
+    expect(rendered).toContain('## Context');
+  });
+
+  describe('Locale section', () => {
+    test('has a Locale heading', () => {
+      expect(rendered).toContain('## Locale');
+    });
+
+    test('contains all locale fields', () => {
+      for (const field of ['city', 'region', 'country', 'timezone', 'localeId', 'confidence']) {
+        expect(rendered).toContain(`**${field}:**`);
+      }
+    });
+
+    test('defaults confidence to low', () => {
+      expect(rendered).toContain('**confidence:** low');
+    });
+  });
+
+  describe('Dashboard Color Preference section', () => {
+    test('has a Dashboard Color Preference heading', () => {
+      expect(rendered).toContain('## Dashboard Color Preference');
+    });
+
+    test('contains all color preference fields', () => {
+      for (const field of ['label', 'hex', 'source', 'applied']) {
+        expect(rendered).toContain(`**${field}:**`);
+      }
+    });
+
+    test('defaults applied to false', () => {
+      expect(rendered).toContain('**applied:** false');
+    });
+  });
+
+  describe('Onboarding Tasks section', () => {
+    test('has an Onboarding Tasks heading', () => {
+      expect(rendered).toContain('## Onboarding Tasks');
+    });
+
+    test('contains all onboarding task entries', () => {
+      for (const task of ['set_name', 'set_locale', 'choose_color', 'first_conversation']) {
+        expect(rendered).toContain(`**${task}:**`);
+      }
+    });
+
+    test('all tasks default to pending', () => {
+      for (const task of ['set_name', 'set_locale', 'choose_color', 'first_conversation']) {
+        expect(rendered).toContain(`**${task}:** pending`);
+      }
+    });
+  });
+
+  describe('Trust Stage section', () => {
+    test('has a Trust Stage heading', () => {
+      expect(rendered).toContain('## Trust Stage');
+    });
+
+    test('contains all trust stage fields', () => {
+      for (const field of ['hatched', 'firstConversationComplete', 'permissionsUnlocked']) {
+        expect(rendered).toContain(`**${field}:**`);
+      }
+    });
+
+    test('all trust stages default to false', () => {
+      for (const field of ['hatched', 'firstConversationComplete', 'permissionsUnlocked']) {
+        expect(rendered).toContain(`**${field}:** false`);
+      }
+    });
+  });
+
+  describe('comment stripping', () => {
+    test('raw template contains comment lines', () => {
+      expect(raw).toContain('_ Lines starting with _');
+    });
+
+    test('rendered template does not contain comment lines', () => {
+      const lines = rendered.split('\n');
+      for (const line of lines) {
+        expect(line.trimStart().startsWith('_')).toBe(false);
+      }
+    });
+  });
+
+  describe('section ordering', () => {
+    test('sections appear in the correct order', () => {
+      const sections = ['# USER', '## Context', '## Locale', '## Dashboard Color Preference', '## Onboarding Tasks', '## Trust Stage'];
+      let lastIdx = -1;
+      for (const section of sections) {
+        const idx = rendered.indexOf(section);
+        expect(idx).toBeGreaterThan(lastIdx);
+        lastIdx = idx;
+      }
+    });
+  });
+
+  describe('client-agnostic', () => {
+    test('template does not contain platform-specific references', () => {
+      expect(rendered).not.toContain('macOS');
+      expect(rendered).not.toContain('darwin');
+      expect(rendered).not.toContain('Windows');
+      expect(rendered).not.toContain('Linux');
+      expect(rendered).not.toContain('iOS');
+      expect(rendered).not.toContain('Android');
+    });
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -58,6 +58,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildConfigSection(getWorkspaceDir()));
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
+  parts.push(buildOnboardingGuidanceSection());
   parts.push(buildSwarmGuidanceSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
@@ -172,6 +173,35 @@ export function buildSwarmGuidanceSection(): string {
     '## Parallel Task Orchestration',
     '',
     'Use `swarm_delegate` only when a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"). For single-focus tasks, work directly — do not decompose them into a swarm.',
+  ].join('\n');
+}
+
+export function buildOnboardingGuidanceSection(): string {
+  return [
+    '## Onboarding State Management',
+    '',
+    'USER.md contains structured onboarding sections that you must keep up to date as you learn about the user. These sections are client-agnostic and persist across sessions.',
+    '',
+    '### Locale',
+    'When the user mentions where they live, their timezone, or their language preferences, update the `## Locale` section in USER.md with the relevant fields (`city`, `region`, `country`, `timezone`, `localeId`). Set `confidence` to `low`, `medium`, or `high` based on how explicit the information was.',
+    '',
+    '### Dashboard Color Preference',
+    'When the user chooses an accent color for their dashboard, update the `## Dashboard Color Preference` section with `label` (color name), `hex` (hex code), and `source` (how it was chosen, e.g. "user_selected", "inferred"). Set `applied` to `true` once the preference has been applied to the dashboard.',
+    '',
+    '### Onboarding Tasks',
+    'The `## Onboarding Tasks` section tracks progress through onboarding steps. Update each task status as appropriate:',
+    '- `pending` — not yet started',
+    '- `in_progress` — currently being worked on',
+    '- `done` — completed',
+    '- `deferred_to_dashboard` — user chose to handle this later via the dashboard UI',
+    '',
+    '### Trust Stage',
+    'The `## Trust Stage` section tracks trust milestones. Update these as the user progresses:',
+    '- `hatched` — the assistant has been activated and the user has begun interacting',
+    '- `firstConversationComplete` — the user has completed their first meaningful conversation',
+    '- `permissionsUnlocked` — the user has granted elevated permissions (e.g. file access, external actions)',
+    '',
+    'Gate permission requests based on trust stage. Do not ask for elevated permissions until `firstConversationComplete` is `true`. Be transparent about what each permission enables.',
   ].join('\n');
 }
 

--- a/assistant/src/config/templates/USER.md
+++ b/assistant/src/config/templates/USER.md
@@ -6,9 +6,45 @@ _Your assistant learns about you over time. Fill in what you're comfortable shar
 
 - **Name:**
 - **Pronouns:**
-- **Timezone:**
 - **What to call you:**
 
 ## Context
 
 _(What do you care about? What are you working on? What are your preferences? Add notes here over time.)_
+
+## Locale
+
+_Geographic and language context. Updated during onboarding or when the user shares location details._
+
+- **city:**
+- **region:**
+- **country:**
+- **timezone:**
+- **localeId:**
+- **confidence:** low
+
+## Dashboard Color Preference
+
+_The user's chosen accent color for their dashboard. Updated during onboarding or when the user changes their preference._
+
+- **label:**
+- **hex:**
+- **source:**
+- **applied:** false
+
+## Onboarding Tasks
+
+_Tracks progress through onboarding steps. Each task is one of: pending, in_progress, done, deferred_to_dashboard._
+
+- **set_name:** pending
+- **set_locale:** pending
+- **choose_color:** pending
+- **first_conversation:** pending
+
+## Trust Stage
+
+_Tracks how far the user has progressed in building trust with the assistant. Values are true or false._
+
+- **hatched:** false
+- **firstConversationComplete:** false
+- **permissionsUnlocked:** false


### PR DESCRIPTION
## Context
Part of #2864
Closes #2865

## Changes
- Added onboarding memory sections to USER.md template (locale, color preference, task states, trust stage)
- Added system prompt rules for maintaining onboarding state
- Added tests for template shape and prompt composition

## Validation
- Type-check passes
- All tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
