### PR TITLE
feat: show change details in file edit/write tool results

### DIFF
--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { formatEditDiff } from '../shared/filesystem/format-diff.js';
 import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
 
 class FileEditTool implements Tool {
@@ -96,9 +97,11 @@ class FileEditTool implements Tool {
 
     const { filePath, matchCount, oldContent, newContent, matchMethod, similarity } = result.value;
 
+    const diffText = formatEditDiff(oldString as string, newString as string);
+
     if (replaceAll) {
       return {
-        content: `Successfully replaced ${matchCount} occurrence${matchCount > 1 ? 's' : ''} in ${filePath}`,
+        content: `Successfully replaced ${matchCount} occurrence${matchCount > 1 ? 's' : ''} in ${filePath}\n${diffText}`,
         isError: false,
         diff: { filePath, oldContent, newContent, isNewFile: false },
       };
@@ -110,7 +113,7 @@ class FileEditTool implements Tool {
         ? ' (matched with whitespace normalization)'
         : ` (fuzzy matched, ${Math.round(similarity * 100)}% similar)`;
     return {
-      content: `Successfully edited ${filePath}${methodNote}`,
+      content: `Successfully edited ${filePath}${methodNote}\n${diffText}`,
       isError: false,
       diff: { filePath, oldContent, newContent, isNewFile: false },
     };

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { formatWriteSummary } from '../shared/filesystem/format-diff.js';
 import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
 
 class FileWriteTool implements Tool {
@@ -64,7 +65,7 @@ class FileWriteTool implements Tool {
 
     const { filePath, oldContent, newContent, isNewFile } = result.value;
     return {
-      content: `Successfully wrote to ${filePath}`,
+      content: `Successfully wrote to ${filePath} ${formatWriteSummary(oldContent, newContent, isNewFile)}`,
       isError: false,
       diff: { filePath, oldContent, newContent, isNewFile },
     };

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -2,6 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { formatEditDiff } from '../shared/filesystem/format-diff.js';
 import { hostPolicy } from '../shared/filesystem/path-policy.js';
 
 class HostFileEditTool implements Tool {
@@ -93,9 +94,11 @@ class HostFileEditTool implements Tool {
 
     const { filePath, matchCount, oldContent, newContent, matchMethod, similarity } = result.value;
 
+    const diffText = formatEditDiff(oldString as string, newString as string);
+
     if (replaceAll) {
       return {
-        content: `Successfully replaced ${matchCount} occurrence${matchCount > 1 ? 's' : ''} in ${filePath}`,
+        content: `Successfully replaced ${matchCount} occurrence${matchCount > 1 ? 's' : ''} in ${filePath}\n${diffText}`,
         isError: false,
         diff: { filePath, oldContent, newContent, isNewFile: false },
       };
@@ -108,7 +111,7 @@ class HostFileEditTool implements Tool {
         : ` (fuzzy matched, ${Math.round(similarity * 100)}% similar)`;
 
     return {
-      content: `Successfully edited ${filePath}${methodNote}`,
+      content: `Successfully edited ${filePath}${methodNote}\n${diffText}`,
       isError: false,
       diff: { filePath, oldContent, newContent, isNewFile: false },
     };

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -2,6 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { formatWriteSummary } from '../shared/filesystem/format-diff.js';
 import { hostPolicy } from '../shared/filesystem/path-policy.js';
 
 class HostFileWriteTool implements Tool {
@@ -61,7 +62,7 @@ class HostFileWriteTool implements Tool {
 
     const { filePath, oldContent, newContent, isNewFile } = result.value;
     return {
-      content: `Successfully wrote to ${filePath}`,
+      content: `Successfully wrote to ${filePath} ${formatWriteSummary(oldContent, newContent, isNewFile)}`,
       isError: false,
       diff: { filePath, oldContent, newContent, isNewFile },
     };

--- a/assistant/src/tools/shared/filesystem/format-diff.ts
+++ b/assistant/src/tools/shared/filesystem/format-diff.ts
@@ -1,0 +1,34 @@
+const MAX_DIFF_LINES = 8;
+
+/**
+ * Build a compact inline diff from an old→new string replacement.
+ * Lines are prefixed with - / + and truncated if the change is large.
+ */
+export function formatEditDiff(oldString: string, newString: string): string {
+  const oldLines = oldString.split('\n');
+  const newLines = newString.split('\n');
+
+  const removed = truncateLines(oldLines, MAX_DIFF_LINES).map(l => `- ${l}`);
+  const added = truncateLines(newLines, MAX_DIFF_LINES).map(l => `+ ${l}`);
+
+  return [...removed, ...added].join('\n');
+}
+
+/**
+ * Build a one-line summary for a file write.
+ */
+export function formatWriteSummary(oldContent: string, newContent: string, isNewFile: boolean): string {
+  const newLineCount = newContent.split('\n').length;
+  if (isNewFile) {
+    return `(new file, ${newLineCount} line${newLineCount !== 1 ? 's' : ''})`;
+  }
+  const oldLineCount = oldContent.split('\n').length;
+  return `(${oldLineCount} → ${newLineCount} lines)`;
+}
+
+function truncateLines(lines: string[], max: number): string[] {
+  if (lines.length <= max) return lines;
+  const kept = lines.slice(0, max);
+  kept.push(`... (${lines.length - max} more lines)`);
+  return kept;
+}


### PR DESCRIPTION
## Summary
- File edit tool results now include a compact diff showing removed/added lines (prefixed with `-`/`+`), truncated to 8 lines per side
- File write tool results now show line count info: `(new file, N lines)` or `(M → N lines)`
- Previously both tools only showed "Successfully edited /path" or "Successfully wrote to /path" with no change details

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
