### PR TITLE
fix: persist step reset during onboarding flow migration

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -81,6 +81,7 @@ final class OnboardingState {
             // beginning so the user doesn't land on the wrong step.
             if storedFlowVersion != Self.currentFlowVersion {
                 currentStep = 0
+                UserDefaults.standard.set(0, forKey: "onboarding.step")
                 UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
             } else {
                 currentStep = saved


### PR DESCRIPTION
## Summary
- Fixes review feedback from PR #2943
- When the onboarding flow version changes, the migration resets `currentStep` to 0 in memory but didn't persist it to UserDefaults
- If the app was killed before `advance()` called `persist()`, the reset would be lost on next launch, defeating the migration entirely
- Now explicitly writes `UserDefaults.standard.set(0, forKey: "onboarding.step")` alongside the flow version update

## Test plan
- [ ] Verify that after a flow version bump, `onboarding.step` is written to UserDefaults as 0
- [ ] Verify that killing the app immediately after migration still correctly restores step 0 on relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
