### PR TITLE
fix: ScrollView fixedSize for correct fittingSize measurement

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -240,6 +240,10 @@ struct SecretPromptView: View {
             }
             .padding(VSpacing.xl)
         }
+        // fixedSize lets the ScrollView report its content's intrinsic height
+        // for fittingSize measurement, while maxHeight caps it to prevent
+        // unbounded growth (scroll kicks in when content exceeds 600pt).
+        .fixedSize(horizontal: false, vertical: true)
         .frame(width: 400)
         .frame(maxHeight: 600)
         .vPanelBackground()


### PR DESCRIPTION
## Summary

Addresses review feedback on #2995.

Wrapping the secret prompt in a `ScrollView` (PR #2995) caused `fittingSize` to return minimal height because `ScrollView` doesn't propagate its content's intrinsic size. This made all panels collapse to the 230pt minimum, pushing the secret field and action buttons below the fold.

## Fix

Added `.fixedSize(horizontal: false, vertical: true)` to the `ScrollView` so it adopts its content's intrinsic height for measurement. The existing `.frame(maxHeight: 600)` still caps the panel size, and scrolling kicks in when content exceeds 600pt.

## Files changed

- `clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
