### PR TITLE
feat: wire Ride Shotgun into AppDelegate and update Settings (#3030 M6)

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -7,7 +7,7 @@ struct VellumAssistantApp: App {
 
     var body: some Scene {
         Settings {
-            SettingsView(store: appDelegate.services.settingsStore, ambientAgent: appDelegate.services.ambientAgent, daemonClient: appDelegate.services.daemonClient)
+            SettingsView(store: appDelegate.services.settingsStore, daemonClient: appDelegate.services.daemonClient)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -169,19 +169,4 @@ public final class AmbientAgent: ObservableObject {
         window.show()
     }
 
-    // MARK: - Compatibility stubs (removed in M6)
-    var isEnabled: Bool {
-        get { false }
-        set { /* no-op */ }
-    }
-    func start() { setupRideShotgun() }
-    func stop() { teardown() }
-    func pause() { /* no-op */ }
-    func resume() { /* no-op */ }
-    var syncClient: AmbientSyncClient? { nil }
-    var insightStore: InsightStore? { nil }
-    var captureIntervalSeconds: Double {
-        get { 30 }
-        set { /* no-op */ }
-    }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -268,7 +268,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let overlay = SessionOverlayWindow(session: session)
         overlay.show()
         self.overlayWindow = overlay
-        self.ambientAgent.pause()
 
         // Close the text response window but keep the text session reference
         // (no de-escalation for MVP — text session is effectively done)
@@ -282,7 +281,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self.overlayWindow = nil
             self.currentSession = nil
             self.currentTextSession = nil
-            self.ambientAgent.resume()
         }
     }
 
@@ -621,12 +619,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
-        let ambientEnabled = ambientAgent.isEnabled
-        let ambientTitle = ambientEnabled ? "Disable Ambient Agent" : "Enable Ambient Agent"
-        let ambientItem = NSMenuItem(title: ambientTitle, action: #selector(toggleAmbientAgent), keyEquivalent: "")
-        ambientItem.target = self
-        ambientItem.image = NSImage(systemSymbolName: ambientEnabled ? "eye.slash" : "eye", accessibilityDescription: nil)
-        menu.addItem(ambientItem)
+        let rideShotgunItem = NSMenuItem(title: "Ride Shotgun", action: #selector(showRideShotgunInvitation), keyEquivalent: "")
+        rideShotgunItem.target = self
+        rideShotgunItem.image = NSImage(systemSymbolName: "binoculars", accessibilityDescription: nil)
+        rideShotgunItem.isEnabled = ambientAgent.currentSession == nil
+        menu.addItem(rideShotgunItem)
 
         let updateItem = NSMenuItem(title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
         updateItem.target = self
@@ -666,9 +663,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         updateManager.checkForUpdates()
     }
 
-    @objc private func toggleAmbientAgent() {
-        ambientAgent.isEnabled = !ambientAgent.isEnabled
-        updateMenuBarIcon()
+    @objc private func showRideShotgunInvitation() {
+        ambientAgent.showInvitation()
     }
 
     @objc private func toggleSkill(_ sender: NSMenuItem) {
@@ -819,11 +815,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupAmbientAgent() {
         ambientAgent.appDelegate = self
         ambientAgent.daemonClient = daemonClient
-
-        if ambientAgent.isEnabled && daemonClient.isConnected {
-            ambientAgent.start()
-            updateMenuBarIcon()
-        }
+        ambientAgent.setupRideShotgun()
     }
 
     func updateMenuBarIcon() {
@@ -996,7 +988,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let hostingController = NSHostingController(rootView: SettingsView(store: services.settingsStore, ambientAgent: services.ambientAgent, daemonClient: services.daemonClient))
+        let hostingController = NSHostingController(rootView: SettingsView(store: services.settingsStore, daemonClient: services.daemonClient))
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 450, height: 700),
             styleMask: [.titled, .closable, .miniaturizable],
@@ -1133,13 +1125,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 let overlay = SessionOverlayWindow(session: session)
                 overlay.show()
                 self.overlayWindow = overlay
-                self.ambientAgent.pause()
                 await session.run()
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
                 overlay.close()
                 self.overlayWindow = nil
                 self.currentSession = nil
-                self.ambientAgent.resume()
 
             default: // text_qa
                 let session = TextSession(
@@ -1155,14 +1145,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 let window = TextResponseWindow(session: session, inputState: inputState)
                 window.show()
                 self.textResponseWindow = window
-                self.ambientAgent.pause()
 
                 // Clean up when the user closes the panel
                 window.onClose = { [weak self] in
                     self?.currentTextSession?.cancel()
                     self?.textResponseWindow = nil
                     self?.currentTextSession = nil
-                    self?.ambientAgent.resume()
                 }
 
                 await session.run()
@@ -1204,14 +1192,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        let approveAction = UNNotificationAction(identifier: "APPROVE_ACTION", title: "Approve", options: [])
-        let dismissAction = UNNotificationAction(identifier: "DISMISS_ACTION", title: "Dismiss", options: [])
-        let automationCategory = UNNotificationCategory(
-            identifier: "AUTOMATION_INSIGHT",
-            actions: [approveAction, dismissAction],
-            intentIdentifiers: []
-        )
-
         let viewAction = UNNotificationAction(
             identifier: "VIEW_ACTIVITY",
             title: "View Results",
@@ -1224,7 +1204,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             options: []
         )
 
-        center.setNotificationCategories([automationCategory, activityCategory])
+        center.setNotificationCategories([activityCategory])
     }
 
     private func registerBundledFonts() {
@@ -1408,7 +1388,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         statusIconCancellable?.cancel()
         voiceInput?.stop()
-        ambientAgent.stop()
+        ambientAgent.teardown()
         surfaceManager.dismissAll()
         toolConfirmationManager.dismissAll()
         secretPromptManager.dismissAll()
@@ -1428,54 +1408,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
-        let userInfo = response.notification.request.content.userInfo
         let categoryId = response.notification.request.content.categoryIdentifier
 
         // Handle activity completion notifications
         if categoryId == "ACTIVITY_COMPLETE" {
             await MainActor.run {
-                // Show main window
                 self.showMainWindow()
-
-                // Optional: Navigate to the completed session/thread
-                // if let sessionId = userInfo["sessionId"] as? String {
-                //     // Navigate to thread containing this session
-                // }
             }
             return
         }
-
-        // Handle automation insight notifications
-        guard categoryId == "AUTOMATION_INSIGHT",
-              let insightId = userInfo["insightId"] as? String,
-              let insightTitle = userInfo["insightTitle"] as? String,
-              let description = userInfo["insightDescription"] as? String else {
-            return
-        }
-
-        let approved: Bool
-        switch response.actionIdentifier {
-        case "APPROVE_ACTION":
-            approved = true
-        case "DISMISS_ACTION":
-            approved = false
-        default:
-            return  // Ignore default tap and other actions
-        }
-
-        let schedule = ScheduleParser.parse(from: description)
-
-        let decision = AutomationDecision(
-            insightId: insightId,
-            insightTitle: insightTitle,
-            description: description,
-            schedule: schedule,
-            approved: approved,
-            reason: nil,
-            source: ProcessInfo.processInfo.hostName
-        )
-
-        let syncClient = await MainActor.run { ambientAgent.syncClient }
-        await syncClient?.sendDecision(decision)
     }
 }

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -14,7 +14,6 @@ public final class AppServices {
     /// Shared settings state consumed by both SettingsView and SettingsPanel.
     /// Lazy because it needs `ambientAgent` and `daemonClient` which are set above.
     public lazy var settingsStore: SettingsStore = SettingsStore(
-        ambientAgent: ambientAgent,
         daemonClient: daemonClient
     )
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1185,8 +1185,7 @@ private struct DrawerMenuItem: View {
 
 #Preview {
     let dc = DaemonClient()
-    let agent = AmbientAgent()
-    MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: agent, settingsStore: SettingsStore(ambientAgent: agent, daemonClient: dc), windowState: MainWindowState())
+    MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), windowState: MainWindowState())
         .frame(width: 900, height: 600)
         .padding(.top, 36)
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -147,22 +147,19 @@ struct SettingsPanel: View {
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
 
-                // AMBIENT AGENT section
+                // RIDE SHOTGUN section
                 VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("AMBIENT AGENT")
+                    Text("RIDE SHOTGUN")
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    HStack {
-                        Text("Enable ambient screen watching")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 12))
-                            .foregroundColor(VColor.textMuted)
-                        Spacer()
-                        VToggle(isOn: $store.ambientEnabled)
-                    }
+                    Text("Ride Shotgun lets the assistant watch how you work for a few minutes, then offers to help based on what it observed.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    Text("Use the menu bar icon or wait for the assistant to offer.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
@@ -354,7 +351,7 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textPrimary)
 
                     VStack(alignment: .leading, spacing: 0) {
-                        privacyBullet(icon: "eye.slash", text: "AI only runs when you trigger it or enable ambient mode")
+                        privacyBullet(icon: "eye.slash", text: "AI only runs when you trigger it or enable Ride Shotgun sessions")
                         Divider().background(VColor.surfaceBorder)
                         privacyBullet(icon: "lock.shield", text: "API key stored in macOS Keychain")
                         Divider().background(VColor.surfaceBorder)
@@ -426,11 +423,10 @@ struct SettingsPanel: View {
 }
 
 #Preview("SettingsPanel") {
-    let agent = AmbientAgent()
     let dc = DaemonClient()
     ZStack {
         VColor.background.ignoresSafeArea()
-        SettingsPanel(onClose: {}, store: SettingsStore(ambientAgent: agent), threadManager: ThreadManager(daemonClient: dc))
+        SettingsPanel(onClose: {}, store: SettingsStore(daemonClient: dc), threadManager: ThreadManager(daemonClient: dc))
     }
     .frame(width: 600, height: 700)
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -17,18 +17,6 @@ public final class SettingsStore: ObservableObject {
     @Published var maxSteps: Double {
         didSet { UserDefaults.standard.set(maxSteps, forKey: "maxStepsPerSession") }
     }
-    @Published var ambientEnabled: Bool {
-        didSet {
-            UserDefaults.standard.set(ambientEnabled, forKey: "ambientAgentEnabled")
-            ambientAgent?.isEnabled = ambientEnabled
-        }
-    }
-    @Published var ambientInterval: Double {
-        didSet {
-            UserDefaults.standard.set(ambientInterval, forKey: "ambientCaptureInterval")
-            ambientAgent?.captureIntervalSeconds = ambientInterval
-        }
-    }
     @Published var activityNotificationsEnabled: Bool {
         didSet {
             UserDefaults.standard.set(activityNotificationsEnabled, forKey: "activityNotificationsEnabled")
@@ -44,12 +32,10 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Private
 
-    private weak var ambientAgent: AmbientAgent?
     private weak var daemonClient: DaemonClient?
     private var cancellables = Set<AnyCancellable>()
 
-    init(ambientAgent: AmbientAgent, daemonClient: DaemonClient? = nil) {
-        self.ambientAgent = ambientAgent
+    init(daemonClient: DaemonClient? = nil) {
         self.daemonClient = daemonClient
 
         // Seed from UserDefaults / Keychain
@@ -58,11 +44,6 @@ public final class SettingsStore: ObservableObject {
 
         let storedMaxSteps = UserDefaults.standard.double(forKey: "maxStepsPerSession")
         self.maxSteps = storedMaxSteps == 0 ? 50 : storedMaxSteps
-
-        self.ambientEnabled = UserDefaults.standard.bool(forKey: "ambientAgentEnabled")
-
-        let storedInterval = UserDefaults.standard.double(forKey: "ambientCaptureInterval")
-        self.ambientInterval = storedInterval == 0 ? 30 : storedInterval
 
         // Default to enabled for notifications
         self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -17,12 +17,10 @@ public struct SettingsView: View {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
         return ActivationKey(rawValue: stored) ?? .fn
     }()
-    var ambientAgent: AmbientAgent
     var daemonClient: DaemonClient?
 
-    public init(store: SettingsStore, ambientAgent: AmbientAgent, daemonClient: DaemonClient? = nil) {
+    public init(store: SettingsStore, daemonClient: DaemonClient? = nil) {
         self.store = store
-        self.ambientAgent = ambientAgent
         self.daemonClient = daemonClient
     }
 
@@ -151,25 +149,14 @@ public struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("Ambient Agent") {
-                Toggle("Enable ambient screen watching", isOn: $store.ambientEnabled)
+            Section("Ride Shotgun") {
+                Text("Ride Shotgun lets the assistant watch how you work for a few minutes, then offers to help based on what it observed.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
-                if store.ambientEnabled {
-                    HStack {
-                        Text("Capture interval")
-                        Spacer()
-                        Text("\(Int(store.ambientInterval))s")
-                            .monospacedDigit()
-                            .foregroundStyle(.secondary)
-                    }
-                    Slider(value: $store.ambientInterval, in: 10...120, step: 5)
-
-                    KnowledgeSection(store: ambientAgent.knowledgeStore)
-
-                    if let insightStore = ambientAgent.insightStore {
-                        InsightsSection(store: insightStore)
-                    }
-                }
+                Text("Use the menu bar icon or wait for the assistant to offer.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Permissions") {
@@ -236,7 +223,7 @@ public struct SettingsView: View {
             }
 
             Section("Privacy & Security") {
-                PrivacyBullet(icon: "eye.slash", text: "AI only runs when you trigger it or enable ambient mode")
+                PrivacyBullet(icon: "eye.slash", text: "AI only runs when you trigger it or enable Ride Shotgun sessions")
                 PrivacyBullet(icon: "lock.shield", text: "API key stored in macOS Keychain")
                 PrivacyBullet(icon: "xmark.shield", text: "Your data is not used to train AI models")
                 PrivacyBullet(icon: "internaldrive", text: "Session logs and knowledge stored locally on your Mac")
@@ -317,116 +304,6 @@ private struct KnowledgeSection: View {
     }
 }
 
-// MARK: - Insights Section
-
-private struct InsightsSection: View {
-    @ObservedObject var store: InsightStore
-    @State private var showingInsights = false
-
-    var body: some View {
-        HStack {
-            Text("Insights found")
-            Spacer()
-            Text("\(store.insightCount)")
-                .monospacedDigit()
-                .foregroundStyle(.secondary)
-        }
-
-        HStack {
-            Button("View Insights") {
-                showingInsights = true
-            }
-            .disabled(store.insights.isEmpty)
-
-            Spacer()
-
-            Button("Clear All") {
-                store.clearAll()
-            }
-            .tint(.red)
-            .disabled(store.insights.isEmpty)
-        }
-        .sheet(isPresented: $showingInsights) {
-            InsightsListView(store: store)
-        }
-    }
-}
-
-private struct InsightsListView: View {
-    @ObservedObject var store: InsightStore
-    @Environment(\.dismiss) var dismiss
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("Knowledge Insights (\(store.insightCount))")
-                    .font(.headline)
-                Spacer()
-                Button("Done") { dismiss() }
-            }
-            .padding()
-
-            Divider()
-
-            if store.insights.isEmpty {
-                Spacer()
-                Text("No insights yet")
-                    .foregroundStyle(.secondary)
-                Spacer()
-            } else {
-                List {
-                    ForEach(store.insights.reversed()) { insight in
-                        HStack(alignment: .top, spacing: 8) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack(spacing: 6) {
-                                    Text(insight.title)
-                                        .fontWeight(.bold)
-                                    Text(insight.category.rawValue.capitalized)
-                                        .font(.caption2)
-                                        .padding(.horizontal, 4)
-                                        .padding(.vertical, 1)
-                                        .background(categoryColor(insight.category).opacity(0.2))
-                                        .foregroundStyle(categoryColor(insight.category))
-                                        .clipShape(Capsule())
-                                }
-                                Text(insight.description)
-                                    .foregroundStyle(.secondary)
-                                HStack(spacing: 4) {
-                                    Text(insight.timestamp, style: .relative)
-                                    Text("ago")
-                                    Text("\u{00b7}")
-                                    Text("\(Int(insight.confidence * 100))%")
-                                }
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
-                            }
-                            Spacer()
-                            Button {
-                                store.dismissInsight(id: insight.id)
-                            } label: {
-                                Image(systemName: "trash")
-                                    .foregroundStyle(.red)
-                            }
-                            .buttonStyle(.borderless)
-                        }
-                        .padding(.vertical, 2)
-                        .opacity(insight.dismissed ? 0.5 : 1.0)
-                    }
-                }
-            }
-        }
-        .frame(width: 550, height: 450)
-    }
-
-    private func categoryColor(_ category: InsightCategory) -> Color {
-        switch category {
-        case .pattern: return Indigo._600
-        case .automation: return Emerald._600
-        case .insight: return Amber._600
-        }
-    }
-}
-
 // MARK: - Privacy & Security
 
 private struct PrivacyBullet: View {
@@ -465,7 +342,7 @@ private struct PrivacyDetailView: View {
                     privacySection(
                         title: "How Velly Works",
                         items: [
-                            "Velly only activates AI when you explicitly trigger a task, use voice input, or enable the ambient agent. It does not run in the background unless you opt in.",
+                            "Velly only activates AI when you explicitly trigger a task, use voice input, or accept a Ride Shotgun invitation. It does not run in the background unless you opt in.",
                             "You are always in control. You can disable the ambient agent, revoke permissions, or clear stored data at any time from Settings.",
                         ]
                     )
@@ -474,7 +351,7 @@ private struct PrivacyDetailView: View {
                         title: "What Data Leaves Your Mac",
                         items: [
                             "When you run a task: screenshots (compressed, max 1280x720) and UI element data (window titles, button labels, text field values) are sent to the Anthropic API over HTTPS.",
-                            "When ambient mode is on: extracted on-screen text (via on-device OCR) and the active app name are sent to Anthropic for analysis. If sync is enabled, ambient observations and insights are also sent to the Velly backend.",
+                            "When Ride Shotgun is active: screenshots and UI element data from the current session are sent to Anthropic for analysis.",
                             "Voice input: speech is transcribed on-device using Apple Speech Recognition. Only the final text is sent to Anthropic as part of the task.",
                         ]
                     )
@@ -522,7 +399,6 @@ private struct PrivacyDetailView: View {
                         items: [
                             "API key: Settings > Anthropic API Key > Clear",
                             "Knowledge entries: Settings > Ambient Agent > Clear All",
-                            "Insights: Settings > Ambient Agent > Clear All",
                             "Session logs: delete files in ~/Library/Application Support/vellum-assistant/logs/",
                         ]
                     )
@@ -612,6 +488,5 @@ private struct KnowledgeEntriesView: View {
 }
 
 #Preview {
-    let agent = AmbientAgent()
-    SettingsView(store: SettingsStore(ambientAgent: agent), ambientAgent: agent)
+    SettingsView(store: SettingsStore())
 }


### PR DESCRIPTION
## Summary
- Replace ambient agent wiring in AppDelegate with ride shotgun setup
- Menu bar now shows "Ride Shotgun" action instead of ambient toggle
- Remove pause/resume calls during computer-use and text sessions
- Remove ambient properties from SettingsStore (ambientEnabled, ambientInterval)
- Remove AmbientAgent dependency from SettingsStore and SettingsView init
- Replace "Ambient Agent" settings section with "Ride Shotgun" info section
- Remove InsightsSection and InsightsListView (InsightStore deleted in M7)
- Update privacy disclosures to reference Ride Shotgun instead of ambient mode
- Remove compatibility stubs from AmbientAgent
- Remove AUTOMATION_INSIGHT notification category and handler

Closes #3030

## Test plan
- [ ] Build passes (`./build.sh`)
- [ ] App launches without errors
- [ ] Menu bar shows "Ride Shotgun" action
- [ ] Settings no longer show ambient agent section
- [ ] Settings show Ride Shotgun info section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
