### PR TITLE
fix: merge legacy skills into workspace when destination pre-exists

### DIFF
--- a/assistant/src/__tests__/platform-workspace-migration.test.ts
+++ b/assistant/src/__tests__/platform-workspace-migration.test.ts
@@ -318,17 +318,99 @@ describe('migrateToWorkspaceLayout', () => {
       'ws-db',
     );
 
-    // Legacy hooks/skills/data should remain at root (not moved due to conflict)
+    // Legacy hooks/data should remain at root (not moved due to conflict)
     expect(existsSync(join(root, 'hooks', 'legacy-hook.sh'))).toBe(true);
     expect(readFileSync(join(root, 'hooks', 'legacy-hook.sh'), 'utf-8')).toBe(
       'root-hook',
     );
-    expect(existsSync(join(root, 'skills', 'legacy-skill.json'))).toBe(true);
+    // Legacy skills entries are merged into workspace (not stranded)
+    expect(existsSync(join(root, 'skills', 'legacy-skill.json'))).toBe(false);
     expect(
-      readFileSync(join(root, 'skills', 'legacy-skill.json'), 'utf-8'),
+      readFileSync(join(ws, 'skills', 'legacy-skill.json'), 'utf-8'),
     ).toBe('root-skill');
     // data dir is also left in place
     expect(existsSync(join(root, 'data', 'logs', 'vellum.log'))).toBe(true);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('legacy skills are merged when workspace/skills was pre-created by ensureDataDir', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    // ensureDataDir pre-created an empty workspace/skills directory
+    mkdirSync(join(ws, 'skills'), { recursive: true });
+
+    // Legacy skills directory has actual skill subdirectories
+    mkdirSync(join(root, 'skills', 'web-search'), { recursive: true });
+    writeFileSync(
+      join(root, 'skills', 'web-search', 'SKILL.md'),
+      '---\nname: Web Search\ndescription: Search the web\n---\nBody',
+    );
+    mkdirSync(join(root, 'skills', 'code-review'), { recursive: true });
+    writeFileSync(
+      join(root, 'skills', 'code-review', 'SKILL.md'),
+      '---\nname: Code Review\ndescription: Review code\n---\nBody',
+    );
+
+    migrateToWorkspaceLayout();
+
+    // Legacy skills should be merged into workspace/skills
+    expect(existsSync(join(ws, 'skills', 'web-search', 'SKILL.md'))).toBe(true);
+    expect(
+      readFileSync(join(ws, 'skills', 'web-search', 'SKILL.md'), 'utf-8'),
+    ).toContain('Web Search');
+    expect(existsSync(join(ws, 'skills', 'code-review', 'SKILL.md'))).toBe(true);
+    expect(
+      readFileSync(join(ws, 'skills', 'code-review', 'SKILL.md'), 'utf-8'),
+    ).toContain('Code Review');
+
+    // Legacy skill dirs should be moved out
+    expect(existsSync(join(root, 'skills', 'web-search'))).toBe(false);
+    expect(existsSync(join(root, 'skills', 'code-review'))).toBe(false);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('legacy skill merge does not overwrite existing workspace skills', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    // Workspace already has a skill with the same ID
+    mkdirSync(join(ws, 'skills', 'web-search'), { recursive: true });
+    writeFileSync(
+      join(ws, 'skills', 'web-search', 'SKILL.md'),
+      'workspace-version',
+    );
+
+    // Legacy also has the same skill and one unique skill
+    mkdirSync(join(root, 'skills', 'web-search'), { recursive: true });
+    writeFileSync(
+      join(root, 'skills', 'web-search', 'SKILL.md'),
+      'legacy-version',
+    );
+    mkdirSync(join(root, 'skills', 'unique-skill'), { recursive: true });
+    writeFileSync(
+      join(root, 'skills', 'unique-skill', 'SKILL.md'),
+      'unique-content',
+    );
+
+    migrateToWorkspaceLayout();
+
+    // Workspace version should not be overwritten
+    expect(
+      readFileSync(join(ws, 'skills', 'web-search', 'SKILL.md'), 'utf-8'),
+    ).toBe('workspace-version');
+
+    // Unique skill from legacy should be merged in
+    expect(existsSync(join(ws, 'skills', 'unique-skill', 'SKILL.md'))).toBe(true);
+    expect(
+      readFileSync(join(ws, 'skills', 'unique-skill', 'SKILL.md'), 'utf-8'),
+    ).toBe('unique-content');
 
     rmSync(base, { recursive: true, force: true });
   });

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, existsSync, statSync, unlinkSync, renameSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, existsSync, statSync, unlinkSync, renameSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 /**
@@ -233,6 +233,36 @@ function mergeSkippedConfigKeys(legacyPath: string, workspacePath: string): void
 }
 
 /**
+ * When migratePath skips the skills directory because the workspace copy
+ * already exists (e.g. pre-created by ensureDataDir), the legacy skills
+ * directory may still contain individual skill subdirectories that were
+ * never moved. This merges any missing skill subdirectories from the
+ * legacy path into the workspace skills path so they are not stranded.
+ */
+function mergeLegacySkills(legacyDir: string, workspaceDir: string): void {
+  if (!existsSync(legacyDir) || !existsSync(workspaceDir)) return;
+
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = readdirSync(legacyDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const src = join(legacyDir, entry.name);
+    const dest = join(workspaceDir, entry.name);
+    if (existsSync(dest)) continue; // already present in workspace
+    try {
+      renameSync(src, dest);
+      migrationLog('info', 'Merged legacy skill into workspace', { from: src, to: dest });
+    } catch (err) {
+      migrationLog('warn', 'Failed to merge legacy skill', { err: String(err), from: src, to: dest });
+    }
+  }
+}
+
+/**
  * Migrate from the flat ~/.vellum layout to the workspace-based layout.
  *
  * Step (a) is special: if the workspace dir doesn't exist yet but the old
@@ -269,6 +299,7 @@ export function migrateToWorkspaceLayout(): void {
   migratePath(join(root, 'hooks'), join(ws, 'hooks'));
   migratePath(join(root, 'IDENTITY.md'), join(ws, 'IDENTITY.md'));
   migratePath(join(root, 'skills'), join(ws, 'skills'));
+  mergeLegacySkills(join(root, 'skills'), join(ws, 'skills'));
   migratePath(join(root, 'SOUL.md'), join(ws, 'SOUL.md'));
   migratePath(join(root, 'USER.md'), join(ws, 'USER.md'));
 }


### PR DESCRIPTION
## Summary
- Addresses codex review feedback on PR #2817 (P1: preserve legacy skills when switching default skills path)
- When `ensureDataDir()` pre-creates `~/.vellum/workspace/skills` before migration, `migratePath()` skips the bulk move, stranding installed skills in `~/.vellum/skills`
- Adds `mergeLegacySkills()` that moves individual entries from the legacy skills dir into workspace, skipping any that already exist (same pattern as `mergeSkippedConfigKeys` for config)
- Updates existing test expectations and adds two new test cases for the merge behavior

## Test plan
- [x] All 14 workspace migration tests pass
- [x] New test: legacy skills merged when workspace/skills pre-created by ensureDataDir
- [x] New test: merge does not overwrite existing workspace skills
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
