### PR TITLE
fix: add pre-flight metadata check to prevent keychain/metadata desync

### DIFF
--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -60,8 +60,8 @@ function loadFile(): LoadResult {
     if (typeof data !== 'object' || data === null) {
       return { version: 1, credentials: [] };
     }
-    if (data.version !== 1) {
-      // Newer format we don't understand — refuse to touch it
+    if (typeof data.version === 'number' && data.version !== 1) {
+      // Newer numeric version we don't understand — refuse to touch it
       return { unknownVersion: true };
     }
     return {
@@ -82,6 +82,18 @@ function saveFile(data: MetadataFile): void {
   const tmpPath = join(dir, `.tmp-${randomUUID()}`);
   writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
   renameSync(tmpPath, path);
+}
+
+/**
+ * Throws if the metadata file has an unrecognized version.
+ * Call this before performing irreversible keychain operations
+ * so the operation fails cleanly before any side effects.
+ */
+export function assertMetadataWritable(): void {
+  const result = loadFile();
+  if (isUnknownVersion(result)) {
+    throw new Error('Credential metadata file has an unrecognized version; refusing to mutate to avoid data loss');
+  }
 }
 
 /**

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -7,7 +7,7 @@ import {
   listSecureKeys,
   getBackendType,
 } from '../../security/secure-keys.js';
-import { upsertCredentialMetadata, deleteCredentialMetadata } from './metadata-store.js';
+import { upsertCredentialMetadata, deleteCredentialMetadata, assertMetadataWritable } from './metadata-store.js';
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput } from './policy-types.js';
 import { credentialBroker } from './broker.js';
@@ -108,20 +108,22 @@ class CredentialStoreTool implements Tool {
         }
         const policy = toPolicyFromInput(policyInput);
 
+        try {
+          assertMetadataWritable();
+        } catch {
+          return { content: 'Error: credential metadata file has an unrecognized version; cannot store credentials', isError: true };
+        }
+
         const key = `credential:${service}:${field}`;
         const ok = setSecureKey(key, value);
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        try {
-          upsertCredentialMetadata(service, field, {
-            allowedTools: policy.allowedTools,
-            allowedDomains: policy.allowedDomains,
-            usageDescription: policy.usageDescription,
-          });
-        } catch (err) {
-          log.warn({ service, field, err }, 'metadata write failed after storing credential');
-        }
+        upsertCredentialMetadata(service, field, {
+          allowedTools: policy.allowedTools,
+          allowedDomains: policy.allowedDomains,
+          usageDescription: policy.usageDescription,
+        });
         return { content: `Stored credential for ${service}/${field}.`, isError: false };
       }
 
@@ -158,16 +160,18 @@ class CredentialStoreTool implements Tool {
           return { content: 'Error: field is required for delete action', isError: true };
         }
 
+        try {
+          assertMetadataWritable();
+        } catch {
+          return { content: 'Error: credential metadata file has an unrecognized version; cannot delete credentials', isError: true };
+        }
+
         const key = `credential:${service}:${field}`;
         const ok = deleteSecureKey(key);
         if (!ok) {
           return { content: `Error: credential ${service}/${field} not found`, isError: true };
         }
-        try {
-          deleteCredentialMetadata(service, field);
-        } catch (err) {
-          log.warn({ service, field, err }, 'metadata cleanup failed after deleting credential');
-        }
+        deleteCredentialMetadata(service, field);
         return { content: `Deleted credential for ${service}/${field}.`, isError: false };
       }
 
@@ -201,6 +205,12 @@ class CredentialStoreTool implements Tool {
         }
         const promptPolicy = toPolicyFromInput(promptPolicyInput);
 
+        try {
+          assertMetadataWritable();
+        } catch {
+          return { content: 'Error: credential metadata file has an unrecognized version; cannot store credentials', isError: true };
+        }
+
         const result = await context.requestSecret({
           service, field, label, description, placeholder,
           purpose: promptPolicy.usageDescription,
@@ -224,15 +234,11 @@ class CredentialStoreTool implements Tool {
           // Inject into broker for one-time use by the next tool call, then discard
           credentialBroker.injectTransient(service, field, result.value);
           // Also upsert metadata so broker policy checks can find the credential
-          try {
-            upsertCredentialMetadata(service, field, {
-              allowedTools: promptPolicy.allowedTools,
-              allowedDomains: promptPolicy.allowedDomains,
-              usageDescription: promptPolicy.usageDescription,
-            });
-          } catch (err) {
-            log.warn({ service, field, err }, 'metadata write failed for transient credential');
-          }
+          upsertCredentialMetadata(service, field, {
+            allowedTools: promptPolicy.allowedTools,
+            allowedDomains: promptPolicy.allowedDomains,
+            usageDescription: promptPolicy.usageDescription,
+          });
           log.info({ service, field, delivery: 'transient_send' }, 'One-time secret delivery used');
           return {
             content: `One-time credential provided for ${service}/${field}. The value was NOT saved to the vault and will be consumed by the next operation.`,
@@ -246,15 +252,11 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        try {
-          upsertCredentialMetadata(service, field, {
-            allowedTools: promptPolicy.allowedTools,
-            allowedDomains: promptPolicy.allowedDomains,
-            usageDescription: promptPolicy.usageDescription,
-          });
-        } catch (err) {
-          log.warn({ service, field, err }, 'metadata write failed after storing credential');
-        }
+        upsertCredentialMetadata(service, field, {
+          allowedTools: promptPolicy.allowedTools,
+          allowedDomains: promptPolicy.allowedDomains,
+          usageDescription: promptPolicy.usageDescription,
+        });
         return { content: `Credential stored for ${service}/${field}.`, isError: false };
       }
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2757 (Codex + Devin).

- **Pre-flight metadata check** -- Exports `assertMetadataWritable()` from `metadata-store.ts` and calls it in `vault.ts` **before** any keychain operations (`setSecureKey`/`deleteSecureKey`). This prevents the keychain and metadata stores from getting out of sync when the metadata file has an unrecognized version.
- **Fix malformed version classification** -- Only treats numeric versions != 1 as genuinely unknown (newer app version). Malformed files (`{}`, `{"version":"1"}`, missing version) are treated as corruption and fall back to an empty v1 structure instead of locking the store into read-only mode.

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit` — pre-existing errors in unrelated test file only)
- [x] All three vault actions (store, delete, prompt) now fail cleanly before any side effects when metadata is unwritable
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
