### PR TITLE
fix: compare all meaningful fields in InlineSurfaceData equality

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -370,7 +370,11 @@ public struct InlineSurfaceData: Identifiable, Equatable {
     public let surfaceMessage: UiSurfaceShowMessage?
 
     public static func == (lhs: InlineSurfaceData, rhs: InlineSurfaceData) -> Bool {
-        lhs.id == rhs.id && lhs.completionState == rhs.completionState
+        lhs.id == rhs.id
+            && lhs.completionState == rhs.completionState
+            && lhs.surfaceType == rhs.surfaceType
+            && lhs.title == rhs.title
+            && lhs.actions == rhs.actions
     }
 
     /// When non-nil, the surface has been completed and should render in collapsed/chip state.

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -315,7 +315,7 @@ public enum SurfaceData: Sendable {
     case fileUpload(FileUploadSurfaceData)
 }
 
-public struct SurfaceActionButton: Identifiable, Sendable {
+public struct SurfaceActionButton: Identifiable, Equatable, Sendable {
     public let id: String
     public let label: String
     public let style: SurfaceActionStyle


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #3091
- Expands `InlineSurfaceData.==` to compare `surfaceType`, `title`, and `actions` in addition to `id` and `completionState`, so surface content updates are properly detected as changes
- Adds `Equatable` conformance to `SurfaceActionButton` (all its fields are already equatable) to enable array comparison

## Context
The original PR #3091 added `completionState` to the equality check but still ignored `surfaceType`, `title`, `data`, `actions`, and `surfaceMessage`. This meant two `InlineSurfaceData` instances with the same `id`/`completionState` but different content would compare as equal, causing missed UI updates.

`data` (`SurfaceData`) and `surfaceMessage` (`UiSurfaceShowMessage`) are excluded because they don't conform to `Equatable`. The included fields cover all the equatable properties that affect the rendered surface.

## Files changed
- `clients/shared/Features/Chat/ChatMessage.swift` — expanded `==` operator
- `clients/shared/Features/Surfaces/SurfaceTypes.swift` — added `Equatable` to `SurfaceActionButton`

## Test plan
- [ ] Verify surfaces with updated title/type/actions are detected as changed and re-render
- [ ] Verify completion state transitions still trigger UI updates
- [ ] Build succeeds on macOS and iOS targets
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
