### PR TITLE
fix: wire relatedViewModel and fix indicator visibility

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -227,6 +227,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             skipSessionCreate: true,
             notificationService: self.services.activityNotificationService
         )
+        // Wire relatedViewModel to enable tool call extraction for notifications
+        session.relatedViewModel = mainWindow?.threadManager.activeViewModel
         self.currentSession = session
 
         let overlay = SessionOverlayWindow(session: session)
@@ -1086,6 +1088,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     skipSessionCreate: true,
                     notificationService: self.services.activityNotificationService
                 )
+                // Wire relatedViewModel to enable tool call extraction for notifications
+                session.relatedViewModel = self.mainWindow?.threadManager.activeViewModel
                 self.currentSession = session
                 let overlay = SessionOverlayWindow(session: session)
                 overlay.show()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -639,10 +639,10 @@ private struct ChatBubble: View {
     }
 
     /// Current step indicator rendered outside the bubble.
-    /// Shows when message is streaming or has tool calls.
+    /// Shows only when there are actual tool calls.
     @ViewBuilder
     private func toolCallChips(_ calls: [ToolCallData]) -> some View {
-        if !isUser && (message.isStreaming || !calls.isEmpty) {
+        if !isUser && !calls.isEmpty {
             CurrentStepIndicator(
                 toolCalls: calls,
                 isActivityPanelOpen: isActivityPanelOpen,

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -78,11 +78,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-<<<<<<< HEAD
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
-=======
         Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
->>>>>>> 96cab3e0 (feat: add vellum.openLink JS bridge and coordinator handler)
     }
 
     func makeNSView(context: Context) -> WKWebView {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -78,8 +78,8 @@ struct SurfaceContainerView: View {
                     appId: viewModel.appId,
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
-                    sandboxMode: viewModel.sandboxMode,
-                    onLinkOpen: viewModel.onLinkOpen
+                    onLinkOpen: viewModel.onLinkOpen,
+                    sandboxMode: viewModel.sandboxMode
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):


### PR DESCRIPTION
Fixes feedback from #2824

## Changes

### 1. Wire relatedViewModel in ComputerUseSession
- **Problem**: `relatedViewModel` was declared but never assigned, causing `extractToolCalls()` to always return an empty array
- **Impact**: Notifications always showed generic "Your task has completed successfully." instead of listing actual tools used
- **Fix**: Assign `mainWindow?.threadManager.activeViewModel` when creating ComputerUseSession instances in AppDelegate
- **Files**: `clients/macos/vellum-assistant/App/AppDelegate.swift`

### 2. Fix CurrentStepIndicator visibility
- **Problem**: Indicator shown for every streaming text message due to `message.isStreaming || !calls.isEmpty` condition
- **Impact**: "Thinking..." spinner appeared below every streaming text response, adding unnecessary UI noise
- **Fix**: Change condition to only show when there are actual tool calls (`!calls.isEmpty`)
- **Files**: `clients/macos/vellum-assistant/Features/Chat/ChatView.swift`

### 3. Resolve merge conflicts
- Fixed parameter ordering for `onLinkOpen` in DynamicPageSurfaceView and SurfaceContainerView

## Test Plan
- [x] Build succeeds
- [ ] Manual test: Create computer use session and verify notification shows tool list
- [ ] Manual test: Send text-only message and verify no indicator appears during streaming
- [ ] Manual test: Send message with tool calls and verify indicator appears

Fixes #2824
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
