### PR TITLE
fix: add closing tag for <dynamic-user-profile>

### DIFF
--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -461,7 +461,7 @@ describe('Memory lifecycle E2E regression', () => {
     expect(runtimeExisting?.status).toBe('active');
     expect(runtimeCandidate?.status).toBe('superseded');
 
-    const profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles\n- prefers concise answers';
+    const profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles\n- prefers concise answers\n</dynamic-user-profile>';
     const baseUserMessage: Message = {
       role: 'user',
       content: [{ type: 'text', text: 'Plan next sprint milestones.' }],

--- a/assistant/src/__tests__/profile-compiler.test.ts
+++ b/assistant/src/__tests__/profile-compiler.test.ts
@@ -238,7 +238,7 @@ describe('profile-compiler', () => {
       importance: 0.7,
     });
 
-    const budget = estimateTextTokens('<dynamic-user-profile>\n- deployment policy: Deploy only on weekdays.') + 2;
+    const budget = estimateTextTokens('<dynamic-user-profile>\n- deployment policy: Deploy only on weekdays.\n</dynamic-user-profile>') + 2;
     const compiled = compileDynamicProfile({ maxInjectTokensOverride: budget });
 
     expect(compiled.tokenEstimate).toBeLessThanOrEqual(budget);

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -7,7 +7,7 @@ let runCalls: Message[][] = [];
 let profileCompilerCalls = 0;
 let profileEnabled = true;
 let memoryEnabled = true;
-let profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles';
+let profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles\n</dynamic-user-profile>';
 
 const persistedMessages: Array<{ id: string; role: string; content: string; createdAt: number }> = [];
 
@@ -257,7 +257,7 @@ describe('Session dynamic profile injection', () => {
     profileCompilerCalls = 0;
     profileEnabled = true;
     memoryEnabled = true;
-    profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles';
+    profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles\n</dynamic-user-profile>';
   });
 
   test('injects profile context for runtime and strips it from persisted history', async () => {

--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -120,5 +120,5 @@ function normalizeWhitespace(input: string, maxLength: number): string {
 
 function renderProfileText(lines: string[]): string {
   if (lines.length === 0) return '';
-  return ['<dynamic-user-profile>', ...lines].join('\n');
+  return ['<dynamic-user-profile>', ...lines, '</dynamic-user-profile>'].join('\n');
 }


### PR DESCRIPTION
## Summary
- Adds closing `</dynamic-user-profile>` tag to the rendered profile text so every opening XML tag has a matching close
- Updates test assertions in profile-compiler, session-profile-injection, and memory-lifecycle-e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
