### PR TITLE
fix: send OAuth open_url only to requesting socket (PR #3101)

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -2952,7 +2952,7 @@ async function handleIntegrationConnect(
   try {
     const oauthConfig = { ...def.oauth2Config, clientId };
     const { tokens, grantedScopes } = await startOAuth2Flow(oauthConfig, {
-      openUrl: (url) => ctx.broadcast({ type: 'open_url', url, title: `Connect ${def.name}` }),
+      openUrl: (url) => ctx.send(socket, { type: 'open_url', url, title: `Connect ${def.name}` }),
     });
 
     // Store tokens in vault


### PR DESCRIPTION
## Summary
- Use `ctx.send(socket, ...)` instead of `ctx.broadcast` for OAuth authorization URL to prevent cross-client popup noise in multi-client scenarios

Addresses remaining review feedback from PR #3101.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
