### PR TITLE
refactor: use XML tags for dynamic profile injection markers

### DIFF
--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -461,7 +461,7 @@ describe('Memory lifecycle E2E regression', () => {
     expect(runtimeExisting?.status).toBe('active');
     expect(runtimeCandidate?.status).toBe('superseded');
 
-    const profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles\n- prefers concise answers';
+    const profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles\n- prefers concise answers';
     const baseUserMessage: Message = {
       role: 'user',
       content: [{ type: 'text', text: 'Plan next sprint milestones.' }],
@@ -469,9 +469,9 @@ describe('Memory lifecycle E2E regression', () => {
 
     const injectedProfileMessage = injectDynamicProfileIntoUserMessage(baseUserMessage, profileText);
     const runtimeUserText = messageText(injectedProfileMessage);
-    expect(runtimeUserText).toContain('[Dynamic profile context start]');
-    expect(runtimeUserText).toContain('[Dynamic User Profile]');
-    expect(runtimeUserText).toContain('[Dynamic profile context end]');
+    expect(runtimeUserText).toContain('<dynamic-profile-context>');
+    expect(runtimeUserText).toContain('<dynamic-user-profile>');
+    expect(runtimeUserText).toContain('</dynamic-profile-context>');
 
     const strippedMessages = stripDynamicProfileMessages([injectedProfileMessage], profileText);
     expect(strippedMessages).toHaveLength(1);

--- a/assistant/src/__tests__/profile-compiler.test.ts
+++ b/assistant/src/__tests__/profile-compiler.test.ts
@@ -238,7 +238,7 @@ describe('profile-compiler', () => {
       importance: 0.7,
     });
 
-    const budget = estimateTextTokens('[Dynamic User Profile]\n- deployment policy: Deploy only on weekdays.') + 2;
+    const budget = estimateTextTokens('<dynamic-user-profile>\n- deployment policy: Deploy only on weekdays.') + 2;
     const compiled = compileDynamicProfile({ maxInjectTokensOverride: budget });
 
     expect(compiled.tokenEstimate).toBeLessThanOrEqual(budget);

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -7,7 +7,7 @@ let runCalls: Message[][] = [];
 let profileCompilerCalls = 0;
 let profileEnabled = true;
 let memoryEnabled = true;
-let profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles';
+let profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles';
 
 const persistedMessages: Array<{ id: string; role: string; content: string; createdAt: number }> = [];
 
@@ -257,7 +257,7 @@ describe('Session dynamic profile injection', () => {
     profileCompilerCalls = 0;
     profileEnabled = true;
     memoryEnabled = true;
-    profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles';
+    profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles';
   });
 
   test('injects profile context for runtime and strips it from persisted history', async () => {
@@ -271,17 +271,17 @@ describe('Session dynamic profile injection', () => {
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
     expect(runtimeUser.role).toBe('user');
     const runtimeText = messageText(runtimeUser);
-    expect(runtimeText).toContain('[Dynamic profile context start]');
-    expect(runtimeText).toContain('[Dynamic User Profile]');
-    expect(runtimeText).toContain('[Dynamic profile context end]');
+    expect(runtimeText).toContain('<dynamic-profile-context>');
+    expect(runtimeText).toContain('<dynamic-user-profile>');
+    expect(runtimeText).toContain('</dynamic-profile-context>');
 
     const persistedUser = session.getMessages().find((message) => message.role === 'user');
     expect(persistedUser).toBeDefined();
     if (persistedUser) {
       const persistedText = messageText(persistedUser);
-      expect(persistedText).not.toContain('[Dynamic profile context start]');
-      expect(persistedText).not.toContain('[Dynamic User Profile]');
-      expect(persistedText).not.toContain('[Dynamic profile context end]');
+      expect(persistedText).not.toContain('<dynamic-profile-context>');
+      expect(persistedText).not.toContain('<dynamic-user-profile>');
+      expect(persistedText).not.toContain('</dynamic-profile-context>');
       // No empty text blocks should remain after stripping
       const emptyBlocks = persistedUser.content.filter(
         (b) => b.type === 'text' && (b as { text: string }).text === '',
@@ -311,10 +311,10 @@ describe('Session dynamic profile injection', () => {
 
   test('strip only targets the last user message, not earlier ones', () => {
     const profile = 'timezone: US/Pacific';
-    const profileMarker = '[Dynamic profile context start]';
+    const profileMarker = '<dynamic-profile-context>';
     const earlyUser: Message = {
       role: 'user',
-      content: [{ type: 'text', text: `I pasted: ${profileMarker}\ntimezone: US/Pacific\n[Dynamic profile context end]` }],
+      content: [{ type: 'text', text: `I pasted: ${profileMarker}\ntimezone: US/Pacific\n</dynamic-profile-context>` }],
     };
     const assistant: Message = {
       role: 'assistant',
@@ -335,7 +335,7 @@ describe('Session dynamic profile injection', () => {
 
   test('strip finds injected message even when tool_result user messages follow it', () => {
     const profile = 'timezone: US/Pacific';
-    const profileMarker = '[Dynamic profile context start]';
+    const profileMarker = '<dynamic-profile-context>';
     const injectedUser = injectDynamicProfileIntoUserMessage(
       { role: 'user', content: [{ type: 'text', text: 'hello' }] },
       profile,
@@ -367,7 +367,7 @@ describe('Session dynamic profile injection', () => {
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
     const runtimeText = messageText(runtimeUser);
-    expect(runtimeText).not.toContain('[Dynamic profile context start]');
+    expect(runtimeText).not.toContain('<dynamic-profile-context>');
     expect(profileCompilerCalls).toBe(0);
   });
 
@@ -381,7 +381,7 @@ describe('Session dynamic profile injection', () => {
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
     const runtimeText = messageText(runtimeUser);
-    expect(runtimeText).not.toContain('[Dynamic profile context start]');
+    expect(runtimeText).not.toContain('<dynamic-profile-context>');
     expect(profileCompilerCalls).toBe(0);
   });
 });

--- a/assistant/src/daemon/session-dynamic-profile.ts
+++ b/assistant/src/daemon/session-dynamic-profile.ts
@@ -11,9 +11,9 @@ export function injectDynamicProfileIntoUserMessage(message: Message, profileTex
   const trimmedProfile = profileText.trim();
   if (trimmedProfile.length === 0) return message;
   const block = [
-    '[Dynamic profile context start]',
+    '<dynamic-profile-context>',
     trimmedProfile,
-    '[Dynamic profile context end]',
+    '</dynamic-profile-context>',
   ].join('\n');
   return {
     ...message,
@@ -27,7 +27,7 @@ export function injectDynamicProfileIntoUserMessage(message: Message, profileTex
 export function stripDynamicProfileMessages(messages: Message[], profileText: string): Message[] {
   const trimmedProfile = profileText.trim();
   if (trimmedProfile.length === 0) return messages;
-  const injectedBlock = `\n\n[Dynamic profile context start]\n${trimmedProfile}\n[Dynamic profile context end]`;
+  const injectedBlock = `\n\n<dynamic-profile-context>\n${trimmedProfile}\n</dynamic-profile-context>`;
   // Find the last user message that actually contains the injected profile block.
   // We can't just target the last user message by role — tool_result messages also
   // have role 'user', so after tool use the last user message won't be the one

--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -120,5 +120,5 @@ function normalizeWhitespace(input: string, maxLength: number): string {
 
 function renderProfileText(lines: string[]): string {
   if (lines.length === 0) return '';
-  return ['[Dynamic User Profile]', ...lines].join('\n');
+  return ['<dynamic-user-profile>', ...lines].join('\n');
 }


### PR DESCRIPTION
## Summary
- Replaces bracket-style markers (`[Dynamic profile context start]`, `[Dynamic User Profile]`, etc.) with proper XML tags (`<dynamic-profile-context>`, `<dynamic-user-profile>`) for consistency with how other dynamic context is injected into prompts
- Updates all test assertions in session-profile-injection, memory-lifecycle-e2e, and profile-compiler tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
