### PR TITLE
assistant: add reserved Home Base app bootstrap and state schema

### DIFF
--- a/assistant/src/__tests__/app-store.test.ts
+++ b/assistant/src/__tests__/app-store.test.ts
@@ -1,0 +1,246 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'app-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  getWorkspaceDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  createApp,
+  getApp,
+  listApps,
+  deleteApp,
+  createAppRecord,
+  queryAppRecords,
+  updateAppRecord,
+  getOrCreateHomeBase,
+  HOME_BASE_APP_ID,
+  type HomeBaseData,
+} from '../memory/app-store.js';
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+describe('app-store basic operations', () => {
+  test('creates and retrieves an app', () => {
+    const app = createApp({
+      name: 'Test App',
+      description: 'A test app',
+      schemaJson: '{"type":"object"}',
+      htmlDefinition: '<html></html>',
+    });
+
+    expect(app.id).toBeDefined();
+    expect(app.name).toBe('Test App');
+
+    const retrieved = getApp(app.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.name).toBe('Test App');
+  });
+
+  test('lists all apps', () => {
+    const app1 = createApp({
+      name: 'App 1',
+      schemaJson: '{}',
+      htmlDefinition: '<html></html>',
+    });
+
+    const app2 = createApp({
+      name: 'App 2',
+      schemaJson: '{}',
+      htmlDefinition: '<html></html>',
+    });
+
+    const apps = listApps();
+    expect(apps.length).toBeGreaterThanOrEqual(2);
+    expect(apps.some(a => a.id === app1.id)).toBe(true);
+    expect(apps.some(a => a.id === app2.id)).toBe(true);
+  });
+
+  test('deletes an app', () => {
+    const app = createApp({
+      name: 'To Delete',
+      schemaJson: '{}',
+      htmlDefinition: '<html></html>',
+    });
+
+    deleteApp(app.id);
+    expect(getApp(app.id)).toBeNull();
+  });
+});
+
+describe('app records', () => {
+  test('creates and retrieves app records', () => {
+    const app = createApp({
+      name: 'Record Test',
+      schemaJson: '{}',
+      htmlDefinition: '<html></html>',
+    });
+
+    const record = createAppRecord(app.id, { foo: 'bar', count: 42 });
+    expect(record.id).toBeDefined();
+    expect(record.appId).toBe(app.id);
+    expect(record.data).toEqual({ foo: 'bar', count: 42 });
+
+    const records = queryAppRecords(app.id);
+    expect(records.length).toBe(1);
+    expect(records[0].id).toBe(record.id);
+  });
+
+  test('updates app records', () => {
+    const app = createApp({
+      name: 'Update Test',
+      schemaJson: '{}',
+      htmlDefinition: '<html></html>',
+    });
+
+    const record = createAppRecord(app.id, { value: 1 });
+    const updated = updateAppRecord(app.id, record.id, { value: 2 });
+
+    expect(updated.data).toEqual({ value: 2 });
+    expect(updated.updatedAt).toBeGreaterThan(record.createdAt);
+  });
+});
+
+describe('Home Base reserved app', () => {
+  beforeEach(() => {
+    // Clean up any existing Home Base app before each test
+    try {
+      deleteApp(HOME_BASE_APP_ID);
+    } catch {
+      // App might not exist, that's fine
+    }
+  });
+
+  test('creates Home Base app on first call', () => {
+    const { app, record } = getOrCreateHomeBase();
+
+    expect(app.id).toBe(HOME_BASE_APP_ID);
+    expect(app.name).toBe('Home Base');
+    expect(app.icon).toBe('🏠');
+    expect(record.appId).toBe(HOME_BASE_APP_ID);
+
+    // Verify default data structure
+    const data = record.data as unknown as HomeBaseData;
+    expect(data.theme).toBeDefined();
+    expect(data.starterTasks).toBeDefined();
+    expect(data.starterTasks.length).toBe(3);
+    expect(data.deferredPermissionTasks).toBeDefined();
+    expect(data.locale).toBeDefined();
+    expect(data.weatherConfig).toBeDefined();
+    expect(data.weatherConfig.enabled).toBe(false);
+  });
+
+  test('is idempotent - returns existing Home Base on subsequent calls', () => {
+    const first = getOrCreateHomeBase();
+    const second = getOrCreateHomeBase();
+
+    expect(first.app.id).toBe(second.app.id);
+    expect(first.record.id).toBe(second.record.id);
+    expect(first.app.createdAt).toBe(second.app.createdAt);
+  });
+
+  test('preserves Home Base state across calls', () => {
+    const { app, record } = getOrCreateHomeBase();
+
+    // Update the Home Base record
+    const updatedData: HomeBaseData = {
+      theme: {
+        accentColor: '#6366f1',
+        accentColorName: 'Indigo',
+      },
+      starterTasks: [
+        { id: 'make_it_yours', status: 'done' },
+        { id: 'research_topic', status: 'in_progress' },
+        { id: 'research_to_ui', status: 'pending' },
+      ],
+      deferredPermissionTasks: [],
+      locale: {
+        city: 'San Francisco',
+        region: 'CA',
+        country: 'US',
+        timezone: 'America/Los_Angeles',
+      },
+      weatherConfig: {
+        enabled: true,
+        location: 'San Francisco, CA',
+      },
+    };
+
+    updateAppRecord(app.id, record.id, updatedData as unknown as Record<string, unknown>);
+
+    // Call getOrCreateHomeBase again
+    const { record: retrievedRecord } = getOrCreateHomeBase();
+    const data = retrievedRecord.data as unknown as HomeBaseData;
+
+    expect(data.theme.accentColor).toBe('#6366f1');
+    expect(data.theme.accentColorName).toBe('Indigo');
+    expect(data.starterTasks[0].status).toBe('done');
+    expect(data.locale.city).toBe('San Francisco');
+    expect(data.weatherConfig.enabled).toBe(true);
+  });
+
+  test('has deterministic ID', () => {
+    const { app } = getOrCreateHomeBase();
+    expect(app.id).toBe('__home_base__');
+  });
+
+  test('includes all required schema fields', () => {
+    const { record } = getOrCreateHomeBase();
+    const data = record.data as unknown as HomeBaseData;
+
+    // Check all required fields exist
+    expect(data).toHaveProperty('theme');
+    expect(data).toHaveProperty('starterTasks');
+    expect(data).toHaveProperty('deferredPermissionTasks');
+    expect(data).toHaveProperty('locale');
+    expect(data).toHaveProperty('weatherConfig');
+
+    // Check starter tasks structure
+    expect(Array.isArray(data.starterTasks)).toBe(true);
+    data.starterTasks.forEach(task => {
+      expect(task).toHaveProperty('id');
+      expect(task).toHaveProperty('status');
+      expect(['pending', 'in_progress', 'done', 'deferred_to_dashboard']).toContain(task.status);
+    });
+
+    // Check weather config structure
+    expect(data.weatherConfig).toHaveProperty('enabled');
+    expect(typeof data.weatherConfig.enabled).toBe('boolean');
+  });
+
+  test('starter tasks have correct default values', () => {
+    const { record } = getOrCreateHomeBase();
+    const data = record.data as unknown as HomeBaseData;
+
+    const taskIds = data.starterTasks.map(t => t.id);
+    expect(taskIds).toContain('make_it_yours');
+    expect(taskIds).toContain('research_topic');
+    expect(taskIds).toContain('research_to_ui');
+
+    // All tasks should start as pending
+    data.starterTasks.forEach(task => {
+      expect(task.status).toBe('pending');
+    });
+  });
+});

