### PR TITLE
fix: distinguish cancelled from fired reminders in status label

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
@@ -118,17 +118,30 @@ private struct ReminderRow: View {
     let reminder: ReminderItem
     let onCancel: () -> Void
 
-    private var fireAtText: String {
+    private var scheduledDateText: String {
         let date = Date(timeIntervalSince1970: Double(reminder.fireAt) / 1000.0)
-        if reminder.status == "pending" {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private var statusDateText: String {
+        switch reminder.status {
+        case "pending":
+            let date = Date(timeIntervalSince1970: Double(reminder.fireAt) / 1000.0)
             let formatter = RelativeDateTimeFormatter()
             formatter.unitsStyle = .abbreviated
-            return formatter.localizedString(for: date, relativeTo: Date())
-        } else {
+            return "Fires: \(formatter.localizedString(for: date, relativeTo: Date()))"
+        case "fired":
+            let timestamp = reminder.firedAt ?? reminder.fireAt
+            let date = Date(timeIntervalSince1970: Double(timestamp) / 1000.0)
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
             formatter.timeStyle = .short
-            return formatter.string(from: date)
+            return "Fired: \(formatter.string(from: date))"
+        default:
+            return "Scheduled for: \(scheduledDateText)"
         }
     }
 
@@ -160,7 +173,7 @@ private struct ReminderRow: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                 HStack(spacing: 6) {
-                    Text(reminder.status == "pending" ? "Fires: \(fireAtText)" : "Fired: \(fireAtText)")
+                    Text(statusDateText)
                     Text("(\(reminder.mode))")
                 }
                 .font(.caption2)


### PR DESCRIPTION
## Summary
- Fix `ReminderRow` in `RemindersView.swift` to properly distinguish between fired and cancelled reminder statuses
- Cancelled reminders now show "Scheduled for: <date>" instead of incorrectly showing "Fired: <date>"
- Fired reminders now use `firedAt` (actual fire time) when available instead of always using the scheduled `fireAt`

Addresses review feedback from codex and devin on PR #2775.

## Test plan
- [x] TypeScript type-check passes
- [x] Swift build succeeds

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
