### PR TITLE
feat: add per-tool execution timeout in ToolExecutor

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -83,6 +83,7 @@ describe('AssistantConfigSchema', () => {
       shellDefaultTimeoutSec: 120,
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
+      toolExecutionTimeoutSec: 120,
     });
     expect(result.sandbox).toEqual({
       enabled: true,

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -118,6 +118,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     shellDefaultTimeoutSec: 120,
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
+    toolExecutionTimeoutSec: 120,
   },
   sandbox: {
     enabled: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -23,6 +23,11 @@ export const TimeoutConfigSchema = z.object({
     .finite('timeouts.permissionTimeoutSec must be finite')
     .positive('timeouts.permissionTimeoutSec must be a positive number')
     .default(300),
+  toolExecutionTimeoutSec: z
+    .number({ error: 'timeouts.toolExecutionTimeoutSec must be a number' })
+    .finite('timeouts.toolExecutionTimeoutSec must be finite')
+    .positive('timeouts.toolExecutionTimeoutSec must be a positive number')
+    .default(120),
 });
 
 export const DockerConfigSchema = z.object({
@@ -811,6 +816,7 @@ export const AssistantConfigSchema = z.object({
     shellMaxTimeoutSec: 600,
     shellDefaultTimeoutSec: 120,
     permissionTimeoutSec: 300,
+    toolExecutionTimeoutSec: 120,
   }),
   sandbox: SandboxConfigSchema.default({
     enabled: true,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -238,6 +238,7 @@ export class ToolExecutor {
 
       // Execute the tool — proxy tools delegate to an external resolver
       let execResult: ToolExecutionResult;
+      const toolTimeoutMs = getConfig().timeouts.toolExecutionTimeoutSec * 1000;
       if (tool.executionMode === 'proxy') {
         if (!context.proxyToolResolver) {
           const msg = `No proxy resolver configured for proxy tool "${name}". This tool requires an external resolver (e.g. a connected macOS client for computer-use tools).`;
@@ -259,9 +260,17 @@ export class ToolExecutor {
           });
           return { content: msg, isError: true };
         }
-        execResult = await context.proxyToolResolver(name, input);
+        execResult = await executeWithTimeout(
+          context.proxyToolResolver(name, input),
+          toolTimeoutMs,
+          name,
+        );
       } else {
-        execResult = await tool.execute(input, context);
+        execResult = await executeWithTimeout(
+          tool.execute(input, context),
+          toolTimeoutMs,
+          name,
+        );
       }
 
       // Secret detection on tool output
@@ -403,6 +412,31 @@ export class ToolExecutor {
       return { content: `Tool "${name}" encountered an unexpected error: ${msg}`, isError: true };
     }
   }
+}
+
+const TIMEOUT_SENTINEL = Symbol('tool-timeout');
+
+/**
+ * Race a tool execution promise against a timeout. Returns a timeout error
+ * result instead of throwing so the agent loop can continue gracefully.
+ */
+async function executeWithTimeout(
+  promise: Promise<ToolExecutionResult>,
+  timeoutMs: number,
+  toolName: string,
+): Promise<ToolExecutionResult> {
+  const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+    setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
+  });
+  const result = await Promise.race([promise, timeoutPromise]);
+  if (result === TIMEOUT_SENTINEL) {
+    const sec = Math.round(timeoutMs / 1000);
+    return {
+      content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,
+      isError: true,
+    };
+  }
+  return result;
 }
 
 function resolveExecutionTarget(toolName: string): ExecutionTarget {


### PR DESCRIPTION
Wrap `tool.execute()` and proxy resolver calls with `Promise.race` to prevent hung tools (browser navigation, stalled network fetch) from blocking the agent loop indefinitely.

## Changes
- Add `executeWithTimeout()` helper in `executor.ts` using a sentinel-based `Promise.race`
- Read timeout from config: `timeouts.toolExecutionTimeoutSec` (default 120s)
- Return a descriptive error result on timeout instead of throwing
- Add `toolExecutionTimeoutSec` to `TimeoutConfig` schema and defaults

## Files modified
- `assistant/src/tools/executor.ts` — timeout wrapping logic
- `assistant/src/config/schema.ts` — new config field
- `assistant/src/config/defaults.ts` — default value
- `assistant/src/__tests__/config-schema.test.ts` — updated test expectation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
