### PR TITLE
fix: merge legacy hooks into workspace when directory move is skipped

### DIFF
--- a/assistant/src/__tests__/migration-ordering.test.ts
+++ b/assistant/src/__tests__/migration-ordering.test.ts
@@ -108,8 +108,10 @@ describe('migration ordering: ensureDataDir before migration', () => {
     expect(existsSync(join(root, 'data'))).toBe(true);
     expect(existsSync(join(ws, 'data', 'db', 'assistant.db'))).toBe(false);
 
-    // hooks/ move is skipped because workspace/hooks/ already exists
+    // hooks/ directory move is skipped because workspace/hooks/ already exists,
+    // but mergeLegacyHooks() moves individual hook files into workspace/hooks/
     expect(existsSync(join(root, 'hooks'))).toBe(true);
+    expect(readFileSync(join(ws, 'hooks', 'on-start.sh'), 'utf-8')).toBe('#!/bin/bash');
 
     // skills/ move is skipped because workspace/skills/ already exists
     expect(existsSync(join(root, 'skills'))).toBe(true);
@@ -202,10 +204,13 @@ describe('migration ordering: ensureDataDir before migration', () => {
     expect(readFileSync(join(ws, 'USER.md'), 'utf-8')).toBe('# User');
 
     // Directories that ensureDataDir pre-creates are the problem:
-    // data/, hooks/, skills/ are NOT migrated because destination exists
+    // data/ is NOT migrated because destination exists
     expect(existsSync(join(root, 'data', 'db', 'assistant.db'))).toBe(true);
-    expect(existsSync(join(root, 'hooks', 'on-start.sh'))).toBe(true);
-    expect(existsSync(join(root, 'skills', 'search.json'))).toBe(true);
+
+    // hooks/ and skills/ directory moves are skipped, but their contents
+    // are merged by mergeLegacyHooks() and mergeLegacySkills()
+    expect(readFileSync(join(ws, 'hooks', 'on-start.sh'), 'utf-8')).toBe('#!/bin/bash');
+    expect(readFileSync(join(ws, 'skills', 'search.json'), 'utf-8')).toBe('{}');
 
     rmSync(base, { recursive: true, force: true });
   });

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -233,6 +233,36 @@ function mergeSkippedConfigKeys(legacyPath: string, workspacePath: string): void
 }
 
 /**
+ * When migratePath skips the hooks directory because the workspace copy
+ * already exists (e.g. pre-created by ensureDataDir), the legacy hooks
+ * directory may still contain individual hook files/subdirectories that
+ * were never moved. This merges any missing entries from the legacy
+ * path into the workspace hooks path so they are not silently lost.
+ */
+function mergeLegacyHooks(legacyDir: string, workspaceDir: string): void {
+  if (!existsSync(legacyDir) || !existsSync(workspaceDir)) return;
+
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = readdirSync(legacyDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const src = join(legacyDir, entry.name);
+    const dest = join(workspaceDir, entry.name);
+    if (existsSync(dest)) continue; // already present in workspace
+    try {
+      renameSync(src, dest);
+      migrationLog('info', 'Merged legacy hook into workspace', { from: src, to: dest });
+    } catch (err) {
+      migrationLog('warn', 'Failed to merge legacy hook', { err: String(err), from: src, to: dest });
+    }
+  }
+}
+
+/**
  * When migratePath skips the skills directory because the workspace copy
  * already exists (e.g. pre-created by ensureDataDir), the legacy skills
  * directory may still contain individual skill subdirectories that were
@@ -297,6 +327,7 @@ export function migrateToWorkspaceLayout(): void {
   mergeSkippedConfigKeys(join(root, 'config.json'), join(ws, 'config.json'));
   migratePath(join(root, 'data'), join(ws, 'data'));
   migratePath(join(root, 'hooks'), join(ws, 'hooks'));
+  mergeLegacyHooks(join(root, 'hooks'), join(ws, 'hooks'));
   migratePath(join(root, 'IDENTITY.md'), join(ws, 'IDENTITY.md'));
   migratePath(join(root, 'skills'), join(ws, 'skills'));
   mergeLegacySkills(join(root, 'skills'), join(ws, 'skills'));


### PR DESCRIPTION
## Summary
- Adds `mergeLegacyHooks()` to handle cases where `workspace/hooks` already exists but legacy `hooks/` still contains user files
- Mirrors the existing `mergeLegacySkills()` pattern — iterates entries in the legacy dir and moves any missing ones to the workspace dir
- Prevents upgraded users from silently losing their hooks when the directory-level migration is skipped
- Updates migration-ordering tests to verify hooks are merged even when `ensureDataDir()` runs first

Addresses Codex review feedback on PR #2805.

## Test plan
- [x] `bun test src/__tests__/migration-ordering.test.ts` — all 4 tests pass
- [x] `bun test src/__tests__/platform.test.ts` — all 4 tests pass
- [x] `bunx tsc --noEmit` — no type errors

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
