### PR TITLE
fix: clean up integration callbacks on disappear and handle send failures

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -392,6 +392,10 @@ struct SettingsPanel: View {
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
         }
+        .onDisappear {
+            daemonClient?.onIntegrationListResponse = nil
+            daemonClient?.onIntegrationConnectResult = nil
+        }
         .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
@@ -444,7 +448,11 @@ struct SettingsPanel: View {
                 } else {
                     VButton(label: "Connect", style: .primary) {
                         connectingIntegration = integration.id
-                        try? daemonClient?.sendIntegrationConnect(integrationId: integration.id)
+                        do {
+                            try daemonClient?.sendIntegrationConnect(integrationId: integration.id)
+                        } catch {
+                            connectingIntegration = nil
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -283,6 +283,10 @@ public struct SettingsView: View {
             }
             try? daemonClient?.sendIntegrationList()
         }
+        .onDisappear {
+            daemonClient?.onIntegrationListResponse = nil
+            daemonClient?.onIntegrationConnectResult = nil
+        }
         .onReceive(permissionTimer) { _ in
             checkPermissions()
         }


### PR DESCRIPTION
## Summary
- Add `onDisappear` handlers in both `SettingsPanel` and `SettingsView` to set `onIntegrationListResponse` and `onIntegrationConnectResult` callbacks to `nil` when the view disappears. This follows the existing pattern from `TrustRulesView` and `RemindersView`, and prevents one view from silently overwriting the other's callbacks when both settings surfaces are open simultaneously.
- Replace `try?` with `do/catch` in `SettingsPanel`'s Connect button so `connectingIntegration` is cleared on send failure, preventing the spinner from getting stuck when the daemon socket is down.

Addresses review feedback from chatgpt-codex-connector[bot] and devin-ai-integration[bot] on PR #3102.

## Test plan
- [ ] Open the main window with the Settings side panel visible (SettingsPanel)
- [ ] Open the standalone Settings window (Cmd+,) -- both views should independently receive integration updates
- [ ] Close one view and verify the other still receives updates
- [ ] Disconnect the daemon and try connecting an integration -- spinner should clear instead of getting stuck

## Files changed
- `clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift`
- `clients/macos/vellum-assistant/Features/Settings/SettingsView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
