### PR TITLE
fix: add retry logic for Telegram API send failures

### DIFF
--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -19,6 +19,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeTimeoutMs: 30000,
     runtimeMaxRetries: 2,
     runtimeInitialBackoffMs: 500,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
     telegramTimeoutMs: 15000,
     maxWebhookPayloadBytes: 256, // very small for testing
     logFile: { dir: undefined, retentionDays: 30 },

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -19,6 +19,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeTimeoutMs: 30000,
     runtimeMaxRetries: 2,
     runtimeInitialBackoffMs: 500,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
     telegramTimeoutMs: 15000,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -19,6 +19,8 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   runtimeTimeoutMs: 30000,
   runtimeMaxRetries: 2,
   runtimeInitialBackoffMs: 500,
+  telegramInitialBackoffMs: 1000,
+  telegramMaxRetries: 3,
   telegramTimeoutMs: 15000,
   maxWebhookPayloadBytes: 1048576,
   logFile: { dir: undefined, retentionDays: 30 },

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -21,6 +21,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeTimeoutMs: 30000,
     runtimeMaxRetries: 2,
     runtimeInitialBackoffMs: 500,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
     telegramTimeoutMs: 15000,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -19,6 +19,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeTimeoutMs: 30000,
     runtimeMaxRetries: 2,
     runtimeInitialBackoffMs: 500,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
     telegramTimeoutMs: 15000,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -19,6 +19,8 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   runtimeTimeoutMs: 30000,
   runtimeMaxRetries: 2,
   runtimeInitialBackoffMs: 500,
