### PR TITLE
fix: clean up ephemeral session state and prevent FK constraint errors

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1519,6 +1519,14 @@ async function handleTaskSubmit(
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
       session.redirectToSecurePrompt(taskIngressCheck.detectedTypes, () => {
         conversationStore.deleteConversation(conversation.id);
+        // Clean up in-memory session and socket binding so the ephemeral
+        // session doesn't accumulate in the daemon's session map.
+        const s = ctx.sessions.get(conversation.id);
+        if (s) {
+          s.dispose();
+          ctx.sessions.delete(conversation.id);
+        }
+        ctx.socketToSession.delete(socket);
       });
       return;
     }

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,7 +1,7 @@
 import { eq, desc, asc, and, count, sql, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { conversations, messages, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments } from './schema.js';
+import { conversations, messages, toolInvocations, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { getLogger } from '../util/logger.js';
@@ -46,6 +46,7 @@ export function getConversation(id: string) {
 export function deleteConversation(id: string): void {
   const db = getDb();
   db.transaction((tx) => {
+    tx.delete(toolInvocations).where(eq(toolInvocations.conversationId, id)).run();
     tx.delete(messages).where(eq(messages.conversationId, id)).run();
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });


### PR DESCRIPTION
## Summary
- **In-memory session cleanup**: After the secret-redirect prompt resolves and the placeholder conversation is deleted from the DB, dispose the `Session` object and remove the `socketToSession` binding so stale entries don't accumulate in the daemon's session map across repeated blocked submissions.
- **FK constraint safety**: Delete `toolInvocations` rows before deleting `conversations` in `deleteConversation()`. The `toolInvocations.conversationId` FK does not use `onDelete: cascade`, so calling `deleteConversation` on a conversation with tool invocations would throw a SQLite FK constraint violation.

Addresses review feedback from chatgpt-codex-connector[bot] and devin-ai-integration[bot] on PR #2956.

## Modified files
- `assistant/src/daemon/handlers.ts` — session + socket cleanup in secret-redirect callback
- `assistant/src/memory/conversation-store.ts` — add `toolInvocations` deletion to `deleteConversation`

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm secret-blocked `task_submit` creates and fully tears down ephemeral session
- [ ] Confirm `deleteConversation` works on conversations that have `toolInvocations` rows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
