### PR TITLE
fix: merge hooks config.json entries during legacy migration

### DIFF
--- a/assistant/src/__tests__/platform-workspace-migration.test.ts
+++ b/assistant/src/__tests__/platform-workspace-migration.test.ts
@@ -422,6 +422,110 @@ describe('migrateToWorkspaceLayout', () => {
     rmSync(base, { recursive: true, force: true });
   });
 
+  test('hooks config.json merge: legacy hook entries are preserved when workspace config exists', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    // Workspace hooks dir already exists with its own config.json
+    mkdirSync(join(ws, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(ws, 'hooks', 'config.json'),
+      JSON.stringify({
+        version: 1,
+        hooks: { 'on-save': { enabled: true } },
+      }),
+    );
+
+    // Legacy hooks dir has config.json with different hook entries
+    mkdirSync(join(root, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(root, 'hooks', 'config.json'),
+      JSON.stringify({
+        version: 1,
+        hooks: {
+          'on-start': { enabled: true, settings: { delay: 100 } },
+          'on-save': { enabled: false }, // conflicts — workspace value should win
+        },
+      }),
+    );
+
+    migrateToWorkspaceLayout();
+
+    // Workspace hooks config should have the missing on-start entry merged in
+    const merged = JSON.parse(
+      readFileSync(join(ws, 'hooks', 'config.json'), 'utf-8'),
+    );
+    expect(merged.hooks['on-start']).toEqual({ enabled: true, settings: { delay: 100 } });
+    // Existing workspace hook entry should not be overwritten
+    expect(merged.hooks['on-save']).toEqual({ enabled: true });
+
+    // Merged hook was removed from legacy config; conflicting one remains
+    const legacyAfter = JSON.parse(
+      readFileSync(join(root, 'hooks', 'config.json'), 'utf-8'),
+    );
+    expect(legacyAfter.hooks['on-start']).toBeUndefined();
+    expect(legacyAfter.hooks['on-save']).toEqual({ enabled: false });
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('hooks config.json merge: legacy file deleted when all hooks merged', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(join(ws, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(ws, 'hooks', 'config.json'),
+      JSON.stringify({ version: 1, hooks: {} }),
+    );
+
+    mkdirSync(join(root, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(root, 'hooks', 'config.json'),
+      JSON.stringify({
+        version: 1,
+        hooks: { 'on-start': { enabled: true } },
+      }),
+    );
+
+    migrateToWorkspaceLayout();
+
+    // All hooks were merged so legacy config.json should be deleted
+    expect(existsSync(join(root, 'hooks', 'config.json'))).toBe(false);
+
+    const merged = JSON.parse(
+      readFileSync(join(ws, 'hooks', 'config.json'), 'utf-8'),
+    );
+    expect(merged.hooks['on-start']).toEqual({ enabled: true });
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('hooks config.json merge: non-object JSON does not crash', () => {
+    const base = makeTmpBase();
+    process.env.BASE_DATA_DIR = base;
+    const root = join(base, '.vellum');
+    const ws = join(root, 'workspace');
+
+    mkdirSync(join(ws, 'hooks'), { recursive: true });
+    writeFileSync(join(ws, 'hooks', 'config.json'), JSON.stringify({ version: 1, hooks: {} }));
+
+    mkdirSync(join(root, 'hooks'), { recursive: true });
+    writeFileSync(join(root, 'hooks', 'config.json'), 'null');
+
+    expect(() => migrateToWorkspaceLayout()).not.toThrow();
+
+    // Workspace config should be unchanged
+    const wsConfig = JSON.parse(readFileSync(join(ws, 'hooks', 'config.json'), 'utf-8'));
+    expect(wsConfig.version).toBe(1);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
   test('stale empty directories from a previous failed run do not cause errors', () => {
     const base = makeTmpBase();
     process.env.BASE_DATA_DIR = base;

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -270,12 +270,68 @@ function mergeLegacyHooks(legacyDir: string, workspaceDir: string): void {
   for (const entry of entries) {
     const src = join(legacyDir, entry.name);
     const dest = join(workspaceDir, entry.name);
-    if (existsSync(dest)) continue; // already present in workspace
+    if (existsSync(dest)) {
+      // config.json needs a merge rather than a skip — the legacy file may
+      // contain hook enabled/settings entries that the workspace copy lacks.
+      if (entry.name === 'config.json') {
+        mergeHooksConfig(src, dest);
+      }
+      continue;
+    }
     try {
       renameSync(src, dest);
       migrationLog('info', 'Merged legacy hook into workspace', { from: src, to: dest });
     } catch (err) {
       migrationLog('warn', 'Failed to merge legacy hook', { err: String(err), from: src, to: dest });
+    }
+  }
+}
+
+/**
+ * Merge missing hook entries from a legacy hooks/config.json into the
+ * workspace hooks/config.json. Only adds hooks that don't already exist
+ * in the workspace config so user changes are never overwritten.
+ */
+function mergeHooksConfig(legacyPath: string, workspacePath: string): void {
+  let legacy: Record<string, unknown>;
+  let workspace: Record<string, unknown>;
+  try {
+    const legacyRaw = JSON.parse(readFileSync(legacyPath, 'utf-8'));
+    const workspaceRaw = JSON.parse(readFileSync(workspacePath, 'utf-8'));
+    if (!isPlainObject(legacyRaw) || !isPlainObject(workspaceRaw)) return;
+    legacy = legacyRaw;
+    workspace = workspaceRaw;
+  } catch {
+    return;
+  }
+
+  const legacyHooks = legacy.hooks;
+  const wsHooks = workspace.hooks;
+  if (!isPlainObject(legacyHooks) || !isPlainObject(wsHooks)) return;
+
+  const merged: string[] = [];
+  for (const hookName of Object.keys(legacyHooks)) {
+    if (!(hookName in wsHooks)) {
+      wsHooks[hookName] = legacyHooks[hookName];
+      merged.push(hookName);
+    }
+  }
+
+  if (merged.length > 0) {
+    try {
+      writeFileSync(workspacePath, JSON.stringify(workspace, null, 2) + '\n');
+      // Remove merged hooks from legacy config to prevent resurrection
+      for (const hookName of merged) {
+        delete legacyHooks[hookName];
+      }
+      if (Object.keys(legacyHooks).length === 0) {
+        unlinkSync(legacyPath);
+      } else {
+        writeFileSync(legacyPath, JSON.stringify(legacy, null, 2) + '\n');
+      }
+      migrationLog('info', 'Merged legacy hooks config entries into workspace', { hooks: merged });
+    } catch (err) {
+      migrationLog('warn', 'Failed to merge legacy hooks config', { err: String(err), hooks: merged });
     }
   }
 }


### PR DESCRIPTION
## Summary
- When `mergeLegacyHooks` encounters a `config.json` that already exists in the workspace hooks directory, it now merges missing hook entries (enabled/settings) from the legacy config instead of unconditionally skipping
- Prevents silently losing user hook configurations after upgrade when `workspace/hooks` was pre-created by `ensureDataDir` or a template install
- Follows the same merge-and-prune pattern as `mergeSkippedConfigKeys`

Addresses feedback from chatgpt-codex-connector on PR #2955.

## Test plan
- [x] Added test: hooks config.json merge preserves legacy hook entries when workspace config exists
- [x] Added test: hooks config.json merge deletes legacy file when all hooks merged
- [x] Added test: hooks config.json merge handles non-object JSON gracefully
- [x] All 25 existing workspace migration tests still pass
- [x] All 4 migration-ordering tests still pass
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
