### PR TITLE
fix: subscribe to active ChatViewModel for menu bar icon updates

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -998,7 +998,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func observeAssistantStatus() {
-        statusIconCancellable = mainWindow?.threadManager.objectWillChange
+        // Subscribe to active ChatViewModel's objectWillChange so menu bar icon
+        // updates when isThinking or errorText changes, even though SwiftUI
+        // views now use ActiveChatViewWrapper for their own observation.
+        statusIconCancellable = mainWindow?.threadManager.$activeThreadId
+            .compactMap { [weak mainWindow] _ in mainWindow?.threadManager.activeViewModel }
+            .flatMap { $0.objectWillChange }
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.updateMenuBarIcon()


### PR DESCRIPTION
## Summary

Fixes menu bar icon not updating when assistant thinking state changes (Codex P2 feedback on PR #3171).

**Root cause**: PR #3171 removed `ChatViewModel` objectWillChange forwarding from `ThreadManager` because SwiftUI views now use `ActiveChatViewWrapper` for observation. However, `AppDelegate.observeAssistantStatus()` still relied on that forwarding to update the menu bar icon.

**Fix**: AppDelegate now subscribes directly to the active `ChatViewModel`'s `objectWillChange` by watching `threadManager.$activeThreadId` and re-subscribing whenever the active thread changes. This ensures menu bar updates work for non-SwiftUI observation while avoiding redundant forwarding for SwiftUI views.

## Test plan

- [x] Build succeeds
- [ ] Manual test: Start a conversation, verify menu bar dot turns green when thinking and gray when idle
- [ ] Manual test: Switch threads, verify icon continues updating for the new active thread
- [ ] Manual test: Trigger an error, verify menu bar dot turns red

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
