### PR TITLE
fix: sort unique tool names in compactFailedToolChip for deterministic ordering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -888,7 +888,7 @@ private struct ChatBubble: View {
 
     /// Failed/denied tool chip — shown when the user denied permission.
     private var compactFailedToolChip: some View {
-        let uniqueNames = Array(Set(message.toolCalls.map(\.toolName)))
+        let uniqueNames = Array(Set(message.toolCalls.map(\.toolName))).sorted()
         let primary = uniqueNames.first ?? "Tool"
         let label = Self.friendlyRunningLabel(primary) + " failed"
 


### PR DESCRIPTION
## Summary
- Adds `.sorted()` to the `Array(Set(...))` pattern in `compactFailedToolChip`, matching the fix already applied to `compactToolChip` in PR #3113
- Without this, the failed tool chip label can flicker between renders when multiple tool names are present due to non-deterministic Set ordering

## Test plan
- [ ] Verify lint passes (`./build.sh lint`)
- [ ] Confirm `compactFailedToolChip` now uses `.sorted()` matching `compactToolChip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
