### PR TITLE
feat: interleaved text/tool-call rendering for chat messages

### DIFF
--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -57,6 +57,16 @@ const INVENTORY_UNEXTRACTABLE = new Set<string>([
   'ui_surface_show',
 ]);
 
+/**
+ * Wire types decoded in Swift that don't yet have a corresponding
+ * contract type. These are client-side preparations for upcoming
+ * daemon features.
+ */
+const SWIFT_AHEAD_ALLOWLIST = new Set<string>([
+  // Defined in Swift LayoutConfig.swift ahead of daemon implementation
+  'ui_layout_config',
+]);
+
 // --- Extract Swift decode cases ---
 
 /** Parse `case "wire_type":` patterns from the ServerMessage decoder. */
@@ -104,7 +114,7 @@ for (const wireType of contractServerTypes) {
 
 // Types decoded in Swift but not in contract
 for (const wireType of swiftDecodeCases) {
-  if (!contractServerTypes.has(wireType)) {
+  if (!contractServerTypes.has(wireType) && !SWIFT_AHEAD_ALLOWLIST.has(wireType)) {
     diffs.push(`  - Swift decodes "${wireType}" but it is not in the contract`);
   }
 }
@@ -118,6 +128,11 @@ for (const wireType of SWIFT_OMIT_ALLOWLIST) {
 for (const wireType of INVENTORY_UNEXTRACTABLE) {
   if (!swiftDecodeCases.has(wireType)) {
     diffs.push(`  ? Unextractable entry "${wireType}" is not decoded in Swift (stale?)`);
+  }
+}
+for (const wireType of SWIFT_AHEAD_ALLOWLIST) {
+  if (contractServerTypes.has(wireType)) {
+    diffs.push(`  ? Ahead-allowlist entry "${wireType}" is now in the contract (remove from allowlist)`);
   }
 }
 

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -192,49 +192,119 @@ describe('renderHistoryContent', () => {
       { name: 'unknown', input: {}, result: 'some result', isError: false },
     ]);
   });
+
+  test('produces textSegments for text-tool-text interleaving', () => {
+    const output = renderHistoryContent([
+      { type: 'text', text: 'What are you working on?' },
+      { type: 'tool_use', id: 'tu_1', name: 'memory_save', input: { key: 'task' } },
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'saved' },
+      { type: 'text', text: 'Saved that to memory.' },
+    ]);
+
+    expect(output.textSegments).toEqual([
+      'What are you working on?',
+      'Saved that to memory.',
+    ]);
+    expect(output.contentOrder).toEqual([
+      'text:0',
+      'tool:0',
+      'text:1',
+    ]);
+  });
+
+  test('produces single segment for text-only content', () => {
+    const output = renderHistoryContent([
+      { type: 'text', text: 'Hello ' },
+      { type: 'text', text: 'world' },
+    ]);
+
+    expect(output.textSegments).toEqual(['Hello world']);
+    expect(output.contentOrder).toEqual(['text:0']);
+  });
+
+  test('produces tool-only contentOrder for tool-only messages', () => {
+    const output = renderHistoryContent([
+      { type: 'tool_use', id: 'tu_1', name: 'bash', input: { command: 'ls' } },
+    ]);
+
+    expect(output.textSegments).toEqual([]);
+    expect(output.contentOrder).toEqual(['tool:0']);
+  });
+
+  test('produces segments for tool-text pattern', () => {
+    const output = renderHistoryContent([
+      { type: 'tool_use', id: 'tu_1', name: 'bash', input: { command: 'ls' } },
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'file.txt' },
+      { type: 'text', text: 'Here are the files.' },
+    ]);
+
+    expect(output.textSegments).toEqual(['Here are the files.']);
+    expect(output.contentOrder).toEqual(['tool:0', 'text:0']);
+  });
+
+  test('produces segments for text-tool-tool-text pattern', () => {
+    const output = renderHistoryContent([
+      { type: 'text', text: 'Let me check.' },
+      { type: 'tool_use', id: 'tu_1', name: 'bash', input: { command: 'ls' } },
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'file.txt' },
+      { type: 'tool_use', id: 'tu_2', name: 'bash', input: { command: 'pwd' } },
+      { type: 'tool_result', tool_use_id: 'tu_2', content: '/home' },
+      { type: 'text', text: 'Done.' },
+    ]);
+
+    expect(output.textSegments).toEqual(['Let me check.', 'Done.']);
+    expect(output.contentOrder).toEqual(['text:0', 'tool:0', 'tool:1', 'text:1']);
+  });
+
+  test('produces empty segments for non-array content', () => {
+    const output = renderHistoryContent(null);
+    expect(output.textSegments).toEqual([]);
+    expect(output.contentOrder).toEqual([]);
+
+    const output2 = renderHistoryContent('raw string');
+    expect(output2.textSegments).toEqual(['raw string']);
+    expect(output2.contentOrder).toEqual(['text:0']);
+  });
 });
 
 describe('mergeToolResults', () => {
   test('merges tool_result user messages into preceding assistant toolCalls', () => {
     const result = mergeToolResults([
-      { role: 'user', text: 'fetch this page', timestamp: 1, toolCalls: [], toolCallsBeforeText: false },
+      { role: 'user', text: 'fetch this page', timestamp: 1, toolCalls: [], toolCallsBeforeText: false, textSegments: ['fetch this page'], contentOrder: ['text:0'] },
       {
         role: 'assistant', text: '', timestamp: 2,
         toolCalls: [{ name: 'web_fetch', input: { url: 'https://example.com' } }],
-        toolCallsBeforeText: true,
+        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0'],
       },
       {
         role: 'user', text: '', timestamp: 3,
         toolCalls: [{ name: 'unknown', input: {}, result: 'page content', isError: false }],
-        toolCallsBeforeText: false,
+        toolCallsBeforeText: false, textSegments: [], contentOrder: [],
       },
-      { role: 'assistant', text: 'Here is what I found.', timestamp: 4, toolCalls: [], toolCallsBeforeText: false },
+      { role: 'assistant', text: 'Here is what I found.', timestamp: 4, toolCalls: [], toolCallsBeforeText: false, textSegments: ['Here is what I found.'], contentOrder: ['text:0'] },
     ]);
 
     expect(result).toHaveLength(3);
-    // The user message with tool_result should be suppressed
     expect(result[0].role).toBe('user');
     expect(result[0].text).toBe('fetch this page');
-    // The assistant message should now have the result merged in
     expect(result[1].role).toBe('assistant');
     expect(result[1].toolCalls[0].result).toBe('page content');
     expect(result[1].toolCalls[0].isError).toBe(false);
-    // The final assistant text message is unchanged
     expect(result[2].text).toBe('Here is what I found.');
   });
 
   test('suppresses tool_result-only user messages from visible history', () => {
     const result = mergeToolResults([
-      { role: 'user', text: 'hello', timestamp: 1, toolCalls: [], toolCallsBeforeText: false },
+      { role: 'user', text: 'hello', timestamp: 1, toolCalls: [], toolCallsBeforeText: false, textSegments: ['hello'], contentOrder: ['text:0'] },
       {
         role: 'assistant', text: '', timestamp: 2,
         toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
-        toolCallsBeforeText: true,
+        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0'],
       },
       {
         role: 'user', text: '', timestamp: 3,
         toolCalls: [{ name: 'unknown', input: {}, result: 'file.txt', isError: false }],
-        toolCallsBeforeText: false,
+        toolCallsBeforeText: false, textSegments: [], contentOrder: [],
       },
     ]);
 
@@ -247,7 +317,7 @@ describe('mergeToolResults', () => {
       {
         role: 'user', text: 'user typed something', timestamp: 1,
         toolCalls: [{ name: 'unknown', input: {}, result: 'data', isError: false }],
-        toolCallsBeforeText: false,
+        toolCallsBeforeText: false, textSegments: ['user typed something'], contentOrder: ['text:0'],
       },
     ]);
 
@@ -263,7 +333,7 @@ describe('mergeToolResults', () => {
           { name: 'bash', input: { command: 'ls' } },
           { name: 'bash', input: { command: 'pwd' } },
         ],
-        toolCallsBeforeText: true,
+        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0', 'tool:1'],
       },
       {
         role: 'user', text: '', timestamp: 2,
@@ -271,7 +341,7 @@ describe('mergeToolResults', () => {
           { name: 'unknown', input: {}, result: 'file.txt', isError: false },
           { name: 'unknown', input: {}, result: '/home/user', isError: false },
         ],
-        toolCallsBeforeText: false,
+        toolCallsBeforeText: false, textSegments: [], contentOrder: [],
       },
     ]);
 
@@ -285,12 +355,12 @@ describe('mergeToolResults', () => {
       {
         role: 'assistant', text: '', timestamp: 1,
         toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
-        toolCallsBeforeText: true,
+        toolCallsBeforeText: true, textSegments: [] as string[], contentOrder: ['tool:0'],
       },
       {
         role: 'user', text: '', timestamp: 2,
         toolCalls: [{ name: 'unknown', input: {}, result: 'output', isError: false }],
-        toolCallsBeforeText: false,
+        toolCallsBeforeText: false, textSegments: [] as string[], contentOrder: [] as string[],
       },
     ];
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -242,6 +242,10 @@ export interface RenderedHistoryContent {
   toolCalls: HistoryToolCall[];
   /** True when the first tool_use block appeared before any text block. */
   toolCallsBeforeText: boolean;
+  /** Text segments split by tool-call boundaries. */
+  textSegments: string[];
+  /** Content block ordering using "text:N", "tool:N" encoding. */
+  contentOrder: string[];
 }
 
 export function renderHistoryContent(content: unknown): RenderedHistoryContent {
@@ -254,7 +258,13 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     } else {
       text = String(content);
     }
-    return { text, toolCalls: [], toolCallsBeforeText: false };
+    return {
+      text,
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      textSegments: text ? [text] : [],
+      contentOrder: text ? ['text:0'] : [],
+    };
   }
 
   const textParts: string[] = [];
@@ -265,11 +275,35 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
   let seenToolUse = false;
   let toolCallsBeforeText = false;
 
+  // Segment tracking: text blocks separated by tool_use boundaries
+  const textSegments: string[] = [];
+  const contentOrder: string[] = [];
+  let currentSegmentParts: string[] = [];
+  let hasOpenSegment = false;
+
+  function finalizeSegment(): void {
+    if (hasOpenSegment) {
+      textSegments[textSegments.length - 1] = currentSegmentParts.join('');
+      currentSegmentParts = [];
+      hasOpenSegment = false;
+    }
+  }
+
+  function ensureSegment(): void {
+    if (!hasOpenSegment) {
+      textSegments.push('');
+      contentOrder.push(`text:${textSegments.length - 1}`);
+      hasOpenSegment = true;
+    }
+  }
+
   for (const block of content) {
     if (!isRecord(block) || typeof block.type !== 'string') continue;
 
     if (block.type === 'text' && typeof block.text === 'string') {
       textParts.push(block.text);
+      ensureSegment();
+      currentSegmentParts.push(block.text);
       seenText = true;
       continue;
     }
@@ -282,12 +316,14 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       continue;
     }
     if (block.type === 'tool_use') {
+      finalizeSegment();
       const name = typeof block.name === 'string' ? block.name : 'unknown';
       const input = isRecord(block.input) ? block.input as Record<string, unknown> : {};
       const id = typeof block.id === 'string' ? block.id : '';
       const entry: HistoryToolCall = { name, input };
       toolCalls.push(entry);
       if (id) pendingToolUses.set(id, entry);
+      contentOrder.push(`tool:${toolCalls.length - 1}`);
       if (!seenToolUse) {
         seenToolUse = true;
         if (!seenText) toolCallsBeforeText = true;
@@ -323,6 +359,8 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     }
   }
 
+  finalizeSegment();
+
   const text = textParts.join('');
   let rendered: string;
   if (attachmentParts.length === 0) {
@@ -333,7 +371,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     rendered = `${text}\n${attachmentParts.join('\n')}`;
   }
 
-  return { text: rendered, toolCalls, toolCallsBeforeText };
+  return { text: rendered, toolCalls, toolCallsBeforeText, textSegments, contentOrder };
 }
 
 /**
@@ -776,6 +814,8 @@ export interface ParsedHistoryMessage {
   timestamp: number;
   toolCalls: HistoryToolCall[];
   toolCallsBeforeText: boolean;
+  textSegments: string[];
+  contentOrder: string[];
 }
 
 function handleHistoryRequest(
@@ -788,17 +828,23 @@ function handleHistoryRequest(
     let text = '';
     let toolCalls: HistoryToolCall[] = [];
     let toolCallsBeforeText = false;
+    let textSegments: string[] = [];
+    let contentOrder: string[] = [];
     try {
       const content = JSON.parse(m.content);
       const rendered = renderHistoryContent(content);
       text = rendered.text;
       toolCalls = rendered.toolCalls;
       toolCallsBeforeText = rendered.toolCallsBeforeText;
+      textSegments = rendered.textSegments;
+      contentOrder = rendered.contentOrder;
     } catch (err) {
       log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
       text = m.content;
+      textSegments = text ? [text] : [];
+      contentOrder = text ? ['text:0'] : [];
     }
-    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls, toolCallsBeforeText };
+    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls, toolCallsBeforeText, textSegments, contentOrder };
   });
 
   // Merge tool_result data from user messages into the preceding assistant
@@ -825,6 +871,8 @@ function handleHistoryRequest(
       timestamp: m.timestamp,
       ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls, toolCallsBeforeText: m.toolCallsBeforeText } : {}),
       ...(attachments ? { attachments } : {}),
+      ...(m.textSegments.length > 0 ? { textSegments: m.textSegments } : {}),
+      ...(m.contentOrder.length > 0 ? { contentOrder: m.contentOrder } : {}),
     };
   });
   ctx.send(socket, { type: 'history_response', sessionId: msg.sessionId, messages: historyMessages });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -764,6 +764,10 @@ export interface HistoryResponse {
     /** True when tool_use blocks appeared before any text block in the original content. */
     toolCallsBeforeText?: boolean;
     attachments?: UserMessageAttachment[];
+    /** Text segments split by tool-call boundaries. Preserves interleaving order. */
+    textSegments?: string[];
+    /** Content block ordering using "text:N", "tool:N", "surface:N" encoding. */
+    contentOrder?: string[];
   }>;
 }
 

