### PR TITLE
feat: add multi-page form data model and FormSurfaceView pagination

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -450,10 +450,19 @@ export interface FormField {
   options?: Array<{ label: string; value: string }>;
 }
 
+export interface FormPage {
+  id: string;
+  title: string;
+  description?: string;
+  fields: FormField[];
+}
+
 export interface FormSurfaceData {
   description?: string;
   fields: FormField[];
   submitLabel?: string;
+  pages?: FormPage[];
+  pageLabels?: { next?: string; back?: string; submit?: string };
 }
 
 export interface ListItem {

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -38,7 +38,8 @@ export const uiShowTool: Tool = {
     '- table: Data table with columns, selectable rows, and action buttons. ' +
     'data shape: { columns: Array<{ id: string, label: string }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }\n' +
     '- form: Input form with typed fields. ' +
-    'data shape: { description?: string, fields: Array<{ id: string, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label: string, placeholder?: string, required?: boolean, defaultValue?: string|number|boolean, options?: Array<{ label: string, value: string }> }>, submitLabel?: string }\n' +
+    'data shape: { description?: string, fields: Array<{ id: string, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label: string, placeholder?: string, required?: boolean, defaultValue?: string|number|boolean, options?: Array<{ label: string, value: string }> }>, submitLabel?: string }. ' +
+    'For multi-page forms, use pages array instead of top-level fields: { pages: [{ id: string, title: string, description?: string, fields: [...] }], pageLabels?: { next?: string, back?: string, submit?: string }, submitLabel?: string }\n' +
     '- list: Selectable list of items. ' +
     'data shape: { items: Array<{ id: string, title: string, subtitle?: string, icon?: string, selected?: boolean }>, selectionMode: "single"|"multiple"|"none" }\n' +
     '- confirmation: Yes/no confirmation dialog. ' +

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -203,6 +203,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             source: """
                 (function() {
                     var style = document.createElement('style');
+                    style.setAttribute('data-vellum-injected', '1');
                     style.textContent = ':root { --bg: #ffffff; --bg-subtle: #f8f9fa; --text: #1a1a2e; --text-secondary: #6b7280; --border: #e5e7eb; --accent: #6366f1; --accent-text: #ffffff; --success: #10b981; --warning: #f59e0b; --error: #ef4444; } @media (prefers-color-scheme: dark) { :root { --bg: #0f172a; --bg-subtle: #1e293b; --text: #f1f5f9; --text-secondary: #94a3b8; --border: #334155; --accent: #818cf8; --accent-text: #ffffff; --success: #34d399; --warning: #fbbf24; --error: #f87171; } }';
                     (document.head || document.documentElement).appendChild(style);
 
@@ -224,6 +225,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 (function() {
                     var style = document.createElement('style');
                     style.id = 'vellum-design-system';
+                    style.setAttribute('data-vellum-injected', '1');
                     style.textContent = `\(Self.designSystemCSS)`;
                     var target = document.head || document.documentElement;
                     target.insertBefore(style, target.firstChild);

--- a/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
@@ -8,29 +8,104 @@ struct FormSurfaceView: View {
     @State private var textValues: [String: String] = [:]
     @State private var toggleValues: [String: Bool] = [:]
     @State private var selectValues: [String: String] = [:]
+    @State private var currentPageIndex: Int = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            if let description = data.description {
-                Text(description)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-            }
+            if let pages = data.pages, !pages.isEmpty {
+                // Multi-page mode
+                pageIndicator(currentPage: currentPageIndex, totalPages: pages.count)
 
-            ForEach(data.fields) { field in
-                fieldView(for: field)
-            }
+                let page = pages[currentPageIndex]
+                Text(page.title)
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
 
-            VButton(
-                label: data.submitLabel ?? "Submit",
-                style: .primary,
-                isFullWidth: true
-            ) {
-                submitForm()
+                if let desc = page.description {
+                    Text(desc)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                ForEach(page.fields) { field in
+                    fieldView(for: field)
+                }
+
+                pageNavigation(currentPage: currentPageIndex, totalPages: pages.count)
+            } else {
+                // Single-page mode (existing behavior)
+                if let description = data.description {
+                    Text(description)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                ForEach(data.fields) { field in
+                    fieldView(for: field)
+                }
+
+                VButton(
+                    label: data.submitLabel ?? "Submit",
+                    style: .primary,
+                    isFullWidth: true
+                ) {
+                    submitForm()
+                }
             }
         }
         .onAppear {
             initializeDefaults()
+        }
+    }
+
+    // MARK: - Page Navigation
+
+    @ViewBuilder
+    private func pageIndicator(currentPage: Int, totalPages: Int) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            ForEach(0..<totalPages, id: \.self) { index in
+                Circle()
+                    .fill(index == currentPage ? VColor.accent : VColor.surfaceBorder)
+                    .frame(width: 6, height: 6)
+            }
+            Spacer()
+            Text("\(currentPage + 1) of \(totalPages)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+    }
+
+    @ViewBuilder
+    private func pageNavigation(currentPage: Int, totalPages: Int) -> some View {
+        HStack(spacing: VSpacing.md) {
+            if currentPage > 0 {
+                VButton(
+                    label: data.pageLabels?.back ?? "Back",
+                    style: .ghost
+                ) {
+                    withAnimation(VAnimation.fast) {
+                        currentPageIndex -= 1
+                    }
+                }
+            }
+            Spacer()
+            if currentPage < totalPages - 1 {
+                VButton(
+                    label: data.pageLabels?.next ?? "Next",
+                    style: .primary
+                ) {
+                    withAnimation(VAnimation.fast) {
+                        currentPageIndex += 1
+                    }
+                }
+            } else {
+                VButton(
+                    label: data.pageLabels?.submit ?? data.submitLabel ?? "Submit",
+                    style: .primary
+                ) {
+                    submitForm()
+                }
+            }
         }
     }
 
@@ -140,7 +215,13 @@ struct FormSurfaceView: View {
     // MARK: - Defaults & Submit
 
     private func initializeDefaults() {
-        for field in data.fields {
+        let allFields: [FormField]
+        if let pages = data.pages {
+            allFields = data.fields + pages.flatMap { $0.fields }
+        } else {
+            allFields = data.fields
+        }
+        for field in allFields {
             guard let defaultValue = field.defaultValue else { continue }
             switch field.type {
             case .text, .textarea, .number, .password:
@@ -159,7 +240,13 @@ struct FormSurfaceView: View {
 
     private func submitForm() {
         var values: [String: Any] = [:]
-        for field in data.fields {
+        let allFields: [FormField]
+        if let pages = data.pages {
+            allFields = data.fields + pages.flatMap { $0.fields }
+        } else {
+            allFields = data.fields
+        }
+        for field in allFields {
             switch field.type {
             case .text, .textarea, .number, .password:
                 values[field.id] = textValues[field.id] ?? ""

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -118,15 +118,45 @@ public struct FormField: Identifiable, Sendable {
     }
 }
 
+public struct FormPage: Identifiable, Sendable {
+    public let id: String
+    public let title: String
+    public let description: String?
+    public let fields: [FormField]
+
+    public init(id: String, title: String, description: String? = nil, fields: [FormField]) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.fields = fields
+    }
+}
+
+public struct FormPageLabels: Sendable {
+    public let next: String?
+    public let back: String?
+    public let submit: String?
+
+    public init(next: String? = nil, back: String? = nil, submit: String? = nil) {
+        self.next = next
+        self.back = back
+        self.submit = submit
+    }
+}
+
 public struct FormSurfaceData: Sendable {
     public let description: String?
     public let fields: [FormField]
     public let submitLabel: String?
+    public let pages: [FormPage]?
+    public let pageLabels: FormPageLabels?
 
-    public init(description: String? = nil, fields: [FormField], submitLabel: String? = nil) {
+    public init(description: String? = nil, fields: [FormField], submitLabel: String? = nil, pages: [FormPage]? = nil, pageLabels: FormPageLabels? = nil) {
         self.description = description
         self.fields = fields
         self.submitLabel = submitLabel
+        self.pages = pages
+        self.pageLabels = pageLabels
     }
 }
 
@@ -452,7 +482,31 @@ public extension Surface {
             fields = parseFormFields(fieldsArray)
         }
 
-        return FormSurfaceData(description: description, fields: fields, submitLabel: submitLabel)
+        var pages = existing.pages
+        if let pagesArray = update["pages"] as? [[String: Any?]] {
+            pages = pagesArray.compactMap { pageDict -> FormPage? in
+                guard let id = pageDict["id"] as? String,
+                      let title = pageDict["title"] as? String else { return nil }
+                let pageFields: [FormField]
+                if let pf = pageDict["fields"] as? [[String: Any?]] {
+                    pageFields = parseFormFields(pf)
+                } else {
+                    pageFields = []
+                }
+                return FormPage(id: id, title: title, description: pageDict["description"] as? String, fields: pageFields)
+            }
+        }
+
+        var pageLabels = existing.pageLabels
+        if let labelsDict = update["pageLabels"] as? [String: Any?] {
+            pageLabels = FormPageLabels(
+                next: labelsDict["next"] as? String,
+                back: labelsDict["back"] as? String,
+                submit: labelsDict["submit"] as? String
+            )
+        }
+
+        return FormSurfaceData(description: description, fields: fields, submitLabel: submitLabel, pages: pages, pageLabels: pageLabels)
     }
 
     private static func mergeListData(existing: ListSurfaceData, update: [String: Any?]) -> ListSurfaceData {
@@ -578,18 +632,52 @@ public extension Surface {
     }
 
     private static func parseFormData(_ dict: [String: Any?]) -> FormSurfaceData? {
-        guard let fieldsArray = dict["fields"] as? [[String: Any?]] else {
-            return nil
+        // Pages mode OR flat fields mode
+        let fields: [FormField]
+        if let fieldsArray = dict["fields"] as? [[String: Any?]] {
+            fields = parseFormFields(fieldsArray)
+        } else {
+            fields = []
         }
 
         let description = dict["description"] as? String
         let submitLabel = dict["submitLabel"] as? String
-        let fields = parseFormFields(fieldsArray)
+
+        var pages: [FormPage]?
+        if let pagesArray = dict["pages"] as? [[String: Any?]] {
+            pages = pagesArray.compactMap { pageDict -> FormPage? in
+                guard let id = pageDict["id"] as? String,
+                      let title = pageDict["title"] as? String else { return nil }
+                let pageFields: [FormField]
+                if let pf = pageDict["fields"] as? [[String: Any?]] {
+                    pageFields = parseFormFields(pf)
+                } else {
+                    pageFields = []
+                }
+                return FormPage(id: id, title: title, description: pageDict["description"] as? String, fields: pageFields)
+            }
+        }
+
+        var pageLabels: FormPageLabels?
+        if let labelsDict = dict["pageLabels"] as? [String: Any?] {
+            pageLabels = FormPageLabels(
+                next: labelsDict["next"] as? String,
+                back: labelsDict["back"] as? String,
+                submit: labelsDict["submit"] as? String
+            )
+        }
+
+        // Need at least fields or pages
+        if fields.isEmpty && (pages?.isEmpty ?? true) {
+            return nil
+        }
 
         return FormSurfaceData(
             description: description,
             fields: fields,
-            submitLabel: submitLabel
+            submitLabel: submitLabel,
+            pages: pages,
+            pageLabels: pageLabels
         )
     }
 


### PR DESCRIPTION
## Summary
- Adds `FormPage` and `FormPageLabels` types to both TypeScript (`ipc-contract.ts`) and Swift (`SurfaceTypes.swift`)
- Updates `FormSurfaceView` with page indicator dots, Back/Next/Submit navigation, and multi-page field collection
- Documents multi-page form support in the `ui_show` tool description
- Single-page forms continue to work unchanged (backwards compatible)

Part of #3068.

## Test plan
- [ ] Verify TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify single-page forms still render and submit correctly
- [ ] Test multi-page form with pages array: page dots, navigation, and field value collection across pages
- [ ] Test custom pageLabels override default Back/Next/Submit text
- [ ] Test ui_update merges pages and pageLabels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
