### PR TITLE
fix: handle bare angle-bracket From headers in sender parser

### DIFF
--- a/assistant/src/integrations/gmail/newsletter-analyzer.ts
+++ b/assistant/src/integrations/gmail/newsletter-analyzer.ts
@@ -21,10 +21,11 @@ function getHeader(headers: GmailHeader[] | undefined, name: string): string | u
 }
 
 function parseSender(from: string): { name: string; email: string } {
-  // "Display Name <email@example.com>" or just "email@example.com"
-  const match = from.match(/^(.+?)\s*<([^>]+)>$/);
+  // Handles "Display Name <email@example.com>", "<email@example.com>", or just "email@example.com"
+  const match = from.match(/^(.*?)\s*<([^>]+)>$/);
   if (match) {
-    return { name: match[1].replace(/^["']|["']$/g, '').trim(), email: match[2].toLowerCase() };
+    const rawName = match[1].replace(/^["']|["']$/g, '').trim();
+    return { name: rawName || match[2], email: match[2].toLowerCase() };
   }
   return { name: from.trim(), email: from.trim().toLowerCase() };
 }


### PR DESCRIPTION
## Summary
- Fixes the `parseSender` regex in `newsletter-analyzer.ts` to handle bare angle-bracket `From` headers like `<news@example.com>` (RFC 5322 name-addr without a display name)
- Changed regex from `(.+?)` to `(.*?)` to accept zero-length name prefixes
- When the name part is empty, falls back to using the email address as the display name

Addresses review feedback from PR #3100 (chatgpt-codex-connector[bot]).

## Test plan
- [x] `bunx tsc --noEmit` passes with no new errors
- [ ] Verify `parseSender('<news@example.com>')` returns `{ name: 'news@example.com', email: 'news@example.com' }`
- [ ] Verify `parseSender('Display Name <news@example.com>')` still returns `{ name: 'Display Name', email: 'news@example.com' }`
- [ ] Verify `parseSender('news@example.com')` still returns `{ name: 'news@example.com', email: 'news@example.com' }`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
