### PR TITLE
fix: remove unused import and improve type safety in daemon

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -59,7 +59,6 @@ import type {
   PublishPageRequest,
   UnpublishPageRequest,
   LinkOpenRequest,
-  IntegrationListRequest,
   IntegrationConnectRequest,
   IntegrationDisconnectRequest,
 } from './ipc-protocol.js';

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1033,15 +1033,16 @@ export class Session {
             // Add surface blocks to content for persistence
             const contentWithSurfaces: ContentBlock[] = [...cleanedContent as ContentBlock[]];
             for (const surface of this.currentTurnSurfaces) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- custom block type for persistence
               contentWithSurfaces.push({
-                type: 'ui_surface' as any,
+                type: 'ui_surface',
                 surfaceId: surface.surfaceId,
                 surfaceType: surface.surfaceType,
                 title: surface.title,
                 data: surface.data,
                 actions: surface.actions,
                 display: surface.display,
-              } as any);
+              } as unknown as ContentBlock);
             }
 
             // Save assistant message with cleaned content (tags stripped) plus surfaces
@@ -1418,7 +1419,7 @@ export class Session {
       try {
         const content = JSON.parse(msg.content);
         if (Array.isArray(content)) {
-          const toolUseBlocks = content.filter((b: any) => b.type === 'tool_use');
+          const toolUseBlocks = content.filter((b: Record<string, unknown>) => b.type === 'tool_use');
           log.info({ messageId: msg.id, blockCount: content.length, toolUseCount: toolUseBlocks.length }, 'Consolidating assistant message content');
           consolidatedContent.push(...content);
         }


### PR DESCRIPTION
## Summary
- Remove unused `IntegrationListRequest` import from handlers.ts
- Replace `any` casts with proper types in session.ts for UI surface persistence and tool_use block filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
