### PR TITLE
docs: dashboard-first UX and trust-earned onboarding architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,11 +39,20 @@ graph TB
         end
 
         subgraph "Main Window"
-            MW_STATE["MainWindowState<br/>cross-view UI state"]
+            MW_STATE["MainWindowState<br/>ContentMode (dashboard | chat)<br/>cross-view UI state"]
             THREAD_MGR["ThreadManager<br/>thread CRUD + delegate"]
             THREAD_RESTORER["ThreadSessionRestorer<br/>daemon session restoration"]
             CHAT_VM["ChatViewModel<br/>session bootstrap + streaming"]
             CHAT_VIEW["ChatView<br/>bubbles + composer + stop"]
+            CHAT_PANEL["ChatPanelView<br/>docked chat panel"]
+            CHAT_WINDOW["ChatWindow<br/>pop-out NSWindow"]
+        end
+
+        subgraph "Dashboard"
+            DASH_VIEW["DashboardView<br/>greeting + cards"]
+            DASH_WEATHER["DashboardWeatherCard<br/>locale-aware weather"]
+            DASH_TASK["DashboardTaskCard<br/>starter task CTA"]
+            DASH_THEME["@AppStorage<br/>dashboardAccentColorHex<br/>dashboardAccentColorName"]
         end
 
         subgraph "Debug Panel"
@@ -889,6 +898,8 @@ graph LR
         S15["trace_event<br/>eventId, sessionId, requestId?,<br/>timestampMs, sequence, kind,<br/>status?, summary, attributes?"]
         S16["session_error<br/>sessionId, code,<br/>userMessage, retryable,<br/>debugDetails?"]
         S17["ipc_blob_probe_result<br/>probeId, ok,<br/>observedNonceSha256?, reason?"]
+        S18["dashboard_theme_update<br/>colorName, colorHex,<br/>appliedAt, tokenMap?"]
+        S19["dashboard_task_kickoff<br/>taskId, displayLabel"]
     end
 
     C0 --> SOCKET
@@ -921,7 +932,189 @@ graph LR
     SOCKET --> S15
     SOCKET --> S16
     SOCKET --> S17
