### PR TITLE
fix: exclude attachment descriptions from textSegments

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -375,14 +375,11 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     }
   }
 
-  // Include attachment descriptions in textSegments so that
-  // textSegments.join('') matches the rendered text field.
-  if (attachmentParts.length > 0) {
-    const attachmentText = attachmentParts.join('\n');
-    const prefix = textParts.length > 0 ? '\n' : '';
-    ensureSegment();
-    currentSegmentParts.push(prefix + attachmentText);
-  }
+  // Attachment descriptions are NOT included in textSegments — they are
+  // rendered separately as attachment chips/images in the UI.  Including
+  // them would cause the "last text segment" heuristic to surface an
+  // attachment descriptor instead of the assistant's actual narrative text
+  // in interleaved history messages.
 
   finalizeSegment();
 


### PR DESCRIPTION
## Summary
- Removes the code in `renderHistoryContent` that appended attachment descriptions (file/image block text) into `textSegments`
- Fixes a bug where the macOS client's `interleavedContent` view would show an attachment descriptor instead of the assistant's actual narrative text for text -> tool -> attachment turns
- The `text` field continues to include attachment descriptions for backward compatibility; attachments are rendered separately as image grids and file chips in the UI

## Test plan
- [x] Existing `server-history-render.test.ts` tests pass (28/28)
- [x] Swift lint passes
- [ ] Verify that interleaved history messages with attachments show the correct narrative text instead of attachment descriptions
- [ ] Verify that attachment-only messages still render attachment chips/images correctly

Addresses feedback from #3110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
