### PR TITLE
assistant: implement starter task flows (color, research, research-to-ui)

### DIFF
--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const TEST_DIR = join(tmpdir(), `vellum-starter-tasks-test-${crypto.randomUUID()}`);
+
+import { mock } from 'bun:test';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => TEST_DIR,
+  getWorkspaceDir: () => TEST_DIR,
+  getWorkspaceConfigPath: () => join(TEST_DIR, 'config.json'),
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
+  getWorkspaceHooksDir: () => join(TEST_DIR, 'hooks'),
+  getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  getHistoryPath: () => join(TEST_DIR, 'history'),
+  getHooksDir: () => join(TEST_DIR, 'hooks'),
+  getIpcBlobDir: () => join(TEST_DIR, 'ipc-blobs'),
+  getSandboxRootDir: () => join(TEST_DIR, 'sandbox'),
+  getSandboxWorkingDir: () => TEST_DIR,
+  getInterfacesDir: () => join(TEST_DIR, 'interfaces'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getPlatformName: () => process.platform,
+  getClipboardCommand: () => null,
+  removeSocketFile: () => {},
+  migratePath: () => {},
+  migrateToWorkspaceLayout: () => {},
+  migrateToDataLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+const { buildStarterTaskPlaybookSection, buildSystemPrompt } = await import('../config/system-prompt.js');
+
+describe('buildStarterTaskPlaybookSection', () => {
+  test('returns a string with the section heading', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('## Starter Task Playbooks');
+  });
+
+  test('documents all three kickoff intents', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('[STARTER_TASK:make_it_yours]');
+    expect(section).toContain('[STARTER_TASK:research_topic]');
+    expect(section).toContain('[STARTER_TASK:research_to_ui]');
+  });
+
+  test('includes the make_it_yours playbook', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('### Playbook: make_it_yours');
+    expect(section).toContain('accent color');
+    expect(section).toContain('Dashboard Color Preference');
+    expect(section).toContain('user_selected');
+  });
+
+  test('includes the research_topic playbook', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('### Playbook: research_topic');
+    expect(section).toContain('web search');
+  });
+
+  test('includes the research_to_ui playbook', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('### Playbook: research_to_ui');
+    expect(section).toContain('app_create');
+  });
+
+  test('includes general rules section', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('### General rules for all starter tasks');
+  });
+
+  test('enforces trust gating in general rules', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('trust gating');
+    expect(section).toContain('do NOT ask for elevated permissions');
+  });
+
+  test('references USER.md onboarding tasks for status tracking', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('## Onboarding Tasks');
+    expect(section).toContain('in_progress');
+    expect(section).toContain('done');
+    expect(section).toContain('deferred_to_dashboard');
+  });
+
+  test('make_it_yours playbook handles locale confirmation', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('locale');
+    expect(section).toContain('confidence: low');
+  });
+
+  test('make_it_yours playbook includes confirmation step', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('Confirm the selection');
+    expect(section).toContain('Sound good?');
+  });
+
+  test('research_to_ui playbook references dynamic UI quality standards', () => {
+    const section = buildStarterTaskPlaybookSection();
+    expect(section).toContain('Dynamic UI quality standards');
+    expect(section).toContain('anti-AI-slop');
+  });
+});
+
+describe('starter task playbook integration with buildSystemPrompt', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('buildSystemPrompt includes the starter task playbook section', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('## Starter Task Playbooks');
+  });
+
+  test('starter task playbook appears after onboarding guidance', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    const onboardingIdx = result.indexOf('## Onboarding State Management');
+    const starterIdx = result.indexOf('## Starter Task Playbooks');
+    expect(onboardingIdx).toBeGreaterThan(-1);
+    expect(starterIdx).toBeGreaterThan(-1);
+    expect(onboardingIdx).toBeLessThan(starterIdx);
+  });
+
+  test('starter task playbook appears before channel awareness', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    const starterIdx = result.indexOf('## Starter Task Playbooks');
+    const channelIdx = result.indexOf('## Channel Awareness & Trust Gating');
+    expect(starterIdx).toBeGreaterThan(-1);
+    expect(channelIdx).toBeGreaterThan(-1);
+    expect(starterIdx).toBeLessThan(channelIdx);
+  });
+
+  test('all three kickoff intents present in full system prompt', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('[STARTER_TASK:make_it_yours]');
+    expect(result).toContain('[STARTER_TASK:research_topic]');
+    expect(result).toContain('[STARTER_TASK:research_to_ui]');
+  });
+});
+
+describe('USER.md template starter task fields', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('USER.md template includes all three starter task fields', () => {
+    const templatePath = join(import.meta.dirname ?? __dirname, '..', 'config', 'templates', 'USER.md');
+    const content = readFileSync(templatePath, 'utf-8');
+    expect(content).toContain('**make_it_yours:** pending');
+    expect(content).toContain('**research_topic:** pending');
+    expect(content).toContain('**research_to_ui:** pending');
+  });
+
+  test('USER.md template preserves existing task fields', () => {
+    const templatePath = join(import.meta.dirname ?? __dirname, '..', 'config', 'templates', 'USER.md');
+    const content = readFileSync(templatePath, 'utf-8');
+    expect(content).toContain('**set_name:** pending');
+    expect(content).toContain('**set_locale:** pending');
+    expect(content).toContain('**first_conversation:** pending');
+  });
+});

