### PR TITLE
fix: parse HTTP status from error messages in classifyError

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -92,6 +92,19 @@ function classifyError(err: unknown): ErrorCategory {
     return 'retryable';
   }
 
+  // Parse HTTP status codes from error messages (e.g., "request failed (429): ...")
+  // Gemini and Ollama backends embed status codes in plain Error messages
+  if (err instanceof Error) {
+    const statusMatch = err.message.match(/\((\d{3})\)/);
+    if (statusMatch) {
+      const status = parseInt(statusMatch[1], 10);
+      if (status === 429) return 'retryable';
+      if (status >= 500) return 'retryable';
+      // 4xx client errors → fatal
+      if (status >= 400 && status < 500) return 'fatal';
+    }
+  }
+
   // Connection/network errors without a status code
   if (err instanceof Error && /ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(err.message)) {
     return 'retryable';


### PR DESCRIPTION
## Summary
Fixes #3156 (Codex P1 feedback) by updating `classifyError` to parse HTTP status codes from error message strings when `err.status` is not available.

## Problem
Gemini and Ollama embedding backends throw plain `Error` objects with status codes embedded in the message (e.g., `"Gemini embeddings request failed (429): ..."`) rather than setting `err.status`. This caused transient 429/5xx errors from those providers to be classified as fatal, preventing retries during rate limits or outages.

## Solution
- Added regex parsing of `(\d{3})` patterns in error messages to extract HTTP status codes
- Same classification logic applies: 429 and 5xx → retryable, 4xx → fatal
- Check runs after `err.status` check and before generic connection error patterns

## Test Plan
- [x] Type-check passes
- [ ] Verify Gemini 429 errors now retry instead of failing immediately
- [ ] Verify Ollama 5xx errors now retry instead of failing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
