### PR TITLE
fix: guard missing allowedDomains in credential broker

### DIFF
--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -161,19 +161,20 @@ export class CredentialBroker {
     }
 
     // Domain policy enforcement — deny if the page domain is not in the credential's allowed list
-    if (metadata.allowedDomains.length > 0) {
+    const browserDomains = metadata.allowedDomains ?? [];
+    if (browserDomains.length > 0) {
       if (!request.domain) {
         return {
           success: false,
           reason: `Credential ${request.service}/${request.field} has a domain policy but no page domain was provided. ` +
-            `Allowed domains: ${metadata.allowedDomains.join(', ')}.`,
+            `Allowed domains: ${browserDomains.join(', ')}.`,
         };
       }
-      if (!isDomainAllowed(request.domain, metadata.allowedDomains)) {
+      if (!isDomainAllowed(request.domain, browserDomains)) {
         return {
           success: false,
           reason: `Domain "${request.domain}" is not allowed for credential ${request.service}/${request.field}. ` +
-            `Allowed domains: ${metadata.allowedDomains.join(', ')}.`,
+            `Allowed domains: ${browserDomains.join(', ')}.`,
         };
       }
     }
@@ -240,11 +241,12 @@ export class CredentialBroker {
 
     // Domain policy enforcement — credentials with domain restrictions are
     // scoped to browser use on those domains and cannot be used server-side.
-    if (metadata.allowedDomains.length > 0) {
+    const serverDomains = metadata.allowedDomains ?? [];
+    if (serverDomains.length > 0) {
       return {
         success: false,
         reason: `Credential ${request.service}/${request.field} has domain restrictions ` +
-          `(${metadata.allowedDomains.join(', ')}) and cannot be used server-side. ` +
+          `(${serverDomains.join(', ')}) and cannot be used server-side. ` +
           'Remove domain restrictions or use a separate credential without domain policy.',
       };
     }


### PR DESCRIPTION
## Summary
- Addresses Devin review feedback on PR #2769
- Adds `?? []` null guards for `metadata.allowedDomains` in both `browserFill()` and `serverUse()` methods
- Prevents `TypeError` on legacy metadata records where `allowedDomains` may be `undefined` (same class of bug already fixed for `allowedTools` in #2769)

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Verified both `browserFill()` and `serverUse()` domain policy branches are guarded

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
