### PR TITLE
fix: address review feedback on vellum-edit-animator.js

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-edit-animator.js
+++ b/clients/macos/vellum-assistant/Resources/vellum-edit-animator.js
@@ -167,7 +167,7 @@
           for (key in newAttrs) allKeys[key] = true;
           for (key in allKeys) {
             if (oldAttrs[key] !== newAttrs[key]) {
-              ops.push({ type: 'attr_change', node: oldChild, attr: key, oldVal: oldAttrs[key] || null, newVal: newAttrs[key] || null });
+              ops.push({ type: 'attr_change', node: oldChild, attr: key, oldVal: oldAttrs[key] !== undefined ? oldAttrs[key] : null, newVal: newAttrs[key] !== undefined ? newAttrs[key] : null });
             }
           }
           // Recurse into children
@@ -319,7 +319,11 @@
 
     // Delete old middle chars
     for (var d = oldMiddle.length; d > 0; d--) {
-      if (cancelled()) return;
+      if (cancelled()) {
+        var cleanupText = document.createTextNode(op.newText);
+        if (wrapper.parentNode) wrapper.parentNode.replaceChild(cleanupText, wrapper);
+        return;
+      }
       currentMiddle = currentMiddle.substring(0, d - 1);
       updateWrapper();
       await sleep(20);
@@ -327,7 +331,11 @@
 
     // Type new middle chars
     for (var t = 1; t <= newMiddle.length; t++) {
-      if (cancelled()) return;
+      if (cancelled()) {
+        var cleanupText2 = document.createTextNode(op.newText);
+        if (wrapper.parentNode) wrapper.parentNode.replaceChild(cleanupText2, wrapper);
+        return;
+      }
       currentMiddle = newMiddle.substring(0, t);
       updateWrapper();
       await sleep(25);
@@ -413,7 +421,8 @@
       imported.style.transform = 'translateY(-8px)';
       imported.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
     }
-    parent.insertBefore(imported, refNode || null);
+    var safeRef = (refNode && refNode.parentNode === parent) ? refNode : null;
+    parent.insertBefore(imported, safeRef);
     if (imported.nodeType === 1) {
       // Force reflow
       void imported.offsetHeight;


### PR DESCRIPTION
## Summary
- Fix cancelled text animation leaving `data-vellum-injected` wrapper in DOM
- Fix empty-string attribute values being coerced to null via `|| null`
- Fix stale refNode in parallel remove+insert causing NotFoundError

Addresses feedback from PR #3062.

## Test plan
- [ ] Cancelled morph cleans up wrapper and leaves plain text node
- [ ] Boolean attributes like `disabled=""` are correctly diffed and applied
- [ ] Parallel remove+insert animations don't throw when refNode is detached

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
