### PR TITLE
fix: preserve insert position when refNode is removed during morph

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-edit-animator.js
+++ b/clients/macos/vellum-assistant/Resources/vellum-edit-animator.js
@@ -526,7 +526,22 @@
       await animateTextReplace(textOps[t], cancelled);
     }
 
-    // Animate style changes and structural changes in parallel
+    // Pre-resolve insert refNodes: if a refNode is queued for removal, walk
+    // to the next sibling that isn't being removed so the insert lands in the
+    // correct position instead of falling back to append-at-end.
+    var removedNodes = [];
+    for (var rn = 0; rn < removeOps.length; rn++) {
+      removedNodes.push(removeOps[rn].node);
+    }
+    for (var ri = 0; ri < insertOps.length; ri++) {
+      var ref = insertOps[ri].refNode;
+      while (ref && removedNodes.indexOf(ref) >= 0) {
+        ref = ref.nextSibling;
+      }
+      insertOps[ri].refNode = ref;
+    }
+
+    // Animate style changes and removes in parallel
     var parallelTasks = [];
 
     for (var s = 0; s < styleOps.length; s++) {
@@ -538,13 +553,21 @@
       parallelTasks.push(animateRemove(removeOps[r].node));
     }
 
-    for (var ins = 0; ins < insertOps.length; ins++) {
-      if (cancelled()) return { cancelled: true };
-      parallelTasks.push(animateInsert(insertOps[ins].node, insertOps[ins].parent, insertOps[ins].refNode));
-    }
-
     if (parallelTasks.length > 0) {
       await Promise.all(parallelTasks);
+    }
+
+    if (cancelled()) return { cancelled: true };
+
+    // Inserts run after removes so refNodes are stable in the DOM
+    var insertTasks = [];
+    for (var ins = 0; ins < insertOps.length; ins++) {
+      if (cancelled()) return { cancelled: true };
+      insertTasks.push(animateInsert(insertOps[ins].node, insertOps[ins].parent, insertOps[ins].refNode));
+    }
+
+    if (insertTasks.length > 0) {
+      await Promise.all(insertTasks);
     }
 
     if (cancelled()) return { cancelled: true };


### PR DESCRIPTION
## Summary
- Pre-resolve insert refNodes by walking past nodes queued for removal, so inserts land in the correct DOM position
- Sequence removes before inserts (removes + styles in parallel, then inserts in parallel) so refNodes are stable when `insertBefore` runs
- Keeps the `safeRef` guard in `animateInsert` as a defensive fallback

Addresses feedback from PR #3076.

## Test plan
- [ ] Replace leading nodes before a kept sibling: verify new content appears in correct position (not appended to end)
- [ ] Parallel remove+insert on same parent: verify DOM order matches expected output
- [ ] Style transitions still animate concurrently with removes
- [ ] Cancellation during remove phase returns `{ cancelled: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
