### PR TITLE
fix: re-add try-catch around post-keychain metadata writes

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -119,11 +119,15 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field, {
-          allowedTools: policy.allowedTools,
-          allowedDomains: policy.allowedDomains,
-          usageDescription: policy.usageDescription,
-        });
+        try {
+          upsertCredentialMetadata(service, field, {
+            allowedTools: policy.allowedTools,
+            allowedDomains: policy.allowedDomains,
+            usageDescription: policy.usageDescription,
+          });
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata write failed after storing credential');
+        }
         return { content: `Stored credential for ${service}/${field}.`, isError: false };
       }
 
@@ -171,7 +175,11 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: `Error: credential ${service}/${field} not found`, isError: true };
         }
-        deleteCredentialMetadata(service, field);
+        try {
+          deleteCredentialMetadata(service, field);
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata delete failed after removing credential');
+        }
         return { content: `Deleted credential for ${service}/${field}.`, isError: false };
       }
 
@@ -260,11 +268,15 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field, {
-          allowedTools: promptPolicy.allowedTools,
-          allowedDomains: promptPolicy.allowedDomains,
-          usageDescription: promptPolicy.usageDescription,
-        });
+        try {
+          upsertCredentialMetadata(service, field, {
+            allowedTools: promptPolicy.allowedTools,
+            allowedDomains: promptPolicy.allowedDomains,
+            usageDescription: promptPolicy.usageDescription,
+          });
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata write failed after storing credential');
+        }
         return { content: `Credential stored for ${service}/${field}.`, isError: false };
       }
 


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #2932 from both `chatgpt-codex-connector[bot]` and `devin-ai-integration[bot]`.

- Re-adds try-catch wrappers around `upsertCredentialMetadata` and `deleteCredentialMetadata` calls that occur **after** successful keychain operations (store, delete, and prompt-persist paths)
- The pre-flight `assertMetadataWritable()` check only validates version compatibility -- it does not protect against filesystem errors (disk full, permissions, I/O failures) during the actual `saveFile()` call
- Without the try-catch, a filesystem error after a successful keychain operation would leave the keychain modified but metadata not updated -- the exact desync PR #2932 aimed to prevent
- The `transient_send` path already had this protection and is unchanged

## Test plan
- [x] Type-check passes (pre-existing error in `http-server.ts` is unrelated)
- [ ] Verify store action succeeds even if metadata write fails (credential in keychain, warning logged)
- [ ] Verify delete action succeeds even if metadata delete fails
- [ ] Verify prompt-persist action succeeds even if metadata write fails

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
