### PR TITLE
fix: prompt for Vercel API token on publish

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -87,6 +87,9 @@ import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { deployHtmlToVercel, deleteVercelDeployment } from '../services/vercel-deploy.js';
 import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedPageByDeploymentId } from '../memory/published-pages-store.js';
 import { credentialBroker } from '../tools/credentials/broker.js';
+import { setSecureKey } from '../security/secure-keys.js';
+import { upsertCredentialMetadata } from '../tools/credentials/metadata-store.js';
+import type { SecretPromptResult } from '../permissions/secret-prompter.js';
 import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId, validateBlobKindEncoding } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
@@ -95,6 +98,9 @@ import type { UserMessageAttachment } from './ipc-contract.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
+
+// Module-level map for non-session secret prompts (e.g. publish_page)
+const pendingStandaloneSecrets = new Map<string, { resolve: (result: SecretPromptResult) => void; timer: ReturnType<typeof setTimeout> }>();
 
 const FALLBACK_SCREEN = { width: 1920, height: 1080 };
 let cachedScreenDims: { width: number; height: number } | null = null;
@@ -647,6 +653,17 @@ function handleSecretResponse(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
+  // Check standalone (non-session) prompts first, since they use a dedicated
+  // requestId that won't collide with session prompts.
+  const standalone = pendingStandaloneSecrets.get(msg.requestId);
+  if (standalone) {
+    clearTimeout(standalone.timer);
+    pendingStandaloneSecrets.delete(msg.requestId);
+    standalone.resolve({ value: msg.value ?? null, delivery: msg.delivery ?? 'store' });
+    return;
+  }
+
+  // Otherwise route to the session's secret prompter
   const sessionId = ctx.socketToSession.get(socket);
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
@@ -654,6 +671,36 @@ function handleSecretResponse(
       session.handleSecretResponse(msg.requestId, msg.value, msg.delivery);
     }
   }
