### PR TITLE
fix: prevent stuck UI when archiving empty thread and wrong session claiming

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -105,19 +105,30 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func archiveThread(id: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
 
-        chatViewModels[id]?.stopGenerating()
         threads[index].isArchived = true
 
         if let sessionId = threads[index].sessionId {
+            chatViewModels[id]?.stopGenerating()
             var archived = archivedSessionIds
             archived.insert(sessionId)
             archivedSessionIds = archived
             // Session ID already known — safe to release the view model.
             chatViewModels.removeValue(forKey: id)
+        } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true {
+            chatViewModels[id]?.stopGenerating()
+            // No session ID and no user messages — a session will never be created,
+            // so there is nothing to backfill. Clean up immediately.
+            chatViewModels.removeValue(forKey: id)
+        } else {
+            // Session ID is nil but user messages exist. Keep the ChatViewModel alive
+            // so the onSessionCreated callback can fire, claim its own session via
+            // the correlation ID, persist the archive state via backfillSessionId,
+            // and then clean up. Use cancelPendingMessage() instead of
+            // stopGenerating() to discard the queued message without clearing the
+            // correlation ID — this prevents the VM from claiming an unrelated
+            // session_info from another thread.
+            chatViewModels[id]?.cancelPendingMessage()
         }
-        // When sessionId is nil, keep the ChatViewModel alive so the
-        // onSessionCreated callback can still fire and persist the archive state
-        // via backfillSessionId. The view model is cleaned up there.
 
         // If the archived thread was active, select an adjacent visible thread
         // or create a new one if none remain.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1169,6 +1169,18 @@ public final class ChatViewModel: ObservableObject {
         try? daemonClient.send(msg)
     }
 
+    /// Cancel the queued user message without clearing `bootstrapCorrelationId`.
+    /// Used when archiving a thread before session_info arrives: we want to
+    /// discard the pending message (so it isn't sent once the session is claimed)
+    /// but preserve the correlation ID so the VM only claims its own session.
+    public func cancelPendingMessage() {
+        pendingUserMessage = nil
+        pendingUserAttachments = nil
+        isWorkspaceRefinementInFlight = false
+        isThinking = false
+        isSending = false
+    }
+
     public func stopGenerating() {
         guard isSending else { return }
 


### PR DESCRIPTION
## Summary

Addresses reviewer feedback from PR #2756:

- **Empty thread stuck UI (Devin):** Archiving an empty thread (no user messages, no sessionId) kept the ChatViewModel in `chatViewModels`, causing `createThread()` to no-op and leaving the UI with no visible threads. Now immediately cleans up the VM when no user messages exist since a session will never be created.

- **Wrong session claiming (Codex):** `stopGenerating()` cleared `bootstrapCorrelationId`, removing the protection against claiming an unrelated `session_info`. Added `cancelPendingMessage()` to ChatViewModel that discards the queued message without clearing the correlation ID, and use it for archived threads awaiting session assignment.

## Test plan

- [ ] Archive a brand-new empty thread (sole visible thread) — verify a new thread is created and UI is not stuck
- [ ] Archive a thread with a pending message before session_info arrives — verify the correct session is archived (not another thread's)
- [ ] Archive a thread with an existing session ID — verify behavior unchanged
- [ ] Start a new thread quickly after archiving one mid-bootstrap — verify second thread works normally

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
