### PR TITLE
fix: always mark workspace dirty for bash regardless of exit code

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -954,17 +954,18 @@ export class Session {
             onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId, imageData: imageBlock?.source.data });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
             // Mark workspace context dirty for mutation tools.
-            // file_write is always dirty regardless of isError because the
-            // file may have been physically written before a post-write error
-            // (e.g. secret-detection blocking after a physical write).
-            // file_edit and bash are only dirty on success — a failed edit
-            // never touches the filesystem, and a non-zero exit code from a
-            // simple command typically means nothing was modified.
+            // file_write and bash are always dirty regardless of isError —
+            // file_write may physically write before a post-write error, and
+            // bash commands can modify the filesystem even when exiting
+            // non-zero (e.g. `mkdir foo && false`, `npm install` with audit
+            // warnings, compound commands where early parts succeed).
+            // file_edit is only dirty on success — a failed edit provably
+            // never touches the filesystem.
             {
               const toolName = toolUseIdToName.get(event.toolUseId);
-              if (toolName === 'file_write') {
+              if (toolName === 'file_write' || toolName === 'bash') {
                 this.markWorkspaceTopLevelDirty();
-              } else if ((toolName === 'file_edit' || toolName === 'bash') && !event.isError) {
+              } else if (toolName === 'file_edit' && !event.isError) {
                 this.markWorkspaceTopLevelDirty();
               }
             }


### PR DESCRIPTION
Bash commands can modify the filesystem and still exit non-zero (e.g. `mkdir foo && false`, `npm install` with audit warnings). Remove the `!event.isError` guard for bash while keeping it for `file_edit` (which provably never writes on failure).

Addresses Codex and Devin feedback on #3024.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
