### PR TITLE
fix: use comprehensive SSRF protection for gmail unsubscribe

### DIFF
--- a/assistant/src/tools/gmail/executors.ts
+++ b/assistant/src/tools/gmail/executors.ts
@@ -12,6 +12,7 @@ import { withValidToken } from '../../integrations/token-manager.js';
 import { getIntegration } from '../../integrations/registry.js';
 import * as gmail from '../../integrations/gmail/client.js';
 import type { GmailMessageFormat } from '../../integrations/gmail/types.js';
+import { isPrivateOrLocalHost } from '../network/url-safety.js';
 import {
   gmailSearchDef,
   gmailListMessagesDef,
@@ -230,9 +231,8 @@ const gmailUnsubscribe = makeGmailTool(gmailUnsubscribeDef, async (input) => {
         if (parsed.protocol !== 'https:') {
           return err('Unsubscribe URL must use HTTPS.');
         }
-        const hostname = parsed.hostname;
-        if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname.endsWith('.local')) {
-          return err('Unsubscribe URL points to a local address.');
+        if (isPrivateOrLocalHost(parsed.hostname)) {
+          return err('Unsubscribe URL points to a local or private address.');
         }
       } catch {
         return err('Invalid unsubscribe URL.');
@@ -244,6 +244,7 @@ const gmailUnsubscribe = makeGmailTool(gmailUnsubscribeDef, async (input) => {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: postHeader,
+          redirect: 'manual',
         });
         if (resp.ok) {
           return ok('Successfully unsubscribed via HTTPS POST.');
@@ -252,7 +253,7 @@ const gmailUnsubscribe = makeGmailTool(gmailUnsubscribeDef, async (input) => {
       }
 
       // Fallback: GET request
-      const resp = await fetch(url);
+      const resp = await fetch(url, { redirect: 'manual' });
       if (resp.ok) {
         return ok('Successfully unsubscribed via HTTPS GET.');
       }


### PR DESCRIPTION
Replace minimal hostname check (localhost/127.0.0.1/::1/.local) with `isPrivateOrLocalHost` from url-safety.ts which covers all private IP ranges (10.x, 172.16-31.x, 192.168.x, 169.254.x), cloud metadata endpoints, and IPv6 variants.

Also disable redirect following on unsubscribe fetch calls to prevent SSRF via redirect chains to internal addresses.

Addresses review feedback on PR #3099.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
