### PR TITLE
fix: close activity panel on thread switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -213,6 +213,12 @@ struct MainWindowView: View {
         .onChange(of: threadManager.activeThreadId) { oldId, newId in
             // Sync activeThreadId changes back to selectedThreadId to keep sidebar selection in sync
             selectedThreadId = newId
+            // Close the activity panel when switching threads — the stored messageId
+            // belongs to the previous thread and won't exist in the new one.
+            if windowState.activePanel == .activity {
+                windowState.activePanel = nil
+                windowState.activityMessageId = nil
+            }
             // Clear stale activeSurfaceId on the old thread and sync the new one
             if let oldId {
                 threadManager.clearActiveSurface(threadId: oldId)


### PR DESCRIPTION
## Summary
- Closes/resets the activity panel when the user switches threads
- The activity panel was bound to `threadManager.activeViewModel` which rebinds to the currently selected thread, but `activityMessageId` stayed from when the panel was opened. Switching threads caused the panel to render empty since the messageId doesn't exist in the new thread.
- Adds a check in the existing `.onChange(of: threadManager.activeThreadId)` handler to clear `activePanel` and `activityMessageId` when the activity panel is open

## Test plan
- [ ] Open the activity panel on a message in thread A
- [ ] Switch to thread B
- [ ] Verify the activity panel closes automatically
- [ ] Verify switching threads without the activity panel open still works normally

Addresses review feedback from PR #2958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