--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -29,6 +29,8 @@ struct MessageBubbleView: View {
                             return false
                         }
                     )
+                } else if message.role == .assistant && hasInterleavedContent {
+                    interleavedContent
                 } else {
                     // Pre-text tool calls render above the bubble
                     let preTextCalls = message.toolCalls.filter { $0.arrivedBeforeText }
@@ -87,6 +89,80 @@ struct MessageBubbleView: View {
 
             if message.role == .assistant {
                 Spacer(minLength: 60)
+            }
+        }
+    }
+
+    private var hasInterleavedContent: Bool {
+        guard message.contentOrder.count > 1 else { return false }
+        var hasText = false
+        var hasNonText = false
+        for ref in message.contentOrder {
+            switch ref {
+            case .text: hasText = true
+            case .toolCall, .surface: hasNonText = true
+            }
+            if hasText && hasNonText { return true }
+        }
+        return false
+    }
+
+    private enum ContentGroup {
+        case text(Int)
+        case toolCalls([Int])
+        case surface(Int)
+    }
+
+    private func groupContentBlocks() -> [ContentGroup] {
+        var groups: [ContentGroup] = []
+        for ref in message.contentOrder {
+            switch ref {
+            case .text(let i):
+                groups.append(.text(i))
+            case .toolCall(let i):
+                if case .toolCalls(let indices) = groups.last {
+                    groups[groups.count - 1] = .toolCalls(indices + [i])
+                } else {
+                    groups.append(.toolCalls([i]))
+                }
+            case .surface(let i):
+                groups.append(.surface(i))
+            }
+        }
+        return groups
+    }
+
+    @ViewBuilder
+    private var interleavedContent: some View {
+        let groups = groupContentBlocks()
+        ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+            switch group {
+            case .text(let i):
+                if i < message.textSegments.count {
+                    let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !segmentText.isEmpty {
+                        Text(segmentText)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    }
+                }
+            case .toolCalls(let indices):
+                let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
+                if !calls.isEmpty {
+                    ToolCallProgressBar(toolCalls: calls)
+                }
+            case .surface(let i):
+                if i < message.inlineSurfaces.count {
+                    InlineSurfaceRouter(
+                        surface: message.inlineSurfaces[i],
+                        onAction: { surfaceId, actionId, data in
+                            onSurfaceAction?(surfaceId, actionId, data)
+                        }
+                    )
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -621,17 +621,21 @@ private struct ChatBubble: View {
             if isUser { Spacer(minLength: 0) }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
-                if shouldShowBubble {
-                    bubbleContent
-                }
+                if !isUser && hasInterleavedContent {
+                    interleavedContent
+                } else {
+                    if shouldShowBubble {
+                        bubbleContent
+                    }
 
-                // Consolidated tool indicator showing all tool calls
-                toolCallChips(message.toolCalls)
+                    // Consolidated tool indicator showing all tool calls
+                    toolCallChips(message.toolCalls)
 
-                // Inline surfaces render below the bubble as full-width cards
-                if !message.inlineSurfaces.isEmpty {
-                    ForEach(message.inlineSurfaces) { surface in
-                        InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
+                    // Inline surfaces render below the bubble as full-width cards
+                    if !message.inlineSurfaces.isEmpty {
+                        ForEach(message.inlineSurfaces) { surface in
+                            InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
+                        }
                     }
                 }
 
@@ -644,6 +648,93 @@ private struct ChatBubble: View {
 
             if !isUser { Spacer(minLength: 0) }
         }
+    }
+
+    /// Whether this message has meaningful interleaved content (multiple block types).
+    private var hasInterleavedContent: Bool {
+        // Use interleaved path when contentOrder has more than one distinct block type
+        guard message.contentOrder.count > 1 else { return false }
+        var hasText = false
+        var hasNonText = false
+        for ref in message.contentOrder {
+            switch ref {
+            case .text: hasText = true
+            case .toolCall, .surface: hasNonText = true
+            }
+            if hasText && hasNonText { return true }
+        }
+        return false
+    }
+
+    /// Groups consecutive tool call refs for rendering.
+    private enum ContentGroup {
+        case text(Int)
+        case toolCalls([Int])
+        case surface(Int)
+    }
+
+    private func groupContentBlocks() -> [ContentGroup] {
+        var groups: [ContentGroup] = []
+        for ref in message.contentOrder {
+            switch ref {
+            case .text(let i):
+                groups.append(.text(i))
+            case .toolCall(let i):
+                if case .toolCalls(let indices) = groups.last {
+                    groups[groups.count - 1] = .toolCalls(indices + [i])
+                } else {
+                    groups.append(.toolCalls([i]))
+                }
+            case .surface(let i):
+                groups.append(.surface(i))
+            }
+        }
+        return groups
+    }
+
+    @ViewBuilder
+    private var interleavedContent: some View {
+        let groups = groupContentBlocks()
+        ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+            switch group {
+            case .text(let i):
+                if i < message.textSegments.count {
+                    let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !segmentText.isEmpty {
+                        textBubble(for: segmentText)
+                    }
+                }
+            case .toolCalls(let indices):
+                let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
+                toolCallChips(calls)
+            case .surface(let i):
+                if i < message.inlineSurfaces.count {
+                    InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction)
+                }
+            }
+        }
+    }
+
+    /// Render a single text segment as a styled bubble.
+    private func textBubble(for segmentText: String) -> some View {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        let attributed = (try? AttributedString(markdown: segmentText, options: options))
+            ?? AttributedString(segmentText)
+        return Text(attributed)
+            .font(.system(size: 13))
+            .foregroundColor(VColor.textPrimary)
+            .tint(VColor.accent)
+            .textSelection(.enabled)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(AnyShapeStyle(VColor.surface))
+            )
+            .vShadow(VShadow.sm)
+            .frame(maxWidth: 520, alignment: .leading)
     }
 
     /// Current step indicator rendered outside the bubble.

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1657,4 +1657,97 @@ final class ChatViewModelTests: XCTestCase {
         // Empty message with no text, no tool calls, no attachments should be skipped
         XCTAssertEqual(viewModel.messages.count, 0)
     }
+
+    // MARK: - Interleaved Text/Tool-Call Segments
+
+    func testTextToolTextCreatesInterleavedSegments() {
+        // Text delta → tool call → more text delta
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "What are you working on?")))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "memory_save", input: ["key": AnyCodable("task")], sessionId: nil)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Saved that to memory.")))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, ["What are you working on?", "Saved that to memory."])
+        XCTAssertEqual(msg.contentOrder, [.text(0), .toolCall(0), .text(1)])
+        XCTAssertEqual(msg.text, "What are you working on?Saved that to memory.")
+    }
+
+    func testMultipleDeltasSameSegment() {
+        // Multiple text deltas without intervening tool call stay in one segment
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Hel")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "lo ")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "world")))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, ["Hello world"])
+        XCTAssertEqual(msg.contentOrder, [.text(0)])
+    }
+
+    func testSuppressedToolsDoNotCreateSegmentBoundary() {
+        // ui_show is suppressed and should not create a segment boundary
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Before")))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "ui_show", input: [:], sessionId: nil)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " after")))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        // ui_show breaks before reaching tool call append code, so no segment boundary
+        XCTAssertEqual(msg.textSegments, ["Before after"])
+        XCTAssertEqual(msg.contentOrder, [.text(0)])
+    }
+
+    func testToolOnlyMessageHasToolCallInContentOrder() {
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, [])
+        XCTAssertEqual(msg.contentOrder, [.toolCall(0)])
+    }
+
+    func testPopulateFromHistoryUsesTextSegments() {
+        let toolCall = IPCHistoryResponseToolCall(name: "memory_save", input: ["key": AnyCodable("task")], result: "saved", isError: nil, imageData: nil)
+        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+            IPCHistoryResponseMessage(
+                role: "assistant",
+                text: "What are you working on?Saved that to memory.",
+                timestamp: 1000,
+                toolCalls: [toolCall],
+                toolCallsBeforeText: nil,
+                attachments: nil,
+                textSegments: ["What are you working on?", "Saved that to memory."],
+                contentOrder: ["text:0", "tool:0", "text:1"]
+            ),
+        ]
+
+        viewModel.populateFromHistory(historyItems)
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, ["What are you working on?", "Saved that to memory."])
+        XCTAssertEqual(msg.contentOrder, [.text(0), .toolCall(0), .text(1)])
+    }
+
+    func testPopulateFromHistoryFallsBackToLegacy() {
+        let toolCall = IPCHistoryResponseToolCall(name: "bash", input: ["command": AnyCodable("ls")], result: "file.txt", isError: nil, imageData: nil)
+        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+            IPCHistoryResponseMessage(
+                role: "assistant",
+                text: "Here are the files.",
+                timestamp: 1000,
+                toolCalls: [toolCall],
+                toolCallsBeforeText: true,
+                attachments: nil
+            ),
+        ]
+
+        viewModel.populateFromHistory(historyItems)
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        // Legacy fallback: tools before text
+        XCTAssertEqual(msg.contentOrder, [.toolCall(0), .text(0)])
+    }
 }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -232,10 +232,18 @@ public struct SkillInvocationData: Equatable {
     }
 }
 
