### PR TITLE
M1: Integration framework types, config schema, metadata extensions

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -164,4 +164,5 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     install: { nodeManager: 'npm' },
     allowBundled: null,
   },
+  integrations: {},
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -671,6 +671,15 @@ export const SkillsConfigSchema = z.object({
   allowBundled: z.array(z.string()).nullable().default(null),
 });
 
+export const IntegrationConfigSchema = z.object({
+  clientId: z.string({ error: 'integrations.*.clientId must be a string' }).optional(),
+});
+
+export const IntegrationsConfigSchema = z.record(
+  z.string(),
+  IntegrationConfigSchema,
+).default({});
+
 export const AssistantConfigSchema = z.object({
   provider: z
     .enum(VALID_PROVIDERS, {
@@ -846,6 +855,7 @@ export const AssistantConfigSchema = z.object({
     install: { nodeManager: 'npm' },
     allowBundled: null,
   }),
+  integrations: IntegrationsConfigSchema,
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -899,3 +909,5 @@ export type SkillsLoadConfig = z.infer<typeof SkillsLoadConfigSchema>;
 export type SkillsInstallConfig = z.infer<typeof SkillsInstallConfigSchema>;
 export type SwarmConfig = z.infer<typeof SwarmConfigSchema>;
 export type SkillsConfig = z.infer<typeof SkillsConfigSchema>;
+export type IntegrationConfig = z.infer<typeof IntegrationConfigSchema>;
+export type IntegrationsConfig = z.infer<typeof IntegrationsConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -27,4 +27,6 @@ export type {
   SkillsInstallConfig,
   SwarmConfig,
   SkillsConfig,
+  IntegrationConfig,
+  IntegrationsConfig,
 } from './schema.js';

--- a/assistant/src/integrations/types.ts
+++ b/assistant/src/integrations/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Core type definitions for the integration framework.
+ *
+ * Integrations connect Vellum to external services (Gmail, Slack, etc.)
+ * via OAuth2, API keys, or bearer tokens.
+ */
+
+export type IntegrationAuthType = 'oauth2' | 'api_key' | 'token';
+
+export interface OAuth2Config {
+  authUrl: string;
+  tokenUrl: string;
+  scopes: string[];
+  clientId: string;
+  extraParams?: Record<string, string>;
+}
+
+export interface IntegrationDefinition {
+  id: string;
+  name: string;
+  description: string;
+  icon?: string;
+  authType: IntegrationAuthType;
+  oauth2Config?: OAuth2Config;
+  credentialFields: string[];
+  allowedTools: string[];
+  /** Maps OAuth2 scopes to the tools they enable. When present, the effective
+   *  allowedTools after OAuth are the union of tools for granted scopes only.
+   *  For non-OAuth integrations this is omitted and allowedTools is used as-is. */
+  scopeToolMapping?: Record<string, string[]>;
+}
+
+export interface IntegrationStatus {
+  id: string;
+  connected: boolean;
+  accountInfo?: string;
+  connectedAt?: number;
+  lastUsed?: number;
+  error?: string;
+}
+
+export interface OAuth2TokenResult {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  scope?: string;
+  tokenType?: string;
+}

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -18,6 +18,8 @@ export interface CredentialMetadata {
   allowedTools: string[];
   allowedDomains: string[];
   usageDescription?: string;
+  expiresAt?: number;
+  grantedScopes?: string[];
   createdAt: number;
   updatedAt: number;
 }
@@ -107,6 +109,8 @@ export function upsertCredentialMetadata(
     allowedTools?: string[];
     allowedDomains?: string[];
     usageDescription?: string;
+    expiresAt?: number;
+    grantedScopes?: string[];
   },
 ): CredentialMetadata {
   const result = loadFile();
@@ -124,6 +128,8 @@ export function upsertCredentialMetadata(
     if (policy?.allowedTools !== undefined) existing.allowedTools = policy.allowedTools;
     if (policy?.allowedDomains !== undefined) existing.allowedDomains = policy.allowedDomains;
     if (policy?.usageDescription !== undefined) existing.usageDescription = policy.usageDescription;
+    if (policy?.expiresAt !== undefined) existing.expiresAt = policy.expiresAt;
+    if (policy?.grantedScopes !== undefined) existing.grantedScopes = policy.grantedScopes;
     existing.updatedAt = now;
     saveFile(data);
     return existing;
@@ -136,6 +142,8 @@ export function upsertCredentialMetadata(
     allowedTools: policy?.allowedTools ?? [],
     allowedDomains: policy?.allowedDomains ?? [],
     usageDescription: policy?.usageDescription,
+    expiresAt: policy?.expiresAt,
+    grantedScopes: policy?.grantedScopes,
     createdAt: now,
     updatedAt: now,
   };


### PR DESCRIPTION
## Summary
Foundation types and config for the extensible integration framework.

## Changes
- **New file**: `assistant/src/integrations/types.ts` — Core type definitions (IntegrationDefinition, IntegrationStatus, OAuth2Config, OAuth2TokenResult) with scopeToolMapping for scope-driven tool authorization
- **Modified**: `assistant/src/config/schema.ts` — Added IntegrationConfigSchema and IntegrationsConfigSchema (Zod), wired into AssistantConfigSchema
- **Modified**: `assistant/src/config/defaults.ts` — Added `integrations: {}` default
- **Modified**: `assistant/src/config/types.ts` — Re-exported IntegrationConfig and IntegrationsConfig types
- **Modified**: `assistant/src/tools/credentials/metadata-store.ts` — Extended CredentialMetadata with `expiresAt` and `grantedScopes` fields, updated upsert logic

## Test plan
- [ ] `bunx tsc --noEmit` passes (no new type errors)
- [ ] Existing tests pass unchanged
- [ ] Config parsing accepts empty `integrations: {}` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
