### PR TITLE
fix: stabilize tool chip icon by sorting unique tool names

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -821,7 +821,7 @@ private struct ChatBubble: View {
             onOpenActivity(message.id)
         } label: {
             HStack(spacing: VSpacing.xs) {
-                let uniqueNames = Array(Set(message.toolCalls.map(\.toolName)))
+                let uniqueNames = Array(Set(message.toolCalls.map(\.toolName))).sorted()
                 let primary = uniqueNames.first ?? "Tool"
 
                 Image(systemName: Self.friendlyToolIcon(primary))


### PR DESCRIPTION
## Summary
- `Array(Set(...))` has non-deterministic order, causing the tool chip icon to flicker on every re-render (e.g. while typing in the composer)
- Added `.sorted()` so the primary tool name is always stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
