### PR TITLE
fix: guard socket unbind to prevent clearing rebound live sessions

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1526,7 +1526,11 @@ async function handleTaskSubmit(
           s.dispose();
           ctx.sessions.delete(conversation.id);
         }
-        ctx.socketToSession.delete(socket);
+        // Only unbind if the socket still points to this ephemeral conversation;
+        // a new task_submit may have already rebound it to a real session.
+        if (ctx.socketToSession.get(socket) === conversation.id) {
+          ctx.socketToSession.delete(socket);
+        }
       });
       return;
     }


### PR DESCRIPTION
## Summary

Addresses review feedback on #3005.

The cleanup callback for ephemeral secret-prompt sessions was unconditionally calling `ctx.socketToSession.delete(socket)`. If the same client socket submitted another `task_submit` before the secret prompt resolved, the socket could already be rebound to a real session — and the unconditional delete would clear that live mapping, breaking the new session.

Now we guard the delete: only unbind if the socket still points to the ephemeral conversation (`ctx.socketToSession.get(socket) === conversation.id`).

## Changes

- `assistant/src/daemon/handlers.ts`: Added conditional check before `socketToSession.delete(socket)` in the secret-prompt cleanup callback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
