### PR TITLE
fix: extend getSecureKey boundary test to catch dynamic imports and require

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -199,8 +199,8 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
 
     for (const filePath of allFiles) {
       const content = readFileSync(filePath, 'utf-8');
-      // Check for imports of getSecureKey (named import or namespace)
-      if (content.match(/\bgetSecureKey\b/) && content.match(/from\s+['"].*secure-keys/)) {
+      // Check for imports of getSecureKey via static import, dynamic import(), or require()
+      if (content.match(/\bgetSecureKey\b/) && (content.match(/from\s+['"].*secure-keys/) || content.match(/(?:import|require)\s*\(\s*['"].*secure-keys/))) {
         const relative = filePath.slice(srcDir.length + 1);
         if (!ALLOWED_IMPORTERS.has(relative)) {
           unauthorizedImporters.push(relative);


### PR DESCRIPTION
Addresses feedback on PR #2816.

The `getSecureKey` import boundary invariant test only matched static `from '...secure-keys'` imports. This left a gap where `await import('...secure-keys')` and `require('...secure-keys')` patterns could bypass the security boundary without tripping CI.

Extended the regex to also match `import()` and `require()` call patterns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
