### PR TITLE
assistant: inject channel capabilities and gate permission asks by trust stage

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -1,0 +1,315 @@
+import { describe, test, expect } from 'bun:test';
+import type { Message } from '../providers/types.js';
+import {
+  applyRuntimeInjections,
+  injectChannelCapabilityContext,
+  resolveChannelCapabilities,
+  stripChannelCapabilityContext,
+} from '../daemon/session-runtime-assembly.js';
+import type { ChannelCapabilities } from '../daemon/session-runtime-assembly.js';
+import { buildChannelAwarenessSection } from '../config/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// resolveChannelCapabilities
+// ---------------------------------------------------------------------------
+
+describe('resolveChannelCapabilities', () => {
+  test('defaults to dashboard when no source channel is provided', () => {
+    const caps = resolveChannelCapabilities();
+    expect(caps.channel).toBe('dashboard');
+    expect(caps.dashboardCapable).toBe(true);
+    expect(caps.supportsDynamicUi).toBe(true);
+    expect(caps.supportsVoiceInput).toBe(true);
+  });
+
+  test('defaults to dashboard for null source channel', () => {
+    const caps = resolveChannelCapabilities(null);
+    expect(caps.channel).toBe('dashboard');
+    expect(caps.dashboardCapable).toBe(true);
+  });
+
+  test('resolves "dashboard" as dashboard-capable', () => {
+    const caps = resolveChannelCapabilities('dashboard');
+    expect(caps.channel).toBe('dashboard');
+    expect(caps.dashboardCapable).toBe(true);
+    expect(caps.supportsDynamicUi).toBe(true);
+    expect(caps.supportsVoiceInput).toBe(true);
+  });
+
+  test('resolves "telegram" as non-dashboard-capable', () => {
+    const caps = resolveChannelCapabilities('telegram');
+    expect(caps.channel).toBe('telegram');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+
+  test('resolves "http-api" as non-dashboard-capable', () => {
+    const caps = resolveChannelCapabilities('http-api');
+    expect(caps.channel).toBe('http-api');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// injectChannelCapabilityContext
+// ---------------------------------------------------------------------------
+
+describe('injectChannelCapabilityContext', () => {
+  const baseUserMessage: Message = {
+    role: 'user',
+    content: [{ type: 'text', text: 'Hello' }],
+  };
+
+  test('injects channel capabilities block for dashboard channel', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'dashboard',
+      dashboardCapable: true,
+      supportsDynamicUi: true,
+      supportsVoiceInput: true,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+
+    // Should prepend a text block with channel_capabilities
+    expect(result.content.length).toBe(2);
+    const injected = result.content[0];
+    expect(injected.type).toBe('text');
+    expect((injected as { type: 'text'; text: string }).text).toContain('<channel_capabilities>');
+    expect((injected as { type: 'text'; text: string }).text).toContain('dashboard_capable: true');
+    expect((injected as { type: 'text'; text: string }).text).toContain('supports_dynamic_ui: true');
+    expect((injected as { type: 'text'; text: string }).text).toContain('</channel_capabilities>');
+    // Should NOT contain constraint rules for dashboard
+    expect((injected as { type: 'text'; text: string }).text).not.toContain('CHANNEL CONSTRAINTS');
+  });
+
+  test('injects constraint rules for non-dashboard channel', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+
+    const injected = result.content[0];
+    const text = (injected as { type: 'text'; text: string }).text;
+    expect(text).toContain('CHANNEL CONSTRAINTS');
+    expect(text).toContain('Do NOT reference the dashboard UI');
+    expect(text).toContain('Do NOT use ui_show');
+    expect(text).toContain('Do NOT ask the user to use voice');
+    expect(text).toContain('dashboard_capable: false');
+  });
+
+  test('preserves original message content after injection', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+
+    // Original content should be at the end
+    const lastBlock = result.content[result.content.length - 1];
+    expect((lastBlock as { type: 'text'; text: string }).text).toBe('Hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripChannelCapabilityContext
+// ---------------------------------------------------------------------------
+
+describe('stripChannelCapabilityContext', () => {
+  test('strips channel_capabilities blocks from user messages', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<channel_capabilities>\nchannel: telegram\n</channel_capabilities>' },
+          { type: 'text', text: 'Hello' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi there' }],
+      },
+    ];
+
+    const result = stripChannelCapabilityContext(messages);
+
+    expect(result.length).toBe(2);
+    expect(result[0].content.length).toBe(1);
+    expect((result[0].content[0] as { type: 'text'; text: string }).text).toBe('Hello');
+    // Assistant message untouched
+    expect(result[1].content.length).toBe(1);
+  });
+
+  test('removes user messages that only contain channel_capabilities', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<channel_capabilities>\nchannel: telegram\n</channel_capabilities>' },
+        ],
+      },
+    ];
+
+    const result = stripChannelCapabilityContext(messages);
+    expect(result.length).toBe(0);
+  });
+
+  test('leaves messages without channel_capabilities untouched', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Normal message' }],
+      },
+    ];
+
+    const result = stripChannelCapabilityContext(messages);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(messages[0]); // Same reference — untouched
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRuntimeInjections with channelCapabilities
+// ---------------------------------------------------------------------------
+
+describe('applyRuntimeInjections with channelCapabilities', () => {
+  const baseMessages: Message[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'What can you do?' }],
+    },
+  ];
+
+  test('injects channel capabilities when provided', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = applyRuntimeInjections(baseMessages, {
+      channelCapabilities: caps,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(2);
+    const injected = result[0].content[0];
+    expect((injected as { type: 'text'; text: string }).text).toContain('<channel_capabilities>');
+  });
+
+  test('does not inject when channelCapabilities is null', () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      channelCapabilities: null,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+  });
+
+  test('does not inject when channelCapabilities is omitted', () => {
+    const result = applyRuntimeInjections(baseMessages, {});
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+  });
+
+  test('combines with other injections', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = applyRuntimeInjections(baseMessages, {
+      softConflictInstruction: 'What is your name?',
+      channelCapabilities: caps,
+    });
+
+    expect(result.length).toBe(1);
+    // softConflictInstruction appends, channelCapabilities prepends
+    expect(result[0].content.length).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildChannelAwarenessSection
+// ---------------------------------------------------------------------------
+
+describe('buildChannelAwarenessSection', () => {
+  test('includes channel awareness heading', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('## Channel Awareness & Trust Gating');
+  });
+
+  test('includes channel-specific rules', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('dashboard_capable');
+    expect(section).toContain('supports_dynamic_ui');
+    expect(section).toContain('supports_voice_input');
+  });
+
+  test('includes trust gating rules for permission asks', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('firstConversationComplete');
+    expect(section).toContain('Permission ask trust gating');
+    expect(section).toContain('Do NOT proactively ask for elevated permissions');
+  });
+
+  test('gates microphone permissions on voice capability', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('Do not ask for microphone permissions');
+  });
+
+  test('gates computer-control on dashboard channel', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('computer-control permissions on non-dashboard');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust-gating behavior: channel constraints for permission asks
+// ---------------------------------------------------------------------------
+
+describe('trust-gating via channel capabilities', () => {
+  test('dashboard channel does not add constraint rules', () => {
+    const caps = resolveChannelCapabilities('dashboard');
+    const message: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'Enable my microphone' }],
+    };
+
+    const result = injectChannelCapabilityContext(message, caps);
+    const injected = (result.content[0] as { type: 'text'; text: string }).text;
+
+    expect(injected).not.toContain('CHANNEL CONSTRAINTS');
+    expect(injected).toContain('dashboard_capable: true');
+  });
+
+  test('non-dashboard channel adds constraint rules preventing UI references', () => {
+    const caps = resolveChannelCapabilities('slack');
+    const message: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'Show me a chart' }],
+    };
+
+    const result = injectChannelCapabilityContext(message, caps);
+    const injected = (result.content[0] as { type: 'text'; text: string }).text;
+
+    expect(injected).toContain('CHANNEL CONSTRAINTS');
+    expect(injected).toContain('Do NOT reference the dashboard UI');
+    expect(injected).toContain('Do NOT use ui_show, ui_update, or app_create');
+    expect(injected).toContain('Present information as well-formatted text');
+    expect(injected).toContain('desktop app');
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -59,6 +59,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
   parts.push(buildOnboardingGuidanceSection());
