### PR TITLE
perf: skip embedding jobs when segment content is unchanged

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -452,6 +452,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE memory_segments ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_summaries ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE memory_segments ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { desc, eq } from 'drizzle-orm';
 import type { MemoryConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
@@ -52,9 +53,18 @@ export function indexMessageNow(
 
   // Wrap all segment inserts and job enqueues in a single transaction so they
   // either all succeed or all roll back, preventing partial/orphaned state.
+  let skippedEmbedJobs = 0;
   db.transaction((tx) => {
     for (const segment of segments) {
       const segmentId = buildSegmentId(input.messageId, segment.segmentIndex);
+      const hash = createHash('sha256').update(segment.text).digest('hex');
+
+      // Check if this segment already exists with the same content hash
+      const existing = tx.select({ contentHash: memorySegments.contentHash })
+        .from(memorySegments)
+        .where(eq(memorySegments.id, segmentId))
+        .get();
+
       tx.insert(memorySegments).values({
         id: segmentId,
         messageId: input.messageId,
@@ -64,6 +74,7 @@ export function indexMessageNow(
         text: segment.text,
         tokenEstimate: segment.tokenEstimate,
         scopeId: input.scopeId ?? 'default',
+        contentHash: hash,
         createdAt: input.createdAt,
         updatedAt: now,
       }).onConflictDoUpdate({
@@ -72,10 +83,16 @@ export function indexMessageNow(
           text: segment.text,
           tokenEstimate: segment.tokenEstimate,
           scopeId: input.scopeId ?? 'default',
+          contentHash: hash,
           updatedAt: now,
         },
       }).run();
-      enqueueMemoryJob('embed_segment', { segmentId }, Date.now(), tx);
+
+      if (existing?.contentHash === hash) {
+        skippedEmbedJobs++;
+      } else {
+        enqueueMemoryJob('embed_segment', { segmentId }, Date.now(), tx);
+      }
     }
 
     if (shouldExtract) {
@@ -87,9 +104,13 @@ export function indexMessageNow(
     enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId }, Date.now(), tx);
   });
 
+  if (skippedEmbedJobs > 0) {
+    log.debug(`Skipped ${skippedEmbedJobs}/${segments.length} embed_segment jobs (content unchanged)`);
+  }
+
   enqueueSummaryRollupJobsIfDue();
 
-  const enqueuedJobs = segments.length + (shouldExtract ? 2 : 1) + (shouldResolveConflicts ? 1 : 0);
+  const enqueuedJobs = (segments.length - skippedEmbedJobs) + (shouldExtract ? 2 : 1) + (shouldResolveConflicts ? 1 : 0);
   return {
     indexedSegments: segments.length,
     enqueuedJobs,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -50,6 +50,7 @@ export const memorySegments = sqliteTable('memory_segments', {
   text: text('text').notNull(),
   tokenEstimate: integer('token_estimate').notNull(),
   scopeId: text('scope_id').notNull().default('default'),
+  contentHash: text('content_hash'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });


### PR DESCRIPTION
Check segment content hash before enqueuing embed_segment jobs on the onConflictDoUpdate path to avoid redundant embedding API calls.

## Changes

- Added `content_hash` column to `memory_segments` table (schema + migration)
- Compute SHA-256 hash of segment text before upserting
- Compare hash against stored value; skip `embed_segment` job if content is identical
- Log when embed jobs are skipped for observability
- Adjust `enqueuedJobs` count to reflect actual enqueued jobs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
