### PR TITLE
fix: show integration connect errors in settings UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -15,6 +15,7 @@ struct SettingsPanel: View {
     @State private var showingReminders = false
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var connectingIntegration: String?
+    @State private var integrationError: (id: String, message: String)?
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
     @AppStorage("themePreference") private var themePreference: String = "system"
 
@@ -430,6 +431,11 @@ struct SettingsPanel: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                 }
+                if let error = integrationError, error.id == integration.id {
+                    Text(error.message)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                }
             }
 
             Spacer()
@@ -447,6 +453,7 @@ struct SettingsPanel: View {
                         .controlSize(.small)
                 } else {
                     VButton(label: "Connect", style: .primary) {
+                        integrationError = nil
                         connectingIntegration = integration.id
                         do {
                             try daemonClient?.sendIntegrationConnect(integrationId: integration.id)
@@ -484,6 +491,11 @@ struct SettingsPanel: View {
         daemonClient?.onIntegrationConnectResult = { [self] result in
             Task { @MainActor in
                 self.connectingIntegration = nil
+                if !result.success, let error = result.error {
+                    self.integrationError = (id: result.integrationId, message: error)
+                } else {
+                    self.integrationError = nil
+                }
                 // Refresh the list after connect/disconnect
                 try? self.daemonClient?.sendIntegrationList()
             }


### PR DESCRIPTION
## Summary
- The `onIntegrationConnectResult` callback was silently ignoring error responses, so failed connection attempts (e.g. missing OAuth clientId) just reset the spinner with no feedback
- Now displays the daemon error message in red text below the integration name when connection fails
- Clears the error when the user retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
