### PR TITLE
fix: restore attachment descriptions in textSegments, use first segment on macOS

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -358,11 +358,16 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     }
   }
 
-  // Attachment descriptions are NOT included in textSegments — they are
-  // rendered separately as attachment chips/images in the UI.  Including
-  // them would cause the "last text segment" heuristic to surface an
-  // attachment descriptor instead of the assistant's actual narrative text
-  // in interleaved history messages.
+  // Include attachment descriptions in textSegments so that clients without
+  // separate attachment UI (e.g. iOS) can display them via `message.text`.
+  // The macOS client handles this by selecting the *first* non-empty text
+  // segment in interleaved content, so trailing attachment segments are safe.
+  if (attachmentParts.length > 0) {
+    const attachmentText = attachmentParts.join('\n');
+    const prefix = textParts.length > 0 ? '\n' : '';
+    ensureSegment();
+    currentSegmentParts.push(prefix + attachmentText);
+  }
 
   finalizeSegment();
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1004,11 +1004,13 @@ private struct ChatBubble: View {
     private var interleavedContent: some View {
         let groups = groupContentBlocks()
 
-        // Only show the last non-empty text segment — each new step overrides the previous.
-        if let lastText = message.textSegments.lazy
+        // Show the first non-empty text segment — the assistant's narrative text.
+        // Attachment descriptions are appended as trailing segments, so picking the
+        // first ensures those descriptors don't replace the actual response text.
+        if let firstText = message.textSegments.lazy
             .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
-            .last(where: { !$0.isEmpty }) {
-            textBubble(for: lastText)
+            .first(where: { !$0.isEmpty }) {
+            textBubble(for: firstText)
         }
 
         // Surfaces still render in order


### PR DESCRIPTION
## Summary
- Reverts the server-side change from PR #3134 that excluded attachment descriptions from `textSegments` — this broke iOS which relies on `message.text` (computed from `textSegments.joined()`) to display attachment info since it has no separate attachment UI
- Restores the original code in `renderHistoryContent` that appends attachment descriptions as trailing text segments
- Fixes the macOS `interleavedContent` view by selecting the **first** non-empty text segment (the narrative text) instead of the **last**, since attachment descriptions are always appended as trailing segments

## Test plan
- [x] `bun test` passes (28 tests, 0 failures) — history render tests confirm attachment descriptions are included in textSegments
- [ ] Verify macOS interleaved content shows narrative text (not attachment descriptors) for text+tool+attachment turns
- [ ] Verify iOS displays attachment descriptions via `message.text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
