### PR TITLE
feat: add session workspace snapshot cache state

### DIFF
--- a/assistant/src/__tests__/session-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/session-workspace-cache-state.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { Message, ProviderResponse } from '../providers/types.js';
+import type { AgentEvent } from '../agent/loop.js';
+
+// ---------------------------------------------------------------------------
+// Mock dependencies — follows session-profile-injection.test.ts pattern
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    contextWindow: {
+      enabled: true,
+      maxInputTokens: 100000,
+      targetInputTokens: 80000,
+      compactThreshold: 0.8,
+      preserveRecentUserTurns: 8,
+      summaryMaxTokens: 512,
+      chunkTokens: 12000,
+    },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    apiKeys: {},
+    memory: { enabled: false },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../config/skills.js', () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module('../config/skill-state.js', () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module('../skills/slash-commands.js', () => ({
+  buildInvocableSlashCatalog: () => new Map(),
+  resolveSlashSkillCommand: () => ({ kind: 'not_slash' }),
+  rewriteKnownSlashCommandPrompt: () => '',
+  parseSlashCandidate: () => ({ kind: 'not_slash' }),
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => [],
+  getConversation: () => ({
+    id: 'conv-1',
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    contextCompactedAt: null,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  addMessage: () => ({ id: 'msg-1' }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => ({ segmentIds: [], orphanedItemIds: [] }),
+  deleteLastExchange: () => 0,
+  isLastUserMessageToolResult: () => false,
+}));
+
+mock.module('../memory/attachments-store.js', () => ({
+  uploadAttachment: () => ({ id: 'att-1' }),
+  linkAttachmentToMessage: () => {},
+}));
+
+mock.module('../memory/retriever.js', () => ({
+  buildMemoryRecall: async () => null,
+  injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
+  injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
+  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+}));
+
+mock.module('../memory/query-builder.js', () => ({
+  buildMemoryQuery: () => '',
+}));
+
+mock.module('../memory/retrieval-budget.js', () => ({
+  computeRecallBudget: () => 0,
+}));
+
+mock.module('../context/window-manager.js', () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    async maybeCompact() { return { compacted: false }; }
+  },
+  createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module('../memory/conflict-store.js', () => ({
+  listPendingConflictDetails: () => [],
+  markConflictAsked: () => true,
+  applyConflictResolution: () => true,
+}));
+
+mock.module('../memory/clarification-resolver.js', () => ({
+  resolveConflictClarification: async () => ({
+    resolution: 'still_unclear',
+    strategy: 'heuristic',
+    resolvedStatement: null,
+    explanation: 'Need user clarification.',
+  }),
+}));
+
+mock.module('../memory/admin.js', () => ({
+  getMemoryConflictAndCleanupStats: () => ({
+    conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
+    cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
+  }),
+}));
+
+mock.module('../memory/profile-compiler.js', () => ({
+  compileDynamicProfile: () => null,
+}));
+
+mock.module('../memory/llm-usage-store.js', () => ({
+  recordUsageEvent: () => ({ id: 'usage-1', createdAt: Date.now() }),
+}));
+
+mock.module('../memory/app-store.js', () => ({
+  getApp: () => null,
+  updateApp: () => {},
+}));
+
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    constructor() {}
+    async run(messages: Message[], onEvent: (event: AgentEvent) => void): Promise<Message[]> {
+      const assistantMessage: Message = {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+      };
+      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 10 });
+      onEvent({ type: 'message_complete', message: assistantMessage });
+      return [...messages, assistantMessage];
+    }
+  },
+}));
+
+import { Session } from '../daemon/session.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(): Session {
+  const provider = {
+    name: 'mock',
+    async sendMessage(): Promise<ProviderResponse> {
+      return { content: [], model: 'mock', usage: { inputTokens: 0, outputTokens: 0 }, stopReason: 'end_turn' };
+    },
+  };
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Session workspace cache state', () => {
+  let session: Session;
+
+  beforeEach(() => {
+    session = makeSession();
+  });
+
+  test('starts with dirty=true and null context', () => {
+    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+    expect(session.getWorkspaceTopLevelContext()).toBeNull();
+  });
+
+  test('refreshWorkspaceTopLevelContextIfNeeded populates context and clears dirty', () => {
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    expect(session.getWorkspaceTopLevelContext()).not.toBeNull();
+    expect(session.getWorkspaceTopLevelContext()!).toContain('<workspace_top_level>');
+    expect(session.getWorkspaceTopLevelContext()!).toContain('</workspace_top_level>');
+  });
+
+  test('refreshWorkspaceTopLevelContextIfNeeded no-ops when not dirty and cache exists', () => {
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    const first = session.getWorkspaceTopLevelContext();
+
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    const second = session.getWorkspaceTopLevelContext();
+
+    // Same reference — no recomputation
+    expect(first).toBe(second);
+  });
+
+  test('markWorkspaceTopLevelDirty sets dirty flag', () => {
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+
+    session.markWorkspaceTopLevelDirty();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+  });
+
+  test('refresh after marking dirty produces fresh context', () => {
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+
+    session.markWorkspaceTopLevelDirty();
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+
+    expect(session.getWorkspaceTopLevelContext()).not.toBeNull();
+    expect(session.getWorkspaceTopLevelContext()!).toContain('<workspace_top_level>');
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -68,7 +68,9 @@ import { ConflictGate } from './session-conflict-gate.js';
 import { injectDynamicProfileIntoUserMessage, stripDynamicProfileMessages } from './session-dynamic-profile.js';
 import { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import { applyRuntimeInjections, stripActiveSurfaceContext } from './session-runtime-assembly.js';
+import { applyRuntimeInjections, stripActiveSurfaceContext, stripWorkspaceTopLevelContext } from './session-runtime-assembly.js';
+import { scanTopLevelDirectories } from '../workspace/top-level-scanner.js';
+import { renderWorkspaceTopLevelContext } from '../workspace/top-level-renderer.js';
 import type { ActiveSurfaceContext } from './session-runtime-assembly.js';
 import type { UsageActor } from '../usage/actors.js';
 import { loadSkillCatalog } from '../config/skills.js';
@@ -129,6 +131,8 @@ export class Session {
   private surfaceUndoStacks = new Map<string, string[]>();
   private static readonly MAX_UNDO_DEPTH = 10;
   private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => boolean;
+  private workspaceTopLevelContext: string | null = null;
+  private workspaceTopLevelDirty = true;
   public readonly traceEmitter: TraceEmitter;
 
   /** Resolved assistant attachment drafts from the most recent exchange. */
@@ -1753,6 +1757,31 @@ export class Session {
         'Cleaned up Qdrant vectors after regenerate',
       );
     }
+  }
+
+  // ── Workspace Top-Level Context ──────────────────────────────────
+
+  /** Refresh workspace top-level directory context if needed. */
+  refreshWorkspaceTopLevelContextIfNeeded(): void {
+    if (!this.workspaceTopLevelDirty && this.workspaceTopLevelContext !== null) return;
+    const snapshot = scanTopLevelDirectories(this.workingDir);
+    this.workspaceTopLevelContext = renderWorkspaceTopLevelContext(snapshot);
+    this.workspaceTopLevelDirty = false;
+  }
+
+  /** Mark workspace top-level context for refresh on next turn. */
+  markWorkspaceTopLevelDirty(): void {
+    this.workspaceTopLevelDirty = true;
+  }
+
+  /** Get the current cached workspace context (for testing). */
+  getWorkspaceTopLevelContext(): string | null {
+    return this.workspaceTopLevelContext;
+  }
+
+  /** Check if workspace context is marked dirty (for testing). */
+  isWorkspaceTopLevelDirty(): boolean {
+    return this.workspaceTopLevelDirty;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds `workspaceTopLevelContext` and `workspaceTopLevelDirty` private fields to Session
- Adds `refreshWorkspaceTopLevelContextIfNeeded()` and `markWorkspaceTopLevelDirty()` methods
- Imports scanner and renderer from workspace module
- No call-site wiring yet — pure cache/dirty model

## Test plan
- [x] `bun test src/__tests__/session-workspace-cache-state.test.ts` — 5 tests pass

Part 6/14 of workspace-files rollout plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
