### PR TITLE
feat: integrate LayoutConfig into MainWindowState

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -12,9 +12,11 @@ final class MainWindowState: ObservableObject {
     @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
     @Published var activityMessageId: UUID?
+    @Published var layoutConfig: LayoutConfig
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey
+        self.layoutConfig = LayoutConfigStore.load()
     }
 
     func toggleActivityPanel(with messageId: UUID) {
@@ -48,5 +50,15 @@ final class MainWindowState: ObservableObject {
         isDynamicExpanded = false
         activeDynamicSurface = nil
         activeDynamicParsedSurface = nil
+    }
+
+    func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {
+        layoutConfig = LayoutConfig.merged(base: layoutConfig, wire: wire)
+        LayoutConfigStore.save(layoutConfig)
+    }
+
+    func resetLayout() {
+        layoutConfig = .default
+        LayoutConfigStore.save(layoutConfig)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `@Published var layoutConfig: LayoutConfig` to `MainWindowState`, loaded from `LayoutConfigStore` on init
- Adds `applyLayoutConfig(_:)` method that merges wire config and persists to store
- Adds `resetLayout()` method that reverts to defaults and persists

Part of #2972. Closes #2975.

## Test plan
- [x] Build passes (`bash build.sh`)
- [ ] Verify layout config loads correctly on app launch
- [ ] Verify `applyLayoutConfig` merges and persists changes
- [ ] Verify `resetLayout` reverts to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
