### PR TITLE
feat: add ui_surface_complete IPC message and daemon tracking

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -596,6 +596,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     sessionId: 'sess-001',
     surfaceId: 'surface-001',
   },
+  ui_surface_complete: {
+    type: 'ui_surface_complete',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
+    summary: 'Confirmed',
+  },
   app_data_response: {
     type: 'app_data_response',
     surfaceId: 'surface-001',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1329,6 +1329,14 @@ export interface UiSurfaceDismiss {
   surfaceId: string;
 }
 
+export interface UiSurfaceComplete {
+  type: 'ui_surface_complete';
+  sessionId: string;
+  surfaceId: string;
+  summary: string;
+  submittedData?: Record<string, unknown>;
+}
+
 export interface UiSurfaceUndoResult {
   type: 'ui_surface_undo_result';
   sessionId: string;
@@ -1373,6 +1381,7 @@ export type ServerMessage =
   | UiSurfaceShow
   | UiSurfaceUpdate
   | UiSurfaceDismiss
+  | UiSurfaceComplete
   | UiSurfaceUndoResult
   | AppDataResponse
   | SkillsListResponse

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -126,6 +126,7 @@ export class Session {
   private pendingSurfaceActions = new Map<string, {
     surfaceType: SurfaceType;
   }>();
+  private lastSurfaceAction = new Map<string, { actionId: string; data?: Record<string, unknown> }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
   /** Per-surface undo stack: stores previous HTML strings for workspace refinement undo. */
   private surfaceUndoStacks = new Map<string, string[]>();
@@ -1543,6 +1544,7 @@ export class Session {
       log.debug({ surfaceId, data }, 'Selection changed (non-terminal, not forwarding)');
       return;
     }
+    this.lastSurfaceAction.set(surfaceId, { actionId, data });
     const content = JSON.stringify({
       surfaceAction: true,
       surfaceId,
@@ -2071,15 +2073,29 @@ export class Session {
 
     if (toolName === 'ui_dismiss') {
       const surfaceId = input.surface_id as string;
-      this.sendToClient({
-        type: 'ui_surface_dismiss',
-        sessionId: this.conversationId,
-        surfaceId,
-      });
+      const lastAction = this.lastSurfaceAction.get(surfaceId);
+      const stored = this.surfaceState.get(surfaceId);
+      if (lastAction) {
+        const summary = this.buildCompletionSummary(stored?.surfaceType, lastAction.actionId, lastAction.data);
+        this.sendToClient({
+          type: 'ui_surface_complete',
+          sessionId: this.conversationId,
+          surfaceId,
+          summary,
+          submittedData: lastAction.data,
+        });
+      } else {
+        this.sendToClient({
+          type: 'ui_surface_dismiss',
+          sessionId: this.conversationId,
+          surfaceId,
+        });
+      }
       this.pendingSurfaceActions.delete(surfaceId);
       this.surfaceState.delete(surfaceId);
       this.surfaceUndoStacks.delete(surfaceId);
-      return { content: 'Surface dismissed', isError: false };
+      this.lastSurfaceAction.delete(surfaceId);
+      return { content: lastAction ? 'Surface completed' : 'Surface dismissed', isError: false };
     }
 
     if (toolName === 'request_computer_control') {
@@ -2211,6 +2227,26 @@ export class Session {
       conversationStore.updateConversationTitle(this.conversationId, title);
       log.info({ conversationId: this.conversationId, title }, 'Auto-generated conversation title');
     }
+  }
+
+  private buildCompletionSummary(surfaceType: string | undefined, actionId: string, data?: Record<string, unknown>): string {
+    if (surfaceType === 'confirmation') {
+      return actionId === 'cancel' ? 'Cancelled' : 'Confirmed';
+    }
+    if (surfaceType === 'form') {
+      return 'Submitted';
+    }
+    if (surfaceType === 'list' && data) {
+      const selected = data.selectedId as string | undefined;
+      if (selected) return `Selected: ${selected}`;
+      const selectedIds = data.selectedIds as string[] | undefined;
+      if (selectedIds?.length) return `Selected ${selectedIds.length} items`;
+    }
+    if (surfaceType === 'table' && data) {
+      const selectedIds = data.selectedIds as string[] | undefined;
+      if (selectedIds?.length) return `Selected ${selectedIds.length} rows`;
+    }
+    return actionId.charAt(0).toUpperCase() + actionId.slice(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `UiSurfaceComplete` interface to the IPC contract (`ipc-contract.ts`) and includes it in the `ServerMessage` union type
- Tracks the last user action per surface in the daemon session via a `lastSurfaceAction` map
- When a surface is dismissed via `ui_dismiss`, sends `ui_surface_complete` (with a human-readable summary) instead of `ui_surface_dismiss` if the user interacted with the surface
- Adds `buildCompletionSummary()` helper that generates contextual summaries based on surface type (confirmation, form, list, table)

Part of #3068.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify confirmation surfaces send "Confirmed"/"Cancelled" summaries
- [ ] Verify form surfaces send "Submitted" summary
- [ ] Verify list/table surfaces include selection counts in summary
- [ ] Verify surfaces dismissed without interaction still send `ui_surface_dismiss`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
