### PR TITLE
feat: add appType field to AppDefinition and app_create tool

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -31,6 +31,7 @@ export interface AppDefinition {
   schemaJson: string;
   htmlDefinition: string;
   version?: string;
+  appType?: 'app' | 'site';
   /** Additional pages keyed by filename (e.g. "settings.html" → HTML content). */
   pages?: Record<string, string>;
   createdAt: number;
@@ -107,6 +108,7 @@ export function createApp(params: {
   schemaJson: string;
   htmlDefinition: string;
   version?: string;
+  appType?: 'app' | 'site';
   pages?: Record<string, string>;
 }): AppDefinition {
   const dir = getAppsDir();
@@ -120,6 +122,7 @@ export function createApp(params: {
     schemaJson: params.schemaJson,
     htmlDefinition: params.htmlDefinition,
     version: params.version,
+    appType: params.appType,
     createdAt: now,
     updatedAt: now,
   };
@@ -170,7 +173,7 @@ export function listApps(): AppDefinition[] {
 
 export function updateApp(
   id: string,
-  updates: Partial<Pick<AppDefinition, 'name' | 'description' | 'icon' | 'preview' | 'schemaJson' | 'htmlDefinition' | 'version' | 'pages'>>,
+  updates: Partial<Pick<AppDefinition, 'name' | 'description' | 'icon' | 'preview' | 'schemaJson' | 'htmlDefinition' | 'version' | 'appType' | 'pages'>>,
 ): AppDefinition {
   validateId(id);
   const existing = getApp(id);

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -63,6 +63,11 @@ export const appCreateTool: Tool = {
               'with <a href="settings.html">. Do not include index.html here — use the html parameter instead.',
             additionalProperties: { type: 'string' },
           },
+          type: {
+            type: 'string',
+            enum: ['app', 'site'],
+            description: "Type of creation: 'app' for interactive apps with data/state, 'site' for presentational content (portfolios, landing pages, blogs)",
+          },
           auto_open: {
             type: 'boolean',
             description:
@@ -96,7 +101,7 @@ export const appCreateTool: Tool = {
             required: ['title'],
           },
         },
-        required: ['name', 'schema_json', 'html'],
+        required: ['name', 'html'],
       },
     };
   },
@@ -104,13 +109,14 @@ export const appCreateTool: Tool = {
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const name = input.name as string;
     const description = input.description as string | undefined;
-    const schemaJson = input.schema_json as string;
+    const schemaJson = (input.schema_json as string | undefined) ?? '{}';
     const htmlDefinition = input.html as string;
     const pages = input.pages as Record<string, string> | undefined;
     const autoOpen = input.auto_open !== false; // default true
     const preview = input.preview as Record<string, unknown> | undefined;
+    const appType = (input.type as string | undefined) === 'site' ? 'site' as const : 'app' as const;
 
-    const app = appStore.createApp({ name, description, schemaJson, htmlDefinition, pages });
+    const app = appStore.createApp({ name, description, schemaJson, htmlDefinition, pages, appType });
 
     // Auto-open the app via the proxy resolver if available
     if (autoOpen && context.proxyToolResolver) {


### PR DESCRIPTION
## Summary
- Adds `appType` field (`'app' | 'site'`) to the `AppDefinition` interface, `createApp()` params, and `updateApp()` partial type
- Adds `type` property to `app_create` tool input schema with enum `['app', 'site']`
- Makes `schema_json` optional in `app_create` (defaults to `'{}'`), since sites don't need a data schema

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify `app_create` works without `schema_json` (should default to `'{}'`)
- [ ] Verify `appType` is persisted in app JSON files
- [ ] Verify `type: 'site'` sets `appType` to `'site'`, anything else defaults to `'app'`

Closes #2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
