### PR TITLE
feat: macOS integration UI with connect/disconnect in Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -13,6 +13,8 @@ struct SettingsPanel: View {
     @State private var showingTrustRules = false
     @State private var showingScheduledTasks = false
     @State private var showingReminders = false
+    @State private var integrations: [IPCIntegrationListResponseIntegration] = []
+    @State private var connectingIntegration: String?
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
     @AppStorage("themePreference") private var themePreference: String = "system"
 
@@ -122,6 +124,27 @@ struct SettingsPanel: View {
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
+
+                // INTEGRATIONS section
+                if daemonClient != nil {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("INTEGRATIONS")
+                            .font(VFont.sectionTitle)
+                            .foregroundColor(VColor.textPrimary)
+
+                        if integrations.isEmpty {
+                            Text("No integrations available")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        } else {
+                            ForEach(integrations, id: \.id) { integration in
+                                integrationRow(integration)
+                            }
+                        }
+                    }
+                    .padding(VSpacing.lg)
+                    .vCard(background: VColor.surfaceSubtle)
+                }
 
                 // COMPUTER USAGE section
                 VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -366,6 +389,8 @@ struct SettingsPanel: View {
         }
         .onAppear {
             store.refreshAPIKeyState()
+            setupIntegrationCallbacks()
+            try? daemonClient?.sendIntegrationList()
         }
         .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
@@ -380,6 +405,79 @@ struct SettingsPanel: View {
         .sheet(isPresented: $showingReminders) {
             if let daemonClient {
                 RemindersView(daemonClient: daemonClient)
+            }
+        }
+    }
+
+    // MARK: - Integration Row
+
+    private func integrationRow(_ integration: IPCIntegrationListResponseIntegration) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Text(integrationIcon(integration.id))
+                .font(.system(size: 14))
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(integrationDisplayName(integration.id))
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                if let account = integration.accountInfo {
+                    Text(account)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+
+            Spacer()
+
+            if integration.connected {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(VColor.success)
+                    .font(.system(size: 14))
+                VButton(label: "Disconnect", style: .danger) {
+                    try? daemonClient?.sendIntegrationDisconnect(integrationId: integration.id)
+                }
+            } else {
+                if connectingIntegration == integration.id {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    VButton(label: "Connect", style: .primary) {
+                        connectingIntegration = integration.id
+                        try? daemonClient?.sendIntegrationConnect(integrationId: integration.id)
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    private func integrationDisplayName(_ id: String) -> String {
+        switch id {
+        case "gmail": return "Gmail"
+        default: return id.capitalized
+        }
+    }
+
+    private func integrationIcon(_ id: String) -> String {
+        switch id {
+        case "gmail": return "\u{1F4E7}"
+        default: return "\u{1F517}"
+        }
+    }
+
+    private func setupIntegrationCallbacks() {
+        daemonClient?.onIntegrationListResponse = { [self] response in
+            Task { @MainActor in
+                self.integrations = response.integrations
+            }
+        }
+        daemonClient?.onIntegrationConnectResult = { [self] result in
+            Task { @MainActor in
+                self.connectingIntegration = nil
+                // Refresh the list after connect/disconnect
+                try? self.daemonClient?.sendIntegrationList()
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -13,6 +13,7 @@ public struct SettingsView: View {
     @State private var showingSkills = false
     @State private var showingTrustRules = false
     @State private var skillsViewModel: SkillsSettingsViewModel?
+    @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var activationKey: ActivationKey = {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
         return ActivationKey(rawValue: stored) ?? .fn
@@ -188,6 +189,36 @@ public struct SettingsView: View {
             }
 
             if let daemonClient {
+                Section("Integrations") {
+                    ForEach(integrations, id: \.id) { integration in
+                        HStack {
+                            Text(integration.id == "gmail" ? "\u{1F4E7}" : "\u{1F517}")
+                            Text(integration.id == "gmail" ? "Gmail" : integration.id.capitalized)
+                            if let account = integration.accountInfo {
+                                Text("(\(account))")
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if integration.connected {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                Button("Disconnect") {
+                                    try? daemonClient.sendIntegrationDisconnect(integrationId: integration.id)
+                                }
+                                .tint(.red)
+                            } else {
+                                Button("Connect") {
+                                    try? daemonClient.sendIntegrationConnect(integrationId: integration.id)
+                                }
+                            }
+                        }
+                    }
+                    if integrations.isEmpty {
+                        Text("No integrations available")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 Section("Skills") {
                     HStack {
                         VStack(alignment: .leading, spacing: 2) {
@@ -240,6 +271,17 @@ public struct SettingsView: View {
             store.refreshAPIKeyState()
             store.refreshVercelKeyState()
             checkPermissions()
+            daemonClient?.onIntegrationListResponse = { response in
+                Task { @MainActor in
+                    self.integrations = response.integrations
+                }
+            }
+            daemonClient?.onIntegrationConnectResult = { _ in
+                Task { @MainActor in
+                    try? self.daemonClient?.sendIntegrationList()
+                }
+            }
+            try? daemonClient?.sendIntegrationList()
         }
         .onReceive(permissionTimer) { _ in
             checkPermissions()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -170,6 +170,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `ui_layout_config` message.
     public var onLayoutConfig: ((UiLayoutConfigMessage) -> Void)?
 
+    /// Called when the daemon sends an `integration_list_response` message.
+    public var onIntegrationListResponse: ((IPCIntegrationListResponse) -> Void)?
+
+    /// Called when the daemon sends an `integration_connect_result` message.
+    public var onIntegrationConnectResult: ((IPCIntegrationConnectResult) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -720,6 +726,23 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(UnpublishPageRequestMessage(deploymentId: deploymentId))
     }
 
+    // MARK: - Integrations
+
+    /// Request the list of registered integrations and their connection status.
+    public func sendIntegrationList() throws {
+        try send(IPCIntegrationListRequest(type: "integration_list"))
+    }
+
+    /// Initiate an OAuth2 connection flow for an integration.
+    public func sendIntegrationConnect(integrationId: String) throws {
+        try send(IPCIntegrationConnectRequest(type: "integration_connect", integrationId: integrationId))
+    }
+
+    /// Disconnect an integration (revoke tokens + remove from vault).
+    public func sendIntegrationDisconnect(integrationId: String) throws {
+        try send(IPCIntegrationDisconnectRequest(type: "integration_disconnect", integrationId: integrationId))
+    }
+
     // MARK: - Link Open
 
     /// Send a link_open_request to the daemon, requesting it open a URL externally.
@@ -980,6 +1003,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         case .signBundlePayload, .getSigningIdentity:
             log.error("Signing operations are not supported on this platform")
         #endif
+        case .integrationListResponse(let msg):
+            onIntegrationListResponse?(msg)
+        case .integrationConnectResult(let msg):
+            onIntegrationConnectResult?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -323,10 +323,25 @@ public struct IPCFormFieldOption: Codable, Sendable {
     public let value: String
 }
 
+public struct IPCFormPage: Codable, Sendable {
+    public let id: String
+    public let title: String
+    public let description: String?
+    public let fields: [IPCFormField]
+}
+
 public struct IPCFormSurfaceData: Codable, Sendable {
     public let description: String?
     public let fields: [IPCFormField]
     public let submitLabel: String?
+    public let pages: [IPCFormPage]?
+    public let pageLabels: IPCFormSurfaceDataPageLabels?
+}
+
+public struct IPCFormSurfaceDataPageLabels: Codable, Sendable {
+    public let next: String?
+    public let back: String?
+    public let submit: String?
 }
 
 public struct IPCGalleryApp: Codable, Sendable {
@@ -432,6 +447,42 @@ public struct IPCHistoryResponseToolCall: Codable, Sendable {
     public let isError: Bool?
     /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
     public let imageData: String?
+}
+
+public struct IPCIntegrationConnectRequest: Codable, Sendable {
+    public let type: String
+    public let integrationId: String
+}
+
+public struct IPCIntegrationConnectResult: Codable, Sendable {
+    public let type: String
+    public let integrationId: String
+    public let success: Bool
+    public let accountInfo: String?
+    public let error: String?
+}
+
+public struct IPCIntegrationDisconnectRequest: Codable, Sendable {
+    public let type: String
+    public let integrationId: String
+}
+
+public struct IPCIntegrationListRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCIntegrationListResponse: Codable, Sendable {
+    public let type: String
+    public let integrations: [IPCIntegrationListResponseIntegration]
+}
+
+public struct IPCIntegrationListResponseIntegration: Codable, Sendable {
+    public let id: String
+    public let connected: Bool
+    public let accountInfo: String?
+    public let connectedAt: Int?
+    public let lastUsed: Double?
+    public let error: String?
 }
 
 public struct IPCIpcBlobProbe: Codable, Sendable {
@@ -1164,6 +1215,14 @@ public struct IPCUiSurfaceAction: Codable, Sendable {
     public let surfaceId: String
     public let actionId: String
     public let data: [String: AnyCodable]?
+}
+
+public struct IPCUiSurfaceComplete: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let summary: String
+    public let submittedData: [String: AnyCodable]?
 }
 
 public struct IPCUiSurfaceDismiss: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1455,6 +1455,8 @@ public enum ServerMessage: Decodable, Sendable {
     case ipcBlobProbeResult(IpcBlobProbeResultMessage)
     case daemonStatus(DaemonStatusMessage)
     case openUrl(OpenUrlMessage)
+    case integrationListResponse(IPCIntegrationListResponse)
+    case integrationConnectResult(IPCIntegrationConnectResult)
     case getSigningIdentity
     case pong
     case unknown(String)
@@ -1653,6 +1655,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "unpublish_page_response":
             let message = try UnpublishPageResponseMessage(from: decoder)
             self = .unpublishPageResponse(message)
+        case "integration_list_response":
+            let message = try IPCIntegrationListResponse(from: decoder)
+            self = .integrationListResponse(message)
+        case "integration_connect_result":
+            let message = try IPCIntegrationConnectResult(from: decoder)
+            self = .integrationConnectResult(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Regenerates `IPCContractGenerated.swift` with integration IPC types from PR5
- Adds `integrationListResponse` and `integrationConnectResult` cases to `ServerMessage` enum
- Adds integration send functions (`sendIntegrationList`, `sendIntegrationConnect`, `sendIntegrationDisconnect`) to `DaemonClient`
- Adds Integrations section to both `SettingsPanel` (main window) and `SettingsView` (standalone window)
- Each integration shows icon, name, account info, connection status badge, and Connect/Disconnect button
- Connect button shows progress indicator during OAuth flow

## Files
- `clients/shared/IPC/Generated/IPCContractGenerated.swift` (regenerated)
- `clients/shared/IPC/IPCMessages.swift` (modified)
- `clients/shared/IPC/DaemonClient.swift` (modified)
- `clients/macos/.../Panels/SettingsPanel.swift` (modified)
- `clients/macos/.../Settings/SettingsView.swift` (modified)

Part of the App Integrations Framework + Gmail feature.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
