### PR TITLE
fix: address PR #2690 feedback (hover race + empty title)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -311,8 +311,15 @@ struct MainWindowView: View {
         .zIndex(menuOpen ? 1 : 0)
         .padding(.horizontal, VSpacing.sm)
         .onHover { hovering in
-            isHoveredThread = hovering ? thread.id : nil
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            if hovering {
+                isHoveredThread = thread.id
+                NSCursor.pointingHand.push()
+            } else {
+                if isHoveredThread == thread.id {
+                    isHoveredThread = nil
+                }
+                NSCursor.pop()
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -346,7 +346,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                     .replacingOccurrences(of: "#", with: "")
                     .replacingOccurrences(of: "\"", with: "")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
-                updateThreadTitle(id: threadId, title: title)
+                updateThreadTitle(id: threadId, title: title.isEmpty ? fallback : title)
             }
         } catch {
             log.warning("Title generation failed: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary

Fixes review feedback from PR #2690:

1. **onHover race condition** (`MainWindowView.swift`): When moving quickly between sidebar thread items, `onHover(false)` for the old thread could fire after `onHover(true)` for the new thread, clearing `isHoveredThread` and causing the ellipsis button to flicker/disappear. Now only clears `isHoveredThread` when it still matches the thread being unhovered.

2. **Empty title after markdown stripping** (`ThreadManager.swift`): After stripping markdown characters (`*`, `#`, `"`), the title could be empty (e.g. if LLM returns `"***"` or `"###"`). Now falls back to the derived title when the stripped result is empty.

## Test plan

- [ ] Move mouse quickly between sidebar thread items — ellipsis button should not flicker
- [ ] Verify thread hover highlighting remains stable during rapid mouse movement
- [ ] Title generation still works normally for well-formed LLM responses
- [ ] If LLM returns only markdown characters as title, fallback title is used instead of empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
