### PR TITLE
feat: wire onLayoutConfig callback in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -341,6 +341,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             try? self?.daemonClient.sendLinkOpenRequest(url: url, metadata: codableMetadata)
         }
 
+        // Forward layout config from daemon to MainWindowState
+        daemonClient.onLayoutConfig = { [weak self] msg in
+            self?.mainWindow?.windowState.applyLayoutConfig(msg)
+        }
+
         // Route dynamic pages to workspace
         surfaceManager.onDynamicPageShow = { [weak self] msg in
             guard let self else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VellumAssistantShared
 
 // MARK: - Domain Types
 
@@ -71,26 +72,6 @@ public struct LayoutConfig: Codable, Equatable, Sendable {
         center: SlotConfig(content: .native(.chat), width: nil, visible: true),
         right: SlotConfig(content: .empty, width: 400, visible: false)
     )
-}
-
-// MARK: - Wire Types (IPC)
-
-public struct UiLayoutConfigMessage: Decodable, Sendable {
-    public let left: SlotConfigWire?
-    public let center: SlotConfigWire?
-    public let right: SlotConfigWire?
-}
-
-public struct SlotConfigWire: Decodable, Sendable {
-    public let content: SlotContentWire?
-    public let width: Double?
-    public let visible: Bool?
-}
-
-public struct SlotContentWire: Decodable, Sendable {
-    public let type: String       // "native" | "surface" | "empty"
-    public let panel: String?     // for native
-    public let surfaceId: String? // for surface
 }
 
 // MARK: - Merge Logic

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -12,9 +12,11 @@ final class MainWindowState: ObservableObject {
     @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
     @Published var activityMessageId: UUID?
+    @Published var layoutConfig: LayoutConfig
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey
+        self.layoutConfig = LayoutConfigStore.load()
     }
 
     func toggleActivityPanel(with messageId: UUID) {
@@ -39,6 +41,11 @@ final class MainWindowState: ObservableObject {
 
     func refreshAPIKeyStatus(isConnected: Bool) {
         hasAPIKey = APIKeyManager.hasAnyKey() || isConnected
+    }
+
+    func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {
+        layoutConfig = LayoutConfig.merged(base: layoutConfig, wire: wire)
+        LayoutConfigStore.save(layoutConfig)
     }
 
     /// Reset all dynamic workspace state. Callers should also reset


### PR DESCRIPTION
## Summary
- Wires `daemonClient.onLayoutConfig` in `setupSurfaceManager()` to forward `ui_layout_config` IPC messages to `MainWindowState.applyLayoutConfig()`
- Adds `@Published var layoutConfig: LayoutConfig` property and `applyLayoutConfig(_:)` method to `MainWindowState`
- Removes duplicate wire type definitions (`UiLayoutConfigMessage`, `SlotConfigWire`, `SlotContentWire`) from `LayoutConfig.swift`, using the canonical definitions from `IPCMessages.swift` in VellumAssistantShared

Part of #2972. Closes #2977.

## Test plan
- [ ] Build succeeds (`bash build.sh`)
- [ ] Verify that `ui_layout_config` messages from the daemon update `MainWindowState.layoutConfig`
- [ ] Verify layout config is persisted via `LayoutConfigStore.save()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
