### PR TITLE
fix: exclude .directory panel from drawer width clamp

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -401,7 +401,7 @@ struct MainWindowView: View {
                         let deltaX = value.location.x - value.startLocation.x
                         let newWidth = initialWidth + Double(deltaX)
                         let minMainContent: CGFloat = 300
-                        let sidePanelVisible = windowState.activePanel != nil && !(windowState.isDynamicExpanded && windowState.activePanel == .generated)
+                        let sidePanelVisible = windowState.activePanel != nil && !(windowState.isDynamicExpanded && windowState.activePanel == .generated) && windowState.activePanel != .directory
                         let activePanelWidth: CGFloat = sidePanelVisible ? sidePanelWidth : 0
                         let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.xs - (VSpacing.xs * 2) - activePanelWidth
 


### PR DESCRIPTION
## Summary

- The `.directory` panel renders `AppDirectoryView` full-screen (no `VSplitView` side panel), but `sidePanelVisible` evaluated to `true` for it
- This artificially reduced the thread drawer's max drag width by ~400pt (the `sidePanelWidth`) when the directory panel was active
- Added `&& windowState.activePanel != .directory` to the `sidePanelVisible` condition, matching the same pattern used for the fullscreen `.generated` workspace

Same class of bug that PR #2924 fixed for `.generated`. Addresses review feedback from `devin-ai-integration[bot]` on #2924.

## Test plan

- [ ] Open the app directory panel and verify the thread drawer can be dragged to full available width
- [ ] Open a regular side panel (e.g. debug) and verify the drawer still correctly reserves space for it
- [ ] Toggle between directory and normal panel states while drawer is open
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
