### PR TITLE
feat: inline tool permission UX with compact chips

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -58,6 +58,8 @@ export function buildSystemPrompt(): string {
   parts.push(buildConfigSection(getWorkspaceDir()));
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
+  parts.push(buildToolPermissionSection());
+  parts.push(buildSystemPermissionSection());
   parts.push(buildSwarmGuidanceSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
@@ -172,6 +174,56 @@ function buildDynamicUiSection(): string {
     'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a visual output rather than displaying raw tool outputs.',
     '- **Weather**: `get_weather` automatically renders a dynamic page with a compact preview card. Do NOT call `ui_show` or `app_create` after `get_weather` — the weather surface is emitted directly. Just respond with a brief natural-language summary.',
     '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished output — use `app_create` for custom UIs, or `ui_show` with domain component classes for predefined data types.',
+  ].join('\n');
+}
+
+function buildToolPermissionSection(): string {
+  return [
+    '## Tool Permissions',
+    '',
+    'Some tools (host_bash, host_file_write, host_file_edit, host_file_read) require the user\'s approval before they run. When you call one of these tools, the user sees **Allow / Don\'t Allow** buttons in the chat directly below your message.',
+    '',
+    '**CRITICAL RULE:** You MUST ALWAYS output a text message BEFORE calling any tool that requires approval. NEVER call a permission-gated tool without preceding text. The user needs context to decide whether to allow.',
+    '',
+    'Your text should follow this pattern:',
+    '1. **Acknowledge** the request conversationally.',
+    '2. **Explain what you need at a high level** (e.g. "I\'ll need to look through your Downloads folder"). Do NOT include raw terminal commands or backtick code. Keep it non-technical.',
+    '3. **State safety** in plain language. Is it read-only? Will it change anything?',
+    '4. **Ask for permission** explicitly at the end.',
+    '',
+    'Style rules:',
+    '- NEVER use em dashes (the long dash). Use commas, periods, or "and" instead.',
+    '- NEVER show raw commands in backticks like `ls -lt ~/Downloads`. Describe the action in plain English.',
+    '- Keep it conversational, like you\'re talking to a friend.',
+    '',
+    'Good examples:',
+    '- "Sure! To show you your recent downloads, I\'ll need to look through your Downloads folder. This is read-only, nothing gets moved or deleted. Can you allow this for me?"',
+    '- "Yes, I can help with that! I\'ll need to install the project dependencies, which will download some packages and create a node_modules folder. Hit Allow to proceed."',
+    '- "Absolutely! I\'ll need to read your shell configuration file to check your setup. I won\'t change anything. Can you allow this?"',
+    '- "I can look into that! I\'ll need to access your contacts database to pull up the info. This is just a read-only lookup, nothing gets modified. Can you allow this?"',
+    '',
+    'Bad examples (NEVER do this):',
+    '- "I\'ll run `ls -lt ~/Desktop/`" (raw command, too technical)',
+    '- "I\'ll list your most recent downloads for you." (doesn\'t ask for permission)',
+    '- Using em dashes anywhere in the response',
+    '- Calling a tool with no preceding text at all',
+    '',
+    'Be conversational and transparent. The user is granting access to their machine, so acknowledge their request, explain what you need in plain language, and ask them to allow it.',
+  ].join('\n');
+}
+
+function buildSystemPermissionSection(): string {
+  return [
+    '## System Permissions',
+    '',
+    'When a tool execution fails with a permission/access error (e.g. "Operation not permitted", "EACCES", sandbox denial), use `request_system_permission` to ask the user to grant the required macOS permission through System Settings.',
+    '',
+    'Common cases:',
+    '- Reading files in ~/Documents, ~/Desktop, ~/Downloads → `full_disk_access`',
+    '- Screen capture / recording → `screen_recording`',
+    '- Accessibility / UI automation → `accessibility`',
+    '',
+    'Do NOT explain how to open System Settings manually — the tool handles it with a clickable button.',
   ].join('\n');
 }
 

--- a/assistant/src/tools/system/request-permission.ts
+++ b/assistant/src/tools/system/request-permission.ts
@@ -1,0 +1,98 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+
+const PERMISSION_TYPES = [
+  'full_disk_access',
+  'accessibility',
+  'screen_recording',
+  'calendar',
+  'contacts',
+  'photos',
+  'location',
+  'microphone',
+  'camera',
+] as const;
+
+type PermissionType = (typeof PERMISSION_TYPES)[number];
+
+const SETTINGS_URLS: Record<PermissionType, string> = {
+  full_disk_access: 'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles',
+  accessibility: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility',
+  screen_recording: 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+  calendar: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars',
+  contacts: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts',
+  photos: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Photos',
+  location: 'x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices',
+  microphone: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone',
+  camera: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Camera',
+};
+
+const FRIENDLY_NAMES: Record<PermissionType, string> = {
+  full_disk_access: 'Full Disk Access',
+  accessibility: 'Accessibility',
+  screen_recording: 'Screen Recording',
+  calendar: 'Calendar',
+  contacts: 'Contacts',
+  photos: 'Photos',
+  location: 'Location Services',
+  microphone: 'Microphone',
+  camera: 'Camera',
+};
+
+class RequestSystemPermissionTool implements Tool {
+  name = 'request_system_permission';
+  description =
+    'Ask the user to grant a macOS system permission (e.g. Full Disk Access) via System Settings. ' +
+    'Use this when a tool execution fails because of a TCC/permission error.';
+  category = 'system';
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          permission_type: {
+            type: 'string',
+            enum: [...PERMISSION_TYPES],
+            description: 'The macOS system permission to request',
+          },
+          reason: {
+            type: 'string',
+            description: 'Short explanation of why this permission is needed (shown to the user)',
+          },
+        },
+        required: ['permission_type', 'reason'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const permType = input.permission_type as string;
+    if (!PERMISSION_TYPES.includes(permType as PermissionType)) {
+      return {
+        content: `Error: unknown permission type "${permType}". Valid types: ${PERMISSION_TYPES.join(', ')}`,
+        isError: true,
+      };
+    }
+
+    const friendly = FRIENDLY_NAMES[permType as PermissionType];
+    const settingsUrl = SETTINGS_URLS[permType as PermissionType];
+
+    return {
+      content: [
+        `The user has been asked to grant ${friendly}.`,
+        `Settings URL: ${settingsUrl}`,
+        `If they approved, retry the original operation.`,
+        `If they denied, acknowledge and suggest alternatives.`,
+      ].join('\n'),
+      isError: false,
+    };
+  }
+}
+
+registerTool(new RequestSystemPermissionTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -30,6 +30,7 @@ export const eagerModules: string[] = [
   './browser/headless-browser.js',
   './weather/get-weather.js',
   './system/system-info.js',
+  './system/request-permission.js',
   './schedule/create.js',
   './schedule/list.js',
   './schedule/update.js',

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -140,6 +140,7 @@ struct ChatView: View {
                 onRemoveAttachment: onRemoveAttachment,
                 onPaste: onPaste,
                 onMicrophoneToggle: onMicrophoneToggle,
+                placeholderText: "What would you like to do?",
                 editorContentHeight: $editorContentHeight,
                 isComposerExpanded: $isComposerExpanded
             )
@@ -276,43 +277,61 @@ struct ChatView: View {
                         }
 
                         if let confirmation = message.confirmation {
-                            ToolConfirmationBubble(
-                                confirmation: confirmation,
-                                onAllow: { onConfirmationAllow(confirmation.requestId) },
-                                onDeny: { onConfirmationDeny(confirmation.requestId) },
-                                onAddTrustRule: onAddTrustRule
-                            )
-                            .id(message.id)
-                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                            if confirmation.state == .pending {
+                                // Check if the preceding assistant message has text
+                                let prevHasText: Bool = {
+                                    guard index > 0 else { return false }
+                                    let prev = messages[index - 1]
+                                    return prev.role == .assistant
+                                        && !prev.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                }()
+
+                                // Show pending confirmations as inline buttons
+                                ToolConfirmationBubble(
+                                    confirmation: confirmation,
+                                    showDescription: !prevHasText,
+                                    onAllow: { onConfirmationAllow(confirmation.requestId) },
+                                    onDeny: { onConfirmationDeny(confirmation.requestId) },
+                                    onAddTrustRule: onAddTrustRule
+                                )
+                                .id(message.id)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                            }
+                            // Decided confirmations are rendered as compact chips
+                            // on the preceding assistant message's ChatBubble — skip here.
                         } else {
+                            // Hide tool call chips when the next message is a pending
+                            // confirmation — the tool hasn't been approved yet.
+                            let nextIsPendingConfirmation = index + 1 < messages.count
+                                && messages[index + 1].confirmation?.state == .pending
+
+                            // Pass decided confirmation from the next message so it
+                            // renders as a compact chip at the bottom of this bubble.
+                            let nextDecidedConfirmation: ToolConfirmationData? = {
+                                guard index + 1 < messages.count,
+                                      let conf = messages[index + 1].confirmation,
+                                      conf.state != .pending else { return nil }
+                                return conf
+                            }()
+
+                            let isLastAssistant = message.role == .assistant
+                                && !message.isStreaming
+                                && index == messages.count - 1
+                                && !isSending
+                                && !isThinking
+
                             ChatBubble(
                                 message: message,
-                                hideToolCalls: false,
+                                hideToolCalls: nextIsPendingConfirmation,
+                                decidedConfirmation: nextDecidedConfirmation,
+                                showRegenerate: isLastAssistant,
+                                onRegenerate: onRegenerate,
                                 onSurfaceAction: onSurfaceAction,
                                 onOpenActivity: onOpenActivity,
                                 isActivityPanelOpen: isActivityPanelOpen
                             )
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
-                        }
-
-                        // Regenerate button on the last assistant message
-                        if message.role == .assistant
-                            && !message.isStreaming
-                            && index == messages.count - 1
-                            && !isSending {
-                            HStack {
-                                Button(action: onRegenerate) {
-                                    Image(systemName: "arrow.trianglehead.counterclockwise")
-                                        .font(.system(size: 13, weight: .medium))
-                                        .foregroundColor(VColor.textMuted)
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel("Regenerate response")
-                                .help("Regenerate response")
-                                Spacer()
-                            }
-                            .padding(.top, -VSpacing.sm)
                         }
                     }
 
@@ -551,6 +570,11 @@ private struct ChatBubble: View {
     let message: ChatMessage
     /// When true, tool call chips are suppressed because a nearby message has inline surfaces.
     let hideToolCalls: Bool
+    /// Decided confirmation from the next message, rendered as a compact chip at the bottom.
+    let decidedConfirmation: ToolConfirmationData?
+    /// Whether to show the regenerate button on this message.
+    let showRegenerate: Bool
+    let onRegenerate: () -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
@@ -576,23 +600,11 @@ private struct ChatBubble: View {
         }
     }
 
-    @Environment(\.colorScheme) private var colorScheme
-
     private var bubbleFill: AnyShapeStyle {
         if isUser {
-            if colorScheme == .dark {
-                AnyShapeStyle(
-                    LinearGradient(
-                        colors: [Meadow.userBubbleGradientStart, Meadow.userBubbleGradientEnd],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-            } else {
-                AnyShapeStyle(VColor.userBubble)
-            }
+            AnyShapeStyle(VColor.userBubble)
         } else {
-            AnyShapeStyle(VColor.surface)
+            AnyShapeStyle(Color.clear)
         }
     }
 
@@ -641,15 +653,19 @@ private struct ChatBubble: View {
                         bubbleContent
                     }
 
-                    // Consolidated tool indicator showing all tool calls
-                    toolCallChips(message.toolCalls)
-
                     // Inline surfaces render below the bubble as full-width cards
                     if !message.inlineSurfaces.isEmpty {
                         ForEach(message.inlineSurfaces) { surface in
                             InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
                         }
                     }
+                }
+
+                // Single unified status area at the bottom of the message:
+                // - In-progress: shows "Running a terminal command ..."
+                // - Complete: shows compact chips ("Ran a terminal command" + "Permission granted")
+                if !isUser {
+                    trailingStatus
                 }
 
                 if let label = statusLabel {
@@ -661,6 +677,222 @@ private struct ChatBubble: View {
 
             if !isUser { Spacer(minLength: 0) }
         }
+    }
+
+    // MARK: - Compact trailing chips (tool calls + permission)
+
+    /// Whether all tool calls are complete and the message is done streaming.
+    private var allToolCallsComplete: Bool {
+        !message.toolCalls.isEmpty && message.toolCalls.allSatisfy { $0.isComplete } && !message.isStreaming
+    }
+
+    private var regenerateButton: some View {
+        Button(action: onRegenerate) {
+            Image(systemName: "arrow.trianglehead.counterclockwise")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(VColor.textMuted)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Regenerate response")
+        .help("Regenerate response")
+    }
+
+    /// Whether the permission was denied, meaning incomplete tools were blocked (not running).
+    private var permissionWasDenied: Bool {
+        decidedConfirmation?.state == .denied || decidedConfirmation?.state == .timedOut
+    }
+
+    @ViewBuilder
+    private var trailingStatus: some View {
+        let hasCompletedTools = allToolCallsComplete && !hideToolCalls && !message.toolCalls.isEmpty
+        let hasInProgressTools = !message.toolCalls.isEmpty && !hideToolCalls && !allToolCallsComplete
+        let hasPermission = decidedConfirmation != nil
+
+        if hasInProgressTools && !permissionWasDenied {
+            // In progress — show single running indicator
+            let current = message.toolCalls.first(where: { !$0.isComplete }) ?? message.toolCalls.last
+            RunningIndicator(label: Self.friendlyRunningLabel(current?.toolName ?? ""))
+                .frame(maxWidth: 520, alignment: .leading)
+        } else if hasCompletedTools || hasPermission || showRegenerate || (hasInProgressTools && permissionWasDenied) {
+            // All done (or denied) — show chips + regenerate on one line
+            HStack(spacing: VSpacing.sm) {
+                if hasCompletedTools {
+                    compactToolChip
+                } else if hasInProgressTools && permissionWasDenied {
+                    compactFailedToolChip
+                }
+                if let confirmation = decidedConfirmation {
+                    compactPermissionChip(confirmation)
+                }
+                if showRegenerate {
+                    regenerateButton
+                }
+                Spacer()
+            }
+            .padding(.top, VSpacing.xxs)
+        }
+    }
+
+    /// Maps raw tool names to user-friendly past-tense labels.
+    private static func friendlyToolLabel(_ toolName: String) -> String {
+        switch toolName.lowercased() {
+        case "host bash", "bash":          return "Ran a terminal command"
+        case "host file read", "file read": return "Read a file"
+        case "host file write", "file write": return "Wrote a file"
+        case "host file edit", "file edit": return "Edited a file"
+        case "web search":                 return "Searched the web"
+        case "web fetch":                  return "Fetched a webpage"
+        case "browser navigate":           return "Opened a page"
+        case "browser click":              return "Clicked on the page"
+        case "browser screenshot":         return "Took a screenshot"
+        default:                           return "Used \(toolName)"
+        }
+    }
+
+    /// Maps raw tool names to user-friendly present-tense labels for the running state.
+    private static func friendlyRunningLabel(_ toolName: String) -> String {
+        switch toolName.lowercased() {
+        case "host bash", "bash":                           return "Running a terminal command"
+        case "host file read", "file read":                 return "Reading a file"
+        case "host file write", "file write":               return "Writing a file"
+        case "host file edit", "file edit":                 return "Editing a file"
+        case "web search":                                  return "Searching the web"
+        case "web fetch":                                   return "Fetching a webpage"
+        case "browser navigate":                            return "Opening a page"
+        case "browser click":                               return "Clicking on the page"
+        case "browser screenshot":                          return "Taking a screenshot"
+        default:                                            return "Running \(toolName)"
+        }
+    }
+
+    /// Icon for a tool category.
+    private static func friendlyToolIcon(_ toolName: String) -> String {
+        switch toolName.lowercased() {
+        case "host bash", "bash":                           return "terminal"
+        case "host file read", "file read":                 return "doc.text"
+        case "host file write", "file write":               return "doc.badge.plus"
+        case "host file edit", "file edit":                 return "pencil"
+        case "web search":                                  return "magnifyingglass"
+        case "web fetch":                                   return "globe"
+        case "browser navigate", "browser click":           return "safari"
+        case "browser screenshot":                          return "camera"
+        default:                                            return "gearshape"
+        }
+    }
+
+    private var compactToolChip: some View {
+        Button {
+            onOpenActivity(message.id)
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                let uniqueNames = Array(Set(message.toolCalls.map(\.toolName)))
+                let primary = uniqueNames.first ?? "Tool"
+
+                Image(systemName: Self.friendlyToolIcon(primary))
+                    .font(.system(size: 12))
+                    .foregroundColor(VColor.textMuted)
+
+                let label: String = {
+                    if uniqueNames.count == 1 {
+                        let base = Self.friendlyToolLabel(primary)
+                        if message.toolCalls.count > 1 {
+                            // e.g. "Ran 3 terminal commands"
+                            return base
+                                .replacingOccurrences(of: "a terminal command", with: "\(message.toolCalls.count) terminal commands")
+                                .replacingOccurrences(of: "a file", with: "\(message.toolCalls.count) files")
+                                .replacingOccurrences(of: "a page", with: "\(message.toolCalls.count) pages")
+                                .replacingOccurrences(of: "a webpage", with: "\(message.toolCalls.count) webpages")
+                        }
+                        return base
+                    }
+                    return "Used \(message.toolCalls.count) tools"
+                }()
+
+                Text(label)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(VColor.textMuted)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs)
+            .background(
+                Capsule().fill(VColor.surface)
+            )
+            .overlay(
+                Capsule().stroke(VColor.surfaceBorder, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering {
+                NSCursor.pointingHand.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
+    }
+
+    /// Failed/denied tool chip — shown when the user denied permission.
+    private var compactFailedToolChip: some View {
+        let uniqueNames = Array(Set(message.toolCalls.map(\.toolName)))
+        let primary = uniqueNames.first ?? "Tool"
+        let label = Self.friendlyRunningLabel(primary) + " failed"
+
+        return HStack(spacing: VSpacing.xs) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundColor(VColor.error)
+
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            Capsule().fill(VColor.surface)
+        )
+        .overlay(
+            Capsule().stroke(VColor.surfaceBorder, lineWidth: 0.5)
+        )
+    }
+
+    private func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
+        let isApproved = confirmation.state == .approved
+        return HStack(spacing: VSpacing.xs) {
+            Group {
+                switch confirmation.state {
+                case .approved:
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                case .denied:
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(VColor.error)
+                case .timedOut:
+                    Image(systemName: "clock.fill")
+                        .foregroundColor(VColor.textMuted)
+                default:
+                    EmptyView()
+                }
+            }
+            .font(.system(size: 12))
+
+            Text(isApproved ? "Permission granted" :
+                 confirmation.state == .denied ? "Permission denied" : "Timed out")
+                .font(VFont.caption)
+                .foregroundColor(isApproved ? VColor.success : VColor.textSecondary)
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            Capsule().fill(isApproved ? VColor.success.opacity(0.1) : VColor.surface)
+        )
+        .overlay(
+            Capsule().stroke(isApproved ? VColor.success.opacity(0.3) : VColor.surfaceBorder, lineWidth: 0.5)
+        )
     }
 
     /// Whether this message has meaningful interleaved content (multiple block types).
@@ -705,21 +937,56 @@ private struct ChatBubble: View {
         return groups
     }
 
+    /// Whether pre-tool text should be collapsed because post-tool text exists.
+    /// When the assistant explains what it'll do, runs the tool, then gives the result,
+    /// we collapse the explanation and just show chips + result.
+    private var shouldCollapsePreToolText: Bool {
+        guard allToolCallsComplete else { return false }
+        let groups = groupContentBlocks()
+        var seenToolCalls = false
+        var hasPreToolText = false
+        var hasPostToolText = false
+        for group in groups {
+            switch group {
+            case .text:
+                if seenToolCalls { hasPostToolText = true }
+                else { hasPreToolText = true }
+            case .toolCalls:
+                seenToolCalls = true
+            case .surface:
+                break
+            }
+        }
+        return hasPreToolText && hasPostToolText
+    }
+
     @ViewBuilder
     private var interleavedContent: some View {
         let groups = groupContentBlocks()
-        ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+        let collapse = shouldCollapsePreToolText
+        // Track whether we've seen a tool call group yet (for collapsing).
+        let firstToolIndex = groups.firstIndex(where: {
+            if case .toolCalls = $0 { return true }
+            return false
+        })
+
+        ForEach(Array(groups.enumerated()), id: \.offset) { offset, group in
             switch group {
             case .text(let i):
-                if i < message.textSegments.count {
-                    let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !segmentText.isEmpty {
-                        textBubble(for: segmentText)
+                // Skip pre-tool text when collapsing
+                let isPreTool = firstToolIndex.map { offset < $0 } ?? false
+                if !(collapse && isPreTool) {
+                    if i < message.textSegments.count {
+                        let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !segmentText.isEmpty {
+                            textBubble(for: segmentText)
+                        }
                     }
                 }
-            case .toolCalls(let indices):
-                let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
-                toolCallChips(calls)
+            case .toolCalls:
+                // Tool calls are rendered as a single unified status at the
+                // bottom of the message — skip them in the interleaved flow.
+                EmptyView()
             case .surface(let i):
                 if i < message.inlineSurfaces.count {
                     InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction)
@@ -753,31 +1020,12 @@ private struct ChatBubble: View {
             .foregroundColor(VColor.textPrimary)
             .tint(VColor.accent)
             .textSelection(.enabled)
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.md)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(AnyShapeStyle(VColor.surface))
-            )
-            .vShadow(VShadow.sm)
             .frame(maxWidth: 520, alignment: .leading)
     }
 
     /// Current step indicator rendered outside the bubble.
     /// Shows only when there are actual tool calls.
-    @ViewBuilder
-    private func toolCallChips(_ calls: [ToolCallData]) -> some View {
-        if !isUser && !calls.isEmpty {
-            CurrentStepIndicator(
-                toolCalls: calls,
-                isActivityPanelOpen: isActivityPanelOpen,
-                isStreaming: message.isStreaming
-            ) {
-                onOpenActivity(message.id)
-            }
-            .frame(maxWidth: 520, alignment: .leading)
-        }
-    }
+    // Tool call status is rendered via trailingStatus at the bottom of the message.
 
     private var hasText: Bool {
         !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -846,8 +1094,8 @@ private struct ChatBubble: View {
                 }
             }
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.md)
+        .padding(.horizontal, isUser ? VSpacing.lg : 0)
+        .padding(.vertical, isUser ? VSpacing.md : 0)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(bubbleFill)
@@ -961,6 +1209,48 @@ private struct ChatBubble: View {
 }
 
 // MARK: - Thinking Indicator
+
+/// Minimal in-progress indicator for tool execution, matching ThinkingIndicator style.
+private struct RunningIndicator: View {
+    var label: String = "Running"
+    @State private var phase: Int = 0
+    @State private var timer: Timer?
+
+    var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            Image(systemName: "terminal")
+                .font(.system(size: 10))
+                .foregroundColor(VColor.textSecondary)
+
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(VColor.textSecondary)
+                    .frame(width: 5, height: 5)
+                    .opacity(dotOpacity(for: index))
+            }
+
+            Spacer()
+        }
+        .onAppear { startAnimation() }
+        .onDisappear { timer?.invalidate() }
+    }
+
+    private func dotOpacity(for index: Int) -> Double {
+        phase == index ? 1.0 : 0.4
+    }
+
+    private func startAnimation() {
+        timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
+            withAnimation(.easeInOut(duration: 0.3)) {
+                phase = (phase + 1) % 3
+            }
+        }
+    }
+}
 
 private struct ThinkingIndicator: View {
     var label: String = "Thinking"

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -49,24 +49,235 @@ public struct ToolConfirmationData: Equatable {
     /// Human-readable preview of the tool input (e.g. the bash command or file path).
     public var commandPreview: String {
         switch toolName {
-        case "bash":
+        case "bash", "host_bash":
             return (input["command"]?.value as? String) ?? ""
-        case "file_read":
+        case "file_read", "host_file_read":
             return "read \((input["path"]?.value as? String) ?? "")"
-        case "file_write":
+        case "file_write", "host_file_write":
             return "write \((input["path"]?.value as? String) ?? "")"
-        case "file_edit":
+        case "file_edit", "host_file_edit":
             return "edit \((input["path"]?.value as? String) ?? "")"
         case "web_fetch":
             return "fetch \((input["url"]?.value as? String) ?? "")"
         case "browser_navigate":
             return "navigate \((input["url"]?.value as? String) ?? "")"
+        case "request_system_permission":
+            return (input["permission_type"]?.value as? String) ?? "system permission"
         default:
             // Fallback: show first string value or tool name
             if let firstString = input.values.compactMap({ $0.value as? String }).first {
                 return firstString
             }
             return ""
+        }
+    }
+
+    /// Whether this is a system permission request (TCC).
+    public var isSystemPermissionRequest: Bool {
+        toolName == "request_system_permission"
+    }
+
+    /// The permission type for system permission requests.
+    public var permissionType: String? {
+        guard isSystemPermissionRequest else { return nil }
+        return input["permission_type"]?.value as? String
+    }
+
+    /// Friendly display name for the permission type.
+    public var permissionFriendlyName: String {
+        guard let type = permissionType else { return "Permission" }
+        switch type {
+        case "full_disk_access": return "Full Disk Access"
+        case "accessibility": return "Accessibility"
+        case "screen_recording": return "Screen Recording"
+        case "calendar": return "Calendar"
+        case "contacts": return "Contacts"
+        case "photos": return "Photos"
+        case "location": return "Location Services"
+        case "microphone": return "Microphone"
+        case "camera": return "Camera"
+        default: return type.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    /// The macOS System Settings deep-link URL for the permission.
+    public var settingsURL: URL? {
+        guard let type = permissionType else { return nil }
+        let urlString: String
+        switch type {
+        case "full_disk_access":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+        case "accessibility":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        case "screen_recording":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        case "calendar":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars"
+        case "contacts":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts"
+        case "photos":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Photos"
+        case "location":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices"
+        case "microphone":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+        case "camera":
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+        default:
+            urlString = "x-apple.systempreferences:com.apple.preference.security"
+        }
+        return URL(string: urlString)
+    }
+
+    /// Friendly, context-aware description for the permission ask.
+    public var humanDescription: String {
+        switch toolName {
+        case "request_system_permission":
+            let reason = (input["reason"]?.value as? String) ?? ""
+            if reason.isEmpty {
+                return "I need \(permissionFriendlyName) to do this for you."
+            }
+            return reason
+        case "bash", "host_bash":
+            return Self.describeBashCommand((input["command"]?.value as? String) ?? "")
+        case "file_write", "host_file_write":
+            let path = (input["path"]?.value as? String) ?? ""
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            return "I\u{2019}d like to save some changes to \(name) \u{2014} that ok?"
+        case "file_edit", "host_file_edit":
+            let path = (input["path"]?.value as? String) ?? ""
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            return "I need to make a quick edit to \(name) \u{2014} cool?"
+        case "file_read", "host_file_read":
+            let path = (input["path"]?.value as? String) ?? ""
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            return "Let me take a peek at \(name) \u{2014} alright?"
+        case "web_fetch":
+            let url = (input["url"]?.value as? String) ?? ""
+            if let host = URL(string: url)?.host {
+                return "I need to grab some info from \(host) \u{2014} that ok?"
+            }
+            return "I need to look something up online \u{2014} that ok?"
+        case "browser_navigate":
+            let url = (input["url"]?.value as? String) ?? ""
+            if let host = URL(string: url)?.host {
+                return "I want to open \(host) for you \u{2014} cool?"
+            }
+            return "I want to open a page for you \u{2014} cool?"
+        default:
+            return "I need to do something on your Mac \u{2014} that ok?"
+        }
+    }
+
+    /// Extracts a friendly folder/file name from a path in a command.
+    private static func friendlyPath(_ command: String) -> String? {
+        // Look for paths like ~/Downloads, /Users/.../folder, ./src, etc.
+        let patterns = command.split(separator: " ").compactMap { token -> String? in
+            let s = String(token)
+            guard s.contains("/") || s.hasPrefix("~") else { return nil }
+            // Clean trailing slashes and pipes
+            let cleaned = s.trimmingCharacters(in: CharacterSet(charactersIn: "/|;&"))
+            if cleaned.isEmpty || cleaned == "~" { return nil }
+            let url = URL(fileURLWithPath: cleaned.replacingOccurrences(of: "~", with: "/Users/you"))
+            let name = url.lastPathComponent
+            return name.isEmpty ? nil : name
+        }
+        return patterns.first
+    }
+
+    private static func describeBashCommand(_ command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespaces)
+        let words = trimmed.split(separator: " ")
+        let first = words.first.map(String.init) ?? ""
+        let path = friendlyPath(trimmed)
+
+        switch first {
+        case "ls":
+            if let p = path {
+                return "To check your \(p) folder, I need to run a quick command"
+            }
+            return "I need to look through some files \u{2014} that ok?"
+        case "cat", "head", "tail", "less", "more":
+            if let p = path {
+                return "I need to read \(p) \u{2014} that ok?"
+            }
+            return "I need to read a file \u{2014} that ok?"
+        case "mkdir":
+            if let p = path {
+                return "I need to create a \(p) folder \u{2014} cool?"
+            }
+            return "I need to create a new folder \u{2014} cool?"
+        case "rm", "rmdir":
+            if let p = path {
+                return "I need to delete \(p) \u{2014} is that alright?"
+            }
+            return "I need to delete some files \u{2014} is that alright?"
+        case "cp":
+            return "I need to copy some files over \u{2014} that ok?"
+        case "mv":
+            return "I need to move something around \u{2014} that ok?"
+        case "git":
+            let sub = words.dropFirst().first.map(String.init) ?? ""
+            switch sub {
+            case "push": return "I\u{2019}m ready to push your code \u{2014} should I go ahead?"
+            case "pull": return "Let me pull the latest code for you \u{2014} cool?"
+            case "commit": return "I want to commit your changes \u{2014} good to go?"
+            case "clone": return "I need to clone a repo \u{2014} that ok?"
+            case "checkout", "switch": return "I want to switch branches \u{2014} cool?"
+            case "status": return "Let me check what\u{2019}s changed \u{2014} that ok?"
+            case "diff": return "I want to see what\u{2019}s changed in the code"
+            case "add": return "I need to stage some files for commit"
+            case "stash": return "I\u{2019}ll set aside your changes for now \u{2014} ok?"
+            case "merge": return "I want to merge these branches \u{2014} should I?"
+            case "rebase": return "I need to rebase your commits \u{2014} that ok?"
+            case "log": return "Let me check the commit history"
+            case "fetch": return "Let me check for updates from the remote"
+            case "reset": return "I need to reset some files \u{2014} is that alright?"
+            default: return "I need to run a git command \u{2014} that ok?"
+            }
+        case "npm", "npx":
+            let sub = words.dropFirst().first.map(String.init) ?? ""
+            switch sub {
+            case "install", "i", "ci": return "I need to install some packages \u{2014} that ok?"
+            case "run": return "I need to run a project script \u{2014} cool?"
+            case "test": return "Let me run the tests for you"
+            default: return "I need to run an npm command \u{2014} that ok?"
+            }
+        case "bun", "bunx":
+            return "I need to run a Bun command \u{2014} that ok?"
+        case "yarn", "pnpm":
+            return "I need to install some packages \u{2014} that ok?"
+        case "pip", "pip3":
+            return "I need to manage some Python packages \u{2014} cool?"
+        case "brew":
+            return "I need to use Homebrew real quick \u{2014} that ok?"
+        case "curl", "wget":
+            return "I need to download something \u{2014} that ok?"
+        case "python", "python3":
+            return "I need to run a Python script \u{2014} cool?"
+        case "node":
+            return "I need to run a script \u{2014} cool?"
+        case "swift":
+            return "I need to run a Swift command \u{2014} that ok?"
+        case "xcodebuild":
+            return "I need to build the project \u{2014} that ok?"
+        case "open":
+            if let p = path {
+                return "I want to open \(p) for you \u{2014} cool?"
+            }
+            return "I want to open something for you \u{2014} cool?"
+        case "sudo":
+            return "I need admin access to run this \u{2014} is that alright?"
+        case "kill", "pkill", "killall":
+            return "I need to stop a running process \u{2014} ok?"
+        case "docker":
+            return "I need to run a Docker command \u{2014} that ok?"
+        case "ssh":
+            return "I need to connect to a remote server \u{2014} that ok?"
+        case "find", "grep", "rg", "ag":
+            return "I need to search for something \u{2014} that ok?"
+        default:
+            return "I need to run a quick command \u{2014} that ok?"
         }
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -986,11 +986,12 @@ public final class ChatViewModel: ObservableObject {
                 text: "",
                 confirmation: confirmation
             )
-            // Insert before the current streaming assistant message so the
-            // confirmation appears between the user message and the response.
+            // Insert after the current streaming assistant message so the
+            // assistant's text appears above the confirmation buttons.
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
-                messages.insert(confirmMsg, at: index)
+                messages[index].isStreaming = false
+                messages.insert(confirmMsg, at: index + 1)
             } else {
                 messages.append(confirmMsg)
             }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -2,161 +2,198 @@ import SwiftUI
 
 public struct ToolConfirmationBubble: View {
     public let confirmation: ToolConfirmationData
+    /// When true, show the humanDescription above buttons (used when no assistant text precedes this).
+    public let showDescription: Bool
     public let onAllow: () -> Void
     public let onDeny: () -> Void
     public let onAddTrustRule: (String, String, String, String) -> Bool
 
-    public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
+    @State private var showDetails = false
+
+    public init(confirmation: ToolConfirmationData, showDescription: Bool = false, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
         self.confirmation = confirmation
+        self.showDescription = showDescription
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAddTrustRule = onAddTrustRule
     }
 
-    @State private var showRulePicker = false
-    @State private var selectedPattern: String = ""
-    @State private var selectedScope: String = ""
-    @State private var ruleSaved = false
-
-    private var isHighRisk: Bool { confirmation.riskLevel.lowercased() == "high" }
-
     private var hasRuleOptions: Bool {
         !confirmation.allowlistOptions.isEmpty && !confirmation.scopeOptions.isEmpty
-    }
-
-    private var executionTarget: String? {
-        confirmation.normalizedExecutionTarget
-    }
-
-    private var isHostTarget: Bool {
-        executionTarget == "host"
-    }
-
-    private var toolDisplayName: String {
-        switch confirmation.toolName {
-        case "file_write": return "Write File"
-        case "file_edit": return "Edit File"
-        case "bash": return "Run Command"
-        case "web_fetch": return "Fetch URL"
-        default: return confirmation.toolName.replacingOccurrences(of: "_", with: " ").capitalized
-        }
     }
 
     private var isDecided: Bool {
         confirmation.state != .pending
     }
 
+    /// The raw command/path preview for the details disclosure.
+    private var detailsPreview: String? {
+        let preview = confirmation.commandPreview
+        return preview.isEmpty ? nil : preview
+    }
+
     public var body: some View {
-        VStack(alignment: .leading, spacing: isDecided ? VSpacing.sm : VSpacing.md) {
+        if confirmation.isSystemPermissionRequest {
+            if isDecided {
+                systemPermissionCollapsed
+            } else {
+                systemPermissionCard
+            }
+        } else {
             if isDecided {
                 collapsedContent
             } else {
-                expandedContent
+                pendingContent
             }
         }
-        .padding(isDecided ? VSpacing.md : VSpacing.lg)
+    }
+
+    // MARK: - System Permission Card (TCC)
+
+    @ViewBuilder
+    private var systemPermissionCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "lock.shield.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(VColor.accent)
+
+                Text(confirmation.permissionFriendlyName)
+                    .font(VFont.bodyBold)
+                    .foregroundColor(VColor.textPrimary)
+            }
+
+            Text(confirmation.humanDescription)
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "Open System Settings", style: .primary) {
+                    #if os(macOS)
+                    if let url = confirmation.settingsURL {
+                        NSWorkspace.shared.open(url)
+                    }
+                    #endif
+                }
+
+                VButton(label: "I\u{2019}ve granted it", style: .ghost) {
+                    onAllow()
+                }
+            }
+        }
+        .padding(VSpacing.lg)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(VColor.surface)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .stroke(isHighRisk ? VColor.error.opacity(0.4) : VColor.warning.opacity(0.4), lineWidth: 1)
-                )
         )
-        .frame(maxWidth: 520)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
     }
-
-    // MARK: - Expanded (pending)
 
     @ViewBuilder
-    private var expandedContent: some View {
-        // Header row: icon + tool name + risk badge
+    private var systemPermissionCollapsed: some View {
         HStack(spacing: VSpacing.sm) {
-            Image(systemName: isHighRisk ? "exclamationmark.triangle.fill" : "shield.checkered")
-                .font(.system(size: 14))
-                .foregroundStyle(isHighRisk ? VColor.error : VColor.warning)
-
-            Text(toolDisplayName)
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
-
-            Text(confirmation.riskLevel.lowercased())
-                .font(VFont.caption)
-                .foregroundColor(isHighRisk ? VColor.error : VColor.warning)
-                .padding(.horizontal, VSpacing.sm)
-                .padding(.vertical, VSpacing.xxs)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill((isHighRisk ? VColor.error : VColor.warning).opacity(0.15))
-                )
-
-            if let executionTarget {
-                Text(executionTarget)
-                    .font(VFont.caption)
-                    .foregroundColor(isHostTarget ? VColor.error : VColor.textSecondary)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xxs)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill((isHostTarget ? VColor.error : VColor.surfaceBorder).opacity(0.15))
-                    )
-            }
-
-            Spacer()
-        }
-
-        // Command preview
-        if !confirmation.commandPreview.isEmpty {
-            Text(confirmation.commandPreview)
-                .font(VFont.monoSmall)
-                .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.sm)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(VColor.backgroundSubtle)
-                .cornerRadius(VRadius.md)
-        }
-
-        // Diff preview (if present)
-        if let diff = confirmation.diff {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(diff.filePath)
-                    .font(VFont.monoSmall)
-                    .foregroundColor(VColor.textSecondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                if diff.isNewFile {
-                    Text("New file")
-                        .font(VFont.caption)
+            Group {
+                switch confirmation.state {
+                case .approved:
+                    Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(VColor.success)
+                case .denied:
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(VColor.error)
+                case .timedOut:
+                    Image(systemName: "clock.fill")
+                        .foregroundColor(VColor.textMuted)
+                default:
+                    EmptyView()
                 }
-
-                ScrollView {
-                    Text(String(diff.newContent.prefix(500)))
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(maxHeight: 120)
-                .padding(VSpacing.sm)
-                .background(VColor.backgroundSubtle)
-                .cornerRadius(VRadius.md)
             }
-        }
+            .font(.system(size: 12))
 
-        // Action buttons
-        HStack(spacing: VSpacing.md) {
+            Text(confirmation.state == .approved
+                 ? "\(confirmation.permissionFriendlyName) granted"
+                 : confirmation.state == .denied
+                 ? "\(confirmation.permissionFriendlyName) skipped"
+                 : "Timed out")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+
             Spacer()
-            VButton(label: "Deny", style: .ghost) {
-                onDeny()
-            }
-            VButton(label: "Allow", style: isHighRisk ? .danger : .primary) {
-                onAllow()
-            }
         }
     }
 
-    // MARK: - Collapsed (decided)
+    // MARK: - Tool Permission (pending)
+
+    @ViewBuilder
+    private var pendingContent: some View {
+        if showDescription {
+            Text(confirmation.humanDescription)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .frame(maxWidth: 520, alignment: .leading)
+        }
+
+        HStack(spacing: VSpacing.sm) {
+            VButton(label: "Don\u{2019}t Allow", style: .ghost) {
+                onDeny()
+            }
+
+            VButton(label: "Allow", style: .primary) {
+                onAllow()
+            }
+
+            if hasRuleOptions {
+                VButton(label: "Always Allow", style: .ghost) {
+                    let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
+                    let scope = confirmation.scopeOptions.first?.scope ?? ""
+                    if !pattern.isEmpty && !scope.isEmpty {
+                        _ = onAddTrustRule(confirmation.toolName, pattern, scope, "allow")
+                    }
+                    onAllow()
+                }
+            }
+
+            Spacer()
+
+            if detailsPreview != nil {
+                Button {
+                    withAnimation(VAnimation.fast) {
+                        showDetails.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 3) {
+                        Text("Details")
+                            .font(.system(size: 10))
+                            .foregroundColor(VColor.textMuted)
+                        Image(systemName: showDetails ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(showDetails ? "Hide details" : "Show details")
+            }
+        }
+
+        if showDetails, let preview = detailsPreview {
+            Text(preview)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textSecondary)
+                .padding(VSpacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.backgroundSubtle)
+                )
+                .textSelection(.enabled)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+    }
+
+    // MARK: - Tool Permission (decided)
 
     @ViewBuilder
     private var collapsedContent: some View {
@@ -178,191 +215,70 @@ public struct ToolConfirmationBubble: View {
             }
             .font(.system(size: 12))
 
-            Text(toolDisplayName)
+            Text(confirmation.state == .approved ? "Permission granted" :
+                 confirmation.state == .denied ? "Permission denied" : "Timed out")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
 
-            if !confirmation.commandPreview.isEmpty {
-                Text(confirmation.commandPreview)
-                    .font(VFont.monoSmall)
-                    .foregroundColor(VColor.textMuted)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-
             Spacer()
-
-            Text(confirmation.state == .approved ? "Allowed" :
-                 confirmation.state == .denied ? "Denied" : "Timed out")
-                .font(VFont.caption)
-                .foregroundColor(
-                    confirmation.state == .approved ? VColor.success :
-                    confirmation.state == .denied ? VColor.error : VColor.textMuted
-                )
         }
-
-        if (confirmation.state == .approved || confirmation.state == .denied) && hasRuleOptions && !ruleSaved {
-            if showRulePicker {
-                rulePickerView
-            } else {
-                HStack {
-                    Spacer()
-                    VButton(
-                        label: confirmation.state == .approved ? "Add to Allowlist" : "Add to Denylist",
-                        style: .ghost
-                    ) {
-                        if selectedPattern.isEmpty, let first = confirmation.allowlistOptions.first {
-                            selectedPattern = first.pattern
-                        }
-                        if selectedScope.isEmpty, let first = confirmation.scopeOptions.first {
-                            selectedScope = first.scope
-                        }
-                        withAnimation(VAnimation.standard) {
-                            showRulePicker = true
-                        }
-                    }
-                }
-            }
-        }
-
-        if ruleSaved {
-            HStack(spacing: VSpacing.xs) {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundColor(VColor.success)
-                Text("Rule saved")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.success)
-            }
-            .transition(.opacity)
-        }
-    }
-
-    @ViewBuilder
-    private var rulePickerView: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            // Pattern picker
-            if confirmation.allowlistOptions.count > 1 {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Pattern")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                    Picker("", selection: $selectedPattern) {
-                        ForEach(confirmation.allowlistOptions, id: \.pattern) { option in
-                            Text(option.label).tag(option.pattern)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .labelsHidden()
-                }
-            } else if let single = confirmation.allowlistOptions.first {
-                HStack(spacing: VSpacing.xs) {
-                    Text("Pattern:")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                    Text(single.label)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.textPrimary)
-                }
-            }
-
-            // Scope picker
-            if confirmation.scopeOptions.count > 1 {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Scope")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                    Picker("", selection: $selectedScope) {
-                        ForEach(confirmation.scopeOptions, id: \.scope) { option in
-                            Text(option.label).tag(option.scope)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .labelsHidden()
-                }
-            } else if let single = confirmation.scopeOptions.first {
-                HStack(spacing: VSpacing.xs) {
-                    Text("Scope:")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                    Text(single.label)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.textPrimary)
-                }
-            }
-
-            // Save / Cancel
-            HStack(spacing: VSpacing.md) {
-                Spacer()
-                VButton(label: "Cancel", style: .ghost) {
-                    withAnimation(VAnimation.standard) {
-                        showRulePicker = false
-                    }
-                }
-                VButton(label: "Save Rule", style: .primary) {
-                    let ruleDecision = confirmation.state == .approved ? "allow" : "deny"
-                    guard onAddTrustRule(confirmation.toolName, selectedPattern, selectedScope, ruleDecision) else { return }
-                    withAnimation(VAnimation.standard) {
-                        showRulePicker = false
-                        ruleSaved = true
-                    }
-                }
-            }
-        }
-        .padding(VSpacing.md)
-        .background(VColor.backgroundSubtle)
-        .cornerRadius(VRadius.md)
-        .transition(.opacity.combined(with: .move(edge: .top)))
     }
 }
 
 #if DEBUG
 #Preview("ToolConfirmationBubble") {
     VStack(spacing: VSpacing.lg) {
+        // System permission request (pending)
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-perm",
+                toolName: "request_system_permission",
+                input: [
+                    "permission_type": AnyCodable("full_disk_access"),
+                    "reason": AnyCodable("I need Full Disk Access to read your Documents folder.")
+                ],
+                riskLevel: "high"
+            ),
+            onAllow: {},
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in true }
+        )
+        // System permission (granted)
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-perm-done",
+                toolName: "request_system_permission",
+                input: [
+                    "permission_type": AnyCodable("full_disk_access"),
+                    "reason": AnyCodable("I need Full Disk Access to read your Documents folder.")
+                ],
+                riskLevel: "high",
+                state: .approved
+            ),
+            onAllow: {},
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in true }
+        )
+        // Tool confirmation (pending)
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
                 requestId: "test-1",
