### PR TITLE
feat: add Vercel API config IPC contract and daemon handler

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -308,6 +308,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'slack_webhook_config',
     action: 'get',
   },
+  vercel_api_config: {
+    type: 'vercel_api_config',
+    action: 'get',
+  },
   link_open_request: {
     type: 'link_open_request',
     url: 'https://example.com',
@@ -873,6 +877,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   slack_webhook_config_response: {
     type: 'slack_webhook_config_response',
     webhookUrl: 'https://hooks.slack.com/services/T00/B00/xxx',
+    success: true,
+  },
+  vercel_api_config_response: {
+    type: 'vercel_api_config_response',
+    hasToken: true,
     success: true,
   },
   open_url: {

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -54,6 +54,7 @@ import type {
   GalleryInstallRequest,
   ShareToSlackRequest,
   SlackWebhookConfigRequest,
+  VercelApiConfigRequest,
   AppUpdatePreviewRequest,
   PublishPageRequest,
   UnpublishPageRequest,
@@ -86,6 +87,8 @@ import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { deployHtmlToVercel, deleteVercelDeployment } from '../services/vercel-deploy.js';
 import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedPageByDeploymentId } from '../memory/published-pages-store.js';
+import { getSecureKey, setSecureKey, deleteSecureKey } from '../security/secure-keys.js';
+import { upsertCredentialMetadata, deleteCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { credentialBroker } from '../tools/credentials/broker.js';
 import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId, validateBlobKindEncoding } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
@@ -449,6 +452,7 @@ const handlers: DispatchMap = {
   gallery_install: handleGalleryInstall,
   share_to_slack: handleShareToSlack,
   slack_webhook_config: handleSlackWebhookConfig,
+  vercel_api_config: handleVercelApiConfig,
   publish_page: handlePublishPage,
   unpublish_page: handleUnpublishPage,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
@@ -2425,6 +2429,59 @@ function handleSlackWebhookConfig(
     log.error({ err }, 'Failed to handle Slack webhook config');
     ctx.send(socket, {
       type: 'slack_webhook_config_response',
+      success: false,
+      error: message,
+    });
+  }
+}
+
+function handleVercelApiConfig(
+  msg: VercelApiConfigRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    if (msg.action === 'get') {
+      const existing = getSecureKey('credential:vercel:api_token');
+      ctx.send(socket, {
+        type: 'vercel_api_config_response',
+        hasToken: !!existing,
+        success: true,
+      });
+    } else if (msg.action === 'set') {
+      if (!msg.apiToken) {
+        ctx.send(socket, {
+          type: 'vercel_api_config_response',
+          hasToken: false,
+          success: false,
+          error: 'apiToken is required for set action',
+        });
+        return;
+      }
+      setSecureKey('credential:vercel:api_token', msg.apiToken);
+      upsertCredentialMetadata('vercel', 'api_token', {
+        allowedTools: ['publish_page', 'unpublish_page'],
+      });
+      ctx.send(socket, {
+        type: 'vercel_api_config_response',
+        hasToken: true,
+        success: true,
+      });
+    } else {
+      deleteSecureKey('credential:vercel:api_token');
+      deleteCredentialMetadata('vercel', 'api_token');
+      ctx.send(socket, {
+        type: 'vercel_api_config_response',
+        hasToken: false,
+        success: true,
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to handle Vercel API config');
+    ctx.send(socket, {
+      type: 'vercel_api_config_response',
+      hasToken: false,
       success: false,
       error: message,
     });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -395,6 +395,19 @@ export interface SlackWebhookConfigRequest {
   webhookUrl?: string;
 }
 
+export interface VercelApiConfigRequest {
+  type: 'vercel_api_config';
+  action: 'get' | 'set' | 'delete';
+  apiToken?: string;
+}
+
+export interface VercelApiConfigResponse {
+  type: 'vercel_api_config_response';
+  hasToken: boolean;
+  success: boolean;
+  error?: string;
+}
+
 export interface LinkOpenRequest {
   type: 'link_open_request';
   url: string;
@@ -611,6 +624,7 @@ export type ClientMessage =
   | ShareAppCloudRequest
   | ShareToSlackRequest
   | SlackWebhookConfigRequest
+  | VercelApiConfigRequest
   | SessionsClearRequest
   | GalleryListRequest
   | GalleryInstallRequest
@@ -1388,6 +1402,7 @@ export type ServerMessage =
   | GalleryInstallResponse
   | ShareToSlackResponse
   | SlackWebhookConfigResponse
+  | VercelApiConfigResponse
   | OpenUrl
   | AppUpdatePreviewResponse
   | PublishPageResponse


### PR DESCRIPTION
Part of #3011. Adds VercelApiConfigRequest/Response IPC types and handleVercelApiConfig daemon handler for get/set/delete of the Vercel API token, including credential metadata management for publish_page and unpublish_page tools.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
