### PR TITLE
fix: quiet noisy warnings in sessions clear

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -57,7 +57,7 @@ export class VellumQdrantClient {
   private collectionReady = false;
 
   constructor(config: QdrantClientConfig) {
-    this.client = new QdrantRestClient({ url: config.url });
+    this.client = new QdrantRestClient({ url: config.url, checkCompatibility: false });
     this.collection = config.collection;
     this.vectorSize = config.vectorSize;
     this.onDisk = config.onDisk;

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -7,7 +7,8 @@ import { homedir } from 'node:os';
  * which pre-creates workspace destination directories and causes migration
  * moves to no-op.
  */
-function migrationLog(level: 'info' | 'warn', msg: string, data?: Record<string, unknown>): void {
+function migrationLog(level: 'info' | 'warn' | 'debug', msg: string, data?: Record<string, unknown>): void {
+  if (level === 'debug') return; // suppress debug-level migration noise
   const prefix = level === 'warn' ? 'WARN' : 'INFO';
   const extra = data ? ' ' + JSON.stringify(data) : '';
   process.stderr.write(`[migration] ${prefix}: ${msg}${extra}\n`);
@@ -180,7 +181,7 @@ export function getWorkspacePromptPath(file: string): string {
 export function migratePath(source: string, destination: string): void {
   if (!existsSync(source)) return;
   if (existsSync(destination)) {
-    migrationLog('warn', 'Migration skipped: destination already exists', { source, destination });
+    migrationLog('debug', 'Migration skipped: destination already exists', { source, destination });
     return;
   }
   try {


### PR DESCRIPTION
## Summary
- Downgrade `migratePath` "destination already exists" log from `warn` to `debug` — this is expected post-migration behavior, not actionable
- Pass `checkCompatibility: false` to `QdrantRestClient` constructor to suppress "Failed to obtain server version" warning when Qdrant server isn't running

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
