### PR TITLE
feat: mark workspace context dirty on successful file_write/file_edit

### DIFF
--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -1,17 +1,16 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { Message, ProviderResponse, ContentBlock } from '../providers/types.js';
+import type { Message, ProviderResponse } from '../providers/types.js';
 import type { AgentEvent } from '../agent/loop.js';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 
 // ---------------------------------------------------------------------------
-// Track what the agent loop sees
+// Configurable agent loop behavior
 // ---------------------------------------------------------------------------
 
-let runCalls: Message[][] = [];
-let agentEventHandlers: Array<(event: AgentEvent) => void> = [];
+let agentLoopScript: (onEvent: (event: AgentEvent) => void) => void = () => {};
 
 // ---------------------------------------------------------------------------
-// Mocks — follows session-profile-injection.test.ts pattern
+// Mocks
 // ---------------------------------------------------------------------------
 
 mock.module('../util/logger.js', () => ({
@@ -34,13 +33,9 @@ mock.module('../config/loader.js', () => ({
     maxTokens: 4096,
     thinking: false,
     contextWindow: {
-      enabled: true,
-      maxInputTokens: 100000,
-      targetInputTokens: 80000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryMaxTokens: 512,
-      chunkTokens: 12000,
+      enabled: true, maxInputTokens: 100000, targetInputTokens: 80000,
+      compactThreshold: 0.8, preserveRecentUserTurns: 8,
+      summaryMaxTokens: 512, chunkTokens: 12000,
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     apiKeys: {},
@@ -51,159 +46,72 @@ mock.module('../config/loader.js', () => ({
   invalidateConfigCache: () => {},
 }));
 
-mock.module('../config/system-prompt.js', () => ({
-  buildSystemPrompt: () => 'system prompt',
-}));
-
-mock.module('../config/skills.js', () => ({
-  loadSkillCatalog: () => [],
-  loadSkillBySelector: () => ({ skill: null }),
-  ensureSkillIcon: async () => null,
-}));
-
-mock.module('../config/skill-state.js', () => ({
-  resolveSkillStates: () => [],
-}));
-
+mock.module('../config/system-prompt.js', () => ({ buildSystemPrompt: () => 'system prompt' }));
+mock.module('../config/skills.js', () => ({ loadSkillCatalog: () => [], loadSkillBySelector: () => ({ skill: null }), ensureSkillIcon: async () => null }));
+mock.module('../config/skill-state.js', () => ({ resolveSkillStates: () => [] }));
 mock.module('../skills/slash-commands.js', () => ({
   buildInvocableSlashCatalog: () => new Map(),
   resolveSlashSkillCommand: () => ({ kind: 'not_slash' }),
   rewriteKnownSlashCommandPrompt: () => '',
   parseSlashCandidate: () => ({ kind: 'not_slash' }),
 }));
-
-mock.module('../permissions/trust-store.js', () => ({
-  addRule: () => {},
-  findHighestPriorityRule: () => null,
-  clearCache: () => {},
-}));
-
-mock.module('../security/secret-allowlist.js', () => ({
-  resetAllowlist: () => {},
-}));
+mock.module('../permissions/trust-store.js', () => ({ addRule: () => {}, findHighestPriorityRule: () => null, clearCache: () => {} }));
+mock.module('../security/secret-allowlist.js', () => ({ resetAllowlist: () => {} }));
 
 mock.module('../memory/conversation-store.js', () => ({
   getMessages: () => [],
   getConversation: () => ({
-    id: 'conv-1',
-    contextSummary: null,
-    contextCompactedMessageCount: 0,
-    contextCompactedAt: null,
-    totalInputTokens: 0,
-    totalOutputTokens: 0,
-    totalEstimatedCost: 0,
+    id: 'conv-1', contextSummary: null, contextCompactedMessageCount: 0,
+    contextCompactedAt: null, totalInputTokens: 0, totalOutputTokens: 0, totalEstimatedCost: 0,
   }),
   addMessage: () => ({ id: 'msg-1' }),
-  updateConversationUsage: () => {},
-  updateConversationTitle: () => {},
+  updateConversationUsage: () => {}, updateConversationTitle: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => ({ segmentIds: [], orphanedItemIds: [] }),
-  deleteLastExchange: () => 0,
-  isLastUserMessageToolResult: () => false,
+  deleteLastExchange: () => 0, isLastUserMessageToolResult: () => false,
 }));
 
-mock.module('../memory/attachments-store.js', () => ({
-  uploadAttachment: () => ({ id: 'att-1' }),
-  linkAttachmentToMessage: () => {},
-}));
-
+mock.module('../memory/attachments-store.js', () => ({ uploadAttachment: () => ({ id: 'att-1' }), linkAttachmentToMessage: () => {} }));
 mock.module('../memory/retriever.js', () => ({
   buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    reason: null,
-    provider: 'mock',
-    model: 'mock',
-    injectedText: '',
-    lexicalHits: 0,
-    semanticHits: 0,
-    recencyHits: 0,
-    entityHits: 0,
-    relationSeedEntityCount: 0,
-    relationTraversedEdgeCount: 0,
-    relationNeighborEntityCount: 0,
-    relationExpandedItemCount: 0,
-    mergedCount: 0,
-    selectedCount: 0,
-    rerankApplied: false,
-    injectedTokens: 0,
-    latencyMs: 0,
-    topCandidates: [],
+    enabled: false, degraded: false, reason: null, provider: 'mock', model: 'mock',
+    injectedText: '', lexicalHits: 0, semanticHits: 0, recencyHits: 0, entityHits: 0,
+    relationSeedEntityCount: 0, relationTraversedEdgeCount: 0, relationNeighborEntityCount: 0,
+    relationExpandedItemCount: 0, mergedCount: 0, selectedCount: 0, rerankApplied: false,
+    injectedTokens: 0, latencyMs: 0, topCandidates: [],
   }),
   injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
   injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
   stripMemoryRecallMessages: (msgs: Message[]) => msgs,
 }));
-
-mock.module('../memory/query-builder.js', () => ({
-  buildMemoryQuery: () => '',
-}));
-
-mock.module('../memory/retrieval-budget.js', () => ({
-  computeRecallBudget: () => 0,
-}));
-
+mock.module('../memory/query-builder.js', () => ({ buildMemoryQuery: () => '' }));
+mock.module('../memory/retrieval-budget.js', () => ({ computeRecallBudget: () => 0 }));
 mock.module('../context/window-manager.js', () => ({
-  ContextWindowManager: class {
-    constructor() {}
-    async maybeCompact() { return { compacted: false }; }
-  },
+  ContextWindowManager: class { async maybeCompact() { return { compacted: false }; } },
   createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
   getSummaryFromContextMessage: () => null,
 }));
-
-mock.module('../memory/conflict-store.js', () => ({
-  listPendingConflictDetails: () => [],
-  markConflictAsked: () => true,
-  applyConflictResolution: () => true,
-}));
-
+mock.module('../memory/conflict-store.js', () => ({ listPendingConflictDetails: () => [], markConflictAsked: () => true, applyConflictResolution: () => true }));
 mock.module('../memory/clarification-resolver.js', () => ({
-  resolveConflictClarification: async () => ({
-    resolution: 'still_unclear',
-    strategy: 'heuristic',
-    resolvedStatement: null,
-    explanation: 'Need user clarification.',
-  }),
+  resolveConflictClarification: async () => ({ resolution: 'still_unclear', strategy: 'heuristic', resolvedStatement: null, explanation: '' }),
 }));
-
 mock.module('../memory/admin.js', () => ({
   getMemoryConflictAndCleanupStats: () => ({
     conflicts: { pending: 0, resolved: 0, oldestPendingAgeMs: null },
     cleanup: { resolvedBacklog: 0, supersededBacklog: 0, resolvedCompleted24h: 0, supersededCompleted24h: 0 },
   }),
 }));
+mock.module('../memory/profile-compiler.js', () => ({ compileDynamicProfile: () => null }));
+mock.module('../memory/llm-usage-store.js', () => ({ recordUsageEvent: () => ({ id: 'usage-1', createdAt: Date.now() }) }));
+mock.module('../memory/app-store.js', () => ({ getApp: () => null, updateApp: () => {} }));
 
-mock.module('../memory/profile-compiler.js', () => ({
-  compileDynamicProfile: () => null,
-}));
-
-mock.module('../memory/llm-usage-store.js', () => ({
-  recordUsageEvent: () => ({ id: 'usage-1', createdAt: Date.now() }),
-}));
-
-mock.module('../memory/app-store.js', () => ({
-  getApp: () => null,
-  updateApp: () => {},
-}));
-
-// Mock agent loop: capture the onEvent handler so tests can inject tool_use/tool_result
 mock.module('../agent/loop.js', () => ({
   AgentLoop: class {
     constructor() {}
     async run(messages: Message[], onEvent: (event: AgentEvent) => void): Promise<Message[]> {
-      runCalls.push(messages);
-      agentEventHandlers.push(onEvent);
-
-      // Simulate a tool_use → tool_result → message_complete cycle
-      onEvent({ type: 'tool_use', id: 'tu_1', name: 'file_write', input: { path: '/tmp/test.txt', content: 'hello' } });
-      onEvent({ type: 'tool_result', toolUseId: 'tu_1', content: 'File written', isError: false });
+      agentLoopScript(onEvent);
       onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 10 });
-
-      const assistantMessage: Message = {
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Done writing file.' }],
-      };
+      const assistantMessage: Message = { role: 'assistant', content: [{ type: 'text', text: 'ok' }] };
       onEvent({ type: 'message_complete', message: assistantMessage });
       return [...messages, assistantMessage];
     }
@@ -211,10 +119,6 @@ mock.module('../agent/loop.js', () => ({
 }));
 
 import { Session } from '../daemon/session.js';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function makeSession(): Session {
   const provider = {
@@ -230,27 +134,73 @@ function makeSession(): Session {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Session tool-use ID tracking', () => {
+describe('Session workspace dirty on file mutations', () => {
   beforeEach(() => {
-    runCalls = [];
-    agentEventHandlers = [];
+    agentLoopScript = () => {};
   });
 
-  test('tool_use events populate the tool_use_id → toolName map', async () => {
+  test('successful file_write marks workspace dirty', async () => {
     const session = makeSession();
     await session.loadFromDb();
 
-    const events: ServerMessage[] = [];
-    await session.processMessage('Write a file', [], (event) => events.push(event));
+    // Prime the cache so dirty=false
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
 
-    // The mock agent loop emits tool_use with name 'file_write' and id 'tu_1'
-    // Verify that tool_use_start events were emitted (shows tracking worked)
-    const toolUseStarts = events.filter(e => e.type === 'tool_use_start');
-    expect(toolUseStarts).toHaveLength(1);
-    expect((toolUseStarts[0] as { toolName: string }).toolName).toBe('file_write');
+    agentLoopScript = (onEvent) => {
+      onEvent({ type: 'tool_use', id: 'tu_1', name: 'file_write', input: { path: '/tmp/a.txt', content: 'hi' } });
+      onEvent({ type: 'tool_result', toolUseId: 'tu_1', content: 'Written', isError: false });
+    };
 
-    // Verify tool_result events were also emitted
-    const toolResults = events.filter(e => e.type === 'tool_result');
-    expect(toolResults).toHaveLength(1);
+    await session.processMessage('Write a file', [], () => {});
+    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+  });
+
+  test('successful file_edit marks workspace dirty', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+
+    agentLoopScript = (onEvent) => {
+      onEvent({ type: 'tool_use', id: 'tu_2', name: 'file_edit', input: { path: '/tmp/a.txt', old_str: 'a', new_str: 'b' } });
+      onEvent({ type: 'tool_result', toolUseId: 'tu_2', content: 'Edited', isError: false });
+    };
+
+    await session.processMessage('Edit a file', [], () => {});
+    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+  });
+
+  test('failed file_write does NOT mark workspace dirty', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+
+    agentLoopScript = (onEvent) => {
+      onEvent({ type: 'tool_use', id: 'tu_3', name: 'file_write', input: { path: '/tmp/a.txt', content: 'hi' } });
+      onEvent({ type: 'tool_result', toolUseId: 'tu_3', content: 'Permission denied', isError: true });
+    };
+
+    await session.processMessage('Write a file', [], () => {});
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+  });
+
+  test('non-mutation tools do NOT mark workspace dirty', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+
+    agentLoopScript = (onEvent) => {
+      onEvent({ type: 'tool_use', id: 'tu_4', name: 'file_read', input: { path: '/tmp/a.txt' } });
+      onEvent({ type: 'tool_result', toolUseId: 'tu_4', content: 'file contents', isError: false });
+    };
+
+    await session.processMessage('Read a file', [], () => {});
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
   });
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -939,6 +939,13 @@ export class Session {
             const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
             onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId, imageData: imageBlock?.source.data });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
+            // Mark workspace context dirty on successful file mutation tools
+            if (!event.isError) {
+              const toolName = toolUseIdToName.get(event.toolUseId);
+              if (toolName === 'file_write' || toolName === 'file_edit') {
+                this.markWorkspaceTopLevelDirty();
+              }
+            }
             // Collect image/file content blocks for assistant attachment conversion
             if (event.contentBlocks) {
               for (const cb of event.contentBlocks) {


### PR DESCRIPTION
## Summary
- Extends tool_result handling to mark workspace context dirty on successful file_write/file_edit
- Failed mutations do not trigger dirty marking
- Non-mutation tools (file_read, etc.) do not trigger dirty marking

## Test plan
- [x] `bun test src/__tests__/session-workspace-tool-tracking.test.ts` — 4 tests pass

Part 8/14 of workspace-files rollout plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
