### PR TITLE
fix: stop WatchSession in cleanup and scope events by watch ID

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -32,6 +32,7 @@ public final class RideShotgunSession: ObservableObject {
     private var daemonClient: DaemonClient?
     private var messageSubscription: Task<Void, Never>?
     private var watchSessionObserver: Task<Void, Never>?
+    private var expectedWatchId: String?
 
     public init(durationSeconds: Int, intervalSeconds: Int = 10) {
         self.durationSeconds = durationSeconds
@@ -89,6 +90,8 @@ public final class RideShotgunSession: ObservableObject {
     private func handleWatchStarted(_ message: WatchStartedMessage, daemonClient: DaemonClient) {
         guard state == .starting else { return }
 
+        expectedWatchId = message.watchId
+
         let session = WatchSession(
             watchId: message.watchId,
             sessionId: message.sessionId,
@@ -122,6 +125,10 @@ public final class RideShotgunSession: ObservableObject {
 
     private func handleRideShotgunResult(_ result: RideShotgunResultMessage) {
         guard state == .capturing || state == .summarizing else { return }
+        guard result.watchId == expectedWatchId else {
+            log.warning("Ignoring ride_shotgun_result for unexpected watchId=\(result.watchId)")
+            return
+        }
 
         summary = result.summary
         observationCount = result.observationCount
@@ -132,6 +139,8 @@ public final class RideShotgunSession: ObservableObject {
     }
 
     private func cleanup() {
+        watchSession?.stop()
+        watchSession = nil
         messageSubscription?.cancel()
         messageSubscription = nil
         watchSessionObserver?.cancel()


### PR DESCRIPTION
## Summary
- Add `watchSession?.stop()` and `watchSession = nil` to `cleanup()` so the capture loop stops when the session completes, preventing resource waste and unnecessary `watch_observation` messages.
- Track `expectedWatchId` from `watchStarted` and validate incoming `rideShotgunResult` messages against it to prevent cross-session interference on shared daemon connections.

Addresses feedback from #3040.

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Start a Ride Shotgun session and verify it completes normally
- [ ] Cancel a session mid-capture and verify the watch loop stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
