### PR TITLE
fix: prevent notify-mode reminders from getting stuck in firing state

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -97,9 +97,14 @@ async function runScheduleOnce(
         failReminder(reminder.id);
       }
     } else {
-      log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
-      notifyReminder({ id: reminder.id, label: reminder.label, message: reminder.message });
-      completeReminder(reminder.id);
+      try {
+        log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
+        notifyReminder({ id: reminder.id, label: reminder.label, message: reminder.message });
+        completeReminder(reminder.id);
+      } catch (err) {
+        log.warn({ err, reminderId: reminder.id }, 'Reminder notification failed, reverting to pending');
+        failReminder(reminder.id);
+      }
     }
     processed += 1;
   }


### PR DESCRIPTION
## Summary
- Wraps the notify-mode reminder path in `scheduler.ts` with try/catch, mirroring the existing error handling in the execute-mode path.
- If `notifyReminder()` throws, `failReminder()` is now called to revert the reminder back to `pending` state, preventing it from being permanently stuck in `firing`.

Addresses review feedback from Codex and Devin on #2923.

## Test plan
- [x] Type-check passes (pre-existing error in `http-server.ts` is unrelated)
- [x] Verify the notify path now matches execute path error handling pattern

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
