### PR TITLE
feat: surface completion UI with CompletedSurfaceChip and shouldShowBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -639,7 +639,11 @@ private struct ChatBubble: View {
     /// that should not appear above the rendered dynamic UI surface.
     private var shouldShowBubble: Bool {
         if isUser { return true }
-        if !message.inlineSurfaces.isEmpty { return false }
+        if !message.inlineSurfaces.isEmpty {
+            // Show bubble text when all surfaces are completed (collapsed to chips)
+            let allCompleted = message.inlineSurfaces.allSatisfy { $0.completionState != nil }
+            if !allCompleted { return false }
+        }
         return hasText || !message.attachments.isEmpty
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1342,6 +1342,19 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
 
+        case .uiSurfaceComplete(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            // Find the inline surface across all messages and set its completionState
+            for msgIndex in messages.indices {
+                if let surfaceIndex = messages[msgIndex].inlineSurfaces.firstIndex(where: { $0.id == msg.surfaceId }) {
+                    messages[msgIndex].inlineSurfaces[surfaceIndex].completionState = SurfaceCompletionState(
+                        summary: msg.summary,
+                        submittedData: msg.submittedData
+                    )
+                    return
+                }
+            }
+
         case .sessionError(let msg):
             guard sessionId != nil, belongsToSession(msg.sessionId) else { return }
             log.error("Session error [\(msg.code.rawValue)]: \(msg.userMessage)")

--- a/clients/shared/Features/Chat/InlineWidgets/CompletedSurfaceChip.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/CompletedSurfaceChip.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Compact chip shown for a completed inline surface, displaying a checkmark and summary.
+public struct CompletedSurfaceChip: View {
+    public let title: String?
+    public let summary: String
+
+    public init(title: String?, summary: String) {
+        self.title = title
+        self.summary = summary
+    }
+
+    public var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(VFont.caption)
+                .foregroundColor(VColor.success)
+
+            if let title {
+                Text(title)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textPrimary)
+            }
+
+            Text(summary)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.backgroundSubtle.opacity(0.5))
+        )
+    }
+}

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -29,6 +29,9 @@ public struct InlineSurfaceRouter: View {
     }
 
     public var body: some View {
+        if let completion = surface.completionState {
+            CompletedSurfaceChip(title: surface.title, summary: completion.summary)
+        } else {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Template cards handle their own header — skip the generic title
             if !isTemplateCard, let title = surface.title {
@@ -71,6 +74,7 @@ public struct InlineSurfaceRouter: View {
         }
         // Consistent width for all widget cards; dynamic page previews are more compact.
         .frame(maxWidth: isDynamicPreview ? 350 : 540, alignment: .leading)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Add `uiSurfaceComplete` handler in ChatViewModel to set `completionState` on inline surfaces when the daemon reports completion
- Create `CompletedSurfaceChip` view showing a checkmark icon and summary text for completed surfaces
- Update `InlineSurfaceRouter` to render the chip instead of the full surface when completed
- Fix `shouldShowBubble` in ChatView to show bubble text when all surfaces are completed (collapsed to chips)

Part of #3068.

## Test plan
- [ ] Verify that when a surface completes, the full widget collapses to a compact chip with checkmark and summary
- [ ] Verify that the bubble text reappears when all surfaces on a message are completed
- [ ] Verify that partially completed messages (some surfaces still active) still hide the bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
