### PR TITLE
fix: require confirmation presence before checking pending state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -340,7 +340,7 @@ struct ChatView: View {
                                 && !message.isStreaming
                                 && (index == messages.count - 1
                                     || (index == messages.count - 2
-                                        && messages[messages.count - 1].confirmation?.state != .pending))
+                                        && messages[messages.count - 1].confirmation != nil && messages[messages.count - 1].confirmation?.state != .pending))
                                 && !isSending
                                 && !isThinking
 


### PR DESCRIPTION
Fixes optional chaining bug where nil confirmation made isLastAssistant true for the wrong message. Both confirmation != nil and confirmation?.state != .pending are now required.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
