### PR TITLE
feat: show Waking up only for first-ever message

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -48,6 +48,7 @@ struct ChatView: View {
     @State private var editorContentHeight: CGFloat = 20
     @State private var isComposerExpanded = false
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
+    @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
     var body: some View {
         ZStack {
@@ -314,7 +315,7 @@ struct ChatView: View {
                     }
 
                     if isThinking {
-                        ThinkingIndicator(label: messages.count <= 1 ? "Waking up..." : "Thinking")
+                        ThinkingIndicator(label: !hasEverSentMessage ? "Waking up..." : "Thinking")
                             .id("thinking-indicator")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
@@ -338,6 +339,10 @@ struct ChatView: View {
                 if isThinking {
                     withAnimation(VAnimation.standard) {
                         proxy.scrollTo("thinking-indicator", anchor: .bottom)
+                    }
+                    // Mark that the user has sent at least one message (after showing "Waking up...")
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        hasEverSentMessage = true
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Show "Waking up..." indicator only for the very first message after signup
- All subsequent messages show "Thinking" instead
- Uses `@AppStorage("hasEverSentMessage")` to persist across sessions, reset on scrub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
