### PR TITLE
macOS: defer microphone/computer-control permission asks to dashboard tasks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EggSceneView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EggSceneView.swift
@@ -20,8 +20,8 @@ struct EggSceneView: View {
                 if progress > 0 {
                     scene.setCrackProgress(progress, animated: false)
                 }
-                // Resume full hatch if restored at step 7 (Alive)
-                if state.currentStep == 7 {
+                // Resume full hatch if restored at step 5 (Alive)
+                if state.currentStep == 5 {
                     scene.triggerFullHatch()
                 }
             }
@@ -29,9 +29,9 @@ struct EggSceneView: View {
                 scene.setCrackProgress(newValue, animated: true)
             }
             .onChange(of: state.currentStep) { old, new in
-                if (4...6).contains(new) && new > old {
+                if (3...4).contains(new) && new > old {
                     scene.triggerDramaticCrack(for: new)
-                } else if new == 7 {
+                } else if new == 5 {
                     scene.triggerFullHatch()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -14,14 +14,14 @@ struct OnboardingStageImage: View {
     @State private var displayedStage: Int = 1
     @State private var isTransitioning = false
 
-    /// Maps onboarding step (0-7) to stage image number (1-5).
+    /// Maps onboarding step (0-5) to stage image number (1-5).
     private var stageNumber: Int {
         switch currentStep {
-        case 0, 1, 2: return 1
-        case 3:       return 2
-        case 4, 5:    return 3
-        case 6:       return 4
-        default:      return 5
+        case 0, 1: return 1
+        case 2:    return 2
+        case 3:    return 3
+        case 4:    return 4
+        default:   return 5
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -23,8 +23,8 @@ struct OnboardingFlowView: View {
                 .opacity(0.25)
                 .allowsHitTesting(false)
 
-                if state.currentStep <= 7 {
-                    // Vertical card layout (steps 0-7)
+                if state.currentStep <= 5 {
+                    // Vertical card layout (steps 0-5)
                     VStack(spacing: 0) {
                         // TOP: Meadow background + stage image
                         ZStack {
@@ -50,12 +50,8 @@ struct OnboardingFlowView: View {
                                 case 3:
                                     FnKeyStepView(state: state)
                                 case 4:
-                                    SpeechPermissionStepView(state: state)
-                                case 5:
                                     AccessibilityPermissionStepView(state: state)
-                                case 6:
-                                    ScreenPermissionStepView(state: state)
-                                case 7:
+                                case 5:
                                     AliveStepView(
                                         state: state,
                                         onComplete: onComplete,
@@ -98,7 +94,7 @@ struct OnboardingFlowView: View {
                     .shadow(color: .black.opacity(0.4), radius: 24, y: 12)
                     .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
                 } else {
-                    // Step 8: Interview — manages its own layout
+                    // Step 6: Interview — manages its own layout
                     InterviewStepView(
                         state: state,
                         daemonClient: daemonClient,

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingProgressDots.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingProgressDots.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// Five cumulative progress dots for the onboarding flow.
 ///
-/// By default maps 8 steps (0-7) to 5 dots. Pass a custom `totalSteps`
+/// By default maps 6 steps (0-5) to 5 dots. Pass a custom `totalSteps`
 /// for flows with a different number of steps (e.g. `totalSteps: 5` for
 /// the first-meeting flow).
 struct OnboardingProgressDots: View {
@@ -12,7 +12,7 @@ struct OnboardingProgressDots: View {
 
     private let totalDots = 5
 
-    init(currentStep: Int, totalSteps: Int = 8) {
+    init(currentStep: Int, totalSteps: Int = 6) {
         self.currentStep = currentStep
         self.totalSteps = totalSteps
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -42,8 +42,10 @@ final class OnboardingState {
     var observationDurationMinutes: Int = 5
     var observationInsights: [String] = []
 
+    /// Only checks permissions that are requested during onboarding.
+    /// Microphone and screen recording are deferred to dashboard tasks.
     var anyPermissionDenied: Bool {
-        !speechGranted || !accessibilityGranted || !screenGranted
+        !accessibilityGranted
     }
 
     /// Continuous crack progress (0.0–1.0) derived from step and permission state.
@@ -55,12 +57,10 @@ final class OnboardingState {
         switch currentStep {
         case 0: return hasHatched ? 0.15 : 0.0
         case 1: return 0.20
-        case 2: return 0.30
-        case 3: return 0.40
-        case 4: return speechGranted ? 0.55 : 0.45
-        case 5: return accessibilityGranted ? 0.75 : 0.60
-        case 6: return screenGranted ? 0.95 : 0.80
-        case 7: return 1.0
+        case 2: return 0.40
+        case 3: return 0.55
+        case 4: return accessibilityGranted ? 0.80 : 0.65
+        case 5: return 1.0
         default: return 1.0
         }
     }
@@ -86,9 +86,9 @@ final class OnboardingState {
         firstMeetingCrackProgress = CGFloat(UserDefaults.standard.double(forKey: "onboarding.firstMeetingCrackProgress"))
 
         // Clamp restored step to the variant's maximum to prevent out-of-range
-        // rendering (e.g. a step saved from the 8-step default flow would be
-        // invalid for the 5-step first-meeting flow).
-        let maxStep = onboardingVariant == .firstMeeting ? 4 : 7
+        // rendering (e.g. a step saved from a previous flow version would be
+        // invalid for the current flow).
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : 5
         if currentStep > maxStep {
             currentStep = maxStep
         }

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -78,11 +78,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-<<<<<<< HEAD
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
-=======
         Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
->>>>>>> 96cab3e0 (feat: add vellum.openLink JS bridge and coordinator handler)
     }
 
     func makeNSView(context: Context) -> WKWebView {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -78,8 +78,8 @@ struct SurfaceContainerView: View {
                     appId: viewModel.appId,
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
-                    sandboxMode: viewModel.sandboxMode,
-                    onLinkOpen: viewModel.onLinkOpen
+                    onLinkOpen: viewModel.onLinkOpen,
+                    sandboxMode: viewModel.sandboxMode
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):


### PR DESCRIPTION
## Context
Part of #2864
Closes #2869

## Changes
- Removed microphone (SpeechPermissionStepView) and screen recording (ScreenPermissionStepView) permission steps from the default onboarding flow
- Hatch + first conversation no longer includes privileged permission requests
- Accessibility permission step retained since it may be needed for basic functionality
- Permission views preserved for later reuse by dashboard tasks
- Updated onboarding state machine: crack progress mapping, step clamping, and `anyPermissionDenied` to only check accessibility
- Updated stage image mapping and egg scene animation triggers for the reduced 6-step flow
- Updated progress dots default from 8 to 6 total steps
- Fixed pre-existing merge conflict in DynamicPageSurfaceView.swift and argument ordering in SurfaceContainerView.swift

## Flow change
**Before (8 steps):** WakeUp -> Naming -> APIKey -> FnKey -> Speech -> Accessibility -> Screen -> Alive -> Interview

**After (6 steps):** WakeUp -> Naming -> APIKey -> FnKey -> Accessibility -> Alive -> Interview

## Validation
- Swift build passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
