### PR TITLE
fix: address PR 3176 review feedback

### DIFF
--- a/assistant/src/providers/failover.ts
+++ b/assistant/src/providers/failover.ts
@@ -70,11 +70,11 @@ export class FailoverProvider implements Provider {
     systemPrompt?: string,
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
-    const now = Date.now();
     let lastError: unknown;
 
     for (const provider of this.providers) {
       const health = this.healthMap.get(provider.name)!;
+      const now = Date.now();
 
       // Skip providers that are still in cooldown
       if (health.unhealthySince !== null) {
@@ -102,7 +102,7 @@ export class FailoverProvider implements Provider {
         lastError = error;
 
         if (isFailoverError(error)) {
-          health.unhealthySince = now;
+          health.unhealthySince = Date.now();
           log.warn(
             {
               provider: provider.name,

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -17,6 +17,8 @@ const DEFAULT_MODELS: Record<string, string> = {
 };
 
 const providers = new Map<string, Provider>();
+let cachedFailoverProvider: FailoverProvider | null = null;
+let cachedFailoverKey: string | null = null;
 
 export function registerProvider(name: string, provider: Provider): void {
   providers.set(name, provider);
@@ -36,6 +38,7 @@ export function getProvider(name: string): Provider {
  * Build a provider that tries the primary provider first, then falls back to
  * others in the configured order. If providerOrder is empty or only contains
  * the primary, returns the primary provider directly (no wrapper overhead).
+ * Caches the FailoverProvider instance so health state persists across calls.
  */
 export function getFailoverProvider(primaryName: string, providerOrder: string[]): Provider {
   const primary = getProvider(primaryName);
@@ -57,7 +60,14 @@ export function getFailoverProvider(primaryName: string, providerOrder: string[]
     return primary;
   }
 
-  return new FailoverProvider(orderedProviders);
+  const cacheKey = `${primaryName}:${providerOrder.join(',')}`;
+  if (cachedFailoverProvider && cachedFailoverKey === cacheKey) {
+    return cachedFailoverProvider;
+  }
+
+  cachedFailoverProvider = new FailoverProvider(orderedProviders);
+  cachedFailoverKey = cacheKey;
+  return cachedFailoverProvider;
 }
 
 export function listProviders(): string[] {
@@ -84,6 +94,8 @@ function resolveModel(config: ProvidersConfig, providerName: keyof typeof DEFAUL
 
 export function initializeProviders(config: ProvidersConfig): void {
   providers.clear();
+  cachedFailoverProvider = null;
+  cachedFailoverKey = null;
 
   if (config.apiKeys.anthropic) {
     const model = resolveModel(config, 'anthropic');


### PR DESCRIPTION
## Summary
- Fixed Codex P2 feedback: Move `Date.now()` inside the failover loop so timestamps are recomputed for each provider attempt
- Fixed Devin feedback: Cache the `FailoverProvider` instance to preserve health state and cooldowns across calls
- Clear the cache in `initializeProviders()` when providers are re-registered

## Details

**Codex P2 (failover.ts:73)**: The original code captured `Date.now()` once at the start of `sendMessage`, causing cooldown checks and `unhealthySince` timestamps to become stale during long failover sequences. Now `Date.now()` is called fresh inside the loop for each provider.

**Devin (registry.ts:60)**: The original `getFailoverProvider()` created a new `FailoverProvider` instance on every call, discarding the `healthMap` that tracks which providers are in cooldown. This made the 60-second cooldown feature ineffective across sessions and even within the same function (e.g., swarm delegate planning and synthesis steps). Now the instance is cached by `primaryName:providerOrder` key and reused, so health state persists.

## Test plan
- [x] Type-check passes
- [ ] Unit tests pass (if applicable)
- [ ] Manual testing: verify cooldown behavior persists across multiple calls

## Related
Addresses feedback on PR #3176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
