### PR TITLE
fix: guard thread archive against in-flight workspace bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -114,14 +114,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             archivedSessionIds = archived
             // Session ID already known — safe to release the view model.
             chatViewModels.removeValue(forKey: id)
-        } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true {
+        } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
+                    && chatViewModels[id]?.isBootstrapping != true {
             chatViewModels[id]?.stopGenerating()
-            // No session ID and no user messages — a session will never be created,
-            // so there is nothing to backfill. Clean up immediately.
+            // No session ID, no user messages, and no bootstrap in flight —
+            // a session will never be created, so there is nothing to backfill.
+            // Clean up immediately.
             chatViewModels.removeValue(forKey: id)
         } else {
-            // Session ID is nil but user messages exist. Keep the ChatViewModel alive
-            // so the onSessionCreated callback can fire, claim its own session via
+            // Session ID is nil but a session is expected (user messages exist
+            // or bootstrap is in flight, e.g. a workspace refinement that
+            // doesn't append a user message). Keep the ChatViewModel alive so
+            // the onSessionCreated callback can fire, claim its own session via
             // the correlation ID, persist the archive state via backfillSessionId,
             // and then clean up. Use cancelPendingMessage() instead of
             // stopGenerating() to discard the queued message without clearing the

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -138,6 +138,10 @@ public final class ChatViewModel: ObservableObject {
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     private var bootstrapCorrelationId: String?
+    /// Whether this view model is currently bootstrapping a new session
+    /// (session_create sent, awaiting session_info). Used by ThreadManager
+    /// to decide whether it's safe to release the VM on archive.
+    public var isBootstrapping: Bool { bootstrapCorrelationId != nil }
     private var messageLoopTask: Task<Void, Never>?
     /// Monotonically increasing ID used to distinguish successive message-loop
     /// tasks so that a cancelled loop's cleanup doesn't clear a newer replacement.


### PR DESCRIPTION
## Summary
- Adds `isBootstrapping` computed property on `ChatViewModel` exposing whether a `session_create` is in flight (correlation ID is set)
- Updates `ThreadManager.archiveThread` to check `isBootstrapping` before cleaning up a VM with no user messages, preventing orphaned sessions from workspace refinements that bootstrap without appending a user message

## Context
Addresses codex review feedback on PR #2936: when `activeSurfaceId != nil`, `sendMessage()` calls `bootstrapSession()` without appending a `.user` message. If the thread was archived before `session_info` arrived, the old check (`messages.contains(where: { $0.role == .user })`) would be false, causing immediate VM cleanup. The session would then be orphaned because `onSessionCreated`/`backfillSessionId` could never fire.

## Test plan
- [ ] Archive a thread during a workspace refinement bootstrap (before session_info arrives) and verify the session is tracked after session_info arrives
- [ ] Archive an empty thread (no messages, no bootstrap) and verify immediate cleanup still works
- [ ] Archive a thread with user messages but no session ID and verify the VM stays alive for backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
