### PR TITLE
fix: only show regenerate after decided confirmations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -340,7 +340,7 @@ struct ChatView: View {
                                 && !message.isStreaming
                                 && (index == messages.count - 1
                                     || (index == messages.count - 2
-                                        && messages[messages.count - 1].confirmation != nil))
+                                        && messages[messages.count - 1].confirmation?.state != .pending))
                                 && !isSending
                                 && !isThinking
 


### PR DESCRIPTION
Fixes review feedback from PR #3089:

The `isLastAssistant` check matched any trailing confirmation (including pending ones), causing the regenerate button to appear while a tool approval was still in progress. Now only matches decided confirmations (`state != .pending`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
