### PR TITLE
feat: add ui_layout_config IPC message type and DaemonClient callback

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -158,6 +158,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `open_url` message.
     public var onOpenUrl: ((OpenUrlMessage) -> Void)?
 
+    /// Called when the daemon sends a `ui_layout_config` message.
+    public var onLayoutConfig: ((UiLayoutConfigMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -879,6 +882,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSurfaceUpdate?(msg)
         case .uiSurfaceDismiss(let msg):
             onSurfaceDismiss?(msg)
+        case .uiLayoutConfig(let msg):
+            onLayoutConfig?(msg)
         case .appDataResponse(let msg):
             onAppDataResponse?(msg)
         case .messageQueued(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -33,6 +33,12 @@ import Foundation
 // │                                 │ code generator cannot emit Swift enums   │
 // │ ServerMessage (enum)            │ Discriminated union with custom          │
 // │                                 │ Decodable init; always hand-maintained   │
+// │ UiLayoutConfigMessage           │ Temporary; canonical home is             │
+// │                                 │ LayoutConfig.swift (M1 / #2973)         │
+// │ SlotConfigWire                  │ Temporary; canonical home is             │
+// │                                 │ LayoutConfig.swift (M1 / #2973)         │
+// │ SlotContentWire                 │ Temporary; canonical home is             │
+// │                                 │ LayoutConfig.swift (M1 / #2973)         │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.
@@ -1365,6 +1371,7 @@ public enum ServerMessage: Decodable, Sendable {
     case uiSurfaceShow(UiSurfaceShowMessage)
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
+    case uiLayoutConfig(UiLayoutConfigMessage)
     case undoComplete(UndoCompleteMessage)
     case generationCancelled(GenerationCancelledMessage)
     case generationHandoff(GenerationHandoffMessage)
@@ -1469,6 +1476,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "ui_surface_dismiss":
             let message = try UiSurfaceDismissMessage(from: decoder)
             self = .uiSurfaceDismiss(message)
+        case "ui_layout_config":
+            let message = try UiLayoutConfigMessage(from: decoder)
+            self = .uiLayoutConfig(message)
         case "undo_complete":
             let message = try UndoCompleteMessage(from: decoder)
             self = .undoComplete(message)
@@ -1597,4 +1607,25 @@ public enum ServerMessage: Decodable, Sendable {
             self = .unknown(type)
         }
     }
+}
+
+// MARK: - Layout Config Wire Types
+// Defined here temporarily; canonical home is LayoutConfig.swift (M1 / #2973)
+
+public struct UiLayoutConfigMessage: Decodable, Sendable {
+    public let left: SlotConfigWire?
+    public let center: SlotConfigWire?
+    public let right: SlotConfigWire?
+}
+
+public struct SlotConfigWire: Decodable, Sendable {
+    public let content: SlotContentWire?
+    public let width: Double?
+    public let visible: Bool?
+}
+
+public struct SlotContentWire: Decodable, Sendable {
+    public let type: String
+    public let panel: String?
+    public let surfaceId: String?
 }


### PR DESCRIPTION
## Summary
- Add `ServerMessage.uiLayoutConfig(UiLayoutConfigMessage)` case and `"ui_layout_config"` decoder branch in `IPCMessages.swift`
- Add `onLayoutConfig` callback in `DaemonClient.swift` with dispatch in `handleServerMessage`
- Include temporary wire type definitions (`UiLayoutConfigMessage`, `SlotConfigWire`, `SlotContentWire`) pending M1 / #2973

Part of #2972. Closes #2974.

## Test plan
- [x] Build passes (`clients/macos/build.sh`)
- [ ] Verify layout config messages are decoded correctly when daemon sends them
- [ ] Confirm callback fires in the app layer when wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
