### PR TITLE
feat: add Swift IPC types and DaemonClient support for Vercel API config

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -152,6 +152,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `slack_webhook_config_response` message.
     public var onSlackWebhookConfigResponse: ((SlackWebhookConfigResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `vercel_api_config_response` message.
+    public var onVercelApiConfigResponse: ((VercelApiConfigResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `publish_page_response` message.
     public var onPublishPageResponse: ((PublishPageResponseMessage) -> Void)?
 
@@ -696,6 +699,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(SlackWebhookConfigRequestMessage(action: action, webhookUrl: webhookUrl))
     }
 
+    /// Get, set, or delete the Vercel API token configuration.
+    public func sendVercelApiConfig(action: String, apiToken: String? = nil) throws {
+        try send(VercelApiConfigRequestMessage(action: action, apiToken: apiToken))
+    }
+
     /// Publish a static page to Vercel.
     public func sendPublishPage(html: String, title: String? = nil) throws {
         try send(PublishPageRequestMessage(html: html, title: title))
@@ -934,6 +942,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onShareToSlackResponse?(msg)
         case .slackWebhookConfigResponse(let msg):
             onSlackWebhookConfigResponse?(msg)
+        case .vercelApiConfigResponse(let msg):
+            onVercelApiConfigResponse?(msg)
         case .publishPageResponse(let msg):
             onPublishPageResponse?(msg)
         case .openUrl(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -296,6 +296,7 @@ public struct IPCDynamicPageSurfaceData: Codable, Sendable {
     public let width: Int?
     public let height: Int?
     public let appId: String?
+    public let appType: String?
     public let preview: IPCDynamicPagePreview?
 }
 
@@ -1343,6 +1344,19 @@ public struct IPCUserMessageAttachment: Codable, Sendable {
     public let mimeType: String
     public let data: String
     public let extractedText: String?
+}
+
+public struct IPCVercelApiConfigRequest: Codable, Sendable {
+    public let type: String
+    public let action: String
+    public let apiToken: String?
+}
+
+public struct IPCVercelApiConfigResponse: Codable, Sendable {
+    public let type: String
+    public let hasToken: Bool
+    public let success: Bool
+    public let error: String?
 }
 
 public struct IPCWatchCompleteRequest: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1358,6 +1358,22 @@ public struct SlackWebhookConfigResponseMessage: Decodable, Sendable {
     public let error: String?
 }
 
+// MARK: - Vercel API Config Messages
+
+/// Sent to get/set/delete the Vercel API token.
+/// Backed by generated `IPCVercelApiConfigRequest`.
+public typealias VercelApiConfigRequestMessage = IPCVercelApiConfigRequest
+
+extension IPCVercelApiConfigRequest {
+    public init(action: String, apiToken: String? = nil) {
+        self.init(type: "vercel_api_config", action: action, apiToken: apiToken)
+    }
+}
+
+/// Response from Vercel API config operations.
+/// Backed by generated `IPCVercelApiConfigResponse`.
+public typealias VercelApiConfigResponseMessage = IPCVercelApiConfigResponse
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 public enum ServerMessage: Decodable, Sendable {
@@ -1413,6 +1429,7 @@ public enum ServerMessage: Decodable, Sendable {
     case signBundlePayload(SignBundlePayloadMessage)
     case shareToSlackResponse(ShareToSlackResponseMessage)
     case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
+    case vercelApiConfigResponse(VercelApiConfigResponseMessage)
     case publishPageResponse(PublishPageResponseMessage)
     case unpublishPageResponse(UnpublishPageResponseMessage)
     case uiSurfaceUndoResult(UiSurfaceUndoResultMessage)
@@ -1585,6 +1602,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "slack_webhook_config_response":
             let message = try SlackWebhookConfigResponseMessage(from: decoder)
             self = .slackWebhookConfigResponse(message)
+        case "vercel_api_config_response":
+            let message = try VercelApiConfigResponseMessage(from: decoder)
+            self = .vercelApiConfigResponse(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
## Summary
- Regenerated `IPCContractGenerated.swift` to pick up new `IPCVercelApiConfigRequest` and `IPCVercelApiConfigResponse` types from the TypeScript IPC contract
- Added `VercelApiConfigRequestMessage`/`VercelApiConfigResponseMessage` typealiases and convenience initializer in `IPCMessages.swift`
- Added `ServerMessage.vercelApiConfigResponse` case with decoder support
- Added `onVercelApiConfigResponse` callback and `sendVercelApiConfig` method to `DaemonClient.swift`

## Test plan
- [x] IPC code generator ran successfully
- [x] Swift decoder drift check passes
- [x] macOS build succeeds

Part of #3011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
