### PR TITLE
feat: add RideShotgunTrigger and RideShotgunSession

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -1,0 +1,140 @@
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "RideShotgunSession")
+
+@MainActor
+public final class RideShotgunSession: ObservableObject {
+    public enum State: Equatable {
+        case idle
+        case starting
+        case capturing
+        case summarizing
+        case complete
+        case failed(String)
+        case cancelled
+    }
+
+    @Published public var state: State = .idle
+    @Published public var summary: String = ""
+    @Published public var observationCount: Int = 0
+
+    // Pass-through from WatchSession
+    @Published public var elapsedSeconds: Double = 0
+    @Published public var captureCount: Int = 0
+    @Published public var currentApp: String = ""
+
+    public let durationSeconds: Int
+    public let intervalSeconds: Int
+
+    private var watchSession: WatchSession?
+    private var daemonClient: DaemonClient?
+    private var messageSubscription: Task<Void, Never>?
+    private var watchSessionObserver: Task<Void, Never>?
+
+    public init(durationSeconds: Int, intervalSeconds: Int = 10) {
+        self.durationSeconds = durationSeconds
+        self.intervalSeconds = intervalSeconds
+    }
+
+    public func start(daemonClient: DaemonClient) {
+        guard state == .idle else {
+            log.warning("Cannot start ride shotgun session: already in state \(String(describing: self.state))")
+            return
+        }
+        self.daemonClient = daemonClient
+        state = .starting
+
+        log.info("Starting ride shotgun session: duration=\(self.durationSeconds)s interval=\(self.intervalSeconds)s")
+
+        // Subscribe to daemon messages for watch_started and ride_shotgun_result
+        let stream = daemonClient.subscribe()
+        messageSubscription = Task { [weak self] in
+            for await message in stream {
+                guard let self else { return }
+                switch message {
+                case .watchStarted(let started):
+                    self.handleWatchStarted(started, daemonClient: daemonClient)
+                case .rideShotgunResult(let result):
+                    self.handleRideShotgunResult(result)
+                default:
+                    break
+                }
+            }
+        }
+
+        // Send ride_shotgun_start to daemon
+        do {
+            try daemonClient.send(RideShotgunStartMessage(
+                durationSeconds: Double(durationSeconds),
+                intervalSeconds: Double(intervalSeconds)
+            ))
+        } catch {
+            log.error("Failed to send ride_shotgun_start: \(error.localizedDescription)")
+            state = .failed("Failed to start session")
+            cleanup()
+        }
+    }
+
+    public func cancel() {
+        log.info("Ride shotgun session cancelled")
+        watchSession?.stop()
+        state = .cancelled
+        cleanup()
+    }
+
+    // MARK: - Private
+
+    private func handleWatchStarted(_ message: WatchStartedMessage, daemonClient: DaemonClient) {
+        guard state == .starting else { return }
+
+        let session = WatchSession(
+            watchId: message.watchId,
+            sessionId: message.sessionId,
+            durationSeconds: durationSeconds,
+            intervalSeconds: intervalSeconds
+        )
+        self.watchSession = session
+        session.start(daemonClient: daemonClient)
+        state = .capturing
+
+        log.info("Watch session started: watchId=\(message.watchId)")
+
+        // Observe WatchSession published properties
+        watchSessionObserver = Task { [weak self, weak session] in
+            guard let session else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 500_000_000) // 0.5s poll
+                guard let self, !Task.isCancelled else { return }
+                self.elapsedSeconds = session.elapsedSeconds
+                self.captureCount = session.captureCount
+                self.currentApp = session.currentApp
+
+                // When WatchSession completes, transition to summarizing
+                if session.state == .complete && self.state == .capturing {
+                    self.state = .summarizing
+                    log.info("Capture complete, waiting for summary...")
+                }
+            }
+        }
+    }
+
+    private func handleRideShotgunResult(_ result: RideShotgunResultMessage) {
+        guard state == .capturing || state == .summarizing else { return }
+
+        summary = result.summary
+        observationCount = result.observationCount
+        state = .complete
+
+        log.info("Ride shotgun session complete: \(result.observationCount) observations")
+        cleanup()
+    }
+
+    private func cleanup() {
+        messageSubscription?.cancel()
+        messageSubscription = nil
+        watchSessionObserver?.cancel()
+        watchSessionObserver = nil
+    }
+}

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunTrigger.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunTrigger.swift
@@ -1,0 +1,92 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "RideShotgunTrigger")
+
+@MainActor
+public final class RideShotgunTrigger: ObservableObject {
+    @Published public var shouldShowInvitation: Bool = false
+
+    private var checkTimer: Timer?
+    private let appLaunchDate = Date()
+
+    /// Minimum time (minutes) since app launch before offering
+    private let minAppRunMinutes: Double = 15
+
+    /// Maximum sessions before we stop auto-offering
+    private let maxAutoOfferSessions: Int = 3
+
+    /// Cooldown after decline or completion (hours)
+    private let cooldownHours: Double = 24
+
+    // MARK: - UserDefaults keys
+    private let totalSessionCountKey = "rideShotgunTotalSessionCount"
+    private let lastDeclinedDateKey = "rideShotgunLastDeclinedDate"
+    private let lastCompletedDateKey = "rideShotgunLastCompletedDate"
+
+    public init() {}
+
+    public func start() {
+        guard checkTimer == nil else { return }
+        checkTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.evaluate()
+            }
+        }
+        log.info("Ride shotgun trigger started")
+    }
+
+    public func stop() {
+        checkTimer?.invalidate()
+        checkTimer = nil
+        shouldShowInvitation = false
+        log.info("Ride shotgun trigger stopped")
+    }
+
+    public func recordSessionStarted() {
+        let count = UserDefaults.standard.integer(forKey: totalSessionCountKey)
+        UserDefaults.standard.set(count + 1, forKey: totalSessionCountKey)
+        shouldShowInvitation = false
+        log.info("Ride shotgun session started (total: \(count + 1))")
+    }
+
+    public func recordDeclined() {
+        UserDefaults.standard.set(Date(), forKey: lastDeclinedDateKey)
+        shouldShowInvitation = false
+        log.info("Ride shotgun invitation declined")
+    }
+
+    public func recordCompleted() {
+        UserDefaults.standard.set(Date(), forKey: lastCompletedDateKey)
+        shouldShowInvitation = false
+        log.info("Ride shotgun session completed")
+    }
+
+    private func evaluate() {
+        // Already showing?
+        guard !shouldShowInvitation else { return }
+
+        // App running long enough?
+        let minutesSinceLaunch = Date().timeIntervalSince(appLaunchDate) / 60
+        guard minutesSinceLaunch >= minAppRunMinutes else { return }
+
+        // Haven't exceeded auto-offer limit?
+        let totalSessions = UserDefaults.standard.integer(forKey: totalSessionCountKey)
+        guard totalSessions < maxAutoOfferSessions else { return }
+
+        // Cooldown since last decline?
+        if let lastDeclined = UserDefaults.standard.object(forKey: lastDeclinedDateKey) as? Date {
+            let hoursSinceDecline = Date().timeIntervalSince(lastDeclined) / 3600
+            guard hoursSinceDecline >= cooldownHours else { return }
+        }
+
+        // Cooldown since last completion?
+        if let lastCompleted = UserDefaults.standard.object(forKey: lastCompletedDateKey) as? Date {
+            let hoursSinceCompletion = Date().timeIntervalSince(lastCompleted) / 3600
+            guard hoursSinceCompletion >= cooldownHours else { return }
+        }
+
+        shouldShowInvitation = true
+        log.info("Ride shotgun invitation triggered")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `RideShotgunTrigger` — a timer-based auto-invitation system that evaluates eligibility (minimum app run time, session count cap, cooldown after decline/completion) and publishes `shouldShowInvitation` for UI consumption.
- Adds `RideShotgunSession` — an `ObservableObject` that orchestrates the full ride-shotgun lifecycle (idle → starting → capturing → summarizing → complete) by sending IPC messages to the daemon and delegating screen capture to `WatchSession`.
- Both classes are `@MainActor` and use the existing `DaemonClient`, `WatchSession`, and generated IPC message types.

Closes #3027

## Test plan
- [ ] Verify TypeScript daemon type-check passes (`bunx tsc --noEmit`)
- [ ] Verify Swift build has no errors related to the new files
- [ ] Manual: confirm `RideShotgunTrigger` does not show invitation before 15 min
- [ ] Manual: confirm `RideShotgunSession` transitions through states correctly when connected to daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
