### PR TITLE
fix: preserve assistant turns when filtering unknown content blocks

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -523,6 +523,60 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
     expect(sent[4].content.some((b) => b.type === 'tool_result' && b.tool_use_id === 'tu_2')).toBe(true);
   });
 
+  test('assistant message with only unknown blocks gets placeholder text', async () => {
+    const messages: Message[] = [
+      userMsg('Start'),
+      // Assistant message with only ui_surface (unknown type) — will be filtered
+      {
+        role: 'assistant',
+        content: [{ type: 'ui_surface' as 'text', text: 'this will be filtered' }],
+      },
+      userMsg('Continue'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    }>;
+
+    // Should preserve alternation: user, assistant (with placeholder), user
+    expect(sent).toHaveLength(3);
+    expect(sent[0].role).toBe('user');
+    expect(sent[1].role).toBe('assistant');
+    expect(sent[1].content).toHaveLength(1);
+    expect(sent[1].content[0].type).toBe('text');
+    expect(sent[1].content[0].text).toBe('[internal blocks omitted]');
+    expect(sent[2].role).toBe('user');
+  });
+
+  test('assistant message with mix of known and unknown blocks keeps known blocks', async () => {
+    const messages: Message[] = [
+      userMsg('Start'),
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Valid text' },
+          { type: 'ui_surface' as 'text', text: 'this will be filtered' },
+          { type: 'text', text: 'More valid text' },
+        ],
+      },
+      userMsg('Continue'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    }>;
+
+    expect(sent).toHaveLength(3);
+    expect(sent[1].role).toBe('assistant');
+    expect(sent[1].content).toHaveLength(2);
+    expect(sent[1].content[0].text).toBe('Valid text');
+    expect(sent[1].content[1].text).toBe('More valid text');
+  });
+
   // -----------------------------------------------------------------------
   // Workspace context injection + cache control
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -333,13 +333,27 @@ export class AnthropicProvider implements Provider {
     const { config, onEvent, signal } = options ?? {};
     let sentMessages: Anthropic.MessageParam[] | undefined;
     try {
-      const formatted = messages.map((m) => ({
-        role: m.role,
-        content: m.content
+      const formatted = messages.map((m) => {
+        const content = m.content
           .map((block) => this.toAnthropicBlockSafe(block))
           .filter((block): block is Anthropic.ContentBlockParam => block !== null)
-          .filter((block) => !(block.type === 'text' && !(block as { text?: string }).text?.trim())),
-      })).filter((m) => m.content.length > 0);
+          .filter((block) => !(block.type === 'text' && !(block as { text?: string }).text?.trim()));
+
+        // Preserve assistant turns that would otherwise become empty after filtering
+        // unknown block types (e.g. ui_surface). Dropping these messages can violate
+        // Anthropic's role alternation requirement.
+        if (content.length === 0 && m.role === 'assistant') {
+          return {
+            role: m.role,
+            content: [{ type: 'text' as const, text: '[internal blocks omitted]' }],
+          };
+        }
+
+        return {
+          role: m.role,
+          content,
+        };
+      }).filter((m) => m.content.length > 0);
 
       sentMessages = ensureToolPairing(formatted);
       const params: Anthropic.MessageCreateParams = {


### PR DESCRIPTION
Addresses Codex P1 feedback on https://github.com/vellum-ai/vellum-assistant/pull/3108

## Problem

When `toAnthropicBlockSafe` returns `null` for unknown content block types (e.g. `ui_surface` from persisted conversation state), an assistant message containing only those blocks would become empty after filtering and get removed by the `content.length > 0` check. This violates Anthropic's role alternation requirement and can cause 400 errors when consecutive same-role turns appear in the conversation.

## Solution

If an assistant message would be empty after filtering unknown blocks, we now insert a placeholder text block `[internal blocks omitted]` to preserve the turn and maintain proper role alternation. User messages are still filtered out when empty (existing behavior).

## Testing

- Added test case for assistant message with only unknown blocks
- Added test case for assistant message with mix of known/unknown blocks
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
