### PR TITLE
fix: trim newlines from onboarding API key and migrate step order

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -65,7 +65,7 @@ struct APIKeyStepView: View {
                 OnboardingButton(
                     title: "Save & Continue",
                     style: .primary,
-                    disabled: apiKey.trimmingCharacters(in: .whitespaces).isEmpty
+                    disabled: apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ) {
                     saveAndContinue()
                 }
@@ -102,7 +102,7 @@ struct APIKeyStepView: View {
     }
 
     private func saveAndContinue() {
-        let trimmed = apiKey.trimmingCharacters(in: .whitespaces)
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         APIKeyManager.setKey(trimmed)
         state.advance()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -22,6 +22,10 @@ enum ActivationKey: String, CaseIterable {
 @Observable
 @MainActor
 final class OnboardingState {
+    /// Bump this version whenever the default-flow step order changes so that
+    /// persisted step indices from a previous layout are not consumed as-is.
+    private static let currentFlowVersion = 2
+
     var currentStep: Int = 0
     var assistantName: String = ""
     var chosenKey: ActivationKey = .fn
@@ -69,8 +73,18 @@ final class OnboardingState {
     /// kills the app when toggling screen-recording permission).
     init() {
         let saved = UserDefaults.standard.integer(forKey: "onboarding.step")
+        let storedFlowVersion = UserDefaults.standard.integer(forKey: "onboarding.flowVersion")
+
         if saved > 0 {
-            currentStep = saved
+            // If the flow layout changed since the step was persisted, the
+            // stored index no longer maps to the same stage. Reset to the
+            // beginning so the user doesn't land on the wrong step.
+            if storedFlowVersion != Self.currentFlowVersion {
+                currentStep = 0
+                UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
+            } else {
+                currentStep = saved
+            }
             assistantName = UserDefaults.standard.string(forKey: "onboarding.name") ?? ""
             if let raw = UserDefaults.standard.string(forKey: "onboarding.key"),
                let key = ActivationKey(rawValue: raw) {
@@ -110,10 +124,11 @@ final class OnboardingState {
         UserDefaults.standard.set(interviewCompleted, forKey: "onboarding.interviewCompleted")
         UserDefaults.standard.set(onboardingVariant.rawValue, forKey: "onboarding.variant")
         UserDefaults.standard.set(Double(firstMeetingCrackProgress), forKey: "onboarding.firstMeetingCrackProgress")
+        UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }


### PR DESCRIPTION
Addresses review feedback on #2725:

- **API key trimming**: Use `.whitespacesAndNewlines` instead of `.whitespaces` when trimming API key input in `APIKeyStepView.saveAndContinue()`, matching the behavior of `SettingsStore.saveAPIKey()`. Previously, pasted keys with trailing newlines would fail authentication.

- **Onboarding step migration**: Add a `currentFlowVersion` constant and `onboarding.flowVersion` persistence key to `OnboardingState`. When the stored flow version doesn't match the current version, the persisted step is reset to 0 instead of being consumed as-is. This prevents users who resume onboarding after updating from being dropped into the wrong stage when step meanings have shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
