### PR TITLE
fix: requeue execute reminders on processing failure

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -5,7 +5,7 @@ import {
   createScheduleRun,
   completeScheduleRun,
 } from './schedule-store.js';
-import { claimDueReminders, setReminderConversationId } from '../tools/reminder/reminder-store.js';
+import { claimDueReminders, setReminderConversationId, requeueReminder } from '../tools/reminder/reminder-store.js';
 
 const log = getLogger('scheduler');
 
@@ -92,7 +92,8 @@ async function runScheduleOnce(
         log.info({ reminderId: reminder.id, label: reminder.label, conversationId: conversation.id }, 'Executing reminder');
         await processMessage(conversation.id, reminder.message);
       } catch (err) {
-        log.warn({ err, reminderId: reminder.id }, 'Reminder execution failed');
+        log.warn({ err, reminderId: reminder.id }, 'Reminder execution failed, requeueing');
+        requeueReminder(reminder.id);
       }
     } else {
       log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');

--- a/assistant/src/tools/reminder/reminder-store.ts
+++ b/assistant/src/tools/reminder/reminder-store.ts
@@ -105,6 +105,21 @@ export function claimDueReminders(now: number): ReminderRow[] {
   return claimed;
 }
 
+/**
+ * Reset a fired reminder back to pending so it can be retried on the next tick.
+ * Used when execute-mode reminder processing fails transiently.
+ */
+export function requeueReminder(id: string): boolean {
+  const db = getDb();
+  const now = Date.now();
+  const result = db
+    .update(reminders)
+    .set({ status: 'pending', firedAt: null, conversationId: null, updatedAt: now })
+    .where(and(eq(reminders.id, id), eq(reminders.status, 'fired')))
+    .run() as unknown as { changes?: number };
+  return (result.changes ?? 0) > 0;
+}
+
 export function setReminderConversationId(id: string, conversationId: string): void {
   const db = getDb();
   db.update(reminders)


### PR DESCRIPTION
## Summary
- Adds `requeueReminder()` to `reminder-store.ts` that resets a fired reminder back to pending status
- Calls it in the scheduler catch block so failed execute-mode reminders are retried on the next tick instead of being silently lost
- Addresses Codex P1 feedback from PR #2744: "Requeue execute reminders when processing fails"

## Note on other feedback
The other Codex finding ("Surface notify reminders through a handled client callback") was already addressed in PR #2744 — `AppDelegate.swift` wires `onReminderFired` to show a `UNNotificationRequest`, and `DaemonClient.swift` dispatches the `reminder_fired` message type to the callback.

## Test plan
- [ ] Verify `requeueReminder` resets status from `fired` to `pending`, clearing `firedAt` and `conversationId`
- [ ] Verify that a failed `processMessage` call in the scheduler triggers requeue
- [ ] Verify the reminder is picked up again on the next scheduler tick
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
