### PR TITLE
fix: don't clear Vercel key input before IPC confirmation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -111,7 +111,6 @@ public struct SettingsView: View {
                         Spacer()
                         Button("Save") {
                             store.saveVercelKey(vercelKeyText)
-                            vercelKeyText = ""
                         }
                         .disabled(vercelKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }


### PR DESCRIPTION
Addresses review feedback on #3033:

Removes premature clearing of `vercelKeyText` in the Save button action. The text field is hidden by the view's conditional rendering when `hasVercelKey` becomes true from the IPC response, so explicit clearing is unnecessary and loses user input on failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
