### PR TITLE
fix: scrub command deletes both legacy and workspace DB paths

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -23,6 +23,8 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
    ```bash
    rm -f ~/.vellum/workspace/data/db/assistant.db ~/.vellum/workspace/data/db/assistant.db-shm ~/.vellum/workspace/data/db/assistant.db-wal
    rm -f ~/.vellum/workspace/data/assistant.db ~/.vellum/workspace/data/assistant.db-shm ~/.vellum/workspace/data/assistant.db-wal
+   rm -f ~/.vellum/data/db/assistant.db ~/.vellum/data/db/assistant.db-shm ~/.vellum/data/db/assistant.db-wal
+   rm -f ~/.vellum/data/assistant.db ~/.vellum/data/assistant.db-shm ~/.vellum/data/assistant.db-wal
    ```
 
 4. Remove caches:


### PR DESCRIPTION
Addresses feedback on PR #2850 from both Codex and Devin.

PR #2850 replaced the legacy `~/.vellum/data/` rm lines with the new `~/.vellum/workspace/data/` paths instead of keeping both. Without the legacy paths, `migrateToWorkspaceLayout()` re-populates the workspace from leftover legacy files on next launch, defeating the scrub.

This fix keeps the new workspace paths AND adds back the legacy paths so all possible DB locations are cleaned.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
