### PR TITLE
fix: tighten composer chat bar padding, radius, and placeholder alignment

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -83,17 +83,17 @@ struct ComposerView: View {
         }
         .padding(.top, isComposerExpanded ? VSpacing.lg : VSpacing.sm)
         .padding(.bottom, VSpacing.sm)
-        .padding(.leading, VSpacing.xl)
-        .padding(.trailing, VSpacing.lg)
+        .padding(.leading, VSpacing.lg)
+        .padding(.trailing, VSpacing.md)
         .background(VColor.surface)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xxl))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xxl)
-                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder.opacity(0.7), lineWidth: 1)
         )
-        .padding(.horizontal, VSpacing.xl)
-        .padding(.top, VSpacing.md)
-        .padding(.bottom, 18)
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.top, VSpacing.sm)
+        .padding(.bottom, VSpacing.md)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
         .animation(VAnimation.fast, value: editorContentHeight)
@@ -150,7 +150,7 @@ struct ComposerView: View {
                     text: $inputText,
                     axis: .vertical
                 )
-                .overlay {
+                .overlay(alignment: .topLeading) {
                     if inputText.isEmpty && ghostSuffix == nil {
                         Text(placeholderText)
                             .font(VFont.body)


### PR DESCRIPTION
## Summary
- Reduce corner radius from `VRadius.xxl` (20pt) to `VRadius.lg` (12pt) for a crisper shape
- Trim inner padding (leading 24→16, trailing 16→12) and outer padding (horizontal 24→16, top 12→8, bottom 18→12) to reduce bloat
- Increase border stroke opacity from 0.5 to 0.7 for better definition
- Anchor placeholder text to `.topLeading` so it sits where the user would start typing instead of floating centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
