### PR TITLE
fix: add afterAll cleanup for keychain dep overrides in invariant tests

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -33,6 +33,11 @@ _overrideDeps({
   isMacOS: () => false,
   isLinux: () => false,
   execFileSync: (() => '') as unknown as typeof import('node:child_process').execFileSync,
+});
+
+// Restore process-level keychain deps so later test files are not affected
+afterAll(() => {
+  _resetDeps();
 });
 
 import { _resetBackend } from '../security/secure-keys.js';


### PR DESCRIPTION
## Summary
- Address PR #2788 codex review feedback: add `afterAll(() => _resetDeps())` to `credential-security-invariants.test.ts` to prevent leaking overridden keychain deps (`isMacOS/isLinux=false`) into later test files in Bun's shared test runner
- Prevents test-order dependence that could mask real backend-selection behavior

## Test plan
- [x] All 22 invariant tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
