### PR TITLE
fix: remove unused variables flagged by eslint

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -6,7 +6,7 @@ import type { Message, ToolDefinition } from '../providers/types.js';
 // ---------------------------------------------------------------------------
 
 let lastStreamParams: Record<string, unknown> | null = null;
-let lastStreamOptions: Record<string, unknown> | null = null;
+let _lastStreamOptions: Record<string, unknown> | null = null;
 
 const fakeResponse = {
   content: [{ type: 'text', text: 'Hello' }],
@@ -36,7 +36,7 @@ mock.module('@anthropic-ai/sdk', () => ({
     messages = {
       stream: (params: Record<string, unknown>, options?: Record<string, unknown>) => {
         lastStreamParams = JSON.parse(JSON.stringify(params));
-        lastStreamOptions = options ?? null;
+        _lastStreamOptions = options ?? null;
         const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
         return {
           on(event: string, cb: (...args: unknown[]) => void) {
@@ -98,7 +98,7 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
 
   beforeEach(() => {
     lastStreamParams = null;
-    lastStreamOptions = null;
+    _lastStreamOptions = null;
     provider = new AnthropicProvider('sk-ant-test', 'claude-sonnet-4-5-20250929');
   });
 

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { Message, ProviderResponse } from '../providers/types.js';
 import type { AgentEvent } from '../agent/loop.js';
-import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
 
 // ---------------------------------------------------------------------------
 // Configurable agent loop behavior

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -68,7 +68,7 @@ import { ConflictGate } from './session-conflict-gate.js';
 import { injectDynamicProfileIntoUserMessage, stripDynamicProfileMessages } from './session-dynamic-profile.js';
 import { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import { applyRuntimeInjections, stripActiveSurfaceContext, stripWorkspaceTopLevelContext } from './session-runtime-assembly.js';
+import { applyRuntimeInjections, stripActiveSurfaceContext } from './session-runtime-assembly.js';
 import { scanTopLevelDirectories } from '../workspace/top-level-scanner.js';
 import { renderWorkspaceTopLevelContext } from '../workspace/top-level-renderer.js';
 import type { ActiveSurfaceContext } from './session-runtime-assembly.js';


### PR DESCRIPTION
## Summary
- Prefix `lastStreamOptions` with `_` in anthropic-provider test (assigned but never read)
- Remove unused `ServerMessage` type import in session-workspace-tool-tracking test
- Remove unused `stripWorkspaceTopLevelContext` import in session.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
