### PR TITLE
fix: mark theme and design-system styles as vellum-injected

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -203,6 +203,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             source: """
                 (function() {
                     var style = document.createElement('style');
+                    style.setAttribute('data-vellum-injected', '1');
                     style.textContent = ':root { --bg: #ffffff; --bg-subtle: #f8f9fa; --text: #1a1a2e; --text-secondary: #6b7280; --border: #e5e7eb; --accent: #6366f1; --accent-text: #ffffff; --success: #10b981; --warning: #f59e0b; --error: #ef4444; } @media (prefers-color-scheme: dark) { :root { --bg: #0f172a; --bg-subtle: #1e293b; --text: #f1f5f9; --text-secondary: #94a3b8; --border: #334155; --accent: #818cf8; --accent-text: #ffffff; --success: #34d399; --warning: #fbbf24; --error: #f87171; } }';
                     (document.head || document.documentElement).appendChild(style);
 
@@ -224,6 +225,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 (function() {
                     var style = document.createElement('style');
                     style.id = 'vellum-design-system';
+                    style.setAttribute('data-vellum-injected', '1');
                     style.textContent = `\(Self.designSystemCSS)`;
                     var target = document.head || document.documentElement;
                     target.insertBefore(style, target.firstChild);


### PR DESCRIPTION
## Summary
- Add `data-vellum-injected` attribute to theme CSS and design-system CSS `<style>` elements
- Prevents `syncHead` in the morph engine from stripping these styles during DOM morph updates

Addresses feedback from PR #3064.

## Test plan
- [ ] After morph, theme CSS variables are still present
- [ ] After morph, design-system CSS is still present
- [ ] Styles are correctly preserved across multiple morph cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
