### PR TITLE
Light mode chat polish: gray bubbles, no shadows, waking up fix

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -315,7 +315,7 @@ struct ChatView: View {
                     }
 
                     if isThinking {
-                        ThinkingIndicator(label: !hasEverSentMessage ? "Waking up..." : "Thinking")
+                        ThinkingIndicator(label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking")
                             .id("thinking-indicator")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
@@ -340,8 +340,9 @@ struct ChatView: View {
                     withAnimation(VAnimation.standard) {
                         proxy.scrollTo("thinking-indicator", anchor: .bottom)
                     }
-                    // Mark that the user has sent at least one message (after showing "Waking up...")
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                } else {
+                    // Thinking finished — mark flag so next message shows "Thinking"
+                    if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                         hasEverSentMessage = true
                     }
                 }
@@ -573,15 +574,21 @@ private struct ChatBubble: View {
         }
     }
 
+    @Environment(\.colorScheme) private var colorScheme
+
     private var bubbleFill: AnyShapeStyle {
         if isUser {
-            AnyShapeStyle(
-                LinearGradient(
-                    colors: [Meadow.userBubbleGradientStart, Meadow.userBubbleGradientEnd],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
+            if colorScheme == .dark {
+                AnyShapeStyle(
+                    LinearGradient(
+                        colors: [Meadow.userBubbleGradientStart, Meadow.userBubbleGradientEnd],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
                 )
-            )
+            } else {
+                AnyShapeStyle(VColor.userBubble)
+            }
         } else {
             AnyShapeStyle(VColor.surface)
         }
@@ -699,13 +706,13 @@ private struct ChatBubble: View {
             if hasText {
                 Text(markdownText)
                     .font(.system(size: 13))
-                    .foregroundColor(isUser ? .white : VColor.textPrimary)
-                    .tint(isUser ? .white : VColor.accent)
+                    .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
+                    .tint(isUser ? VColor.userBubbleText : VColor.accent)
                     .textSelection(.enabled)
             } else if !message.attachments.isEmpty {
                 Text(attachmentSummary)
                     .font(VFont.caption)
-                    .foregroundColor(isUser ? .white.opacity(0.8) : VColor.textSecondary)
+                    .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary)
             }
 
             if !partitioned.images.isEmpty {
@@ -735,7 +742,6 @@ private struct ChatBubble: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(bubbleFill)
         )
-        .vShadow(VShadow.sm)
         .frame(maxWidth: 520, alignment: isUser ? .trailing : .leading)
         .opacity(bubbleOpacity)
     }
@@ -759,22 +765,22 @@ private struct ChatBubble: View {
         HStack(spacing: VSpacing.xs) {
             Image(systemName: fileIcon(for: attachment.mimeType))
                 .font(VFont.caption)
-                .foregroundColor(isUser ? .white.opacity(0.8) : VColor.textSecondary)
+                .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary)
 
             Text(attachment.filename)
                 .font(VFont.caption)
-                .foregroundColor(isUser ? .white : VColor.textPrimary)
+                .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                 .lineLimit(1)
 
             Text(formattedFileSize(base64Length: attachment.dataLength))
                 .font(VFont.small)
-                .foregroundColor(isUser ? .white.opacity(0.6) : VColor.textMuted)
+                .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.textMuted)
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .background(
             RoundedRectangle(cornerRadius: VRadius.sm)
-                .fill(isUser ? Color.white.opacity(0.15) : VColor.surfaceBorder.opacity(0.5))
+                .fill(isUser ? VColor.userBubbleText.opacity(0.15) : VColor.surfaceBorder.opacity(0.5))
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -57,11 +57,6 @@ final class MainWindowState: ObservableObject {
         activeDynamicParsedSurface = nil
     }
 
-    func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {
-        layoutConfig = LayoutConfig.merged(base: layoutConfig, wire: wire)
-        LayoutConfigStore.save(layoutConfig)
-    }
-
     func resetLayout() {
         layoutConfig = .default
         LayoutConfigStore.save(layoutConfig)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1025,10 +1025,6 @@ private struct NewConversationButton: View {
             .padding(.vertical, VSpacing.sm)
             .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(isHovered ? VColor.surfaceBorder.opacity(0.8) : VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
-            )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -123,7 +123,7 @@ public enum VColor {
     // Backgrounds
     public static let background = adaptiveColor(light: .white, dark: Slate._950)
     public static let backgroundSubtle = adaptiveColor(light: Slate._100, dark: Slate._800)
-    public static let chatBackground = adaptiveColor(light: Slate._50, dark: Slate._900)
+    public static let chatBackground = adaptiveColor(light: .white, dark: Slate._900)
     public static let surface = adaptiveColor(light: .white, dark: Slate._800)
     public static let surfaceBorder = adaptiveColor(light: Slate._200, dark: Slate._700)
     public static let surfaceSubtle = adaptiveColor(light: Slate._50, dark: Slate._900)
@@ -146,6 +146,11 @@ public enum VColor {
     public static let success = adaptiveColor(light: Emerald._700, dark: Emerald._600)
     public static let error = adaptiveColor(light: Rose._700, dark: Rose._600)
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
+
+    // Chat
+    public static let userBubble = adaptiveColor(light: Slate._200, dark: Violet._600)
+    public static let userBubbleText = adaptiveColor(light: Slate._900, dark: .white)
+    public static let userBubbleTextSecondary = adaptiveColor(light: Slate._600, dark: Color.white.opacity(0.8))
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Slate._100, dark: Slate._700)


### PR DESCRIPTION
## Summary
- User message bubbles now use gray (Slate._200) in light mode instead of purple, keeping violet gradient in dark mode
- Removed shadows from chat message bubbles and set white chat background for better contrast in light mode
- Fixed "Waking up..." indicator to only appear for the very first user message and persist through the entire response
- Removed border from New Conversation sidebar button
- Removed duplicate `applyLayoutConfig` method (merge artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
