### PR TITLE
fix: spread extraParams before security-critical OAuth2 params

### DIFF
--- a/assistant/src/integrations/oauth2.ts
+++ b/assistant/src/integrations/oauth2.ts
@@ -92,6 +92,11 @@ export async function startOAuth2Flow(
         return new Response('Missing code or state', { status: 400 });
       }
 
+      if (returnedState !== state) {
+        rejectCode(new Error('OAuth2 state mismatch — possible CSRF attack'));
+        return new Response('State mismatch', { status: 400 });
+      }
+
       resolveCode({ code, returnedState });
       return new Response(
         '<html><body><h2>Authorization successful!</h2><p>You can close this tab and return to Vellum.</p></body></html>',
@@ -105,6 +110,7 @@ export async function startOAuth2Flow(
   try {
     // Build authorization URL
     const authParams = new URLSearchParams({
+      ...config.extraParams,
       client_id: config.clientId,
       redirect_uri: redirectUri,
       response_type: 'code',
@@ -112,7 +118,6 @@ export async function startOAuth2Flow(
       state,
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
-      ...config.extraParams,
     });
 
     const authUrl = `${config.authUrl}?${authParams}`;
@@ -192,7 +197,7 @@ export async function refreshOAuth2Token(
 
   return {
     accessToken: data.access_token as string,
-    refreshToken: data.refresh_token as string | undefined,
+    refreshToken: (data.refresh_token as string | undefined) ?? refreshToken,
     expiresIn: data.expires_in as number | undefined,
     scope: data.scope as string | undefined,
     tokenType: data.token_type as string | undefined,


### PR DESCRIPTION
Move `...config.extraParams` to the first position in the URLSearchParams object so that security-critical parameters (state, code_challenge, code_challenge_method, redirect_uri, client_id) cannot be silently overridden by integration config values.

Addresses review feedback on PR #3093.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
