### PR TITLE
fix: skip side-panel width clamp in fullscreen generated workspace

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -392,7 +392,8 @@ struct MainWindowView: View {
                         let deltaX = value.location.x - value.startLocation.x
                         let newWidth = initialWidth + Double(deltaX)
                         let minMainContent: CGFloat = 300
-                        let activePanelWidth: CGFloat = windowState.activePanel != nil ? sidePanelWidth : 0
+                        let sidePanelVisible = windowState.activePanel != nil && !(windowState.isDynamicExpanded && windowState.activePanel == .generated)
+                        let activePanelWidth: CGFloat = sidePanelVisible ? sidePanelWidth : 0
                         let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.xs - (VSpacing.xs * 2) - activePanelWidth
 
                         // Update width without animation to prevent jitter


### PR DESCRIPTION
## Summary

- When `isDynamicExpanded && activePanel == .generated`, the view renders a full-window dynamic workspace instead of a `VSplitView` with a side panel
- The drawer drag clamp was checking `activePanel != nil` to subtract `sidePanelWidth` (400pt), which incorrectly applied to the `.generated` panel state
- Added a `sidePanelVisible` check that excludes the fullscreen generated workspace case, so the drawer max width is no longer artificially reduced by ~400pt

Addresses feedback from Codex and Devin on #2748.

## Test plan

- [ ] Open a dynamic workspace (`.generated` panel expanded) and verify the thread drawer can be dragged to full available width
- [ ] Open a regular side panel (e.g. debug panel) and verify the drawer still correctly reserves space for it
- [ ] Toggle between generated workspace and normal panel states while drawer is open
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
