### PR TITLE
fix: address review feedback on interleaved text/tool-call rendering

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -359,6 +359,15 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     }
   }
 
+  // Include attachment descriptions in textSegments so that
+  // textSegments.join('') matches the rendered text field.
+  if (attachmentParts.length > 0) {
+    const attachmentText = attachmentParts.join('\n');
+    const prefix = textParts.length > 0 ? '\n' : '';
+    ensureSegment();
+    currentSegmentParts.push(prefix + attachmentText);
+  }
+
   finalizeSegment();
 
   const text = textParts.join('');

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -304,6 +304,8 @@ export class RuntimeHttpServer {
         timestamp: msg.createdAt,
         toolCalls: rendered.toolCalls,
         toolCallsBeforeText: rendered.toolCallsBeforeText,
+        textSegments: rendered.textSegments,
+        contentOrder: rendered.contentOrder,
         id: msg.id,
       };
     });

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -726,6 +726,19 @@ private struct ChatBubble: View {
                 }
             }
         }
+
+        // Attachments are not part of contentOrder but must still be rendered
+        let partitioned = partitionedAttachments
+        if !partitioned.images.isEmpty {
+            attachmentImageGrid(partitioned.images)
+        }
+        if !partitioned.files.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(partitioned.files) { attachment in
+                    fileAttachmentChip(attachment)
+                }
+            }
+        }
     }
 
     /// Render a single text segment as a styled bubble.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1072,6 +1072,7 @@ public final class ChatViewModel: ObservableObject {
                 let surfIdx = messages[index].inlineSurfaces.count
                 messages[index].inlineSurfaces.append(inlineSurface)
                 messages[index].contentOrder.append(.surface(surfIdx))
+                lastContentWasToolCall = true
             } else if let lastUserIndex = messages.lastIndex(where: { $0.role == .user }),
                       let idx = messages[lastUserIndex...].lastIndex(where: { $0.role == .assistant }) {
                 // Scope to the current turn so we never attach to an assistant message
@@ -1079,6 +1080,7 @@ public final class ChatViewModel: ObservableObject {
                 let surfIdx = messages[idx].inlineSurfaces.count
                 messages[idx].inlineSurfaces.append(inlineSurface)
                 messages[idx].contentOrder.append(.surface(surfIdx))
+                lastContentWasToolCall = true
             } else {
                 var newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
                 newMsg.contentOrder = [.surface(0)]


### PR DESCRIPTION
## Summary
- Surface events now create segment boundaries during streaming by setting `lastContentWasToolCall` flag, fixing text-before-surface ordering
- Attachment images/files now render in interleaved mode on macOS (previously skipped when `hasInterleavedContent` was true)
- Attachment descriptions (`[File attachment]`, `[Image attachment]`) are now included in `textSegments` on the daemon side, so `textSegments.join('')` matches the rendered text field
- Fix pre-existing type error in `http-server.ts` where `textSegments`/`contentOrder` were missing from `ParsedHistoryMessage`

Addresses review feedback from Codex and Devin on #2984.

## Test plan
- [x] TypeScript type-check passes
- [x] Surface events set boundary flag so next text delta starts new segment
- [x] Attachments render below interleaved content blocks on macOS
- [x] Attachment descriptions preserved in textSegments from daemon

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
