### PR TITLE
feat: add IPC connection limit enforcement

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -55,6 +55,7 @@ export class DaemonServer {
   private lastConfigRefreshTime = 0;
   private blobSweepTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly CONFIG_REFRESH_INTERVAL_MS = 30_000;
+  private static readonly MAX_CONNECTIONS = 50;
 
   constructor() {
     this.socketPath = getSocketPath();
@@ -415,6 +416,13 @@ export class DaemonServer {
   }
 
   private handleConnection(socket: net.Socket): void {
+    if (this.connectedSockets.size >= DaemonServer.MAX_CONNECTIONS) {
+      log.warn({ current: this.connectedSockets.size, max: DaemonServer.MAX_CONNECTIONS }, 'Connection limit reached, rejecting client');
+      socket.write(serialize({ type: 'error', message: `Connection limit reached (max ${DaemonServer.MAX_CONNECTIONS})` }));
+      socket.destroy();
+      return;
+    }
+
     log.info('Client connected');
     this.connectedSockets.add(socket);
     const parser = createMessageParser({ maxLineSize: MAX_LINE_SIZE });


### PR DESCRIPTION
## Summary
- Add a `MAX_CONNECTIONS` constant (50) to `DaemonServer`
- Reject new IPC connections with an error message when the limit is reached
- Prevents resource exhaustion from runaway or misbehaving clients

## Changes
- `assistant/src/daemon/server.ts`: Added connection count check at the top of `handleConnection()` — if `connectedSockets.size >= MAX_CONNECTIONS`, the socket receives an error and is destroyed before being registered
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
