### PR TITLE
fix: clean up file watcher debounce timer map to prevent unbounded growth

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -49,6 +49,7 @@ export class DaemonServer {
   private httpPort: number | undefined;
   private watchers: FSWatcher[] = [];
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private static readonly MAX_DEBOUNCE_ENTRIES = 1000;
   private suppressConfigReload = false;
   private lastConfigFingerprint = '';
   private lastConfigRefreshTime = 0;
@@ -202,6 +203,7 @@ export class DaemonServer {
             handlers[file]();
           }, 200);
           this.debounceTimers.set(file, timer);
+          this.enforceDebounceLimit();
         });
         this.watchers.push(watcher);
         log.info({ dir }, `Watching ${label}`);
@@ -302,6 +304,22 @@ export class DaemonServer {
     this.watchers = [];
   }
 
+  /**
+   * Evict the oldest debounce entries when the map exceeds the safety cap.
+   * Map iteration order follows insertion order, so the first keys are oldest.
+   */
+  private enforceDebounceLimit(): void {
+    if (this.debounceTimers.size <= DaemonServer.MAX_DEBOUNCE_ENTRIES) return;
+    const excess = this.debounceTimers.size - DaemonServer.MAX_DEBOUNCE_ENTRIES;
+    let removed = 0;
+    for (const [key, timer] of this.debounceTimers) {
+      if (removed >= excess) break;
+      clearTimeout(timer);
+      this.debounceTimers.delete(key);
+      removed++;
+    }
+  }
+
   private startSkillsWatchers(evictSessions: () => void): void {
     const skillsDir = getWorkspaceSkillsDir();
     if (!existsSync(skillsDir)) return;
@@ -316,6 +334,7 @@ export class DaemonServer {
         evictSessions();
       }, 200);
       this.debounceTimers.set(key, timer);
+      this.enforceDebounceLimit();
     };
 
     try {


### PR DESCRIPTION
## Summary

- Add `MAX_DEBOUNCE_ENTRIES` constant (1000) to `DaemonServer`
- Add `enforceDebounceLimit()` method that evicts oldest entries (by Map insertion order) when the map exceeds the cap
- Call the method after every insertion into `debounceTimers` (both `watchDir` and `scheduleSkillsReload`)
- Existing cleanup (delete on timer fire, clear on stop) is preserved

## Why

The `debounceTimers` Map could grow without bound under heavy file churn, especially from recursive skills directory watchers. Each unique filename gets an entry. While entries are deleted when timers fire, rapid changes to many distinct files could accumulate entries faster than they expire.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
