### PR TITLE
macOS: make dashboard default and move chat to docked/pop-out panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWindow.swift
@@ -1,0 +1,106 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// A separate window that hosts the chat panel in pop-out mode.
+/// Shares the same ThreadManager and MainWindowState as the main window
+/// so message/session state is preserved when switching between docked
+/// and popped-out chat.
+@MainActor
+final class ChatWindow {
+    private var window: NSWindow?
+    private let threadManager: ThreadManager
+    private let windowState: MainWindowState
+    private let ambientAgent: AmbientAgent
+    private let onMicrophoneToggle: () -> Void
+    /// Called when the user closes the pop-out window so the main window
+    /// can revert to docked chat mode.
+    private let onClose: () -> Void
+
+    init(
+        threadManager: ThreadManager,
+        windowState: MainWindowState,
+        ambientAgent: AmbientAgent,
+        onMicrophoneToggle: @escaping () -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.threadManager = threadManager
+        self.windowState = windowState
+        self.ambientAgent = ambientAgent
+        self.onMicrophoneToggle = onMicrophoneToggle
+        self.onClose = onClose
+    }
+
+    var isVisible: Bool {
+        window?.isVisible ?? false
+    }
+
+    func show() {
+        if let existing = window {
+            if existing.isMiniaturized {
+                existing.deminiaturize(nil)
+            }
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let chatPanel = ChatPanelView(
+            threadManager: threadManager,
+            windowState: windowState,
+            ambientAgent: ambientAgent,
+            onMicrophoneToggle: onMicrophoneToggle
+        )
+
+        let hostingController = NSHostingController(rootView: chatPanel)
+
+        let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let windowWidth: CGFloat = min(480, screenFrame.width * 0.35)
+        let windowHeight: CGFloat = min(screenFrame.height * 0.7, 700)
+        let windowRect = NSRect(
+            x: screenFrame.maxX - windowWidth - 32,
+            y: screenFrame.midY - windowHeight / 2,
+            width: windowWidth,
+            height: windowHeight
+        )
+
+        let window = NSWindow(
+            contentRect: windowRect,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.title = "Chat"
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.backgroundColor = NSColor(VColor.chatBackground)
+        window.isReleasedWhenClosed = false
+        window.contentMinSize = NSSize(width: 320, height: 400)
+        window.setFrame(windowRect, display: false)
+        window.setFrameAutosaveName("ChatPopOutWindow")
+
+        // Observe the window closing to revert to docked mode
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onClose()
+                self?.window = nil
+            }
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/ChatPanelView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ChatPanelView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import VellumAssistantShared
+import UniformTypeIdentifiers
+
+/// Reusable chat panel that wraps the existing ChatView for use in both
+/// docked (inside the main window) and pop-out (separate ChatWindow) modes.
+/// It binds to a ThreadManager and MainWindowState so that message/session
+/// state is shared regardless of where the panel is displayed.
+struct ChatPanelView: View {
+    @ObservedObject var threadManager: ThreadManager
+    @ObservedObject var windowState: MainWindowState
+    let ambientAgent: AmbientAgent
+    let onMicrophoneToggle: () -> Void
+
+    var body: some View {
+        Group {
+            if let viewModel = threadManager.activeViewModel {
+                ChatView(
+                    messages: viewModel.messages,
+                    inputText: Binding(
+                        get: { viewModel.inputText },
+                        set: { viewModel.inputText = $0 }
+                    ),
+                    hasAPIKey: windowState.hasAPIKey,
+                    isThinking: viewModel.isThinking,
+                    isSending: viewModel.isSending,
+                    errorText: viewModel.errorText,
+                    pendingQueuedCount: viewModel.pendingQueuedCount,
+                    suggestion: viewModel.suggestion,
+                    pendingAttachments: viewModel.pendingAttachments,
+                    isRecording: viewModel.isRecording,
+                    onOpenSettings: {
+                        windowState.activePanel = .settings
+                    },
+                    onSend: viewModel.sendMessage,
+                    onStop: viewModel.stopGenerating,
+                    onDismissError: viewModel.dismissError,
+                    onAcceptSuggestion: viewModel.acceptSuggestion,
+                    onAttach: { Self.openFilePicker(viewModel: viewModel) },
+                    onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
+                    onDropFiles: { urls in urls.forEach { viewModel.addAttachment(url: $0) } },
+                    onDropImageData: { data, name in
+                        let filename: String
+                        if let name {
+                            let basename = (name as NSString).lastPathComponent
+                            let base = (basename as NSString).deletingPathExtension
+                            filename = base.isEmpty ? "Dropped Image.png" : "\(base).png"
+                        } else {
+                            filename = "Dropped Image.png"
+                        }
+                        viewModel.addAttachment(imageData: data, filename: filename)
+                    },
+                    onPaste: { viewModel.addAttachmentFromPasteboard() },
+                    onMicrophoneToggle: onMicrophoneToggle,
+                    onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
+                    onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
+                    onAddTrustRule: { toolName, pattern, scope, decision in return viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },
+                    onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
+                    onRegenerate: { viewModel.regenerateLastMessage() },
+                    sessionError: viewModel.sessionError,
+                    onRetry: { viewModel.retryAfterSessionError() },
+                    onDismissSessionError: { viewModel.dismissSessionError() },
+                    onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
+                    watchSession: ambientAgent.activeWatchSession,
+                    onStopWatch: { viewModel.stopWatchSession() },
+                    onOpenActivity: { toolCalls in
+                        windowState.toggleActivityPanel(with: toolCalls)
+                    },
+                    isActivityPanelOpen: windowState.activePanel == .activity
+                )
+            } else {
+                VStack {
+                    Spacer()
+                    Text("No active conversation")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(VColor.chatBackground)
+            }
+        }
+    }
+
+    @MainActor
+    private static func openFilePicker(viewModel: ChatViewModel) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = [
+            .png, .jpeg, .gif, .webP, .pdf, .plainText, .commaSeparatedText,
+            UTType("net.daringfireball.markdown") ?? .plainText,
+        ]
+        guard panel.runModal() == .OK else { return }
+        for url in panel.urls {
+            viewModel.addAttachment(url: url)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -12,6 +12,9 @@ final class MainWindow {
     let windowState = MainWindowState()
     var onMicrophoneToggle: (() -> Void)?
 
+    /// The pop-out chat window, created on demand when the user pops out chat.
+    private var chatWindow: ChatWindow?
+
     // Forwarding accessors — keeps existing references working while
     // ownership lives in the `services` container.
     private var daemonClient: DaemonClient { services.daemonClient }
@@ -83,7 +86,7 @@ final class MainWindow {
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, onMicrophoneToggle: onMicrophoneToggle ?? {}, onPopOutChat: { [weak self] in self?.popOutChat() }, onDockChat: { [weak self] in self?.dockChat() }))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let windowWidth = min(screenFrame.width * 0.8, 1200)
@@ -148,6 +151,9 @@ final class MainWindow {
     }
 
     func close() {
+        chatWindow?.close()
+        chatWindow = nil
+        windowState.isChatPoppedOut = false
         if let observer = layoutObserver {
             NotificationCenter.default.removeObserver(observer)
             layoutObserver = nil
@@ -155,5 +161,39 @@ final class MainWindow {
         defaultTrafficLightOrigin = nil
         window?.close()
         window = nil
+    }
+
+    // MARK: - Pop-out / Dock Chat
+
+    /// Open the chat in a separate window, switching the main window to
+    /// dashboard mode.
+    private func popOutChat() {
+        guard chatWindow == nil else {
+            chatWindow?.show()
+            return
+        }
+
+        let chatWin = ChatWindow(
+            threadManager: threadManager,
+            windowState: windowState,
+            ambientAgent: ambientAgent,
+            onMicrophoneToggle: onMicrophoneToggle ?? {},
+            onClose: { [weak self] in
+                self?.windowState.isChatPoppedOut = false
+                self?.chatWindow = nil
+            }
+        )
+        chatWin.show()
+        chatWindow = chatWin
+        windowState.isChatPoppedOut = true
+        windowState.contentMode = .dashboard
+    }
+
+    /// Close the pop-out chat window and dock it back into the main window.
+    private func dockChat() {
+        chatWindow?.close()
+        chatWindow = nil
+        windowState.isChatPoppedOut = false
+        windowState.contentMode = .chat
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -1,10 +1,17 @@
 import SwiftUI
 import VellumAssistantShared
 
+/// Which top-level content the main window displays.
+enum ContentMode: String, CaseIterable {
+    case dashboard
+    case chat
+}
+
 /// Cross-view UI state for the main window, extracted from `MainWindowView`
 /// to make it explicit, injectable, and easier to preview.
 @MainActor
 final class MainWindowState: ObservableObject {
+    @Published var contentMode: ContentMode = .dashboard
     @Published var activePanel: SidePanelType?
     @Published var isDynamicExpanded = false
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
@@ -12,6 +19,8 @@ final class MainWindowState: ObservableObject {
     @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
     @Published var activityToolCalls: [ToolCallData] = []
+    /// Whether the chat is popped out into its own window.
+    @Published var isChatPoppedOut = false
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -30,8 +30,10 @@ struct MainWindowView: View {
     let ambientAgent: AmbientAgent
     let settingsStore: SettingsStore
     let onMicrophoneToggle: () -> Void
+    let onPopOutChat: () -> Void
+    let onDockChat: () -> Void
 
-    init(threadManager: ThreadManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, onMicrophoneToggle: @escaping () -> Void = {}) {
+    init(threadManager: ThreadManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, onMicrophoneToggle: @escaping () -> Void = {}, onPopOutChat: @escaping () -> Void = {}, onDockChat: @escaping () -> Void = {}) {
         self.threadManager = threadManager
         self.zoomManager = zoomManager
         self.traceStore = traceStore
@@ -41,6 +43,8 @@ struct MainWindowView: View {
         self.settingsStore = settingsStore
         self.windowState = windowState
         self.onMicrophoneToggle = onMicrophoneToggle
+        self.onPopOutChat = onPopOutChat
+        self.onDockChat = onDockChat
         let savedSidebarOpen = UserDefaults.standard.bool(forKey: "sidebarOpen")
         _columnVisibility = State(initialValue: savedSidebarOpen ? .all : .detailOnly)
     }
@@ -107,12 +111,33 @@ struct MainWindowView: View {
                     VStack(spacing: 0) {
                         // Button bar (matches ThreadTabBar height and style)
                         VStack(spacing: 0) {
-                            HStack(spacing: 0) {
-                                // Thread drawer toggle
-                                VIconButton(label: "Threads", icon: "sidebar.left", isActive: columnVisibility != .detailOnly, iconOnly: true) {
-                                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                                        columnVisibility = (columnVisibility == .detailOnly) ? .all : .detailOnly
-                                        sidebarOpen = (columnVisibility != .detailOnly)
+                            HStack(spacing: VSpacing.sm) {
+                                // Thread drawer toggle (only in chat mode)
+                                if windowState.contentMode == .chat {
+                                    VIconButton(label: "Threads", icon: "sidebar.left", isActive: columnVisibility != .detailOnly, iconOnly: true) {
+                                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                                            columnVisibility = (columnVisibility == .detailOnly) ? .all : .detailOnly
+                                            sidebarOpen = (columnVisibility != .detailOnly)
+                                        }
+                                    }
+                                }
+
+                                // Content mode toggle (dashboard / chat)
+                                ContentModeToggle(contentMode: $windowState.contentMode)
+
+                                // Pop-out / dock button for chat mode
+                                if windowState.contentMode == .chat {
+                                    VIconButton(
+                                        label: windowState.isChatPoppedOut ? "Dock Chat" : "Pop Out Chat",
+                                        icon: windowState.isChatPoppedOut ? "rectangle.center.inset.filled" : "rectangle.portrait.on.rectangle.portrait",
+                                        isActive: windowState.isChatPoppedOut,
+                                        iconOnly: true
+                                    ) {
+                                        if windowState.isChatPoppedOut {
+                                            onDockChat()
+                                        } else {
+                                            onPopOutChat()
+                                        }
                                     }
                                 }
 
@@ -124,22 +149,28 @@ struct MainWindowView: View {
                             .background(VColor.background)
                         }
 
-                        // Content area with left drawer + chat + right panel
-                        HStack(spacing: 0) {
-                            // Left: Thread drawer (conditional)
-                            if columnVisibility != .detailOnly {
-                                threadDrawerView
-                                    .animation(nil, value: threadDrawerWidth)  // Disable animation on width changes
-                                    .transition(.move(edge: .leading))
+                        // Content area
+                        if windowState.contentMode == .dashboard {
+                            // Dashboard mode: placeholder (populated in M7)
+                            DashboardPlaceholderView()
+                        } else {
+                            // Chat mode: left drawer + chat + right panel
+                            HStack(spacing: 0) {
+                                // Left: Thread drawer (conditional)
+                                if columnVisibility != .detailOnly {
+                                    threadDrawerView
+                                        .animation(nil, value: threadDrawerWidth)  // Disable animation on width changes
+                                        .transition(.move(edge: .leading))
 
-                                drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
+                                    drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
+                                }
+
+                                // Center: Chat + right panel
+                                chatContentView(geometry: geometry)
                             }
-
-                            // Center: Chat + right panel
-                            chatContentView(geometry: geometry)
+                            .coordinateSpace(name: drawerDragCoordinateSpaceName)
+                            .animation(isDrawerDragging ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: columnVisibility)
                         }
-                        .coordinateSpace(name: drawerDragCoordinateSpaceName)
-                        .animation(isDrawerDragging ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: columnVisibility)
                     }
                 } else {
                     // Tab mode: Traditional layout
@@ -1090,6 +1121,74 @@ private struct ArchivePopup: View {
             isHovered = hovering
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
         }
+    }
+}
+
+// MARK: - Dashboard Placeholder
+
+/// Placeholder view for the dashboard tab. Will be populated with cards in M7.
+struct DashboardPlaceholderView: View {
+    var body: some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+
+            Image(systemName: "square.grid.2x2")
+                .font(.system(size: 48, weight: .light))
+                .foregroundColor(VColor.textMuted)
+
+            Text("Dashboard")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Your dashboard will appear here")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.background)
+    }
+}
+
+// MARK: - Content Mode Toggle
+
+/// A segmented toggle for switching between Dashboard and Chat modes.
+struct ContentModeToggle: View {
+    @Binding var contentMode: ContentMode
+
+    var body: some View {
+        HStack(spacing: 0) {
+            modeButton(.dashboard, icon: "square.grid.2x2", label: "Dashboard")
+            modeButton(.chat, icon: "bubble.left.and.bubble.right", label: "Chat")
+        }
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private func modeButton(_ mode: ContentMode, icon: String, label: String) -> some View {
+        Button {
+            withAnimation(VAnimation.fast) {
+                contentMode = mode
+            }
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .foregroundColor(contentMode == mode ? VColor.textPrimary : VColor.textMuted)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs + 1)
+            .background(contentMode == mode ? VColor.backgroundSubtle : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -3,10 +3,33 @@ import SwiftUI
 
 struct NavigationToolbar: View {
     @Binding var activePanel: SidePanelType?
+    @Binding var contentMode: ContentMode
+    var isChatPoppedOut: Bool = false
+    var onPopOutChat: (() -> Void)?
+    var onDockChat: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: VSpacing.sm) {
+                // Left group -- content mode toggle
+                ContentModeToggle(contentMode: $contentMode)
+
+                // Pop-out / dock button for chat mode
+                if contentMode == .chat {
+                    VIconButton(
+                        label: isChatPoppedOut ? "Dock Chat" : "Pop Out Chat",
+                        icon: isChatPoppedOut ? "rectangle.center.inset.filled" : "rectangle.portrait.on.rectangle.portrait",
+                        isActive: isChatPoppedOut,
+                        iconOnly: true
+                    ) {
+                        if isChatPoppedOut {
+                            onDockChat?()
+                        } else {
+                            onPopOutChat?()
+                        }
+                    }
+                }
+
                 Spacer()
 
                 // Right group — labeled buttons
@@ -54,9 +77,10 @@ struct NavigationToolbar_Preview: PreviewProvider {
 
 private struct NavigationToolbarPreviewWrapper: View {
     @State private var panel: SidePanelType? = .settings
+    @State private var mode: ContentMode = .dashboard
 
     var body: some View {
-        NavigationToolbar(activePanel: $panel)
+        NavigationToolbar(activePanel: $panel, contentMode: $mode)
     }
 }
 #endif


### PR DESCRIPTION
## Context
Part of #2864
Closes #2870

## Changes
- Added `ContentMode` enum (`.dashboard`, `.chat`) to `MainWindowState` for top-level content switching
- Main window defaults to dashboard view with a placeholder (to be populated with cards in M7)
- Created `ChatPanelView` as a reusable chat container that wraps `ChatView` with all necessary bindings
- Created `ChatWindow` for pop-out chat mode in a separate macOS window
- Added `ContentModeToggle` segmented control to the main window button bar
- Added pop-out/dock toggle button when in chat mode
- Thread/session state is shared between docked and pop-out modes via the same `ThreadManager` and `MainWindowState` instances
- Updated `MainWindow` to manage the chat pop-out window lifecycle
- Updated `NavigationToolbar` with content mode and pop-out support (for tab mode)

## Validation
- `swift build` passes with no errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
