### PR TITLE
fix: merge legacy data/ entries on workspace/data collision

### DIFF
--- a/assistant/src/__tests__/platform-workspace-migration.test.ts
+++ b/assistant/src/__tests__/platform-workspace-migration.test.ts
@@ -318,7 +318,7 @@ describe('migrateToWorkspaceLayout', () => {
       'ws-db',
     );
 
-    // Legacy hooks/data should remain at root (not moved due to conflict)
+    // Legacy hooks should remain at root (not moved due to conflict)
     expect(existsSync(join(root, 'hooks', 'legacy-hook.sh'))).toBe(true);
     expect(readFileSync(join(root, 'hooks', 'legacy-hook.sh'), 'utf-8')).toBe(
       'root-hook',
@@ -328,8 +328,15 @@ describe('migrateToWorkspaceLayout', () => {
     expect(
       readFileSync(join(ws, 'skills', 'legacy-skill.json'), 'utf-8'),
     ).toBe('root-skill');
-    // data dir is also left in place
-    expect(existsSync(join(root, 'data', 'logs', 'vellum.log'))).toBe(true);
+    // Legacy data entries are merged into workspace/data (not orphaned)
+    expect(existsSync(join(root, 'data', 'logs', 'vellum.log'))).toBe(false);
+    expect(
+      readFileSync(join(ws, 'data', 'logs', 'vellum.log'), 'utf-8'),
+    ).toBe('root-log');
+    // Existing workspace data entries are preserved
+    expect(readFileSync(join(ws, 'data', 'db', 'assistant.db'), 'utf-8')).toBe(
+      'ws-db',
+    );
 
     rmSync(base, { recursive: true, force: true });
   });
@@ -582,6 +589,45 @@ describe('migrateToWorkspaceLayout', () => {
 
     // Workspace config should be unchanged
     expect(readFileSync(join(ws, 'config.json'), 'utf-8')).toBe(wsBefore);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('sandbox/fs extraction with user data/ dir does not orphan internal state', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(root, { recursive: true });
+
+    // Legacy data dir: sandbox/fs contains a user project with its own data/ folder
+    const dataDir = join(root, 'data');
+    mkdirSync(join(dataDir, 'sandbox', 'fs', 'data', 'models'), { recursive: true });
+    writeFileSync(join(dataDir, 'sandbox', 'fs', 'data', 'models', 'model.pkl'), 'user-model');
+    writeFileSync(join(dataDir, 'sandbox', 'fs', 'app.py'), 'user-app');
+
+    // Internal state dirs inside data/
+    mkdirSync(join(dataDir, 'db'), { recursive: true });
+    writeFileSync(join(dataDir, 'db', 'assistant.db'), 'internal-db');
+    mkdirSync(join(dataDir, 'logs'), { recursive: true });
+    writeFileSync(join(dataDir, 'logs', 'vellum.log'), 'internal-log');
+    mkdirSync(join(dataDir, 'sandbox', 'metadata'), { recursive: true });
+    writeFileSync(join(dataDir, 'sandbox', 'metadata', 'state.json'), 'sandbox-state');
+
+    migrateToWorkspaceLayout();
+
+    // (a) sandbox/fs was extracted to workspace root
+    expect(readFileSync(join(ws, 'app.py'), 'utf-8')).toBe('user-app');
+    // User's data/ directory is now workspace/data
+    expect(readFileSync(join(ws, 'data', 'models', 'model.pkl'), 'utf-8')).toBe('user-model');
+
+    // Internal state from root/data/ was merged into workspace/data/
+    expect(readFileSync(join(ws, 'data', 'db', 'assistant.db'), 'utf-8')).toBe('internal-db');
+    expect(readFileSync(join(ws, 'data', 'logs', 'vellum.log'), 'utf-8')).toBe('internal-log');
+
+    // sandbox/ subdir from root/data/ was merged too
+    expect(readFileSync(join(ws, 'data', 'sandbox', 'metadata', 'state.json'), 'utf-8')).toBe('sandbox-state');
 
     rmSync(base, { recursive: true, force: true });
   });

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -263,6 +263,36 @@ function mergeLegacySkills(legacyDir: string, workspaceDir: string): void {
 }
 
 /**
+ * When migratePath skips the data directory because workspace/data already
+ * exists (e.g. the user's project had a data/ folder that was extracted from
+ * sandbox/fs), the legacy data directory may still contain internal state
+ * subdirectories (db/, logs/, sandbox/, etc.) that need to be preserved.
+ * This merges any missing entries from the legacy data path into workspace/data.
+ */
+function mergeLegacyDataEntries(legacyDir: string, workspaceDir: string): void {
+  if (!existsSync(legacyDir) || !existsSync(workspaceDir)) return;
+
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = readdirSync(legacyDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const src = join(legacyDir, entry.name);
+    const dest = join(workspaceDir, entry.name);
+    if (existsSync(dest)) continue; // already present in workspace
+    try {
+      renameSync(src, dest);
+      migrationLog('info', 'Merged legacy data entry into workspace', { from: src, to: dest });
+    } catch (err) {
+      migrationLog('warn', 'Failed to merge legacy data entry', { err: String(err), from: src, to: dest });
+    }
+  }
+}
+
+/**
  * Migrate from the flat ~/.vellum layout to the workspace-based layout.
  *
  * Step (a) is special: if the workspace dir doesn't exist yet but the old
@@ -296,6 +326,7 @@ export function migrateToWorkspaceLayout(): void {
   migratePath(join(root, 'config.json'), join(ws, 'config.json'));
   mergeSkippedConfigKeys(join(root, 'config.json'), join(ws, 'config.json'));
   migratePath(join(root, 'data'), join(ws, 'data'));
+  mergeLegacyDataEntries(join(root, 'data'), join(ws, 'data'));
   migratePath(join(root, 'hooks'), join(ws, 'hooks'));
   migratePath(join(root, 'IDENTITY.md'), join(ws, 'IDENTITY.md'));
   migratePath(join(root, 'skills'), join(ws, 'skills'));


### PR DESCRIPTION
## Summary
- Addresses Codex P1 review feedback on PR #2793
- When `sandbox/fs` extraction creates `workspace/` and the user's project already contains a `data/` directory, `workspace/data` exists before `migratePath` tries to move `root/data` there — previously skipping the move and orphaning internal state (db, logs, etc.)
- Adds `mergeLegacyDataEntries()` to merge individual subdirectories from `root/data` into `workspace/data` when the directory-level move is skipped (same pattern as `mergeLegacySkills`)
- Adds dedicated test for sandbox/fs extraction with user `data/` collision
- Updates existing "destination directory conflicts" test to verify data entries are merged (not orphaned)

## Test plan
- [x] `bun test src/__tests__/platform-workspace-migration.test.ts` — 15 tests, 109 assertions pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
