### PR TITLE
fix: parse HTTP-date format Retry-After headers

### DIFF
--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -20,9 +20,19 @@ function computeDelay(
   retryAfterHeader: string | null,
 ): number {
   if (retryAfterHeader) {
+    // Try parsing as numeric seconds first (e.g., "120")
     const seconds = Number(retryAfterHeader);
     if (Number.isFinite(seconds) && seconds > 0) {
       return seconds * 1000;
+    }
+
+    // Fall back to HTTP-date format (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")
+    const targetTime = new Date(retryAfterHeader).getTime();
+    if (Number.isFinite(targetTime)) {
+      const delayMs = targetTime - Date.now();
+      if (delayMs > 0) {
+        return delayMs;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Parse RFC-date format `Retry-After` headers in addition to numeric seconds. The HTTP spec allows both formats, but the previous implementation only handled numeric values.

When a proxy/CDN returns `Retry-After: Fri, 31 Dec 1999 23:59:59 GMT`, the code now parses it via `new Date()` and computes the delay from `Date.now()`, preventing premature retry exhaustion.

## Changes

- `/Users/sidd/vocify/vellum-wt-swarm-task-16/gateway/src/telegram/api.ts:17-40` — Added fallback parsing for HTTP-date format in `computeDelay()`

## Test plan

- Type-check passes: `bunx tsc --noEmit`
- Existing tests pass (no behavioral changes to happy path)
- Logic review: falls back gracefully if date parsing fails

## Related

Addresses codex P2 feedback on https://github.com/vellum-ai/vellum-assistant/pull/3164
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
