### PR TITLE
fix: measure secret prompt panel height after window attachment

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -48,16 +48,25 @@ final class SecretPromptManager {
         let hostingController = NSHostingController(rootView: view)
         hostingController.sizingOptions = .preferredContentSize
 
-        let preferredSize = hostingController.view.fittingSize
-        let panelHeight = min(max(preferredSize.height, 230), 600)
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
+            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: 300),
             styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
         )
 
         panel.contentViewController = hostingController
+
+        // Re-measure now that the view is in the window hierarchy.
+        // Use contentView.fittingSize (not the hosting controller's view directly)
+        // so AppKit can resolve layout constraints against the panel.
+        let panelHeight: CGFloat
+        if let fittingSize = panel.contentView?.fittingSize {
+            panelHeight = min(max(fittingSize.height, 230), 600)
+        } else {
+            panelHeight = 300
+        }
+        panel.setContentSize(NSSize(width: panelWidth, height: panelHeight))
         panel.level = .floating
         panel.isMovableByWindowBackground = true
         panel.titleVisibility = .hidden
@@ -142,97 +151,94 @@ struct SecretPromptView: View {
     }
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                // Header
-                HStack(spacing: VSpacing.md) {
-                    Image(systemName: "lock.shield.fill")
-                        .font(.title2)
-                        .foregroundStyle(VColor.accent)
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Header
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: "lock.shield.fill")
+                    .font(.title2)
+                    .foregroundStyle(VColor.accent)
 
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Secure Credential")
-                            .font(VFont.headline)
-                            .foregroundColor(VColor.textPrimary)
-                        Text(label)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                    }
-
-                    Spacer()
-                }
-
-                // Description
-                if let description = description {
-                    Text(description)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Secure Credential")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textPrimary)
+                    Text(label)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                // Usage context
-                if hasContext {
-                    usageContextSection
+                Spacer()
+            }
+
+            // Description
+            if let description = description {
+                Text(description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+
+            // Usage context
+            if hasContext {
+                usageContextSection
+            }
+
+            // Secure input
+            SecureField(placeholder, text: $secretValue)
+                .textFieldStyle(.roundedBorder)
+                .font(VFont.mono)
+
+            // Safety explainer
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                safetyBullet(
+                    icon: "key.fill",
+                    text: "Stored in your Mac's Keychain, not sent to any server"
+                )
+                safetyBullet(
+                    icon: "eye.slash.fill",
+                    text: "The AI never sees this value — only your Mac can read it"
+                )
+            }
+
+            if saved {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                    Text("Saved to Keychain")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
                 }
-
-                // Secure input
-                SecureField(placeholder, text: $secretValue)
-                    .textFieldStyle(.roundedBorder)
-                    .font(VFont.mono)
-
-                // Safety explainer
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    safetyBullet(
-                        icon: "key.fill",
-                        text: "Stored in your Mac's Keychain, not sent to any server"
-                    )
-                    safetyBullet(
-                        icon: "eye.slash.fill",
-                        text: "The AI never sees this value — only your Mac can read it"
-                    )
-                }
-
-                if saved {
-                    HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(VColor.success)
-                        Text("Saved to Keychain")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.success)
+            } else {
+                // Buttons
+                HStack(spacing: VSpacing.lg) {
+                    Spacer()
+                    VButton(label: "Cancel", style: .ghost) {
+                        onCancel()
                     }
-                } else {
-                    // Buttons
-                    HStack(spacing: VSpacing.lg) {
-                        Spacer()
-                        VButton(label: "Cancel", style: .ghost) {
-                            onCancel()
+                    VButton(label: "Save", style: .primary) {
+                        guard !secretValue.isEmpty else { return }
+                        if onSave(secretValue) {
+                            withAnimation(VAnimation.standard) { saved = true }
                         }
-                        VButton(label: "Save", style: .primary) {
+                    }
+                    .disabled(secretValue.isEmpty)
+                }
+
+                if allowOneTimeSend {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10))
+                            .foregroundColor(VColor.warning)
+                        VButton(label: "Send Once (not saved)", style: .ghost) {
                             guard !secretValue.isEmpty else { return }
-                            if onSave(secretValue) {
-                                withAnimation(VAnimation.standard) { saved = true }
-                            }
+                            _ = onSendOnce(secretValue)
                         }
                         .disabled(secretValue.isEmpty)
                     }
-
-                    if allowOneTimeSend {
-                        HStack(spacing: VSpacing.xs) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .font(.system(size: 10))
-                                .foregroundColor(VColor.warning)
-                            VButton(label: "Send Once (not saved)", style: .ghost) {
-                                guard !secretValue.isEmpty else { return }
-                                _ = onSendOnce(secretValue)
-                            }
-                            .disabled(secretValue.isEmpty)
-                        }
-                    }
                 }
             }
-            .padding(VSpacing.xl)
         }
+        .padding(VSpacing.xl)
         .frame(width: 400)
-        .frame(maxHeight: 600)
         .vPanelBackground()
     }
 


### PR DESCRIPTION
## Summary
Addresses Devin review feedback from PR #2758.

- **Moved `fittingSize` measurement after `contentViewController` assignment** so the view is in the window hierarchy when measured (matching `SurfaceManager.swift`'s pattern)
- **Removed `ScrollView` wrapper** from `SecretPromptView` body — `ScrollView` reports near-zero fitting height on its scroll axis, defeating dynamic sizing. The panel height is now clamped to 230-600pt based on actual content size.

## Problem
The `fittingSize` was queried on the hosting controller's view before it was attached to a panel, and the `ScrollView` wrapper caused `fittingSize` to return near-zero. This meant all panels resolved to the 230pt minimum regardless of content — the exact problem PR #2758 was trying to fix.

## Test plan
- [ ] Verify secret prompt panels size correctly for minimal content (no context fields)
- [ ] Verify panels grow taller when context fields (purpose, tools, domains) are present
- [ ] Verify panels with long descriptions don't exceed 600pt
- [ ] Build succeeds with `swift build`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
