### PR TITLE
fix: log and retry failed Qdrant vector deletions

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -4,6 +4,7 @@ import type { Message, ContentBlock, ImageContent } from '../providers/types.js'
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { getQdrantClient } from '../memory/qdrant-client.js';
+import { enqueueMemoryJob } from '../memory/jobs-store.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { CheckpointDecision } from '../agent/loop.js';
@@ -1906,6 +1907,8 @@ export class Session {
 
   /**
    * Delete Qdrant vector entries for the given segment and item IDs.
+   * Individual deletion failures are logged and enqueued as retry jobs
+   * to prevent silently orphaned vectors.
    */
   private async cleanupQdrantVectors(segmentIds: string[], orphanedItemIds: string[]): Promise<void> {
     let qdrant: ReturnType<typeof getQdrantClient>;
@@ -1915,18 +1918,40 @@ export class Session {
       return; // Qdrant not initialized — nothing to clean up.
     }
 
-    const deletions: Promise<void>[] = [];
+    if (segmentIds.length === 0 && orphanedItemIds.length === 0) return;
+
+    const targets: Array<{ targetType: string; targetId: string }> = [];
     for (const segId of segmentIds) {
-      deletions.push(qdrant.deleteByTarget('segment', segId));
+      targets.push({ targetType: 'segment', targetId: segId });
     }
     for (const itemId of orphanedItemIds) {
-      deletions.push(qdrant.deleteByTarget('item', itemId));
+      targets.push({ targetType: 'item', targetId: itemId });
     }
 
-    if (deletions.length > 0) {
-      await Promise.all(deletions);
+    const results = await Promise.allSettled(
+      targets.map((t) => qdrant.deleteByTarget(t.targetType, t.targetId)),
+    );
+
+    let succeeded = 0;
+    let failed = 0;
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        succeeded++;
+      } else {
+        failed++;
+        const { targetType, targetId } = targets[i];
+        log.warn(
+          { err: result.reason, targetType, targetId, conversationId: this.conversationId },
+          'Qdrant vector deletion failed, enqueuing retry job',
+        );
+        enqueueMemoryJob('delete_qdrant_vectors', { targetType, targetId });
+      }
+    }
+
+    if (succeeded > 0) {
       log.info(
-        { conversationId: this.conversationId, segments: segmentIds.length, items: orphanedItemIds.length },
+        { conversationId: this.conversationId, succeeded, failed, segments: segmentIds.length, items: orphanedItemIds.length },
         'Cleaned up Qdrant vectors after regenerate',
       );
     }

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -18,7 +18,8 @@ export type MemoryJobType =
   | 'refresh_monthly_summary'
   | 'build_conversation_summary'
   | 'backfill'
-  | 'rebuild_index';
+  | 'rebuild_index'
+  | 'delete_qdrant_vectors';
 
 const EMBED_JOB_TYPES: MemoryJobType[] = ['embed_segment', 'embed_item', 'embed_summary'];
 

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -284,6 +284,9 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
     case 'rebuild_index':
       rebuildIndexJob();
       return;
+    case 'delete_qdrant_vectors':
+      await deleteQdrantVectorsJob(job);
+      return;
     default:
       throw new Error(`Unknown memory job type: ${(job as { type: string }).type}`);
   }
@@ -948,6 +951,16 @@ function rebuildIndexJob(): void {
   for (const segment of segments) {
     enqueueMemoryJob('embed_segment', { segmentId: segment.id });
   }
+}
+
+async function deleteQdrantVectorsJob(job: MemoryJob): Promise<void> {
+  const targetType = asString(job.payload.targetType);
+  const targetId = asString(job.payload.targetId);
+  if (!targetType || !targetId) return;
+
+  const qdrant = getQdrantClient();
+  await qdrant.deleteByTarget(targetType, targetId);
+  log.info({ targetType, targetId }, 'Retried Qdrant vector deletion succeeded');
 }
 
 async function embedAndUpsert(


### PR DESCRIPTION
## Summary

- Qdrant vector cleanup after message deletion was fire-and-forget — if deletion failed (Qdrant down, network error), vectors were silently orphaned
- Added `delete_qdrant_vectors` job type to the memory jobs system
- Changed `cleanupQdrantVectors` to use `Promise.allSettled` so individual failures don't block other deletions
- On failure: logs the error and enqueues a retry job handled by the existing memory jobs worker with its retry/backoff logic

## Files changed

- `assistant/src/memory/jobs-store.ts` — added `delete_qdrant_vectors` to `MemoryJobType`
- `assistant/src/daemon/session.ts` — rewrote `cleanupQdrantVectors` to catch per-deletion failures and enqueue retry jobs
- `assistant/src/memory/jobs-worker.ts` — added `deleteQdrantVectorsJob` handler in the job processor switch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