+    SOCKET --> S18
+    SOCKET --> S19
 ```
+
+---
+
+## Dashboard-First UX and Trust-Earned Onboarding
+
+The macOS app defaults to a dashboard view (`ContentMode.dashboard`) instead of a raw chat interface. Chat is available as a docked side panel or a pop-out window. This architecture moves the assistant from a chat-first experience to a dashboard-first experience where the assistant controls the UI via IPC messages and system prompt playbooks.
+
+### Content Mode and Window Layout
+
+`MainWindowState` holds a `contentMode: ContentMode` enum (`.dashboard` or `.chat`). On launch, the main window renders `DashboardView` as the default. Chat access is handled through two mechanisms:
+
+- **Docked chat** (`ChatPanelView`): An inline panel within the main window, toggled from the dashboard.
+- **Pop-out chat** (`ChatWindow`): A separate `NSWindow` that hosts `ChatPanelView`. Both modes share the same `ThreadManager` and `MainWindowState`, so message and session state is preserved when switching.
+
+```
+Main Window (default: dashboard mode)
+┌─────────────────────────────────────────────┐
+│  NavigationToolbar                          │
+├─────────────────────────────────────────────┤
+│                                             │
+│  DashboardView                              │
+│  ├─ Greeting (time-of-day)                  │
+│  ├─ Weather card (locale-aware)             │
+│  ├─ Starter task cards                      │
+│  │   ├─ Make It Yours (color flow)          │
+│  │   ├─ Research Something                  │
+│  │   └─ Turn It Into a UI                   │
+│  └─ Deferred permission cards               │
+│                                             │
+├─────────────────────────────────────────────┤
+│  ChatPanelView (docked) — or pop-out window │
+└─────────────────────────────────────────────┘
+```
+
+### Assistant-Owned Onboarding Logic
+
+Onboarding state lives in the assistant's `USER.md` template (not in the Swift client). The daemon's system prompt includes sections that instruct the model to maintain:
+
+- **Locale**: city, region, country, timezone, localeId, confidence level.
+- **Dashboard Color Preference**: label, hex, source, applied status.
+- **Onboarding Tasks**: `set_name`, `set_locale`, `make_it_yours`, `research_topic`, `research_to_ui`, `first_conversation` — each tracked as `pending`, `in_progress`, `done`, or `deferred_to_dashboard`.
+- **Trust Stage**: `hatched`, `firstConversationComplete`, `permissionsUnlocked` — boolean milestones.
+
+The system prompt's `buildOnboardingGuidanceSection()` tells the model how to update these sections. This makes onboarding state portable across channels and sessions — the Swift client is not the source of truth.
+
+### Simplified macOS Onboarding Flow
+
+The macOS onboarding flow (`OnboardingFlowView` / `OnboardingState`) was reduced from 8 steps to 6 by deferring microphone and screen recording permission requests. The `anyPermissionDenied` check now only verifies Accessibility permission. Microphone and screen recording permissions are deferred to dashboard task cards, requested only when the user engages with a feature that needs them (trust-earned, not upfront).
+
+### Channel Capability Routing
+
+Each turn receives a `<channel_capabilities>` block injected via `injectChannelCapabilityContext()` in `session-runtime-assembly.ts`. The block declares:
+
+| Field | Description |
+|-------|-------------|
+| `channel` | Raw identifier: `"dashboard"`, `"telegram"`, `"http-api"` |
+| `dashboardCapable` | Can render the dashboard UI, apps, dynamic pages |
+| `supportsDynamicUi` | Can handle `ui_show` / `ui_update` / `app_create` |
+| `supportsVoiceInput` | Has microphone/voice capability |
+
+When `dashboardCapable` is `false`, the system prompt instructs the model to:
+- Never reference dashboard UI, settings panels, or visual pickers.
+- Never call `ui_show`, `ui_update`, or `app_create`.
+- Present data as formatted text.
+- Defer dashboard-specific actions, telling the user to complete them from the desktop app.
+
+This is stripped from persisted history via `stripChannelCapabilityContext()`.
+
+### Trust-Gated Permission Requests
+
+The system prompt's `buildChannelAwarenessSection()` enforces trust gating:
+
+1. Do not ask for elevated permissions (microphone, computer control, file access) until `firstConversationComplete` is `true` in USER.md.
+2. Only ask for permissions relevant to the current channel.
+3. Do not ask for microphone on channels where `supportsVoiceInput` is `false`.
+4. Do not ask for computer-control on non-dashboard channels.
+
+This means during `hatch` (first onboarding) and the first conversation, no permission prompts are shown. Permissions are earned through usage.
+
+### Starter Task Playbooks
+
+The system prompt includes deterministic playbooks for three starter tasks, triggered by dashboard CTA cards:
+
+| Task ID | Kickoff Intent | Flow |
+|---------|---------------|------|
+| `make_it_yours` | `[STARTER_TASK:make_it_yours]` | Color personalisation: confirm locale, present color options, apply via `dashboard_theme_update` IPC |
+| `research_topic` | `[STARTER_TASK:research_topic]` | Research a user-chosen topic using available tools, synthesise findings |
+| `research_to_ui` | `[STARTER_TASK:research_to_ui]` | Transform research into an interactive HTML page via `app_create` |
+
+Each playbook updates the onboarding task status in USER.md (`in_progress` → `done` or `deferred_to_dashboard`). All playbooks respect trust gating — no elevated permission asks during starter tasks.
+
+### IPC Contract: Dashboard Control Messages
+
+Two new server-to-client IPC message types enable assistant-driven dashboard updates:
+
+| Message | Fields | Purpose |
+|---------|--------|---------|
+| `dashboard_theme_update` | `colorName`, `colorHex`, `appliedAt`, `tokenMap?` | Apply accent color to dashboard UI |
+| `dashboard_task_kickoff` | `taskId`, `displayLabel` | Signal a starter task activation |
+
+The macOS client handles `dashboard_theme_update` by persisting the color via `@AppStorage("dashboardAccentColorHex")` and `@AppStorage("dashboardAccentColorName")`, ensuring the theme survives app relaunch.
+
+### Color Preference Flow (End-to-End)
+
+```
+Dashboard CTA → "Make It Yours"
+        ↓
+User message: [STARTER_TASK:make_it_yours]
+        ↓
+System prompt playbook activates
+        ↓
+Assistant presents color options
+        ↓
+User selects a color
+        ↓
+Assistant updates USER.md (color preference section)
+        ↓
+Daemon sends dashboard_theme_update IPC message
+        ↓
+DaemonClient (Swift) receives message
+        ↓
+DashboardView applies color via @AppStorage
+        ↓
+Color persists across relaunch
+```
+
+---
+
+## Cross-Channel QA Checklist
+
+Use this matrix to validate the dashboard-first UX, trust-earned onboarding, and channel deferral behavior.
+
+### macOS Dashboard-Capable Onboarding
+
+- [ ] On first launch, the main window defaults to `DashboardView` (not chat).
+- [ ] The greeting text reflects the current time of day (morning/afternoon/evening).
+- [ ] The weather card displays weather for the user's locale (falls back to Palo Alto, CA when locale is not set).
+- [ ] All three starter task cards are visible: "Make It Yours", "Research Something", "Turn It Into a UI".
+- [ ] Clicking "Make It Yours" sends `[STARTER_TASK:make_it_yours]` to the daemon and the assistant begins the color flow.
+- [ ] After selecting a color, the dashboard accent color updates and is visible immediately.
+- [ ] The accent color persists after quitting and relaunching the app (`@AppStorage` persistence).
+- [ ] Clicking "Research Something" triggers the research playbook.
+- [ ] Clicking "Turn It Into a UI" triggers the research-to-UI playbook.
+- [ ] Onboarding task statuses in USER.md update correctly (`pending` → `in_progress` → `done`).
+
+### Trust-Gated Permissions
+
+- [ ] During the onboarding hatch/egg flow, NO permission prompts appear for microphone or screen recording.
+- [ ] The simplified onboarding only requests Accessibility permission (not microphone or screen recording).
+- [ ] After first conversation completes and `firstConversationComplete` is set to `true` in USER.md, the assistant may request permissions when relevant.
+- [ ] Permission cards appear on the dashboard for deferred permissions (microphone, screen recording).
+
+### Non-Dashboard Channel Deferral
+
+- [ ] On Telegram: the assistant never references dashboard UI, settings panels, or visual pickers.
+- [ ] On Telegram: `ui_show`, `ui_update`, and `app_create` are never called.
+- [ ] On Telegram: dashboard-specific actions (accent color, task cards) are deferred with a message to complete them from the desktop app.
+- [ ] On HTTP API: the same deferral behavior applies.
+- [ ] On channels without voice support: the assistant never asks the user to use voice or microphone input.
+
+### Locale and Weather Behavior
+
+- [ ] When the user has no locale set in USER.md, the weather card defaults to Palo Alto, CA.
+- [ ] After the user sets their locale during onboarding, the weather card updates to the correct location.
+- [ ] The locale `confidence` field updates appropriately (`low` → `medium` → `high`).
+
+### Dashboard Color Persistence
+
+- [ ] The selected accent color hex value is stored in `@AppStorage("dashboardAccentColorHex")`.
+- [ ] The color name is stored in `@AppStorage("dashboardAccentColorName")`.
+- [ ] Both values survive app relaunch.
+- [ ] The `dashboard_theme_update` IPC message includes `colorName`, `colorHex`, and `appliedAt`.
+
+### Chat Dock / Pop-Out State
+
+- [ ] The chat panel can be docked inside the main window (inline `ChatPanelView`).
+- [ ] The chat panel can be popped out into a separate `ChatWindow`.
+- [ ] Message state and session state are preserved when switching between docked and popped-out modes.
+- [ ] The `isChatPoppedOut` state on `MainWindowState` tracks the current mode.
+- [ ] Closing the pop-out window reverts to docked mode gracefully.
 
 ---
 

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -41,9 +41,10 @@ All UI and feature code lives in `Features/`, organized by domain:
 
 | Module | Purpose |
 |--------|---------|
-| `Chat/` | ChatView, ChatViewModel (multi-turn messaging), ChatMessage model |
-| `MainWindow/` | MainWindowView shell, ThreadTabBar, NavigationToolbar, ThreadManager, 6 side panels |
-| `Onboarding/` | Multi-step first-launch flow (OnboardingFlowView → OnboardingState) |
+| `Chat/` | ChatView, ChatViewModel (multi-turn messaging), ChatMessage model, ChatPanelView (docked/pop-out), ChatWindow (pop-out NSWindow) |
+| `MainWindow/` | MainWindowView shell (dashboard-first via ContentMode), ThreadTabBar, NavigationToolbar, ThreadManager, 6 side panels |
+| `MainWindow/Dashboard/` | Dashboard cards (DashboardView, DashboardTaskCard, DashboardWeatherCard, theme color persistence) |
+| `Onboarding/` | Simplified 6-step first-launch flow (naming, Accessibility — mic/screen-recording deferred) |
 | `Session/` | Session overlay UI for computer-use task execution |
 | `Settings/` | API key entry, hotkey config, permission status |
 | `Ambient/` | Background screen monitoring UI |
@@ -56,8 +57,10 @@ All UI and feature code lives in `Features/`, organized by domain:
 **Main window layout** (`MainWindowView`):
 ```
 ThreadTabBar          (row 1 — thread tabs, extends into titlebar)
