### PR TITLE
fix: restore ScrollView for oversized secret prompt panels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -151,94 +151,97 @@ struct SecretPromptView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            // Header
-            HStack(spacing: VSpacing.md) {
-                Image(systemName: "lock.shield.fill")
-                    .font(.title2)
-                    .foregroundStyle(VColor.accent)
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                // Header
+                HStack(spacing: VSpacing.md) {
+                    Image(systemName: "lock.shield.fill")
+                        .font(.title2)
+                        .foregroundStyle(VColor.accent)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Secure Credential")
-                        .font(VFont.headline)
-                        .foregroundColor(VColor.textPrimary)
-                    Text(label)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Secure Credential")
+                            .font(VFont.headline)
+                            .foregroundColor(VColor.textPrimary)
+                        Text(label)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+
+                    Spacer()
+                }
+
+                // Description
+                if let description = description {
+                    Text(description)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                Spacer()
-            }
-
-            // Description
-            if let description = description {
-                Text(description)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-            }
-
-            // Usage context
-            if hasContext {
-                usageContextSection
-            }
-
-            // Secure input
-            SecureField(placeholder, text: $secretValue)
-                .textFieldStyle(.roundedBorder)
-                .font(VFont.mono)
-
-            // Safety explainer
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                safetyBullet(
-                    icon: "key.fill",
-                    text: "Stored in your Mac's Keychain, not sent to any server"
-                )
-                safetyBullet(
-                    icon: "eye.slash.fill",
-                    text: "The AI never sees this value — only your Mac can read it"
-                )
-            }
-
-            if saved {
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
-                    Text("Saved to Keychain")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.success)
-                }
-            } else {
-                // Buttons
-                HStack(spacing: VSpacing.lg) {
-                    Spacer()
-                    VButton(label: "Cancel", style: .ghost) {
-                        onCancel()
-                    }
-                    VButton(label: "Save", style: .primary) {
-                        guard !secretValue.isEmpty else { return }
-                        if onSave(secretValue) {
-                            withAnimation(VAnimation.standard) { saved = true }
-                        }
-                    }
-                    .disabled(secretValue.isEmpty)
+                // Usage context
+                if hasContext {
+                    usageContextSection
                 }
 
-                if allowOneTimeSend {
+                // Secure input
+                SecureField(placeholder, text: $secretValue)
+                    .textFieldStyle(.roundedBorder)
+                    .font(VFont.mono)
+
+                // Safety explainer
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    safetyBullet(
+                        icon: "key.fill",
+                        text: "Stored in your Mac's Keychain, not sent to any server"
+                    )
+                    safetyBullet(
+                        icon: "eye.slash.fill",
+                        text: "The AI never sees this value — only your Mac can read it"
+                    )
+                }
+
+                if saved {
                     HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 10))
-                            .foregroundColor(VColor.warning)
-                        VButton(label: "Send Once (not saved)", style: .ghost) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                        Text("Saved to Keychain")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.success)
+                    }
+                } else {
+                    // Buttons
+                    HStack(spacing: VSpacing.lg) {
+                        Spacer()
+                        VButton(label: "Cancel", style: .ghost) {
+                            onCancel()
+                        }
+                        VButton(label: "Save", style: .primary) {
                             guard !secretValue.isEmpty else { return }
-                            _ = onSendOnce(secretValue)
+                            if onSave(secretValue) {
+                                withAnimation(VAnimation.standard) { saved = true }
+                            }
                         }
                         .disabled(secretValue.isEmpty)
                     }
+
+                    if allowOneTimeSend {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 10))
+                                .foregroundColor(VColor.warning)
+                            VButton(label: "Send Once (not saved)", style: .ghost) {
+                                guard !secretValue.isEmpty else { return }
+                                _ = onSendOnce(secretValue)
+                            }
+                            .disabled(secretValue.isEmpty)
+                        }
+                    }
                 }
             }
+            .padding(VSpacing.xl)
         }
-        .padding(VSpacing.xl)
         .frame(width: 400)
+        .frame(maxHeight: 600)
         .vPanelBackground()
     }
 


### PR DESCRIPTION
## Summary
- Restores the `ScrollView` wrapper in `SecretPromptView` that was removed in PR #2935
- Re-adds `.frame(maxHeight: 600)` constraint to prevent unbounded growth
- Keeps the post-window-attachment height measurement improvement from #2935
- Fixes regression where long descriptions or usage-context lists would clip Save/Cancel buttons

Addresses review feedback from chatgpt-codex-connector[bot] on #2935.

## Test plan
- [ ] Open a secret prompt with a short description -- panel should size correctly
- [ ] Open a secret prompt with a long description and many usage-context items -- content should scroll, Save/Cancel should remain accessible

Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
