### PR TITLE
M4: Integration registry + Gmail definition

### DIFF
--- a/assistant/src/integrations/definitions/gmail.ts
+++ b/assistant/src/integrations/definitions/gmail.ts
@@ -1,0 +1,56 @@
+import type { IntegrationDefinition } from '../types.js';
+
+export const gmailIntegration: IntegrationDefinition = {
+  id: 'gmail',
+  name: 'Gmail',
+  description: 'Read, organize, and manage your email',
+  icon: '�',
+  authType: 'oauth2',
+  oauth2Config: {
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    scopes: [
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/gmail.modify',
+      'https://www.googleapis.com/auth/gmail.send',
+      'https://www.googleapis.com/auth/userinfo.email',
+    ],
+    clientId: '', // loaded from config at runtime
+    extraParams: { access_type: 'offline', prompt: 'consent' },
+  },
+  credentialFields: ['access_token', 'refresh_token'],
+  allowedTools: [
+    'gmail_search',
+    'gmail_list_messages',
+    'gmail_get_message',
+    'gmail_archive',
+    'gmail_batch_archive',
+    'gmail_label',
+    'gmail_batch_label',
+    'gmail_mark_read',
+    'gmail_trash',
+    'gmail_draft',
+    'gmail_send',
+    'gmail_unsubscribe',
+  ],
+  scopeToolMapping: {
+    'https://www.googleapis.com/auth/gmail.readonly': [
+      'gmail_search',
+      'gmail_list_messages',
+      'gmail_get_message',
+    ],
+    'https://www.googleapis.com/auth/gmail.modify': [
+      'gmail_archive',
+      'gmail_batch_archive',
+      'gmail_label',
+      'gmail_batch_label',
+      'gmail_mark_read',
+      'gmail_trash',
+      'gmail_unsubscribe',
+    ],
+    'https://www.googleapis.com/auth/gmail.send': [
+      'gmail_draft',
+      'gmail_send',
+    ],
+  },
+};

--- a/assistant/src/integrations/definitions/index.ts
+++ b/assistant/src/integrations/definitions/index.ts
@@ -1,0 +1,1 @@
+export { gmailIntegration } from './gmail.js';

--- a/assistant/src/integrations/registry.ts
+++ b/assistant/src/integrations/registry.ts
@@ -1,0 +1,64 @@
+/**
+ * Integration registry — manages integration definitions and lifecycle.
+ *
+ * Connection status is derived live from vault presence rather than a
+ * separate status store.
+ */
+
+import type { IntegrationDefinition, IntegrationStatus } from './types.js';
+import { getSecureKey, deleteSecureKey } from '../security/secure-keys.js';
+import {
+  getCredentialMetadata,
+  deleteCredentialMetadata,
+} from '../tools/credentials/metadata-store.js';
+
+const integrations = new Map<string, IntegrationDefinition>();
+
+export function registerIntegration(definition: IntegrationDefinition): void {
+  integrations.set(definition.id, definition);
+}
+
+export function getIntegration(id: string): IntegrationDefinition | undefined {
+  return integrations.get(id);
+}
+
+export function listIntegrations(): IntegrationDefinition[] {
+  return [...integrations.values()];
+}
+
+/** Derive connection status from vault presence. */
+export function getStatus(id: string): IntegrationStatus {
+  const def = integrations.get(id);
+  if (!def) {
+    return { id, connected: false, error: 'Integration not found' };
+  }
+
+  const accessToken = getSecureKey(`integration:${id}:access_token`);
+  if (!accessToken) {
+    return { id, connected: false };
+  }
+
+  const metadata = getCredentialMetadata(`integration:${id}`, 'access_token');
+  return {
+    id,
+    connected: true,
+    connectedAt: metadata?.createdAt,
+    lastUsed: metadata?.updatedAt,
+  };
+}
+
+/** Get status for all registered integrations. */
+export function listStatuses(): IntegrationStatus[] {
+  return listIntegrations().map((def) => getStatus(def.id));
+}
+
+/** Remove all credentials for an integration from the vault. */
+export function disconnect(id: string): void {
+  const def = integrations.get(id);
+  if (!def) return;
+
+  for (const field of def.credentialFields) {
+    deleteSecureKey(`integration:${id}:${field}`);
+    deleteCredentialMetadata(`integration:${id}`, field);
+  }
+}


### PR DESCRIPTION
## Summary
Integration registry for managing definitions and lifecycle, plus Gmail integration definition.

## Changes
- **New file**: `assistant/src/integrations/registry.ts` — registerIntegration, getIntegration, listIntegrations, getStatus (live from vault), listStatuses, disconnect
- **New file**: `assistant/src/integrations/definitions/gmail.ts` — Gmail OAuth2 config, scope-to-tool mapping, credential fields
- **New file**: `assistant/src/integrations/definitions/index.ts` — re-export

## Test plan
- [ ] `bunx tsc --noEmit` passes (no new type errors)
- [ ] Registry CRUD operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
