### PR TITLE
fix: guard allowedTools with Array.isArray in tool policy matcher

### DIFF
--- a/assistant/src/__tests__/tool-policy.test.ts
+++ b/assistant/src/__tests__/tool-policy.test.ts
@@ -26,6 +26,10 @@ describe('isToolAllowed', () => {
     expect(isToolAllowed('browser_fill_credential', undefined as unknown as string[])).toBe(false);
   });
 
+  test('denies when allowedTools is a string (not an array)', () => {
+    expect(isToolAllowed('b', 'browser_fill_credential' as unknown as string[])).toBe(false);
+  });
+
   test('denies when toolName is empty', () => {
     expect(isToolAllowed('', ['browser_fill_credential'])).toBe(false);
   });

--- a/assistant/src/tools/credentials/tool-policy.ts
+++ b/assistant/src/tools/credentials/tool-policy.ts
@@ -18,7 +18,7 @@
  * 3. Fail-closed on empty or missing list
  */
 export function isToolAllowed(toolName: string, allowedTools: string[]): boolean {
-  if (!allowedTools || allowedTools.length === 0) return false;
+  if (!Array.isArray(allowedTools) || allowedTools.length === 0) return false;
   if (!toolName || typeof toolName !== 'string') return false;
 
   return allowedTools.includes(toolName);


### PR DESCRIPTION
## Summary

- Replaces truthiness check (`!allowedTools`) with `Array.isArray(allowedTools)` in `isToolAllowed` so malformed policy data (e.g. a string) doesn't bypass fail-closed behavior via substring matching
- Adds test verifying a string value is correctly denied

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/2713

## Test plan

- [x] Existing tool-policy tests pass (11/11)
- [x] New test: string `allowedTools` is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
