### PR TITLE
feat: add Swift IPC decode and data model for surface completion

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -373,13 +373,28 @@ public struct InlineSurfaceData: Identifiable, Equatable {
         lhs.id == rhs.id
     }
 
-    public init(id: String, surfaceType: SurfaceType, title: String?, data: SurfaceData, actions: [SurfaceActionButton], surfaceMessage: UiSurfaceShowMessage? = nil) {
+    /// When non-nil, the surface has been completed and should render in collapsed/chip state.
+    public var completionState: SurfaceCompletionState?
+
+    public init(id: String, surfaceType: SurfaceType, title: String?, data: SurfaceData, actions: [SurfaceActionButton], surfaceMessage: UiSurfaceShowMessage? = nil, completionState: SurfaceCompletionState? = nil) {
         self.id = id
         self.surfaceType = surfaceType
         self.title = title
         self.data = data
         self.actions = actions
         self.surfaceMessage = surfaceMessage
+        self.completionState = completionState
+    }
+}
+
+/// Tracks the completed state of an inline surface after user interaction.
+public struct SurfaceCompletionState: Equatable {
+    public let summary: String
+    public let submittedData: [String: AnyCodable]?
+
+    public init(summary: String, submittedData: [String: AnyCodable]? = nil) {
+        self.summary = summary
+        self.submittedData = submittedData
     }
 }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -77,6 +77,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `ui_surface_dismiss` message.
     public var onSurfaceDismiss: ((UiSurfaceDismissMessage) -> Void)?
 
+    /// Called when the daemon sends a `ui_surface_complete` message.
+    public var onSurfaceComplete: ((UiSurfaceCompleteMessage) -> Void)?
+
     /// Called when the daemon sends an `app_data_response` message.
     public var onAppDataResponse: ((AppDataResponseMessage) -> Void)?
 
@@ -893,6 +896,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSurfaceUpdate?(msg)
         case .uiSurfaceDismiss(let msg):
             onSurfaceDismiss?(msg)
+        case .uiSurfaceComplete(let msg):
+            onSurfaceComplete?(msg)
         case .uiLayoutConfig(let msg):
             onLayoutConfig?(msg)
         case .appDataResponse(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -33,6 +33,8 @@ import Foundation
 // │                                 │ code generator cannot emit Swift enums   │
 // │ ServerMessage (enum)            │ Discriminated union with custom          │
 // │                                 │ Decodable init; always hand-maintained   │
+// │ UiSurfaceCompleteMessage        │ Uses AnyCodable for `submittedData`;     │
+// │                                 │ contract type is skipped (SKIP_TYPES)    │
 // │ UiLayoutConfigMessage           │ Temporary; canonical home is             │
 // │                                 │ LayoutConfig.swift (M1 / #2973)         │
 // │ SlotConfigWire                  │ Temporary; canonical home is             │
@@ -738,6 +740,14 @@ public struct UiSurfaceUpdateMessage: Decodable, Sendable {
 /// Backed by generated `IPCUiSurfaceDismiss`.
 public typealias UiSurfaceDismissMessage = IPCUiSurfaceDismiss
 
+/// Surface completion message from daemon, sent when user interaction completes a surface.
+public struct UiSurfaceCompleteMessage: Decodable, Sendable {
+    public let sessionId: String
+    public let surfaceId: String
+    public let summary: String
+    public let submittedData: [String: AnyCodable]?
+}
+
 /// Confirms undo/regenerate removed messages.
 public typealias UndoCompleteMessage = IPCUndoComplete
 
@@ -1401,6 +1411,7 @@ public enum ServerMessage: Decodable, Sendable {
     case uiSurfaceShow(UiSurfaceShowMessage)
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
+    case uiSurfaceComplete(UiSurfaceCompleteMessage)
     case uiLayoutConfig(UiLayoutConfigMessage)
     case undoComplete(UndoCompleteMessage)
     case generationCancelled(GenerationCancelledMessage)
@@ -1508,6 +1519,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "ui_surface_dismiss":
             let message = try UiSurfaceDismissMessage(from: decoder)
             self = .uiSurfaceDismiss(message)
+        case "ui_surface_complete":
+            let message = try UiSurfaceCompleteMessage(from: decoder)
+            self = .uiSurfaceComplete(message)
         case "ui_layout_config":
             let message = try UiLayoutConfigMessage(from: decoder)
             self = .uiLayoutConfig(message)


### PR DESCRIPTION
## Summary
- Add `UiSurfaceCompleteMessage` struct to `IPCMessages.swift` for decoding `ui_surface_complete` daemon messages (uses AnyCodable for `submittedData`)
- Wire up `onSurfaceComplete` callback in `DaemonClient` to forward surface completion events
- Add `SurfaceCompletionState` struct and `completionState` property to `InlineSurfaceData` for tracking completed inline surfaces

Part of #3068.

## Test plan
- [ ] Verify Swift builds cleanly with new types
- [ ] Confirm `ui_surface_complete` messages decode correctly via DaemonClient
- [ ] Verify `SurfaceCompletionState` equality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
