### PR TITLE
fix: wrap notify-mode reminder in try/catch to prevent stuck firing state

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -97,9 +97,14 @@ async function runScheduleOnce(
         failReminder(reminder.id);
       }
     } else {
-      log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
-      notifyReminder({ id: reminder.id, label: reminder.label, message: reminder.message });
-      completeReminder(reminder.id);
+      try {
+        log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
+        notifyReminder({ id: reminder.id, label: reminder.label, message: reminder.message });
+        completeReminder(reminder.id);
+      } catch (err) {
+        log.warn({ err, reminderId: reminder.id }, 'Reminder notification failed, reverting to pending');
+        failReminder(reminder.id);
+      }
     }
     processed += 1;
   }


### PR DESCRIPTION
## Summary

- The `notify` branch in the scheduler's reminder processing loop lacked try/catch error handling
- If `notifyReminder()` threw, `completeReminder()` was skipped and `failReminder()` was never called, leaving the reminder permanently stuck in `firing` state
- Since `claimDueReminders()` only selects `pending` reminders, a stuck `firing` reminder could never be retried or completed
- Added try/catch matching the pattern already used by the `execute` branch, calling `failReminder()` on error to revert to `pending` for retry

Addresses review feedback from `devin-ai-integration[bot]` and `chatgpt-codex-connector[bot]` on #2923.

## Test plan

- [ ] Existing reminder tests pass (16/16)
- [ ] Verify notify-mode reminders are reverted to pending on notification failure
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
