### PR TITLE
fix: prevent startDaemon from pre-creating workspace dirs

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { cpSync, readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { cpSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
 
 import { resolve } from 'node:path';
 import * as Sentry from '@sentry/node';
@@ -7,6 +7,7 @@ import {
   getInterfacesDir,
   getSocketPath,
   getPidPath,
+  getRootDir,
   ensureDataDir,
   migrateToDataLayout,
   migrateToWorkspaceLayout,
@@ -93,7 +94,14 @@ export async function startDaemon(): Promise<{
     return { pid: status.pid, alreadyRunning: true };
   }
 
-  ensureDataDir();
+  // Only create the root dir for socket/PID — the daemon process itself
+  // handles migration + full ensureDataDir() in runDaemon(). Calling
+  // ensureDataDir() here would pre-create workspace destination dirs
+  // and cause migration moves to no-op.
+  const rootDir = getRootDir();
+  if (!existsSync(rootDir)) {
+    mkdirSync(rootDir, { recursive: true });
+  }
 
   // Clean up stale socket (only if it's actually a Unix socket)
   const socketPath = getSocketPath();


### PR DESCRIPTION
## Summary
- `startDaemon()` called `ensureDataDir()` before spawning the daemon process, pre-creating `workspace/data`, `workspace/hooks`, `workspace/skills`
- When the daemon later ran `migrateToWorkspaceLayout()`, moves no-oped because destinations already existed
- Replace `ensureDataDir()` with root-dir-only creation — the daemon process handles migration + full `ensureDataDir()` in `runDaemon()`

## Test plan
- [x] Verify `startDaemon()` only creates `~/.vellum/` root dir (for socket/PID)
- [x] Verify daemon process runs migration before `ensureDataDir()` in `runDaemon()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