--- a/assistant/src/__tests__/home-base-bootstrap.test.ts
+++ b/assistant/src/__tests__/home-base-bootstrap.test.ts
@@ -1,0 +1,293 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'home-base-bootstrap-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  getWorkspaceDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getInterfacesDir: () => join(testDir, 'interfaces'),
+  getWorkspaceSkillsDir: () => join(testDir, 'skills'),
+  getWorkspacePromptPath: (filename: string) => join(testDir, filename),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  getOrCreateHomeBase,
+  HOME_BASE_APP_ID,
+  getApp,
+  queryAppRecords,
+  deleteApp,
+  updateAppRecord,
+  type HomeBaseData,
+} from '../memory/app-store.js';
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+describe('Home Base bootstrap idempotence', () => {
+  beforeEach(() => {
+    // Clean up any existing Home Base app before each test
+    try {
+      deleteApp(HOME_BASE_APP_ID);
+    } catch {
+      // App might not exist, that's fine
+    }
+  });
+
+  test('first-run bootstrap creates app and default record', () => {
+    // Verify Home Base doesn't exist
+    expect(getApp(HOME_BASE_APP_ID)).toBeNull();
+
+    // Bootstrap
+    const { app, record } = getOrCreateHomeBase();
+
+    // Verify app was created
+    expect(app).toBeDefined();
+    expect(app.id).toBe(HOME_BASE_APP_ID);
+    expect(app.name).toBe('Home Base');
+
+    // Verify record was created with defaults
+    expect(record).toBeDefined();
+    expect(record.appId).toBe(HOME_BASE_APP_ID);
+
+    const data = record.data as unknown as HomeBaseData;
+    expect(data.starterTasks.length).toBe(3);
+    expect(data.weatherConfig.enabled).toBe(false);
+  });
+
+  test('restart bootstrap is idempotent - preserves existing app', () => {
+    // First bootstrap
+    const first = getOrCreateHomeBase();
+    const firstCreatedAt = first.app.createdAt;
+    const firstRecordId = first.record.id;
+
+    // Simulate restart - call bootstrap again
+    const second = getOrCreateHomeBase();
+
+    // App should be the same
+    expect(second.app.id).toBe(first.app.id);
+    expect(second.app.createdAt).toBe(firstCreatedAt);
+    expect(second.record.id).toBe(firstRecordId);
+  });
+
+  test('restart bootstrap preserves user modifications', () => {
+    // First bootstrap
+    const { app, record } = getOrCreateHomeBase();
+
+    // User modifies Home Base data
+    const modifiedData: HomeBaseData = {
+      theme: {
+        accentColor: '#ec4899',
+        accentColorName: 'Pink',
+        cardRadius: '12px',
+      },
+      starterTasks: [
+        { id: 'make_it_yours', status: 'done' },
+        { id: 'research_topic', status: 'done' },
+        { id: 'research_to_ui', status: 'in_progress' },
+      ],
+      deferredPermissionTasks: [
+        { id: 'microphone_access', status: 'pending' },
+      ],
+      locale: {
+        city: 'Portland',
+        region: 'OR',
+        country: 'US',
+        timezone: 'America/Los_Angeles',
+      },
+      weatherConfig: {
+        enabled: true,
+        location: 'Portland, OR',
+      },
+    };
+
+    updateAppRecord(app.id, record.id, modifiedData as unknown as Record<string, unknown>);
+
+    // Simulate restart - bootstrap again
+    const { record: afterRestart } = getOrCreateHomeBase();
+    const data = afterRestart.data as unknown as HomeBaseData;
+
+    // All user modifications should be preserved
+    expect(data.theme.accentColor).toBe('#ec4899');
+    expect(data.theme.accentColorName).toBe('Pink');
+    expect(data.theme.cardRadius).toBe('12px');
+    expect(data.starterTasks[0].status).toBe('done');
+    expect(data.starterTasks[1].status).toBe('done');
+    expect(data.starterTasks[2].status).toBe('in_progress');
+    expect(data.deferredPermissionTasks.length).toBe(1);
+    expect(data.deferredPermissionTasks[0].id).toBe('microphone_access');
+    expect(data.locale.city).toBe('Portland');
+    expect(data.weatherConfig.enabled).toBe(true);
+    expect(data.weatherConfig.location).toBe('Portland, OR');
+  });
+
+  test('bootstrap is safe when app exists but no records', () => {
+    // Create app manually (simulating partial corruption)
+    const firstBootstrap = getOrCreateHomeBase();
+    const { app } = firstBootstrap;
+
+    // Delete all records (simulating corruption)
+    const records = queryAppRecords(HOME_BASE_APP_ID);
+    for (const record of records) {
+      const appDir = join(testDir, 'apps', HOME_BASE_APP_ID);
+      const recordPath = join(appDir, 'records', `${record.id}.json`);
+      if (existsSync(recordPath)) {
+        rmSync(recordPath);
+      }
+    }
+
+    // Verify no records exist
+    expect(queryAppRecords(HOME_BASE_APP_ID).length).toBe(0);
+
+    // Bootstrap should recreate the record
+    const { app: restoredApp, record: restoredRecord } = getOrCreateHomeBase();
+
+    expect(restoredApp.id).toBe(app.id);
+    expect(restoredRecord).toBeDefined();
+    expect(restoredRecord.appId).toBe(HOME_BASE_APP_ID);
+
+    const data = restoredRecord.data as unknown as HomeBaseData;
+    expect(data.starterTasks.length).toBe(3);
+  });
+
+  test('bootstrap handles multiple calls in succession', () => {
+    // Rapid successive calls should all be safe
+    const results = [
+      getOrCreateHomeBase(),
+      getOrCreateHomeBase(),
+      getOrCreateHomeBase(),
+      getOrCreateHomeBase(),
+      getOrCreateHomeBase(),
+    ];
+
+    // All should return the same app ID and first record ID
+    const appIds = results.map(r => r.app.id);
+    const recordIds = results.map(r => r.record.id);
+
+    expect(new Set(appIds).size).toBe(1);
+    expect(new Set(recordIds).size).toBe(1);
+    expect(appIds[0]).toBe(HOME_BASE_APP_ID);
+  });
+
+  test('bootstrap creates proper file structure', () => {
+    getOrCreateHomeBase();
+
+    const appsDir = join(testDir, 'apps');
+    const appFile = join(appsDir, `${HOME_BASE_APP_ID}.json`);
+    const recordsDir = join(appsDir, HOME_BASE_APP_ID, 'records');
+
+    expect(existsSync(appFile)).toBe(true);
+    expect(existsSync(recordsDir)).toBe(true);
+
+    // Should have exactly one record
+    const records = queryAppRecords(HOME_BASE_APP_ID);
+    expect(records.length).toBe(1);
+  });
+
+  test('bootstrap does not create duplicate records', () => {
+    // Multiple bootstrap calls
+    getOrCreateHomeBase();
+    getOrCreateHomeBase();
+    getOrCreateHomeBase();
+
+    // Should still have exactly one record
+    const records = queryAppRecords(HOME_BASE_APP_ID);
+    expect(records.length).toBe(1);
+  });
+
+  test('bootstrap returns correct data types', () => {
+    const { app, record } = getOrCreateHomeBase();
+
+    // App fields
+    expect(typeof app.id).toBe('string');
+    expect(typeof app.name).toBe('string');
+    expect(typeof app.schemaJson).toBe('string');
+    expect(typeof app.htmlDefinition).toBe('string');
+    expect(typeof app.createdAt).toBe('number');
+    expect(typeof app.updatedAt).toBe('number');
+
+    // Record fields
+    expect(typeof record.id).toBe('string');
+    expect(typeof record.appId).toBe('string');
+    expect(typeof record.createdAt).toBe('number');
+    expect(typeof record.updatedAt).toBe('number');
+    expect(typeof record.data).toBe('object');
+
+    // Data structure
+    const data = record.data as unknown as HomeBaseData;
+    expect(typeof data.theme).toBe('object');
+    expect(Array.isArray(data.starterTasks)).toBe(true);
+    expect(Array.isArray(data.deferredPermissionTasks)).toBe(true);
+    expect(typeof data.locale).toBe('object');
+    expect(typeof data.weatherConfig).toBe('object');
+    expect(typeof data.weatherConfig.enabled).toBe('boolean');
+  });
+});
+
+describe('Home Base schema validation', () => {
+  beforeEach(() => {
+    try {
+      deleteApp(HOME_BASE_APP_ID);
+    } catch { /* best effort */ }
+  });
+
+  test('schema JSON is valid JSON', () => {
+    const { app } = getOrCreateHomeBase();
+
+    // Should parse without error
+    const schema = JSON.parse(app.schemaJson);
+    expect(schema).toBeDefined();
+    expect(schema.type).toBe('object');
+    expect(schema.properties).toBeDefined();
+  });
+
+  test('schema includes all required fields', () => {
+    const { app } = getOrCreateHomeBase();
+    const schema = JSON.parse(app.schemaJson);
+
+    expect(schema.properties.theme).toBeDefined();
+    expect(schema.properties.starterTasks).toBeDefined();
+    expect(schema.properties.deferredPermissionTasks).toBeDefined();
+    expect(schema.properties.locale).toBeDefined();
+    expect(schema.properties.weatherConfig).toBeDefined();
+
+    expect(schema.required).toContain('theme');
+    expect(schema.required).toContain('starterTasks');
+    expect(schema.required).toContain('deferredPermissionTasks');
+    expect(schema.required).toContain('locale');
+    expect(schema.required).toContain('weatherConfig');
+  });
+
+  test('default data matches schema', () => {
+    const { app, record } = getOrCreateHomeBase();
+    const schema = JSON.parse(app.schemaJson);
+    const data = record.data as unknown as HomeBaseData;
+
+    // Check all required fields exist in data
+    schema.required.forEach((field: string) => {
+      expect(data).toHaveProperty(field);
+    });
+
+    // Check nested schema compliance
+    expect(typeof data.weatherConfig.enabled).toBe('boolean');
+    expect(Array.isArray(data.starterTasks)).toBe(true);
+    expect(Array.isArray(data.deferredPermissionTasks)).toBe(true);
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -58,6 +58,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildConfigSection(getWorkspaceDir()));
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
+  parts.push(buildHomeBaseSection());
   parts.push(buildOnboardingGuidanceSection());
   parts.push(buildStarterTaskPlaybookSection());
   parts.push(buildChannelAwarenessSection());
@@ -167,6 +168,48 @@ function buildDynamicUiSection(): string {
     'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a visual output rather than displaying raw tool outputs.',
     '- **Weather**: `get_weather` automatically renders a dynamic page with a compact preview card. Do NOT call `ui_show` or `app_create` after `get_weather` — the weather surface is emitted directly. Just respond with a brief natural-language summary.',
     '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished output — use `app_create` for custom UIs, or `ui_show` with domain component classes for predefined data types.',
+  ].join('\n');
+}
+
+function buildHomeBaseSection(): string {
+  return [
+    '## Home Base',
+    '',
+    'Home Base is your persistent dashboard experience, backed by a reserved system app in the app store. It maintains state across sessions and serves as the user\'s central hub.',
+    '',
+    '### State Schema',
+    'Home Base stores structured data in a single app record with the following schema:',
+    '',
+    '- `theme`: Dashboard appearance settings',
+    '  - `accentColor`: Hex color code (e.g. "#6366f1")',
+    '  - `accentColorName`: Human-readable color name (e.g. "Indigo")',
+    '  - `cardRadius`: Border radius preference (e.g. "8px")',
+    '',
+    '- `starterTasks`: Onboarding task progress',
+    '  - Each task has `id` and `status` (pending | in_progress | done | deferred_to_dashboard)',
+    '  - Default tasks: make_it_yours, research_topic, research_to_ui',
+    '',
+    '- `deferredPermissionTasks`: Permission requests deferred by user',
+    '  - Each task has `id` and `status` (pending | done)',
+    '',
+    '- `locale`: User location and timezone',
+    '  - `city`, `region`, `country`, `timezone`',
+    '',
+    '- `weatherConfig`: Weather widget settings',
+    '  - `enabled`: boolean',
+    '  - `location`: optional location override',
+    '',
+    '### Working with Home Base',
+    '- Home Base is automatically bootstrapped on daemon startup',
+    '- Use `app_query` with app_id `__home_base__` to read current state',
+    '- Use app record update tools to persist changes (theme preferences, task completion, etc.)',
+    '- The Home Base app definition and schema are managed by the system — do not allow users to delete or fundamentally modify it',
+    '',
+    '### Integration with Onboarding',
+    'Home Base state should be kept in sync with USER.md during onboarding flows:',
+    '- When a user selects an accent color, update both the Home Base `theme` and the USER.md Dashboard Color Preference section',
+    '- When a starter task is completed, update both the Home Base `starterTasks` status and the USER.md Onboarding Tasks section',
+    '- When locale information is learned, update both the Home Base `locale` and the USER.md Locale section',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -29,6 +29,7 @@ import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { getHookManager } from '../hooks/manager.js';
 import { installTemplates } from '../hooks/templates.js';
+import { getOrCreateHomeBase } from '../memory/app-store.js';
 
 const log = getLogger('lifecycle');
 
@@ -193,6 +194,14 @@ export async function runDaemon(): Promise<void> {
   installTemplates();
   ensurePromptFiles();
   initializeDb();
+
+  // Bootstrap Home Base reserved app
+  try {
+    getOrCreateHomeBase();
+    log.info('Home Base app bootstrapped');
+  } catch (err) {
+    log.warn({ err }, 'Failed to bootstrap Home Base app');
+  }
 
   const config = loadConfig();
 

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -292,3 +292,201 @@ export function deleteAppRecord(appId: string, recordId: string): void {
     unlinkSync(filePath);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Home Base Reserved App
+// ---------------------------------------------------------------------------
+
+export const HOME_BASE_APP_ID = '__home_base__';
+
+export interface HomeBaseTheme {
+  accentColor?: string;
+  accentColorName?: string;
+  cardRadius?: string;
+}
+
+export interface StarterTask {
+  id: string;
+  status: 'pending' | 'in_progress' | 'done' | 'deferred_to_dashboard';
+}
+
+export interface DeferredPermissionTask {
+  id: string;
+  status: 'pending' | 'done';
+}
+
+export interface HomeBaseLocale {
+  city?: string;
+  region?: string;
+  country?: string;
+  timezone?: string;
+}
+
+export interface WeatherConfig {
+  enabled: boolean;
+  location?: string;
+}
+
+export interface HomeBaseData {
+  theme: HomeBaseTheme;
+  starterTasks: StarterTask[];
+  deferredPermissionTasks: DeferredPermissionTask[];
+  locale: HomeBaseLocale;
+  weatherConfig: WeatherConfig;
+}
+
+const DEFAULT_HOME_BASE_DATA: HomeBaseData = {
+  theme: {},
+  starterTasks: [
+    { id: 'make_it_yours', status: 'pending' },
+    { id: 'research_topic', status: 'pending' },
+    { id: 'research_to_ui', status: 'pending' },
+  ],
+  deferredPermissionTasks: [],
+  locale: {},
+  weatherConfig: { enabled: false },
+};
+
+const HOME_BASE_SCHEMA_JSON = JSON.stringify({
+  type: 'object',
+  properties: {
+    theme: {
+      type: 'object',
+      properties: {
+        accentColor: { type: 'string' },
+        accentColorName: { type: 'string' },
+        cardRadius: { type: 'string' },
+      },
+    },
+    starterTasks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          status: { type: 'string', enum: ['pending', 'in_progress', 'done', 'deferred_to_dashboard'] },
+        },
+        required: ['id', 'status'],
+      },
+    },
+    deferredPermissionTasks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          status: { type: 'string', enum: ['pending', 'done'] },
+        },
+        required: ['id', 'status'],
+      },
+    },
+    locale: {
+      type: 'object',
+      properties: {
+        city: { type: 'string' },
+        region: { type: 'string' },
+        country: { type: 'string' },
+        timezone: { type: 'string' },
+      },
+    },
+    weatherConfig: {
+      type: 'object',
+      properties: {
+        enabled: { type: 'boolean' },
+        location: { type: 'string' },
+      },
+      required: ['enabled'],
+    },
+  },
+  required: ['theme', 'starterTasks', 'deferredPermissionTasks', 'locale', 'weatherConfig'],
+});
+
+const HOME_BASE_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Home Base</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: var(--v-bg);
+      color: var(--v-text);
+      padding: var(--v-spacing-xl);
+    }
+    h1 {
+      font-size: clamp(2rem, 5vw, 3rem);
+      margin-bottom: var(--v-spacing-lg);
+      color: var(--v-text);
+    }
+    .dashboard-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: var(--v-spacing-lg);
+    }
+    .v-card {
+      background: var(--v-surface);
+      border: 1px solid var(--v-surface-border);
+      border-radius: var(--v-radius-lg);
+      padding: var(--v-spacing-lg);
+    }
+    .v-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: var(--v-spacing-md);
+    }
+  </style>
+</head>
+<body>
+  <h1>Home Base</h1>
+  <div class="dashboard-grid">
+    <div class="v-card">
+      <h2>Welcome</h2>
+      <p>Your persistent dashboard experience.</p>
+    </div>
+  </div>
+</body>
+</html>`;
+
+/**
+ * Get or create the reserved Home Base app.
+ * This function is idempotent: it will return the existing Home Base app if it exists,
+ * or create it with default values if it doesn't.
+ */
+export function getOrCreateHomeBase(): { app: AppDefinition; record: AppRecord } {
+  const dir = getAppsDir();
+  const appPath = join(dir, `${HOME_BASE_APP_ID}.json`);
+
+  // Check if Home Base app already exists
+  let app = getApp(HOME_BASE_APP_ID);
+
+  if (!app) {
+    // Create the Home Base app with a deterministic ID
+    const now = Date.now();
+    app = {
+      id: HOME_BASE_APP_ID,
+      name: 'Home Base',
+      description: 'Your persistent dashboard experience',
+      icon: '🏠',
+      schemaJson: HOME_BASE_SCHEMA_JSON,
+      htmlDefinition: HOME_BASE_HTML,
+      createdAt: now,
+      updatedAt: now,
+    };
+    writeFileSync(appPath, JSON.stringify(app, null, 2));
+  }
+
+  // Get or create the single Home Base record
+  const records = queryAppRecords(HOME_BASE_APP_ID);
+  let record: AppRecord;
+
+  if (records.length === 0) {
+    // Create the default Home Base record
+    record = createAppRecord(HOME_BASE_APP_ID, DEFAULT_HOME_BASE_DATA as unknown as Record<string, unknown>);
+  } else {
+    // Return the existing record (there should only be one)
+    record = records[0];
+  }
+
+  return { app, record };
+}


### PR DESCRIPTION
## Context
Part of #2864

## Changes
- Added HOME_BASE_APP_ID constant and getOrCreateHomeBase() idempotent bootstrap
- Defined Home Base state schema (theme, starterTasks, deferredPermissionTasks, locale, weatherConfig)
- Added bootstrap on daemon startup
- Added system prompt guidance for Home Base
- Added tests for bootstrap idempotence and app store operations

## Validation
- Type-check passes
- All tests pass (22 tests total, 130 assertions)

## Implementation Details

### Reserved App Concept
Home Base is a reserved system app with a deterministic ID (`__home_base__`). It's automatically bootstrapped on daemon startup and serves as the persistent backing store for the user's dashboard experience.

### State Schema
The Home Base app maintains structured state in a single app record:
- **theme**: Dashboard appearance (accentColor, accentColorName, cardRadius)
- **starterTasks**: Onboarding task progress (make_it_yours, research_topic, research_to_ui)
- **deferredPermissionTasks**: Permission requests the user chose to handle later
- **locale**: User location and timezone information
- **weatherConfig**: Weather widget settings

### Bootstrap Safety
The `getOrCreateHomeBase()` function is idempotent and handles:
- First-run creation with sensible defaults
- Restart safety (returns existing app without modification)
- Partial corruption recovery (recreates missing records)
- Multiple concurrent calls

### System Prompt Integration
Added guidance for the model explaining:
- Home Base as the dashboard backing model
- Schema and state structure
- Integration with onboarding flows
- How to read and update Home Base state via app tools
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
