### PR TITLE
docs: address Codex review feedback on credential storage docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -334,7 +334,7 @@ Types that use Combine `$`-prefixed publishers (e.g., `VoiceTranscriptionViewMod
 graph LR
     subgraph "macOS Keychain"
         K1["API Key<br/>service: vellum-assistant<br/>account: anthropic<br/>stored via /usr/bin/security CLI"]
-        K2["Credential Secrets<br/>key: credential:{service}:{field}<br/>stored via secure-keys.ts"]
+        K2["Credential Secrets<br/>key: credential:{service}:{field}<br/>stored via secure-keys.ts<br/>(encrypted file fallback if Keychain unavailable)"]
     end
 
     subgraph "UserDefaults (plist)"
@@ -1638,6 +1638,7 @@ sequenceDiagram
         UI->>IPC: secret_response {requestId, value, delivery: "transient_send"}
         IPC->>Prompter: resolve(value, "transient_send")
         Prompter->>Vault: {value, delivery: "transient_send"}
+        Note over Vault: Hands value to CredentialBroker<br/>for single-use consumption
         Vault->>Model: "One-time credential provided" (no value in output)
     else Cancel
         UI->>IPC: secret_response {requestId, value: null}
@@ -1676,16 +1677,17 @@ graph TB
 
 The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send Once" button in the secret prompt UI. When used:
 
-- The secret value is forwarded to the requesting tool for immediate use
+- The secret value is handed to the `CredentialBroker`, which holds it in memory for the next `consume` or `browserFill` call
 - The value is **not** persisted to the keychain
-- The tool output confirms delivery without including the secret value
+- The broker discards the value after a single use
+- The vault tool output confirms delivery without including the secret value — the value is never returned to the model
 - The config gate must be explicitly enabled by the operator
 
 ### Storage Layout
 
 | Component | Location | What it stores |
 |-----------|----------|----------------|
-| Secret values | macOS Keychain | Encrypted credential values keyed as `credential:{service}:{field}` |
+| Secret values | macOS Keychain (primary) or encrypted file fallback | Encrypted credential values keyed as `credential:{service}:{field}`. Falls back to encrypted file backend on Linux/headless or when Keychain is unavailable. |
 | Credential metadata | `~/.vellum/workspace/data/credentials/metadata.json` | Service, field, label, policy (allowedTools, allowedDomains), timestamps |
 | Config | `~/.vellum/workspace/config.*` | `secretDetection` settings: enabled, action, entropyThreshold, allowOneTimeSend |
 
@@ -1710,7 +1712,7 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 | What | Where | Format | ORM/Driver | Retention |
 |------|-------|--------|-----------|-----------|
 | API key | macOS Keychain | Encrypted binary | `/usr/bin/security` CLI | Permanent |
-| Credential secrets | macOS Keychain | Encrypted binary | `secure-keys.ts` wrapper | Permanent (until deleted via tool) |
+| Credential secrets | macOS Keychain (or encrypted file fallback) | Encrypted binary | `secure-keys.ts` wrapper | Permanent (until deleted via tool) |
 | Credential metadata | `~/.vellum/workspace/data/credentials/metadata.json` | JSON | Atomic file write | Permanent (until deleted via tool) |
 | User preferences | UserDefaults | plist | Foundation | Permanent |
 | Ambient observations | `~/Library/.../knowledge.json` | JSON array | Swift Codable | Max 500 entries, FIFO |

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Run `vellum doctor` for a full diagnostic check including sandbox backend status
 
 The assistant can store and use credentials (API keys, tokens, passwords) without exposing secret values to the LLM or logs.
 
-- **Storage**: Secret values are stored in the macOS Keychain via `secure-keys.ts`. Metadata (service, field, label, usage policy) is stored in a JSON file at `~/.vellum/workspace/data/credentials/metadata.json`.
+- **Storage**: Secret values are stored in the macOS Keychain via `secure-keys.ts`, with an encrypted file fallback for Linux/headless environments or degraded Keychain sessions. Metadata (service, field, label, usage policy) is stored in a JSON file at `~/.vellum/workspace/data/credentials/metadata.json`.
 - **Secret prompt**: When a credential is needed, a floating `SecretPromptView` panel appears. The user enters the value in a `SecureField` — the LLM never sees it.
 - **Ingress blocking**: Inbound user messages are scanned for secrets (regex + entropy). If `secretDetection.action` is `block` (the default), messages containing secrets are rejected with a notice to use the secure prompt instead.
 - **Usage policy**: Each credential can specify `allowedTools` and `allowedDomains`. The `CredentialBroker` enforces these policies at use time.

--- a/docs/security/credential-storage.md
+++ b/docs/security/credential-storage.md
@@ -38,7 +38,7 @@ The `CredentialBroker` enforces these policies at use time. Requests outside the
 
 | Component | Location | Contents |
 |-----------|----------|----------|
-| Secret values | macOS Keychain | Encrypted values keyed as `credential:{service}:{field}` |
+| Secret values | macOS Keychain (primary) or encrypted file fallback | Encrypted values keyed as `credential:{service}:{field}`. On Linux/headless or when Keychain is unavailable, `secure-keys.ts` falls back to an encrypted file backend. |
 | Credential metadata | JSON file (`~/.vellum/data/credentials/metadata.json`) | Service, field, label, usage policy, timestamps |
 | Config | `~/.vellum/config.*` | `secretDetection` settings |
 
@@ -51,7 +51,7 @@ This split means the daemon process can enumerate credentials and check policies
 3. The macOS client shows a floating `SecretPromptView` panel with a `SecureField`.
 4. The user enters the value and clicks "Save" (or "Send Once" if enabled).
 5. The client sends `secret_response` back via IPC.
-6. The vault tool stores the value in the Keychain (for "store" delivery) or injects it into the `CredentialBroker` for immediate one-time use (for "transient_send" delivery). The broker holds the value in memory and discards it after the next `consume` or `browserFill` call.
+6. For "store" delivery, the vault tool stores the value in the Keychain. For "transient_send" delivery, the vault tool hands the value to the `CredentialBroker`, which holds it in memory for the next `consume` or `browserFill` call and then discards it. Note: the value is never returned to the vault tool's output or passed back to the model.
 7. The tool returns a metadata-only confirmation to the model.
 
 ### Secret ingress blocking
@@ -87,7 +87,7 @@ All credential security settings live under `secretDetection` in the assistant c
 ### Operator guidance
 
 - **Default posture is strict**: `action: "block"` and `allowOneTimeSend: false` ensure secrets always go through the Keychain.
-- **Relaxing `action` to `"warn"` or `"redact"`**: Allows secrets in messages but logs a warning or masks them. Useful during migration but reduces security.
+- **Relaxing `action` to `"warn"` or `"redact"`**: These modes do **not** block inbound messages. When set to `"warn"`, a warning is logged but the message passes through to the model unchanged. When set to `"redact"`, detected secrets are masked in logs but the message itself still passes through. Only `"block"` prevents secrets from reaching the model context. Useful during migration but significantly reduces security.
 - **Enabling `allowOneTimeSend`**: Adds a "Send Once" button to the secret prompt. The value is used for one operation and then discarded. Useful for temporary tokens. The value is still never shown to the model.
 
 ## Rollback


### PR DESCRIPTION
## Summary
Addresses three feedback items from Codex review on PR #2772:

- **Document encrypted file fallback**: Storage tables and diagrams now note that `secure-keys.ts` falls back to an encrypted file backend when macOS Keychain is unavailable (Linux/headless/degraded sessions)
- **Clarify transient_send flow**: One-time send documentation now explicitly states the value is handed to `CredentialBroker` for single-use consumption, not returned to the vault tool output or model
- **Clarify warn/redact behavior**: Operator guidance now explicitly states that only `"block"` prevents secrets from reaching model context; `"warn"` and `"redact"` pass messages through unchanged

## Test plan
- [x] Docs-only change, no code modifications
- [x] Verified all three files render correctly with consistent information

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
