### PR TITLE
perf: memoize ChatTimestampTimeZone.resolve() to avoid repeated filesystem reads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -3,17 +3,49 @@ import VellumAssistantShared
 import UniformTypeIdentifiers
 
 private enum ChatTimestampTimeZone {
+    private static var cachedZone: TimeZone?
+    private static var cacheTimestamp: Date?
+    private static let cacheInterval: TimeInterval = 60
+    private static var observer: NSObjectProtocol?
+
     /// Prefer the host's configured timezone over process-level TZ overrides
     /// so chat dividers stay in the user's real local timezone.
+    /// Caches the result to avoid repeated filesystem reads in hot rendering paths.
     static func resolve() -> TimeZone {
+        // Check if we have a valid cached value
+        if let cached = cachedZone,
+           let timestamp = cacheTimestamp,
+           Date().timeIntervalSince(timestamp) < cacheInterval {
+            return cached
+        }
+
+        // Register for timezone change notifications if not already registered
+        if observer == nil {
+            observer = NotificationCenter.default.addObserver(
+                forName: NSNotification.Name.NSSystemTimeZoneDidChange,
+                object: nil,
+                queue: nil
+            ) { _ in
+                cachedZone = nil
+                cacheTimestamp = nil
+            }
+        }
+
+        // Resolve timezone from /etc/localtime
+        let resolved: TimeZone
         if let symlink = try? FileManager.default.destinationOfSymbolicLink(atPath: "/etc/localtime"),
            let markerRange = symlink.range(of: "/zoneinfo/") {
             let identifier = String(symlink[markerRange.upperBound...])
-            if let tz = TimeZone(identifier: identifier) {
-                return tz
-            }
+            resolved = TimeZone(identifier: identifier) ?? .autoupdatingCurrent
+        } else {
+            resolved = .autoupdatingCurrent
         }
-        return .autoupdatingCurrent
+
+        // Update cache
+        cachedZone = resolved
+        cacheTimestamp = Date()
+
+        return resolved
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds memoization to `ChatTimestampTimeZone.resolve()` with a 60-second TTL cache
- Registers for `NSSystemTimeZoneDidChange` notifications to invalidate cache on system timezone changes
- Eliminates redundant `/etc/localtime` symlink reads in hot SwiftUI rendering paths

## Context
Addresses Codex P2 feedback on #3119: "Memoize timezone resolution in hot rendering path"

The `ChatTimestampTimeZone.resolve()` helper performs a synchronous filesystem read of `/etc/localtime` on every call. This function is called from three SwiftUI rendering paths (`shouldShowTimestamp`, `formattedTimestamp`, and `formattedTime`) that reevaluate frequently for every visible message. In larger chats or during streaming updates, this adds avoidable disk I/O on the main thread.

## Changes
1. Added static cached state: `cachedZone`, `cacheTimestamp`, and `observer`
2. Check cache validity (60-second TTL) before re-resolving
3. Register observer for `NSSystemTimeZoneDidChange` (one-time, on first resolve)
4. Cache invalidation clears `cachedZone` and `cacheTimestamp` on notification

## Test plan
- Build succeeds
- Timezone rendering remains correct across multiple messages
- Cache automatically refreshes after 60 seconds or on system timezone change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
