### PR TITLE
fix: align workspace-edit guidance with host-file approval flow

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -278,7 +278,7 @@ function buildConfigSection(configDir: string): string {
     '',
     '### Proactive Workspace Editing',
     '',
-    'You should actively update your workspace files as you learn. No confirmation is needed. Use `host_file_edit` to make targeted edits.',
+    'You should actively update your workspace files as you learn. You don\'t need to ask the user whether it\'s okay — just briefly explain what you\'re updating, then use `host_file_edit` to make targeted edits.',
     '',
     '**USER.md** — update when you learn:',
     '- Their name, pronouns, timezone, or what they prefer to be called',


### PR DESCRIPTION
Addresses feedback from codex and devin bots on PR #3067.

## Changes
Changed the workspace editing guidance in `system-prompt.ts` from "No confirmation is needed" to "You don't need to ask the user whether it's okay — just briefly explain what you're updating" to align with the existing CRITICAL RULE that requires pre-tool text before permission-gated tools.

## Why
The previous wording contradicted the Tool Permissions section, which mandates that the assistant MUST output explanatory text before calling any permission-gated tool like `host_file_edit`. Since `host_file_edit` triggers an Allow/Don't Allow dialog by default, the user needs context to make an informed decision.

## Related
- Original PR: #3067
- Codex feedback: https://github.com/vellum-ai/vellum-assistant/pull/3067#discussion_r2002889321
- Devin feedback: https://github.com/vellum-ai/vellum-assistant/pull/3067#discussion_r2002889322
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
