### PR TITLE
feat: add LayoutConfig types and LayoutConfigStore for configurable UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+// MARK: - Domain Types
+
+public enum NativePanelId: String, Codable, Equatable, Sendable {
+    case chat, threadList, activity, settings, agent, debug, doctor, directory, generated
+}
+
+public enum SlotContent: Equatable, Sendable {
+    case native(NativePanelId)
+    case surface(surfaceId: String)
+    case empty
+}
+
+extension SlotContent: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type, panel, surfaceId
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "native":
+            let panel = try container.decode(NativePanelId.self, forKey: .panel)
+            self = .native(panel)
+        case "surface":
+            let surfaceId = try container.decode(String.self, forKey: .surfaceId)
+            self = .surface(surfaceId: surfaceId)
+        case "empty":
+            self = .empty
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown SlotContent type: \(type)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .native(let panelId):
+            try container.encode("native", forKey: .type)
+            try container.encode(panelId, forKey: .panel)
+        case .surface(let surfaceId):
+            try container.encode("surface", forKey: .type)
+            try container.encode(surfaceId, forKey: .surfaceId)
+        case .empty:
+            try container.encode("empty", forKey: .type)
+        }
+    }
+}
+
+public struct SlotConfig: Codable, Equatable, Sendable {
+    public var content: SlotContent
+    public var width: Double?
+    public var visible: Bool
+}
+
+public struct LayoutConfig: Codable, Equatable, Sendable {
+    public var version: Int
+    public var left: SlotConfig
+    public var center: SlotConfig
+    public var right: SlotConfig
+
+    public static let `default` = LayoutConfig(
+        version: 1,
+        left: SlotConfig(content: .native(.threadList), width: 240, visible: true),
+        center: SlotConfig(content: .native(.chat), width: nil, visible: true),
+        right: SlotConfig(content: .empty, width: 400, visible: false)
+    )
+}
+
+// MARK: - Wire Types (IPC)
+
+public struct UiLayoutConfigMessage: Decodable, Sendable {
+    public let left: SlotConfigWire?
+    public let center: SlotConfigWire?
+    public let right: SlotConfigWire?
+}
+
+public struct SlotConfigWire: Decodable, Sendable {
+    public let content: SlotContentWire?
+    public let width: Double?
+    public let visible: Bool?
+}
+
+public struct SlotContentWire: Decodable, Sendable {
+    public let type: String       // "native" | "surface" | "empty"
+    public let panel: String?     // for native
+    public let surfaceId: String? // for surface
+}
+
+// MARK: - Merge Logic
+
+extension LayoutConfig {
+    public static func merged(base: LayoutConfig, wire: UiLayoutConfigMessage) -> LayoutConfig {
+        var result = base
+        if let left = wire.left { result.left = SlotConfig.merged(base: base.left, wire: left) }
+        if let center = wire.center { result.center = SlotConfig.merged(base: base.center, wire: center) }
+        if let right = wire.right { result.right = SlotConfig.merged(base: base.right, wire: right) }
+        return result
+    }
+}
+
+extension SlotConfig {
+    static func merged(base: SlotConfig, wire: SlotConfigWire) -> SlotConfig {
+        var result = base
+        if let content = wire.content { result.content = SlotContent.from(wire: content) ?? base.content }
+        if let width = wire.width { result.width = width }
+        if let visible = wire.visible { result.visible = visible }
+        return result
+    }
+}
+
+extension SlotContent {
+    static func from(wire: SlotContentWire) -> SlotContent? {
+        switch wire.type {
+        case "native":
+            guard let panel = wire.panel, let id = NativePanelId(rawValue: panel) else { return nil }
+            return .native(id)
+        case "surface":
+            guard let surfaceId = wire.surfaceId else { return nil }
+            return .surface(surfaceId: surfaceId)
+        case "empty":
+            return .empty
+        default:
+            return nil
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfigStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfigStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum LayoutConfigStore {
+    private static var configURL: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("vellum-assistant/layout-config.json")
+    }
+
+    public static func load() -> LayoutConfig {
+        guard let data = try? Data(contentsOf: configURL),
+              let config = try? JSONDecoder().decode(LayoutConfig.self, from: data) else {
+            return .default
+        }
+        return config
+    }
+
+    public static func save(_ config: LayoutConfig) {
+        let url = configURL
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        guard let data = try? encoder.encode(config) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+}


### PR DESCRIPTION
## Summary
- Add domain types (`LayoutConfig`, `SlotConfig`, `SlotContent`, `NativePanelId`) with `Codable`, `Equatable`, and `Sendable` conformances
- Add IPC wire types (`UiLayoutConfigMessage`, `SlotConfigWire`, `SlotContentWire`) for partial layout updates from the daemon
- Add merge logic to apply partial wire updates onto an existing `LayoutConfig`
- Add `LayoutConfigStore` for JSON persistence to Application Support

Part of #2972. Closes #2973.

## Test plan
- [x] Build compiles cleanly with `./build.sh`
- [ ] Verify round-trip encoding/decoding of `LayoutConfig` with all `SlotContent` variants
- [ ] Verify `LayoutConfig.merged` correctly applies partial updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
