### PR TITLE
fix: wrap migrateItem mkdirSync in try/catch

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -428,11 +428,11 @@ export function migrateToDataLayout(): void {
   function migrateItem(oldPath: string, newPath: string): void {
     if (!existsSync(oldPath)) return;
     if (existsSync(newPath)) return;
-    const newDir = dirname(newPath);
-    if (!existsSync(newDir)) {
-      mkdirSync(newDir, { recursive: true });
-    }
     try {
+      const newDir = dirname(newPath);
+      if (!existsSync(newDir)) {
+        mkdirSync(newDir, { recursive: true });
+      }
       renameSync(oldPath, newPath);
       migrationLog('info', 'Migrated path', { from: oldPath, to: newPath });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Moves `mkdirSync` inside the `try/catch` block in `migrateItem` (within `migrateToDataLayout`) so filesystem errors during parent directory creation are caught and logged as warnings instead of crashing the entire migration
- This is the same fix that PR #2951 applied to `migratePath` -- the structurally identical `migrateItem` helper was missed

## Context
Addresses devin-ai-integration[bot] review feedback on PR #2951: the `migrateItem` helper had `mkdirSync` outside its `try/catch`, violating the no-throw contract that migration functions should have.

## Test plan
- [ ] Verify `migrateToDataLayout` continues past a `mkdirSync` failure (e.g. read-only parent) instead of aborting
- [ ] Verify normal migration still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
