### PR TITLE
ci: print failed test file summary at end of CI test run

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -19,6 +19,7 @@ EXPERIMENTAL_FILES=(
 
 found_test=0
 any_failed=0
+failed_files=()
 while IFS= read -r test_file; do
   found_test=1
 
@@ -35,11 +36,13 @@ while IFS= read -r test_file; do
     echo "==> Running ${test_file}"
     if ! bun test --test-name-pattern '^(?!.*\[experimental\])' "${test_file}"; then
       any_failed=1
+      failed_files+=("${test_file}")
     fi
   else
     echo "==> Running ${test_file}"
     if ! bun test "${test_file}"; then
       any_failed=1
+      failed_files+=("${test_file}")
     fi
   fi
 done < <(find src/__tests__ -maxdepth 1 -type f -name '*.test.ts' | sort)
@@ -51,6 +54,12 @@ fi
 
 if [[ ${any_failed} -ne 0 ]]; then
   echo ""
-  echo "Some test files had failures (see above)."
+  echo "========================================"
+  echo "  FAILED TEST FILES (${#failed_files[@]}):"
+  echo "========================================"
+  for f in "${failed_files[@]}"; do
+    echo "  ✗ ${f}"
+  done
+  echo "========================================"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Collects failed test file names during the test run and prints a clear summary at the end
- Replaces the generic "Some test files had failures (see above)." message with a list of exactly which files failed
- Makes it immediately obvious from the bottom of the GHA log which tests need attention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