-                toolName: "bash",
-                input: ["command": AnyCodable("git push origin main")],
-                riskLevel: "medium",
-                diff: nil,
-                allowlistOptions: [
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "git push", description: "This exact command", pattern: "git push"),
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "git *", description: "Any git command", pattern: "git *"),
-                ],
-                scopeOptions: [
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "This project", scope: "/Users/test/project"),
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "Everywhere", scope: "everywhere"),
-                ]
+                toolName: "host_bash",
+                input: ["command": AnyCodable("ls -lt ~/Downloads/ | head -50")],
+                riskLevel: "low",
+                executionTarget: "host"
             ),
             onAllow: {},
             onDeny: {},
             onAddTrustRule: { _, _, _, _ in true }
         )
+        // Tool confirmation (approved)
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
                 requestId: "test-2",
-                toolName: "file_write",
-                input: ["path": AnyCodable("/Users/test/project/src/main.swift")],
-                riskLevel: "high",
-                diff: ConfirmationRequestMessage.ConfirmationDiffInfo(
-                    filePath: "/Users/test/project/src/main.swift",
-                    oldContent: "",
-                    newContent: "import Foundation\n\nfunc hello() {\n    print(\"Hello, World!\")\n}",
-                    isNewFile: true
-                )
-            ),
-            onAllow: {},
-            onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
-        )
-        // Collapsed: approved
-        ToolConfirmationBubble(
-            confirmation: ToolConfirmationData(
-                requestId: "test-3",
-                toolName: "bash",
+                toolName: "host_bash",
                 input: ["command": AnyCodable("npm install")],
                 riskLevel: "medium",
-                diff: nil,
                 allowlistOptions: [
                     ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "npm install", description: "This exact command", pattern: "npm install"),
                 ],
@@ -370,20 +286,6 @@ public struct ToolConfirmationBubble: View {
                     ConfirmationRequestMessage.ConfirmationScopeOption(label: "Everywhere", scope: "everywhere"),
                 ],
                 state: .approved
-            ),
-            onAllow: {},
-            onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
-        )
-        // Collapsed: denied
-        ToolConfirmationBubble(
-            confirmation: ToolConfirmationData(
-                requestId: "test-4",
-                toolName: "bash",
-                input: ["command": AnyCodable("rm -rf /")],
-                riskLevel: "high",
-                diff: nil,
-                state: .denied
             ),
             onAllow: {},
             onDeny: {},


### PR DESCRIPTION
## Summary
- Redesign tool permission flow: compact trailing chips replace the large CurrentStepIndicator card, with friendly labels like "Ran a terminal command" and green "Permission granted" pills
- Collapse pre-tool explanation text once the final answer arrives; show a minimal animated RunningIndicator during execution; handle denied permissions with "failed" chip state
- Add conversational system prompt guidance so the LLM explains actions in plain language before requesting approval, and add `request_system_permission` daemon tool for macOS TCC permission cards
- Merge regenerate button, tool chips, and permission chips into a single trailing line; always use "What would you like to do?" as composer placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
