### PR TITLE
fix: scroll to bottom anchor so content stays above composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -364,6 +364,10 @@ struct ChatView: View {
                             .id("thinking-indicator")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
+
+                    // Invisible anchor at the very bottom of all content
+                    Color.clear.frame(height: 1)
+                        .id("scroll-bottom-anchor")
                 }
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, useThreadDrawer ? VSpacing.xs : VSpacing.md)
@@ -375,14 +379,12 @@ struct ChatView: View {
             .scrollDisabled(messages.isEmpty && !isThinking)
             .onAppear {
                 // Scroll to bottom on initial load
-                if let lastMessage = messages.last {
-                    proxy.scrollTo(lastMessage.id, anchor: .bottom)
-                }
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
             .onChange(of: isThinking) {
                 if isThinking {
                     withAnimation(VAnimation.standard) {
-                        proxy.scrollTo("thinking-indicator", anchor: .bottom)
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
                 } else {
                     // Thinking finished — mark flag so next message shows "Thinking"
@@ -393,9 +395,12 @@ struct ChatView: View {
             }
             .onChange(of: streamingScrollTrigger) {
                 withAnimation(VAnimation.fast) {
-                    if let lastMessage = messages.last {
-                        proxy.scrollTo(lastMessage.id, anchor: .bottom)
-                    }
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+            }
+            .onChange(of: messages.count) {
+                withAnimation(VAnimation.fast) {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Added invisible scroll anchor at the bottom of chat content
- All scroll-to-bottom calls now target the anchor instead of `lastMessage.id`, ensuring streamed content stays above the composer input
- Added `messages.count` change trigger for scroll-to-bottom when new messages arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
