### PR TITLE
fix: strict ISO 8601 validation for reminder fire_at + architecture docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,6 +101,7 @@ graph TB
             DB_ATTACH["attachments"]
             DB_CHAN["channel_inbound_events"]
             DB_KEYS["conversation_keys"]
+            DB_REMINDERS["reminders"]
         end
 
         subgraph "Tracing"
@@ -368,6 +369,7 @@ graph LR
         EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
         JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill,<br/>conflict resolution, cleanup<br/>Status: pending → running →<br/>completed | failed"]
         ATT["attachments<br/>───────────────<br/>base64-encoded file data<br/>mime_type, size_bytes<br/>Linked to messages via<br/>message_attachments join"]
+        REM["reminders<br/>───────────────<br/>One-time scheduled reminders<br/>label, message, fireAt<br/>mode: notify | execute<br/>status: pending → fired | cancelled"]
     end
 
     subgraph "~/.vellum/workspace/data/ipc-blobs/"

--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -78,6 +78,45 @@ describe('reminder tool', () => {
     expect(result.content).toContain('Invalid timestamp');
   });
 
+  test('create rejects non-ISO date formats like MM/DD/YYYY', async () => {
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: '03/04/2027',
+      label: 'Ambiguous date',
+      message: 'This format is locale-dependent',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid timestamp');
+  });
+
+  test('create rejects ISO timestamp without timezone', async () => {
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: '2027-03-15T09:00:00',
+      label: 'No timezone',
+      message: 'Missing timezone offset',
+    }, dummyContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid timestamp');
+  });
+
+  test('create accepts ISO timestamp with timezone offset', async () => {
+    const future = new Date(Date.now() + 120_000);
+    const offset = '-05:00';
+    const isoWithOffset = future.toISOString().replace('Z', offset);
+    const result = await reminderTool.execute({
+      action: 'create',
+      fire_at: isoWithOffset,
+      label: 'With offset',
+      message: 'Has explicit timezone',
+    }, dummyContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Reminder created');
+  });
+
   test('create defaults mode to notify', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
     const result = await reminderTool.execute({

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -48,9 +48,13 @@ function createAction(input: Record<string, unknown>): ToolExecutionResult {
     return { content: 'Error: mode must be "notify" or "execute"', isError: true };
   }
 
+  // Require strict ISO 8601 with timezone offset or Z to avoid ambiguous parsing
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})$/.test(fireAtStr)) {
+    return { content: `Error: Invalid timestamp "${fireAtStr}". Use ISO 8601 format with timezone (e.g. "2025-03-15T09:00:00Z" or "2025-03-15T09:00:00-05:00").`, isError: true };
+  }
   const fireAt = new Date(fireAtStr).getTime();
   if (isNaN(fireAt)) {
-    return { content: `Error: Invalid timestamp "${fireAtStr}". Use ISO 8601 format (e.g. "2025-03-15T09:00:00Z").`, isError: true };
+    return { content: `Error: Invalid timestamp "${fireAtStr}". Use ISO 8601 format with timezone (e.g. "2025-03-15T09:00:00Z").`, isError: true };
   }
   if (fireAt <= Date.now()) {
     return { content: 'Error: fire_at must be in the future', isError: true };


### PR DESCRIPTION
## Summary
Addresses feedback from PR #2741:

- **P2 — Strict ISO 8601 validation**: The `fire_at` field now rejects non-ISO date formats (e.g. `03/04/2026`, `2025-03-15T09:00:00` without timezone). Only ISO 8601 with explicit timezone (`Z` or `+/-HH:MM`) is accepted, preventing locale-dependent parsing ambiguity.
- **P1 — Architecture docs**: Added `reminders` table to the system overview diagram and detailed schema section in `ARCHITECTURE.md`.
- Added tests for rejected formats (MM/DD/YYYY, timezone-less ISO) and accepted format with explicit offset.

## Test plan
- [x] All 18 reminder tests pass (`bun test src/__tests__/reminder.test.ts`)
- [x] New tests cover: non-ISO format rejection, timezone-less rejection, explicit offset acceptance
- [x] Type-check passes (pre-existing errors in unrelated file only)

Addresses #2741
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
