### PR TITLE
fix: address review feedback on token manager

### DIFF
--- a/assistant/src/integrations/token-manager.ts
+++ b/assistant/src/integrations/token-manager.ts
@@ -52,12 +52,16 @@ async function doRefresh(integrationId: string, definition: IntegrationDefinitio
   const result = await refreshOAuth2Token(config.tokenUrl, runtimeClientId, refreshToken);
 
   // Store the new access token
-  setSecureKey(`integration:${integrationId}:access_token`, result.accessToken);
+  if (!setSecureKey(`integration:${integrationId}:access_token`, result.accessToken)) {
+    throw new Error(`Failed to store refreshed access token for "${integrationId}"`);
+  }
 
-  // Update metadata with new expiry
-  const expiresAt = result.expiresIn
+  // Update metadata with new expiry.
+  // Use null to explicitly clear a stale expiresAt when the provider omits
+  // expires_in (or returns 0), so isTokenExpired won't keep forcing refreshes.
+  const expiresAt = result.expiresIn != null && result.expiresIn > 0
     ? Date.now() + result.expiresIn * 1000
-    : undefined;
+    : null;
 
   upsertCredentialMetadata(`integration:${integrationId}`, 'access_token', {
     expiresAt,
@@ -65,7 +69,9 @@ async function doRefresh(integrationId: string, definition: IntegrationDefinitio
 
   // If a new refresh token was issued, store it too
   if (result.refreshToken) {
-    setSecureKey(`integration:${integrationId}:refresh_token`, result.refreshToken);
+    if (!setSecureKey(`integration:${integrationId}:refresh_token`, result.refreshToken)) {
+      throw new Error(`Failed to store refreshed refresh token for "${integrationId}"`);
+    }
     upsertCredentialMetadata(`integration:${integrationId}`, 'refresh_token', {});
   }
 
@@ -91,25 +97,20 @@ export async function withValidToken<T>(
     throw new TokenExpiredError(integrationId, `No access token found for "${integrationId}". Authorization required.`);
   }
 
-  // Proactively refresh if expired or about to expire
+  // Proactively refresh if expired or about to expire.
+  // Let doRefresh errors propagate directly so transient failures (network,
+  // 5xx) are surfaced to callers instead of being masked as TokenExpiredError.
   if (isTokenExpired(integrationId)) {
-    try {
-      token = await doRefresh(integrationId, definition);
-    } catch {
-      throw new TokenExpiredError(integrationId);
-    }
+    token = await doRefresh(integrationId, definition);
   }
 
   try {
     return await callback(token);
   } catch (err: unknown) {
-    // Check if this is a 401 response — attempt one refresh + retry
+    // Check if this is a 401 response — attempt one refresh + retry.
+    // Let doRefresh errors propagate directly for the same reason.
     if (is401Error(err)) {
-      try {
-        token = await doRefresh(integrationId, definition);
-      } catch {
-        throw new TokenExpiredError(integrationId);
-      }
+      token = await doRefresh(integrationId, definition);
       return callback(token);
     }
     throw err;

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -109,7 +109,8 @@ export function upsertCredentialMetadata(
     allowedTools?: string[];
     allowedDomains?: string[];
     usageDescription?: string;
-    expiresAt?: number;
+    /** Pass `null` to explicitly clear a previously-set expiry. */
+    expiresAt?: number | null;
     grantedScopes?: string[];
   },
 ): CredentialMetadata {
@@ -128,7 +129,13 @@ export function upsertCredentialMetadata(
     if (policy?.allowedTools !== undefined) existing.allowedTools = policy.allowedTools;
     if (policy?.allowedDomains !== undefined) existing.allowedDomains = policy.allowedDomains;
     if (policy?.usageDescription !== undefined) existing.usageDescription = policy.usageDescription;
-    if (policy?.expiresAt !== undefined) existing.expiresAt = policy.expiresAt;
+    if (policy?.expiresAt !== undefined) {
+      if (policy.expiresAt === null) {
+        delete existing.expiresAt;
+      } else {
+        existing.expiresAt = policy.expiresAt;
+      }
+    }
     if (policy?.grantedScopes !== undefined) existing.grantedScopes = policy.grantedScopes;
     existing.updatedAt = now;
     saveFile(data);
@@ -142,7 +149,7 @@ export function upsertCredentialMetadata(
     allowedTools: policy?.allowedTools ?? [],
     allowedDomains: policy?.allowedDomains ?? [],
     usageDescription: policy?.usageDescription,
-    expiresAt: policy?.expiresAt,
+    expiresAt: policy?.expiresAt ?? undefined,
     grantedScopes: policy?.grantedScopes,
     createdAt: now,
     updatedAt: now,


### PR DESCRIPTION
## Summary

Addresses review feedback from Codex and Devin on PR #3094 (token manager for OAuth2):

- **Check `setSecureKey` return values**: `doRefresh` now throws if secure storage writes fail, preventing silent token persistence loss that could lead to permanent access loss after refresh token rotation
- **Clear stale `expiresAt` on missing `expires_in`**: When the OAuth2 provider omits `expires_in` (or returns 0), we now explicitly clear the metadata expiry via `null` instead of passing `undefined` (which was silently ignored by `upsertCredentialMetadata`). This prevents unnecessary refresh on every API call
- **Preserve transient refresh errors**: Removed blanket `catch` blocks in `withValidToken` that converted all `doRefresh` failures into `TokenExpiredError`, masking transient issues (network errors, 5xx) as "re-authorization required"

## Files modified
- `assistant/src/integrations/token-manager.ts` — all three fixes
- `assistant/src/tools/credentials/metadata-store.ts` — accept `null` for `expiresAt` to support explicit clearing

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify token refresh works when provider returns `expires_in`
- [ ] Verify no infinite refresh loop when provider omits `expires_in`
- [ ] Verify transient refresh errors are surfaced (not masked as TokenExpiredError)

Addresses feedback from #3094.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
