### PR TITLE
feat: add Ride Shotgun floating windows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Ambient/RideShotgunInvitationWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Ambient/RideShotgunInvitationWindow.swift
@@ -1,0 +1,136 @@
+import VellumAssistantShared
+import AppKit
+import SwiftUI
+
+final class RideShotgunInvitationWindow {
+    private var panel: NSPanel?
+    private let onAccept: (Int) -> Void  // durationSeconds
+    private let onDecline: () -> Void
+
+    init(onAccept: @escaping (Int) -> Void, onDecline: @escaping () -> Void) {
+        self.onAccept = onAccept
+        self.onDecline = onDecline
+    }
+
+    func show() {
+        let view = RideShotgunInvitationView(
+            onAccept: { [weak self] duration in
+                self?.close()
+                self?.onAccept(duration)
+            },
+            onDecline: { [weak self] in
+                self?.close()
+                self?.onDecline()
+            }
+        )
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 380, height: 320),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.95
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.maxX - 380 - 20
+            let y = screenFrame.minY + 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}
+
+private struct RideShotgunInvitationView: View {
+    let onAccept: (Int) -> Void
+    let onDecline: () -> Void
+    @State private var selectedDuration: Int = 180 // 3 minutes default
+
+    private let durations: [(label: String, seconds: Int)] = [
+        ("1 min", 60),
+        ("3 min", 180),
+        ("5 min", 300),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            HStack {
+                Image(systemName: "binoculars.fill")
+                    .foregroundStyle(VColor.accent)
+                    .font(.title2)
+                Text("Ride Shotgun?")
+                    .font(VFont.headline)
+                Spacer()
+            }
+
+            Text("I'll watch how you work for a few minutes to understand how I can help.")
+                .font(VFont.body)
+                .foregroundStyle(VColor.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // AX preview placeholder
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("What I can see:")
+                    .font(VFont.caption)
+                    .foregroundStyle(VColor.textMuted)
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surface)
+                    .frame(height: 60)
+                    .overlay(
+                        Text("Screen content preview")
+                            .font(VFont.caption)
+                            .foregroundStyle(VColor.textMuted)
+                    )
+            }
+
+            // Duration picker
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Duration")
+                    .font(VFont.caption)
+                    .foregroundStyle(VColor.textMuted)
+                HStack(spacing: VSpacing.sm) {
+                    ForEach(durations, id: \.seconds) { option in
+                        Button(option.label) {
+                            selectedDuration = option.seconds
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(selectedDuration == option.seconds ? VColor.accent : nil)
+                    }
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Not now") {
+                    onDecline()
+                }
+                .keyboardShortcut(.escape, modifiers: [])
+
+                Button("Let's go") {
+                    onAccept(selectedDuration)
+                }
+                .keyboardShortcut(.return, modifiers: [])
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 380)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Ambient/RideShotgunProgressWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Ambient/RideShotgunProgressWindow.swift
@@ -1,0 +1,100 @@
+import VellumAssistantShared
+import AppKit
+import SwiftUI
+
+final class RideShotgunProgressWindow {
+    private var panel: NSPanel?
+    private let session: RideShotgunSession
+    private let onStop: () -> Void
+
+    init(session: RideShotgunSession, onStop: @escaping () -> Void) {
+        self.session = session
+        self.onStop = onStop
+    }
+
+    func show() {
+        let view = RideShotgunProgressView(
+            session: session,
+            onStop: { [weak self] in
+                self?.close()
+                self?.onStop()
+            }
+        )
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 80),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.95
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.maxX - 300 - 20
+            let y = screenFrame.minY + 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}
+
+private struct RideShotgunProgressView: View {
+    @ObservedObject var session: RideShotgunSession
+    let onStop: () -> Void
+
+    var body: some View {
+        VStack(spacing: VSpacing.sm) {
+            HStack {
+                Image(systemName: "binoculars.fill")
+                    .foregroundStyle(VColor.accent)
+                    .symbolEffect(.pulse)
+                Text("Riding shotgun...")
+                    .font(VFont.bodyMedium)
+                Spacer()
+                Button {
+                    onStop()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Stop")
+            }
+
+            ProgressView(value: session.elapsedSeconds, total: Double(session.durationSeconds))
+                .tint(VColor.accent)
+
+            HStack {
+                if !session.currentApp.isEmpty {
+                    Text(session.currentApp)
+                        .font(VFont.caption)
+                        .foregroundStyle(VColor.textMuted)
+                        .lineLimit(1)
+                }
+                Spacer()
+                Text("\(Int(session.elapsedSeconds))s / \(session.durationSeconds)s")
+                    .font(VFont.caption)
+                    .foregroundStyle(VColor.textMuted)
+            }
+        }
+        .padding()
+        .frame(width: 300)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Ambient/RideShotgunSummaryWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Ambient/RideShotgunSummaryWindow.swift
@@ -1,0 +1,114 @@
+import VellumAssistantShared
+import AppKit
+import SwiftUI
+
+final class RideShotgunSummaryWindow {
+    private var panel: NSPanel?
+    private let summary: String
+    private let onDismiss: () -> Void
+    private let onHelp: (String) -> Void
+
+    init(summary: String, onDismiss: @escaping () -> Void, onHelp: @escaping (String) -> Void) {
+        self.summary = summary
+        self.onDismiss = onDismiss
+        self.onHelp = onHelp
+    }
+
+    func show() {
+        let view = RideShotgunSummaryView(
+            summary: summary,
+            onDismiss: { [weak self] in
+                self?.close()
+                self?.onDismiss()
+            },
+            onHelp: { [weak self] in
+                guard let self else { return }
+                self.close()
+                self.onHelp(self.summary)
+            }
+        )
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 400),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.95
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.maxX - 420 - 20
+            let y = screenFrame.minY + 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+
+        // Auto-dismiss after 5 minutes
+        DispatchQueue.main.asyncAfter(deadline: .now() + 300) { [weak self] in
+            if self?.panel != nil {
+                self?.close()
+                self?.onDismiss()
+            }
+        }
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}
+
+private struct RideShotgunSummaryView: View {
+    let summary: String
+    let onDismiss: () -> Void
+    let onHelp: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            HStack {
+                Image(systemName: "binoculars.fill")
+                    .foregroundStyle(VColor.accent)
+                Text("Here's what I noticed")
+                    .font(VFont.headline)
+                Spacer()
+            }
+
+            ScrollView {
+                Text(summary)
+                    .font(VFont.body)
+                    .foregroundStyle(VColor.textSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 280)
+
+            HStack {
+                Spacer()
+                Button("Dismiss") {
+                    onDismiss()
+                }
+                .keyboardShortcut(.escape, modifiers: [])
+
+                Button("Help me with something") {
+                    onHelp()
+                }
+                .keyboardShortcut(.return, modifiers: [])
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 420)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds three NSPanel-based floating windows for the Ride Shotgun feature (#3028)
- `RideShotgunInvitationWindow`: consent dialog with duration picker (1/3/5 min)
- `RideShotgunProgressWindow`: compact progress bar showing elapsed time and current app
- `RideShotgunSummaryWindow`: post-observation summary with dismiss/help actions and 5-min auto-dismiss

All windows follow the existing `AmbientSuggestionWindow` pattern with `.nonactivatingPanel`, `.utilityWindow`, `.hudWindow` style masks and `.floating` level.

## Test plan
- [ ] Verify each window renders correctly when `show()` is called
- [ ] Confirm windows position at bottom-right of screen
- [ ] Test invitation duration picker selects correct values
- [ ] Test progress window updates with `RideShotgunSession` state
- [ ] Test summary window auto-dismisses after 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
