### PR TITLE
fix: reset snapshot gate on HTML changes and scope error handling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -270,10 +270,15 @@ struct AppDirectoryView: View {
         pendingResponses = 2
 
         Task { @MainActor in
+            // Save the previous onError handler so we can restore it once our
+            // requests complete, avoiding swallowing unrelated daemon errors.
+            let previousOnError = daemonClient.onError
+
             daemonClient.onAppsListResponse = { response in
                 self.localApps = response.apps
                 self.pendingResponses -= 1
                 if self.pendingResponses <= 0 {
+                    daemonClient.onError = previousOnError
                     self.buildDisplayItems()
                     self.isLoading = false
                 }
@@ -283,18 +288,22 @@ struct AppDirectoryView: View {
                 self.sharedApps = response.apps
                 self.pendingResponses -= 1
                 if self.pendingResponses <= 0 {
+                    daemonClient.onError = previousOnError
                     self.buildDisplayItems()
                     self.isLoading = false
                 }
             }
 
-            daemonClient.onError = { _ in
+            daemonClient.onError = { error in
                 if self.isLoading {
                     self.pendingResponses -= 1
                     if self.pendingResponses <= 0 {
+                        daemonClient.onError = previousOnError
                         self.buildDisplayItems()
                         self.isLoading = false
                     }
+                } else {
+                    previousOnError?(error)
                 }
             }
 
@@ -311,6 +320,7 @@ struct AppDirectoryView: View {
             }
 
             if pendingResponses <= 0 {
+                daemonClient.onError = previousOnError
                 buildDisplayItems()
                 isLoading = false
             }

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -377,10 +377,14 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         context.coordinator.desiredTopInset = newTop
         context.coordinator.desiredBottomInset = newBottom
 
+        // Update the snapshot callback so navigating between surfaces picks up the new closure.
+        context.coordinator.onSnapshotCaptured = onSnapshotCaptured
+
         // Reload if the HTML content has changed.
         if data.html != context.coordinator.currentHTML {
             let previousHTML = context.coordinator.currentHTML
             context.coordinator.currentHTML = data.html
+            context.coordinator.hasCapturedSnapshot = false
             let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
 
             if previousHTML.isEmpty {
@@ -447,7 +451,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var desiredBottomInset: Int = 0
         /// JSON string with {x, y} scroll position to restore after the next page load.
         var pendingScrollRestore: String?
-        private var hasCapturedSnapshot = false
+        var hasCapturedSnapshot = false
 
         init(
             onAction: @escaping (String, Any?) -> Void,


### PR DESCRIPTION
## Summary
- Reset `hasCapturedSnapshot` when HTML content changes so preview snapshots are recaptured after each page reload
- Update `onSnapshotCaptured` callback in `updateNSView` so navigating between surfaces picks up the correct closure
- Scope `onError` handling in `AppDirectoryView` by saving/restoring the previous handler to avoid swallowing unrelated daemon errors

Addresses review feedback on #2778.

## Test plan
- [ ] Verify that switching between different app surfaces recaptures preview snapshots correctly
- [ ] Verify that daemon errors unrelated to app listing are not swallowed while AppDirectoryView is loading
- [ ] Verify that AppDirectoryView still handles its own errors gracefully during fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