-NavigationToolbar     (row 2 — Chat tab + panel toggle buttons)
-VSplitView            (row 3 — ChatView + optional side panel)
+NavigationToolbar     (row 2 — Dashboard/Chat tab + panel toggle buttons)
+ContentMode.dashboard → DashboardView (default on launch)
+ContentMode.chat      → VSplitView (ChatView + optional side panel)
+Chat can also pop out via ChatWindow (separate NSWindow with ChatPanelView)
 ```
 
 **Data flow**: `ThreadManager` (`@MainActor ObservableObject`) owns `[ThreadModel]` and a dictionary of `ChatViewModel` instances keyed by thread ID. `MainWindowView` binds to the active `ChatViewModel` via `threadManager.activeViewModel`. ThreadManager subscribes to each nested ChatViewModel's `objectWillChange` and forwards it via Combine so SwiftUI picks up changes.
@@ -113,7 +116,7 @@ The package is split into two targets for Xcode Preview support:
 
 ### Onboarding
 
-`Features/Onboarding/` — multi-step flow (`OnboardingFlowView` → `OnboardingState`) covering wake-up animation, naming, permissions (screen recording, microphone), Fn key setup, and an alive-check step. Shown on first launch; skip with `--skip-onboarding` in debug.
+`Features/Onboarding/` — simplified 6-step flow (`OnboardingFlowView` → `OnboardingState`) covering wake-up animation, naming, Accessibility permission, Fn key setup, and an alive-check step. Microphone and screen recording permissions are deferred to dashboard task cards (trust-earned onboarding). Shown on first launch; skip with `--skip-onboarding` in debug. Onboarding state (locale, color preference, tasks, trust stage) is owned by the assistant's `USER.md`, not the Swift client.
 
 ## Design System (`DesignSystem/`)
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -187,26 +187,29 @@ The app will auto-reconnect if the daemon restarts. For development, `bun run de
 
 ## Permissions
 
