### PR TITLE
fix: address PR #2703 feedback (popup visibility + cursor + underscore)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -292,11 +292,11 @@ struct MainWindowView: View {
             }
             .buttonStyle(.plain)
             .frame(width: 24)
-            .opacity(isSelected || isHoveredThread == thread.id ? 1 : 0)
+            .opacity(isSelected || isHoveredThread == thread.id || menuOpen ? 1 : 0)
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
-        .background(isSelected || isHoveredThread == thread.id ? Color.white.opacity(0.08) : Color.clear)
+        .background(isSelected || isHoveredThread == thread.id || menuOpen ? Color.white.opacity(0.08) : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(alignment: .topTrailing) {
             if menuOpen {
@@ -1097,6 +1097,9 @@ private struct ArchivePopup: View {
         .onHover { hovering in
             isHovered = hovering
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+        .onDisappear {
+            if isHovered { NSCursor.pop() }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -345,6 +345,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 let title = raw.replacingOccurrences(of: "*", with: "")
                     .replacingOccurrences(of: "#", with: "")
                     .replacingOccurrences(of: "\"", with: "")
+                    .replacingOccurrences(of: "_", with: " ")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 updateThreadTitle(id: threadId, title: title.isEmpty ? fallback : title)
             }


### PR DESCRIPTION
Fixes review feedback from PR #2703:

1. **Popup visibility**: Include `menuOpen` state in ellipsis opacity and hover highlight conditions so they stay visible while the archive popup is open.
2. **Cursor leak**: Pop pushed cursor when archive popup disappears to prevent cursor accumulation.
3. **Underscore stripping**: Restore underscore markdown marker removal in title sanitization.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
