### PR TITLE
fix: always mark workspace dirty for bash regardless of isError

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -943,17 +943,13 @@ export class Session {
             const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
             onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId, imageData: imageBlock?.source.data });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
-            // Mark workspace context dirty for mutation tools.
-            // file_write/file_edit always mark dirty regardless of isError because
-            // ToolExecutor can physically write the file and then flip isError=true
-            // (e.g. secret-detection block mode), so the filesystem has changed.
-            // bash only marks dirty on success since a failed command typically
-            // means no mutation occurred.
+            // Mark workspace context dirty for mutation tools regardless of
+            // isError — a non-zero exit code or post-write error does not mean
+            // the filesystem was untouched (e.g. `mkdir foo && false`, or
+            // secret-detection blocking after a physical write).
             {
               const toolName = toolUseIdToName.get(event.toolUseId);
-              if (toolName === 'file_write' || toolName === 'file_edit') {
-                this.markWorkspaceTopLevelDirty();
-              } else if (!event.isError && toolName === 'bash') {
+              if (toolName === 'file_write' || toolName === 'file_edit' || toolName === 'bash') {
                 this.markWorkspaceTopLevelDirty();
               }
             }


### PR DESCRIPTION
## Summary
- Removes the `!event.isError` guard when marking workspace context dirty for `bash` tool results
- A bash command can mutate the filesystem and still exit non-zero (e.g. `mkdir foo && false`), which previously left `workspaceTopLevelDirty` false and caused stale workspace context on the next turn
- Now `bash` behaves the same as `file_write`/`file_edit` — always marks dirty regardless of error status

Addresses feedback on #2890.

## Test plan
- [x] Pre-existing type errors only (unrelated `session-workspace-injection.test.ts`); no new errors introduced
- [x] Existing `session-workspace-cache-state.test.ts` tests pass (lifecycle tests for dirty flag)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
