### PR TITLE
fix: make activity panel reactive to live tool call updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -35,7 +35,7 @@ struct ChatView: View {
     let onCopyDebugInfo: () -> Void
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
-    let onOpenActivity: ([ToolCallData]) -> Void
+    let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
@@ -541,7 +541,7 @@ private struct ChatBubble: View {
     /// When true, tool call chips are suppressed because a nearby message has inline surfaces.
     let hideToolCalls: Bool
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
-    let onOpenActivity: ([ToolCallData]) -> Void
+    let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
 
     private var isUser: Bool { message.role == .user }
@@ -648,7 +648,7 @@ private struct ChatBubble: View {
                 isActivityPanelOpen: isActivityPanelOpen,
                 isStreaming: message.isStreaming
             ) {
-                onOpenActivity(calls)
+                onOpenActivity(message.id)
             }
             .frame(maxWidth: 520, alignment: .leading)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -11,19 +11,20 @@ final class MainWindowState: ObservableObject {
     @Published var activeDynamicParsedSurface: Surface?
     @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
-    @Published var activityToolCalls: [ToolCallData] = []
+    @Published var activityMessageId: UUID?
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey
     }
 
-    func toggleActivityPanel(with toolCalls: [ToolCallData]) {
-        if activePanel == .activity {
-            // Close if already open
+    func toggleActivityPanel(with messageId: UUID) {
+        if activePanel == .activity && activityMessageId == messageId {
+            // Close if already open with the same message
             activePanel = nil
+            activityMessageId = nil
         } else {
-            // Open with new tool calls
-            self.activityToolCalls = toolCalls
+            // Open with new message or update to different message
+            self.activityMessageId = messageId
             self.activePanel = .activity
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -498,9 +498,9 @@ struct MainWindowView: View {
                         onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
                         watchSession: ambientAgent.activeWatchSession,
                         onStopWatch: { viewModel.stopWatchSession() },
-                        onOpenActivity: { toolCalls in
-                            print("DEBUG: onOpenActivity called with \(toolCalls.count) tool calls")
-                            windowState.toggleActivityPanel(with: toolCalls)
+                        onOpenActivity: { messageId in
+                            print("DEBUG: onOpenActivity called with message ID: \(messageId)")
+                            windowState.toggleActivityPanel(with: messageId)
                             print("DEBUG: activePanel is now \(String(describing: windowState.activePanel))")
                         },
                         isActivityPanelOpen: windowState.activePanel == .activity
@@ -869,10 +869,17 @@ struct MainWindowView: View {
             case .doctor:
                 DoctorPanel(onClose: { windowState.activePanel = nil })
             case .activity:
-                ActivityPanel(
-                    toolCalls: windowState.activityToolCalls,
-                    onClose: { windowState.activePanel = nil }
-                )
+                if let viewModel = threadManager.activeViewModel,
+                   let messageId = windowState.activityMessageId {
+                    ActivityPanel(
+                        viewModel: viewModel,
+                        messageId: messageId,
+                        onClose: { windowState.activePanel = nil }
+                    )
+                } else {
+                    Color.clear.frame(width: 0, height: 0)
+                        .onAppear { windowState.activePanel = nil }
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -2,8 +2,13 @@ import SwiftUI
 import VellumAssistantShared
 
 struct ActivityPanel: View {
-    let toolCalls: [ToolCallData]
+    @ObservedObject var viewModel: ChatViewModel
+    let messageId: UUID
     let onClose: () -> Void
+
+    private var toolCalls: [ToolCallData] {
+        viewModel.messages.first(where: { $0.id == messageId })?.toolCalls ?? []
+    }
 
     var body: some View {
         VSidePanel(title: "Activity", onClose: onClose) {
@@ -208,31 +213,46 @@ struct ActivityStepView: View {
 #if DEBUG
 struct ActivityPanel_Previews: PreviewProvider {
     static var previews: some View {
-        ActivityPanel(
-            toolCalls: [
-                ToolCallData(
-                    toolName: "Web Search",
-                    inputSummary: "flights from New York to London next week",
-                    result: "Found 5 search results",
-                    isComplete: true
-                ),
-                ToolCallData(
-                    toolName: "Browser Navigate",
-                    inputSummary: "https://www.google.com/travel/flights",
-                    result: "Navigated successfully",
-                    isComplete: true
-                ),
-                ToolCallData(
-                    toolName: "Browser Screenshot",
-                    inputSummary: "",
-                    isComplete: true
-                ),
-                ToolCallData(
-                    toolName: "Browser Click",
-                    inputSummary: "[aria-label=\"Departure\"]",
-                    isComplete: false
-                )
-            ],
+        let dc = DaemonClient()
+        let viewModel = ChatViewModel(daemonClient: dc)
+        let messageId = UUID()
+
+        // Add a message with tool calls to the view model
+        viewModel.messages = [
+            ChatMessage(
+                id: messageId,
+                role: .assistant,
+                text: "Finding flights for you",
+                toolCalls: [
+                    ToolCallData(
+                        toolName: "Web Search",
+                        inputSummary: "flights from New York to London next week",
+                        result: "Found 5 search results",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Navigate",
+                        inputSummary: "https://www.google.com/travel/flights",
+                        result: "Navigated successfully",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Screenshot",
+                        inputSummary: "",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Click",
+                        inputSummary: "[aria-label=\"Departure\"]",
+                        isComplete: false
+                    )
+                ]
+            )
+        ]
+
+        return ActivityPanel(
+            viewModel: viewModel,
+            messageId: messageId,
             onClose: {}
         )
         .frame(height: 600)

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -78,11 +78,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-<<<<<<< HEAD
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
-=======
         Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
->>>>>>> 96cab3e0 (feat: add vellum.openLink JS bridge and coordinator handler)
     }
 
     func makeNSView(context: Context) -> WKWebView {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -78,8 +78,8 @@ struct SurfaceContainerView: View {
                     appId: viewModel.appId,
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
-                    sandboxMode: viewModel.sandboxMode,
-                    onLinkOpen: viewModel.onLinkOpen
+                    onLinkOpen: viewModel.onLinkOpen,
+                    sandboxMode: viewModel.sandboxMode
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):


### PR DESCRIPTION
## Summary

Fixes the critical feedback from #2670 where the Activity panel showed stale tool call data that never updated.

### Changes

**1. Fixed stale data bug**
- Activity panel now stores a **message ID reference** instead of a snapshot of tool calls
- `ActivityPanel` observes `ChatViewModel` and derives live tool calls from the message on each render
- Tool results, errors, and screenshots now appear immediately as they arrive

**2. Fixed toggle UX issue**  
- `toggleActivityPanel` now compares message IDs before closing
- Clicking a different message's indicator updates the panel instead of closing it
- Only closes if clicking the same message indicator twice

### Files Modified

- `MainWindowState.swift` — Store `activityMessageId: UUID?` instead of `activityToolCalls`
- `ActivityPanel.swift` — Accept `ChatViewModel` + `messageId`, derive live tool calls via computed property
- `MainWindowView.swift` — Pass message ID to `onOpenActivity`, conditionally render panel with viewModel
- `ChatView.swift` — Update `onOpenActivity` signature to accept `UUID`

Also resolved merge conflicts in `DynamicPageSurfaceView.swift` and `SurfaceContainerView.swift`.

### How It Works

Before:
```swift
// CurrentStepIndicator passes snapshot
onOpenActivity(toolCalls) // [ToolCallData] frozen at click time
```

After:
```swift
// CurrentStepIndicator passes message ID
onOpenActivity(message.id) // UUID reference to live message

// ActivityPanel derives live data
private var toolCalls: [ToolCallData] {
    viewModel.messages.first(where: { $0.id == messageId })?.toolCalls ?? []
}
```

Addresses https://github.com/vellum-ai/vellum-assistant/pull/2670

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
