### PR TITLE
fix: add error handler for rejected connections to prevent daemon crash

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -415,6 +415,9 @@ export class DaemonServer {
   private handleConnection(socket: net.Socket): void {
     if (this.connectedSockets.size >= DaemonServer.MAX_CONNECTIONS) {
       log.warn({ current: this.connectedSockets.size, max: DaemonServer.MAX_CONNECTIONS }, 'Connection limit reached, rejecting client');
+      socket.on('error', (err) => {
+        log.error({ err }, 'Socket error while rejecting connection');
+      });
       socket.write(serialize({ type: 'error', message: `Connection limit reached (max ${DaemonServer.MAX_CONNECTIONS})` }));
       socket.destroy();
       return;


### PR DESCRIPTION
## Summary
Adds an error handler to the socket before writing the rejection message when the connection limit is reached.

## What changed
- Added `socket.on('error', ...)` handler in the connection-limit rejection block in `assistant/src/daemon/server.ts` (line 418-420)

## Why
When the connection limit is reached, the socket is written to and destroyed without an error handler. If `socket.write()` triggers an error (e.g., `EPIPE` if the client disconnects), the unhandled error event will crash the daemon process. This fix ensures the error is logged instead of crashing.

## Related
Addresses feedback from devin-ai-integration[bot] on PR #3158
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
