### PR TITLE
fix: update composerReservedHeight to match ComposerView padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -119,7 +119,7 @@ struct ChatView: View {
         let expanded = isComposerExpanded
         let topPad: CGFloat = expanded ? VSpacing.lg : VSpacing.sm
         let buttonRow: CGFloat = expanded ? 28 + VSpacing.xs : 0
-        let base: CGFloat = VSpacing.md + 18 + topPad + VSpacing.sm + contentHeight + buttonRow
+        let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + VSpacing.sm + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 44
         let error: CGFloat = sessionError != nil ? 60 : (errorText != nil ? 36 : 0)
         let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -964,7 +964,7 @@ private struct DynamicWorkspaceWrapper: View {
         let buttonRow: CGFloat = expanded ? 28 + VSpacing.xs : 0
         let hasAttachments = !viewModel.pendingAttachments.isEmpty
         let attachmentStrip: CGFloat = hasAttachments ? VSpacing.sm + 36 + VSpacing.xs : 0
-        return VSpacing.md + 18 + topPad + VSpacing.sm + contentHeight + buttonRow + attachmentStrip
+        return VSpacing.sm + VSpacing.md + topPad + VSpacing.sm + contentHeight + buttonRow + attachmentStrip
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
Addresses Devin feedback on PR #3179 by updating stale padding calculations in `composerReservedHeight` computed properties.

## Changes
- **ChatView.swift:122** — Changed `VSpacing.md + 18` (30pt) to `VSpacing.sm + VSpacing.md` (20pt)
- **MainWindowView.swift:967** — Changed `VSpacing.md + 18` (30pt) to `VSpacing.sm + VSpacing.md` (20pt)

## Context
PR #3179 updated ComposerView to use `VSpacing.sm + VSpacing.md` for padding, but these two files still calculated reserved height with the old `VSpacing.md + 18` formula, creating a 10pt visual gap.

## Test plan
- [x] Build succeeded
- [ ] Manual verification that chat composer bottom padding matches reserved scroll height

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
