### PR TITLE
fix: clean up ephemeral secret-redirect conversations and gate setSecureKey result

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1454,11 +1454,15 @@ async function handleTaskSubmit(
         type: 'error',
         message: taskIngressCheck.userNotice!,
       });
-      // Create a session so the secret_response lifecycle works end-to-end
+      // Create an ephemeral session so the secret_response lifecycle works
+      // end-to-end. The conversation is deleted after the prompt resolves
+      // to avoid accumulating placeholder entries in session history.
       const conversation = conversationStore.createConversation('(blocked — secret detected)');
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
-      session.redirectToSecurePrompt(taskIngressCheck.detectedTypes);
+      session.redirectToSecurePrompt(taskIngressCheck.detectedTypes, () => {
+        conversationStore.deleteConversation(conversation.id);
+      });
       return;
     }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -380,8 +380,12 @@ export class Session {
    * Redirect the user to the secure credential prompt after an ingress block.
    * If the user enters a value, it is stored in the vault (or injected as
    * transient) so the credential is available for later tool use.
+   *
+   * @param onComplete Called after the prompt resolves (success, cancel, or
+   *   timeout) so the caller can clean up ephemeral resources like placeholder
+   *   conversations.
    */
-  redirectToSecurePrompt(detectedTypes: string[]): void {
+  redirectToSecurePrompt(detectedTypes: string[], onComplete?: () => void): void {
     const service = 'detected';
     const field = detectedTypes.join(',');
     this.secretPrompter.prompt(
@@ -402,11 +406,17 @@ export class Session {
         log.info({ service, field, delivery: 'transient_send' }, 'Ingress redirect: transient credential injected');
       } else {
         const key = `credential:${service}:${field}`;
-        setSecureKey(key, result.value);
-        try { upsertCredentialMetadata(service, field, {}); } catch {}
-        log.info({ service, field }, 'Ingress redirect: credential stored');
+        const stored = setSecureKey(key, result.value);
+        if (stored) {
+          try { upsertCredentialMetadata(service, field, {}); } catch {}
+          log.info({ service, field }, 'Ingress redirect: credential stored');
+        } else {
+          log.warn({ service, field }, 'Ingress redirect: secure storage write failed');
+        }
       }
-    }).catch(() => { /* prompt timeout or cancel is fine */ });
+    }).catch(() => { /* prompt timeout or cancel is fine */ }).finally(() => {
+      onComplete?.();
+    });
   }
 
   isProcessing(): boolean {

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -38,6 +38,19 @@ export function getConversation(id: string) {
   return result ?? null;
 }
 
+/**
+ * Delete a conversation and all its messages.
+ * Used for ephemeral conversations (e.g. secret-redirect placeholders)
+ * that should not persist in session history.
+ */
+export function deleteConversation(id: string): void {
+  const db = getDb();
+  db.transaction((tx) => {
+    tx.delete(messages).where(eq(messages.conversationId, id)).run();
+    tx.delete(conversations).where(eq(conversations.id, id)).run();
+  });
+}
+
 export function listConversations(limit?: number) {
   const db = getDb();
   const query = db


### PR DESCRIPTION
## Summary
Addresses two Codex review findings on PR #2809:

- **Ephemeral conversation cleanup**: Secret-blocked `task_submit` created persistent conversations that accumulated in session history. Now the placeholder conversation is deleted after the prompt resolves via an `onComplete` callback in `redirectToSecurePrompt`.
- **setSecureKey result check**: The `setSecureKey` return value was ignored -- metadata was upserted and success logged even when secure storage write failed. Now gates metadata upsert and logging on a successful write, and logs a warning on failure.
- Adds `deleteConversation()` to `conversation-store.ts` for ephemeral cleanup.

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify that blocked task_submit conversations do not persist in session lists after the secret prompt resolves
- [ ] Verify that a failed `setSecureKey` does not create dangling credential metadata

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