+}
+
+/**
+ * Send a `secret_request` to the client and wait for the response,
+ * outside of a session context (e.g. from handler-level code like publish_page).
+ */
+function requestSecretStandalone(
+  socket: net.Socket,
+  ctx: HandlerContext,
+  params: { service: string; field: string; label: string; description?: string; placeholder?: string; allowedTools?: string[] },
+): Promise<SecretPromptResult> {
+  const requestId = uuid();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      pendingStandaloneSecrets.delete(requestId);
+      resolve({ value: null, delivery: 'store' });
+    }, 120_000);
+    pendingStandaloneSecrets.set(requestId, { resolve, timer });
+    ctx.send(socket, {
+      type: 'secret_request',
+      requestId,
+      service: params.service,
+      field: params.field,
+      label: params.label,
+      description: params.description,
+      placeholder: params.placeholder,
+      purpose: 'Publish site apps to the web',
+      allowedTools: params.allowedTools,
+    });
+  });
 }
 
 function handleSessionList(socket: net.Socket, ctx: HandlerContext): void {
@@ -2171,29 +2218,66 @@ async function handlePublishPage(
       return;
     }
 
-    const useResult = await credentialBroker.serverUse({
+    const publishExecute = async (token: string) => {
+      const name = msg.title
+        ? msg.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50)
+        : `vellum-page-${Date.now()}`;
+
+      const result = await deployHtmlToVercel({ html: msg.html, name, token });
+
+      const id = uuid();
+      createPublishedPage({
+        id,
+        deploymentId: result.deploymentId,
+        publicUrl: result.url,
+        pageTitle: msg.title,
+        htmlHash,
+      });
+
+      return { url: result.url, deploymentId: result.deploymentId };
+    };
+
+    let useResult = await credentialBroker.serverUse({
       service: 'vercel',
       field: 'api_token',
       toolName: 'publish_page',
-      execute: async (token) => {
-        const name = msg.title
-          ? msg.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50)
-          : `vellum-page-${Date.now()}`;
-
-        const result = await deployHtmlToVercel({ html: msg.html, name, token });
-
-        const id = uuid();
-        createPublishedPage({
-          id,
-          deploymentId: result.deploymentId,
-          publicUrl: result.url,
-          pageTitle: msg.title,
-          htmlHash,
-        });
-
-        return { url: result.url, deploymentId: result.deploymentId };
-      },
+      execute: publishExecute,
     });
+
+    // If no credential found, prompt the user and retry
+    if (!useResult.success && useResult.reason?.includes('No credential found')) {
+      const allowedTools = ['publish_page', 'unpublish_page'];
+      const secretResult = await requestSecretStandalone(socket, ctx, {
+        service: 'vercel',
+        field: 'api_token',
+        label: 'Vercel API Token',
+        description: 'Required to publish site apps to the web. Create a token at vercel.com/account/tokens.',
+        placeholder: 'Enter your Vercel API token',
+        allowedTools,
+      });
+
+      if (!secretResult.value) {
+        ctx.send(socket, {
+          type: 'publish_page_response',
+          success: false,
+          error: 'Cancelled',
+        });
+        return;
+      }
+
+      // Store the credential
+      const storageKey = `credential:vercel:api_token`;
+      setSecureKey(storageKey, secretResult.value);
+      upsertCredentialMetadata('vercel', 'api_token', { allowedTools });
+
+      // Retry with the newly stored credential
+      useResult = await credentialBroker.serverUse({
+        service: 'vercel',
+        field: 'api_token',
+        toolName: 'publish_page',
+        execute: publishExecute,
+      });
+    }
 
     if (useResult.success && useResult.result) {
       ctx.send(socket, {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -480,6 +480,7 @@ export interface DynamicPageSurfaceData {
   width?: number;
   height?: number;
   appId?: string;
+  appType?: string;
   preview?: DynamicPagePreview;
 }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -2103,7 +2103,7 @@ export class Session {
       const app = getApp(appId);
       if (!app) return { content: `App not found: ${appId}`, isError: true };
 
-      const surfaceData: DynamicPageSurfaceData = { html: app.htmlDefinition, appId: app.id, preview };
+      const surfaceData: DynamicPageSurfaceData = { html: app.htmlDefinition, appId: app.id, appType: app.appType, preview };
       const surfaceId = uuid();
       this.surfaceState.set(surfaceId, {
         surfaceType: 'dynamic_page',

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -14,6 +14,7 @@ struct MainWindowView: View {
     @State private var shareFileURL: URL?
     @State private var isPublishing = false
     @State private var publishedUrl: String?
+    @State private var publishError: String?
     @State private var isHoveredThread: UUID?
     @State private var threadMenuOpenId: UUID?
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
@@ -58,6 +59,7 @@ struct MainWindowView: View {
     private func publishPage(html: String, title: String?) {
         guard !isPublishing else { return }
         isPublishing = true
+        publishError = nil
 
         Task { @MainActor in
             daemonClient.onPublishPageResponse = { response in
@@ -66,6 +68,14 @@ struct MainWindowView: View {
                     publishedUrl = url
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(url, forType: .string)
+                } else if let error = response.error, error != "Cancelled" {
+                    publishError = error
+                    // Auto-dismiss error after 5 seconds
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                        if publishError == error {
+                            withAnimation(VAnimation.standard) { publishError = nil }
+                        }
+                    }
                 }
             }
 
@@ -790,47 +800,8 @@ struct MainWindowView: View {
                         .animation(VAnimation.standard, value: viewModel.surfaceUndoCount)
                     }
 
-                    // Share button — bundle app and share via system share sheet
-                    if let appId = data.appId {
-                        Button(action: {
-                            bundleAndShare(appId: appId)
-                        }) {
-                            Group {
-                                if isBundling {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                        .scaleEffect(0.7)
-                                } else {
-                                    Image(systemName: "square.and.arrow.up")
-                                        .font(.system(size: 12, weight: .medium))
-                                }
-                            }
-                            .foregroundColor(VColor.textPrimary)
-                            .frame(width: 32, height: 32)
-                            .background(
-                                Circle()
-                                    .fill(VColor.surface.opacity(0.85))
-                                    .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(isBundling)
-                        .accessibilityLabel("Share")
-                        .background(
-                            ShareSheetButton(
-                                items: shareFileURL != nil ? [shareFileURL!] : [],
-                                isPresented: Binding(
-                                    get: { showSharePicker },
-                                    set: { newValue in
-                                        showSharePicker = newValue
-                                        if !newValue { shareFileURL = nil }
-                                    }
-                                )
-                            )
-                            .frame(width: 1, height: 1)
-                        )
-                    } else {
-                        // Publish button for static pages
+                    // Publish button — for static pages or site-type apps
+                    if data.appId == nil || data.appType == "site" {
                         Button(action: {
                             publishPage(html: data.html, title: data.preview?.title)
                         }) {
@@ -886,6 +857,69 @@ struct MainWindowView: View {
                             .accessibilityLabel("Copy published URL")
                             .frame(maxWidth: 200)
                         }
+
+                        // Show error pill on publish failure
+                        if let error = publishError {
+                            HStack(spacing: VSpacing.xs) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.system(size: 10, weight: .medium))
+                                Text(error)
+                                    .font(VFont.caption)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                            .foregroundColor(VColor.error)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.vertical, VSpacing.xs)
+                            .background(
+                                Capsule()
+                                    .fill(VColor.error.opacity(0.15))
+                                    .overlay(Capsule().stroke(VColor.error.opacity(0.3), lineWidth: 1))
+                            )
+                            .frame(maxWidth: 200)
+                            .transition(.opacity)
+                        }
+                    }
+
+                    // Share button — bundle app and share via system share sheet
+                    if let appId = data.appId {
+                        Button(action: {
+                            bundleAndShare(appId: appId)
+                        }) {
+                            Group {
+                                if isBundling {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .scaleEffect(0.7)
+                                } else {
+                                    Image(systemName: "square.and.arrow.up")
+                                        .font(.system(size: 12, weight: .medium))
+                                }
+                            }
+                            .foregroundColor(VColor.textPrimary)
+                            .frame(width: 32, height: 32)
+                            .background(
+                                Circle()
+                                    .fill(VColor.surface.opacity(0.85))
+                                    .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isBundling)
+                        .accessibilityLabel("Share")
+                        .background(
+                            ShareSheetButton(
+                                items: shareFileURL != nil ? [shareFileURL!] : [],
+                                isPresented: Binding(
+                                    get: { showSharePicker },
+                                    set: { newValue in
+                                        showSharePicker = newValue
+                                        if !newValue { shareFileURL = nil }
+                                    }
+                                )
+                            )
+                            .frame(width: 1, height: 1)
+                        )
                     }
                 }
                 .padding(.horizontal, VSpacing.xl)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1043,15 +1043,15 @@ public final class ChatViewModel: ObservableObject {
 
         case .uiSurfaceShow(let msg):
             guard belongsToSession(msg.sessionId) else { return }
-            guard msg.display == nil || msg.display == "inline" else { break }
+            guard msg.display == nil || msg.display == "inline" || msg.display == "panel" else { break }
             guard let surface = Surface.from(msg) else { break }
 
-            // On macOS, dynamic pages with no explicit display mode are routed
-            // to the workspace by SurfaceManager. If the dynamic page has a
-            // preview, also render a compact preview card inline in chat.
+            // On macOS, dynamic pages with no explicit display mode (or "panel")
+            // are routed to the workspace by SurfaceManager. If the dynamic page
+            // has a preview, also render a compact preview card inline in chat.
             // On iOS there is no workspace, so dynamic pages always render inline.
             #if os(macOS)
-            if case .dynamicPage(let dpData) = surface.data, msg.display == nil {
+            if case .dynamicPage(let dpData) = surface.data, msg.display == nil || msg.display == "panel" {
                 isThinking = false
                 // Only render inline preview if the dynamic page has preview metadata
                 guard dpData.preview != nil else { break }

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -208,13 +208,15 @@ public struct DynamicPageSurfaceData: Sendable {
     public let width: Int?
     public let height: Int?
     public let appId: String?
+    public let appType: String?
     public let preview: DynamicPagePreview?
 
-    public init(html: String, width: Int? = nil, height: Int? = nil, appId: String? = nil, preview: DynamicPagePreview? = nil) {
+    public init(html: String, width: Int? = nil, height: Int? = nil, appId: String? = nil, appType: String? = nil, preview: DynamicPagePreview? = nil) {
         self.html = html
         self.width = width
         self.height = height
         self.appId = appId
+        self.appType = appType
         self.preview = preview
     }
 }
@@ -505,10 +507,11 @@ public extension Surface {
         let width: Int? = update.keys.contains("width") ? (update["width"] as? Int) : existing.width
         let height: Int? = update.keys.contains("height") ? (update["height"] as? Int) : existing.height
         let appId: String? = update.keys.contains("appId") ? (update["appId"] as? String) : existing.appId
+        let appType: String? = update.keys.contains("appType") ? (update["appType"] as? String) : existing.appType
         let preview: DynamicPagePreview? = update.keys.contains("preview")
             ? parseDynamicPagePreview(update["preview"] as? [String: Any?])
             : existing.preview
-        return DynamicPageSurfaceData(html: html, width: width, height: height, appId: appId, preview: preview)
+        return DynamicPageSurfaceData(html: html, width: width, height: height, appId: appId, appType: appType, preview: preview)
     }
 
     // MARK: - Field Parsing Helpers
@@ -636,6 +639,7 @@ public extension Surface {
             width: dict["width"] as? Int,
             height: dict["height"] as? Int,
             appId: dict["appId"] as? String,
+            appType: dict["appType"] as? String,
             preview: parseDynamicPagePreview(dict["preview"] as? [String: Any?])
         )
     }


### PR DESCRIPTION
## Summary
- When clicking Publish without a stored Vercel token, the daemon now prompts for the credential via `secret_request`, stores it, and retries the publish automatically
- Added standalone secret prompt routing in `handleSecretResponse` (checked before session routing) so handler-level code can request secrets outside of a session context
- Swift client now shows an error pill on publish failures (auto-dismisses after 5s, suppressed for user cancellations)

## Test plan
- [ ] Remove Vercel credential: `security delete-generic-password -s vellum-assistant -a "credential:vercel:api_token"`
- [ ] Open a site app, click Publish → expect Secure Credential panel
- [ ] Enter token, click Save → expect publish completes, URL appears
- [ ] Click Publish on another site → should work without prompting (credential stored)
- [ ] Remove credential, click Publish, cancel the prompt → button resets, no error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
