### PR TITLE
fix: break ensureDataDir circular dependency in migration and logger

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -1,6 +1,6 @@
 import pino from 'pino';
 import pinoPretty from 'pino-pretty';
-import { getLogPath, ensureDataDir } from './platform.js';
+import { getLogPath } from './platform.js';
 
 let rootLogger: pino.Logger | null = null;
 
@@ -19,7 +19,6 @@ function getRootLogger(): pino.Logger {
     }
 
     try {
-      ensureDataDir();
       const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true });
 
       if (process.env.VELLUM_DEBUG === '1') {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,9 +1,17 @@
 import { mkdirSync, existsSync, statSync, unlinkSync, renameSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { getLogger } from './logger.js';
-
-const log = getLogger('platform');
+/**
+ * Stderr-only logger for migration code. Using the pino logger during
+ * migration is unsafe because pino initialization calls ensureDataDir(),
+ * which pre-creates workspace destination directories and causes migration
+ * moves to no-op.
+ */
+function migrationLog(level: 'info' | 'warn', msg: string, data?: Record<string, unknown>): void {
+  const prefix = level === 'warn' ? 'WARN' : 'INFO';
+  const extra = data ? ' ' + JSON.stringify(data) : '';
+  process.stderr.write(`[migration] ${prefix}: ${msg}${extra}\n`);
+}
 
 export function isMacOS(): boolean {
   return process.platform === 'darwin';
@@ -172,10 +180,7 @@ export function getWorkspacePromptPath(file: string): string {
 export function migratePath(source: string, destination: string): void {
   if (!existsSync(source)) return;
   if (existsSync(destination)) {
-    log.warn(
-      { source, destination },
-      'Migration skipped: destination already exists',
-    );
+    migrationLog('warn', 'Migration skipped: destination already exists', { source, destination });
     return;
   }
   const destDir = dirname(destination);
@@ -184,9 +189,9 @@ export function migratePath(source: string, destination: string): void {
   }
   try {
     renameSync(source, destination);
-    log.info({ from: source, to: destination }, 'Migrated path');
+    migrationLog('info', 'Migrated path', { from: source, to: destination });
   } catch (err) {
-    log.warn({ err, from: source, to: destination }, 'Failed to migrate path');
+    migrationLog('warn', 'Failed to migrate path', { err: String(err), from: source, to: destination });
   }
 }
 
@@ -213,9 +218,9 @@ export function migrateToWorkspaceLayout(): void {
     if (existsSync(sandboxFs)) {
       try {
         renameSync(sandboxFs, ws);
-        log.info({ from: sandboxFs, to: ws }, 'Extracted sandbox/fs as workspace root');
+        migrationLog('info', 'Extracted sandbox/fs as workspace root', { from: sandboxFs, to: ws });
       } catch (err) {
-        log.warn({ err, from: sandboxFs, to: ws }, 'Failed to extract sandbox/fs');
+        migrationLog('warn', 'Failed to extract sandbox/fs', { err: String(err), from: sandboxFs, to: ws });
       }
     }
   }
@@ -281,9 +286,9 @@ export function migrateToDataLayout(): void {
     }
     try {
       renameSync(oldPath, newPath);
-      log.info({ from: oldPath, to: newPath }, 'Migrated path');
+      migrationLog('info', 'Migrated path', { from: oldPath, to: newPath });
     } catch (err) {
-      log.warn({ err, from: oldPath, to: newPath }, 'Failed to migrate path');
+      migrationLog('warn', 'Failed to migrate path', { err: String(err), from: oldPath, to: newPath });
     }
   }
 


### PR DESCRIPTION
## Summary
- Migration code used the pino logger, which called `ensureDataDir()` during initialization — this pre-created workspace destination directories, causing migration moves to no-op
- Replace pino logger in migration functions (`migratePath`, `migrateToWorkspaceLayout`, `migrateToDataLayout`) with stderr-based `migrationLog()` that never triggers `ensureDataDir()`
- Remove `ensureDataDir()` call from `logger.ts` — pino's `mkdir: true` option already creates parent directories

## Test plan
- [x] All 10 existing migration tests pass (88 assertions)
- [x] Migration output now shows `[migration] INFO/WARN` stderr format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
