### PR TITLE
fix: include layoutConfig.left.visible in sidebar hit testing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -122,7 +122,7 @@ struct MainWindowView: View {
                         threadDrawerView
                             .frame(width: sidebarOpen && windowState.layoutConfig.left.visible ? (windowState.layoutConfig.left.width ?? threadDrawerWidth) : 0, alignment: .leading)
                             .clipped()
-                            .allowsHitTesting(sidebarOpen)
+                            .allowsHitTesting(sidebarOpen && windowState.layoutConfig.left.visible)
                             .animation(isDrawerDragging ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: sidebarOpen)
                             .animation(nil, value: threadDrawerWidth)
 


### PR DESCRIPTION
## Summary

- Aligns `.allowsHitTesting` condition with the `.frame(width:)` condition for the sidebar in `MainWindowView`
- When the daemon sets `layoutConfig.left.visible = false` while `sidebarOpen` persists as `true` in `@AppStorage`, the sidebar had 0 width but hit testing remained enabled, causing an invisible hit-test region
- Adds `&& windowState.layoutConfig.left.visible` to the `.allowsHitTesting` modifier

Addresses review feedback from PR #3063.

## Test plan

- [ ] Toggle sidebar open, verify hit testing works normally
- [ ] Have daemon set `layoutConfig.left.visible = false` while `sidebarOpen` is `true` — verify sidebar area no longer intercepts clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
