### PR TITLE
feat: polish app widget preview and add progressive loading indicators

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -788,6 +788,11 @@ private struct ChatBubble: View {
     @ViewBuilder
     private var trailingStatus: some View {
         let hasCompletedTools = allToolCallsComplete && !hideToolCalls && !message.toolCalls.isEmpty
+        /// True when there is at least one tool call that hasn't finished yet.
+        let hasActuallyRunningTool = !hideToolCalls && message.toolCalls.contains(where: { !$0.isComplete })
+        /// All individual tool calls done but message still streaming (model generating next tool call).
+        let toolsCompleteButStillStreaming = !hideToolCalls && !message.toolCalls.isEmpty
+            && message.toolCalls.allSatisfy({ $0.isComplete }) && message.isStreaming
         let hasInProgressTools = !message.toolCalls.isEmpty && !hideToolCalls && !allToolCallsComplete
         let hasPermission = decidedConfirmation != nil
         let hasStreamingCode = message.streamingCodePreview != nil && !(message.streamingCodePreview?.isEmpty ?? true)
@@ -800,10 +805,19 @@ private struct ChatBubble: View {
                 CodePreviewView(code: message.streamingCodePreview!)
             }
             .frame(maxWidth: 520, alignment: .leading)
-        } else if hasInProgressTools && !permissionWasDenied {
-            // In progress — show single running indicator
-            let current = message.toolCalls.first(where: { !$0.isComplete }) ?? message.toolCalls.last
-            RunningIndicator(label: Self.friendlyRunningLabel(current?.toolName ?? ""))
+        } else if hasActuallyRunningTool && !permissionWasDenied {
+            // In progress — show single running indicator for the active tool
+            let current = message.toolCalls.first(where: { !$0.isComplete })!
+            let progressive = Self.progressiveLabels(for: current.toolName)
+            RunningIndicator(
+                label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary),
+                progressiveLabels: progressive,
+                labelInterval: progressive.isEmpty ? 6 : 15
+            )
+                .frame(maxWidth: 520, alignment: .leading)
+        } else if toolsCompleteButStillStreaming && !permissionWasDenied {
+            // All tools done but model is still working (generating next tool call)
+            RunningIndicator(label: "Working")
                 .frame(maxWidth: 520, alignment: .leading)
         } else if hasCompletedTools || hasPermission || showRegenerate || (hasInProgressTools && permissionWasDenied) {
             // All done (or denied) — show chips + regenerate on one line
@@ -842,7 +856,7 @@ private struct ChatBubble: View {
     }
 
     /// Maps raw tool names to user-friendly present-tense labels for the running state.
-    private static func friendlyRunningLabel(_ toolName: String) -> String {
+    private static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil) -> String {
         switch toolName.lowercased() {
         case "host bash", "bash":                           return "Running a terminal command"
         case "host file read", "file read":                 return "Reading a file"
@@ -855,8 +869,38 @@ private struct ChatBubble: View {
         case "browser screenshot":                          return "Taking a screenshot"
         case "app create":                                  return "Building your app"
         case "app update":                                  return "Updating your app"
-        case "skill load":                                  return "Loading a skill"
+        case "skill load":
+            if let name = inputSummary, !name.isEmpty {
+                let display = name.replacingOccurrences(of: "-", with: " ").replacingOccurrences(of: "_", with: " ")
+                return "Loading \(display)"
+            }
+            return "Loading a skill"
         default:                                            return "Running \(toolName)"
+        }
+    }
+
+    /// Progressive labels for long-running tools. Cycles through these over time.
+    private static func progressiveLabels(for toolName: String) -> [String] {
+        switch toolName.lowercased() {
+        case "app create":
+            return [
+                "Choosing a visual direction",
+                "Designing the layout",
+                "Writing the interface",
+                "Adding styles and colors",
+                "Wiring up interactions",
+                "Polishing the details",
+                "Almost there",
+            ]
+        case "app update":
+            return [
+                "Reviewing your app",
+                "Applying changes",
+                "Updating the interface",
+                "Polishing the details",
+            ]
+        default:
+            return []
         }
     }
 
@@ -1342,10 +1386,23 @@ private struct ChatBubble: View {
 // MARK: - Thinking Indicator
 
 /// Minimal in-progress indicator for tool execution, matching ThinkingIndicator style.
+/// Supports progressive labels that cycle on a timer for long-running tools.
 private struct RunningIndicator: View {
     var label: String = "Running"
+    /// Optional sequence of labels to cycle through over time.
+    var progressiveLabels: [String] = []
+    /// Seconds between each label transition.
+    var labelInterval: TimeInterval = 6
+
     @State private var phase: Int = 0
     @State private var timer: Timer?
+    @State private var currentLabelIndex: Int = 0
+    @State private var labelTimer: Timer?
+
+    private var displayLabel: String {
+        if progressiveLabels.isEmpty { return label }
+        return progressiveLabels[min(currentLabelIndex, progressiveLabels.count - 1)]
+    }
 
     var body: some View {
         HStack(spacing: VSpacing.xs) {
@@ -1353,9 +1410,10 @@ private struct RunningIndicator: View {
                 .font(.system(size: 10))
                 .foregroundColor(VColor.textSecondary)
 
-            Text(label)
+            Text(displayLabel)
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
+                .animation(.easeInOut(duration: 0.3), value: currentLabelIndex)
 
             ForEach(0..<3, id: \.self) { index in
                 Circle()
@@ -1366,18 +1424,33 @@ private struct RunningIndicator: View {
 
             Spacer()
         }
-        .onAppear { startAnimation() }
-        .onDisappear { timer?.invalidate() }
+        .onAppear {
+            startDotAnimation()
+            startLabelCycling()
+        }
+        .onDisappear {
+            timer?.invalidate()
+            labelTimer?.invalidate()
+        }
     }
 
     private func dotOpacity(for index: Int) -> Double {
         phase == index ? 1.0 : 0.4
     }
 
-    private func startAnimation() {
+    private func startDotAnimation() {
         timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
             withAnimation(.easeInOut(duration: 0.3)) {
                 phase = (phase + 1) % 3
+            }
+        }
+    }
+
+    private func startLabelCycling() {
+        guard !progressiveLabels.isEmpty else { return }
+        labelTimer = Timer.scheduledTimer(withTimeInterval: labelInterval, repeats: true) { _ in
+            if currentLabelIndex < progressiveLabels.count - 1 {
+                currentLabelIndex += 1
             }
         }
     }

--- a/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
@@ -1,9 +1,15 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 /// Standard card chrome for inline chat widgets.
 /// Applies consistent padding, background, border, corner radius, and shadow
 /// so all widget types (card, dynamic page, table, list) share the same visual treatment.
 public struct InlineWidgetCardModifier: ViewModifier {
+    let interactive: Bool
+    @State private var isHovered: Bool = false
+
     public func body(content: Content) -> some View {
         content
             .padding(VSpacing.lg)
@@ -14,14 +20,63 @@ public struct InlineWidgetCardModifier: ViewModifier {
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.lg)
                     .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
+                    .allowsHitTesting(false)
             )
-            .vShadow(VShadow.sm)
+            .overlay(
+                Group {
+                    if interactive && isHovered {
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(VColor.hoverOverlay.opacity(0.03))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+                                    .blur(radius: 3)
+                                    .padding(1)
+                                    .mask(RoundedRectangle(cornerRadius: VRadius.lg))
+                            )
+                    }
+                }
+                .allowsHitTesting(false)
+            )
+            .onHover { hovering in
+                guard interactive else { return }
+                isHovered = hovering
+            }
+            .overlay(
+                Group {
+                    if interactive {
+                        PointingHandCursorView()
+                    }
+                }
+                .allowsHitTesting(false)
+            )
+            .animation(VAnimation.fast, value: isHovered)
     }
 }
 
+#if os(macOS)
+/// An NSView that sets the cursor to pointingHand over its entire bounds
+/// using `addCursorRect`, which takes priority over SwiftUI Button cursor resets.
+private struct PointingHandCursorView: NSViewRepresentable {
+    func makeNSView(context: Context) -> PointingHandNSView {
+        PointingHandNSView()
+    }
+
+    func updateNSView(_ nsView: PointingHandNSView, context: Context) {
+        nsView.resetCursorRects()
+    }
+}
+
+private class PointingHandNSView: NSView {
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
+}
+#endif
+
 public extension View {
-    func inlineWidgetCard() -> some View {
-        modifier(InlineWidgetCardModifier())
+    func inlineWidgetCard(interactive: Bool = false) -> some View {
+        modifier(InlineWidgetCardModifier(interactive: interactive))
     }
 }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -854,25 +854,22 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Extract a code preview from accumulated tool input JSON.
-    /// For app_create/app_update: shows the raw JSON immediately, then switches
-    /// to showing just the HTML once the `html` field starts streaming.
+    /// Shows the HTML code as it streams during app_create/app_update.
     static func extractCodePreview(from accumulatedJson: String, toolName: String) -> String? {
         guard !accumulatedJson.isEmpty else { return nil }
         let isAppTool = toolName == "app_create" || toolName == "app_update"
         guard isAppTool else { return nil }
 
-        // Once the html field appears, show just the HTML content
+        // Show the HTML code as it streams in
         let markers = ["\"html\": \"", "\"html\":\""]
         for marker in markers {
             if let range = accumulatedJson.range(of: marker) {
                 var html = String(accumulatedJson[range.upperBound...])
-                // Strip trailing JSON delimiters
                 if html.hasSuffix("\"}") {
                     html = String(html.dropLast(2))
                 } else if html.hasSuffix("\"") {
                     html = String(html.dropLast(1))
                 }
-                // Unescape JSON string escapes
                 html = html
                     .replacingOccurrences(of: "\\n", with: "\n")
                     .replacingOccurrences(of: "\\t", with: "\t")
@@ -882,8 +879,7 @@ public final class ChatViewModel: ObservableObject {
             }
         }
 
-        // Before the html field appears, show the raw JSON being generated
-        return accumulatedJson
+        return nil
     }
 
     public func handleServerMessage(_ message: ServerMessage) {
@@ -1006,8 +1002,20 @@ public final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
-                messages[index].streamingCodePreview = nil
-                messages[index].streamingCodeToolName = nil
+                // Delay clearing the code preview so users can see the HTML being written
+                let hadCodePreview = messages[index].streamingCodePreview != nil
+                if hadCodePreview {
+                    let msgId = existingId
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+                        guard let self,
+                              let idx = self.messages.firstIndex(where: { $0.id == msgId }) else { return }
+                        self.messages[idx].streamingCodePreview = nil
+                        self.messages[idx].streamingCodeToolName = nil
+                    }
+                } else {
+                    messages[index].streamingCodePreview = nil
+                    messages[index].streamingCodeToolName = nil
+                }
                 // Check if this message has completed tool calls
                 let toolCalls = messages[index].toolCalls
                 if !toolCalls.isEmpty && toolCalls.allSatisfy({ $0.isComplete }) {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -6,8 +6,6 @@ public struct InlineDynamicPagePreview: View {
     public let preview: DynamicPagePreview
     public let onViewOutput: () -> Void
 
-    @State private var isHovered: Bool = false
-
     public init(preview: DynamicPagePreview, onViewOutput: @escaping () -> Void) {
         self.preview = preview
         self.onViewOutput = onViewOutput
@@ -17,29 +15,32 @@ public struct InlineDynamicPagePreview: View {
         Button {
             onViewOutput()
         } label: {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.xl) {
+                // Icon + title row
+                HStack(spacing: VSpacing.sm) {
                     if let icon = preview.icon {
                         Text(icon)
-                            .font(.system(size: 24))
+                            .font(.system(size: 28))
                     }
 
-                    Text(preview.title)
-                        .font(VFont.headline)
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(2)
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text(preview.title)
+                            .font(VFont.bodyBold)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(2)
 
-                    if let subtitle = preview.subtitle {
-                        Text(subtitle)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                            .lineLimit(1)
+                        if let subtitle = preview.subtitle {
+                            Text(subtitle)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                        }
                     }
                 }
 
                 if let description = preview.description, !description.isEmpty {
                     Text(description)
-                        .font(VFont.body)
+                        .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                         .lineLimit(3)
                 }
@@ -52,18 +53,10 @@ public struct InlineDynamicPagePreview: View {
                     }
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { hovering in
-            #if os(macOS)
-            if hovering { NSCursor.pointingHand.set() }
-            else { NSCursor.arrow.set() }
-            #endif
-            isHovered = hovering
-        }
-        .scaleEffect(isHovered ? 1.015 : 1.0)
-        .animation(.easeInOut(duration: 0.15), value: isHovered)
         .accessibilityLabel("View output: \(preview.title)")
         .accessibilityAddTraits(.isButton)
     }
@@ -76,7 +69,12 @@ public struct InlineDynamicPagePreview: View {
             Text(value)
                 .font(VFont.captionMedium)
                 .foregroundColor(VColor.textPrimary)
+                .lineLimit(1)
         }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.surfaceSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
     }
 }
 

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -33,8 +33,8 @@ public struct InlineSurfaceRouter: View {
             CompletedSurfaceChip(title: surface.title, summary: completion.summary)
         } else {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Template cards handle their own header — skip the generic title
-            if !isTemplateCard, let title = surface.title {
+            // Template cards and dynamic page previews handle their own header
+            if !isTemplateCard, !isDynamicPreview, let title = surface.title {
                 Text(title)
                     .font(VFont.cardTitle)
                     .foregroundColor(VColor.textPrimary)
@@ -47,7 +47,7 @@ public struct InlineSurfaceRouter: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .inlineWidgetCard()
+        .inlineWidgetCard(interactive: isDynamicPreview)
         .overlay(alignment: .topTrailing) {
             if isDynamicPreview {
                 Button {


### PR DESCRIPTION
## Summary
- Add progressive loading labels that cycle during long-running tools (e.g. "Choosing a visual direction" → "Designing the layout" → ... for app_create)
- Show actual skill name in loading indicator (e.g. "Loading app builder" instead of "Loading a skill")
- Fix loading indicator state machine to handle gaps between tool calls (shows "Working" instead of disappearing)
- Polish inline widget card with interactive hover effects and hand cursor
- Simplify streaming code preview to HTML-only extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
