### PR TITLE
fix: refresh onPageChanged binding in DynamicPageSurfaceView.updateNSView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -368,6 +368,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     func updateNSView(_ webView: WKWebView, context: Context) {
         context.coordinator.onAction = onAction
         context.coordinator.onDataRequest = onDataRequest
+        context.coordinator.onPageChanged = onPageChanged
         context.coordinator.onLinkOpen = onLinkOpen
 
         // Keep the coordinator's desired insets up-to-date so webView(_:didFinish:)


### PR DESCRIPTION
## Summary
- Updates DynamicPageSurfaceView.updateNSView to refresh the onPageChanged callback alongside onAction, onDataRequest, and onLinkOpen
- Prevents stale page-change bindings when the workspace surface changes while staying in the generated panel
- Addresses Codex review feedback on #2825

## Test plan
- [ ] Open a multi-page app in generated panel
- [ ] Switch surfaces while staying in the generated panel
- [ ] Verify page changes are written to the correct thread's view model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
