### PR TITLE
fix: center-align composer placeholder text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -146,10 +146,18 @@ struct ComposerView: View {
 
             ZStack(alignment: .leading) {
                 TextField(
-                    ghostSuffix != nil ? "" : placeholderText,
+                    "",
                     text: $inputText,
                     axis: .vertical
                 )
+                .overlay {
+                    if inputText.isEmpty && ghostSuffix == nil {
+                        Text(placeholderText)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                            .allowsHitTesting(false)
+                    }
+                }
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
                 .lineSpacing(4)


### PR DESCRIPTION
## Summary
- Replace the TextField's built-in placeholder with a custom centered overlay so the placeholder text appears centered in the composer input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
