### PR TITLE
fix: use reference identity for transient credential race guard

### DIFF
--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -29,8 +29,10 @@ const log = getLogger('credential-broker');
  */
 export class CredentialBroker {
   private tokens = new Map<string, UsageToken>();
-  /** Transient values for one-time send: consumed on first read, never persisted. */
-  private transientValues = new Map<string, string>();
+  /** Transient values for one-time send: consumed on first read, never persisted.
+   *  Values are wrapped in objects so post-await guards use reference identity
+   *  (not string value equality) to detect concurrent replacements. */
+  private transientValues = new Map<string, { value: string }>();
 
   /**
    * Inject a value for one-time use. The value is consumed on the next
@@ -38,7 +40,7 @@ export class CredentialBroker {
    */
   injectTransient(service: string, field: string, value: string): void {
     const key = `credential:${service}:${field}`;
-    this.transientValues.set(key, value);
+    this.transientValues.set(key, { value });
     log.info({ service, field }, 'Transient credential injected for one-time use');
   }
 
@@ -105,7 +107,7 @@ export class CredentialBroker {
     if (transient !== undefined) {
       this.transientValues.delete(storageKey);
       log.info({ tokenId, storageKey, transient: true }, 'Usage token consumed (transient)');
-      return { success: true, storageKey, value: transient };
+      return { success: true, storageKey, value: transient.value };
     }
 
     log.info({ tokenId, storageKey }, 'Usage token consumed');
@@ -185,7 +187,7 @@ export class CredentialBroker {
     // Deletion is deferred until after a successful fill so the value survives
     // transient failures (e.g. stale element, page navigation, Playwright timeout).
     const transient = this.transientValues.get(storageKey);
-    const value = transient ?? getSecureKey(storageKey);
+    const value = transient?.value ?? getSecureKey(storageKey);
     if (!value) {
       return {
         success: false,
@@ -259,7 +261,7 @@ export class CredentialBroker {
 
     const storageKey = `credential:${request.service}:${request.field}`;
     const transient = this.transientValues.get(storageKey);
-    const value = transient ?? getSecureKey(storageKey);
+    const value = transient?.value ?? getSecureKey(storageKey);
     if (!value) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

Addresses feedback on PR #3000 from Codex and Devin reviewers.

The post-await guard `this.transientValues.get(storageKey) === transient` used JavaScript `===` on strings, which performs **value equality**. If a second `injectTransient()` writes the same plaintext while an earlier call is awaiting its async fill/execute, the guard passes and deletes the newly injected credential.

**Fix:** Wrap transient values in `{ value: string }` objects so `===` performs reference identity comparison. Each `injectTransient()` call creates a new wrapper object, making concurrent replacements correctly detectable even when the plaintext is identical.

## Changes

- `broker.ts`: Changed `transientValues` from `Map<string, string>` to `Map<string, { value: string }>`
- `broker.ts`: Updated `injectTransient()` to wrap values in objects
- `broker.ts`: Updated all `.get()` call sites (`consume`, `browserFill`, `serverUse`) to unwrap via `.value`
- Post-await guards now correctly use object reference identity

## Test plan

- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] No test files directly access `transientValues` internals, so existing tests remain valid
- [x] The `injectTransient` public API signature is unchanged (still takes `string`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
