### PR TITLE
fix: add missing integration IPC types to snapshot test

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -326,6 +326,17 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'unpublish_page',
     deploymentId: 'dpl-001',
   },
+  integration_list: {
+    type: 'integration_list',
+  },
+  integration_connect: {
+    type: 'integration_connect',
+    integrationId: 'gmail',
+  },
+  integration_disconnect: {
+    type: 'integration_disconnect',
+    integrationId: 'gmail',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -918,6 +929,23 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   unpublish_page_response: {
     type: 'unpublish_page_response',
     success: true,
+  },
+  integration_list_response: {
+    type: 'integration_list_response',
+    integrations: [
+      {
+        id: 'gmail',
+        connected: true,
+        accountInfo: 'user@gmail.com',
+        connectedAt: 1700000000,
+      },
+    ],
+  },
+  integration_connect_result: {
+    type: 'integration_connect_result',
+    integrationId: 'gmail',
+    success: true,
+    accountInfo: 'user@gmail.com',
   },
 };
 


### PR DESCRIPTION
## Summary
- Added `integration_list`, `integration_connect`, `integration_disconnect` client message fixtures to ipc-snapshot test
- Added `integration_list_response`, `integration_connect_result` server message fixtures to ipc-snapshot test
- Fixes `tsc --noEmit` CI failure caused by incomplete `Record<ClientMessageType | ServerMessageType, ...>` objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
