### PR TITLE
fix: require explanation for workspace edits to align with permission model

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -262,7 +262,7 @@ function buildWorkspaceReflectionSection(): string {
     '- Did they mention a project, tool, or workflow you should remember?',
     '- Did you adapt your style in a way that worked well and should persist?',
     '',
-    'If yes, update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response. Don\'t mention that you\'re doing it unless the update is significant enough to warrant a note.',
+    'If yes, briefly explain what you\'re updating, then update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response.',
   ].join('\n');
 }
 


### PR DESCRIPTION
Addresses feedback from PR #3074 on system-prompt.ts line 265.

## Changes
- Removed the conflicting "Don't mention that you're doing it" instruction from the Workspace Reflection section
- Model now always explains workspace file updates before calling host_file_edit
- Aligns with the approval-gated permission flow for host_file_edit

## Why
The original instruction conflicted with the permission model: host_file_edit is approval-gated and requires user context. The old wording encouraged silent edits, causing unexpected Allow/Don't Allow prompts with insufficient explanation. This fix ensures the model provides context before every workspace edit, matching the guidance in the Proactive Workspace Editing section (line 281).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
