### PR TITLE
fix: mark workspace dirty for file mutations regardless of isError

### DIFF
--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -172,7 +172,9 @@ describe('Session workspace dirty on file mutations', () => {
     expect(session.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
-  test('failed file_write does NOT mark workspace dirty', async () => {
+  test('file_write with isError still marks workspace dirty (secret-detection block)', async () => {
+    // ToolExecutor can physically write the file and then flip isError=true
+    // in secret-detection block mode — the filesystem has changed.
     const session = makeSession();
     await session.loadFromDb();
 
@@ -181,11 +183,11 @@ describe('Session workspace dirty on file mutations', () => {
 
     agentLoopScript = (onEvent) => {
       onEvent({ type: 'tool_use', id: 'tu_3', name: 'file_write', input: { path: '/tmp/a.txt', content: 'hi' } });
-      onEvent({ type: 'tool_result', toolUseId: 'tu_3', content: 'Permission denied', isError: true });
+      onEvent({ type: 'tool_result', toolUseId: 'tu_3', content: 'Blocked: secret detected', isError: true });
     };
 
     await session.processMessage('Write a file', [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
   test('successful bash marks workspace dirty', async () => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -943,10 +943,17 @@ export class Session {
             const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
             onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId, imageData: imageBlock?.source.data });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
-            // Mark workspace context dirty on successful mutation tools
-            if (!event.isError) {
+            // Mark workspace context dirty for mutation tools.
+            // file_write/file_edit always mark dirty regardless of isError because
+            // ToolExecutor can physically write the file and then flip isError=true
+            // (e.g. secret-detection block mode), so the filesystem has changed.
+            // bash only marks dirty on success since a failed command typically
+            // means no mutation occurred.
+            {
               const toolName = toolUseIdToName.get(event.toolUseId);
-              if (toolName === 'file_write' || toolName === 'file_edit' || toolName === 'bash') {
+              if (toolName === 'file_write' || toolName === 'file_edit') {
+                this.markWorkspaceTopLevelDirty();
+              } else if (!event.isError && toolName === 'bash') {
                 this.markWorkspaceTopLevelDirty();
               }
             }


### PR DESCRIPTION
## Summary
- file_write/file_edit now always mark workspace context dirty, regardless of isError
- ToolExecutor can physically write a file then flip isError=true in secret-detection block mode — the filesystem has changed but the old !isError guard skipped markWorkspaceTopLevelDirty()
- bash retains the isError guard since failed commands typically don't mutate the filesystem
- Updated test to verify file_write with isError=true still marks dirty

Addresses feedback on PR #2889
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
