### PR TITLE
perf: add early termination to memory recall candidate collection

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -825,6 +825,7 @@ exports[`IPC message snapshots ServerMessage types secret_detected serializes to
 
 exports[`IPC message snapshots ServerMessage types memory_recalled serializes to expected JSON 1`] = `
 {
+  "earlyTerminated": false,
   "entityHits": 3,
   "injectedTokens": 480,
   "latencyMs": 55,

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -538,6 +538,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     relationTraversedEdgeCount: 5,
     relationNeighborEntityCount: 3,
     relationExpandedItemCount: 4,
+    earlyTerminated: false,
     mergedCount: 18,
     selectedCount: 10,
     rerankApplied: false,

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -169,6 +169,7 @@ mock.module('../memory/retriever.js', () => ({
     relationTraversedEdgeCount: 0,
     relationNeighborEntityCount: 0,
     relationExpandedItemCount: 0,
+    earlyTerminated: false,
     mergedCount: 0,
     selectedCount: 0,
     rerankApplied: false,

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -146,6 +146,7 @@ mock.module('../memory/retriever.js', () => ({
     relationTraversedEdgeCount: 0,
     relationNeighborEntityCount: 0,
     relationExpandedItemCount: 0,
+    earlyTerminated: false,
     mergedCount: 0,
     selectedCount: 0,
     rerankApplied: false,

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -78,7 +78,7 @@ mock.module('../memory/retriever.js', () => ({
     enabled: false, degraded: false, reason: null, provider: 'mock', model: 'mock',
     injectedText: '', lexicalHits: 0, semanticHits: 0, recencyHits: 0, entityHits: 0,
     relationSeedEntityCount: 0, relationTraversedEdgeCount: 0, relationNeighborEntityCount: 0,
-    relationExpandedItemCount: 0, mergedCount: 0, selectedCount: 0, rerankApplied: false,
+    relationExpandedItemCount: 0, earlyTerminated: false, mergedCount: 0, selectedCount: 0, rerankApplied: false,
     injectedTokens: 0, latencyMs: 0, topCandidates: [],
   }),
   injectMemoryRecallIntoUserMessage: (msg: Message) => msg,

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -77,7 +77,7 @@ mock.module('../memory/retriever.js', () => ({
     enabled: false, degraded: false, reason: null, provider: 'mock', model: 'mock',
     injectedText: '', lexicalHits: 0, semanticHits: 0, recencyHits: 0, entityHits: 0,
     relationSeedEntityCount: 0, relationTraversedEdgeCount: 0, relationNeighborEntityCount: 0,
-    relationExpandedItemCount: 0, mergedCount: 0, selectedCount: 0, rerankApplied: false,
+    relationExpandedItemCount: 0, earlyTerminated: false, mergedCount: 0, selectedCount: 0, rerankApplied: false,
     injectedTokens: 0, latencyMs: 0, topCandidates: [],
   }),
   injectMemoryRecallIntoUserMessage: (msg: Message) => msg,

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -61,6 +61,12 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         maxInjectTokens: 10000,
         targetHeadroomTokens: 10000,
       },
+      earlyTermination: {
+        enabled: true,
+        minCandidates: 20,
+        minHighConfidence: 10,
+        confidenceThreshold: 0.7,
+      },
     },
     segmentation: {
       targetTokens: 450,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -248,6 +248,27 @@ export const MemoryDynamicBudgetConfigSchema = z.object({
     .default(10000),
 });
 
+export const MemoryEarlyTerminationConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.retrieval.earlyTermination.enabled must be a boolean' })
+    .default(true),
+  minCandidates: z
+    .number({ error: 'memory.retrieval.earlyTermination.minCandidates must be a number' })
+    .int('memory.retrieval.earlyTermination.minCandidates must be an integer')
+    .positive('memory.retrieval.earlyTermination.minCandidates must be a positive integer')
+    .default(20),
+  minHighConfidence: z
+    .number({ error: 'memory.retrieval.earlyTermination.minHighConfidence must be a number' })
+    .int('memory.retrieval.earlyTermination.minHighConfidence must be an integer')
+    .positive('memory.retrieval.earlyTermination.minHighConfidence must be a positive integer')
+    .default(10),
+  confidenceThreshold: z
+    .number({ error: 'memory.retrieval.earlyTermination.confidenceThreshold must be a number' })
+    .min(0, 'memory.retrieval.earlyTermination.confidenceThreshold must be >= 0')
+    .max(1, 'memory.retrieval.earlyTermination.confidenceThreshold must be <= 1')
+    .default(0.7),
+});
+
 /**
  * Per-kind freshness windows (in days). Items older than their window
  * (based on lastSeenAt) are down-ranked unless recently reinforced.
@@ -347,6 +368,12 @@ export const MemoryRetrievalConfigSchema = z.object({
     minInjectTokens: 1200,
     maxInjectTokens: 10000,
     targetHeadroomTokens: 10000,
+  }),
+  earlyTermination: MemoryEarlyTerminationConfigSchema.default({
+    enabled: true,
+    minCandidates: 20,
+    minHighConfidence: 10,
+    confidenceThreshold: 0.7,
   }),
 });
 
@@ -555,6 +582,12 @@ export const MemoryConfigSchema = z.object({
       minInjectTokens: 1200,
       maxInjectTokens: 10000,
       targetHeadroomTokens: 10000,
+    },
+    earlyTermination: {
+      enabled: true,
+      minCandidates: 20,
+      minHighConfidence: 10,
+      confidenceThreshold: 0.7,
     },
   }),
   segmentation: MemorySegmentationConfigSchema.default({
@@ -767,6 +800,12 @@ export const AssistantConfigSchema = z.object({
         minInjectTokens: 1200,
         maxInjectTokens: 10000,
         targetHeadroomTokens: 10000,
+      },
+      earlyTermination: {
+        enabled: true,
+        minCandidates: 20,
+        minHighConfidence: 10,
+        confidenceThreshold: 0.7,
       },
     },
     segmentation: {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -916,6 +916,7 @@ export interface MemoryRecalled {
   relationTraversedEdgeCount?: number;
   relationNeighborEntityCount?: number;
   relationExpandedItemCount?: number;
+  earlyTerminated?: boolean;
   mergedCount: number;
   selectedCount: number;
   rerankApplied: boolean;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -836,6 +836,7 @@ export class Session {
             relationTraversedEdgeCount: recall.relationTraversedEdgeCount,
             relationNeighborEntityCount: recall.relationNeighborEntityCount,
             relationExpandedItemCount: recall.relationExpandedItemCount,
+            earlyTerminated: recall.earlyTerminated,
             mergedCount: recall.mergedCount,
             selectedCount: recall.selectedCount,
             rerankApplied: recall.rerankApplied,

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -73,6 +73,7 @@ export interface MemoryRecallResult {
   relationTraversedEdgeCount: number;
   relationNeighborEntityCount: number;
   relationExpandedItemCount: number;
+  earlyTerminated: boolean;
   mergedCount: number;
   selectedCount: number;
   rerankApplied: boolean;
@@ -98,6 +99,7 @@ interface CollectedCandidates {
   relationTraversedEdgeCount: number;
   relationNeighborEntityCount: number;
   relationExpandedItemCount: number;
+  earlyTerminated: boolean;
   merged: Candidate[];
 }
 
@@ -142,6 +144,7 @@ async function collectAndMergeCandidates(
   // Build the list of scope IDs to include in queries
   const scopeIds = buildScopeFilter(scopeId, scopePolicy);
 
+  // ── Phase 1: cheap local searches (always run) ─────────────────────
   const lexical = lexicalSearch(query, config.memory.retrieval.lexicalTopK, excludeMessageIds, scopeIds);
 
   const recency = opts?.conversationId
@@ -152,38 +155,6 @@ async function collectAndMergeCandidates(
         scopeIds,
       )
     : [];
-
-  let semantic: Candidate[] = [];
-  if (queryVector) {
-    try {
-      semantic = await semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds);
-    } catch (err) {
-      if (isQdrantConnectionError(err)) {
-        log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
-      } else {
-        log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
-      }
-    }
-  }
-
-  let entity: Candidate[] = [];
-  let relationSeedEntityCount = 0;
-  let relationTraversedEdgeCount = 0;
-  let relationNeighborEntityCount = 0;
-  let relationExpandedItemCount = 0;
-  if (config.memory.entity.enabled) {
-    const entitySearchResult = entitySearch(
-      query,
-      config.memory.entity,
-      scopeIds,
-      excludeMessageIds,
-    );
-    entity = entitySearchResult.candidates;
-    relationSeedEntityCount = entitySearchResult.relationSeedEntityCount;
-    relationTraversedEdgeCount = entitySearchResult.relationTraversedEdgeCount;
-    relationNeighborEntityCount = entitySearchResult.relationNeighborEntityCount;
-    relationExpandedItemCount = entitySearchResult.relationExpandedItemCount;
-  }
 
   // Direct item search supplements FTS with LIKE-based matching.
   // Overfetch when exclusions are present so that filtering doesn't
@@ -208,6 +179,56 @@ async function collectAndMergeCandidates(
     directItems = directItems.slice(0, directLimit);
   }
 
+  // ── Early termination check ────────────────────────────────────────
+  // If cheap sources already produced enough high-confidence candidates,
+  // skip the expensive semantic search (Qdrant network call) and entity
+  // relation traversal to reduce recall latency.
+  const etConfig = config.memory.retrieval.earlyTermination;
+  const cheapCandidates = [...lexical, ...recency, ...directItems];
+  const canTerminateEarly = etConfig.enabled
+    && cheapCandidates.length >= etConfig.minCandidates
+    && cheapCandidates.filter((c) => c.confidence >= etConfig.confidenceThreshold).length >= etConfig.minHighConfidence;
+
+  // ── Phase 2: expensive searches (skipped on early termination) ─────
+  let semantic: Candidate[] = [];
+  if (queryVector && !canTerminateEarly) {
+    try {
+      semantic = await semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds);
+    } catch (err) {
+      if (isQdrantConnectionError(err)) {
+        log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
+      } else {
+        log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
+      }
+    }
+  }
+
+  let entity: Candidate[] = [];
+  let relationSeedEntityCount = 0;
+  let relationTraversedEdgeCount = 0;
+  let relationNeighborEntityCount = 0;
+  let relationExpandedItemCount = 0;
+  if (config.memory.entity.enabled && !canTerminateEarly) {
+    const entitySearchResult = entitySearch(
+      query,
+      config.memory.entity,
+      scopeIds,
+      excludeMessageIds,
+    );
+    entity = entitySearchResult.candidates;
+    relationSeedEntityCount = entitySearchResult.relationSeedEntityCount;
+    relationTraversedEdgeCount = entitySearchResult.relationTraversedEdgeCount;
+    relationNeighborEntityCount = entitySearchResult.relationNeighborEntityCount;
+    relationExpandedItemCount = entitySearchResult.relationExpandedItemCount;
+  }
+
+  if (canTerminateEarly) {
+    log.debug(
+      { cheapCandidateCount: cheapCandidates.length, highConfidenceCount: cheapCandidates.filter((c) => c.confidence >= etConfig.confidenceThreshold).length },
+      'Early termination: skipping semantic and entity search — sufficient high-confidence candidates from cheap sources',
+    );
+  }
+
   const relationScoreMultiplier = config.memory.entity.enabled && config.memory.entity.relationRetrieval.enabled
     ? config.memory.entity.relationRetrieval.neighborScoreMultiplier
     : undefined;
@@ -222,6 +243,7 @@ async function collectAndMergeCandidates(
     relationTraversedEdgeCount,
     relationNeighborEntityCount,
     relationExpandedItemCount,
+    earlyTerminated: canTerminateEarly,
     merged,
   };
 }
@@ -350,6 +372,7 @@ export async function buildMemoryRecall(
     relationTraversedEdgeCount,
     relationNeighborEntityCount,
     relationExpandedItemCount,
+    earlyTerminated,
   } = collected;
   let merged = applySourceCaps(collected.merged, config);
 
@@ -410,6 +433,7 @@ export async function buildMemoryRecall(
     relationTraversedEdgeCount,
     relationNeighborEntityCount,
     relationExpandedItemCount,
+    earlyTerminated,
     mergedCount,
     selected: selected.length,
     maxInjectTokens,
@@ -432,6 +456,7 @@ export async function buildMemoryRecall(
     relationTraversedEdgeCount,
     relationNeighborEntityCount,
     relationExpandedItemCount,
+    earlyTerminated,
     mergedCount,
     selectedCount: selected.length,
     rerankApplied,
@@ -1693,6 +1718,7 @@ function emptyResult(
     relationTraversedEdgeCount: 0,
     relationNeighborEntityCount: 0,
     relationExpandedItemCount: 0,
+    earlyTerminated: false,
     mergedCount: 0,
     selectedCount: 0,
     rerankApplied: false,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -555,6 +555,7 @@ public struct IPCMemoryRecalled: Codable, Sendable {
     public let relationTraversedEdgeCount: Int?
     public let relationNeighborEntityCount: Int?
     public let relationExpandedItemCount: Int?
+    public let earlyTerminated: Bool?
     public let mergedCount: Int
     public let selectedCount: Int
     public let rerankApplied: Bool


### PR DESCRIPTION
Short-circuit candidate collection in `collectAndMergeCandidates()` when cheap local sources (lexical, recency, direct item search) already produce enough high-confidence results, skipping the expensive semantic search (Qdrant network call) and entity relation traversal.

## Changes

- Add `earlyTermination` config to `MemoryRetrievalConfig` with four tunable knobs:
  - `enabled` (default: true) — toggle the optimization
  - `minCandidates` (default: 20) — minimum total candidates from cheap sources
  - `minHighConfidence` (default: 10) — minimum high-confidence candidates required
  - `confidenceThreshold` (default: 0.7) — what counts as "high confidence"
- Reorganize `collectAndMergeCandidates()` into two phases:
  - **Phase 1** (always runs): lexical, recency, direct item search — all cheap local SQLite queries
  - **Phase 2** (skipped on early termination): semantic search and entity relation traversal
- Add `earlyTerminated` field to `MemoryRecallResult` and `MemoryRecalled` IPC event for observability
- Update IPC contract, snapshot, and test fixtures

## Rationale

When the local DB already has rich data for a query (many high-confidence lexical/direct matches), the semantic search (Qdrant network round-trip) and entity relation traversal add latency without improving recall quality. This optimization lets us skip those expensive sources when we're already confident in the results.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
