### PR TITLE
fix: correct misleading test name in migration ordering test

### DIFF
--- a/assistant/src/__tests__/migration-ordering.test.ts
+++ b/assistant/src/__tests__/migration-ordering.test.ts
@@ -68,7 +68,7 @@ function populateLegacyLayout(root: string): void {
 }
 
 describe('migration ordering: ensureDataDir before migration', () => {
-  test('ensureDataDir() before migrateToWorkspaceLayout() does NOT prevent migration', () => {
+  test('ensureDataDir() before migrateToWorkspaceLayout() prevents directory migration', () => {
     // This is the critical regression test. Before the fix, calling
     // ensureDataDir() first would pre-create workspace/data, workspace/hooks,
     // workspace/skills — causing migrateToWorkspaceLayout() to skip those


### PR DESCRIPTION
Addresses feedback on PR #2888.

The test was named `ensureDataDir() before migrateToWorkspaceLayout() does NOT prevent migration` but its assertions prove the opposite — that calling `ensureDataDir()` before migration **does** prevent directory migration (`data/`, `hooks/`, `skills/` stay at the old location). Renamed to accurately reflect the tested behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
