### PR TITLE
fix: add missing IPC snapshot test entries

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1366,3 +1366,48 @@ exports[`IPC message snapshots ServerMessage types ui_surface_undo_result serial
   "type": "ui_surface_undo_result",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types link_open_request serializes to expected JSON 1`] = `
+{
+  "type": "link_open_request",
+  "url": "https://example.com",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types publish_page serializes to expected JSON 1`] = `
+{
+  "html": "<html><body>Hello</body></html>",
+  "type": "publish_page",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types unpublish_page serializes to expected JSON 1`] = `
+{
+  "deploymentId": "dpl-001",
+  "type": "unpublish_page",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types open_url serializes to expected JSON 1`] = `
+{
+  "title": "Example",
+  "type": "open_url",
+  "url": "https://example.com",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types publish_page_response serializes to expected JSON 1`] = `
+{
+  "deploymentId": "dpl-001",
+  "publicUrl": "https://example.vercel.app",
+  "success": true,
+  "type": "publish_page_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types unpublish_page_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "unpublish_page_response",
+}
+`;


### PR DESCRIPTION
## Summary
- Added 6 missing snapshot entries for recently added IPC message types: `link_open_request`, `publish_page`, `unpublish_page`, `open_url`, `publish_page_response`, and `unpublish_page_response`
- These types had test fixtures and type definitions but no corresponding snapshot file entries, causing CI failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
