### PR TITLE
fix: keep reminders pending until execution succeeds

### DIFF
--- a/assistant/src/__tests__/reminder-store.test.ts
+++ b/assistant/src/__tests__/reminder-store.test.ts
@@ -8,6 +8,8 @@ import {
   listReminders,
   cancelReminder,
   claimDueReminders,
+  completeReminder,
+  failReminder,
   setReminderConversationId,
 } from '../tools/reminder/reminder-store.js';
 
@@ -121,7 +123,7 @@ describe('reminder-store', () => {
     const claimed = claimDueReminders(now);
     expect(claimed).toHaveLength(1);
     expect(claimed[0].label).toBe('Past');
-    expect(claimed[0].status).toBe('fired');
+    expect(claimed[0].status).toBe('firing');
     expect(claimed[0].firedAt).toBe(now);
   });
 
@@ -157,6 +159,49 @@ describe('reminder-store', () => {
 
     expect(first).toHaveLength(1);
     expect(second).toHaveLength(0);
+  });
+
+  // ── completeReminder ─────────────────────────────────────────────
+
+  test('completeReminder transitions firing to fired', () => {
+    const now = Date.now();
+    const r = insertReminder({ label: 'Complete me', message: 'x', fireAt: now - 1000, mode: 'notify' });
+
+    claimDueReminders(now);
+    expect(getReminder(r.id)!.status).toBe('firing');
+
+    completeReminder(r.id);
+    expect(getReminder(r.id)!.status).toBe('fired');
+  });
+
+  // ── failReminder ────────────────────────────────────────────────
+
+  test('failReminder reverts firing back to pending', () => {
+    const now = Date.now();
+    const r = insertReminder({ label: 'Fail me', message: 'x', fireAt: now - 1000, mode: 'execute' });
+
+    claimDueReminders(now);
+    expect(getReminder(r.id)!.status).toBe('firing');
+
+    failReminder(r.id);
+
+    const fetched = getReminder(r.id)!;
+    expect(fetched.status).toBe('pending');
+    expect(fetched.firedAt).toBeNull();
+  });
+
+  test('failReminder allows the reminder to be reclaimed', () => {
+    const now = Date.now();
+    const r = insertReminder({ label: 'Retry me', message: 'x', fireAt: now - 1000, mode: 'execute' });
+
+    // Claim, then fail
+    claimDueReminders(now);
+    failReminder(r.id);
+
+    // Should be claimable again
+    const reclaimed = claimDueReminders(now);
+    expect(reclaimed).toHaveLength(1);
+    expect(reclaimed[0].id).toBe(r.id);
   });
 
   // ── setReminderConversationId ──────────────────────────────────────

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -225,7 +225,7 @@ export const reminders = sqliteTable('reminders', {
   message: text('message').notNull(),
   fireAt: integer('fire_at').notNull(),           // epoch ms, absolute timestamp
   mode: text('mode').notNull(),                   // 'notify' | 'execute'
-  status: text('status').notNull(),               // 'pending' | 'fired' | 'cancelled'
+  status: text('status').notNull(),               // 'pending' | 'firing' | 'fired' | 'cancelled'
   firedAt: integer('fired_at'),
   conversationId: text('conversation_id'),
   createdAt: integer('created_at').notNull(),

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -5,7 +5,7 @@ import {
   createScheduleRun,
   completeScheduleRun,
 } from './schedule-store.js';
-import { claimDueReminders, setReminderConversationId } from '../tools/reminder/reminder-store.js';
+import { claimDueReminders, completeReminder, failReminder, setReminderConversationId } from '../tools/reminder/reminder-store.js';
 
 const log = getLogger('scheduler');
 
@@ -91,12 +91,15 @@ async function runScheduleOnce(
       try {
         log.info({ reminderId: reminder.id, label: reminder.label, conversationId: conversation.id }, 'Executing reminder');
         await processMessage(conversation.id, reminder.message);
+        completeReminder(reminder.id);
       } catch (err) {
-        log.warn({ err, reminderId: reminder.id }, 'Reminder execution failed');
+        log.warn({ err, reminderId: reminder.id }, 'Reminder execution failed, reverting to pending');
+        failReminder(reminder.id);
       }
     } else {
       log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
       notifyReminder({ id: reminder.id, label: reminder.label, message: reminder.message });
+      completeReminder(reminder.id);
     }
     processed += 1;
   }

--- a/assistant/src/tools/reminder/reminder-store.ts
+++ b/assistant/src/tools/reminder/reminder-store.ts
@@ -9,7 +9,7 @@ export interface ReminderRow {
   message: string;
   fireAt: number;
   mode: 'notify' | 'execute';
-  status: 'pending' | 'fired' | 'cancelled';
+  status: 'pending' | 'firing' | 'fired' | 'cancelled';
   firedAt: number | null;
   conversationId: string | null;
   createdAt: number;
@@ -73,8 +73,9 @@ export function cancelReminder(id: string): boolean {
 
 /**
  * Claim all pending reminders where fire_at <= now.
- * Uses optimistic locking: UPDATE ... SET status='fired' WHERE status='pending' AND id=?
- * Same pattern as claimDueSchedules in schedule-store.ts.
+ * Transitions to 'firing' (not 'fired') so the reminder stays recoverable
+ * if execution fails. Call completeReminder() after successful delivery
+ * to move to the terminal 'fired' state.
  */
 export function claimDueReminders(now: number): ReminderRow[] {
   const db = getDb();
@@ -89,7 +90,7 @@ export function claimDueReminders(now: number): ReminderRow[] {
   for (const row of candidates) {
     const result = db
       .update(reminders)
-      .set({ status: 'fired', firedAt: now, updatedAt: now })
+      .set({ status: 'firing', firedAt: now, updatedAt: now })
       .where(and(eq(reminders.id, row.id), eq(reminders.status, 'pending')))
       .run() as unknown as { changes?: number };
 
@@ -97,12 +98,30 @@ export function claimDueReminders(now: number): ReminderRow[] {
 
     claimed.push(parseRow({
       ...row,
-      status: 'fired',
+      status: 'firing',
       firedAt: now,
       updatedAt: now,
     }));
   }
   return claimed;
+}
+
+/** Mark a claimed reminder as successfully delivered. */
+export function completeReminder(id: string): void {
+  const db = getDb();
+  db.update(reminders)
+    .set({ status: 'fired', updatedAt: Date.now() })
+    .where(and(eq(reminders.id, id), eq(reminders.status, 'firing')))
+    .run();
+}
+
+/** Revert a claimed reminder back to pending so it can be retried. */
+export function failReminder(id: string): void {
+  const db = getDb();
+  db.update(reminders)
+    .set({ status: 'pending', firedAt: null, updatedAt: Date.now() })
+    .where(and(eq(reminders.id, id), eq(reminders.status, 'firing')))
+    .run();
 }
 
 export function setReminderConversationId(id: string, conversationId: string): void {

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -73,7 +73,9 @@ function listAction(): ToolExecutionResult {
   const lines = all.map((r) => {
     const status = r.status === 'fired'
       ? `fired at ${formatLocalDate(r.firedAt!)}`
-      : r.status;
+      : r.status === 'firing'
+        ? 'firing'
+        : r.status;
     return `  - [${r.id}] "${r.label}" — ${formatLocalDate(r.fireAt)} (${r.mode}, ${status})`;
   });
 


### PR DESCRIPTION
## Summary
- Adds a `firing` intermediate state to reminders so they are not permanently marked as `fired` at claim time
- On successful delivery/execution, `completeReminder()` transitions `firing` -> `fired`
- On failure, `failReminder()` reverts `firing` -> `pending` so the reminder is retried on the next scheduler tick
- Addresses Codex review feedback from PR #2738: reminders were permanently lost if execution failed between claim and delivery

## Test plan
- [x] All 31 existing + new reminder tests pass
- [x] New tests for `completeReminder` (firing -> fired) and `failReminder` (firing -> pending, allows reclaim)
- [x] Type-check passes (pre-existing errors in unrelated file only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
