### PR TITLE
fix: add solid background to HUD window panels for light mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Ambient/RideShotgunInvitationWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Ambient/RideShotgunInvitationWindow.swift
@@ -132,5 +132,6 @@ private struct RideShotgunInvitationView: View {
         }
         .padding()
         .frame(width: 380)
+        .vPanelBackground()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Ambient/RideShotgunProgressWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Ambient/RideShotgunProgressWindow.swift
@@ -96,5 +96,6 @@ private struct RideShotgunProgressView: View {
         }
         .padding()
         .frame(width: 300)
+        .vPanelBackground()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Ambient/RideShotgunSummaryWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Ambient/RideShotgunSummaryWindow.swift
@@ -115,5 +115,6 @@ private struct RideShotgunSummaryView: View {
         }
         .padding()
         .frame(width: 420)
+        .vPanelBackground()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
@@ -1,3 +1,4 @@
+import VellumAssistantShared
 import AppKit
 import SwiftUI
 
@@ -16,6 +17,7 @@ struct ThinkingIndicatorView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .vPanelBackground()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
@@ -73,6 +73,7 @@ struct VoiceTranscriptionView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .frame(width: 320)
+        .vPanelBackground()
         .onChange(of: viewModel.transcriptionText) {
             if viewModel.transcriptionText.isEmpty {
                 viewModel.contentHeight = 0


### PR DESCRIPTION
## Summary
- HUD window panels (`.hudWindow`) use translucent material that becomes light in light mode, making VColor text tokens invisible
- Added `.vPanelBackground()` to 5 panel views: RideShotgunInvitation, RideShotgunProgress, RideShotgunSummary, ThinkingIndicator, VoiceTranscription
- Matches the pattern already used by ToolConfirmationView and SecretPromptView

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
