### PR TITLE
feat: add end-of-turn reflection to prompt workspace file updates

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -61,6 +61,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildToolPermissionSection());
   parts.push(buildSystemPermissionSection());
   parts.push(buildSwarmGuidanceSection());
+  parts.push(buildWorkspaceReflectionSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
 }
@@ -232,6 +233,21 @@ export function buildSwarmGuidanceSection(): string {
     '## Parallel Task Orchestration',
     '',
     'Use `swarm_delegate` only when a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"). For single-focus tasks, work directly — do not decompose them into a swarm.',
+  ].join('\n');
+}
+
+function buildWorkspaceReflectionSection(): string {
+  return [
+    '## Workspace Reflection',
+    '',
+    'Before you finish responding to a conversation, pause and consider: did you learn anything worth saving?',
+    '',
+    '- Did the user share personal facts (name, role, timezone, preferences)?',
+    '- Did they correct your behavior or express a preference about how you communicate?',
+    '- Did they mention a project, tool, or workflow you should remember?',
+    '- Did you adapt your style in a way that worked well and should persist?',
+    '',
+    'If yes, update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response. Don\'t mention that you\'re doing it unless the update is significant enough to warrant a note.',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Adds a "Workspace Reflection" section to the system prompt
- Nudges the assistant to review each conversation before finishing and consider whether anything learned should be saved to USER.md, SOUL.md, or IDENTITY.md
- Covers: personal facts, behavior corrections, projects/tools/workflows, and style adaptations
- Instructs the agent to update silently unless the change is significant enough to mention

## Test plan
- [x] All 33 system-prompt tests pass
- [x] Prompt-only change, no runtime logic modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
