### PR TITLE
fix: validate hostname format instead of requiring registrable domain

### DIFF
--- a/assistant/src/__tests__/domain-policy.test.ts
+++ b/assistant/src/__tests__/domain-policy.test.ts
@@ -68,6 +68,16 @@ describe('isDomainAllowed', () => {
     expect(isDomainAllowed('localhost', ['localhost'])).toBe(false);
   });
 
+  // ── Internal / non-registrable hosts ────────────────────────────────
+
+  test('allows exact match for single-label intranet host', () => {
+    expect(isDomainAllowed('intranet', ['intranet'])).toBe(true);
+  });
+
+  test('allows exact match for internal two-label host', () => {
+    expect(isDomainAllowed('vault.corp', ['vault.corp'])).toBe(true);
+  });
+
   // ── URL extraction ──────────────────────────────────────────────────
 
   test('extracts hostname from full URL', () => {

--- a/assistant/src/tools/credentials/domain-policy.ts
+++ b/assistant/src/tools/credentials/domain-policy.ts
@@ -27,10 +27,6 @@ export function isDomainAllowed(requestHost: string, allowedDomains: string[]): 
   const requestInfo = normalizeDomain(requestHost);
   if (!requestInfo) return false;
 
-  // Require a valid registrable domain — rejects malformed hostnames that
-  // normalizeDomain doesn't explicitly filter (e.g. strings with spaces/symbols).
-  if (!requestInfo.registrableDomain) return false;
-
   for (const allowed of allowedDomains) {
     const allowedInfo = normalizeDomain(allowed);
     if (!allowedInfo) continue;

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -60,6 +60,12 @@ export function normalizeDomain(input: string): DomainInfo | null {
     return null;
   }
 
+  // Reject malformed hostnames (e.g. strings with spaces, symbols, consecutive
+  // dots). Valid DNS labels contain only alphanumerics, hyphens, and dots.
+  if (!/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/.test(hostname)) {
+    return null;
+  }
+
   const result = parse(hostname);
   const registrableDomain = result.domain || null;
 


### PR DESCRIPTION
## Summary
- Moves malformed-hostname rejection from `isDomainAllowed` into `normalizeDomain` using a DNS-character regex, so it applies consistently across all callers
- Removes the blanket `!registrableDomain` guard that blocked valid internal hosts (e.g. single-label intranet names, `.corp` zones) from exact-matching
- Adds test coverage for internal host exact-match scenarios

Addresses Codex feedback on PR #2764.

## Test plan
- [x] New tests: `allows exact match for single-label intranet host`, `allows exact match for internal two-label host`
- [x] Existing test `denies malformed host even when same string is in allowed list` still passes
- [x] All 23 domain-policy tests pass
- [x] All 16 domain-normalize tests pass
- [x] Type-check clean (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
