### PR TITLE
fix: use fixed-width hex in sanitizeToolId for full injectivity

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -17,7 +17,7 @@ function sanitizeToolId(id: string): string {
   // Escape `x` itself (to `x78`) so it can safely serve as the hex-escape
   // prefix without collisions.  E.g. "a:" → "ax3a", "ax3a" → "ax783a".
   return id.replace(TOOL_ID_RE, (ch) => {
-    const hex = ch.charCodeAt(0).toString(16).padStart(2, '0');
+    const hex = ch.charCodeAt(0).toString(16).padStart(4, '0');
     return `x${hex}`;
   });
 }


### PR DESCRIPTION
Change `padStart(2, '0')` to `padStart(4, '0')` in `sanitizeToolId` so every escaped character produces exactly 4 hex digits. This prevents collisions between ASCII escapes and Unicode characters (e.g., `'x0'` vs `'\u0780'` both producing `'x780'`).

Addresses Codex feedback on #3015.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