-The app requires three macOS permissions:
-- **Accessibility** — For reading UI element trees and injecting mouse/keyboard events
-- **Screen Recording** — For capturing screenshots (vision fallback when AX tree is sparse)
-- **Microphone** — For voice input via speech recognition
+The app requests macOS permissions progressively based on trust stage, not all at once during onboarding:
 
-Grant these in System Settings → Privacy & Security.
+- **Accessibility** — Requested during onboarding (required for reading UI element trees and injecting mouse/keyboard events)
+- **Screen Recording** — Deferred to dashboard task cards (needed for capturing screenshots when AX tree is sparse)
+- **Microphone** — Deferred to dashboard task cards (needed for voice input via speech recognition)
+
+Grant these in System Settings → Privacy & Security when prompted. Screen Recording and Microphone are only requested after the user has completed their first conversation (trust-earned, not upfront).
 
 ## Usage
 
-1. Launch the app — an onboarding flow guides you through permissions and setup on first run
+1. Launch the app — a simplified onboarding flow guides you through naming and Accessibility permission on first run
 2. The app appears as a sparkles icon in your menu bar
 3. Open Settings (click icon → gear) and enter your Anthropic API key
-4. Click the menu bar icon or press `⌘⇧G` to open the task input
-5. Type a task (e.g., "Fill in the name field with John Smith") and press Go
-6. Or hold the Fn key to dictate a task via voice
-7. Watch the overlay as vellum-assistant works through the task
-8. Press Escape at any time to cancel
-9. The main window shows a chat interface — type a message to start a conversation
-10. Responses stream in real-time from the daemon
-11. Click the stop button to cancel an in-progress generation
+4. The main window opens to a **dashboard** with a greeting, weather card, and starter task cards
+5. Use the starter task cards to personalise your dashboard (accent color), research a topic, or build a UI
+6. Chat is available as a docked panel in the main window or as a pop-out window
+7. Click the menu bar icon or press `⌘⇧G` to open the task input
+8. Type a task (e.g., "Fill in the name field with John Smith") and press Go
+9. Or hold the Fn key to dictate a task via voice
+10. Watch the overlay as vellum-assistant works through the task
+11. Press Escape at any time to cancel
+12. Responses stream in real-time from the daemon
+13. Click the stop button to cancel an in-progress generation
 
 ### Opportunistic Message Queueing
 
