### PR TITLE
fix: preserve long-lived profile facts in ranking score

### DIFF
--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -99,8 +99,8 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
   };
 }
 
-/** Half-life for recency decay — items seen this many ms ago score ~0.5. (7 days) */
-const RECENCY_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000;
+/** Half-life for recency decay — items seen this many ms ago score ~0.5. (30 days) */
+const RECENCY_HALF_LIFE_MS = 30 * 24 * 60 * 60 * 1000;
 
 function recencyScore(lastSeenAt: number, nowMs: number): number {
   const ageMs = Math.max(0, nowMs - lastSeenAt);
@@ -109,7 +109,10 @@ function recencyScore(lastSeenAt: number, nowMs: number): number {
 
 function candidateRankScore(c: ProfileCandidate, nowMs: number): number {
   const importance = c.importance ?? 0.5;
-  return importance * recencyScore(c.lastSeenAt, nowMs);
+  const recency = recencyScore(c.lastSeenAt, nowMs);
+  // Use weighted additive formula: importance dominates, recency is a minor boost
+  // This preserves high-importance items even when they haven't been seen recently
+  return importance * 0.7 + recency * 0.3;
 }
 
 function compareProfileCandidates(left: ProfileCandidate, right: ProfileCandidate, nowMs: number): number {


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback on PR #3155 about recency dominating importance in profile memory ranking.

## Changes
- Changed from multiplicative `importance * recency` to weighted additive formula (70% importance, 30% recency)
- Increased half-life from 7 days to 30 days
- High-importance memories now maintain ranking even when not recently accessed

## Test plan
- [x] Type-check passes
- [x] All profile-compiler tests pass
- [x] Formula now preserves high-importance items (e.g., importance=1.0 at 30 days scores 0.85 instead of 0.05)

## Context
Previously, with the 7-day half-life multiplicative formula, an importance=1.0 item unseen for 30 days scored ~0.05, so any freshly seen low-importance item > 0.05 would outrank it. This degraded long-term memory quality for stable user preferences and constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
