### PR TITLE
fix: resolve type errors and missing mock exports breaking CI

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -270,18 +270,18 @@ describe('renderHistoryContent', () => {
 describe('mergeToolResults', () => {
   test('merges tool_result user messages into preceding assistant toolCalls', () => {
     const result = mergeToolResults([
-      { role: 'user', text: 'fetch this page', timestamp: 1, toolCalls: [], toolCallsBeforeText: false, textSegments: ['fetch this page'], contentOrder: ['text:0'] },
+      { role: 'user', text: 'fetch this page', timestamp: 1, toolCalls: [], toolCallsBeforeText: false, textSegments: ['fetch this page'], contentOrder: ['text:0'], surfaces: [] },
       {
         role: 'assistant', text: '', timestamp: 2,
         toolCalls: [{ name: 'web_fetch', input: { url: 'https://example.com' } }],
-        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0'],
+        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0'], surfaces: [],
       },
       {
         role: 'user', text: '', timestamp: 3,
         toolCalls: [{ name: 'unknown', input: {}, result: 'page content', isError: false }],
-        toolCallsBeforeText: false, textSegments: [], contentOrder: [],
+        toolCallsBeforeText: false, textSegments: [], contentOrder: [], surfaces: [],
       },
-      { role: 'assistant', text: 'Here is what I found.', timestamp: 4, toolCalls: [], toolCallsBeforeText: false, textSegments: ['Here is what I found.'], contentOrder: ['text:0'] },
+      { role: 'assistant', text: 'Here is what I found.', timestamp: 4, toolCalls: [], toolCallsBeforeText: false, textSegments: ['Here is what I found.'], contentOrder: ['text:0'], surfaces: [] },
     ]);
 
     expect(result).toHaveLength(3);
@@ -295,16 +295,16 @@ describe('mergeToolResults', () => {
 
   test('suppresses tool_result-only user messages from visible history', () => {
     const result = mergeToolResults([
-      { role: 'user', text: 'hello', timestamp: 1, toolCalls: [], toolCallsBeforeText: false, textSegments: ['hello'], contentOrder: ['text:0'] },
+      { role: 'user', text: 'hello', timestamp: 1, toolCalls: [], toolCallsBeforeText: false, textSegments: ['hello'], contentOrder: ['text:0'], surfaces: [] },
       {
         role: 'assistant', text: '', timestamp: 2,
         toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
-        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0'],
+        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0'], surfaces: [],
       },
       {
         role: 'user', text: '', timestamp: 3,
         toolCalls: [{ name: 'unknown', input: {}, result: 'file.txt', isError: false }],
-        toolCallsBeforeText: false, textSegments: [], contentOrder: [],
+        toolCallsBeforeText: false, textSegments: [], contentOrder: [], surfaces: [],
       },
     ]);
 
@@ -317,7 +317,7 @@ describe('mergeToolResults', () => {
       {
         role: 'user', text: 'user typed something', timestamp: 1,
         toolCalls: [{ name: 'unknown', input: {}, result: 'data', isError: false }],
-        toolCallsBeforeText: false, textSegments: ['user typed something'], contentOrder: ['text:0'],
+        toolCallsBeforeText: false, textSegments: ['user typed something'], contentOrder: ['text:0'], surfaces: [],
       },
     ]);
 
@@ -333,7 +333,7 @@ describe('mergeToolResults', () => {
           { name: 'bash', input: { command: 'ls' } },
           { name: 'bash', input: { command: 'pwd' } },
         ],
-        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0', 'tool:1'],
+        toolCallsBeforeText: true, textSegments: [], contentOrder: ['tool:0', 'tool:1'], surfaces: [],
       },
       {
         role: 'user', text: '', timestamp: 2,
@@ -341,7 +341,7 @@ describe('mergeToolResults', () => {
           { name: 'unknown', input: {}, result: 'file.txt', isError: false },
           { name: 'unknown', input: {}, result: '/home/user', isError: false },
         ],
-        toolCallsBeforeText: false, textSegments: [], contentOrder: [],
+        toolCallsBeforeText: false, textSegments: [], contentOrder: [], surfaces: [],
       },
     ]);
 
@@ -355,12 +355,12 @@ describe('mergeToolResults', () => {
       {
         role: 'assistant', text: '', timestamp: 1,
         toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
-        toolCallsBeforeText: true, textSegments: [] as string[], contentOrder: ['tool:0'],
+        toolCallsBeforeText: true, textSegments: [] as string[], contentOrder: ['tool:0'], surfaces: [],
       },
       {
         role: 'user', text: '', timestamp: 2,
         toolCalls: [{ name: 'unknown', input: {}, result: 'output', isError: false }],
-        toolCallsBeforeText: false, textSegments: [] as string[], contentOrder: [] as string[],
+        toolCallsBeforeText: false, textSegments: [] as string[], contentOrder: [] as string[], surfaces: [],
       },
     ];
 

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -17,6 +17,12 @@ mock.module('../util/platform.js', () => ({
   isLinux: () => process.platform === 'linux',
   isWindows: () => process.platform === 'win32',
   getPlatformName: () => process.platform,
+  getWorkspaceConfigPath: () => join(TEST_DIR, 'config.json'),
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
+  getWorkspaceDir: () => TEST_DIR,
+  getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
 }));
 
 mock.module('../util/logger.js', () => ({

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -96,6 +96,7 @@ import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
 import { getAttachmentsForMessageUnscoped } from '../memory/attachments-store.js';
 import type { UserMessageAttachment } from './ipc-contract.js';
+import { listStatuses as listIntegrationStatuses, disconnect as disconnectIntegration } from '../integrations/registry.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -555,6 +556,18 @@ const handlers: DispatchMap = {
       return;
     }
     log.warn({ sessionId: msg.sessionId, surfaceId: msg.surfaceId }, 'No session found for surface undo');
+  },
+  integration_list: (_msg, socket, ctx) => {
+    const statuses = listIntegrationStatuses();
+    ctx.send(socket, { type: 'integration_list_response', integrations: statuses });
+  },
+  integration_connect: (msg, socket, ctx) => {
+    // TODO: Implement credential prompt flow for connecting integrations.
+    ctx.send(socket, { type: 'integration_connect_result', integrationId: msg.integrationId, success: false, error: 'Not yet implemented' });
+  },
+  integration_disconnect: (msg, socket, ctx) => {
+    disconnectIntegration(msg.integrationId);
+    ctx.send(socket, { type: 'integration_connect_result', integrationId: msg.integrationId, success: true });
   },
 };
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -306,6 +306,7 @@ export class RuntimeHttpServer {
         toolCallsBeforeText: rendered.toolCallsBeforeText,
         textSegments: rendered.textSegments,
         contentOrder: rendered.contentOrder,
+        surfaces: rendered.surfaces,
         id: msg.id,
       };
     });


### PR DESCRIPTION
## Summary
- Add missing `surfaces: []` to all `ParsedHistoryMessage` test data objects in `server-history-render.test.ts` and add `surfaces: rendered.surfaces` in `http-server.ts`
- Add missing platform mock exports (`getWorkspaceConfigPath`, `getWorkspaceSkillsDir`, etc.) in `skills.test.ts` to fix `SyntaxError: Export named 'getWorkspaceConfigPath' not found`
- Add `integration_list`, `integration_connect`, and `integration_disconnect` handlers to the dispatch map in `handlers.ts` to satisfy exhaustive type check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
