### PR TITLE
feat: newsletter analyzer helper for email declutter

### DIFF
--- a/assistant/src/integrations/gmail/newsletter-analyzer.ts
+++ b/assistant/src/integrations/gmail/newsletter-analyzer.ts
@@ -1,0 +1,90 @@
+/**
+ * Newsletter detection and grouping helper.
+ *
+ * NOT a tool — this is a utility function used by the LLM-driven
+ * declutter flow to group messages by sender for the table surface.
+ */
+
+import type { GmailMessage, GmailHeader } from './types.js';
+
+export interface NewsletterGroup {
+  senderEmail: string;
+  senderName: string;
+  messageCount: number;
+  hasUnsubscribe: boolean;
+  messageIds: string[];
+  sampleSubjects: string[];
+}
+
+function getHeader(headers: GmailHeader[] | undefined, name: string): string | undefined {
+  return headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+function parseSender(from: string): { name: string; email: string } {
+  // "Display Name <email@example.com>" or just "email@example.com"
+  const match = from.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    return { name: match[1].replace(/^["']|["']$/g, '').trim(), email: match[2].toLowerCase() };
+  }
+  return { name: from.trim(), email: from.trim().toLowerCase() };
+}
+
+/**
+ * Group a list of Gmail messages by sender for newsletter analysis.
+ *
+ * Expects messages fetched with `format=metadata` and
+ * `metadataHeaders=["From", "Subject", "List-Unsubscribe"]`.
+ *
+ * Returns groups sorted by message count (descending), filtered to
+ * senders with at least `minMessages` messages.
+ */
+export function groupBySender(
+  messages: GmailMessage[],
+  minMessages = 3,
+  maxSampleSubjects = 3,
+): NewsletterGroup[] {
+  const groups = new Map<string, {
+    senderName: string;
+    senderEmail: string;
+    messageIds: string[];
+    subjects: string[];
+    hasUnsubscribe: boolean;
+  }>();
+
+  for (const msg of messages) {
+    const headers = msg.payload?.headers;
+    const from = getHeader(headers, 'From');
+    if (!from) continue;
+
+    const { name, email } = parseSender(from);
+    const existing = groups.get(email);
+    const subject = getHeader(headers, 'Subject') ?? '';
+    const hasUnsub = !!getHeader(headers, 'List-Unsubscribe');
+
+    if (existing) {
+      existing.messageIds.push(msg.id);
+      existing.subjects.push(subject);
+      if (hasUnsub) existing.hasUnsubscribe = true;
+    } else {
+      groups.set(email, {
+        senderName: name,
+        senderEmail: email,
+        messageIds: [msg.id],
+        subjects: [subject],
+        hasUnsubscribe: hasUnsub,
+      });
+    }
+  }
+
+  return [...groups.values()]
+    .filter((g) => g.messageIds.length >= minMessages)
+    .sort((a, b) => b.messageIds.length - a.messageIds.length)
+    .map((g) => ({
+      senderEmail: g.senderEmail,
+      senderName: g.senderName,
+      messageCount: g.messageIds.length,
+      hasUnsubscribe: g.hasUnsubscribe,
+      messageIds: g.messageIds,
+      sampleSubjects: g.subjects.slice(0, maxSampleSubjects),
+    }));
+}


### PR DESCRIPTION
## Summary
- Adds `groupBySender` utility function for the LLM-driven email declutter flow
- Groups Gmail messages by sender email, filters by minimum message count
- Detects newsletter patterns via `List-Unsubscribe` header presence
- Returns sorted groups (by count descending) with sample subjects
- This is a helper function (NOT a tool) — used by the LLM to build table surface data

## Files
- `assistant/src/integrations/gmail/newsletter-analyzer.ts` (new)

Part of the App Integrations Framework + Gmail feature.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
