### PR TITLE
fix: resolve DaemonClient deinit data race

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -254,28 +254,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     deinit {
         // Swift 5.9+: deinit on @MainActor class is NOT guaranteed to run on main actor.
-        // Cannot use MainActor.assumeIsolated here as it would crash if deinit runs on
-        // a background thread (e.g., if last reference is released from a background context).
+        // Only call thread-safe cancellation methods here — Task.cancel() and
+        // NWConnection.cancel() are safe from any thread.
         //
-        // Instead, we access the properties directly. While this is technically a data race,
-        // the cleanup operations are all thread-safe:
-        // - Task.cancel() is thread-safe
-        // - NWConnection.cancel() is thread-safe
-        // - AsyncStream.Continuation.finish() is thread-safe
-        //
-        // Setting shouldReconnect and accessing subscribers are data races, but they're
-        // benign in deinit since the object is being destroyed and no other code can
-        // access these properties.
-        shouldReconnect = false
+        // Subscriber continuations are NOT finished here because iterating the
+        // @MainActor-isolated `subscribers` dictionary would be a data race.
+        // Callers should call disconnect() before releasing the last reference
+        // to ensure subscriber streams terminate cleanly.
         reconnectTask?.cancel()
         pingTask?.cancel()
         pongTimeoutTask?.cancel()
         blobProbeTask?.cancel()
         connection?.cancel()
-        for continuation in subscribers.values {
-            continuation.finish()
-        }
-        subscribers.removeAll()
     }
 
     // MARK: - Socket Path


### PR DESCRIPTION
## Summary
- Remove data-racy accesses to `@MainActor`-isolated properties (`shouldReconnect`, `subscribers`) from `DaemonClient.deinit`, which is not guaranteed to run on the main actor in Swift 5.9+
- Only thread-safe operations (`Task.cancel()`, `NWConnection.cancel()`) remain in deinit
- Document that callers should use `disconnect()` before releasing the last reference to ensure subscriber streams terminate cleanly

## Test plan
- [ ] Verify macOS app builds without warnings
- [ ] Verify existing `DaemonClientProbeTests` still pass (they call `disconnect()` in tearDown)
- [ ] Confirm no runtime crashes on app quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
