### PR TITLE
fix: remove ScrollView that inverted show more/less labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1111,27 +1111,12 @@ private struct ChatBubble: View {
 
             if hasText {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    if isExpanded && message.text.count > truncationLimit {
-                        // For expanded long messages, use a scrollable container with fixed height
-                        ScrollView {
-                            Text(markdownText)
-                                .font(.system(size: 13))
-                                .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                                .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .frame(height: 400)
-                        .background(Color.black.opacity(0.1))
-                        .cornerRadius(4)
-                    } else {
-                        Text(markdownText)
-                            .font(.system(size: 13))
-                            .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                            .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                            .textSelection(.enabled)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                    Text(markdownText)
+                        .font(.system(size: 13))
+                        .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
+                        .tint(isUser ? VColor.userBubbleText : VColor.accent)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
 
                     if shouldTruncate || (isExpanded && (message.text.count > truncationLimit || message.text.components(separatedBy: .newlines).count > lineLimit)) {
                         Button(action: { isExpanded.toggle() }) {


### PR DESCRIPTION
## Summary
- The expanded state used a 400px ScrollView container that visually showed LESS content than the collapsed state (which showed 2000 chars fully laid out), making the "Show more" / "Show less" labels appear swapped
- Removed the ScrollView branch so both states use the same text layout — `displayText` handles truncation correctly via `shouldTruncate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
