### PR TITLE
Default parallel workers to one-per-task instead of 12

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -9,7 +9,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a feature descriptio
 Extract these flags from `$ARGUMENTS` before treating the remainder as the feature description:
 
 - `--auto` — skip the pause between rounds (default: pause and ask before sweep)
-- `--workers N` — parallel worker count for swarm phases (default: 12)
+- `--workers N` — parallel worker count for swarm phases (default: one per task — no cap)
 - `--skip-plan` — skip planning; use issues already in the "Ready" column of the GH project
 
 Everything after stripping flags is the **feature description**.
@@ -180,7 +180,7 @@ gh api graphql -f query='mutation {
 
 Read and follow the instructions in `.claude/commands/swarm.md` with these modifications:
 
-- Pass the `--workers` count (or default 12) as the first argument.
+- Pass the `--workers` count (or default: one per task) as the first argument.
 - **After each milestone task completes and its PR merges**, update the corresponding GitHub issue. Skip this for non-milestone tasks (e.g., "Address the feedback on ..." items from Phase 5 — those are PR-based and have no associated milestone issue):
   1. Set the project board status to "Done":
 

--- a/.claude/commands/check-reviews-and-swarm.md
+++ b/.claude/commands/check-reviews-and-swarm.md
@@ -4,7 +4,7 @@ Arguments (optional): $ARGUMENTS
 
 Parse positional arguments (these are passed through to `/swarm`):
 
-- **First argument** (optional): number of parallel workers (default: 12).
+- **First argument** (optional): number of parallel workers (default: one per task — no cap).
 - **Second argument** (optional): maximum number of tasks to complete before shutting down.
 
 ## Phase 1: Check reviews

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -11,7 +11,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a feature descriptio
 Extract these flags from `$ARGUMENTS` before treating the remainder as the feature description:
 
 - `--auto` — skip the pause between rounds (default: pause and ask before sweep)
-- `--workers N` — parallel worker count for swarm phases (default: 12)
+- `--workers N` — parallel worker count for swarm phases (default: one per task — no cap)
 - `--skip-plan` — skip planning; use issues already in the "Ready" column of the GH project
 - `--branch NAME` — custom feature branch name (default: auto-generated from feature description as `feature/<kebab-case-summary>`)
 

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -4,10 +4,10 @@ Arguments (optional): $ARGUMENTS
 
 Parse positional arguments:
 
-- **First argument** (optional): number of parallel workers (default: 12). Example: `/swarm 5` runs 5 workers.
-- **Second argument** (optional): maximum number of tasks to complete before automatically shutting down. Example: `/swarm 12 10` runs 12 workers and stops after completing 10 tasks.
+- **First argument** (optional): number of parallel workers (default: one per task — no cap). Example: `/swarm 5` runs 5 workers.
+- **Second argument** (optional): maximum number of tasks to complete before automatically shutting down. Example: `/swarm 8 10` runs 8 workers and stops after completing 10 tasks.
 
-If no arguments are provided, default to 12 workers with no task limit (run until TODO.md is empty or the user says to stop).
+If no arguments are provided, default to one worker per available task (no artificial cap) with no task limit (run until TODO.md is empty or the user says to stop).
 
 ## Repo-specific gotchas (include these in every agent prompt)
 
@@ -18,7 +18,7 @@ If no arguments are provided, default to 12 workers with no task limit (run unti
 ## Phase 1: Setup
 
 1. Read .private/TODO.md. Keep an internal list of which items are currently in-flight.
-2. Parse the arguments: note the worker count (default: 12) and max-tasks limit (if provided). Track a **completed count** starting at 0.
+2. Parse the arguments: note the worker count (default: number of tasks in TODO.md) and max-tasks limit (if provided). Track a **completed count** starting at 0.
 3. Create a team with `TeamCreate` (team name: `swarm`).
 
 ## Phase 2: Pick the next task


### PR DESCRIPTION
## Summary
- Updated swarm, blitz, safe-blitz, and check-reviews-and-swarm commands to default to one worker per available task (no artificial cap) instead of a hardcoded limit of 12
- Workers can still be explicitly limited via the first argument or `--workers N` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
