### PR TITLE
fix: use pricing overrides and persist assistantId in usage events

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -23,7 +23,7 @@ import { allAppTools } from '../tools/apps/definitions.js';
 import { requestComputerControlTool } from '../tools/computer-use/request-computer-control.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
-import { estimateCost, resolvePricing } from '../util/pricing.js';
+import { estimateCost, resolvePricingWithOverrides } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
 import { TraceEmitter } from './trace-emitter.js';
 import { classifySessionError, isUserCancellation, buildSessionErrorMessage } from './session-error.js';
@@ -2344,7 +2344,8 @@ export class Session {
 
     // Dual-write: persist per-turn usage event to the new ledger table
     try {
-      const pricing = resolvePricing(this.provider.name, model, inputTokens, outputTokens);
+      const config = getConfig();
+      const pricing = resolvePricingWithOverrides(this.provider.name, model, inputTokens, outputTokens, config.pricingOverrides);
       recordUsageEvent(
         {
           actor,
@@ -2354,7 +2355,7 @@ export class Session {
           outputTokens,
           cacheCreationInputTokens: null,
           cacheReadInputTokens: null,
-          assistantId: null,
+          assistantId: this.assistantId,
           conversationId: this.conversationId,
           runId: null,
           requestId,


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #1688 (Cost tracking and budget enforcement)
- Uses `resolvePricingWithOverrides` instead of `resolvePricing` in `session.ts` so that user-configured `pricingOverrides` are actually respected when recording LLM usage events
- Persists `this.assistantId` instead of hardcoded `null` so usage events are properly associated with their assistant and can be queried by assistant ID

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify that configuring `pricingOverrides` in user config now affects recorded usage event costs
- [ ] Verify that usage events have the correct `assistantId` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
