### PR TITLE
fix: make sanitizeToolId hex-encoding injective by escaping x

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -9,11 +9,13 @@ import type {
 } from "../types.js";
 import { ProviderError } from "../../util/errors.js";
 
-const TOOL_ID_RE = /[^a-zA-Z0-9_-]/g;
+const TOOL_ID_RE = /[^a-wyzA-Z0-9_-]/g;
 
 /** Anthropic requires tool_use IDs to match ^[a-zA-Z0-9_-]+$ */
 function sanitizeToolId(id: string): string {
   if (!id) return 'empty';
+  // Escape `x` itself (to `x78`) so it can safely serve as the hex-escape
+  // prefix without collisions.  E.g. "a:" → "ax3a", "ax3a" → "ax783a".
   return id.replace(TOOL_ID_RE, (ch) => {
     const hex = ch.charCodeAt(0).toString(16).padStart(2, '0');
     return `x${hex}`;


### PR DESCRIPTION
## What

Excludes lowercase `x` from the passthrough character class in `sanitizeToolId` so that literal `x` is hex-encoded to `x78`.

## Why

The previous implementation allowed `x` through unchanged, but used it as the escape prefix for hex codes. This meant distinct inputs could collide — e.g. `sanitizeToolId('a:')` and `sanitizeToolId('ax3a')` both produced `ax3a`. Escaping `x` itself makes the encoding injective (no collisions).

## How

Changed the regex from `/[^a-zA-Z0-9_-]/g` to `/[^a-wyzA-Z0-9_-]/g`, which excludes lowercase `x` from the allowed set.

Addresses feedback on #2990.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
