### PR TITLE
fix: harden workspace config merge against non-object JSON and stale resurrection

### DIFF
--- a/assistant/src/__tests__/platform-workspace-migration.test.ts
+++ b/assistant/src/__tests__/platform-workspace-migration.test.ts
@@ -318,9 +318,9 @@ describe('migrateToWorkspaceLayout', () => {
       'ws-db',
     );
 
-    // Legacy hooks should remain at root (not moved due to conflict)
-    expect(existsSync(join(root, 'hooks', 'legacy-hook.sh'))).toBe(true);
-    expect(readFileSync(join(root, 'hooks', 'legacy-hook.sh'), 'utf-8')).toBe(
+    // Legacy hook entries are merged into workspace (not stranded)
+    expect(existsSync(join(root, 'hooks', 'legacy-hook.sh'))).toBe(false);
+    expect(readFileSync(join(ws, 'hooks', 'legacy-hook.sh'), 'utf-8')).toBe(
       'root-hook',
     );
     // Legacy skills entries are merged into workspace (not stranded)
@@ -565,8 +565,107 @@ describe('migrateToWorkspaceLayout', () => {
     expect(merged.model).toBe('claude-3');
     expect(merged.theme).toBe('light'); // workspace value wins over legacy
 
-    // Legacy config still exists (migratePath skipped the move)
+    // Merged key (slackWebhookUrl) was removed from legacy config;
+    // shared key (theme) remains so the file is kept.
     expect(existsSync(join(root, 'config.json'))).toBe(true);
+    const remaining = JSON.parse(readFileSync(join(root, 'config.json'), 'utf-8'));
+    expect(remaining.slackWebhookUrl).toBeUndefined();
+    expect(remaining.theme).toBe('dark');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('config key merge: legacy file deleted when all keys were merged', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Legacy config has only keys missing from workspace
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({ slackWebhookUrl: 'https://hooks.slack.com/old' }),
+    );
+    writeFileSync(
+      join(ws, 'config.json'),
+      JSON.stringify({ model: 'claude-3' }),
+    );
+
+    migrateToWorkspaceLayout();
+
+    const merged = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(merged.slackWebhookUrl).toBe('https://hooks.slack.com/old');
+    expect(merged.model).toBe('claude-3');
+
+    // Legacy config should be deleted since all its keys were merged
+    expect(existsSync(join(root, 'config.json'))).toBe(false);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('config key merge: does not resurrect keys deleted from workspace', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Legacy config has slackWebhookUrl
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({ slackWebhookUrl: 'https://hooks.slack.com/old', theme: 'dark' }),
+    );
+    writeFileSync(
+      join(ws, 'config.json'),
+      JSON.stringify({ model: 'claude-3' }),
+    );
+
+    // First run merges slackWebhookUrl into workspace
+    migrateToWorkspaceLayout();
+    const afterFirst = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(afterFirst.slackWebhookUrl).toBe('https://hooks.slack.com/old');
+
+    // User deletes slackWebhookUrl from workspace config
+    delete afterFirst.slackWebhookUrl;
+    writeFileSync(join(ws, 'config.json'), JSON.stringify(afterFirst));
+
+    // Second run should NOT resurrect the deleted key
+    migrateToWorkspaceLayout();
+    const afterSecond = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(afterSecond.slackWebhookUrl).toBeUndefined();
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('config key merge: non-object JSON in config files does not crash', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // null is valid JSON but not a plain object
+    writeFileSync(join(root, 'config.json'), 'null');
+    writeFileSync(join(ws, 'config.json'), JSON.stringify({ model: 'claude-3' }));
+
+    expect(() => migrateToWorkspaceLayout()).not.toThrow();
+    // Workspace config should be unchanged
+    const wsConfig = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(wsConfig.model).toBe('claude-3');
+
+    // Array legacy config
+    writeFileSync(join(root, 'config.json'), '[1,2,3]');
+    expect(() => migrateToWorkspaceLayout()).not.toThrow();
+    expect(JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8')).model).toBe('claude-3');
+
+    // Array workspace config
+    writeFileSync(join(root, 'config.json'), JSON.stringify({ theme: 'dark' }));
+    writeFileSync(join(ws, 'config.json'), '[1,2,3]');
+    expect(() => migrateToWorkspaceLayout()).not.toThrow();
 
     rmSync(base, { recursive: true, force: true });
   });

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -202,14 +202,21 @@ export function migratePath(source: string, destination: string): void {
  * top-level keys from the legacy file into the workspace file so they are
  * not silently lost during upgrade.
  */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
 function mergeSkippedConfigKeys(legacyPath: string, workspacePath: string): void {
   if (!existsSync(legacyPath) || !existsSync(workspacePath)) return;
 
   let legacy: Record<string, unknown>;
   let workspace: Record<string, unknown>;
   try {
-    legacy = JSON.parse(readFileSync(legacyPath, 'utf-8'));
-    workspace = JSON.parse(readFileSync(workspacePath, 'utf-8'));
+    const legacyRaw = JSON.parse(readFileSync(legacyPath, 'utf-8'));
+    const workspaceRaw = JSON.parse(readFileSync(workspacePath, 'utf-8'));
+    if (!isPlainObject(legacyRaw) || !isPlainObject(workspaceRaw)) return;
+    legacy = legacyRaw;
+    workspace = workspaceRaw;
   } catch {
     return; // malformed JSON — skip silently
   }
@@ -225,6 +232,16 @@ function mergeSkippedConfigKeys(legacyPath: string, workspacePath: string): void
   if (merged.length > 0) {
     try {
       writeFileSync(workspacePath, JSON.stringify(workspace, null, 2) + '\n');
+      // Remove merged keys from legacy config so they are not resurrected
+      // if a user later deletes them from the workspace config.
+      for (const key of merged) {
+        delete legacy[key];
+      }
+      if (Object.keys(legacy).length === 0) {
+        unlinkSync(legacyPath);
+      } else {
+        writeFileSync(legacyPath, JSON.stringify(legacy, null, 2) + '\n');
+      }
       migrationLog('info', 'Merged legacy config keys into workspace config', { keys: merged });
     } catch (err) {
       migrationLog('warn', 'Failed to merge legacy config keys', { err: String(err), keys: merged });


### PR DESCRIPTION
## Summary
- Validates parsed JSON is a plain object before calling `Object.keys` in `mergeSkippedConfigKeys`, preventing `TypeError` crashes when legacy/workspace config contains `null`, arrays, or other non-object JSON values (addresses [Devin review](https://github.com/vellum-ai/vellum-assistant/pull/2930#discussion_r2810222833))
- Removes merged keys from the legacy config file after successful merge, preventing deleted workspace settings from being resurrected on every startup (addresses [Codex review](https://github.com/vellum-ai/vellum-assistant/pull/2930#discussion_r2810223166))
- Fixes pre-existing test bug where hooks merge test expected legacy hooks to stay at root, but `mergeLegacyHooks` correctly moves them to workspace

## Test plan
- [x] Added test: non-object JSON (null, array) in config files does not crash
- [x] Added test: merged keys are removed from legacy config so they are not resurrected
- [x] Added test: legacy file is deleted when all keys were merged
- [x] Fixed pre-existing test: hooks merge assertion now matches actual behavior
- [x] All 18 migration tests pass

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
