### PR TITLE
build: deduplicate bun installation in Dockerfiles

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -45,9 +45,8 @@ RUN apt-get update && apt-get install -y \
     sudo \
     && rm -rf /var/lib/apt/lists/*
 
-# Install bun in runner stage too
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+# Copy bun binary from builder instead of re-installing
+COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 
 # Create non-root user that also has sudo access so it can like install stuff
 RUN groupadd --system --gid 1001 assistant && \
@@ -70,8 +69,6 @@ ENV BUN_INSTALL="/data/.bun"
 ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 ENV PYTHONUSERBASE="/data/.python"
 ENV PATH="${PYTHONUSERBASE}/bin:${PATH}"
-RUN mv /root/.bun/bin/bun /usr/local/bin/bun && \
-    rm -rf /root/.bun
 
 # Configure apt/dpkg to install future packages to /data
 RUN mkdir -p /data/dpkg/info /data/dpkg/updates /data/dpkg/triggers && \

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -27,9 +27,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://bun.sh/install | bash && \
-    mv /root/.bun/bin/bun /usr/local/bin/bun && \
-    rm -rf /root/.bun
+# Copy bun binary from builder instead of re-installing
+COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 
 RUN groupadd --system --gid 1001 gateway && \
     useradd --system --uid 1001 --gid gateway --create-home gateway


### PR DESCRIPTION
Copy bun binary from builder to runner stage instead of re-installing via curl in both stages. Faster builds and reduced attack surface.

## Changes
- `assistant/Dockerfile`: Replace `curl | bash` bun install in runner with `COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun`. Remove the now-unnecessary `mv` + `rm` cleanup step.
- `gateway/Dockerfile`: Replace `curl | bash` + `mv` + `rm` in runner with a single `COPY --from=builder`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
