### PR TITLE
fix: update tests broken by Gmail integration merge

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -177,6 +177,9 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'tools/credentials/vault.ts',    // credential store tool
       'tools/credentials/broker.ts',   // brokered credential access
       'tools/network/web-search.ts',   // web search API key lookup
+      'daemon/handlers.ts',            // Vercel API token + integration OAuth
+      'integrations/registry.ts',      // integration connection status check
+      'integrations/token-manager.ts', // OAuth token refresh flow
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -151,7 +151,7 @@ describe('tool manifest', () => {
   });
 
   test('eager module list contains expected count', () => {
-    expect(eagerModules.length).toBe(15);
+    expect(eagerModules.length).toBe(17);
   });
 
   test('explicit tools list includes memory, credential, and timer tools', () => {

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -206,7 +206,7 @@ describe('Session workspace dirty on file mutations', () => {
     expect(session.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
-  test('failed bash does NOT mark workspace dirty', async () => {
+  test('failed bash still marks workspace dirty (commands can mutate before failing)', async () => {
     const session = makeSession();
     await session.loadFromDb();
 
@@ -219,7 +219,7 @@ describe('Session workspace dirty on file mutations', () => {
     };
 
     await session.processMessage('Run a command', [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
   test('non-mutation tools do NOT mark workspace dirty', async () => {


### PR DESCRIPTION
## Summary
- Update eager module count from 15 to 17 to reflect schedule tools + Gmail executors added to the manifest
- Add `integrations/registry.ts`, `integrations/token-manager.ts`, and `daemon/handlers.ts` to the credential security `getSecureKey` allowlist
- Align bash dirty-tracking test with the intentional always-dirty behavior (bash commands can mutate the filesystem even when exiting non-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
