### PR TITLE
Fix workspace top-left overlap and add My Apps menu action

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -573,6 +573,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         newChatItem.image = NSImage(systemSymbolName: "plus.message", accessibilityDescription: nil)
         menu.addItem(newChatItem)
 
+        let myAppsItem = NSMenuItem(title: "My Apps", action: #selector(openAppCollection), keyEquivalent: "")
+        myAppsItem.target = self
+        myAppsItem.image = NSImage(systemSymbolName: "square.grid.2x2", accessibilityDescription: nil)
+        menu.addItem(myAppsItem)
+
         menu.addItem(NSMenuItem.separator())
 
         // Skills submenu
@@ -660,6 +665,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func openNewChat() {
         showMainWindow()
         mainWindow?.threadManager.createThread()
+    }
+
+    @objc private func openAppCollection() {
+        showMainWindow()
+        mainWindow?.windowState.activePanel = .directory
     }
 
     @objc private func checkForUpdates() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -51,6 +51,12 @@ struct MainWindowView: View {
     /// but requires complex window geometry inspection.
     private let trafficLightPadding: CGFloat = 78
 
+    /// When a generated surface is expanded into the workspace, hide the
+    /// global sidebar toggle so workspace controls own the top-left slot.
+    private var isGeneratedWorkspaceOpen: Bool {
+        windowState.isDynamicExpanded && windowState.activePanel == .generated
+    }
+
     private func pageURL(for appId: String) -> URL? {
         guard let port = daemonClient.httpPort else { return nil }
         return URL(string: "http://localhost:\(port)/pages/\(appId)")
@@ -127,7 +133,7 @@ struct MainWindowView: View {
                         chatContentView(geometry: geometry)
                             .overlay(alignment: .topLeading) {
                                 // Toggle button when sidebar is hidden
-                                if !sidebarOpen && windowState.layoutConfig.left.visible {
+                                if !sidebarOpen && windowState.layoutConfig.left.visible && !isGeneratedWorkspaceOpen {
                                     HStack(spacing: 0) {
                                         VIconButton(label: "Threads", icon: "sidebar.left", isActive: false, iconOnly: true) {
                                             withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -909,7 +915,8 @@ struct MainWindowView: View {
                         )
                     }
                 }
-                .padding(.horizontal, VSpacing.xl)
+                .padding(.leading, trafficLightPadding)
+                .padding(.trailing, VSpacing.xl)
                 .padding(.top, VSpacing.md)
 
                 Spacer()


### PR DESCRIPTION
## Summary
- hide the drawer sidebar toggle while a generated workspace is open so workspace controls own the top-left area
- offset the workspace top bar using traffic light padding so the "< Chat" pill does not sit under macOS window controls
- add a new menu-bar action, **My Apps**, to open the main window directly to the app directory panel

## Testing
- manual UI verification requested in-app
- build/test not run here due local environment toolchain constraints
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