+  telegramInitialBackoffMs: 1000,
+  telegramMaxRetries: 3,
   telegramTimeoutMs: 15000,
   maxWebhookPayloadBytes: 1048576,
   logFile: { dir: undefined, retentionDays: 30 },

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -26,6 +26,8 @@ export type GatewayConfig = {
   shutdownDrainMs: number;
   telegramApiBaseUrl: string;
   telegramBotToken: string | undefined;
+  telegramInitialBackoffMs: number;
+  telegramMaxRetries: number;
   telegramTimeoutMs: number;
   telegramWebhookSecret: string | undefined;
   unmappedPolicy: "reject" | "default";
@@ -149,6 +151,16 @@ export function loadConfig(): GatewayConfig {
     throw new Error("GATEWAY_TELEGRAM_TIMEOUT_MS must be a positive number");
   }
 
+  const telegramMaxRetries = Number(process.env.GATEWAY_TELEGRAM_MAX_RETRIES || "3");
+  if (!Number.isInteger(telegramMaxRetries) || telegramMaxRetries < 0) {
+    throw new Error("GATEWAY_TELEGRAM_MAX_RETRIES must be a non-negative integer");
+  }
+
+  const telegramInitialBackoffMs = Number(process.env.GATEWAY_TELEGRAM_INITIAL_BACKOFF_MS || "1000");
+  if (!Number.isFinite(telegramInitialBackoffMs) || telegramInitialBackoffMs <= 0) {
+    throw new Error("GATEWAY_TELEGRAM_INITIAL_BACKOFF_MS must be a positive number");
+  }
+
   const maxWebhookPayloadBytes = Number(process.env.GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES || String(1024 * 1024));
   if (!Number.isFinite(maxWebhookPayloadBytes) || maxWebhookPayloadBytes <= 0) {
     throw new Error("GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES must be a positive number");
@@ -214,6 +226,8 @@ export function loadConfig(): GatewayConfig {
     shutdownDrainMs,
     telegramApiBaseUrl,
     telegramBotToken,
+    telegramInitialBackoffMs,
+    telegramMaxRetries,
     telegramTimeoutMs,
     telegramWebhookSecret,
     unmappedPolicy,

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -1,9 +1,108 @@
 import type { GatewayConfig } from "../config.js";
+import { getLogger } from "../logger.js";
+
+const log = getLogger("telegram-api");
 
 interface TelegramApiResponse<T> {
   ok: boolean;
   result?: T;
   description?: string;
+  parameters?: { retry_after?: number };
+}
+
+function isRetryable(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function computeDelay(
+  attempt: number,
+  initialBackoffMs: number,
+  retryAfterHeader: string | null,
+): number {
+  if (retryAfterHeader) {
+    const seconds = Number(retryAfterHeader);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return seconds * 1000;
+    }
+  }
+
+  const exponential = initialBackoffMs * Math.pow(2, attempt - 1);
+  // Add jitter: 0–50% of the computed delay
+  const jitter = Math.random() * exponential * 0.5;
+  return exponential + jitter;
+}
+
+async function retryableFetch<T>(
+  config: GatewayConfig,
+  method: string,
+  doFetch: () => Promise<Response>,
+): Promise<T> {
+  let lastError: Error | null = null;
+  let lastRetryAfter: string | null = null;
+
+  for (let attempt = 0; attempt <= config.telegramMaxRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = computeDelay(
+        attempt,
+        config.telegramInitialBackoffMs,
+        lastRetryAfter,
+      );
+      log.debug({ attempt, delay, method }, "Retrying Telegram API call");
+      await new Promise((r) => setTimeout(r, delay));
+    }
+
+    lastRetryAfter = null;
+
+    let response: Response;
+    try {
+      response = await doFetch();
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      log.warn({ err: lastError, attempt, method }, "Telegram API fetch failed");
+      continue;
+    }
+
+    if (!isRetryable(response.status) && !response.ok) {
+      const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
+      throw new Error(
+        data.description
+          ? `Telegram ${method} failed: ${data.description}`
+          : `Telegram ${method} failed with status ${response.status}`,
+      );
+    }
+
+    if (isRetryable(response.status)) {
+      const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
+      lastRetryAfter =
+        response.headers.get("retry-after") ??
+        (data.parameters?.retry_after != null
+          ? String(data.parameters.retry_after)
+          : null);
+      lastError = new Error(
+        data.description
+          ? `Telegram ${method} failed: ${data.description}`
+          : `Telegram ${method} failed with status ${response.status}`,
+      );
+      log.warn(
+        { status: response.status, attempt, method, retryAfter: lastRetryAfter },
+        "Telegram API returned retryable error",
+      );
+      continue;
+    }
+
+    const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
+    if (!data.ok || data.result === undefined) {
+      throw new Error(
+        data.description
+          ? `Telegram ${method} failed: ${data.description}`
+          : `Telegram ${method} failed with status ${response.status}`,
+      );
+    }
+
+    return data.result;
+  }
+
+  throw lastError ?? new Error(`Telegram ${method} failed after retries`);
 }
 
 export async function callTelegramApi<T>(
@@ -11,24 +110,17 @@ export async function callTelegramApi<T>(
   method: string,
   body: Record<string, unknown>,
 ): Promise<T> {
-  const url = `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`;
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(config.telegramTimeoutMs),
-  });
-
-  const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
-  if (!response.ok || !data.ok || data.result === undefined) {
-    throw new Error(
-      data.description
-        ? `Telegram ${method} failed: ${data.description}`
-        : `Telegram ${method} failed with status ${response.status}`,
-    );
-  }
-
-  return data.result;
+  return retryableFetch<T>(config, method, () =>
+    fetch(
+      `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(config.telegramTimeoutMs),
+      },
+    ),
+  );
 }
 
 export async function callTelegramApiMultipart<T>(
@@ -36,21 +128,14 @@ export async function callTelegramApiMultipart<T>(
   method: string,
   form: FormData,
 ): Promise<T> {
-  const url = `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`;
-  const response = await fetch(url, {
-    method: "POST",
-    body: form,
-    signal: AbortSignal.timeout(config.telegramTimeoutMs),
-  });
-
-  const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
-  if (!response.ok || !data.ok || data.result === undefined) {
-    throw new Error(
-      data.description
-        ? `Telegram ${method} failed: ${data.description}`
-        : `Telegram ${method} failed with status ${response.status}`,
-    );
-  }
-
-  return data.result;
+  return retryableFetch<T>(config, method, () =>
+    fetch(
+      `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
+      {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(config.telegramTimeoutMs),
+      },
+    ),
+  );
 }


### PR DESCRIPTION
## Summary

Add exponential backoff with jitter for transient Telegram API failures (429 rate limits and 5xx server errors) to prevent permanent message loss.

- Extract shared `retryableFetch` helper in `gateway/src/telegram/api.ts` that wraps both `callTelegramApi` and `callTelegramApiMultipart`
- Retry on 429 (rate limit — respects both HTTP `Retry-After` header and Telegram's `parameters.retry_after` in response body) and 5xx server errors
- Don't retry on 4xx client errors (bad request, unauthorized, etc.)
- Network errors (fetch failures) are also retried
- Configurable via `GATEWAY_TELEGRAM_MAX_RETRIES` (default 3) and `GATEWAY_TELEGRAM_INITIAL_BACKOFF_MS` (default 1000ms)
- Backoff: exponential (1s, 2s, 4s) plus random jitter (0–50% of computed delay)
- New config fields added to `GatewayConfig` type and all test `makeConfig` helpers updated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
