### PR TITLE
fix: show only last text segment in multi-step assistant messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -972,23 +972,17 @@ private struct ChatBubble: View {
     private var interleavedContent: some View {
         let groups = groupContentBlocks()
 
+        // Only show the last non-empty text segment — each new step overrides the previous.
+        if let lastText = message.textSegments.lazy
+            .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+            .last(where: { !$0.isEmpty }) {
+            textBubble(for: lastText)
+        }
+
+        // Surfaces still render in order
         ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
-            switch group {
-            case .text(let i):
-                if i < message.textSegments.count {
-                    let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !segmentText.isEmpty {
-                        textBubble(for: segmentText)
-                    }
-                }
-            case .toolCalls:
-                // Tool calls are rendered as a single unified status at the
-                // bottom of the message — skip them in the interleaved flow.
-                EmptyView()
-            case .surface(let i):
-                if i < message.inlineSurfaces.count {
-                    InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction)
-                }
+            if case .surface(let i) = group, i < message.inlineSurfaces.count {
+                InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction)
             }
         }
 


### PR DESCRIPTION
## Summary
- When assistant runs multiple tools, only the last non-empty text segment is now displayed instead of stacking all segments vertically
- Intermediate text (e.g. permission asks) is overridden by the final output
- Surfaces and attachments continue to render normally below the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
