### PR TITLE
feat: weight profile items by importance and recency

### DIFF
--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -67,9 +67,10 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
     .orderBy(desc(memoryItems.lastSeenAt))
     .all();
 
+  const nowMs = Date.now();
   const trusted = rows
     .filter((row) => TRUST_RANK[row.verificationState] !== undefined)
-    .sort(compareProfileCandidates);
+    .sort((a, b) => compareProfileCandidates(a, b, nowMs));
 
   const selectedLines: string[] = [];
   const seenKeys = new Set<string>();
@@ -98,18 +99,28 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
   };
 }
 
-function compareProfileCandidates(left: ProfileCandidate, right: ProfileCandidate): number {
+/** Half-life for recency decay — items seen this many ms ago score ~0.5. (7 days) */
+const RECENCY_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000;
+
+function recencyScore(lastSeenAt: number, nowMs: number): number {
+  const ageMs = Math.max(0, nowMs - lastSeenAt);
+  return Math.pow(0.5, ageMs / RECENCY_HALF_LIFE_MS);
+}
+
+function candidateRankScore(c: ProfileCandidate, nowMs: number): number {
+  const importance = c.importance ?? 0.5;
+  return importance * recencyScore(c.lastSeenAt, nowMs);
+}
+
+function compareProfileCandidates(left: ProfileCandidate, right: ProfileCandidate, nowMs: number): number {
   const trustDelta = (TRUST_RANK[right.verificationState] ?? 0) - (TRUST_RANK[left.verificationState] ?? 0);
   if (trustDelta !== 0) return trustDelta;
 
-  const importanceDelta = (right.importance ?? 0) - (left.importance ?? 0);
-  if (importanceDelta !== 0) return importanceDelta;
+  const scoreDelta = candidateRankScore(right, nowMs) - candidateRankScore(left, nowMs);
+  if (scoreDelta !== 0) return scoreDelta;
 
   const confidenceDelta = right.confidence - left.confidence;
   if (confidenceDelta !== 0) return confidenceDelta;
-
-  const lastSeenDelta = right.lastSeenAt - left.lastSeenAt;
-  if (lastSeenDelta !== 0) return lastSeenDelta;
 
   return right.firstSeenAt - left.firstSeenAt;
 }


### PR DESCRIPTION
## Summary
- Replace cascading tiebreaker sort in profile-compiler.ts with a composite `importance * recencyScore` ranking
- Recency uses exponential decay with a 7-day half-life (`0.5^(age / 7d)`)
- Null importance defaults to 0.5 so unrated items still rank reasonably
- Trust rank remains the primary sort key; confidence is a final tiebreaker

## Why
Previously, a tiny importance difference completely dominated recency (and vice versa within the same tier). A trivial recent preference could outrank a high-confidence long-standing one. The composite score balances both signals.

## Test plan
- [ ] Verify items with high importance but older lastSeenAt rank above low-importance recent items
- [ ] Verify null-importance items default to 0.5 and rank in the middle
- [ ] Verify trust rank still takes priority over the composite score
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
