### PR TITLE
fix: await permission lifecycle hooks instead of fire-and-forget

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -131,7 +131,7 @@ export class ToolExecutor {
           sandboxed,
         });
 
-        void getHookManager().trigger('permission-request', {
+        await getHookManager().trigger('permission-request', {
           toolName: name,
           input: sanitizeToolInput(name, input),
           riskLevel,
@@ -152,7 +152,7 @@ export class ToolExecutor {
 
         decision = response.decision;
 
-        void getHookManager().trigger('permission-resolve', {
+        await getHookManager().trigger('permission-resolve', {
           toolName: name,
           decision: response.decision,
           riskLevel,


### PR DESCRIPTION
Change `void getHookManager().trigger()` to `await` for `permission-request` and `permission-resolve` hooks so security-critical hooks execute in order and complete before the permission flow continues.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
