### PR TITLE
feat: add Vercel API Key settings UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -10,6 +10,7 @@ public final class SettingsStore: ObservableObject {
 
     @Published var hasKey: Bool
     @Published var hasBraveKey: Bool
+    @Published var hasVercelKey: Bool = false
 
     // MARK: - Settings Values
 
@@ -44,10 +45,12 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Private
 
     private weak var ambientAgent: AmbientAgent?
+    private weak var daemonClient: DaemonClient?
     private var cancellables = Set<AnyCancellable>()
 
     init(ambientAgent: AmbientAgent, daemonClient: DaemonClient? = nil) {
         self.ambientAgent = ambientAgent
+        self.daemonClient = daemonClient
 
         // Seed from UserDefaults / Keychain
         self.hasKey = APIKeyManager.getKey() != nil
@@ -74,6 +77,17 @@ public final class SettingsStore: ObservableObject {
         daemonClient?.$isTrustRulesSheetOpen
             .receive(on: RunLoop.main)
             .assign(to: &$isAnyTrustRulesSheetOpen)
+
+        // Wire up Vercel API config IPC response
+        daemonClient?.onVercelApiConfigResponse = { [weak self] response in
+            guard let self else { return }
+            if response.success {
+                self.hasVercelKey = response.hasToken
+            }
+        }
+
+        // Refresh Vercel key state on init
+        refreshVercelKeyState()
     }
 
     // MARK: - API Key Actions
@@ -105,5 +119,19 @@ public final class SettingsStore: ObservableObject {
     func refreshAPIKeyState() {
         hasKey = APIKeyManager.getKey() != nil
         hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
+    }
+
+    func saveVercelKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        try? daemonClient?.sendVercelApiConfig(action: "set", apiToken: trimmed)
+    }
+
+    func clearVercelKey() {
+        try? daemonClient?.sendVercelApiConfig(action: "delete")
+    }
+
+    func refreshVercelKeyState() {
+        try? daemonClient?.sendVercelApiConfig(action: "get")
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ public struct SettingsView: View {
     @ObservedObject var store: SettingsStore
     @State private var apiKeyText = ""
     @State private var braveKeyText = ""
+    @State private var vercelKeyText = ""
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
     @State private var showingPrivacy = false
@@ -84,6 +85,35 @@ public struct SettingsView: View {
                             braveKeyText = ""
                         }
                         .disabled(braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+
+            Section("Vercel API Key") {
+                if store.hasVercelKey {
+                    HStack {
+                        Text("Token configured")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Clear") {
+                            store.clearVercelKey()
+                            vercelKeyText = ""
+                        }
+                        .tint(.red)
+                    }
+                } else {
+                    SecureField("Enter Vercel API token", text: $vercelKeyText)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Text("Get your API token at vercel.com/account/tokens")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Save") {
+                            store.saveVercelKey(vercelKeyText)
+                            vercelKeyText = ""
+                        }
+                        .disabled(vercelKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
                 }
             }
@@ -222,6 +252,7 @@ public struct SettingsView: View {
         .frame(width: 450, height: 700)
         .onAppear {
             store.refreshAPIKeyState()
+            store.refreshVercelKeyState()
             checkPermissions()
         }
         .onReceive(permissionTimer) { _ in


### PR DESCRIPTION
Part of #3011.

## Summary
- Add `hasVercelKey` published property and `daemonClient` stored reference to `SettingsStore`
- Wire up `onVercelApiConfigResponse` callback for IPC-based Vercel key state management
- Add `saveVercelKey`, `clearVercelKey`, and `refreshVercelKeyState` methods using daemon IPC
- Add "Vercel API Key" section to `SettingsView` with SecureField + Save/Clear buttons matching the Anthropic/Brave key pattern

## Test plan
- [ ] Open Settings and verify the Vercel API Key section appears after Brave Search API Key
- [ ] Enter a token, click Save, and verify "Token configured" state appears
- [ ] Click Clear and verify the input field reappears
- [ ] Close and reopen Settings to verify state persists via daemon IPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
