### PR TITLE
feat: apply card theme to floating tool confirmation popup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -336,7 +336,7 @@ struct ChatView: View {
                                 // Show pending confirmations as inline buttons
                                 ToolConfirmationBubble(
                                     confirmation: confirmation,
-                                    showDescription: !prevHasText,
+                                    showDescription: true,
                                     onAllow: { onConfirmationAllow(confirmation.requestId) },
                                     onDeny: { onConfirmationDeny(confirmation.requestId) },
                                     onAddTrustRule: onAddTrustRule

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -65,7 +65,7 @@ final class ToolConfirmationManager {
         let panelHeight: CGFloat = message.diff != nil ? 340 : 160
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
-            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow],
             backing: .buffered,
             defer: false
         )
@@ -75,7 +75,8 @@ final class ToolConfirmationManager {
         panel.isMovableByWindowBackground = true
         panel.titleVisibility = .hidden
         panel.titlebarAppearsTransparent = true
-        panel.alphaValue = 0.95
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
 
@@ -311,7 +312,13 @@ struct ToolConfirmationView: View {
         }
         .padding(VSpacing.xl)
         .frame(width: 420)
-        .vPanelBackground()
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .stroke(VColor.surfaceBorder, lineWidth: 0.5)
+        )
+        .vShadow(VShadow.lg)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Replace HUD window style on floating tool confirmation popup with clean card styling (matching Ride Shotgun invitation)
- Clear background, rounded corners, border, and shadow instead of dark translucent HUD
- Always show humanDescription in in-chat confirmation bubbles so users always see what action is being requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
