### PR TITLE
fix: emit synthetic user message when carryover has no remaining content

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -581,6 +581,58 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
   // Workspace context injection + cache control
   // -----------------------------------------------------------------------
 
+  test('carryover with tool_result-only user turn emits synthetic user message', async () => {
+    // This tests the fix for consecutive assistant messages when:
+    // - assistant has both tool_use blocks and trailing non-tool blocks (carryover)
+    // - following user message contains ONLY tool_result blocks (no other content)
+    const messages: Message[] = [
+      userMsg('Read file'),
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'file_read', input: {} },
+          { type: 'text', text: 'Checking the file now.' }, // carryover content
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          // ONLY tool_result, no other content
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'file contents', is_error: false },
+        ],
+      },
+      assistantMsg('Next response'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string; tool_use_id?: string }>;
+    }>;
+
+    // Expected structure:
+    // 1. user(Read file)
+    // 2. assistant(tool_use)
+    // 3. user(tool_result)
+    // 4. assistant(Checking the file now.)
+    // 5. user((continue))  <-- synthetic user message to maintain alternation
+    // 6. assistant(Next response)
+    expect(sent).toHaveLength(6);
+    expect(sent[0].role).toBe('user');
+    expect(sent[1].role).toBe('assistant');
+    expect(sent[1].content[0].type).toBe('tool_use');
+    expect(sent[2].role).toBe('user');
+    expect(sent[2].content[0].type).toBe('tool_result');
+    expect(sent[3].role).toBe('assistant');
+    expect(sent[3].content[0].type).toBe('text');
+    expect(sent[3].content[0].text).toBe('Checking the file now.');
+    expect(sent[4].role).toBe('user');
+    expect(sent[4].content[0].type).toBe('text');
+    expect(sent[4].content[0].text).toBe('(continue)');
+    expect(sent[5].role).toBe('assistant');
+    expect(sent[5].content[0].text).toBe('Next response');
+  });
+
   test('multi-turn with workspace injection: cache on last two user turns only', async () => {
     const messages: Message[] = [
       // Turn 1: workspace + user text (should NOT get cache - it's the 3rd-to-last user turn)

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -250,12 +250,15 @@ function ensureToolPairing(
           role: 'assistant' as const,
           content: carryoverContent,
         });
-        if (normalized.remainingContent.length > 0) {
-          result.push({
-            role: 'user' as const,
-            content: normalized.remainingContent,
-          });
-        }
+        // Always emit a trailing user message to maintain alternation, even if the
+        // original user turn had only tool_result blocks. Use a synthetic placeholder
+        // when remainingContent is empty.
+        result.push({
+          role: 'user' as const,
+          content: normalized.remainingContent.length > 0
+            ? normalized.remainingContent
+            : [{ type: 'text' as const, text: '(continue)' }],
+        });
       } else {
         // No carryover assistant text to restore, so preserve existing behavior
         // and keep additional user blocks in the same message.


### PR DESCRIPTION
## Summary
Fixes a role alternation violation in the Anthropic client when an assistant message with both tool_use blocks and trailing carryover content is followed by a user message containing ONLY tool_result blocks.

## Problem
When `pairToolUseWithResults` reconstructed collapsed chronology:
- assistant(tool_use...) → user(tool_result...) → assistant(carryover)

And the original user turn had no content besides tool_result blocks, `normalized.remainingContent` was empty, so no trailing user message was emitted. This left consecutive assistant messages, violating Anthropic's strict role alternation rules.

## Solution
Always emit a trailing user message after carryover content, even when `remainingContent` is empty. In that case, use a synthetic placeholder `(continue)` to maintain proper alternation.

## Changes
- `/Users/sidd/vocify/vellum-wt-swarm-task-28/assistant/src/providers/anthropic/client.ts` (lines 242-262): Modified carryover reconstruction to always push a trailing user message
- `/Users/sidd/vocify/vellum-wt-swarm-task-28/assistant/src/__tests__/anthropic-provider.test.ts`: Added test case covering this edge case

## Test Plan
✅ Type-check passes
✅ All existing tests pass
✅ New test verifies the fix handles tool_result-only user turns correctly

Addresses feedback from Codex and Devin on PR #3132.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
