### PR TITLE
fix: prevent chat composer text clipping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import VellumAssistantShared
 
 struct ComposerView: View {
+    private let composerVerticalTextInset: CGFloat = 2
+
     @Binding var inputText: String
     let hasAPIKey: Bool
     let isSending: Bool
@@ -160,7 +162,6 @@ struct ComposerView: View {
                 }
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .lineSpacing(4)
                 .textFieldStyle(.plain)
                 .lineLimit(1...)
                 .focused($isComposerFocused)
@@ -175,13 +176,15 @@ struct ComposerView: View {
                         + Text(ghostSuffix)
                             .font(VFont.body)
                             .foregroundColor(VColor.textMuted.opacity(0.5)))
-                            .lineSpacing(4)
                             .lineLimit(1...)
                             .fixedSize(horizontal: false, vertical: true)
                             .allowsHitTesting(false)
                             .accessibilityHidden(true)
                     }
                 }
+                // AppKit's multiline TextField can under-report its rendered height,
+                // which clips the bottom row when the composer is tightly framed.
+                .padding(.vertical, composerVerticalTextInset)
                 .background(
                     GeometryReader { geo in
                         Color.clear


### PR DESCRIPTION
## Summary
- remove custom multiline line spacing in the chat composer input and ghost suffix overlay
- add a small vertical inset to avoid AppKit text metric under-reporting at tight heights
- preserve existing composer behavior while preventing bottom-row text clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
