### PR TITLE
fix: harden mergeSkippedConfigKeys against crashes and key resurrection

### DIFF
--- a/assistant/src/__tests__/platform-workspace-migration.test.ts
+++ b/assistant/src/__tests__/platform-workspace-migration.test.ts
@@ -692,6 +692,117 @@ describe('migrateToWorkspaceLayout', () => {
     rmSync(base, { recursive: true, force: true });
   });
 
+  test('config key merge: non-object JSON (null) does not crash', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Legacy config contains null (valid JSON but not an object)
+    writeFileSync(join(root, 'config.json'), 'null');
+    writeFileSync(join(ws, 'config.json'), JSON.stringify({ theme: 'dark' }));
+
+    // Should not throw
+    expect(() => migrateToWorkspaceLayout()).not.toThrow();
+
+    // Workspace config should be unchanged
+    const parsed = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(parsed.theme).toBe('dark');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('config key merge: non-object JSON (array) does not crash', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Legacy config is an array
+    writeFileSync(join(root, 'config.json'), '[1, 2, 3]');
+    writeFileSync(join(ws, 'config.json'), JSON.stringify({ model: 'gpt-4' }));
+
+    expect(() => migrateToWorkspaceLayout()).not.toThrow();
+
+    const parsed = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(parsed.model).toBe('gpt-4');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('config key merge: merged keys are removed from legacy to prevent resurrection', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Legacy has slackWebhookUrl (missing from workspace) and theme (already in workspace)
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({ slackWebhookUrl: 'https://hooks.slack.com/old', theme: 'dark' }),
+    );
+    writeFileSync(
+      join(ws, 'config.json'),
+      JSON.stringify({ model: 'claude-3', theme: 'light' }),
+    );
+
+    migrateToWorkspaceLayout();
+
+    // Merged key should be in workspace
+    const merged = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(merged.slackWebhookUrl).toBe('https://hooks.slack.com/old');
+
+    // Legacy should no longer contain the merged key
+    const legacyAfter = JSON.parse(readFileSync(join(root, 'config.json'), 'utf-8'));
+    expect(legacyAfter.slackWebhookUrl).toBeUndefined();
+    // Non-merged key should still be in legacy
+    expect(legacyAfter.theme).toBe('dark');
+
+    // Second run should be a no-op (no keys to merge)
+    const wsBeforeSecond = readFileSync(join(ws, 'config.json'), 'utf-8');
+    migrateToWorkspaceLayout();
+    expect(readFileSync(join(ws, 'config.json'), 'utf-8')).toBe(wsBeforeSecond);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('config key merge: legacy file deleted when all keys have been merged', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(ws, { recursive: true });
+
+    // Legacy only has keys missing from workspace
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({ slackWebhookUrl: 'https://hooks.slack.com/old' }),
+    );
+    writeFileSync(
+      join(ws, 'config.json'),
+      JSON.stringify({ model: 'claude-3' }),
+    );
+
+    migrateToWorkspaceLayout();
+
+    // Legacy file should be deleted (all keys were merged)
+    expect(existsSync(join(root, 'config.json'))).toBe(false);
+
+    // Workspace should have the merged key
+    const merged = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
+    expect(merged.slackWebhookUrl).toBe('https://hooks.slack.com/old');
+    expect(merged.model).toBe('claude-3');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
   test('sandbox/fs extraction with user data/ dir does not orphan internal state', () => {
     const base = makeTmpBase();
     process.env.BASE_DATA_DIR = base;


### PR DESCRIPTION
## Summary
- Validates parsed JSON is a plain object before calling `Object.keys()` in `mergeSkippedConfigKeys`. Config files containing valid non-object JSON (null, arrays) would crash the daemon on startup with `TypeError`.
- Removes merged keys from legacy config after successful merge to prevent resurrection. Previously, keys deleted from workspace config were re-added from the stale legacy file on every startup.
- When all legacy keys have been merged, the legacy config file is deleted entirely.
- Adds 4 new tests: non-object JSON (null), non-object JSON (array), key resurrection prevention, and legacy file deletion when empty.

Addresses review feedback from devin-ai-integration and chatgpt-codex-connector on PR #2930.

## Test plan
- [x] `bun test platform-workspace-migration.test.ts` — 18 pass, 1 pre-existing fail (unrelated `destination directory conflicts` test)
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing error in `ipc-validate.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
