### PR TITLE
fix: wrap mkdirSync in try/catch in migratePath

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -183,11 +183,11 @@ export function migratePath(source: string, destination: string): void {
     migrationLog('warn', 'Migration skipped: destination already exists', { source, destination });
     return;
   }
-  const destDir = dirname(destination);
-  if (!existsSync(destDir)) {
-    mkdirSync(destDir, { recursive: true });
-  }
   try {
+    const destDir = dirname(destination);
+    if (!existsSync(destDir)) {
+      mkdirSync(destDir, { recursive: true });
+    }
     renameSync(source, destination);
     migrationLog('info', 'Migrated path', { from: source, to: destination });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Moves `mkdirSync(destDir, { recursive: true })` inside the existing `try/catch` block in `migratePath`
- Ensures filesystem errors during parent-directory creation are logged instead of thrown, matching the function's documented no-throw contract
- Addresses Codex review feedback on PR #2791

## Test plan
- [x] `bun test src/__tests__/platform-move-helper.test.ts` -- 6 tests pass
- [x] `bunx tsc --noEmit` -- type-check passes

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
