### PR TITLE
fix: strengthen workspace refresh timing assertions

### DIFF
--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -270,12 +270,15 @@ describe('Session workspace dirty-refresh E2E', () => {
     };
     await session.processMessage('Edit a file', [], () => {});
 
-    // file_edit marks dirty, but scanner was not re-called yet (dirty happens mid-turn)
-    // Next turn should trigger a fresh scan
+    // No rescan should happen during the mutation turn itself
+    const afterMutation = scanCallCount;
+    expect(afterMutation).toBe(afterFirst);
+
+    // Next turn should trigger exactly one fresh scan
     agentLoopScript = () => {};
     await session.processMessage('What happened?', [], () => {});
 
-    expect(scanCallCount).toBeGreaterThan(afterFirst);
+    expect(scanCallCount).toBe(afterMutation + 1);
   });
 
   test('successful bash causes refresh next turn', async () => {
@@ -291,10 +294,15 @@ describe('Session workspace dirty-refresh E2E', () => {
     };
     await session.processMessage('Run a command', [], () => {});
 
+    // No rescan should happen during the mutation turn itself
+    const afterMutation = scanCallCount;
+    expect(afterMutation).toBe(afterFirst);
+
+    // Next turn should trigger exactly one fresh scan
     agentLoopScript = () => {};
     await session.processMessage('What now?', [], () => {});
 
-    expect(scanCallCount).toBeGreaterThan(afterFirst);
+    expect(scanCallCount).toBe(afterMutation + 1);
   });
 
   test('failed tool results do not trigger refresh', async () => {


### PR DESCRIPTION
Addresses feedback on PR #2896.

Changes the `toBeGreaterThan(afterFirst)` assertions in the dirty-refresh E2E tests to be precise about timing:

- After the mutation turn (file_edit / bash), asserts `scanCallCount` has **not** increased (no rescan during the mutation turn itself)
- On the following turn, asserts exactly `afterMutation + 1` (one fresh scan, not just "more than before")

This catches regressions where scanning happens at the wrong time (e.g., during the mutation turn instead of the next turn, or multiple rescans).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
