### PR TITLE
fix: use autoupdatingCurrent timezone for local-time timestamps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -261,7 +261,7 @@ struct ChatView: View {
         let previous = messages[index - 1].timestamp
         // Always show a divider when crossing a calendar-day boundary (in local timezone)
         var calendar = Calendar.current
-        calendar.timeZone = .current
+        calendar.timeZone = .autoupdatingCurrent
         if !calendar.isDate(current, inSameDayAs: previous) { return true }
         let gap = current.timeIntervalSince(previous)
         return gap > 300
@@ -641,7 +641,7 @@ private struct ChatBubble: View {
     }
 
     private var formattedTimestamp: String {
-        let tz = TimeZone.current
+        let tz = TimeZone.autoupdatingCurrent
         var calendar = Calendar.current
         calendar.timeZone = tz
         let formatter = DateFormatter()
@@ -1386,7 +1386,7 @@ private struct TimestampDivider: View {
     let date: Date
 
     private var formattedTime: String {
-        let tz = TimeZone.current
+        let tz = TimeZone.autoupdatingCurrent
         var calendar = Calendar.current
         calendar.timeZone = tz
         let formatter = DateFormatter()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -89,6 +89,7 @@ struct TraceRowView: View {
     private var formattedTimestamp: String {
         let date = Date(timeIntervalSince1970: event.timestampMs / 1000)
         let formatter = DateFormatter()
+        formatter.timeZone = .autoupdatingCurrent
         formatter.dateFormat = "HH:mm:ss.SSS"
         return formatter.string(from: date)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
@@ -121,6 +121,7 @@ private struct ReminderRow: View {
     private var scheduledDateText: String {
         let date = Date(timeIntervalSince1970: Double(reminder.fireAt) / 1000.0)
         let formatter = DateFormatter()
+        formatter.timeZone = .autoupdatingCurrent
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)
@@ -137,6 +138,7 @@ private struct ReminderRow: View {
             let timestamp = reminder.firedAt ?? reminder.fireAt
             let date = Date(timeIntervalSince1970: Double(timestamp) / 1000.0)
             let formatter = DateFormatter()
+            formatter.timeZone = .autoupdatingCurrent
             formatter.dateStyle = .medium
             formatter.timeStyle = .short
             return "Fired: \(formatter.string(from: date))"


### PR DESCRIPTION
## Summary
- Switch all timestamp formatters from `TimeZone.current` to `TimeZone.autoupdatingCurrent` in ChatView.swift — `.current` can snapshot UTC in certain app lifecycle contexts (menu bar / LSUIElement apps), while `.autoupdatingCurrent` always tracks the system timezone
- Add explicit `timeZone = .autoupdatingCurrent` to TraceRowView and RemindersView formatters that were previously relying on the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
