### PR TITLE
fix: optimistic delete for trust rules instead of full refresh

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -107,7 +107,9 @@ struct TrustRulesView: View {
 
     @MainActor private func deleteRule(id: String) {
         try? daemonClient.sendRemoveTrustRule(id: id)
-        loadRules()
+        withAnimation {
+            rules.removeAll { $0.id == id }
+        }
     }
 
     private func isDefaultRule(_ rule: TrustRuleItem) -> Bool {


### PR DESCRIPTION
## Summary
- When deleting a trust rule, remove it from the local array with animation instead of calling `loadRules()` which sets `isLoading=true` and replaces the whole list with a spinner
- The rule animates out in place; no visible flash or window refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
