### PR TITLE
fix: include all config fields in session fingerprint

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -221,15 +221,7 @@ export class DaemonServer {
   }
 
   private configFingerprint(config: ReturnType<typeof getConfig>): string {
-    return JSON.stringify({
-      provider: config.provider,
-      model: config.model,
-      maxTokens: config.maxTokens,
-      rateLimit: config.rateLimit,
-      thinking: config.thinking,
-      contextWindow: config.contextWindow,
-      apiKeys: config.apiKeys,
-    });
+    return JSON.stringify(config);
   }
 
   /**


### PR DESCRIPTION
Hash the full config object in `configFingerprint()` instead of a subset, so changes to memory config, skills, timeouts, sandbox, secretDetection, swarm, and other fields trigger session eviction.

Previously only `provider`, `model`, `maxTokens`, `rateLimit`, `thinking`, `contextWindow`, and `apiKeys` were hashed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
