### PR TITLE
fix: exercise actual timeout path in secret prompt log hygiene test

### DIFF
--- a/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
+++ b/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
@@ -24,6 +24,17 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+// Use a tiny timeout so the setTimeout branch fires quickly in tests
+const mockConfig = {
+  timeouts: { permissionTimeoutSec: 0.01 },
+  secretDetection: { allowOneTimeSend: false },
+};
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+}));
+
 // Import after mock so SecretPrompter picks up the captured logger
 const { SecretPrompter } = await import('../permissions/secret-prompter.js');
 
@@ -66,17 +77,20 @@ describe('secret prompt log hygiene', () => {
   });
 
   test('prompt timeout logs only metadata, not the secret value', async () => {
-    const promise = prompter.prompt('svc', 'key', 'Label');
-    const requestId = (sentMessages[0] as SecretRequest).requestId;
+    // Let the setTimeout branch in SecretPrompter.prompt() actually fire
+    // (mockConfig sets permissionTimeoutSec to 0.01s = 10ms)
+    const result = await prompter.prompt('svc', 'key', 'Label');
 
-    // Simulate a normal resolve (timeout would also log metadata only)
-    prompter.resolveSecret(requestId, undefined);
-    await promise;
+    // Timeout resolves with null value
+    expect(result.value).toBeNull();
 
-    // Verify no log contains any value-like content beyond metadata
+    // A warn log should have been emitted for the timeout
+    expect(logCalls.some((c) => c.level === 'warn')).toBe(true);
+
+    // The timeout log must only contain metadata (requestId, service, field),
+    // never a "value" key
     for (const call of logCalls) {
       const serialized = JSON.stringify(call.args);
-      // Metadata fields are fine
       expect(serialized).not.toContain('"value"');
     }
   });


### PR DESCRIPTION
## Summary
- Fixes the "prompt timeout logs only metadata, not the secret value" test to actually exercise the `setTimeout` branch in `SecretPrompter.prompt()`
- Previously the test manually called `resolveSecret` before the timer fired, so the timeout code path was never tested (flagged by Codex review on PR #2745)
- Now mocks `getConfig` with a 10ms timeout and awaits the promise directly, letting the real timer fire

## Test plan
- [x] `bun test src/__tests__/secret-prompt-log-hygiene.test.ts` passes (4/4 tests, 8 assertions)
- [x] No new type errors introduced (pre-existing errors in other files only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
