### PR TITLE
fix: wrap mkdirSync in try/catch inside migrateToDataLayout's migrateItem

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -428,11 +428,11 @@ export function migrateToDataLayout(): void {
   function migrateItem(oldPath: string, newPath: string): void {
     if (!existsSync(oldPath)) return;
     if (existsSync(newPath)) return;
-    const newDir = dirname(newPath);
-    if (!existsSync(newDir)) {
-      mkdirSync(newDir, { recursive: true });
-    }
     try {
+      const newDir = dirname(newPath);
+      if (!existsSync(newDir)) {
+        mkdirSync(newDir, { recursive: true });
+      }
       renameSync(oldPath, newPath);
       migrationLog('info', 'Migrated path', { from: oldPath, to: newPath });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Moves `mkdirSync` inside the existing `try/catch` block in the `migrateItem` helper within `migrateToDataLayout`, matching the pattern already used in `migratePath`.
- Without this fix, a filesystem error during parent-directory creation (e.g. permission denied, read-only filesystem) would crash the entire data-layout migration instead of logging a warning and continuing with remaining items.

## Context
Addresses review feedback from devin-ai-integration[bot] on PR #2951, which noted that the `migrateItem` function had the same unguarded `mkdirSync` bug that #2951 fixed in `migratePath`.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Change is structurally identical to the already-reviewed fix in `migratePath`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