@@ -313,16 +316,24 @@ Ambient/              Background screen-watching agent
   KnowledgeCron       Triggers periodic insight analysis
   InsightStore        Higher-level insights derived from observations
   ScreenOCR           Vision framework OCR
-Features/Chat/        Main window chat interface
+Features/Chat/        Chat interface (docked panel or pop-out window)
   ChatMessage         Message model (role, text, streaming state)
   ChatView            Presentational view (bubbles, composer, thinking, error banner)
   ChatViewModel       Session bootstrap, streaming, cancel via daemon IPC
+  ChatPanelView       Reusable chat panel (shared between docked and pop-out modes)
+  ChatWindow          Pop-out NSWindow for standalone chat
 Features/MainWindow/Panels/
   DebugPanel          Real-time trace viewer (metrics strip + timeline)
   TraceTimelineView   Events grouped by requestId with status indicators
   TraceRowView        Individual trace event display
+Features/MainWindow/Dashboard/
+  DashboardView       Main dashboard (greeting, weather, task cards, theme color)
+  DashboardTaskCard   Starter task CTA card
+  DashboardTaskModel  Task model and definitions
+  DashboardWeatherCard Weather display card
+  DashboardWeatherService Locale-aware weather data
 UI/                   SwiftUI views + overlay windows
-  Onboarding/         First-launch setup flow (permissions, naming, Fn key)
+  Onboarding/         First-launch setup flow (naming, Accessibility — 6 steps)
 Logging/
   TraceStore          In-memory trace event store (per-session, dedup, retention cap)
   Session recording   JSON logs to ~/Library/App Support/


### PR DESCRIPTION
## Context
Part of #2864
Closes #2872

## Changes
- Updated ARCHITECTURE.md with dashboard-first architecture sections:
  - Assistant-owned onboarding logic (USER.md memory schema, trust stages)
  - Channel capability routing and deferral
  - Trust-gated permission requests
  - Starter task playbooks (make_it_yours, research_topic, research_to_ui)
  - Dashboard-first shell (ContentMode, ChatPanelView, ChatWindow)
  - Color preference capture and dashboard_theme_update IPC flow
  - New IPC messages in protocol diagram (dashboard_theme_update, dashboard_task_kickoff)
- Added cross-channel QA checklist covering:
  - macOS dashboard-capable onboarding
  - Trust-gated permissions
  - Non-dashboard channel deferral (Telegram/iOS)
  - Locale and weather behavior
  - Dashboard color persistence
  - Chat dock/pop-out state preservation
- Updated clients/macos/README.md with dashboard-first usage flow and deferred permissions
- Updated clients/macos/CLAUDE.md with Dashboard/ module, ChatPanelView/ChatWindow, simplified onboarding

## Validation
- TypeScript type-check passes
- Swift build passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
