### PR TITLE
M3: Token manager for OAuth2 token lifecycle

### DIFF
--- a/assistant/src/integrations/token-manager.ts
+++ b/assistant/src/integrations/token-manager.ts
@@ -1,0 +1,120 @@
+/**
+ * Token manager for integration OAuth2 tokens.
+ *
+ * Provides the ONLY way tools should access integration tokens:
+ * `withValidToken(integrationId, callback)` — auto-refreshes expired
+ * tokens and retries on 401 responses.
+ */
+
+import { getSecureKey, setSecureKey } from '../security/secure-keys.js';
+import {
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from '../tools/credentials/metadata-store.js';
+import { refreshOAuth2Token } from './oauth2.js';
+import type { IntegrationDefinition } from './types.js';
+
+/** Buffer before expiry to trigger proactive refresh (5 minutes). */
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+export class TokenExpiredError extends Error {
+  constructor(
+    public readonly integrationId: string,
+    message?: string,
+  ) {
+    super(message ?? `Token for integration "${integrationId}" has expired and could not be refreshed. Re-authorization required.`);
+    this.name = 'TokenExpiredError';
+  }
+}
+
+function isTokenExpired(integrationId: string): boolean {
+  const metadata = getCredentialMetadata(`integration:${integrationId}`, 'access_token');
+  if (!metadata?.expiresAt) return false;
+  return Date.now() >= metadata.expiresAt - EXPIRY_BUFFER_MS;
+}
+
+async function doRefresh(integrationId: string, definition: IntegrationDefinition): Promise<string> {
+  const refreshToken = getSecureKey(`integration:${integrationId}:refresh_token`);
+  if (!refreshToken) {
+    throw new TokenExpiredError(integrationId, `No refresh token available for "${integrationId}". Re-authorization required.`);
+  }
+
+  const config = definition.oauth2Config;
+  if (!config) {
+    throw new TokenExpiredError(integrationId, `Integration "${integrationId}" has no OAuth2 config for token refresh.`);
+  }
+
+  const result = await refreshOAuth2Token(config.tokenUrl, config.clientId, refreshToken);
+
+  // Store the new access token
+  setSecureKey(`integration:${integrationId}:access_token`, result.accessToken);
+
+  // Update metadata with new expiry
+  const expiresAt = result.expiresIn
+    ? Date.now() + result.expiresIn * 1000
+    : undefined;
+
+  upsertCredentialMetadata(`integration:${integrationId}`, 'access_token', {
+    expiresAt,
+  });
+
+  // If a new refresh token was issued, store it too
+  if (result.refreshToken) {
+    setSecureKey(`integration:${integrationId}:refresh_token`, result.refreshToken);
+    upsertCredentialMetadata(`integration:${integrationId}`, 'refresh_token', {});
+  }
+
+  return result.accessToken;
+}
+
+/**
+ * Execute a callback with a valid access token for the given integration.
+ *
+ * This is the ONLY way tools should access integration tokens. The method:
+ * 1. Reads the access token from the vault
+ * 2. Checks expiry and proactively refreshes if needed
+ * 3. Calls the callback with the valid token
+ * 4. If the callback throws a 401-like error, attempts one refresh + retry
+ */
+export async function withValidToken<T>(
+  integrationId: string,
+  definition: IntegrationDefinition,
+  callback: (token: string) => Promise<T>,
+): Promise<T> {
+  let token = getSecureKey(`integration:${integrationId}:access_token`);
+  if (!token) {
+    throw new TokenExpiredError(integrationId, `No access token found for "${integrationId}". Authorization required.`);
+  }
+
+  // Proactively refresh if expired or about to expire
+  if (isTokenExpired(integrationId)) {
+    try {
+      token = await doRefresh(integrationId, definition);
+    } catch {
+      throw new TokenExpiredError(integrationId);
+    }
+  }
+
+  try {
+    return await callback(token);
+  } catch (err: unknown) {
+    // Check if this is a 401 response — attempt one refresh + retry
+    if (is401Error(err)) {
+      try {
+        token = await doRefresh(integrationId, definition);
+      } catch {
+        throw new TokenExpiredError(integrationId);
+      }
+      return callback(token);
+    }
+    throw err;
+  }
+}
+
+function is401Error(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    if ('status' in err && (err as { status: number }).status === 401) return true;
+    if ('statusCode' in err && (err as { statusCode: number }).statusCode === 401) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
Token manager providing auto-refresh and 401-retry for integration OAuth2 tokens.

## Changes
- **New file**: `assistant/src/integrations/token-manager.ts`
  - `withValidToken(integrationId, definition, callback)` — the ONLY way tools access tokens
  - Proactive refresh: refreshes 5 minutes before expiry
  - 401 retry: on auth failure, attempts one refresh + retry before giving up
  - `TokenExpiredError` for when re-authorization is needed
  - Stores refreshed tokens back to vault via `setSecureKey`
  - Updates metadata with new `expiresAt` via `upsertCredentialMetadata`

## Design decisions
- Tools never access vault directly — always go through `withValidToken`
- 5-minute buffer before expiry avoids mid-request token expiration
- Single retry on 401 to handle race conditions between expiry check and API call

## Test plan
- [ ] `bunx tsc --noEmit` passes (no new type errors)
- [ ] Token refresh logic can be tested with mock vault/metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
