### PR TITLE
fix: restore body > * width baseline with overlay exemption

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -182,6 +182,10 @@ body {
   justify-content: center;
   -webkit-font-smoothing: antialiased;
 }
+body > *:not(#vellum-bottom-fade):not(#vellum-branding):not(#v-toast-container) {
+  width: 100%;
+  max-width: 900px;
+}
 
 @media (prefers-color-scheme: dark) {
   body {


### PR DESCRIPTION
## Summary
- Restores the full-width baseline for direct body children that was removed in #2819
- Exempts fixed-position overlay elements (`#vellum-bottom-fade`, `#vellum-branding`, `#v-toast-container`) that need full viewport width
- Without this rule, pages shrink to content width in the centered flex container since `body` uses `align-items: center`
- Addresses Codex review feedback on #2819

## Test plan
- [ ] Verify pages (weather, etc.) display at proper width
- [ ] Verify `#vellum-bottom-fade` overlay spans full viewport width
- [ ] Verify `#vellum-branding` badge positioned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