--- a/assistant/src/__tests__/user-template.test.ts
+++ b/assistant/src/__tests__/user-template.test.ts
@@ -69,13 +69,13 @@ describe('USER.md template shape', () => {
     });
 
     test('contains all onboarding task entries', () => {
-      for (const task of ['set_name', 'set_locale', 'choose_color', 'first_conversation']) {
+      for (const task of ['set_name', 'set_locale', 'make_it_yours', 'research_topic', 'research_to_ui', 'first_conversation']) {
         expect(rendered).toContain(`**${task}:**`);
       }
     });
 
     test('all tasks default to pending', () => {
-      for (const task of ['set_name', 'set_locale', 'choose_color', 'first_conversation']) {
+      for (const task of ['set_name', 'set_locale', 'make_it_yours', 'research_topic', 'research_to_ui', 'first_conversation']) {
         expect(rendered).toContain(`**${task}:** pending`);
       }
     });

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -59,6 +59,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
   parts.push(buildOnboardingGuidanceSection());
+  parts.push(buildStarterTaskPlaybookSection());
   parts.push(buildChannelAwarenessSection());
   parts.push(buildSwarmGuidanceSection());
 
@@ -224,6 +225,54 @@ export function buildOnboardingGuidanceSection(): string {
     '- `permissionsUnlocked` — the user has granted elevated permissions (e.g. file access, external actions)',
     '',
     'Gate permission requests based on trust stage. Do not ask for elevated permissions until `firstConversationComplete` is `true`. Be transparent about what each permission enables.',
+  ].join('\n');
+}
+
+export function buildStarterTaskPlaybookSection(): string {
+  return [
+    '## Starter Task Playbooks',
+    '',
+    'When the user clicks a starter task card in the dashboard, you receive a deterministic kickoff message in the format `[STARTER_TASK:<task_id>]`. Follow the playbook for that task exactly.',
+    '',
+    '### Kickoff intent contract',
+    '- `[STARTER_TASK:make_it_yours]` — "Make it yours" color personalisation flow',
+    '- `[STARTER_TASK:research_topic]` — "Research something for me" flow',
+    '- `[STARTER_TASK:research_to_ui]` — "Turn it into a webpage or interactive UI" flow',
+    '',
+    '### Playbook: make_it_yours',
+    'Goal: Help the user choose an accent color for their dashboard.',
+    '',
+    '1. If the user\'s locale is missing or has `confidence: low` in USER.md, briefly confirm their location/language before proceeding.',
+    '2. Present a concise set of accent color options (e.g. 5-7 curated colors with names and hex codes). Keep it short and scannable.',
+    '3. Let the user pick one. Accept color names, hex values, or descriptions (e.g. "something warm").',
+    '4. Confirm the selection: "I\'ll set your accent color to **{label}** ({hex}). Sound good?"',
+    '5. On confirmation:',
+    '   - Update the `## Dashboard Color Preference` section in USER.md with `label`, `hex`, `source: "user_selected"`, and `applied: true`.',
+    '   - Update the `## Onboarding Tasks` section: set `make_it_yours` to `done`.',
+    '   - Emit the color preference using `ui_show` with `surface_type: "config_update"` and `data: { key: "accent_color", value: "<hex>" }`.',
+    '6. If the user declines or wants to skip, set `make_it_yours` to `deferred_to_dashboard` in USER.md and move on.',
+    '',
+    '### Playbook: research_topic',
+    'Goal: Research a topic the user is interested in and summarise findings.',
+    '',
+    '1. Ask the user what topic they\'d like researched. Be specific: "What would you like me to look into?"',
+    '2. Once given a topic, use available tools (web search, browser, etc.) to gather information.',
+    '3. Synthesise the findings into a clear, well-structured summary.',
+    '4. Update the `## Onboarding Tasks` section in USER.md: set `research_topic` to `done`.',
+    '',
+    '### Playbook: research_to_ui',
+    'Goal: Transform research (from a prior research_topic task or current conversation context) into a visual webpage or interactive UI.',
+    '',
+    '1. Check the conversation history for prior research content. If none exists, ask the user what content they\'d like visualised.',
+    '2. Synthesise the research into a polished, interactive HTML page using `app_create`.',
+    '3. Follow all Dynamic UI quality standards (anti-AI-slop rules, design tokens, hover states, etc.).',
+    '4. Update the `## Onboarding Tasks` section in USER.md: set `research_to_ui` to `done`.',
+    '',
+    '### General rules for all starter tasks',
+    '- Update the relevant task status in the `## Onboarding Tasks` section of USER.md as you progress (`in_progress` when starting, `done` when complete).',
+    '- Respect trust gating: do NOT ask for elevated permissions during any starter task flow. These are introductory experiences.',
+    '- Keep responses concise and action-oriented. Avoid lengthy explanations of what you\'re about to do.',
+    '- If the user deviates from the flow, adapt gracefully. Complete the task if possible, or mark it as `deferred_to_dashboard`.',
   ].join('\n');
 }
 

--- a/assistant/src/config/templates/USER.md
+++ b/assistant/src/config/templates/USER.md
@@ -38,7 +38,9 @@ _Tracks progress through onboarding steps. Each task is one of: pending, in_prog
 
 - **set_name:** pending
 - **set_locale:** pending
-- **choose_color:** pending
+- **make_it_yours:** pending
+- **research_topic:** pending
+- **research_to_ui:** pending
 - **first_conversation:** pending
 
 ## Trust Stage


### PR DESCRIPTION
## Context
Part of #2864
Closes #2867

## Changes
- Added starter task playbook section to system prompt with kickoff intent contracts
- Defined conversational flows for make_it_yours (color), research_topic, and research_to_ui
- Updated USER.md task state fields to match starter tasks
- Added tests for playbook content and kickoff patterns

## Validation
- Type-check passes
- All tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
