### PR TITLE
fix: add cycle detection to entity relation traversal

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -174,6 +174,7 @@ describe('AssistantConfigSchema', () => {
       maxNeighborEntities: 20,
       maxEdges: 40,
       neighborScoreMultiplier: 0.7,
+      maxDepth: 3,
     });
   });
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -99,6 +99,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         maxNeighborEntities: 20,
         maxEdges: 40,
         neighborScoreMultiplier: 0.7,
+        maxDepth: 3,
       },
     },
     conflicts: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -454,12 +454,18 @@ export const MemoryEntityConfigSchema = z.object({
       .gt(0, 'memory.entity.relationRetrieval.neighborScoreMultiplier must be > 0')
       .lte(1, 'memory.entity.relationRetrieval.neighborScoreMultiplier must be <= 1')
       .default(0.7),
+    maxDepth: z
+      .number({ error: 'memory.entity.relationRetrieval.maxDepth must be a number' })
+      .int('memory.entity.relationRetrieval.maxDepth must be an integer')
+      .positive('memory.entity.relationRetrieval.maxDepth must be a positive integer')
+      .default(3),
   }).default({
     enabled: true,
     maxSeedEntities: 8,
     maxNeighborEntities: 20,
     maxEdges: 40,
     neighborScoreMultiplier: 0.7,
+    maxDepth: 3,
   }),
 });
 
@@ -589,6 +595,7 @@ export const MemoryConfigSchema = z.object({
       maxNeighborEntities: 20,
       maxEdges: 40,
       neighborScoreMultiplier: 0.7,
+      maxDepth: 3,
     },
   }),
   conflicts: MemoryConflictsConfigSchema.default({
@@ -795,6 +802,7 @@ export const AssistantConfigSchema = z.object({
         maxNeighborEntities: 20,
         maxEdges: 40,
         neighborScoreMultiplier: 0.7,
+        maxDepth: 3,
       },
     },
     conflicts: {

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -839,6 +839,7 @@ function entitySearch(
     seedEntityIds,
     relationConfig.maxEdges,
     relationConfig.maxNeighborEntities,
+    relationConfig.maxDepth,
   );
   const relationNeighborEntityCount = neighborEntityIds.length;
   const directItemIds = new Set(directCandidates.map((candidate) => candidate.id));
@@ -926,49 +927,73 @@ function findMatchedEntities(query: string, maxMatches: number): MatchedEntityRo
   return matchedEntities;
 }
 
+/**
+ * BFS traversal across entity relations with visited-set cycle detection
+ * and configurable max depth to prevent unbounded graph walking.
+ */
 function findNeighborEntities(
   seedEntityIds: string[],
   maxEdges: number,
   maxNeighborEntities: number,
+  maxDepth: number = 3,
 ): { neighborEntityIds: string[]; traversedEdgeCount: number } {
-  if (seedEntityIds.length === 0 || maxEdges <= 0 || maxNeighborEntities <= 0) {
+  if (seedEntityIds.length === 0 || maxEdges <= 0 || maxNeighborEntities <= 0 || maxDepth <= 0) {
     return { neighborEntityIds: [], traversedEdgeCount: 0 };
   }
 
   const db = getDb();
-  const rows = db
-    .select({
-      sourceEntityId: memoryEntityRelations.sourceEntityId,
-      targetEntityId: memoryEntityRelations.targetEntityId,
-    })
-    .from(memoryEntityRelations)
-    .where(or(
-      inArray(memoryEntityRelations.sourceEntityId, seedEntityIds),
-      inArray(memoryEntityRelations.targetEntityId, seedEntityIds),
-    ))
-    .orderBy(desc(memoryEntityRelations.lastSeenAt))
-    .limit(Math.max(1, maxEdges))
-    .all();
-
-  const seedSet = new Set(seedEntityIds);
-  const seen = new Set<string>();
+  const visited = new Set<string>(seedEntityIds);
   const neighbors: string[] = [];
-  for (const row of rows) {
-    if (seedSet.has(row.sourceEntityId) && !seedSet.has(row.targetEntityId) && !seen.has(row.targetEntityId)) {
-      neighbors.push(row.targetEntityId);
-      seen.add(row.targetEntityId);
+  let totalEdgesTraversed = 0;
+
+  // BFS frontier starts with seed entities
+  let frontier = [...seedEntityIds];
+
+  for (let depth = 0; depth < maxDepth; depth++) {
+    if (frontier.length === 0 || neighbors.length >= maxNeighborEntities) break;
+
+    const edgeBudget = maxEdges - totalEdgesTraversed;
+    if (edgeBudget <= 0) break;
+
+    const rows = db
+      .select({
+        sourceEntityId: memoryEntityRelations.sourceEntityId,
+        targetEntityId: memoryEntityRelations.targetEntityId,
+      })
+      .from(memoryEntityRelations)
+      .where(or(
+        inArray(memoryEntityRelations.sourceEntityId, frontier),
+        inArray(memoryEntityRelations.targetEntityId, frontier),
+      ))
+      .orderBy(desc(memoryEntityRelations.lastSeenAt))
+      .limit(Math.max(1, edgeBudget))
+      .all();
+
+    totalEdgesTraversed += rows.length;
+
+    const nextFrontier: string[] = [];
+    const frontierSet = new Set(frontier);
+    for (const row of rows) {
+      if (neighbors.length >= maxNeighborEntities) break;
+      if (frontierSet.has(row.sourceEntityId) && !visited.has(row.targetEntityId)) {
+        visited.add(row.targetEntityId);
+        neighbors.push(row.targetEntityId);
+        nextFrontier.push(row.targetEntityId);
+      }
+      if (neighbors.length >= maxNeighborEntities) break;
+      if (frontierSet.has(row.targetEntityId) && !visited.has(row.sourceEntityId)) {
+        visited.add(row.sourceEntityId);
+        neighbors.push(row.sourceEntityId);
+        nextFrontier.push(row.sourceEntityId);
+      }
     }
-    if (neighbors.length >= maxNeighborEntities) break;
-    if (seedSet.has(row.targetEntityId) && !seedSet.has(row.sourceEntityId) && !seen.has(row.sourceEntityId)) {
-      neighbors.push(row.sourceEntityId);
-      seen.add(row.sourceEntityId);
-    }
-    if (neighbors.length >= maxNeighborEntities) break;
+
+    frontier = nextFrontier;
   }
 
   return {
     neighborEntityIds: neighbors.slice(0, maxNeighborEntities),
-    traversedEdgeCount: rows.length,
+    traversedEdgeCount: totalEdgesTraversed,
   };
 }
 


### PR DESCRIPTION
## Summary
- Convert `findNeighborEntities` from single-pass neighbor lookup to BFS with a visited `Set<string>` to prevent cycles from circular entity relationships
- Add configurable `maxDepth` parameter (default 3) to bound traversal depth even without cycles
- Edge and neighbor limits are respected per BFS level, and remaining edge budget carries across levels

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Config schema test updated to include `maxDepth` field
- [ ] Manual testing with circular entity relations in dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
