### PR TITLE
fix: use host workspace path for host_file_edit instructions

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -56,11 +56,9 @@ export function buildSystemPrompt(): string {
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
   if (user) parts.push(user);
-  const config = getConfig();
-  const visibleDir = config.sandbox.enabled && config.sandbox.backend === 'docker'
-    ? '/workspace'
-    : getWorkspaceDir();
-  parts.push(buildConfigSection(visibleDir));
+  // Always use the host-visible workspace path for host file tools (host_file_edit, host_file_read)
+  // regardless of Docker sandboxing. Container-only paths like /workspace don't exist on the host.
+  parts.push(buildConfigSection(getWorkspaceDir()));
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
   parts.push(buildToolPermissionSection());


### PR DESCRIPTION
Fixes the issue where Docker-enabled sandboxing was advertising container-only paths for host file tools.

## Changes
- Modified `system-prompt.ts` to always use the host-visible workspace path (`getWorkspaceDir()`) for the config section, regardless of Docker sandboxing status
- Removed the conditional logic that switched to `/workspace` when Docker was enabled
- Added a comment explaining why host paths must be used for host file tools

## Why
The system prompt instructs the model to use `host_file_edit` and `host_file_read` for workspace updates (IDENTITY.md, SOUL.md, USER.md). These tools require absolute host paths, not container paths. When Docker sandboxing is enabled, the previous code advertised `/workspace/...` paths, which don't exist on the host and cause host file tool operations to fail.

## Testing
- Type-check passes
- Addresses inline review feedback from chatgpt-codex-connector on PR #3145
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
