### PR TITLE
fix: show default error when integration connect fails with nil error (PR #3141)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -491,8 +491,8 @@ struct SettingsPanel: View {
         daemonClient?.onIntegrationConnectResult = { [self] result in
             Task { @MainActor in
                 self.connectingIntegration = nil
-                if !result.success, let error = result.error {
-                    self.integrationError = (id: result.integrationId, message: error)
+                if !result.success {
+                    self.integrationError = (id: result.integrationId, message: result.error ?? "Connection failed")
                 } else {
                     self.integrationError = nil
                 }


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #3141:

- When `result.success` is `false` but `result.error` is `nil`, the settings panel now shows "Connection failed" instead of silently clearing the error state. Previously the spinner would disappear with no indication of failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
