### PR TITLE
fix: buildCompletionSummary dead selectedId check and grammar

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -2399,13 +2399,13 @@ export class Session {
       return 'Submitted';
     }
     if (surfaceType === 'list' && data) {
-      const selected = data.selectedId as string | undefined;
-      if (selected) return `Selected: ${selected}`;
       const selectedIds = data.selectedIds as string[] | undefined;
+      if (selectedIds?.length === 1) return `Selected: ${selectedIds[0]}`;
       if (selectedIds?.length) return `Selected ${selectedIds.length} items`;
     }
     if (surfaceType === 'table' && data) {
       const selectedIds = data.selectedIds as string[] | undefined;
+      if (selectedIds?.length === 1) return `Selected 1 row`;
       if (selectedIds?.length) return `Selected ${selectedIds.length} rows`;
     }
     return actionId.charAt(0).toUpperCase() + actionId.slice(1);


### PR DESCRIPTION
Addresses feedback on #3078. Removes dead `selectedId` check (client sends `selectedIds`), adds single-item summary for lists, fixes singular/plural grammar for tables.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
