### PR TITLE
fix: use async/await for callAsyncJavaScript in DynamicPageSurfaceView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -417,26 +417,26 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 context.coordinator.morphGeneration += 1
                 let currentGen = context.coordinator.morphGeneration
                 let htmlForMorph = data.html
-                webView.callAsyncJavaScript(
-                    "return await window.vellum.morphWithAnimation(newHTML)",
-                    arguments: ["newHTML": htmlForMorph],
-                    in: nil,
-                    contentWorld: .page
-                ) { result in
-                    // Stale callback — a newer update has arrived
-                    guard context.coordinator.morphGeneration == currentGen else { return }
+                Task { @MainActor in
+                    do {
+                        let value = try await webView.callAsyncJavaScript(
+                            "return await window.vellum.morphWithAnimation(newHTML)",
+                            arguments: ["newHTML": htmlForMorph],
+                            in: nil,
+                            contentWorld: .page
+                        )
+                        // Stale callback — a newer update has arrived
+                        guard context.coordinator.morphGeneration == currentGen else { return }
 
-                    switch result {
-                    case .success(let value):
                         let dict = value as? [String: Any]
                         if dict?["success"] as? Bool == true {
                             // Morph succeeded — trigger snapshot since didFinish won't fire
                             context.coordinator.captureSnapshotAfterMorph(generation: currentGen)
                         } else {
-                            // Fallback or cancelled
                             self.fullReload(webView, html: htmlForMorph, origin: origin, coordinator: context.coordinator)
                         }
-                    case .failure:
+                    } catch {
+                        guard context.coordinator.morphGeneration == currentGen else { return }
                         self.fullReload(webView, html: htmlForMorph, origin: origin, coordinator: context.coordinator)
                     }
                 }


### PR DESCRIPTION
## Summary
- `callAsyncJavaScript` is an `async throws` method — the completion-handler overload doesn't exist, causing a build error ("extra trailing closure passed in call")
- Wrapped the call in `Task { @MainActor in }` with `do/catch` to use the correct async/await API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
