### PR TITLE
fix: correct mock paths and vacuous assertion in credential E2E tests

### DIFF
--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -40,13 +40,14 @@ mock.module('../security/secure-keys.js', () => ({
   getBackendType: () => 'encrypted',
 }));
 
-mock.module('./metadata-store.js', () => ({
+mock.module('../tools/credentials/metadata-store.js', () => ({
   upsertCredentialMetadata: () => {},
   deleteCredentialMetadata: () => {},
   getCredentialMetadata: () => null,
+  assertMetadataWritable: () => {},
 }));
 
-mock.module('./policy-validate.js', () => ({
+mock.module('../tools/credentials/policy-validate.js', () => ({
   validatePolicyInput: () => ({ valid: true, errors: [] }),
   toPolicyFromInput: (input: Record<string, unknown>) => ({
     allowedTools: input.allowed_tools ?? [],
@@ -277,7 +278,12 @@ describe('E2E: domain policy enforcement', () => {
 // ---------------------------------------------------------------------------
 
 describe('E2E: cross-cutting secret leak prevention', () => {
-  beforeEach(() => storedKeys.clear());
+  beforeEach(() => {
+    storedKeys.clear();
+    mockConfig.secretDetection.enabled = true;
+    mockConfig.secretDetection.action = 'block';
+    mockConfig.secretDetection.allowOneTimeSend = false;
+  });
 
   test('store output never contains the stored value', async () => {
     const secret = ['sk', '-proj-', 'abc123xyz'].join('');
@@ -304,8 +310,8 @@ describe('E2E: cross-cutting secret leak prevention', () => {
   test('ingress notice never contains the detected secret', () => {
     const awsKey = ['AKIA', 'IOSFODNN7', 'REALKEY'].join('');
     const check = checkIngressForSecrets(awsKey);
-    if (check.userNotice) {
-      expect(check.userNotice).not.toContain(awsKey);
-    }
+    expect(check.blocked).toBe(true);
+    expect(check.userNotice).toBeDefined();
+    expect(check.userNotice).not.toContain(awsKey);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes mock module specifiers for `metadata-store` and `policy-validate` to use correct relative paths (`../tools/credentials/...`) so mocks actually intercept the modules imported by `vault.ts` (previously mocked as `./metadata-store.js` from `__tests__/`, which resolved to a different path)
- Adds missing `assertMetadataWritable` export to the metadata-store mock
- Resets `mockConfig.secretDetection` state in the cross-cutting `beforeEach` to prevent leaked mutable state from earlier describe blocks causing tests to pass vacuously
- Replaces conditional `if (check.userNotice)` guard with unconditional assertions so the ingress leak-prevention test always validates the security invariant

Addresses review feedback from codex and devin on #2773.

## Test plan
- [ ] `bunx tsc --noEmit` passes (verified locally)
- [ ] Credential security E2E tests pass with corrected mock interception

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
