### PR TITLE
macOS+shared: add starter/deferred-permission cards and wire CTAs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardTaskCard.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardTaskCard.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A reusable card component for displaying a dashboard task.
+/// Shows an emoji icon, title, subtitle, and a CTA button that triggers
+/// the task's kickoff intent in the chat.
+struct DashboardTaskCard: View {
+    let task: DashboardTask
+    let accentColor: Color?
+    let onTap: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text(task.emoji)
+                    .font(VFont.cardEmoji)
+
+                Spacer(minLength: VSpacing.xs)
+
+                Text(task.title)
+                    .font(VFont.cardTitle)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+
+                Text(task.subtitle)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(2)
+
+                Spacer(minLength: VSpacing.sm)
+
+                HStack {
+                    Spacer()
+                    Text("Start")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.buttonV)
+                        .background(accentColor ?? VColor.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                }
+            }
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isHovered ? VColor.surface.opacity(0.9) : VColor.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(isHovered ? (accentColor ?? VColor.accent).opacity(0.4) : VColor.surfaceBorder, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(VAnimation.fast) {
+                isHovered = hovering
+            }
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardTaskModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardTaskModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Data model for dashboard task cards. Each task has a stable ID matching
+/// the starter-task playbook so the daemon can reference tasks by ID when
+/// sending `dashboard_task_kickoff` messages.
+struct DashboardTask: Identifiable, Equatable {
+    let id: String
+    let emoji: String
+    let title: String
+    let subtitle: String
+    /// The kickoff intent sent to the chat when the CTA is tapped
+    /// (e.g. "[STARTER_TASK:make_it_yours]").
+    let kickoffIntent: String
+    let category: Category
+
+    enum Category: String, CaseIterable {
+        case starter
+        case deferredPermission
+    }
+}
+
+// MARK: - Built-in Tasks
+
+extension DashboardTask {
+    /// Starter tasks that appear on the dashboard by default.
+    static let starterTasks: [DashboardTask] = [
+        DashboardTask(
+            id: "make_it_yours",
+            emoji: "\u{1F3A8}",
+            title: "Make it yours",
+            subtitle: "Pick a color with your agent",
+            kickoffIntent: "[STARTER_TASK:make_it_yours]",
+            category: .starter
+        ),
+        DashboardTask(
+            id: "research_topic",
+            emoji: "\u{1F50D}",
+            title: "Research something for me",
+            subtitle: "Ask your agent to dig into any topic",
+            kickoffIntent: "[STARTER_TASK:research_topic]",
+            category: .starter
+        ),
+        DashboardTask(
+            id: "research_to_ui",
+            emoji: "\u{1F310}",
+            title: "Turn it into a webpage",
+            subtitle: "Transform research into a visual page",
+            kickoffIntent: "[STARTER_TASK:research_to_ui]",
+            category: .starter
+        ),
+    ]
+
+    /// Deferred permission tasks that unlock additional capabilities.
+    static let deferredPermissionTasks: [DashboardTask] = [
+        DashboardTask(
+            id: "enable_voice",
+            emoji: "\u{1F3A4}",
+            title: "Enable voice mode",
+            subtitle: "Talk to your agent hands-free",
+            kickoffIntent: "[STARTER_TASK:enable_voice]",
+            category: .deferredPermission
+        ),
+        DashboardTask(
+            id: "enable_computer_control",
+            emoji: "\u{1F5A5}",
+            title: "Enable computer control",
+            subtitle: "Let your agent interact with your screen",
+            kickoffIntent: "[STARTER_TASK:enable_computer_control]",
+            category: .deferredPermission
+        ),
+    ]
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// The main dashboard view that replaces the placeholder. Displays a greeting,
+/// weather card, starter task cards, and deferred permission cards. Supports
+/// theme color persistence via `@AppStorage`.
+struct DashboardView: View {
+    let onTaskKickoff: (DashboardTask) -> Void
+
+    @StateObject private var weatherService = DashboardWeatherService()
+    @AppStorage("dashboardAccentColorHex") private var accentColorHex: String = ""
+    @AppStorage("dashboardAccentColorName") private var accentColorName: String = ""
+    @State private var showDeferredSection = false
+
+    private var accentColor: Color? {
+        guard !accentColorHex.isEmpty else { return nil }
+        return Color(hex: accentColorHex)
+    }
+
+    private var greetingText: String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        switch hour {
+        case 5..<12: return "Good morning"
+        case 12..<17: return "Good afternoon"
+        case 17..<22: return "Good evening"
+        default: return "Good evening"
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.section) {
+                // Greeting
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text(greetingText)
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    if !accentColorName.isEmpty {
+                        HStack(spacing: VSpacing.sm) {
+                            Circle()
+                                .fill(accentColor ?? VColor.accent)
+                                .frame(width: 10, height: 10)
+                            Text("Theme: \(accentColorName)")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                }
+
+                // Weather card
+                DashboardWeatherCard(weatherService: weatherService)
+
+                // Starter tasks
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("GET STARTED")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textMuted)
+
+                    LazyVGrid(
+                        columns: [
+                            GridItem(.flexible(), spacing: VSpacing.md),
+                            GridItem(.flexible(), spacing: VSpacing.md),
+                            GridItem(.flexible(), spacing: VSpacing.md),
+                        ],
+                        spacing: VSpacing.md
+                    ) {
+                        ForEach(DashboardTask.starterTasks) { task in
+                            DashboardTaskCard(
+                                task: task,
+                                accentColor: accentColor,
+                                onTap: { onTaskKickoff(task) }
+                            )
+                        }
+                    }
+                }
+
+                // Deferred permission tasks
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Button {
+                        withAnimation(VAnimation.standard) {
+                            showDeferredSection.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: VSpacing.sm) {
+                            Text("MORE OPTIONS")
+                                .font(VFont.headline)
+                                .foregroundColor(VColor.textMuted)
+
+                            Image(systemName: showDeferredSection ? "chevron.up" : "chevron.down")
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(VColor.textMuted)
+
+                            Spacer()
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+
+                    if showDeferredSection {
+                        LazyVGrid(
+                            columns: [
+                                GridItem(.flexible(), spacing: VSpacing.md),
+                                GridItem(.flexible(), spacing: VSpacing.md),
+                                GridItem(.flexible(), spacing: VSpacing.md),
+                            ],
+                            spacing: VSpacing.md
+                        ) {
+                            ForEach(DashboardTask.deferredPermissionTasks) { task in
+                                DashboardTaskCard(
+                                    task: task,
+                                    accentColor: accentColor,
+                                    onTap: { onTaskKickoff(task) }
+                                )
+                            }
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                }
+
+                Spacer(minLength: VSpacing.xxxl)
+            }
+            .padding(.horizontal, VSpacing.page)
+            .padding(.top, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.background)
+        .onAppear {
+            weatherService.fetchIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dashboardThemeDidUpdate)) { notification in
+            if let colorHex = notification.userInfo?["colorHex"] as? String {
+                accentColorHex = colorHex
+            }
+            if let colorName = notification.userInfo?["colorName"] as? String {
+                accentColorName = colorName
+            }
+        }
+    }
+}
+
+// MARK: - Color hex initializer
+
+private extension Color {
+    /// Initialize a Color from a CSS hex string (e.g. "#1E90FF" or "1E90FF").
+    init(hex string: String) {
+        let hex = string.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r, g, b: Double
+        switch hex.count {
+        case 6:
+            r = Double((int >> 16) & 0xFF) / 255
+            g = Double((int >> 8) & 0xFF) / 255
+            b = Double(int & 0xFF) / 255
+        default:
+            r = 0; g = 0; b = 0
+        }
+        self.init(.sRGB, red: r, green: g, blue: b, opacity: 1)
+    }
+}
+
+// MARK: - Notification Name
+
+extension Notification.Name {
+    /// Posted when a `dashboard_theme_update` message is received from the daemon.
+    static let dashboardThemeDidUpdate = Notification.Name("dashboardThemeDidUpdate")
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardWeatherCard.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardWeatherCard.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A compact card that displays current weather on the dashboard.
+struct DashboardWeatherCard: View {
+    @ObservedObject var weatherService: DashboardWeatherService
+
+    var body: some View {
+        Group {
+            if let weather = weatherService.weather {
+                HStack(spacing: VSpacing.md) {
+                    Text(weather.conditionEmoji)
+                        .font(.system(size: 28))
+
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        HStack(spacing: VSpacing.sm) {
+                            Text(weather.temperature)
+                                .font(VFont.cardTitle)
+                                .foregroundColor(VColor.textPrimary)
+
+                            Text(weather.condition)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+
+                        Text(weather.location)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+
+                    Spacer()
+                }
+                .padding(VSpacing.lg)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
+            } else if weatherService.isLoading {
+                HStack(spacing: VSpacing.md) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading weather...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                    Spacer()
+                }
+                .padding(VSpacing.lg)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardWeatherService.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardWeatherService.swift
@@ -1,0 +1,105 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "WeatherService")
+
+/// Simple weather data model for the dashboard card.
+struct WeatherData: Equatable {
+    let location: String
+    let temperature: String
+    let condition: String
+    let conditionEmoji: String
+}
+
+/// Fetches weather data for the dashboard. Uses the Open-Meteo API (no API key required)
+/// with a hardcoded fallback location of Palo Alto, CA. The actual locale will come from
+/// USER.md memory in the future.
+@MainActor
+final class DashboardWeatherService: ObservableObject {
+    @Published var weather: WeatherData?
+    @Published var isLoading = false
+
+    private var lastFetchDate: Date?
+    /// Minimum interval between fetches (15 minutes).
+    private let fetchInterval: TimeInterval = 900
+
+    /// Palo Alto, CA coordinates (fallback).
+    private let defaultLatitude = 37.4419
+    private let defaultLongitude = -122.1430
+    private let defaultLocation = "Palo Alto, CA"
+
+    func fetchIfNeeded() {
+        if let lastFetch = lastFetchDate, Date().timeIntervalSince(lastFetch) < fetchInterval {
+            return
+        }
+        fetch()
+    }
+
+    func fetch() {
+        guard !isLoading else { return }
+        isLoading = true
+
+        Task {
+            do {
+                let data = try await fetchWeather()
+                self.weather = data
+                self.lastFetchDate = Date()
+            } catch {
+                log.warning("Weather fetch failed: \(error.localizedDescription)")
+                // Use placeholder data on failure
+                self.weather = WeatherData(
+                    location: defaultLocation,
+                    temperature: "--",
+                    condition: "Unavailable",
+                    conditionEmoji: "\u{2601}\u{FE0F}"
+                )
+            }
+            self.isLoading = false
+        }
+    }
+
+    private func fetchWeather() async throws -> WeatherData {
+        let urlString = "https://api.open-meteo.com/v1/forecast?latitude=\(defaultLatitude)&longitude=\(defaultLongitude)&current=temperature_2m,weather_code&temperature_unit=fahrenheit&timezone=auto"
+        guard let url = URL(string: urlString) else {
+            throw URLError(.badURL)
+        }
+
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        guard let current = json?["current"] as? [String: Any],
+              let temp = current["temperature_2m"] as? Double,
+              let weatherCode = current["weather_code"] as? Int else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        let (condition, emoji) = Self.decodeWeatherCode(weatherCode)
+        return WeatherData(
+            location: defaultLocation,
+            temperature: "\(Int(temp.rounded()))\u{00B0}F",
+            condition: condition,
+            conditionEmoji: emoji
+        )
+    }
+
+    /// Decode WMO weather code to human-readable condition and emoji.
+    private static func decodeWeatherCode(_ code: Int) -> (String, String) {
+        switch code {
+        case 0: return ("Clear sky", "\u{2600}\u{FE0F}")
+        case 1: return ("Mainly clear", "\u{1F324}\u{FE0F}")
+        case 2: return ("Partly cloudy", "\u{26C5}")
+        case 3: return ("Overcast", "\u{2601}\u{FE0F}")
+        case 45, 48: return ("Foggy", "\u{1F32B}\u{FE0F}")
+        case 51, 53, 55: return ("Drizzle", "\u{1F326}\u{FE0F}")
+        case 61, 63, 65: return ("Rain", "\u{1F327}\u{FE0F}")
+        case 66, 67: return ("Freezing rain", "\u{1F327}\u{FE0F}")
+        case 71, 73, 75: return ("Snow", "\u{1F328}\u{FE0F}")
+        case 77: return ("Snow grains", "\u{1F328}\u{FE0F}")
+        case 80, 81, 82: return ("Showers", "\u{1F326}\u{FE0F}")
+        case 85, 86: return ("Snow showers", "\u{1F328}\u{FE0F}")
+        case 95: return ("Thunderstorm", "\u{26C8}\u{FE0F}")
+        case 96, 99: return ("Thunderstorm with hail", "\u{26C8}\u{FE0F}")
+        default: return ("Unknown", "\u{1F324}\u{FE0F}")
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -50,6 +50,16 @@ final class MainWindow {
                 self?.traceStore.ingest(msg)
             }
         }
+        services.daemonClient.onDashboardThemeUpdate = { [weak self] msg in
+            Task { @MainActor in
+                self?.handleDashboardThemeUpdate(msg)
+            }
+        }
+        services.daemonClient.onDashboardTaskKickoff = { [weak self] msg in
+            Task { @MainActor in
+                self?.handleDashboardTaskKickoff(msg)
+            }
+        }
         observeDaemonReconnects()
     }
 
@@ -195,5 +205,32 @@ final class MainWindow {
         chatWindow = nil
         windowState.isChatPoppedOut = false
         windowState.contentMode = .chat
+    }
+
+    // MARK: - Dashboard Message Handlers
+
+    /// Apply a theme/color update from the daemon to the dashboard.
+    /// Persists the color in `@AppStorage` via a notification so that
+    /// `DashboardView` can pick it up reactively.
+    private func handleDashboardThemeUpdate(_ msg: DashboardThemeUpdateMessage) {
+        NotificationCenter.default.post(
+            name: .dashboardThemeDidUpdate,
+            object: nil,
+            userInfo: [
+                "colorHex": msg.colorHex,
+                "colorName": msg.colorName,
+            ]
+        )
+    }
+
+    /// Handle a task kickoff directive from the daemon. Creates a new thread,
+    /// switches to chat mode, and sends the kickoff message.
+    private func handleDashboardTaskKickoff(_ msg: DashboardTaskKickoffMessage) {
+        threadManager.createThread()
+        windowState.contentMode = .chat
+        if let viewModel = threadManager.activeViewModel {
+            viewModel.inputText = "[STARTER_TASK:\(msg.taskId)]"
+            viewModel.sendMessage()
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -151,8 +151,16 @@ struct MainWindowView: View {
 
                         // Content area
                         if windowState.contentMode == .dashboard {
-                            // Dashboard mode: placeholder (populated in M7)
-                            DashboardPlaceholderView()
+                            // Dashboard mode: full card layout
+                            DashboardView(onTaskKickoff: { task in
+                                // Switch to chat and send the kickoff message
+                                threadManager.createThread()
+                                windowState.contentMode = .chat
+                                if let viewModel = threadManager.activeViewModel {
+                                    viewModel.inputText = task.kickoffIntent
+                                    viewModel.sendMessage()
+                                }
+                            })
                         } else {
                             // Chat mode: left drawer + chat + right panel
                             HStack(spacing: 0) {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -158,6 +158,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `open_url` message.
     public var onOpenUrl: ((OpenUrlMessage) -> Void)?
 
+    /// Called when the daemon sends a `dashboard_theme_update` message.
+    public var onDashboardThemeUpdate: ((DashboardThemeUpdateMessage) -> Void)?
+
+    /// Called when the daemon sends a `dashboard_task_kickoff` message.
+    public var onDashboardTaskKickoff: ((DashboardTaskKickoffMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -941,6 +947,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onTraceEvent?(msg)
         case .error(let msg):
             onError?(msg)
+        case .dashboardThemeUpdate(let msg):
+            onDashboardThemeUpdate?(msg)
+        case .dashboardTaskKickoff(let msg):
+            onDashboardTaskKickoff?(msg)
         #if os(macOS)
         case .signBundlePayload(let msg):
             handleSignBundlePayload(msg)


### PR DESCRIPTION
## Context
Part of #2864
Closes #2871

## Changes
- Added `DashboardView` replacing `DashboardPlaceholderView` with full card layout
- Added `DashboardTaskCard` reusable component using VCard-style design tokens
- Added `DashboardTaskModel` with stable task IDs matching the starter-task playbook (make_it_yours, research_topic, research_to_ui, enable_voice, enable_computer_control)
- Added `DashboardWeatherCard` + `DashboardWeatherService` (Open-Meteo API, no key required)
- Wired CTA buttons to create a new thread, switch to chat mode, and send kickoff intents
- Added `dashboard_theme_update` handling in `MainWindow` and `DaemonClient`: persists accent color in `@AppStorage`, broadcasts via `NotificationCenter` for reactive UI updates
- Added `dashboard_task_kickoff` handling for daemon-driven task initiation
- Collapsible "More Options" section for deferred permission tasks
- Time-of-day greeting on the dashboard

## Validation
- `swift build` passes

## Test plan
- [ ] Launch app, verify dashboard shows greeting, weather card, and 3 starter task cards
- [ ] Click a starter task card CTA, verify it switches to chat and sends the kickoff intent
- [ ] Verify "More Options" section toggles open/closed with deferred permission cards
- [ ] Simulate `dashboard_theme_update` IPC message, verify accent color persists and applies
- [ ] Simulate `dashboard_task_kickoff` IPC message, verify new thread created with kickoff message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
