### PR TITLE
fix: protect system timers from debounce eviction

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -196,14 +196,15 @@ export class DaemonServer {
           if (!filename) return;
           const file = String(filename);
           if (!handlers[file]) return;
-          const existing = this.debounceTimers.get(file);
+          const key = `file:${file}`;
+          const existing = this.debounceTimers.get(key);
           if (existing) clearTimeout(existing);
           const timer = setTimeout(() => {
-            this.debounceTimers.delete(file);
+            this.debounceTimers.delete(key);
             log.info({ file }, 'File changed, reloading');
             handlers[file]();
           }, 200);
-          this.debounceTimers.set(file, timer);
+          this.debounceTimers.set(key, timer);
           this.enforceDebounceLimit();
         });
         this.watchers.push(watcher);
@@ -298,8 +299,10 @@ export class DaemonServer {
   }
 
   /**
-   * Evict the oldest debounce entries when the map exceeds the safety cap.
+   * Evict the oldest file-watcher debounce entries when the map exceeds the safety cap.
    * Map iteration order follows insertion order, so the first keys are oldest.
+   * Protects system timers (keys starting with '__') from eviction, so critical
+   * timers like '__suppress_reset__' are never cleared during bursts of file events.
    */
   private enforceDebounceLimit(): void {
     if (this.debounceTimers.size <= DaemonServer.MAX_DEBOUNCE_ENTRIES) return;
@@ -307,6 +310,8 @@ export class DaemonServer {
     let removed = 0;
     for (const [key, timer] of this.debounceTimers) {
       if (removed >= excess) break;
+      // Skip system timers (those with keys starting with '__')
+      if (key.startsWith('__')) continue;
       clearTimeout(timer);
       this.debounceTimers.delete(key);
       removed++;


### PR DESCRIPTION
## Summary
- Prefix file-watcher timer keys with `file:` to distinguish them from system timers
- Skip system timer keys (those starting with `__`) during `enforceDebounceLimit` eviction
- Prevents critical timers like `__suppress_reset__` from being cleared during file event bursts

## Context
Addresses feedback on PR #3152. The original implementation could evict the `__suppress_reset__` timer during bursts of skill file events, permanently disabling config hot-reload since `suppressConfigReload` would never be reset to `false`.

## Test plan
- Manual testing: Verify that config hot-reload continues to work after bursts of skill file changes
- Verify that the debounce limit still works for file-watcher timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
