### PR TITLE
security: extend secret scanning to cover contentBlocks

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -281,7 +281,12 @@ export class ToolExecutor {
         const diffMatches = execResult.diff
           ? scanText(execResult.diff.newContent, entropyConfig)
           : [];
-        const allMatches = [...contentMatches, ...diffMatches];
+        const blockMatches = (execResult.contentBlocks ?? []).flatMap((block) => {
+          if (block.type === 'text') return scanText(block.text, entropyConfig);
+          if (block.type === 'file' && block.extracted_text) return scanText(block.extracted_text, entropyConfig);
+          return [];
+        });
+        const allMatches = [...contentMatches, ...diffMatches, ...blockMatches];
 
         if (allMatches.length > 0) {
           const matchSummary = allMatches.map((m) => ({
@@ -310,6 +315,17 @@ export class ToolExecutor {
                 ...execResult.diff,
                 newContent: redactSecrets(execResult.diff.newContent, entropyConfig),
               };
+            }
+            if (execResult.contentBlocks) {
+              execResult.contentBlocks = execResult.contentBlocks.map((block) => {
+                if (block.type === 'text') {
+                  return { ...block, text: redactSecrets(block.text, entropyConfig) };
+                }
+                if (block.type === 'file' && block.extracted_text) {
+                  return { ...block, extracted_text: redactSecrets(block.extracted_text, entropyConfig) };
+                }
+                return block;
+              });
             }
           } else if (sdConfig.action === 'block') {
             const types = [...new Set(allMatches.map((m) => m.type))].join(', ');


### PR DESCRIPTION
## Summary
- Secret detection in `ToolExecutor.execute()` previously only scanned `execResult.content` and `execResult.diff.newContent`, missing `execResult.contentBlocks` which can contain rich content with embedded secrets.
- Now scans text blocks' `.text` and file blocks' `.extracted_text` fields for secrets.
- When the action is `redact`, redacts secrets found in contentBlocks the same way content and diff are redacted.
- When the action is `block`, contentBlock matches are included in the total count that triggers blocking.

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
