### PR TITLE
fix: update IPC inventory and check setSecureKey return in Vercel handler

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -90,8 +90,6 @@ import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedP
 import { getSecureKey, setSecureKey, deleteSecureKey } from '../security/secure-keys.js';
 import { upsertCredentialMetadata, deleteCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { credentialBroker } from '../tools/credentials/broker.js';
-import { setSecureKey } from '../security/secure-keys.js';
-import { upsertCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import type { SecretPromptResult } from '../permissions/secret-prompter.js';
 import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId, validateBlobKindEncoding } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
@@ -2611,7 +2609,16 @@ function handleVercelApiConfig(
         });
         return;
       }
-      setSecureKey('credential:vercel:api_token', msg.apiToken);
+      const stored = setSecureKey('credential:vercel:api_token', msg.apiToken);
+      if (!stored) {
+        ctx.send(socket, {
+          type: 'vercel_api_config_response',
+          hasToken: false,
+          success: false,
+          error: 'Failed to store API token in secure storage',
+        });
+        return;
+      }
       upsertCredentialMetadata('vercel', 'api_token', {
         allowedTools: ['publish_page', 'unpublish_page'],
       });

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -64,6 +64,7 @@
     "UpdateTrustRule",
     "UsageRequest",
     "UserMessage",
+    "VercelApiConfigRequest",
     "WatchObservation"
   ],
   "serverMessageTypes": [
@@ -134,6 +135,7 @@
     "UnpublishPageResponse",
     "UsageResponse",
     "UsageUpdate",
+    "VercelApiConfigResponse",
     "WatchCompleteRequest",
     "WatchStarted"
   ],
@@ -202,6 +204,7 @@
     "update_trust_rule",
     "usage_request",
     "user_message",
+    "vercel_api_config",
     "watch_observation"
   ],
   "serverWireTypes": [
@@ -271,6 +274,7 @@
     "unpublish_page_response",
     "usage_response",
     "usage_update",
+    "vercel_api_config_response",
     "watch_complete_request",
     "watch_started"
   ]


### PR DESCRIPTION
## Summary
- Regenerated `ipc-contract-inventory.json` to include `VercelApiConfigRequest`/`VercelApiConfigResponse` entries that were missing after #3022
- Check `setSecureKey` return value in `handleVercelApiConfig` before calling `upsertCredentialMetadata` — respond with error on failure
- Remove duplicate imports of `setSecureKey` and `upsertCredentialMetadata` that were introduced in #3022

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] `bun run ipc:inventory` shows no drift
- [ ] Vercel API config handler returns error when secure storage fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