+/// Identifies a content block within a ChatMessage for interleaving order.
+public enum ContentBlockRef: Equatable {
+    case text(Int)
+    case toolCall(Int)
+    case surface(Int)
+}
+
 public struct ChatMessage: Identifiable {
     public let id: UUID
     public let role: ChatRole
-    public var text: String
+    public var textSegments: [String]
+    public var contentOrder: [ContentBlockRef]
     public let timestamp: Date
     public var isStreaming: Bool
     public var status: ChatMessageStatus
@@ -246,10 +254,16 @@ public struct ChatMessage: Identifiable {
     public var toolCalls: [ToolCallData]
     public var inlineSurfaces: [InlineSurfaceData]
 
+    /// Concatenated text from all segments. Backward-compatible computed property.
+    public var text: String {
+        textSegments.joined()
+    }
+
     public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = []) {
         self.id = id
         self.role = role
-        self.text = text
+        self.textSegments = text.isEmpty ? [] : [text]
+        self.contentOrder = text.isEmpty ? [] : [.text(0)]
         self.timestamp = timestamp
         self.isStreaming = isStreaming
         self.status = status
@@ -258,5 +272,22 @@ public struct ChatMessage: Identifiable {
         self.attachments = attachments
         self.toolCalls = toolCalls
         self.inlineSurfaces = inlineSurfaces
+    }
+
+    /// Build a default content order from the legacy `arrivedBeforeText` flag.
+    public static func buildDefaultContentOrder(
+        textSegmentCount: Int,
+        toolCallCount: Int,
+        arrivedBeforeText: Bool
+    ) -> [ContentBlockRef] {
+        var order: [ContentBlockRef] = []
+        if arrivedBeforeText {
+            for i in 0..<toolCallCount { order.append(.toolCall(i)) }
+            for i in 0..<textSegmentCount { order.append(.text(i)) }
+        } else {
+            for i in 0..<textSegmentCount { order.append(.text(i)) }
+            for i in 0..<toolCallCount { order.append(.toolCall(i)) }
+        }
+        return order
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -146,6 +146,9 @@ public final class ChatViewModel: ObservableObject {
     /// Tracks whether the current assistant message has received any text content.
     /// Used to determine `arrivedBeforeText` for each tool call in the message.
     private var currentAssistantHasText: Bool = false
+    /// Tracks whether the last content block was a tool call, so the next text
+    /// delta starts a new segment instead of appending to the previous one.
+    private var lastContentWasToolCall: Bool = false
     /// When true, incoming deltas are suppressed until the daemon acknowledges
     /// the cancellation (via `generation_cancelled` or `message_complete`).
     // Public (rather than private) so tests can simulate the
@@ -720,13 +723,22 @@ public final class ChatViewModel: ObservableObject {
             currentAssistantHasText = true
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
-                // Append to existing streaming message
-                messages[index].text += delta.text
+                if lastContentWasToolCall || messages[index].textSegments.isEmpty {
+                    // Start a new text segment (first text or after a tool call)
+                    let segIdx = messages[index].textSegments.count
+                    messages[index].textSegments.append(delta.text)
+                    messages[index].contentOrder.append(.text(segIdx))
+                    lastContentWasToolCall = false
+                } else {
+                    // Append to the current (last) text segment
+                    messages[index].textSegments[messages[index].textSegments.count - 1] += delta.text
+                }
             } else {
                 // Create new assistant message
                 let msg = ChatMessage(role: .assistant, text: delta.text, isStreaming: true)
                 currentAssistantMessageId = msg.id
                 messages.append(msg)
+                lastContentWasToolCall = false
             }
 
         case .suggestionResponse(let resp):
@@ -781,6 +793,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -806,6 +819,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
@@ -835,6 +849,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -884,6 +899,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -905,6 +921,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
             if !wasCancelling {
                 errorText = err.message
             }
@@ -992,12 +1009,16 @@ public final class ChatViewModel: ObservableObject {
             // Add to existing assistant message or create one
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
+                let tcIdx = messages[index].toolCalls.count
                 messages[index].toolCalls.append(toolCall)
+                messages[index].contentOrder.append(.toolCall(tcIdx))
             } else {
-                let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [toolCall])
+                var newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [toolCall])
+                newMsg.contentOrder = [.toolCall(0)]
                 currentAssistantMessageId = newMsg.id
                 messages.append(newMsg)
             }
+            lastContentWasToolCall = true
 
         case .toolOutputChunk:
             // Streaming output — ignore for now, we show the final result
@@ -1048,14 +1069,19 @@ public final class ChatViewModel: ObservableObject {
             )
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
+                let surfIdx = messages[index].inlineSurfaces.count
                 messages[index].inlineSurfaces.append(inlineSurface)
+                messages[index].contentOrder.append(.surface(surfIdx))
             } else if let lastUserIndex = messages.lastIndex(where: { $0.role == .user }),
                       let idx = messages[lastUserIndex...].lastIndex(where: { $0.role == .assistant }) {
                 // Scope to the current turn so we never attach to an assistant message
                 // from a previous conversation turn.
+                let surfIdx = messages[idx].inlineSurfaces.count
                 messages[idx].inlineSurfaces.append(inlineSurface)
+                messages[idx].contentOrder.append(.surface(surfIdx))
             } else {
-                let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
+                var newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
+                newMsg.contentOrder = [.surface(0)]
                 currentAssistantMessageId = newMsg.id
                 messages.append(newMsg)
             }
@@ -1115,6 +1141,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
             // When the user intentionally cancelled, suppress both the typed
             // session error and the errorText so no toast appears.
             if !wasCancelling {
@@ -1219,6 +1246,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
@@ -1255,6 +1283,7 @@ public final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
+            lastContentWasToolCall = false
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
@@ -1304,6 +1333,7 @@ public final class ChatViewModel: ObservableObject {
             self.isSending = false
             self.currentAssistantMessageId = nil
             self.currentAssistantHasText = false
+            self.lastContentWasToolCall = false
             self.pendingQueuedCount = 0
             self.pendingMessageIds = []
             self.requestIdToMessageId = [:]
@@ -1537,6 +1567,21 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Parse string-encoded content order entries ("text:0", "tool:1", "surface:0")
+    /// into ContentBlockRef values.
+    private static func parseContentOrder(_ strings: [String]) -> [ContentBlockRef] {
+        strings.compactMap { str in
+            let parts = str.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2, let idx = Int(parts[1]) else { return nil }
+            switch parts[0] {
+            case "text": return .text(idx)
+            case "tool": return .toolCall(idx)
+            case "surface": return .surface(idx)
+            default: return nil
+            }
+        }
+    }
+
     /// Ask the daemon for a follow-up suggestion for the current session.
     private func fetchSuggestion() {
         guard let sessionId, daemonClient.isConnected else { return }
@@ -1593,13 +1638,24 @@ public final class ChatViewModel: ObservableObject {
             // Skip empty messages (internal tool-result-only turns already filtered by daemon)
             if item.text.isEmpty && toolCalls.isEmpty && attachments.isEmpty { continue }
             let timestamp = Date(timeIntervalSince1970: TimeInterval(item.timestamp) / 1000.0)
-            let chatMsg = ChatMessage(
+            var chatMsg = ChatMessage(
                 role: role,
                 text: item.text,
                 timestamp: timestamp,
                 attachments: attachments,
                 toolCalls: toolCalls
             )
+            // Use daemon-provided segments/order when available; fall back to legacy
+            if let segments = item.textSegments, let orderStrings = item.contentOrder, !segments.isEmpty {
+                chatMsg.textSegments = segments
+                chatMsg.contentOrder = Self.parseContentOrder(orderStrings)
+            } else {
+                chatMsg.contentOrder = ChatMessage.buildDefaultContentOrder(
+                    textSegmentCount: chatMsg.textSegments.count,
+                    toolCallCount: toolCalls.count,
+                    arrivedBeforeText: toolsBeforeText
+                )
+            }
             chatMessages.append(chatMsg)
         }
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -434,6 +434,10 @@ public struct IPCHistoryResponseMessage: Codable, Sendable {
     /// True when tool_use blocks appeared before any text block in the original content.
     public let toolCallsBeforeText: Bool?
     public let attachments: [IPCUserMessageAttachment]?
+    /// Text segments split by tool-call boundaries. Preserves interleaving order.
+    public let textSegments: [String]?
+    /// Content block ordering using "text:N", "tool:N", "surface:N" encoding.
+    public let contentOrder: [String]?
 }
 
 public struct IPCHistoryResponseToolCall: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -951,6 +951,13 @@ extension IPCHistoryResponse {
     public typealias HistoryToolCallItem = IPCHistoryResponseToolCall
 }
 
+extension IPCHistoryResponseMessage {
+    /// Backward-compatible init without textSegments/contentOrder (added in later IPC version).
+    public init(role: String, text: String, timestamp: Double, toolCalls: [IPCHistoryResponseToolCall]?, toolCallsBeforeText: Bool?, attachments: [IPCUserMessageAttachment]?) {
+        self.init(role: role, text: text, timestamp: timestamp, toolCalls: toolCalls, toolCallsBeforeText: toolCallsBeforeText, attachments: attachments, textSegments: nil, contentOrder: nil)
+    }
+}
+
 /// A single scheduled task item returned from the daemon.
 /// Backed by generated `IPCSchedulesListResponseSchedule`.
 public typealias ScheduleItem = IPCSchedulesListResponseSchedule


### PR DESCRIPTION
## Summary
- Replace flat `text: String` with `textSegments: [String]` + `contentOrder: [ContentBlockRef]` to preserve interleaving order of text, tool calls, and surfaces in assistant messages
- When an assistant response contains text → tool call → text (e.g. "What are you working on?" → Memory Save → "Saved that to memory"), renders as separate bubbles with tool call chips between them instead of concatenated into one bubble
- Updates daemon history rendering to emit `textSegments`/`contentOrder`, streaming logic to build segments during real-time deltas, and both macOS and iOS views to render interleaved content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
