### PR TITLE
fix: tighten hostname validation to reject malformed DNS labels

### DIFF
--- a/assistant/src/__tests__/domain-policy.test.ts
+++ b/assistant/src/__tests__/domain-policy.test.ts
@@ -60,6 +60,18 @@ describe('isDomainAllowed', () => {
     expect(isDomainAllowed('not a valid host!!!', ['not a valid host!!!'])).toBe(false);
   });
 
+  test('denies hostname with consecutive dots', () => {
+    expect(isDomainAllowed('a..b', ['a..b'])).toBe(false);
+  });
+
+  test('denies hostname with label starting with hyphen', () => {
+    expect(isDomainAllowed('-foo.example.com', ['example.com'])).toBe(false);
+  });
+
+  test('denies hostname with label ending with hyphen', () => {
+    expect(isDomainAllowed('foo-.example.com', ['example.com'])).toBe(false);
+  });
+
   test('denies IP addresses', () => {
     expect(isDomainAllowed('192.168.1.1', ['192.168.1.1'])).toBe(false);
   });

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -60,9 +60,10 @@ export function normalizeDomain(input: string): DomainInfo | null {
     return null;
   }
 
-  // Reject malformed hostnames (e.g. strings with spaces, symbols, consecutive
-  // dots). Valid DNS labels contain only alphanumerics, hyphens, and dots.
-  if (!/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/.test(hostname)) {
+  // Reject malformed hostnames. Each DNS label must start and end with an
+  // alphanumeric and contain only alphanumerics/hyphens — no consecutive dots,
+  // no labels starting or ending with hyphens.
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/.test(hostname)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #2929 from codex and devin bots.

- **Tightened hostname validation regex** in `domain-normalize.ts` to validate each DNS label individually instead of the whole string. The previous regex `^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$` accepted malformed hostnames like `a..b` (consecutive dots) or `foo-.bar` (labels ending with hyphens). The new per-label regex `^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$` properly rejects these.
- **Added test cases** for consecutive dots, labels starting with hyphens, and labels ending with hyphens.

## Test plan

- [x] All 26 domain-policy tests pass (including 3 new edge case tests)
- [x] Type-check passes (only pre-existing unrelated error in http-server.ts)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
