### PR TITLE
fix: configurable userinfo URL, clearable accountInfo, refresh token guard (PR #3139)

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -2969,11 +2969,12 @@ async function handleIntegrationConnect(
 
     const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : undefined;
 
-    // Fetch account info (email) if userinfo scope was granted
+    // Fetch account info (email) if the integration has a userinfo endpoint
     let accountInfo: string | undefined;
-    if (grantedScopes.some((s) => s.includes('userinfo'))) {
+    const userinfoUrl = def.oauth2Config.userinfoUrl;
+    if (userinfoUrl && grantedScopes.some((s) => s.includes('userinfo'))) {
       try {
-        const resp = await fetch('https://www.googleapis.com/oauth2/v1/userinfo', {
+        const resp = await fetch(userinfoUrl, {
           headers: { Authorization: `Bearer ${tokens.accessToken}` },
         });
         if (resp.ok) {
@@ -2989,14 +2990,16 @@ async function handleIntegrationConnect(
       allowedTools: def.allowedTools,
       expiresAt,
       grantedScopes,
-      accountInfo,
+      accountInfo: accountInfo ?? null,
     });
 
     if (tokens.refreshToken) {
-      if (!setSecureKey(`integration:${def.id}:refresh_token`, tokens.refreshToken)) {
+      const refreshStored = setSecureKey(`integration:${def.id}:refresh_token`, tokens.refreshToken);
+      if (!refreshStored) {
         log.warn({ integrationId: def.id }, 'Failed to store refresh token in secure storage');
+      } else {
+        upsertCredentialMetadata(`integration:${def.id}`, 'refresh_token', {});
       }
-      upsertCredentialMetadata(`integration:${def.id}`, 'refresh_token', {});
     }
 
     ctx.send(socket, {

--- a/assistant/src/integrations/definitions/gmail.ts
+++ b/assistant/src/integrations/definitions/gmail.ts
@@ -17,6 +17,7 @@ export const gmailIntegration: IntegrationDefinition = {
     ],
     clientId: '', // loaded from config at runtime
     extraParams: { access_type: 'offline', prompt: 'consent' },
+    userinfoUrl: 'https://www.googleapis.com/oauth2/v1/userinfo',
   },
   credentialFields: ['access_token', 'refresh_token'],
   allowedTools: [

--- a/assistant/src/integrations/types.ts
+++ b/assistant/src/integrations/types.ts
@@ -13,6 +13,8 @@ export interface OAuth2Config {
   scopes: string[];
   clientId: string;
   extraParams?: Record<string, string>;
+  /** URL to fetch user identity info after OAuth. If omitted, account info is not fetched. */
+  userinfoUrl?: string;
 }
 
 export interface IntegrationDefinition {

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -113,7 +113,8 @@ export function upsertCredentialMetadata(
     /** Pass `null` to explicitly clear a previously-set expiry. */
     expiresAt?: number | null;
     grantedScopes?: string[];
-    accountInfo?: string;
+    /** Pass `null` to explicitly clear a previously-set account info. */
+    accountInfo?: string | null;
   },
 ): CredentialMetadata {
   const result = loadFile();
@@ -139,7 +140,13 @@ export function upsertCredentialMetadata(
       }
     }
     if (policy?.grantedScopes !== undefined) existing.grantedScopes = policy.grantedScopes;
-    if (policy?.accountInfo !== undefined) existing.accountInfo = policy.accountInfo;
+    if (policy?.accountInfo !== undefined) {
+      if (policy.accountInfo === null) {
+        delete existing.accountInfo;
+      } else {
+        existing.accountInfo = policy.accountInfo;
+      }
+    }
     existing.updatedAt = now;
     saveFile(data);
     return existing;
@@ -154,7 +161,7 @@ export function upsertCredentialMetadata(
     usageDescription: policy?.usageDescription,
     expiresAt: policy?.expiresAt ?? undefined,
     grantedScopes: policy?.grantedScopes,
-    accountInfo: policy?.accountInfo,
+    accountInfo: policy?.accountInfo ?? undefined,
     createdAt: now,
     updatedAt: now,
   };


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #3139:

- **Configurable userinfo URL**: Move the Google-specific userinfo endpoint from hardcoded in `handleIntegrationConnect` to `OAuth2Config.userinfoUrl`, preventing token leakage to wrong providers when non-Google integrations are added
- **Clearable accountInfo**: Support `accountInfo: null` in `upsertCredentialMetadata` (same pattern as `expiresAt: null`) so reconnects that don't return user info clear stale account identity instead of keeping it forever
- **Refresh token metadata guard**: Only write refresh token metadata when `setSecureKey` succeeds, preventing orphaned metadata records

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
