### PR TITLE
feat: add site badge and appType to app directory UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -204,6 +204,16 @@ struct AppDirectoryView: View {
                         .foregroundColor(VColor.textPrimary)
                         .lineLimit(1)
 
+                    if item.appType == "site" {
+                        Text("Site")
+                            .font(VFont.small)
+                            .foregroundColor(Emerald._400)
+                            .padding(.horizontal, VSpacing.xs)
+                            .padding(.vertical, 1)
+                            .background(Emerald._900.opacity(0.5))
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+                    }
+
                     if item.isShared {
                         HStack(spacing: 2) {
                             Image(systemName: "person.2.fill")
@@ -319,6 +329,7 @@ struct AppDirectoryView: View {
                 preview: app.preview,
                 dateLabel: formatDate(app.createdAt),
                 isShared: false,
+                appType: app.appType,
                 localAppId: app.id,
                 sharedUUID: nil
             ))
@@ -333,6 +344,7 @@ struct AppDirectoryView: View {
                 preview: app.preview,
                 dateLabel: formatISO(app.installedAt),
                 isShared: true,
+                appType: nil,
                 localAppId: nil,
                 sharedUUID: app.uuid
             ))
@@ -408,6 +420,7 @@ private struct DirectoryAppItem: Identifiable {
     let preview: String?
     let dateLabel: String
     let isShared: Bool
+    let appType: String?
     let localAppId: String?
     let sharedUUID: String?
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -14,6 +14,7 @@ private struct DisplayAppItem: Identifiable {
     let signerDisplayName: String?
     let version: String?
     let updateAvailable: Bool?
+    let appType: String?
 
     /// For local apps: the app store ID used for bundling.
     let localAppId: String?
@@ -210,6 +211,16 @@ struct GeneratedPanel: View {
 
                     if let tier = item.trustTier {
                         trustBadge(tier: tier)
+                    }
+
+                    if item.appType == "site" {
+                        Text("Site")
+                            .font(VFont.small)
+                            .foregroundColor(Emerald._400)
+                            .padding(.horizontal, VSpacing.xs)
+                            .padding(.vertical, 1)
+                            .background(Emerald._900.opacity(0.5))
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
                     }
 
                     if item.updateAvailable == true {
@@ -522,6 +533,7 @@ struct GeneratedPanel: View {
                 signerDisplayName: nil,
                 version: app.version,
                 updateAvailable: nil,
+                appType: app.appType,
                 localAppId: app.id,
                 sharedUUID: nil
             ))
@@ -541,6 +553,7 @@ struct GeneratedPanel: View {
                 signerDisplayName: app.signerDisplayName,
                 version: app.version,
                 updateAvailable: app.updateAvailable,
+                appType: nil,
                 localAppId: nil,
                 sharedUUID: app.uuid
             ))

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -77,6 +77,7 @@ public struct IPCAppsListResponseApp: Codable, Sendable {
     public let createdAt: Int
     public let version: String?
     public let contentId: String?
+    public let appType: String?
 }
 
 public struct IPCAppUpdatePreviewRequest: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Regenerate IPC contract to include the new `appType` field on `IPCAppsListResponseApp`
- Add `appType` to `DisplayAppItem` (GeneratedPanel) and `DirectoryAppItem` (AppDirectoryView)
- Show an Emerald "Site" badge for apps with `appType == "site"` in both the side panel list and the full-screen app directory grid

## Test plan
- [ ] Verify build succeeds (pre-existing SurfaceContainerView error is on main, unrelated)
- [ ] Open Dynamic panel — apps with `appType: "site"` should show a green "Site" badge
- [ ] Open App Directory — site-type apps should show the "Site" badge next to the name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
