### PR TITLE
fix: clear currentSession when ride shotgun completes with empty summary

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -113,6 +113,8 @@ public final class AmbientAgent: ObservableObject {
             progressWindow = nil
             if let summary = currentSession?.summary, !summary.isEmpty {
                 showSummary(summary)
+            } else {
+                currentSession = nil
             }
             rideShotgunTrigger.recordCompleted()
             sessionCancellable?.cancel()


### PR DESCRIPTION
## Summary
- When a ride shotgun session completes with an empty summary, `showSummary()` is never called, so `currentSession` is never set to `nil`. This permanently blocks starting new sessions because `startRideShotgun()` guards on `currentSession == nil`.
- Added an `else` branch in the `.complete` case of `handleSessionStateChange()` to clear `currentSession` when the summary is empty.

## Test plan
- [x] Build passes (`./build.sh`)
- [ ] Start a ride shotgun session that completes with an empty summary — verify a new session can be started afterward
- [ ] Start a ride shotgun session that completes with a non-empty summary — verify the summary window still appears and session clears on dismiss

Addresses feedback from #3042 and #3043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
