### PR TITLE
fix: resolve unused binding and ViewBuilder return warnings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -254,7 +254,7 @@ struct MainWindowView: View {
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected = thread.id == threadManager.activeThreadId
         let menuOpen = threadMenuOpenId == thread.id
-        return HStack(spacing: 0) {
+        HStack(spacing: 0) {
             Button(action: {
                 threadMenuOpenId = nil
                 threadManager.selectThread(id: thread.id)

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -648,7 +648,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 }
                 guard let image = image,
                       let tiff = image.tiffRepresentation,
-                      let bitmap = NSBitmapImageRep(data: tiff) else {
+                      let _ = NSBitmapImageRep(data: tiff) else {
                     completion(nil)
                     return
                 }


### PR DESCRIPTION
## Summary
- Replace unused `bitmap` binding with `_` in `DynamicPageSurfaceView.swift` to silence no-usage warning
- Remove explicit `return` in `@ViewBuilder` function `threadItem` in `MainWindowView.swift` to fix result builder warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
