### PR TITLE
fix: correct tool_result content type in workspace injection tests

### DIFF
--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -266,7 +266,7 @@ describe('Session workspace dirty-refresh E2E', () => {
     // Simulate a turn where the agent uses file_edit
     agentLoopScript = (onEvent) => {
       onEvent({ type: 'tool_use', id: 'tu-1', name: 'file_edit', input: {} });
-      onEvent({ type: 'tool_result', toolUseId: 'tu-1', content: [{ type: 'text', text: 'done' }], isError: false });
+      onEvent({ type: 'tool_result', toolUseId: 'tu-1', content: 'done', isError: false });
     };
     await session.processMessage('Edit a file', [], () => {});
 
@@ -290,7 +290,7 @@ describe('Session workspace dirty-refresh E2E', () => {
 
     agentLoopScript = (onEvent) => {
       onEvent({ type: 'tool_use', id: 'tu-2', name: 'bash', input: {} });
-      onEvent({ type: 'tool_result', toolUseId: 'tu-2', content: [{ type: 'text', text: 'ok' }], isError: false });
+      onEvent({ type: 'tool_result', toolUseId: 'tu-2', content: 'ok', isError: false });
     };
     await session.processMessage('Run a command', [], () => {});
 
@@ -314,7 +314,7 @@ describe('Session workspace dirty-refresh E2E', () => {
 
     agentLoopScript = (onEvent) => {
       onEvent({ type: 'tool_use', id: 'tu-3', name: 'file_edit', input: {} });
-      onEvent({ type: 'tool_result', toolUseId: 'tu-3', content: [{ type: 'text', text: 'error' }], isError: true });
+      onEvent({ type: 'tool_result', toolUseId: 'tu-3', content: 'error', isError: true });
     };
     await session.processMessage('Try editing', [], () => {});
 


### PR DESCRIPTION
## Summary
- Fix 3 TypeScript errors in `session-workspace-injection.test.ts` where `tool_result` event `content` was passed as `[{ type, text }]` array instead of plain `string` as required by the `AgentEvent` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
