### PR TITLE
feat: strip workspace context from persisted session history

### DIFF
--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -187,4 +187,30 @@ describe('Session workspace injection', () => {
     const firstText = (firstBlock as { type: 'text'; text: string }).text;
     expect(firstText).toContain('<workspace_top_level>');
   });
+
+  test('workspace context is stripped from persisted history', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    await session.processMessage('Hello', [], () => {});
+
+    const persistedMessages = session.getMessages();
+    for (const msg of persistedMessages) {
+      const text = messageText(msg);
+      expect(text).not.toContain('<workspace_top_level>');
+    }
+  });
+
+  test('no empty user messages after stripping workspace context', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    await session.processMessage('Hello', [], () => {});
+
+    const persistedMessages = session.getMessages();
+    const emptyUserMsgs = persistedMessages.filter(
+      (m) => m.role === 'user' && m.content.length === 0,
+    );
+    expect(emptyUserMsgs).toHaveLength(0);
+  });
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -68,7 +68,7 @@ import { ConflictGate } from './session-conflict-gate.js';
 import { injectDynamicProfileIntoUserMessage, stripDynamicProfileMessages } from './session-dynamic-profile.js';
 import { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import { applyRuntimeInjections, stripActiveSurfaceContext } from './session-runtime-assembly.js';
+import { applyRuntimeInjections, stripActiveSurfaceContext, stripWorkspaceTopLevelContext } from './session-runtime-assembly.js';
 import { scanTopLevelDirectories } from '../workspace/top-level-scanner.js';
 import { renderWorkspaceTopLevelContext } from '../workspace/top-level-renderer.js';
 import type { ActiveSurfaceContext } from './session-runtime-assembly.js';
@@ -1165,8 +1165,10 @@ export class Session {
       });
       const restoredHistory = [...preRepairMessages, ...newMessages];
       const recallStripped = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
-      this.messages = stripActiveSurfaceContext(
-        stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+      this.messages = stripWorkspaceTopLevelContext(
+        stripActiveSurfaceContext(
+          stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+        ),
       );
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);


### PR DESCRIPTION
## Summary
- Wire `stripWorkspaceTopLevelContext` into the post-run cleanup chain alongside existing recall/profile/surface stripping
- Workspace context blocks (`<workspace_top_level>`) are never persisted in conversation history
- Add tests verifying stripping works and no empty user messages remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
