### PR TITLE
fix: wrap memory indexer operations in database transaction

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -45,42 +45,48 @@ export function indexMessageNow(
     config.segmentation.targetTokens,
     config.segmentation.overlapTokens,
   );
-  for (const segment of segments) {
-    const segmentId = buildSegmentId(input.messageId, segment.segmentIndex);
-    db.insert(memorySegments).values({
-      id: segmentId,
-      messageId: input.messageId,
-      conversationId: input.conversationId,
-      role: input.role,
-      segmentIndex: segment.segmentIndex,
-      text: segment.text,
-      tokenEstimate: segment.tokenEstimate,
-      scopeId: input.scopeId ?? 'default',
-      createdAt: input.createdAt,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: memorySegments.id,
-      set: {
-        text: segment.text,
-        tokenEstimate: segment.tokenEstimate,
-        scopeId: input.scopeId ?? 'default',
-        updatedAt: now,
-      },
-    }).run();
-    enqueueMemoryJob('embed_segment', { segmentId });
-  }
-
   const shouldExtract =
     input.role === 'user' ||
     (input.role === 'assistant' && config.extraction.extractFromAssistant);
-  if (shouldExtract) {
-    enqueueMemoryJob('extract_items', { messageId: input.messageId });
-  }
   const shouldResolveConflicts = input.role === 'user' && config.conflicts.enabled;
-  if (shouldResolveConflicts) {
-    enqueueResolvePendingConflictsForMessageJob(input.messageId, input.scopeId ?? 'default');
-  }
-  enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId });
+
+  // Wrap all segment inserts and job enqueues in a single transaction so they
+  // either all succeed or all roll back, preventing partial/orphaned state.
+  db.transaction((tx) => {
+    for (const segment of segments) {
+      const segmentId = buildSegmentId(input.messageId, segment.segmentIndex);
+      tx.insert(memorySegments).values({
+        id: segmentId,
+        messageId: input.messageId,
+        conversationId: input.conversationId,
+        role: input.role,
+        segmentIndex: segment.segmentIndex,
+        text: segment.text,
+        tokenEstimate: segment.tokenEstimate,
+        scopeId: input.scopeId ?? 'default',
+        createdAt: input.createdAt,
+        updatedAt: now,
+      }).onConflictDoUpdate({
+        target: memorySegments.id,
+        set: {
+          text: segment.text,
+          tokenEstimate: segment.tokenEstimate,
+          scopeId: input.scopeId ?? 'default',
+          updatedAt: now,
+        },
+      }).run();
+      enqueueMemoryJob('embed_segment', { segmentId }, Date.now(), tx);
+    }
+
+    if (shouldExtract) {
+      enqueueMemoryJob('extract_items', { messageId: input.messageId }, Date.now(), tx);
+    }
+    if (shouldResolveConflicts) {
+      enqueueResolvePendingConflictsForMessageJob(input.messageId, input.scopeId ?? 'default', tx);
+    }
+    enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId }, Date.now(), tx);
+  });
+
   enqueueSummaryRollupJobsIfDue();
 
   const enqueuedJobs = segments.length + (shouldExtract ? 2 : 1) + (shouldResolveConflicts ? 1 : 0);

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -39,8 +39,9 @@ export function enqueueMemoryJob(
   type: MemoryJobType,
   payload: Record<string, unknown>,
   runAfter = Date.now(),
+  dbOverride?: Parameters<ReturnType<typeof getDb>['transaction']>[0] extends (tx: infer T) => unknown ? T : never,
 ): string {
-  const db = getDb();
+  const db = dbOverride ?? getDb();
   const id = uuid();
   const now = Date.now();
   db.insert(memoryJobs).values({
@@ -99,14 +100,15 @@ export function enqueueBackfillEntityRelationsJob(force = false): string {
 export function enqueueResolvePendingConflictsForMessageJob(
   messageId: string,
   scopeId = 'default',
+  dbOverride?: Parameters<ReturnType<typeof getDb>['transaction']>[0] extends (tx: infer T) => unknown ? T : never,
 ): string {
   const normalizedMessageId = messageId.trim();
   if (!normalizedMessageId) {
     throw new Error('enqueueResolvePendingConflictsForMessageJob requires a non-empty messageId');
   }
   const normalizedScopeId = scopeId.trim() || 'default';
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { get: (...params: unknown[]) => unknown } } }).$client;
+  // Dedup check always uses root db since tx doesn't expose $client
+  const raw = (getDb() as unknown as { $client: { query: (q: string) => { get: (...params: unknown[]) => unknown } } }).$client;
   const existing = raw.query(`
     SELECT id
     FROM memory_jobs
@@ -122,7 +124,7 @@ export function enqueueResolvePendingConflictsForMessageJob(
   return enqueueMemoryJob('resolve_pending_conflicts_for_message', {
     messageId: normalizedMessageId,
     scopeId: normalizedScopeId,
-  });
+  }, Date.now(), dbOverride);
 }
 
 export function enqueueCleanupResolvedConflictsJob(retentionMs?: number): string {


### PR DESCRIPTION
Segment INSERTs and job enqueues in `indexMessageNow()` were not wrapped in a transaction, so a failure partway through (e.g. job enqueue fails after segment insert succeeds) would leave the database in an inconsistent state with no recovery path.

**Changes:**
- Wrap all segment inserts and their corresponding job enqueues in a single `db.transaction()` call in `indexer.ts` so they either all succeed or all roll back atomically
- Add an optional `dbOverride` parameter to `enqueueMemoryJob()` and `enqueueResolvePendingConflictsForMessageJob()` in `jobs-store.ts` so they can participate in an external transaction
- `enqueueSummaryRollupJobsIfDue()` remains outside the transaction as it is a separate periodic concern with its own checkpoint mechanism
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
