### PR TITLE
fix: address PR #2785 feedback on transient credential handling

### DIFF
--- a/assistant/src/tools/credentials/broker-types.ts
+++ b/assistant/src/tools/credentials/broker-types.ts
@@ -39,6 +39,8 @@ export interface ConsumeResult {
   success: boolean;
   /** The storage key to read the secret from (only present on success). */
   storageKey?: string;
+  /** The resolved value when a transient (one-time) credential was consumed. */
+  value?: string;
   /** Error reason if consumption failed. */
   reason?: string;
 }

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -99,15 +99,16 @@ export class CredentialBroker {
 
     token.consumed = true;
     const storageKey = `credential:${token.service}:${token.field}`;
-    // Check for transient value first (one-time send) — consume and discard
+    // Check for transient value first (one-time send) — consume and return the value
+    // directly since transient values are never persisted to secure storage.
     const transient = this.transientValues.get(storageKey);
     if (transient !== undefined) {
       this.transientValues.delete(storageKey);
       log.info({ tokenId, storageKey, transient: true }, 'Usage token consumed (transient)');
-    } else {
-      log.info({ tokenId, storageKey }, 'Usage token consumed');
+      return { success: true, storageKey, value: transient };
     }
 
+    log.info({ tokenId, storageKey }, 'Usage token consumed');
     return { success: true, storageKey };
   }
 
@@ -180,12 +181,11 @@ export class CredentialBroker {
     }
 
     const storageKey = `credential:${request.service}:${request.field}`;
-    // Check transient values first (one-time send), then fall back to keychain
+    // Check transient values first (one-time send), then fall back to keychain.
+    // Deletion is deferred until after a successful fill so the value survives
+    // transient failures (e.g. stale element, page navigation, Playwright timeout).
     const transient = this.transientValues.get(storageKey);
     const value = transient ?? getSecureKey(storageKey);
-    if (transient !== undefined) {
-      this.transientValues.delete(storageKey);
-    }
     if (!value) {
       return {
         success: false,
@@ -195,6 +195,10 @@ export class CredentialBroker {
 
     try {
       await request.fill(value);
+      // Only discard the transient value after a successful fill
+      if (transient !== undefined) {
+        this.transientValues.delete(storageKey);
+      }
       log.info(
         { service: request.service, field: request.field, tool: request.toolName },
         'Browser fill completed',
@@ -254,9 +258,6 @@ export class CredentialBroker {
     const storageKey = `credential:${request.service}:${request.field}`;
     const transient = this.transientValues.get(storageKey);
     const value = transient ?? getSecureKey(storageKey);
-    if (transient !== undefined) {
-      this.transientValues.delete(storageKey);
-    }
     if (!value) {
       return {
         success: false,
@@ -266,6 +267,9 @@ export class CredentialBroker {
 
     try {
       const result = await request.execute(value);
+      if (transient !== undefined) {
+        this.transientValues.delete(storageKey);
+      }
       log.info(
         { service: request.service, field: request.field, tool: request.toolName },
         'Server-side credential use completed',

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -7,7 +7,7 @@ import {
   listSecureKeys,
   getBackendType,
 } from '../../security/secure-keys.js';
-import { upsertCredentialMetadata, deleteCredentialMetadata, assertMetadataWritable } from './metadata-store.js';
+import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata, assertMetadataWritable } from './metadata-store.js';
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput } from './policy-types.js';
 import { credentialBroker } from './broker.js';
@@ -233,12 +233,20 @@ class CredentialStoreTool implements Tool {
           }
           // Inject into broker for one-time use by the next tool call, then discard
           credentialBroker.injectTransient(service, field, result.value);
-          // Also upsert metadata so broker policy checks can find the credential
-          upsertCredentialMetadata(service, field, {
-            allowedTools: promptPolicy.allowedTools,
-            allowedDomains: promptPolicy.allowedDomains,
-            usageDescription: promptPolicy.usageDescription,
-          });
+          // Ensure metadata exists so broker policy checks work, but don't
+          // overwrite an existing record — a stored credential's policy should
+          // not be silently replaced by the transient prompt's policy.
+          if (!getCredentialMetadata(service, field)) {
+            try {
+              upsertCredentialMetadata(service, field, {
+                allowedTools: promptPolicy.allowedTools,
+                allowedDomains: promptPolicy.allowedDomains,
+                usageDescription: promptPolicy.usageDescription,
+              });
+            } catch (err) {
+              log.warn({ service, field, err }, 'metadata write failed for transient credential');
+            }
+          }
           log.info({ service, field, delivery: 'transient_send' }, 'One-time secret delivery used');
           return {
             content: `One-time credential provided for ${service}/${field}. The value was NOT saved to the vault and will be consumed by the next operation.`,


### PR DESCRIPTION
## Summary
- Addresses review feedback from Devin and Codex on PR #2785 (transient credential broker)
- `consume()` now returns the transient value directly via a new `value` field on `ConsumeResult`, fixing the bug where transient values were deleted but unretrievable via `getSecureKey()`
- `browserFill()` and `serverUse()` defer transient value deletion until after the callback succeeds, preventing permanent credential loss on fill/execute failures
- Vault `transient_send` path now guards metadata upsert with an existence check, preventing accidental overwrite of a stored credential's policy

## Test plan
- [ ] Verify `consume()` returns `value` for transient credentials and `undefined` for persistent ones
- [ ] Verify `browserFill()` retains transient credential on fill failure, consumes on success
- [ ] Verify `serverUse()` retains transient credential on execute failure, consumes on success
- [ ] Verify transient send does not overwrite existing metadata for a stored credential
- [ ] Type-check passes (`bunx tsc --noEmit`)

Addresses #2785

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
