### PR TITLE
fix: use direct background in ThinkingIndicatorView to preserve fittingSize

### DIFF
--- a/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
@@ -17,7 +17,7 @@ struct ThinkingIndicatorView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .vPanelBackground()
+        .background(VColor.backgroundSubtle)
     }
 }
 


### PR DESCRIPTION
Replaces `.vPanelBackground()` with `.background(VColor.backgroundSubtle)` in `ThinkingIndicatorView`. The `.vPanelBackground()` modifier applies `.frame(maxWidth: .infinity, maxHeight: .infinity)` which breaks `NSHostingView.fittingSize`-based window sizing used by `ThinkingIndicatorWindow` for panel dimensions and positioning.

The other views modified in PR #3177 (RideShotgun*, VoiceTranscription*) are unaffected because they have explicit `.frame(width: X)` constraints before `.vPanelBackground()`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
