### PR TITLE
fix: forward policy context in computer-use session requestSecret

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -414,6 +414,7 @@ export class ComputerUseSession {
             params.service, params.field, params.label,
             params.description, params.placeholder,
             this.sessionId,
+            params.purpose, params.allowedTools, params.allowedDomains,
           );
         },
       });


### PR DESCRIPTION
## Summary
- Fixes the issue identified by Devin review on PR #2781 where `purpose`, `allowedTools`, and `allowedDomains` were silently dropped in `computer-use-session.ts`'s `requestSecret` callback
- The `session.ts` callback was correctly updated in #2781 but the equivalent callback in `computer-use-session.ts` was missed, causing policy context to be lost during computer-use sessions

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Existing tests unaffected (mock `requestSecret` functions don't depend on these params)

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/2781

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
