### PR TITLE
feat: mark workspace context dirty on successful bash

### DIFF
--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -188,6 +188,38 @@ describe('Session workspace dirty on file mutations', () => {
     expect(session.isWorkspaceTopLevelDirty()).toBe(false);
   });
 
+  test('successful bash marks workspace dirty', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+
+    agentLoopScript = (onEvent) => {
+      onEvent({ type: 'tool_use', id: 'tu_5', name: 'bash', input: { command: 'mkdir /tmp/new-dir' } });
+      onEvent({ type: 'tool_result', toolUseId: 'tu_5', content: '', isError: false });
+    };
+
+    await session.processMessage('Run a command', [], () => {});
+    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+  });
+
+  test('failed bash does NOT mark workspace dirty', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    session.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+
+    agentLoopScript = (onEvent) => {
+      onEvent({ type: 'tool_use', id: 'tu_6', name: 'bash', input: { command: 'false' } });
+      onEvent({ type: 'tool_result', toolUseId: 'tu_6', content: 'exit code 1', isError: true });
+    };
+
+    await session.processMessage('Run a command', [], () => {});
+    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+  });
+
   test('non-mutation tools do NOT mark workspace dirty', async () => {
     const session = makeSession();
     await session.loadFromDb();

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -939,10 +939,10 @@ export class Session {
             const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
             onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId, imageData: imageBlock?.source.data });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
-            // Mark workspace context dirty on successful file mutation tools
+            // Mark workspace context dirty on successful mutation tools
             if (!event.isError) {
               const toolName = toolUseIdToName.get(event.toolUseId);
-              if (toolName === 'file_write' || toolName === 'file_edit') {
+              if (toolName === 'file_write' || toolName === 'file_edit' || toolName === 'bash') {
                 this.markWorkspaceTopLevelDirty();
               }
             }


### PR DESCRIPTION
## Summary
- Extends dirty trigger to include successful bash tool results
- Failed bash commands do not trigger refresh

## Test plan
- [x] `bun test src/__tests__/session-workspace-tool-tracking.test.ts` — 6 tests pass

Part 9/14 of workspace-files rollout plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