+  parts.push(buildChannelAwarenessSection());
   parts.push(buildSwarmGuidanceSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
@@ -165,6 +166,27 @@ function buildDynamicUiSection(): string {
     'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a visual output rather than displaying raw tool outputs.',
     '- **Weather**: `get_weather` automatically renders a dynamic page with a compact preview card. Do NOT call `ui_show` or `app_create` after `get_weather` — the weather surface is emitted directly. Just respond with a brief natural-language summary.',
     '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished output — use `app_create` for custom UIs, or `ui_show` with domain component classes for predefined data types.',
+  ].join('\n');
+}
+
+export function buildChannelAwarenessSection(): string {
+  return [
+    '## Channel Awareness & Trust Gating',
+    '',
+    'Each turn may include a `<channel_capabilities>` block in the user message describing what the current channel supports. Use this to adapt your behaviour:',
+    '',
+    '### Channel-specific rules',
+    '- When `dashboard_capable` is `false`, never reference the dashboard UI, settings panels, dynamic pages, or visual pickers. Present data as formatted text.',
+    '- When `supports_dynamic_ui` is `false`, do not call `ui_show`, `ui_update`, or `app_create`.',
+    '- When `supports_voice_input` is `false`, do not ask the user to speak or use their microphone.',
+    '- Non-dashboard channels should defer dashboard-specific actions. Tell the user they can complete those steps later from the desktop app.',
+    '',
+    '### Permission ask trust gating',
+    '- Do NOT proactively ask for elevated permissions (microphone, computer control, file access) until the trust stage field `firstConversationComplete` in USER.md is `true`.',
+    '- Even after `firstConversationComplete`, only ask for permissions that are relevant to the current channel capabilities.',
+    '- Do not ask for microphone permissions on channels where `supports_voice_input` is `false`.',
+    '- Do not ask for computer-control permissions on non-dashboard channels.',
+    '- When you do request a permission, be transparent about what it enables and why you need it.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -12,6 +12,7 @@ import { resetAllowlist } from '../security/secret-allowlist.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session } from './session.js';
+import { resolveChannelCapabilities } from './session-runtime-assembly.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import {
   serialize,
@@ -654,6 +655,7 @@ export class DaemonServer {
     conversationId: string,
     content: string,
     attachmentIds?: string[],
+    sourceChannel?: string,
   ): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
 
@@ -666,6 +668,7 @@ export class DaemonServer {
     // Set assistantId AFTER the isProcessing check so a rejected request
     // doesn't mutate the session state visible to an in-flight request.
     session.setAssistantId(assistantId);
+    session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
@@ -700,6 +703,7 @@ export class DaemonServer {
     conversationId: string,
     content: string,
     attachmentIds?: string[],
+    sourceChannel?: string,
   ): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
 
@@ -710,6 +714,7 @@ export class DaemonServer {
     // Set assistantId AFTER the isProcessing check so a rejected request
     // doesn't mutate the session state visible to an in-flight request.
     session.setAssistantId(assistantId);
+    session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -7,6 +7,33 @@
 
 import type { Message } from '../providers/types.js';
 
+/**
+ * Describes the capabilities of the channel through which the user is
+ * interacting.  Used to gate UI-specific references and permission asks.
+ */
+export interface ChannelCapabilities {
+  /** The raw channel identifier (e.g. "dashboard", "telegram", "http-api"). */
+  channel: string;
+  /** Whether this channel can render the dashboard UI (apps, dynamic pages). */
+  dashboardCapable: boolean;
+  /** Whether the channel supports dynamic UI surfaces (ui_show / ui_update). */
+  supportsDynamicUi: boolean;
+  /** Whether the channel supports voice/microphone input. */
+  supportsVoiceInput: boolean;
+}
+
+/** Derive channel capabilities from a raw source channel identifier. */
+export function resolveChannelCapabilities(sourceChannel?: string | null): ChannelCapabilities {
+  const channel = sourceChannel ?? 'dashboard';
+  const isDashboard = channel === 'dashboard';
+  return {
+    channel,
+    dashboardCapable: isDashboard,
+    supportsDynamicUi: isDashboard,
+    supportsVoiceInput: isDashboard,
+  };
+}
+
 /** Context about the active workspace surface, passed to applyRuntimeInjections. */
 export interface ActiveSurfaceContext {
   surfaceId: string;
@@ -174,6 +201,60 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
 }
 
 /**
+ * Prepend channel capability context to the last user message so the
+ * model knows what the current channel can and cannot do.
+ */
+export function injectChannelCapabilityContext(message: Message, caps: ChannelCapabilities): Message {
+  const lines: string[] = ['<channel_capabilities>'];
+  lines.push(`channel: ${caps.channel}`);
+  lines.push(`dashboard_capable: ${caps.dashboardCapable}`);
+  lines.push(`supports_dynamic_ui: ${caps.supportsDynamicUi}`);
+  lines.push(`supports_voice_input: ${caps.supportsVoiceInput}`);
+
+  if (!caps.dashboardCapable) {
+    lines.push('');
+    lines.push('CHANNEL CONSTRAINTS:');
+    lines.push('- Do NOT reference the dashboard UI, settings panels, or visual preference pickers.');
+    lines.push('- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.');
+    lines.push('- Present information as well-formatted text instead of dynamic UI.');
+    lines.push('- Defer dashboard-specific actions (e.g. accent color selection) by telling the user');
+    lines.push('  they can complete those steps later from the desktop app.');
+  }
+
+  if (!caps.supportsVoiceInput) {
+    lines.push('- Do NOT ask the user to use voice or microphone input.');
+  }
+
+  lines.push('</channel_capabilities>');
+
+  const block = lines.join('\n');
+  return {
+    ...message,
+    content: [
+      { type: 'text', text: block },
+      ...message.content,
+    ],
+  };
+}
+
+/**
+ * Strip `<channel_capabilities>` blocks injected by
+ * `injectChannelCapabilityContext`.
+ */
+export function stripChannelCapabilityContext(messages: Message[]): Message[] {
+  return messages.map((message) => {
+    if (message.role !== 'user') return message;
+    const nextContent = message.content.filter((block) => {
+      if (block.type !== 'text') return true;
+      return !block.text.startsWith('<channel_capabilities>');
+    });
+    if (nextContent.length === message.content.length) return message;
+    if (nextContent.length === 0) return null;
+    return { ...message, content: nextContent };
+  }).filter((message): message is NonNullable<typeof message> => message !== null);
+}
+
+/**
  * Strip `<active_workspace>` (and legacy `<active_dynamic_page>`) blocks
  * injected by `injectActiveSurfaceContext`.  Called after the agent run to
  * prevent the (potentially 100 KB) surface HTML from persisting in session
@@ -203,6 +284,7 @@ export function applyRuntimeInjections(
   options: {
     softConflictInstruction?: string | null;
     activeSurface?: ActiveSurfaceContext | null;
+    channelCapabilities?: ChannelCapabilities | null;
   },
 ): Message[] {
   let result = runMessages;
@@ -223,6 +305,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectActiveSurfaceContext(userTail, options.activeSurface),
+      ];
+    }
+  }
+
+  if (options.channelCapabilities) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === 'user') {
+      result = [
+        ...result.slice(0, -1),
+        injectChannelCapabilityContext(userTail, options.channelCapabilities),
       ];
     }
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -68,8 +68,8 @@ import { ConflictGate } from './session-conflict-gate.js';
 import { injectDynamicProfileIntoUserMessage, stripDynamicProfileMessages } from './session-dynamic-profile.js';
 import { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import { applyRuntimeInjections, stripActiveSurfaceContext } from './session-runtime-assembly.js';
-import type { ActiveSurfaceContext } from './session-runtime-assembly.js';
+import { applyRuntimeInjections, stripActiveSurfaceContext, stripChannelCapabilityContext } from './session-runtime-assembly.js';
+import type { ActiveSurfaceContext, ChannelCapabilities } from './session-runtime-assembly.js';
 import type { UsageActor } from '../usage/actors.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
@@ -121,6 +121,7 @@ export class Session {
   private readonly queue = new MessageQueue();
   private currentActiveSurfaceId?: string;
   private currentPage?: string;
+  private channelCapabilities?: ChannelCapabilities;
   private pendingSurfaceActions = new Map<string, {
     surfaceType: SurfaceType;
   }>();
@@ -515,6 +516,10 @@ export class Session {
     this.assistantId = assistantId;
   }
 
+  setChannelCapabilities(caps: ChannelCapabilities): void {
+    this.channelCapabilities = caps;
+  }
+
   private async approveHostAttachmentRead(filePath: string): Promise<boolean> {
     const toolName = 'host_file_read';
     const input = { path: filePath };
@@ -866,6 +871,7 @@ export class Session {
       runMessages = applyRuntimeInjections(runMessages, {
         softConflictInstruction,
         activeSurface,
+        channelCapabilities: this.channelCapabilities ?? null,
       });
 
       // Pre-run repair: fix any message ordering issues before sending to provider.
@@ -1146,8 +1152,10 @@ export class Session {
       });
       const restoredHistory = [...preRepairMessages, ...newMessages];
       const recallStripped = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
-      this.messages = stripActiveSurfaceContext(
-        stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+      this.messages = stripChannelCapabilityContext(
+        stripActiveSurfaceContext(
+          stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+        ),
       );
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -35,6 +35,7 @@ export type MessageProcessor = (
   conversationId: string,
   content: string,
   attachmentIds?: string[],
+  sourceChannel?: string,
 ) => Promise<{ messageId: string }>;
 
 /**
@@ -47,6 +48,7 @@ export type NonBlockingMessageProcessor = (
   conversationId: string,
   content: string,
   attachmentIds?: string[],
+  sourceChannel?: string,
 ) => Promise<{ messageId: string }>;
 
 export interface RuntimeHttpServerOptions {
@@ -498,9 +500,10 @@ export class RuntimeHttpServer {
       conversationKey?: string;
       content?: string;
       attachmentIds?: string[];
+      sourceChannel?: string;
     };
 
-    const { conversationKey, content, attachmentIds } = body;
+    const { conversationKey, content, attachmentIds, sourceChannel } = body;
 
     if (!conversationKey) {
       return Response.json(
@@ -553,6 +556,7 @@ export class RuntimeHttpServer {
         mapping.conversationId,
         content ?? '',
         hasAttachments ? attachmentIds : undefined,
+        sourceChannel,
       );
       return Response.json({ accepted: true, messageId: result.messageId });
     } catch (err) {
@@ -887,7 +891,7 @@ export class RuntimeHttpServer {
     let processingSucceeded = false;
     if (!result.duplicate && this.processMessage) {
       try {
-        await this.processMessage(assistantId, result.conversationId, content ?? '', hasAttachments ? attachmentIds : undefined);
+        await this.processMessage(assistantId, result.conversationId, content ?? '', hasAttachments ? attachmentIds : undefined, sourceChannel);
         processingSucceeded = true;
       } catch (err) {
         console.error(`[runtime-http] Processing failed`, err);


### PR DESCRIPTION
## Context
Part of #2864
Closes #2866

## Changes
- Added `ChannelCapabilities` interface and `resolveChannelCapabilities()` helper to derive capabilities from a source channel identifier
- Extended `session-runtime-assembly.ts` with `injectChannelCapabilityContext()` to prepend `<channel_capabilities>` context to user messages and `stripChannelCapabilityContext()` to clean up after the agent loop
- Added `buildChannelAwarenessSection()` to the system prompt with channel-specific behavioral rules and trust-gating guidance for permission asks
- Threaded `sourceChannel` from HTTP server endpoints (`handleSendMessage`, `handleChannelInbound`) through the daemon server (`processMessage`, `persistAndProcessMessage`) to the session pipeline
- Session stores channel capabilities and passes them to `applyRuntimeInjections` each turn
- Added 22 tests covering capability resolution, context injection/stripping, trust-gating behavior, and system prompt content

## Validation
- Type-check passes (`bunx tsc --noEmit`)
- All 22 new tests pass
- All 41 existing system-prompt tests pass (no regressions)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
