### PR TITLE
fix: only remove trust rule from UI when IPC delete succeeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -106,9 +106,13 @@ struct TrustRulesView: View {
     }
 
     @MainActor private func deleteRule(id: String) {
-        try? daemonClient.sendRemoveTrustRule(id: id)
-        withAnimation {
-            rules.removeAll { $0.id == id }
+        do {
+            try daemonClient.sendRemoveTrustRule(id: id)
+            withAnimation {
+                rules.removeAll { $0.id == id }
+            }
+        } catch {
+            // IPC failed — keep the rule visible
         }
     }
 


### PR DESCRIPTION
## Summary
- Wraps `deleteRule` IPC call in `do/catch` instead of `try?` so the rule only disappears from the UI when the daemon actually confirms deletion
- When the daemon is disconnected (or any IPC error occurs), the rule stays visible rather than silently vanishing

Addresses feedback from PR #3034.

## Test plan
- [ ] Delete a trust rule with daemon running — row should animate away
- [ ] Disconnect daemon, attempt delete — row should remain visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
