### PR TITLE
fix: clear timeout timer in executeWithTimeout to prevent leaks

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -441,10 +441,12 @@ async function executeWithTimeout(
   timeoutMs: number,
   toolName: string,
 ): Promise<ToolExecutionResult> {
+  let timeoutHandle: ReturnType<typeof setTimeout>;
   const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
-    setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
+    timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
   });
   const result = await Promise.race([promise, timeoutPromise]);
+  clearTimeout(timeoutHandle!);
   if (result === TIMEOUT_SENTINEL) {
     const sec = Math.round(timeoutMs / 1000);
     return {


### PR DESCRIPTION
Addresses Codex P2 and Devin feedback on https://github.com/vellum-ai/vellum-assistant/pull/3160

## Summary
- Store the `setTimeout` timer handle and clear it with `clearTimeout()` after `Promise.race` settles
- Prevents timer leaks that keep the event loop alive and can delay process shutdown

## Root Cause
PR #3160 added `executeWithTimeout()` to wrap tool calls with a timeout, but the `setTimeout` timer was never cleared when the tool promise won the race. Every successful tool execution left a dangling timer running for up to 120 seconds.

## Fix
Store the timer handle in a `let` variable and call `clearTimeout(timeoutHandle!)` immediately after the race resolves, before checking the result. This ensures the timer is always cleaned up regardless of which promise wins.

## Test Plan
- [x] Type-check passes: `bunx tsc --noEmit`
- [x] Follows pattern used elsewhere in the codebase (e.g. `shell.ts:92`, `runner.ts:106`, `web-fetch.ts:649`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
