### PR TITLE
fix: use actual matched text in edit diff and handle empty strings

### DIFF
--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -95,9 +95,9 @@ class FileEditTool implements Tool {
       }
     }
 
-    const { filePath, matchCount, oldContent, newContent, matchMethod, similarity } = result.value;
+    const { filePath, matchCount, oldContent, newContent, matchMethod, similarity, actualOld, actualNew } = result.value;
 
-    const diffText = formatEditDiff(oldString as string, newString as string);
+    const diffText = formatEditDiff(actualOld, actualNew);
 
     if (replaceAll) {
       return {

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -92,9 +92,9 @@ class HostFileEditTool implements Tool {
       }
     }
 
-    const { filePath, matchCount, oldContent, newContent, matchMethod, similarity } = result.value;
+    const { filePath, matchCount, oldContent, newContent, matchMethod, similarity, actualOld, actualNew } = result.value;
 
-    const diffText = formatEditDiff(oldString as string, newString as string);
+    const diffText = formatEditDiff(actualOld, actualNew);
 
     if (replaceAll) {
       return {

--- a/assistant/src/tools/shared/filesystem/edit-engine.ts
+++ b/assistant/src/tools/shared/filesystem/edit-engine.ts
@@ -6,7 +6,7 @@ import type { MatchMethod } from '../../filesystem/fuzzy-match.js';
 // ---------------------------------------------------------------------------
 
 export type EditEngineResult =
-  | { ok: true; updatedContent: string; matchCount: number; matchMethod: MatchMethod; similarity: number }
+  | { ok: true; updatedContent: string; matchCount: number; matchMethod: MatchMethod; similarity: number; actualOld: string; actualNew: string }
   | { ok: false; reason: 'not_found' }
   | { ok: false; reason: 'ambiguous'; matchCount: number };
 
@@ -34,7 +34,7 @@ export function applyEdit(
     }
     const count = content.split(oldString).length - 1;
     const updatedContent = content.split(oldString).join(newString);
-    return { ok: true, updatedContent, matchCount: count, matchMethod: 'exact', similarity: 1 };
+    return { ok: true, updatedContent, matchCount: count, matchMethod: 'exact', similarity: 1, actualOld: oldString, actualNew: newString };
   }
 
   // Single-match path: cascading exact -> whitespace -> fuzzy
@@ -52,5 +52,5 @@ export function applyEdit(
     : newString;
 
   const updatedContent = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
-  return { ok: true, updatedContent, matchCount: 1, matchMethod: match.method, similarity: match.similarity };
+  return { ok: true, updatedContent, matchCount: 1, matchMethod: match.method, similarity: match.similarity, actualOld: match.matched, actualNew: adjustedNewString };
 }

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -207,6 +207,8 @@ export class FileSystemOps {
         newContent: result.updatedContent,
         matchMethod: result.matchMethod,
         similarity: result.similarity,
+        actualOld: result.actualOld,
+        actualNew: result.actualNew,
       },
     };
   }

--- a/assistant/src/tools/shared/filesystem/format-diff.ts
+++ b/assistant/src/tools/shared/filesystem/format-diff.ts
@@ -5,11 +5,12 @@ const MAX_DIFF_LINES = 8;
  * Lines are prefixed with - / + and truncated if the change is large.
  */
 export function formatEditDiff(oldString: string, newString: string): string {
-  const oldLines = oldString.split('\n');
-  const newLines = newString.split('\n');
-
-  const removed = truncateLines(oldLines, MAX_DIFF_LINES).map(l => `- ${l}`);
-  const added = truncateLines(newLines, MAX_DIFF_LINES).map(l => `+ ${l}`);
+  const removed = oldString.length > 0
+    ? truncateLines(oldString.split('\n'), MAX_DIFF_LINES).map(l => `- ${l}`)
+    : [];
+  const added = newString.length > 0
+    ? truncateLines(newString.split('\n'), MAX_DIFF_LINES).map(l => `+ ${l}`)
+    : [];
 
   return [...removed, ...added].join('\n');
 }

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -69,6 +69,10 @@ export interface EditOutput {
   matchMethod: 'exact' | 'whitespace' | 'fuzzy';
   /** Match similarity score (0–1). Always 1 for exact/whitespace, <1 for fuzzy. */
   similarity: number;
+  /** The text that was actually matched in the file (may differ from the requested old_string for fuzzy/whitespace matches). */
+  actualOld: string;
+  /** The replacement text actually written (may have adjusted indentation for non-exact matches). */
+  actualNew: string;
 }
 
 export type EditResult =


### PR DESCRIPTION
## Summary
- **Build edit diff from applied file contents**: `formatEditDiff` now receives the text that was actually matched and replaced on disk (`actualOld`/`actualNew`) instead of the requested `old_string`/`new_string`. For non-exact matches (whitespace normalization or fuzzy), `applyEdit` matches different source text and adjusts replacement indentation, so the original inputs didn't reflect what ended up on disk.
- **Omit added marker when replacement text is empty**: Deletion edits (`new_string: ""`) no longer emit a spurious `+ ` line. Previously `"".split('\n')` returned `['']`, so pure removals looked like remove-and-add-blank changes.

Addresses review feedback from PR #3092.

## Files changed
- `assistant/src/tools/shared/filesystem/edit-engine.ts` — return `actualOld`/`actualNew` from `applyEdit`
- `assistant/src/tools/shared/filesystem/types.ts` — add `actualOld`/`actualNew` to `EditOutput`
- `assistant/src/tools/shared/filesystem/file-ops-service.ts` — pass through new fields
- `assistant/src/tools/shared/filesystem/format-diff.ts` — skip empty old/new strings
- `assistant/src/tools/filesystem/edit.ts` — use `actualOld`/`actualNew` for diff
- `assistant/src/tools/host-filesystem/edit.ts` — use `actualOld`/`actualNew` for diff

## Test plan
- [ ] Existing edit-engine tests pass (additive fields don't break)
- [ ] Verify type checking passes (`bunx tsc --noEmit`)
- [ ] Deletion edit (`new_string: ""`) no longer shows spurious `+ ` line
- [ ] Fuzzy/whitespace matched edits show actual matched text in diff output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
