### PR TITLE
fix: add length-prefix delimiters to hash computation in clawhub

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -70,8 +70,11 @@ function computeSkillHash(skillDir: string): string | null {
 
   const hasher = new Bun.CryptoHasher('sha256');
   for (const file of files) {
-    // Include the relative path in the hash so renames are detected
-    hasher.update(file.relPath);
+    // Length-prefix each segment to prevent boundary ambiguity collisions
+    const pathBuf = Buffer.from(file.relPath, 'utf-8');
+    hasher.update(`${pathBuf.length}:`);
+    hasher.update(pathBuf);
+    hasher.update(`${file.content.length}:`);
     hasher.update(file.content);
   }
   return hasher.digest('hex');


### PR DESCRIPTION
## Summary
Addresses review feedback on PR #3162 by adding length-prefix delimiters to the hash computation in `clawhub.ts`.

## Changes
- Modified `computeSkillHash()` to use length-prefixed segments (format: `"length:content"`) for both file paths and file contents
- Prevents boundary ambiguity collisions where different file trees could produce identical hashes

## Why
Without delimiters, the hash computation was vulnerable to collisions:
- Path "a" + content "bc" would hash identically to path "ab" + content "c"
- Cross-file boundaries were also ambiguous

This undermined the integrity check's security goal of detecting CDN tampering.

## Test plan
- [x] Type-check passes
- [x] Follows the length-prefix pattern suggested by both Codex and Devin reviews

Resolves review feedback on #3162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
