### PR TITLE
feat: add provider failover with health checking

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -5,6 +5,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   provider: 'anthropic',
   model: 'claude-opus-4-6', // alias: claude-opus-4
   apiKeys: {},
+  providerOrder: [],
   maxTokens: 64000,
   thinking: {
     enabled: false,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -697,6 +697,11 @@ export const AssistantConfigSchema = z.object({
   apiKeys: z
     .record(z.string(), z.string({ error: 'Each apiKeys value must be a string' }))
     .default({}),
+  providerOrder: z
+    .array(z.enum(VALID_PROVIDERS, {
+      error: `Each providerOrder entry must be one of: ${VALID_PROVIDERS.join(', ')}`,
+    }))
+    .default([]),
   maxTokens: z
     .number({ error: 'maxTokens must be a number' })
     .int('maxTokens must be an integer')

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -2,7 +2,7 @@ import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 import Anthropic from '@anthropic-ai/sdk';
 import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
-import { getProvider, initializeProviders } from '../providers/registry.js';
+import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getLogger } from '../util/logger.js';
@@ -2736,7 +2736,7 @@ function handleCuSessionCreate(
   }
 
   const config = getConfig();
-  let provider = getProvider(config.provider);
+  let provider = getFailoverProvider(config.provider, config.providerOrder);
   const { rateLimit } = config;
   if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
     provider = new RateLimitProvider(provider, rateLimit, ctx.sharedRequestTimestamps);

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -3,7 +3,7 @@ import { existsSync, chmodSync, readdirSync, watch, type FSWatcher } from 'node:
 import { join } from 'node:path';
 import { getSocketPath, getRootDir, getWorkspaceDir, getWorkspaceSkillsDir, getSandboxWorkingDir, removeSocketFile } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
-import { getProvider, initializeProviders } from '../providers/registry.js';
+import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
 import { getConfig, invalidateConfigCache } from '../config/loader.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
@@ -578,7 +578,7 @@ export class DaemonServer {
 
       const createPromise = (async () => {
         const config = getConfig();
-        let provider = getProvider(config.provider);
+        let provider = getFailoverProvider(config.provider, config.providerOrder);
         const { rateLimit } = config;
         if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
           provider = new RateLimitProvider(provider, rateLimit, this.sharedRequestTimestamps);

--- a/assistant/src/providers/failover.ts
+++ b/assistant/src/providers/failover.ts
@@ -1,0 +1,129 @@
+import type { Provider, ProviderResponse, SendMessageOptions, Message, ToolDefinition } from './types.js';
+import { ProviderError } from '../util/errors.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('failover');
+
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+interface ProviderHealth {
+  unhealthySince: number | null;
+}
+
+/**
+ * Determine whether an error should trigger failover to the next provider.
+ * Connection errors, auth errors, and 5xx server errors trigger failover.
+ * 4xx client errors do NOT trigger failover (except 429 rate limit).
+ */
+function isFailoverError(error: unknown): boolean {
+  if (error instanceof ProviderError && error.statusCode !== undefined) {
+    // 429 rate limit — try next provider
+    if (error.statusCode === 429) return true;
+    // 5xx server errors — try next provider
+    if (error.statusCode >= 500) return true;
+    // Other 4xx — don't failover (bad request, auth with wrong format, etc.)
+    return false;
+  }
+
+  // Network errors — try next provider
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EPIPE') {
+      return true;
+    }
+    if (error.cause instanceof Error) {
+      const causeCode = (error.cause as NodeJS.ErrnoException).code;
+      if (causeCode === 'ECONNRESET' || causeCode === 'ECONNREFUSED' || causeCode === 'ETIMEDOUT' || causeCode === 'EPIPE') {
+        return true;
+      }
+    }
+  }
+
+  // ProviderError without a status code = connection/unknown failure
+  if (error instanceof ProviderError && error.statusCode === undefined) {
+    return true;
+  }
+
+  return false;
+}
+
+export class FailoverProvider implements Provider {
+  public readonly name: string;
+  private readonly healthMap = new Map<string, ProviderHealth>();
+
+  constructor(
+    private readonly providers: Provider[],
+    private readonly cooldownMs: number = DEFAULT_COOLDOWN_MS,
+  ) {
+    if (providers.length === 0) {
+      throw new Error('FailoverProvider requires at least one provider');
+    }
+    this.name = providers[0].name;
+    for (const p of providers) {
+      this.healthMap.set(p.name, { unhealthySince: null });
+    }
+  }
+
+  async sendMessage(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    const now = Date.now();
+    let lastError: unknown;
+
+    for (const provider of this.providers) {
+      const health = this.healthMap.get(provider.name)!;
+
+      // Skip providers that are still in cooldown
+      if (health.unhealthySince !== null) {
+        const elapsed = now - health.unhealthySince;
+        if (elapsed < this.cooldownMs) {
+          log.debug(
+            { provider: provider.name, cooldownRemainingMs: this.cooldownMs - elapsed },
+            'Skipping unhealthy provider (in cooldown)',
+          );
+          continue;
+        }
+        // Cooldown expired — give it another chance
+        log.info({ provider: provider.name }, 'Provider cooldown expired, retrying');
+      }
+
+      try {
+        const response = await provider.sendMessage(messages, tools, systemPrompt, options);
+        // Success — mark healthy
+        if (health.unhealthySince !== null) {
+          log.info({ provider: provider.name }, 'Provider recovered, marking healthy');
+          health.unhealthySince = null;
+        }
+        return response;
+      } catch (error) {
+        lastError = error;
+
+        if (isFailoverError(error)) {
+          health.unhealthySince = now;
+          log.warn(
+            {
+              provider: provider.name,
+              error: error instanceof Error ? error.message : String(error),
+              statusCode: error instanceof ProviderError ? error.statusCode : undefined,
+            },
+            'Provider failed, marked unhealthy',
+          );
+          continue;
+        }
+
+        // Non-failover error (e.g. 400 bad request) — don't try other providers
+        throw error;
+      }
+    }
+
+    // All providers exhausted
+    throw lastError ?? new ProviderError(
+      'All configured providers are unavailable',
+      this.name,
+      undefined,
+    );
+  }
+}

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -5,6 +5,7 @@ import { GeminiProvider } from "./gemini/client.js";
 import { OllamaProvider } from "./ollama/client.js";
 import { FireworksProvider } from "./fireworks/client.js";
 import { RetryProvider } from "./retry.js";
+import { FailoverProvider } from "./failover.js";
 import { ConfigError } from "../util/errors.js";
 
 const DEFAULT_MODELS: Record<string, string> = {
@@ -29,6 +30,34 @@ export function getProvider(name: string): Provider {
     );
   }
   return provider;
+}
+
+/**
+ * Build a provider that tries the primary provider first, then falls back to
+ * others in the configured order. If providerOrder is empty or only contains
+ * the primary, returns the primary provider directly (no wrapper overhead).
+ */
+export function getFailoverProvider(primaryName: string, providerOrder: string[]): Provider {
+  const primary = getProvider(primaryName);
+
+  // Build the ordered list: primary first, then remaining from providerOrder
+  const orderedProviders: Provider[] = [primary];
+  const seen = new Set<string>([primaryName]);
+
+  for (const name of providerOrder) {
+    if (seen.has(name)) continue;
+    const p = providers.get(name);
+    if (p) {
+      orderedProviders.push(p);
+      seen.add(name);
+    }
+  }
+
+  if (orderedProviders.length === 1) {
+    return primary;
+  }
+
+  return new FailoverProvider(orderedProviders);
 }
 
 export function listProviders(): string[] {

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -3,7 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
-import { getProvider } from '../../providers/registry.js';
+import { getFailoverProvider } from '../../providers/registry.js';
 import { resolveSwarmLimits } from '../../swarm/limits.js';
 import { generatePlan } from '../../swarm/router-planner.js';
 import { executeSwarm } from '../../swarm/orchestrator.js';
@@ -84,7 +84,7 @@ export const swarmDelegateTool: Tool = {
 
       // Generate plan
       context.onOutput?.('Planning task decomposition...\n');
-      const planProvider = getProvider(config.provider);
+      const planProvider = getFailoverProvider(config.provider, config.providerOrder);
       const plan = await generatePlan({
         objective: extraContext ? `${objective}\n\nContext: ${extraContext}` : objective,
         provider: planProvider,
@@ -106,7 +106,7 @@ export const swarmDelegateTool: Tool = {
       const backend = createClaudeCodeBackend();
       let synthesisProvider: typeof planProvider | undefined;
       try {
-        synthesisProvider = getProvider(config.provider);
+        synthesisProvider = getFailoverProvider(config.provider, config.providerOrder);
       } catch {
         // No provider available for synthesis — will use fallback
       }


### PR DESCRIPTION
## Summary
- Add `FailoverProvider` that tries providers in order when the primary fails with connection errors, 5xx, or 429
- Add `providerOrder` config field (array of provider names) to specify failover order
- Failed providers are marked unhealthy with a 60-second cooldown before retrying
- Non-failover errors (4xx except 429) are thrown immediately without trying other providers
- All call sites (`server.ts`, `handlers.ts`, `delegate.ts`) updated to use `getFailoverProvider()`

## How it works
Users configure `providerOrder: ["openai", "gemini"]` in their config. The primary provider is always tried first. If it fails with a retryable error, the next provider in the list is attempted. If all providers fail, the last error is thrown.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Verify existing tests still pass
- [ ] Manual test: configure `providerOrder` with multiple providers, verify failover works when primary is down
- [ ] Verify no failover on 400 errors (client-side issues)
- [ ] Verify cooldown: after a provider fails, it's skipped for 60 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
