### PR TITLE
feat: inline form/confirmation rendering and system prompt guidance

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -175,6 +175,16 @@ function buildDynamicUiSection(): string {
     'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a visual output rather than displaying raw tool outputs.',
     '- **Weather**: `get_weather` automatically renders a dynamic page with a compact preview card. Do NOT call `ui_show` or `app_create` after `get_weather` — the weather surface is emitted directly. Just respond with a brief natural-language summary.',
     '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished output — use `app_create` for custom UIs, or `ui_show` with domain component classes for predefined data types.',
+    '',
+    '### Presenting choices to the user',
+    'When you need the user to make a choice or provide structured input, prefer interactive UI surfaces over plain text:',
+    '- **Simple option selection** (2-8 choices): Use a `list` surface with `selectionMode: "single"`',
+    '- **Structured input** (names, settings, config): Use a `form` surface with typed fields',
+    '- **Complex configuration** (many fields, logical grouping): Use a multi-page `form` with `pages` array',
+    '- **Destructive or important actions**: Use a `confirmation` surface',
+    '- **Data review/selection**: Use a `table` surface with selectable rows',
+    '',
+    'Interactive surfaces provide a better user experience than asking the user to type their choice. Only fall back to plain text when the interaction is conversational or doesn\'t fit a structured format.',
   ].join('\n');
 }
 

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -109,6 +109,18 @@ public struct InlineSurfaceRouter: View {
                 }
                 onAction(surface.id, actionId, payload)
             }
+        case .form(let data):
+            FormSurfaceView(data: data) { values in
+                var payload: [String: AnyCodable]? = nil
+                if let values {
+                    payload = values.mapValues { AnyCodable($0) }
+                }
+                onAction(surface.id, "submit", payload)
+            }
+        case .confirmation(let data):
+            ConfirmationSurfaceView(data: data, actions: surface.actions) { actionId in
+                onAction(surface.id, actionId, nil)
+            }
         default:
             InlineFallbackChip(surfaceType: surface.surfaceType)
         }

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -1,10 +1,15 @@
-import VellumAssistantShared
 import SwiftUI
 
-struct ConfirmationSurfaceView: View {
-    let data: ConfirmationSurfaceData
-    let actions: [SurfaceActionButton]
-    let onAction: (String) -> Void
+public struct ConfirmationSurfaceView: View {
+    public let data: ConfirmationSurfaceData
+    public let actions: [SurfaceActionButton]
+    public let onAction: (String) -> Void
+
+    public init(data: ConfirmationSurfaceData, actions: [SurfaceActionButton], onAction: @escaping (String) -> Void) {
+        self.data = data
+        self.actions = actions
+        self.onAction = onAction
+    }
 
     /// The action ID to emit when the user cancels.
     /// Uses the first server-provided action ID if exactly 2 actions are defined, otherwise defaults to "cancel".
@@ -24,7 +29,7 @@ struct ConfirmationSurfaceView: View {
         return "confirm"
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // Header with icon
             HStack(spacing: VSpacing.md) {
@@ -63,37 +68,4 @@ struct ConfirmationSurfaceView: View {
             }
         }
     }
-}
-
-#Preview("Default") {
-    ConfirmationSurfaceView(
-        data: ConfirmationSurfaceData(
-            message: "Delete this file?",
-            detail: "This action cannot be undone. The file will be permanently removed.",
-            confirmLabel: "Delete",
-            cancelLabel: "Keep",
-            destructive: true
-        ),
-        actions: [
-            SurfaceActionButton(id: "cancel", label: "Keep", style: .secondary),
-            SurfaceActionButton(id: "confirm", label: "Delete", style: .destructive),
-        ],
-        onAction: { _ in }
-    )
-    .padding()
-}
-
-#Preview("Non-destructive") {
-    ConfirmationSurfaceView(
-        data: ConfirmationSurfaceData(
-            message: "Submit this form?",
-            detail: "Your responses will be sent to the server.",
-            confirmLabel: nil,
-            cancelLabel: nil,
-            destructive: false
-        ),
-        actions: [],
-        onAction: { _ in }
-    )
-    .padding()
 }

--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -1,16 +1,20 @@
-import VellumAssistantShared
 import SwiftUI
 
-struct FormSurfaceView: View {
-    let data: FormSurfaceData
-    let onSubmit: ([String: Any]?) -> Void
+public struct FormSurfaceView: View {
+    public let data: FormSurfaceData
+    public let onSubmit: ([String: Any]?) -> Void
 
     @State private var textValues: [String: String] = [:]
     @State private var toggleValues: [String: Bool] = [:]
     @State private var selectValues: [String: String] = [:]
     @State private var currentPageIndex: Int = 0
 
-    var body: some View {
+    public init(data: FormSurfaceData, onSubmit: @escaping ([String: Any]?) -> Void) {
+        self.data = data
+        self.onSubmit = onSubmit
+    }
+
+    public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             if let pages = data.pages, !pages.isEmpty {
                 // Multi-page mode
@@ -258,26 +262,4 @@ struct FormSurfaceView: View {
         }
         onSubmit(values)
     }
-}
-
-#Preview {
-    FormSurfaceView(
-        data: FormSurfaceData(
-            description: "Configure your assistant preferences.",
-            fields: [
-                FormField(id: "name", type: .text, label: "Name", placeholder: "Enter your name", required: true, defaultValue: nil, options: nil),
-                FormField(id: "bio", type: .textarea, label: "Bio", placeholder: "Tell us about yourself", required: false, defaultValue: nil, options: nil),
-                FormField(id: "role", type: .select, label: "Role", placeholder: "Select a role", required: true, defaultValue: nil, options: [
-                    FormFieldOption(label: "Developer", value: "dev"),
-                    FormFieldOption(label: "Designer", value: "design"),
-                    FormFieldOption(label: "Manager", value: "pm"),
-                ]),
-                FormField(id: "notifications", type: .toggle, label: "Enable notifications", placeholder: nil, required: false, defaultValue: .boolean(true), options: nil),
-            ],
-            submitLabel: "Save"
-        ),
-        onSubmit: { _ in }
-    )
-    .padding()
-    .frame(width: 380)
 }


### PR DESCRIPTION
## Summary
- Move `FormSurfaceView` and `ConfirmationSurfaceView` from the macOS-only target (`VellumAssistantLib`) to the shared target (`VellumAssistantShared`) so they can be used across platforms
- Add explicit `.form` and `.confirmation` cases to `InlineSurfaceRouter` so these surface types render inline in chat instead of falling back to a generic chip
- Update the system prompt with a "Presenting choices to the user" section that guides the LLM to prefer interactive UI surfaces over plain text

Part of #3068.

## Test plan
- [ ] Verify form surfaces render inline in chat with all field types (text, textarea, select, toggle, password)
- [ ] Verify confirmation surfaces render inline with confirm/cancel buttons
- [ ] Verify multi-page forms work correctly inline
- [ ] Verify the macOS panel rendering (`SurfaceContainerView`) still works since it now uses the shared versions
- [ ] Verify fallback chip still renders for unknown surface types
- [ ] Verify TypeScript type-check passes for system prompt changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
