### PR TITLE
fix: merge legacy config keys during workspace migration

### DIFF
--- a/assistant/src/__tests__/platform-workspace-migration.test.ts
+++ b/assistant/src/__tests__/platform-workspace-migration.test.ts
@@ -447,6 +447,63 @@ describe('migrateToWorkspaceLayout', () => {
     rmSync(base, { recursive: true, force: true });
   });
 
+  test('config key merge: legacy slackWebhookUrl is preserved when workspace config already exists', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Legacy root config has slackWebhookUrl that was written by old code
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({ slackWebhookUrl: 'https://hooks.slack.com/old', theme: 'dark' }),
+    );
+
+    // Workspace config already exists with different keys but no slackWebhookUrl
+    writeFileSync(
+      join(ws, 'config.json'),
+      JSON.stringify({ model: 'claude-3', theme: 'light' }),
+    );
+
+    migrateToWorkspaceLayout();
+
+    // Workspace config should have the missing slackWebhookUrl merged in
+    const merged = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(merged.slackWebhookUrl).toBe('https://hooks.slack.com/old');
+    // Existing workspace keys should be preserved (not overwritten)
+    expect(merged.model).toBe('claude-3');
+    expect(merged.theme).toBe('light'); // workspace value wins over legacy
+
+    // Legacy config still exists (migratePath skipped the move)
+    expect(existsSync(join(root, 'config.json'))).toBe(true);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('config key merge: no-op when legacy config has no extra keys', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Both configs have the same keys
+    writeFileSync(join(root, 'config.json'), JSON.stringify({ theme: 'dark' }));
+    writeFileSync(join(ws, 'config.json'), JSON.stringify({ theme: 'light' }));
+
+    const wsBefore = readFileSync(join(ws, 'config.json'), 'utf-8');
+
+    migrateToWorkspaceLayout();
+
+    // Workspace config should be unchanged
+    expect(readFileSync(join(ws, 'config.json'), 'utf-8')).toBe(wsBefore);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
   test('mixed partial migration with sandbox/fs already extracted', () => {
     const base = makeTmpBase();
     process.env.BASE_DATA_DIR = base;

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, existsSync, statSync, unlinkSync, renameSync } from 'node:fs';
+import { mkdirSync, existsSync, statSync, unlinkSync, renameSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 /**
@@ -196,6 +196,43 @@ export function migratePath(source: string, destination: string): void {
 }
 
 /**
+ * When migratePath skips config.json because the workspace copy already
+ * exists, the legacy root config may still contain keys (e.g. slackWebhookUrl)
+ * that were never written to the workspace config. This merges any missing
+ * top-level keys from the legacy file into the workspace file so they are
+ * not silently lost during upgrade.
+ */
+function mergeSkippedConfigKeys(legacyPath: string, workspacePath: string): void {
+  if (!existsSync(legacyPath) || !existsSync(workspacePath)) return;
+
+  let legacy: Record<string, unknown>;
+  let workspace: Record<string, unknown>;
+  try {
+    legacy = JSON.parse(readFileSync(legacyPath, 'utf-8'));
+    workspace = JSON.parse(readFileSync(workspacePath, 'utf-8'));
+  } catch {
+    return; // malformed JSON — skip silently
+  }
+
+  const merged: string[] = [];
+  for (const key of Object.keys(legacy)) {
+    if (!(key in workspace)) {
+      workspace[key] = legacy[key];
+      merged.push(key);
+    }
+  }
+
+  if (merged.length > 0) {
+    try {
+      writeFileSync(workspacePath, JSON.stringify(workspace, null, 2) + '\n');
+      migrationLog('info', 'Merged legacy config keys into workspace config', { keys: merged });
+    } catch (err) {
+      migrationLog('warn', 'Failed to merge legacy config keys', { err: String(err), keys: merged });
+    }
+  }
+}
+
+/**
  * Migrate from the flat ~/.vellum layout to the workspace-based layout.
  *
  * Step (a) is special: if the workspace dir doesn't exist yet but the old
@@ -227,6 +264,7 @@ export function migrateToWorkspaceLayout(): void {
 
   // (b)-(h) Move legacy root-level items into workspace
   migratePath(join(root, 'config.json'), join(ws, 'config.json'));
+  mergeSkippedConfigKeys(join(root, 'config.json'), join(ws, 'config.json'));
   migratePath(join(root, 'data'), join(ws, 'data'));
   migratePath(join(root, 'hooks'), join(ws, 'hooks'));
   migratePath(join(root, 'IDENTITY.md'), join(ws, 'IDENTITY.md'));


### PR DESCRIPTION
## Summary
- Addresses [Codex P1 feedback on PR #2813](https://github.com/vellum-ai/vellum-assistant/pull/2813): switching Slack handlers to `loadRawConfig()` could lose `slackWebhookUrl` when it was written to the legacy root `config.json` but `migratePath` skips because workspace `config.json` already exists.
- Adds `mergeSkippedConfigKeys()` to `migrateToWorkspaceLayout()` — after `migratePath` skips the config move, any top-level keys present in the legacy config but missing from the workspace config are merged in.
- Adds 2 tests covering the merge behavior and the no-op case.

## Test plan
- [x] `bun test src/__tests__/platform-workspace-migration.test.ts` — 12 tests pass (10 existing + 2 new)
- [x] `bun test src/__tests__/handlers-slack-config.test.ts` — 4 tests pass
- [x] `bunx tsc --noEmit` — no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
