### PR TITLE
fix: re-add try-catch around post-keychain metadata mutations

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -119,11 +119,15 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field, {
-          allowedTools: policy.allowedTools,
-          allowedDomains: policy.allowedDomains,
-          usageDescription: policy.usageDescription,
-        });
+        try {
+          upsertCredentialMetadata(service, field, {
+            allowedTools: policy.allowedTools,
+            allowedDomains: policy.allowedDomains,
+            usageDescription: policy.usageDescription,
+          });
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata write failed after storing credential');
+        }
         return { content: `Stored credential for ${service}/${field}.`, isError: false };
       }
 
@@ -171,7 +175,11 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: `Error: credential ${service}/${field} not found`, isError: true };
         }
-        deleteCredentialMetadata(service, field);
+        try {
+          deleteCredentialMetadata(service, field);
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata delete failed after removing credential');
+        }
         return { content: `Deleted credential for ${service}/${field}.`, isError: false };
       }
 
@@ -260,11 +268,15 @@ class CredentialStoreTool implements Tool {
         if (!ok) {
           return { content: 'Error: failed to store credential', isError: true };
         }
-        upsertCredentialMetadata(service, field, {
-          allowedTools: promptPolicy.allowedTools,
-          allowedDomains: promptPolicy.allowedDomains,
-          usageDescription: promptPolicy.usageDescription,
-        });
+        try {
+          upsertCredentialMetadata(service, field, {
+            allowedTools: promptPolicy.allowedTools,
+            allowedDomains: promptPolicy.allowedDomains,
+            usageDescription: promptPolicy.usageDescription,
+          });
+        } catch (err) {
+          log.warn({ service, field, err }, 'metadata write failed after storing credential');
+        }
         return { content: `Credential stored for ${service}/${field}.`, isError: false };
       }
 


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #2932 from codex and devin bots.

- **Re-added try-catch wrappers** around `upsertCredentialMetadata` and `deleteCredentialMetadata` calls that occur after successful keychain operations. The `assertMetadataWritable()` pre-flight check only catches version mismatches — filesystem errors (disk full, permissions) during the actual write need graceful handling to prevent keychain/metadata desync.
- **Three locations fixed** in `vault.ts`:
  1. Store action: `upsertCredentialMetadata` after `setSecureKey`
  2. Delete action: `deleteCredentialMetadata` after `deleteSecureKey`
  3. Prompt persist path: `upsertCredentialMetadata` after `setSecureKey`
- The transient_send path already had a try-catch (no change needed).

## Test plan

- [x] Type-check passes (only pre-existing unrelated error in http-server.ts)
- [x] Manual code review confirms all post-keychain metadata mutations are wrapped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
