### PR TITLE
fix: return queue-full error to client instead of silent drop

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -635,7 +635,7 @@ async function handleUserMessage(
       });
       ctx.send(socket, buildSessionErrorMessage(msg.sessionId, {
         code: 'QUEUE_FULL',
-        userMessage: 'The message queue is full. Please wait and try again.',
+        userMessage: 'Message queue is full (max depth: 10). Please wait for current messages to be processed.',
         retryable: true,
         debugDetails: 'Message rejected — session queue is full',
       }));

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -104,7 +104,7 @@ export function classifySessionError(
   if (ctx.phase === 'queue') {
     return {
       code: 'QUEUE_FULL',
-      userMessage: 'The message queue is full. Please wait and try again.',
+      userMessage: 'Message queue is full (max depth: 10). Please wait for current messages to be processed.',
       retryable: true,
       debugDetails: truncateDebugDetails(message),
     };

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1724,7 +1724,12 @@ export class Session {
         status: 'error',
         attributes: { reason: 'queue_full', source: 'surface_action' },
       });
-      onEvent({ type: 'error', message: 'Surface action rejected — session queue is full' });
+      onEvent(buildSessionErrorMessage(this.conversationId, {
+        code: 'QUEUE_FULL',
+        userMessage: 'Message queue is full (max depth: 10). Please wait for current messages to be processed.',
+        retryable: true,
+        debugDetails: 'Surface action rejected — session queue is full',
+      }));
       return;
     }
 


### PR DESCRIPTION
Send a `session_error` message back to the client when the MessageQueue is full instead of silently dropping the message.

## Changes

- **`session.ts`**: Surface action handler now sends a proper `session_error` with `QUEUE_FULL` code via `buildSessionErrorMessage` instead of a generic `error` event
- **`handlers.ts`**: Updated `userMessage` to be more descriptive: "Message queue is full (max depth: 10). Please wait for current messages to be processed."
- **`session-error.ts`**: Updated the `queue` phase classifier message to be consistent with the other paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
