### PR TITLE
fix: harden tool_use/tool_result pairing with immutable repair and monotonic timestamps

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -343,6 +343,137 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
     expect(user.content[2].cache_control).toEqual({ type: 'ephemeral' });
   });
 
+  // -----------------------------------------------------------------------
+  // ensureToolPairing — tool_use / tool_result pairing repair
+  // -----------------------------------------------------------------------
+
+  test('tool_use with missing tool_result gets synthetic result injected', async () => {
+    const messages: Message[] = [
+      userMsg('Do something'),
+      toolUseMsg('tu_1', 'file_read'),
+      userMsg('Thanks'),   // user text but no tool_result for tu_1
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string; is_error?: boolean }>;
+    }>;
+
+    // The second user message (after assistant) should now contain a synthetic tool_result
+    const userAfterAssistant = sent[2];
+    expect(userAfterAssistant.role).toBe('user');
+    const toolResults = userAfterAssistant.content.filter((b) => b.type === 'tool_result');
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].tool_use_id).toBe('tu_1');
+    expect(toolResults[0].is_error).toBe(true);
+  });
+
+  test('tool_use at end of messages gets synthetic user message appended', async () => {
+    const messages: Message[] = [
+      userMsg('Read file'),
+      toolUseMsg('tu_end', 'file_read'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string }>;
+    }>;
+
+    // A synthetic user message should have been appended
+    expect(sent).toHaveLength(3);
+    expect(sent[2].role).toBe('user');
+    const toolResults = sent[2].content.filter((b) => b.type === 'tool_result');
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].tool_use_id).toBe('tu_end');
+  });
+
+  test('tool_use with matching tool_result passes through unchanged', async () => {
+    const messages: Message[] = [
+      userMsg('Read file'),
+      toolUseMsg('tu_ok', 'file_read'),
+      toolResultMsg('tu_ok', 'file contents'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string }>;
+    }>;
+
+    // No synthetic messages or blocks added
+    expect(sent).toHaveLength(3);
+    const toolResults = sent[2].content.filter((b) => b.type === 'tool_result');
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].tool_use_id).toBe('tu_ok');
+  });
+
+  test('multiple tool_use with partial results gets missing ones filled', async () => {
+    const messages: Message[] = [
+      userMsg('Do things'),
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_a', name: 'file_read', input: {} },
+          { type: 'tool_use', id: 'tu_b', name: 'file_write', input: {} },
+          { type: 'tool_use', id: 'tu_c', name: 'bash', input: {} },
+        ],
+      },
+      // Only tu_a has a result
+      toolResultMsg('tu_a', 'result A'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string; is_error?: boolean }>;
+    }>;
+
+    const userAfterAssistant = sent[2];
+    const toolResults = userAfterAssistant.content.filter((b) => b.type === 'tool_result');
+    expect(toolResults).toHaveLength(3);
+
+    // tu_a: original result
+    expect(toolResults.find((r) => r.tool_use_id === 'tu_a')!.is_error).toBeFalsy();
+    // tu_b and tu_c: synthetic
+    expect(toolResults.find((r) => r.tool_use_id === 'tu_b')!.is_error).toBe(true);
+    expect(toolResults.find((r) => r.tool_use_id === 'tu_c')!.is_error).toBe(true);
+  });
+
+  test('consecutive assistant messages with tool_use each get synthetic results', async () => {
+    const messages: Message[] = [
+      userMsg('Start'),
+      toolUseMsg('tu_1', 'file_read'),
+      // missing tool_result for tu_1, then another assistant
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tu_2', name: 'bash', input: {} }],
+      },
+      userMsg('Done'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string }>;
+    }>;
+
+    // Should be: user, assistant(tu_1), synthetic_user(tu_1), assistant(tu_2), user_with_synthetic(tu_2)
+    expect(sent).toHaveLength(5);
+    expect(sent[0].role).toBe('user');
+    expect(sent[1].role).toBe('assistant');
+    expect(sent[2].role).toBe('user');
+    expect(sent[2].content.some((b) => b.type === 'tool_result' && b.tool_use_id === 'tu_1')).toBe(true);
+    expect(sent[3].role).toBe('assistant');
+    expect(sent[4].role).toBe('user');
+    expect(sent[4].content.some((b) => b.type === 'tool_result' && b.tool_use_id === 'tu_2')).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Workspace context injection + cache control
+  // -----------------------------------------------------------------------
+
   test('multi-turn with workspace injection: cache on last two user turns only', async () => {
     const messages: Message[] = [
       // Turn 1: workspace + user text (should NOT get cache - it's the 3rd-to-last user turn)

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -9,6 +9,20 @@ import { deleteOrphanAttachments } from './attachments-store.js';
 
 const log = getLogger('conversation-store');
 
+/**
+ * Monotonic timestamp source for message ordering. Two messages saved within
+ * the same millisecond (e.g., tool_results user message + assistant message in
+ * message_complete) would get the same Date.now(), making their reload order
+ * non-deterministic. This counter ensures every call returns a strictly
+ * increasing value so insertion order is always preserved.
+ */
+let lastTimestamp = 0;
+function monotonicNow(): number {
+  const now = Date.now();
+  lastTimestamp = Math.max(now, lastTimestamp + 1);
+  return lastTimestamp;
+}
+
 export function createConversation(title?: string) {
   const db = getDb();
   const now = Date.now();
@@ -75,7 +89,7 @@ export function getLatestConversation() {
 
 export function addMessage(conversationId: string, role: string, content: string) {
   const db = getDb();
-  const now = Date.now();
+  const now = monotonicNow();
   const message = {
     id: uuid(),
     conversationId,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -27,71 +27,146 @@ function sanitizeToolId(id: string): string {
 
 const SYNTHETIC_RESULT = '<synthesized_result>tool result missing from history</synthesized_result>';
 
+/** Type-guard for tool_use blocks in Anthropic-formatted content. */
+function isToolUseBlock(block: unknown): block is Anthropic.ToolUseBlockParam {
+  return typeof block === 'object' && block !== null && (block as { type: string }).type === 'tool_use';
+}
+
+/** Type-guard for tool_result blocks in Anthropic-formatted content. */
+function isToolResultBlock(block: unknown): block is Anthropic.ToolResultBlockParam {
+  return typeof block === 'object' && block !== null && (block as { type: string }).type === 'tool_result';
+}
+
 /**
- * Last-line-of-defense validation that ensures every assistant message with
- * tool_use blocks has matching tool_result blocks in the immediately following
- * user message.  Runs on the FINAL Anthropic-formatted messages after block
- * conversion, filtering, and message filtering — catching any edge case that
- * the upstream repairHistory logic misses.
+ * Build a short diagnostic summary of a message array for error logging.
+ * Shows role + block types (with tool_use/tool_result IDs) for each message.
+ */
+function summarizeMessages(messages: Anthropic.MessageParam[]): string[] {
+  return messages.map((m, idx) => {
+    const content = Array.isArray(m.content) ? m.content : [{ type: 'text' }];
+    const blockDescs = content.map((b) => {
+      const bt = (b as { type: string }).type;
+      if (bt === 'tool_use') return `tool_use(${(b as { id: string }).id})`;
+      if (bt === 'tool_result') return `tool_result(${(b as { tool_use_id: string }).tool_use_id})`;
+      return bt;
+    });
+    return `[${idx}] ${m.role}: ${blockDescs.join(', ') || '(empty)'}`;
+  });
+}
+
+/**
+ * Last-line-of-defense fix that ensures every assistant message with tool_use
+ * blocks has matching tool_result blocks in the immediately following user
+ * message.  Runs on the FINAL Anthropic-formatted messages after block
+ * conversion, filtering, and empty-message filtering.
+ *
+ * Builds a fresh result array without mutating the input.
  */
 function ensureToolPairing(
   messages: Anthropic.MessageParam[],
 ): Anthropic.MessageParam[] {
   const result: Anthropic.MessageParam[] = [];
 
-  for (let i = 0; i < messages.length; i++) {
+  let i = 0;
+  while (i < messages.length) {
     const msg = messages[i];
-    result.push(msg);
 
-    if (msg.role !== 'assistant') continue;
+    if (msg.role !== 'assistant') {
+      result.push(msg);
+      i++;
+      continue;
+    }
+
+    // Assistant message — push it and check for tool_use blocks
+    result.push(msg);
     const content = Array.isArray(msg.content) ? msg.content : [];
     const toolUseIds = new Set<string>();
     for (const block of content) {
-      if (typeof block === 'object' && block !== null && 'type' in block && block.type === 'tool_use') {
-        toolUseIds.add((block as Anthropic.ToolUseBlockParam).id);
-      }
+      if (isToolUseBlock(block)) toolUseIds.add(block.id);
     }
-    if (toolUseIds.size === 0) continue;
 
-    // Check the next message for matching tool_result blocks
+    if (toolUseIds.size === 0) {
+      i++;
+      continue;
+    }
+
+    // There are tool_use blocks — ensure the next message has matching tool_results
     const next = messages[i + 1];
     if (next && next.role === 'user') {
       const nextContent = Array.isArray(next.content) ? next.content : [];
       const matchedIds = new Set<string>();
       for (const block of nextContent) {
-        if (typeof block === 'object' && block !== null && 'type' in block && block.type === 'tool_result') {
-          const trId = (block as Anthropic.ToolResultBlockParam).tool_use_id;
-          if (toolUseIds.has(trId)) matchedIds.add(trId);
+        if (isToolResultBlock(block) && toolUseIds.has(block.tool_use_id)) {
+          matchedIds.add(block.tool_use_id);
         }
       }
+
       const missingIds = [...toolUseIds].filter((id) => !matchedIds.has(id));
       if (missingIds.length > 0) {
-        log.warn({ missingCount: missingIds.length, totalToolUse: toolUseIds.size }, 'Injecting synthetic tool_result blocks in Anthropic client');
-        // Inject synthetic tool_result blocks into the existing next user message
-        const patchedContent = [
-          ...nextContent,
-          ...missingIds.map((id) => ({
-            type: 'tool_result' as const,
-            tool_use_id: id,
-            content: SYNTHETIC_RESULT,
-            is_error: true,
-          })),
-        ];
-        // Replace the next message in-place — it hasn't been pushed to result yet
-        messages[i + 1] = { role: 'user', content: patchedContent };
+        log.warn(
+          { missingCount: missingIds.length, missingIds, totalToolUse: toolUseIds.size, msgIndex: i },
+          'Injecting synthetic tool_result blocks in Anthropic client',
+        );
+        // Push a new user message that merges the original content with synthetic results
+        result.push({
+          role: 'user' as const,
+          content: [
+            ...nextContent,
+            ...missingIds.map((id) => ({
+              type: 'tool_result' as const,
+              tool_use_id: id,
+              content: SYNTHETIC_RESULT,
+              is_error: true,
+            })),
+          ],
+        });
+        i += 2; // skip both assistant (already pushed) and original user (replaced)
+      } else {
+        // All tool_use IDs matched — next message is fine, will be pushed next iteration
+        i++;
       }
     } else {
-      // No following user message, or next message is assistant — inject one
-      log.warn({ toolUseCount: toolUseIds.size }, 'Injecting synthetic tool_result user message in Anthropic client');
-      const syntheticContent = [...toolUseIds].map((id) => ({
-        type: 'tool_result' as const,
-        tool_use_id: id,
-        content: SYNTHETIC_RESULT,
-        is_error: true,
-      }));
-      // Insert a synthetic user message right after the assistant message.
-      // Splice into the source array so subsequent iterations see the updated structure.
-      messages.splice(i + 1, 0, { role: 'user', content: syntheticContent });
+      // No following user message or next is assistant — inject synthetic user
+      log.warn(
+        { toolUseCount: toolUseIds.size, toolUseIds: [...toolUseIds], msgIndex: i, nextRole: next?.role },
+        'Injecting synthetic tool_result user message in Anthropic client',
+      );
+      result.push({
+        role: 'user' as const,
+        content: [...toolUseIds].map((id) => ({
+          type: 'tool_result' as const,
+          tool_use_id: id,
+          content: SYNTHETIC_RESULT,
+          is_error: true,
+        })),
+      });
+      i++; // advance past the assistant; next message (if any) processed next iteration
+    }
+  }
+
+  // Self-validation: verify no tool_use/tool_result mismatches remain
+  for (let j = 0; j < result.length; j++) {
+    const m = result[j];
+    if (m.role !== 'assistant') continue;
+    const c = Array.isArray(m.content) ? m.content : [];
+    const ids = new Set<string>();
+    for (const block of c) {
+      if (isToolUseBlock(block)) ids.add(block.id);
+    }
+    if (ids.size === 0) continue;
+
+    const nxt = result[j + 1];
+    const nxtContent = nxt && nxt.role === 'user' && Array.isArray(nxt.content) ? nxt.content : [];
+    const matched = new Set<string>();
+    for (const block of nxtContent) {
+      if (isToolResultBlock(block) && ids.has(block.tool_use_id)) matched.add(block.tool_use_id);
+    }
+    const still = [...ids].filter((id) => !matched.has(id));
+    if (still.length > 0) {
+      log.error(
+        { unmatchedIds: still, msgIndex: j, messageSummary: summarizeMessages(result) },
+        'ensureToolPairing self-validation FAILED — tool_use IDs still unmatched after repair',
+      );
     }
   }
 
@@ -115,6 +190,7 @@ export class AnthropicProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
+    let sentMessages: Anthropic.MessageParam[] | undefined;
     try {
       const formatted = messages.map((m) => ({
         role: m.role,
@@ -124,10 +200,11 @@ export class AnthropicProvider implements Provider {
           .filter((block) => !(block.type === 'text' && !(block as { text?: string }).text?.trim())),
       })).filter((m) => m.content.length > 0);
 
+      sentMessages = ensureToolPairing(formatted);
       const params: Anthropic.MessageCreateParams = {
         model: this.model,
         max_tokens: 64000,
-        messages: ensureToolPairing(formatted),
+        messages: sentMessages,
         ...config,
       };
 
@@ -195,6 +272,13 @@ export class AnthropicProvider implements Provider {
       };
     } catch (error) {
       if (error instanceof Anthropic.APIError) {
+        // Log detailed message structure for tool_use/tool_result ordering errors
+        if (error.status === 400 && /tool_use.*tool_result|tool_result.*tool_use/i.test(error.message) && sentMessages) {
+          log.error(
+            { messageSummary: summarizeMessages(sentMessages), messageCount: sentMessages.length },
+            'Anthropic 400: tool_use/tool_result pairing error — dumping message structure',
+          );
+        }
         throw new ProviderError(
           `Anthropic API error (${error.status}): ${error.message}`,
           'anthropic',


### PR DESCRIPTION
## Summary
- Rewrote `ensureToolPairing` in the Anthropic client to build a fresh result array instead of mutating the input, eliminating potential reference-sharing issues between the input and output arrays
- Added self-validation pass that logs detailed diagnostics if any tool_use/tool_result mismatches remain after repair, plus error-time logging that dumps the exact message structure when the API returns a 400
- Added monotonic timestamps (`monotonicNow()`) to `addMessage` in the conversation store — two messages saved within the same millisecond (e.g., tool_results + assistant in `message_complete`) previously got identical `createdAt` values, making their reload order non-deterministic via `ORDER BY created_at ASC`
- Added 5 new test cases covering ensureToolPairing edge cases (missing results, trailing tool_use, partial results, consecutive assistants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
