### PR TITLE
fix: handle open -a flag in activity notifications

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -78,11 +78,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-<<<<<<< HEAD
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
-=======
         Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
->>>>>>> 96cab3e0 (feat: add vellum.openLink JS bridge and coordinator handler)
     }
 
     func makeNSView(context: Context) -> WKWebView {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -78,8 +78,8 @@ struct SurfaceContainerView: View {
                     appId: viewModel.appId,
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
-                    sandboxMode: viewModel.sandboxMode,
-                    onLinkOpen: viewModel.onLinkOpen
+                    onLinkOpen: viewModel.onLinkOpen,
+                    sandboxMode: viewModel.sandboxMode
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -156,6 +156,12 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         }
 
         if command.contains("open ") {
+            // Handle 'open -a AppName' pattern
+            if command.contains("open -a ") {
+                if let app = command.components(separatedBy: "open -a ").last?.components(separatedBy: " ").first {
+                    return "Opened \(app)"
+                }
+            }
             if let app = command.components(separatedBy: "open ").last?.components(separatedBy: " ").first {
                 return "Opened \(app)"
             }


### PR DESCRIPTION
Fixes the extractBashAction method to properly extract app names from `open -a AppName` commands.

## Problem
The previous implementation would produce "Opened -a" instead of the actual app name when processing commands like `open -a Spotify`:
1. Split by "open " → ["", "-a Spotify"]
2. .last → "-a Spotify"
3. Split by " " → ["-a", "Spotify"]
4. .first → "-a" ← wrong!

## Solution
Check for the `open -a ` pattern specifically and extract the app name after the -a flag before falling back to the generic `open ` pattern.

## Additional fixes
- Resolved merge conflicts from recent link opening feature (#2859)
- Fixed argument order in SurfaceContainerView

Addresses feedback from #2873
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
