### PR TITLE
fix: suppress ride shotgun triggers during active sessions

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -41,6 +41,14 @@ public final class AmbientAgent: ObservableObject {
         rideShotgunTrigger.start()
     }
 
+    func pause() {
+        rideShotgunTrigger.stop()
+    }
+
+    func resume() {
+        rideShotgunTrigger.start()
+    }
+
     func teardown() {
         rideShotgunTrigger.stop()
         currentSession?.cancel()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -724,6 +724,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.thinkingWindow = nil
                     self?.currentSession?.cancel()
                     self?.currentTextSession?.cancel()
+                    self?.ambientAgent.resume()
                     self?.surfaceManager.dismissAll()
                     self?.toolConfirmationManager.dismissAll()
                     self?.secretPromptManager.dismissAll()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -268,6 +268,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let overlay = SessionOverlayWindow(session: session)
         overlay.show()
         self.overlayWindow = overlay
+        self.ambientAgent.pause()
 
         // Close the text response window but keep the text session reference
         // (no de-escalation for MVP — text session is effectively done)
@@ -281,6 +282,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self.overlayWindow = nil
             self.currentSession = nil
             self.currentTextSession = nil
+            self.ambientAgent.resume()
         }
     }
 
@@ -1125,11 +1127,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 let overlay = SessionOverlayWindow(session: session)
                 overlay.show()
                 self.overlayWindow = overlay
+                self.ambientAgent.pause()
                 await session.run()
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
                 overlay.close()
                 self.overlayWindow = nil
                 self.currentSession = nil
+                self.ambientAgent.resume()
 
             default: // text_qa
                 let session = TextSession(
@@ -1145,12 +1149,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 let window = TextResponseWindow(session: session, inputState: inputState)
                 window.show()
                 self.textResponseWindow = window
+                self.ambientAgent.pause()
 
                 // Clean up when the user closes the panel
                 window.onClose = { [weak self] in
                     self?.currentTextSession?.cancel()
                     self?.textResponseWindow = nil
                     self?.currentTextSession = nil
+                    self?.ambientAgent.resume()
                 }
 
                 await session.run()


### PR DESCRIPTION
## Summary
- Add `pause()` and `resume()` methods to AmbientAgent that stop/start the RideShotgunTrigger timer
- Call `pause()` when a computer-use or text session starts
- Call `resume()` when the session ends
- Prevents ride shotgun invitation windows from appearing mid-task

Addresses feedback from #3043.

## Test plan
- [ ] Start a computer-use session and verify no ride shotgun invitations appear
- [ ] End the session and verify ride shotgun triggers resume normally
- [ ] `./build.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
