### PR TITLE
fix: update ActivityPanel to use viewModel+messageId API

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -460,9 +460,12 @@ struct MainWindowView: View {
             VSplitView(panelWidth: $sidePanelWidth, showPanel: windowState.activePanel == .activity, main: {
                 chatView
             }, panel: {
-                if windowState.activePanel == .activity {
+                if windowState.activePanel == .activity,
+                   let viewModel = threadManager.activeViewModel,
+                   let messageId = windowState.activityMessageId {
                     ActivityPanel(
-                        toolCalls: windowState.activityToolCalls,
+                        viewModel: viewModel,
+                        messageId: messageId,
                         onClose: { windowState.activePanel = nil }
                     )
                 }
@@ -521,8 +524,8 @@ struct MainWindowView: View {
                 onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
                 watchSession: ambientAgent.activeWatchSession,
                 onStopWatch: { viewModel.stopWatchSession() },
-                onOpenActivity: { toolCalls in
-                    windowState.toggleActivityPanel(with: toolCalls)
+                onOpenActivity: { messageId in
+                    windowState.toggleActivityPanel(with: messageId)
                 },
                 isActivityPanelOpen: windowState.activePanel == .activity
             )


### PR DESCRIPTION
## Summary
- Update ActivityPanel instantiation in full-window panels layout to use the new `viewModel` + `messageId` init instead of the removed `toolCalls` parameter
- Fixes build break caused by ActivityPanel API change after #2957

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
