### PR TITLE
fix: expand messages and tool results by default

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -624,7 +624,7 @@ private struct ChatBubble: View {
 
     private var isUser: Bool { message.role == .user }
 
-    @State private var isExpanded = false
+    @State private var isExpanded = true
     private let truncationLimit = 2000  // Character limit before truncation
     private let lineLimit = 50  // Maximum lines before truncation
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -53,7 +53,7 @@ struct ActivityPanel: View {
 
 struct ActivityStepView: View {
     let toolCall: ToolCallData
-    @State private var isResultExpanded = false
+    @State private var isResultExpanded = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
- Default `isExpanded` to `true` in ChatBubble so chat messages show full content immediately
- Default `isResultExpanded` to `true` in ActivityStepView so tool results show full content immediately
- Users can still click "Show less" to collapse long content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
