### PR TITLE
fix: log warning when Qdrant is unavailable during memory recall

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -158,7 +158,11 @@ async function collectAndMergeCandidates(
     try {
       semantic = await semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds);
     } catch (err) {
-      log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
+      if (isQdrantConnectionError(err)) {
+        log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
+      } else {
+        log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
+      }
     }
   }
 
@@ -1695,6 +1699,11 @@ function buildFtsMatchQuery(text: string): string | null {
 function isAbortError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return err.name === 'AbortError' || err.name === 'APIUserAbortError';
+}
+
+function isQdrantConnectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(err.message);
 }
 
 // ── Simple search API for memory tools ───────────────────────────────


### PR DESCRIPTION
Add a specific warning log when Qdrant connection fails during semantic search so degraded memory recall is visible instead of silently returning zero results.

Introduces `isQdrantConnectionError()` helper that detects connection-level failures (ECONNREFUSED, ECONNRESET, ETIMEDOUT, ENETUNREACH, fetch failed) — matching the same pattern used in `jobs-worker.ts`. When a Qdrant connection error is caught, the log message explicitly says "Qdrant is unavailable" rather than the generic "Semantic search failed".

The existing graceful degradation behavior is unchanged — semantic search still falls back silently so other retrieval methods (lexical, recency, entity) continue working.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
