### PR TITLE
fix: disable hit testing on hidden archive button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -282,6 +282,7 @@ struct MainWindowView: View {
             .buttonStyle(.plain)
             .frame(width: 24)
             .opacity(isSelected || isHoveredThread == thread.id ? 1 : 0)
+            .allowsHitTesting(isSelected || isHoveredThread == thread.id)
             .accessibilityLabel("Archive \(thread.title)")
         }
         .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
Add `.allowsHitTesting()` to the archive button so it cannot be clicked when invisible (opacity 0). Both Codex and Devin flagged this as a P1 issue on #3010 — the button directly calls `archiveThread()` which is destructive with no confirmation dialog.

In SwiftUI, `.opacity(0)` does not disable hit testing, so the invisible button remained clickable. Adding `.allowsHitTesting(isSelected || isHoveredThread == thread.id)` ensures the button is only interactive when visible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
