### PR TITLE
feat: add Swift IPC types for ride shotgun

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -18,23 +18,6 @@ public struct IPCAddTrustRule: Codable, Sendable {
     public let decision: String
 }
 
-public struct IPCAmbientObservation: Codable, Sendable {
-    public let type: String
-    public let requestId: String
-    public let ocrText: String
-    public let appName: String?
-    public let windowTitle: String?
-    public let timestamp: Double
-}
-
-public struct IPCAmbientResult: Codable, Sendable {
-    public let type: String
-    public let requestId: String
-    public let decision: String
-    public let summary: String?
-    public let suggestion: String?
-}
-
 public struct IPCAppDataRequest: Codable, Sendable {
     public let type: String
     public let surfaceId: String
@@ -676,6 +659,20 @@ public struct IPCRemindersListResponseReminder: Codable, Sendable {
 public struct IPCRemoveTrustRule: Codable, Sendable {
     public let type: String
     public let id: String
+}
+
+public struct IPCRideShotgunResult: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let watchId: String
+    public let summary: String
+    public let observationCount: Int
+}
+
+public struct IPCRideShotgunStart: Codable, Sendable {
+    public let type: String
+    public let durationSeconds: Double
+    public let intervalSeconds: Double
 }
 
 public struct IPCSandboxSetRequest: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -189,13 +189,13 @@ extension IPCCuObservation {
     }
 }
 
-/// Sent by the ambient agent with OCR text from periodic screen captures.
-/// Backed by generated `IPCAmbientObservation`.
-public typealias AmbientObservationMessage = IPCAmbientObservation
+/// Sent to start a ride shotgun observation session.
+/// Backed by generated `IPCRideShotgunStart`.
+public typealias RideShotgunStartMessage = IPCRideShotgunStart
 
-extension IPCAmbientObservation {
-    public init(requestId: String, ocrText: String, appName: String?, windowTitle: String?, timestamp: Double) {
-        self.init(type: "ambient_observation", requestId: requestId, ocrText: ocrText, appName: appName, windowTitle: windowTitle, timestamp: timestamp)
+extension IPCRideShotgunStart {
+    public init(durationSeconds: Double, intervalSeconds: Double) {
+        self.init(type: "ride_shotgun_start", durationSeconds: durationSeconds, intervalSeconds: intervalSeconds)
     }
 }
 
@@ -686,8 +686,8 @@ public typealias MemoryStatusMessage = IPCMemoryStatus
 /// Daemon response after classifying and routing a task_submit.
 public typealias TaskRoutedMessage = IPCTaskRouted
 
-/// Result from ambient observation analysis.
-public typealias AmbientResultMessage = IPCAmbientResult
+/// Result from a ride shotgun observation session.
+public typealias RideShotgunResultMessage = IPCRideShotgunResult
 
 /// Instructs the client to open a URL in the browser.
 /// Backed by generated `IPCOpenUrl`.
@@ -1390,7 +1390,7 @@ public enum ServerMessage: Decodable, Sendable {
     case memoryStatus(MemoryStatusMessage)
     case taskRouted(TaskRoutedMessage)
     case error(ErrorMessage)
-    case ambientResult(AmbientResultMessage)
+    case rideShotgunResult(RideShotgunResultMessage)
     case uiSurfaceShow(UiSurfaceShowMessage)
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
@@ -1488,9 +1488,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "error":
             let message = try ErrorMessage(from: decoder)
             self = .error(message)
-        case "ambient_result":
-            let message = try AmbientResultMessage(from: decoder)
-            self = .ambientResult(message)
+        case "ride_shotgun_result":
+            let message = try RideShotgunResultMessage(from: decoder)
+            self = .rideShotgunResult(message)
         case "ui_surface_show":
             let message = try UiSurfaceShowMessage(from: decoder)
             self = .uiSurfaceShow(message)


### PR DESCRIPTION
## Summary
- Regenerated `IPCContractGenerated.swift` to replace `IPCAmbientObservation`/`IPCAmbientResult` with `IPCRideShotgunStart`/`IPCRideShotgunResult`
- Updated `IPCMessages.swift`: replaced `AmbientObservationMessage`/`AmbientResultMessage` typealiases and convenience inits with `RideShotgunStartMessage`/`RideShotgunResultMessage`
- Updated `ServerMessage` enum: replaced `.ambientResult` case with `.rideShotgunResult` and its decoder

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun run check:ipc-generated` confirms generated file is up to date
- [x] `bun run ipc:check-swift-drift` confirms decoder is in sync

Part of #3026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
