### PR TITLE
fix: address PR #2957 feedback (panel, window min, flow version)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -107,7 +107,7 @@ final class MainWindow {
         window.titlebarAppearsTransparent = true
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
-        window.contentMinSize = NSSize(width: 500, height: 400)
+        window.contentMinSize = NSSize(width: 800, height: 600)
         window.setFrame(windowRect, display: false)
         window.setFrameAutosaveName("MainWindow")
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -563,6 +563,12 @@ struct MainWindowView: View {
             )
         case .doctor:
             DoctorPanel(onClose: { windowState.activePanel = nil })
+        case .generated:
+            // Generated panel is handled inline in chatContentView when expanded;
+            // if we reach here, isDynamicExpanded is false — clear activePanel so
+            // the user falls back to the chat view instead of seeing a blank screen.
+            Color.clear.frame(width: 0, height: 0)
+                .onAppear { windowState.activePanel = nil }
         default:
             EmptyView()
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -24,7 +24,7 @@ enum ActivationKey: String, CaseIterable {
 final class OnboardingState {
     /// Bump this version whenever the default-flow step order changes so that
     /// persisted step indices from a previous layout are not consumed as-is.
-    private static let currentFlowVersion = 2
+    private static let currentFlowVersion = 3
 
     var currentStep: Int = 0
     var assistantName: String = "Velly"


### PR DESCRIPTION
## Summary

Fixes review feedback from PR #2957:

- **Generated panel handling**: Clear `activePanel` when `.generated` is routed to `fullWindowPanel` but `isDynamicExpanded` is `false`, preventing the main content area from going blank with no path back to chat.
- **Window minimum size**: Align NSWindow `contentMinSize` (was 500x400) with `MainWindowView`'s `.frame(minWidth: 800, minHeight: 600)` constraint, preventing content clipping when users resize the window below the SwiftUI minimum.
- **Flow version bump**: Bump `currentFlowVersion` from 2 to 3 so users mid-onboarding on the old 8-step flow get properly reset to step 0 via the version migration mechanism.

## Test plan

- [ ] Verify that collapsing the generated panel (setting `isDynamicExpanded = false` while `activePanel == .generated`) falls back to the chat view instead of showing a blank screen
- [ ] Verify the window cannot be resized smaller than 800x600
- [ ] Verify that a user with persisted onboarding step from the old flow (version 2) gets reset to step 0 on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
