### PR TITLE
fix: address PR #3052 feedback (regenerate + deny + confirmation)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -297,8 +297,30 @@ struct ChatView: View {
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                             }
-                            // Decided confirmations are rendered as compact chips
-                            // on the preceding assistant message's ChatBubble — skip here.
+                            // Decided confirmations are normally rendered as compact chips
+                            // on the preceding assistant message's ChatBubble. But if there
+                            // is no preceding assistant message, render them inline so they
+                            // don't disappear entirely.
+                            else {
+                                let hasPrecedingAssistant: Bool = {
+                                    guard index > 0 else { return false }
+                                    return messages[index - 1].role == .assistant
+                                }()
+
+                                if !hasPrecedingAssistant {
+                                    ToolConfirmationBubble(
+                                        confirmation: confirmation,
+                                        showDescription: true,
+                                        onAllow: { onConfirmationAllow(confirmation.requestId) },
+                                        onDeny: { onConfirmationDeny(confirmation.requestId) },
+                                        onAddTrustRule: onAddTrustRule
+                                    )
+                                    .id(message.id)
+                                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                }
+                                // When there IS a preceding assistant message, the decided
+                                // confirmation is rendered as a chip on that bubble — skip here.
+                            }
                         } else {
                             // Hide tool call chips when the next message is a pending
                             // confirmation — the tool hasn't been approved yet.
@@ -316,7 +338,9 @@ struct ChatView: View {
 
                             let isLastAssistant = message.role == .assistant
                                 && !message.isStreaming
-                                && index == messages.count - 1
+                                && (index == messages.count - 1
+                                    || (index == messages.count - 2
+                                        && messages[messages.count - 1].confirmation != nil))
                                 && !isSending
                                 && !isThinking
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -79,6 +79,10 @@ public struct ToolConfirmationBubble: View {
                 VButton(label: "I\u{2019}ve granted it", style: .ghost) {
                     onAllow()
                 }
+
+                VButton(label: "Skip", style: .ghost) {
+                    onDeny()
+                }
             }
         }
         .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- **Regenerate visibility**: Updated `isLastAssistant` check to account for trailing decided confirmation messages, so the regenerate button shows correctly after tool permission flow
- **Deny button**: Added explicit "Skip" deny button to system permission cards so users can reject inline instead of being blocked
- **Orphan confirmations**: Decided confirmations without a preceding assistant bubble now render inline instead of disappearing

## Test plan
- [ ] Verify regenerate button appears after approving/denying a tool permission
- [ ] Verify system permission cards show "Open System Settings", "I've granted it", and "Skip" buttons
- [ ] Verify decided confirmations render inline when there is no preceding assistant message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
