### PR TITLE
fix: generate summary before firing completion notifier on timeout

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -7,10 +7,9 @@ import {
   registerWatchCompletionNotifier,
   unregisterWatchCompletionNotifier,
   fireWatchStartNotifier,
-  fireWatchCompletionNotifier,
 } from '../tools/watch/watch-state.js';
 import type { WatchSession } from '../tools/watch/watch-state.js';
-import { lastSummaryBySession } from './watch-handler.js';
+import { lastSummaryBySession, generateSummary } from './watch-handler.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('ride-shotgun-handler');
@@ -38,12 +37,13 @@ export async function handleRideShotgunStart(
 
   watchSessions.set(watchId, session);
 
-  // Set timeout for duration expiry (same pattern as screen-watch.ts)
-  session.timeoutHandle = setTimeout(() => {
+  // Set timeout for duration expiry — generate summary before firing notifier
+  session.timeoutHandle = setTimeout(async () => {
     session.status = 'completing';
     session.timeoutHandle = undefined;
-    log.info({ watchId }, 'Ride shotgun session duration expired, marking as completing');
-    fireWatchCompletionNotifier(sessionId, session);
+    log.info({ watchId }, 'Ride shotgun session duration expired, generating summary');
+    session.status = 'completed';
+    await generateSummary(session);
   }, durationSeconds * 1000);
 
   // Register completion notifier to send summary back to client

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -7,6 +7,7 @@ import {
   registerWatchCompletionNotifier,
   unregisterWatchCompletionNotifier,
   fireWatchStartNotifier,
+  fireWatchCompletionNotifier,
 } from '../tools/watch/watch-state.js';
 import type { WatchSession } from '../tools/watch/watch-state.js';
 import { lastSummaryBySession, generateSummary } from './watch-handler.js';
@@ -44,6 +45,11 @@ export async function handleRideShotgunStart(
     log.info({ watchId }, 'Ride shotgun session duration expired, generating summary');
     session.status = 'completed';
     await generateSummary(session);
+    // Fallback: if generateSummary failed or returned empty, fire notifier
+    // anyway so the client always receives a response
+    if (!lastSummaryBySession.has(sessionId)) {
+      fireWatchCompletionNotifier(sessionId, session);
+    }
   }, durationSeconds * 1000);
 
   // Register completion notifier to send summary back to client

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -43,8 +43,8 @@ export async function handleRideShotgunStart(
     session.status = 'completing';
     session.timeoutHandle = undefined;
     log.info({ watchId }, 'Ride shotgun session duration expired, generating summary');
-    session.status = 'completed';
     await generateSummary(session);
+    session.status = 'completed';
     // Fallback: if generateSummary failed or returned empty, fire notifier
     // anyway so the client always receives a response
     if (!lastSummaryBySession.has(sessionId)) {

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -126,7 +126,7 @@ async function generateCommentary(session: WatchSession): Promise<void> {
   }
 }
 
-async function generateSummary(session: WatchSession): Promise<void> {
+export async function generateSummary(session: WatchSession): Promise<void> {
   try {
     const client = new Anthropic();
 


### PR DESCRIPTION
## Summary
- Generate summary from collected observations when ride shotgun timeout fires
- Fire the completion notifier only after the summary is ready
- Prevents the client from receiving an empty summary on timeout

Addresses feedback from #3046.

## Test plan
- [ ] Ride shotgun timeout delivers a non-empty summary when observations were collected
- [ ] Normal (non-timeout) completion still works correctly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
