### PR TITLE
fix: return accurate result for integration disconnect

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -502,8 +502,12 @@ export function handleIntegrationDisconnect(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  disconnectIntegration(msg.integrationId);
-  log.info({ integrationId: msg.integrationId }, 'Integration disconnected');
+  const success = disconnectIntegration(msg.integrationId);
+  if (!success) {
+    log.warn({ integrationId: msg.integrationId }, 'Integration not found for disconnect');
+  } else {
+    log.info({ integrationId: msg.integrationId }, 'Integration disconnected');
+  }
   // Send updated list so the client refreshes
   handleIntegrationList(socket, ctx);
 }

--- a/assistant/src/integrations/registry.ts
+++ b/assistant/src/integrations/registry.ts
@@ -58,10 +58,12 @@ export function listStatuses(): IntegrationStatus[] {
  * Remove all credentials for an integration from the vault.
  * Secure keys are deleted first in a separate pass so that a failure in
  * metadata deletion cannot leave secrets partially cleaned up.
+ *
+ * @returns true if the integration was found and disconnected, false if not found
  */
-export function disconnect(id: string): void {
+export function disconnect(id: string): boolean {
   const def = integrations.get(id);
-  if (!def) return;
+  if (!def) return false;
 
   for (const field of def.credentialFields) {
     deleteSecureKey(`integration:${id}:${field}`);
@@ -69,4 +71,6 @@ export function disconnect(id: string): void {
   for (const field of def.credentialFields) {
     deleteCredentialMetadata(`integration:${id}`, field);
   }
+
+  return true;
 }


### PR DESCRIPTION
## Summary
- Make `disconnect()` return a boolean indicating success
- Update handler to log appropriately based on disconnect result
- Addresses Codex P2 feedback on PR 3136

## Details
Previously, the disconnect handler would unconditionally log success even when the integration ID was unknown, since `disconnect()` silently returned for unknown IDs. While the handler sends back the integration list which reflects the actual state, proper logging helps with debugging and makes the behavior more explicit.

## Test plan
- Type-check passes
- Integration disconnect with valid ID logs success
- Integration disconnect with invalid ID logs warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
