### PR TITLE
fix: tri-state width handling in SlotConfigWire

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -90,7 +90,10 @@ extension SlotConfig {
     static func merged(base: SlotConfig, wire: SlotConfigWire) -> SlotConfig {
         var result = base
         if let content = wire.content { result.content = SlotContent.from(wire: content) ?? base.content }
-        if let width = wire.width { result.width = width }
+        // Tri-state width: .none = field missing (keep base), .some(nil) = explicit null (reset), .some(value) = update
+        if let widthUpdate = wire.width {
+            result.width = widthUpdate
+        }
         if let visible = wire.visible { result.visible = visible }
         return result
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -57,11 +57,6 @@ final class MainWindowState: ObservableObject {
         activeDynamicParsedSurface = nil
     }
 
-    func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {
-        layoutConfig = LayoutConfig.merged(base: layoutConfig, wire: wire)
-        LayoutConfigStore.save(layoutConfig)
-    }
-
     func resetLayout() {
         layoutConfig = .default
         LayoutConfigStore.save(layoutConfig)

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1627,8 +1627,27 @@ public struct UiLayoutConfigMessage: Decodable, Sendable {
 
 public struct SlotConfigWire: Decodable, Sendable {
     public let content: SlotContentWire?
-    public let width: Double?
+    /// Tri-state width: `.none` = field missing (preserve base), `.some(nil)` = explicit null (reset to nil), `.some(value)` = new value.
+    public let width: Optional<Double>?
     public let visible: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case content, width, visible
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decodeIfPresent(SlotContentWire.self, forKey: .content)
+        visible = try container.decodeIfPresent(Bool.self, forKey: .visible)
+
+        if container.contains(.width) {
+            // Field is present in JSON — decode as .some(Double) or .some(nil) for explicit null
+            width = .some(try container.decodeIfPresent(Double.self, forKey: .width))
+        } else {
+            // Field is missing from JSON — outer nil signals "no change"
+            width = .none
+        }
+    }
 }
 
 public struct SlotContentWire: Decodable, Sendable {


### PR DESCRIPTION
## Summary
- Changes `SlotConfigWire.width` from `Double?` to `Optional<Optional<Double>>` (tri-state) with custom `Decodable` init that distinguishes missing fields from explicit JSON `null`
- Updates merge logic in `SlotConfig.merged(base:wire:)` to handle all three cases: missing (preserve base), explicit null (reset to nil), value present (update)
- Removes duplicate `applyLayoutConfig` method in `MainWindowState.swift`

Addresses review feedback from PR #2978.

## Test plan
- [ ] Build succeeds (`bash build.sh`)
- [ ] Verify partial update `{"center": {"width": null}}` correctly resets width to nil
- [ ] Verify partial update `{"center": {"width": 500}}` correctly sets width to 500
- [ ] Verify partial update `{"center": {"visible": true}}` preserves existing width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
