### PR TITLE
fix: guard find pipelines in build.sh watch loop against missing paths

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -364,7 +364,7 @@ if [ "$CMD" = "run" ]; then
                 -not -path '*/.build/*' \
                 -not -path '*/dist/*' \
                 \( -name "*.swift" -o -name "*.xcassets" -o -path "*.xcassets/*" \) \
-                2>/dev/null | sort > "$WATCH_MANIFEST"
+                2>/dev/null | sort > "$WATCH_MANIFEST" || true
         }
         snapshot_watched_files
 
@@ -390,7 +390,7 @@ if [ "$CMD" = "run" ]; then
                     -not -path '*/.build/*' \
                     -not -path '*/dist/*' \
                     \( -name "*.swift" -o -name "*.xcassets" -o -path "*.xcassets/*" \) \
-                    2>/dev/null | sort > "$CURRENT_MANIFEST"
+                    2>/dev/null | sort > "$CURRENT_MANIFEST" || true
                 if ! diff -q "$WATCH_MANIFEST" "$CURRENT_MANIFEST" > /dev/null 2>&1; then
                     CHANGED="(file added or removed)"
                 fi


### PR DESCRIPTION
## Summary

- Adds `|| true` guards to two `find` pipelines in the build.sh file watcher that were missing them, preventing the watch loop from crashing under `set -euo pipefail` when a watched path is temporarily inaccessible (e.g. during `git rebase` or `git checkout`).

Addresses review feedback from Codex (P2) and Devin on PR #2750.

## Test plan

- [x] Verified `|| true` is appended after both `sort` redirections (snapshot and deletion-detection pipelines)
- [x] Confirmed the existing modification-detection `find` already had its guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
