### PR TITLE
fix: enforce domain policy in serverUse and restore publish handler error handling

### DIFF
--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -173,4 +173,44 @@ describe('CredentialBroker.serverUse', () => {
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain('test-vercel-token');
   });
+
+  test('denies when credential has domain restrictions', async () => {
+    upsertCredentialMetadata('vercel', 'api_token', {
+      allowedTools: ['publish_page'],
+      allowedDomains: ['vercel.com'],
+    });
+    setSecureKey('credential:vercel:api_token', 'test-vercel-token');
+
+    const result = await broker.serverUse({
+      service: 'vercel',
+      field: 'api_token',
+      toolName: 'publish_page',
+      execute: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('domain restrictions');
+    expect(result.reason).toContain('vercel.com');
+  });
+
+  test('allows when credential has no domain restrictions', async () => {
+    upsertCredentialMetadata('vercel', 'api_token', {
+      allowedTools: ['publish_page'],
+      allowedDomains: [],
+    });
+    setSecureKey('credential:vercel:api_token', 'test-vercel-token');
+
+    const result = await broker.serverUse({
+      service: 'vercel',
+      field: 'api_token',
+      toolName: 'publish_page',
+      execute: async (token) => {
+        expect(token).toBe('test-vercel-token');
+        return { ok: true };
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ ok: true });
+  });
 });

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -2103,58 +2103,68 @@ async function handlePublishPage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  // Hash the HTML for dedup — can be done before credential check
-  const htmlHash = createHash('sha256').update(msg.html).digest('hex');
+  try {
+    // Hash the HTML for dedup — can be done before credential check
+    const htmlHash = createHash('sha256').update(msg.html).digest('hex');
 
-  // Check if already published (no credential needed)
-  const existing = getPublishedPageByHash(htmlHash);
-  if (existing) {
-    ctx.send(socket, {
-      type: 'publish_page_response',
-      success: true,
-      publicUrl: existing.publicUrl,
-      deploymentId: existing.deploymentId,
-    });
-    return;
-  }
-
-  const useResult = await credentialBroker.serverUse({
-    service: 'vercel',
-    field: 'api_token',
-    toolName: 'publish_page',
-    execute: async (token) => {
-      const name = msg.title
-        ? msg.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50)
-        : `vellum-page-${Date.now()}`;
-
-      const result = await deployHtmlToVercel({ html: msg.html, name, token });
-
-      const id = uuid();
-      createPublishedPage({
-        id,
-        deploymentId: result.deploymentId,
-        publicUrl: result.url,
-        pageTitle: msg.title,
-        htmlHash,
+    // Check if already published (no credential needed)
+    const existing = getPublishedPageByHash(htmlHash);
+    if (existing) {
+      ctx.send(socket, {
+        type: 'publish_page_response',
+        success: true,
+        publicUrl: existing.publicUrl,
+        deploymentId: existing.deploymentId,
       });
+      return;
+    }
 
-      return { url: result.url, deploymentId: result.deploymentId };
-    },
-  });
+    const useResult = await credentialBroker.serverUse({
+      service: 'vercel',
+      field: 'api_token',
+      toolName: 'publish_page',
+      execute: async (token) => {
+        const name = msg.title
+          ? msg.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50)
+          : `vellum-page-${Date.now()}`;
 
-  if (useResult.success && useResult.result) {
-    ctx.send(socket, {
-      type: 'publish_page_response',
-      success: true,
-      publicUrl: useResult.result.url,
-      deploymentId: useResult.result.deploymentId,
+        const result = await deployHtmlToVercel({ html: msg.html, name, token });
+
+        const id = uuid();
+        createPublishedPage({
+          id,
+          deploymentId: result.deploymentId,
+          publicUrl: result.url,
+          pageTitle: msg.title,
+          htmlHash,
+        });
+
+        return { url: result.url, deploymentId: result.deploymentId };
+      },
     });
-  } else {
-    log.error({ reason: useResult.reason }, 'Failed to publish page');
+
+    if (useResult.success && useResult.result) {
+      ctx.send(socket, {
+        type: 'publish_page_response',
+        success: true,
+        publicUrl: useResult.result.url,
+        deploymentId: useResult.result.deploymentId,
+      });
+    } else {
+      log.error({ reason: useResult.reason }, 'Failed to publish page');
+      ctx.send(socket, {
+        type: 'publish_page_response',
+        success: false,
+        error: useResult.reason ?? 'Failed to publish page',
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to publish page');
     ctx.send(socket, {
       type: 'publish_page_response',
       success: false,
-      error: useResult.reason ?? 'Failed to publish page',
+      error: message,
     });
   }
 }
@@ -2164,31 +2174,41 @@ async function handleUnpublishPage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const useResult = await credentialBroker.serverUse({
-    service: 'vercel',
-    field: 'api_token',
-    toolName: 'unpublish_page',
-    execute: async (token) => {
-      await deleteVercelDeployment(msg.deploymentId, token);
+  try {
+    const useResult = await credentialBroker.serverUse({
+      service: 'vercel',
+      field: 'api_token',
+      toolName: 'unpublish_page',
+      execute: async (token) => {
+        await deleteVercelDeployment(msg.deploymentId, token);
 
-      const record = getPublishedPageByDeploymentId(msg.deploymentId);
-      if (record) {
-        markDeleted(record.id);
-      }
-    },
-  });
-
-  if (useResult.success) {
-    ctx.send(socket, {
-      type: 'unpublish_page_response',
-      success: true,
+        const record = getPublishedPageByDeploymentId(msg.deploymentId);
+        if (record) {
+          markDeleted(record.id);
+        }
+      },
     });
-  } else {
-    log.error({ reason: useResult.reason, deploymentId: msg.deploymentId }, 'Failed to unpublish page');
+
+    if (useResult.success) {
+      ctx.send(socket, {
+        type: 'unpublish_page_response',
+        success: true,
+      });
+    } else {
+      log.error({ reason: useResult.reason, deploymentId: msg.deploymentId }, 'Failed to unpublish page');
+      ctx.send(socket, {
+        type: 'unpublish_page_response',
+        success: false,
+        error: useResult.reason ?? 'Failed to unpublish page',
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, deploymentId: msg.deploymentId }, 'Failed to unpublish page');
     ctx.send(socket, {
       type: 'unpublish_page_response',
       success: false,
-      error: useResult.reason ?? 'Failed to unpublish page',
+      error: message,
     });
   }
 }

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -238,6 +238,17 @@ export class CredentialBroker {
       };
     }
 
+    // Domain policy enforcement — credentials with domain restrictions are
+    // scoped to browser use on those domains and cannot be used server-side.
+    if (metadata.allowedDomains.length > 0) {
+      return {
+        success: false,
+        reason: `Credential ${request.service}/${request.field} has domain restrictions ` +
+          `(${metadata.allowedDomains.join(', ')}) and cannot be used server-side. ` +
+          'Remove domain restrictions or use a separate credential without domain policy.',
+      };
+    }
+
     const storageKey = `credential:${request.service}:${request.field}`;
     const transient = this.transientValues.get(storageKey);
     const value = transient ?? getSecureKey(storageKey);


### PR DESCRIPTION
Addresses feedback on PR #2847.

## Changes

1. **P1 — Domain policy enforcement in `serverUse`**: Credentials with `allowed_domains` are now rejected by `serverUse`. These credentials are scoped to browser use on specific domains and cannot be domain-verified server-side. Callers get a clear error with guidance to use a separate credential without domain restrictions.

2. **P2 — Restore try/catch in publish handlers**: `handlePublishPage` and `handleUnpublishPage` now wrap their entire bodies in try/catch, matching the pre-broker pattern. This ensures that exceptions from pre-broker code (e.g. `createHash`, `getPublishedPageByHash`, DB errors) are caught and an error response is sent to the client instead of producing an unhandled rejection that leaves the client hanging.

3. **Tests**: Added two tests for domain policy enforcement in `serverUse` — one verifying rejection with domain restrictions, one verifying allowance without.

## Files modified
- `assistant/src/tools/credentials/broker.ts` — domain policy check in `serverUse`
- `assistant/src/daemon/handlers.ts` — try/catch in `handlePublishPage` and `handleUnpublishPage`
- `assistant/src/__tests__/credential-broker-server-use.test.ts` — domain policy tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
