### PR TITLE
fix: call fireWatchCompletionNotifier on ride shotgun timeout

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -7,6 +7,7 @@ import {
   registerWatchCompletionNotifier,
   unregisterWatchCompletionNotifier,
   fireWatchStartNotifier,
+  fireWatchCompletionNotifier,
 } from '../tools/watch/watch-state.js';
 import type { WatchSession } from '../tools/watch/watch-state.js';
 import { lastSummaryBySession } from './watch-handler.js';
@@ -42,6 +43,7 @@ export async function handleRideShotgunStart(
     session.status = 'completing';
     session.timeoutHandle = undefined;
     log.info({ watchId }, 'Ride shotgun session duration expired, marking as completing');
+    fireWatchCompletionNotifier(sessionId, session);
   }, durationSeconds * 1000);
 
   // Register completion notifier to send summary back to client


### PR DESCRIPTION
## Summary
- The timeout callback in `ride-shotgun-handler.ts` set `session.status = 'completing'` but did not call `fireWatchCompletionNotifier()`, so the `ride_shotgun_result` message was never sent to the client on timeout expiry unless another `watch_observation` happened to arrive.
- Added the missing `fireWatchCompletionNotifier(sessionId, session)` call and its import, matching the pattern in `screen-watch.ts`.

Follows up on PR #3038.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm ride shotgun sessions send `ride_shotgun_result` when duration expires without any further observations arriving

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
