### PR TITLE
fix: use container-visible /workspace path in system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -44,6 +44,12 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    sandbox: { enabled: true, backend: 'docker' },
+  }),
+}));
+
 // Import after mock
 const { buildSystemPrompt, ensurePromptFiles, stripCommentLines } = await import('../config/system-prompt.js');
 
@@ -152,6 +158,11 @@ describe('buildSystemPrompt', () => {
     const result = buildSystemPrompt();
     expect(result).toContain('## Parallel Task Orchestration');
     expect(result).toContain('swarm_delegate');
+  });
+
+  test('config section uses /workspace when Docker sandbox is enabled', () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain('Your configuration directory is `/workspace/`');
   });
 
   test('omits user skills from catalog when none are configured', () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync, copyFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getWorkspaceDir, getWorkspacePromptPath } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
+import { getConfig } from './loader.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 
 const log = getLogger('system-prompt');
@@ -55,7 +56,11 @@ export function buildSystemPrompt(): string {
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
   if (user) parts.push(user);
-  parts.push(buildConfigSection(getWorkspaceDir()));
+  const config = getConfig();
+  const visibleDir = config.sandbox.enabled && config.sandbox.backend === 'docker'
+    ? '/workspace'
+    : getWorkspaceDir();
+  parts.push(buildConfigSection(visibleDir));
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
   parts.push(buildToolPermissionSection());


### PR DESCRIPTION
## Summary
- `buildConfigSection` was embedding the host filesystem path (e.g. `~/.vellum/workspace`) in the system prompt, but the assistant runs bash commands inside a Docker container where the workspace is mounted at `/workspace`
- Now checks the sandbox config: uses `/workspace` when Docker sandbox is enabled, falls back to the host path otherwise
- Added test coverage for the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
