### PR TITLE
fix: include completionState in InlineSurfaceData equality and clamp safePageIndex lower bound

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -370,7 +370,7 @@ public struct InlineSurfaceData: Identifiable, Equatable {
     public let surfaceMessage: UiSurfaceShowMessage?
 
     public static func == (lhs: InlineSurfaceData, rhs: InlineSurfaceData) -> Bool {
-        lhs.id == rhs.id
+        lhs.id == rhs.id && lhs.completionState == rhs.completionState
     }
 
     /// When non-nil, the surface has been completed and should render in collapsed/chip state.

--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -11,7 +11,7 @@ public struct FormSurfaceView: View {
 
     private var safePageIndex: Int {
         guard let pages = data.pages, !pages.isEmpty else { return 0 }
-        return min(currentPageIndex, pages.count - 1)
+        return max(0, min(currentPageIndex, pages.count - 1))
     }
 
     public init(data: FormSurfaceData, onSubmit: @escaping ([String: Any]?) -> Void) {


### PR DESCRIPTION
## Summary
- **InlineSurfaceData.==** only compared `id`, so SwiftUI could skip re-rendering when `completionState` changed — preventing `CompletedSurfaceChip` from appearing after surface completion
- **FormSurfaceView.safePageIndex** only clamped the upper bound; added `max(0, ...)` for defensive lower-bound safety

## Test plan
- [ ] Complete an inline surface (form/list) and verify the `CompletedSurfaceChip` renders
- [ ] Navigate multi-page forms and confirm no index crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
