### PR TITLE
fix: make Qdrant client unavailability retryable in delete job

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -958,7 +958,13 @@ async function deleteQdrantVectorsJob(job: MemoryJob): Promise<void> {
   const targetId = asString(job.payload.targetId);
   if (!targetType || !targetId) return;
 
-  const qdrant = getQdrantClient();
+  let qdrant;
+  try {
+    qdrant = getQdrantClient();
+  } catch {
+    throw new BackendUnavailableError('Qdrant client not initialized');
+  }
+
   await qdrant.deleteByTarget(targetType, targetId);
   log.info({ targetType, targetId }, 'Retried Qdrant vector deletion succeeded');
 }


### PR DESCRIPTION
## Summary
- Wrap `getQdrantClient()` call in `deleteQdrantVectorsJob` with try-catch
- Throw `BackendUnavailableError` when Qdrant client is not initialized
- Ensures deletion jobs are deferred with exponential backoff instead of permanently failing

## Context
Addresses feedback on PR #3163 from Codex and Devin. The original implementation would permanently fail deletion jobs after one attempt if the Qdrant client wasn't initialized, leaving orphaned vectors.

This fix mirrors the pattern already used in `embedAndUpsert` (lines 984-988), converting missing-client errors into `BackendUnavailableError` which triggers the deferral path with exponential backoff.

## Test plan
- Type-checked with `bunx tsc --noEmit`
- Follows established pattern from `embedAndUpsert`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
