### PR TITLE
fix: address PR #2963 feedback (sidebar hit testing + top inset)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -122,6 +122,7 @@ struct MainWindowView: View {
                         threadDrawerView
                             .frame(width: sidebarOpen && windowState.layoutConfig.left.visible ? (windowState.layoutConfig.left.width ?? threadDrawerWidth) : 0, alignment: .leading)
                             .clipped()
+                            .allowsHitTesting(sidebarOpen)
                             .animation(isDrawerDragging ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: sidebarOpen)
                             .animation(nil, value: threadDrawerWidth)
 
@@ -131,6 +132,7 @@ struct MainWindowView: View {
 
                         // Right: Chat content
                         chatContentView(geometry: geometry)
+                            .padding(.top, !sidebarOpen && windowState.layoutConfig.left.visible && !isGeneratedWorkspaceOpen ? 36 : 0)
                             .overlay(alignment: .topLeading) {
                                 // Toggle button when sidebar is hidden
                                 if !sidebarOpen && windowState.layoutConfig.left.visible && !isGeneratedWorkspaceOpen {


### PR DESCRIPTION
## Summary
Fixes review feedback from PR #2963:

- **Sidebar hit testing**: Added `.allowsHitTesting(sidebarOpen)` after `.clipped()` so the closed sidebar no longer intercepts clicks/hovers in the chat area. SwiftUI's `.clipped()` only clips drawing, not hit testing, so buttons, scroll views, and hover targets in the collapsed sidebar were still intercepting events and causing phantom cursor changes.
- **Top inset**: Added top padding (36pt) to the chat content area when the sidebar is closed, so the overlay sidebar toggle button doesn't obscure chat content. The padding is only applied when the toggle button is visible (`!sidebarOpen && layoutConfig.left.visible && !isGeneratedWorkspaceOpen`).

## Test plan
- [ ] Open the app in drawer mode with the sidebar closed
- [ ] Verify clicks in the chat area near the left edge work correctly (no phantom cursor changes or intercepted events)
- [ ] Verify the sidebar toggle button does not overlap/obscure the top of chat content
- [ ] Open the sidebar and verify it functions normally
- [ ] Close the sidebar again and verify the top padding appears correctly
- [ ] Verify no layout issues when switching to generated workspace mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
