### PR TITLE
fix: scope auto-dismiss timer to panel instance in RideShotgunSummaryWindow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Ambient/RideShotgunSummaryWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Ambient/RideShotgunSummaryWindow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 final class RideShotgunSummaryWindow {
     private var panel: NSPanel?
+    private var autoDismissWork: DispatchWorkItem?
     private let summary: String
     private let onDismiss: () -> Void
     private let onHelp: (String) -> Void
@@ -55,16 +56,20 @@ final class RideShotgunSummaryWindow {
         panel.orderFront(nil)
         self.panel = panel
 
-        // Auto-dismiss after 5 minutes
-        DispatchQueue.main.asyncAfter(deadline: .now() + 300) { [weak self] in
-            if self?.panel != nil {
-                self?.close()
-                self?.onDismiss()
-            }
+        // Auto-dismiss after 5 minutes, scoped to this specific panel instance
+        autoDismissWork?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.panel === panel else { return }
+            self.close()
+            self.onDismiss()
         }
+        autoDismissWork = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 300, execute: workItem)
     }
 
     func close() {
+        autoDismissWork?.cancel()
+        autoDismissWork = nil
         panel?.close()
         panel = nil
     }


### PR DESCRIPTION
## Summary
- Fixes a bug where stale auto-dismiss timers in `RideShotgunSummaryWindow.show()` could close a newly shown panel if `show()` was called again before the previous 5-minute timer fired.
- Stores the timer as a `DispatchWorkItem` property, cancels it on re-show and close, and verifies panel identity (`===`) before dismissing.

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Show summary window, close manually, verify no stale timer fires
- [ ] Show summary window twice in quick succession, verify only the latest panel is auto-dismissed

Addresses feedback from #3041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
