### PR TITLE
fix: enlarge regenerate button hit area so tooltip appears on hover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -774,6 +774,8 @@ private struct ChatBubble: View {
             Image(systemName: "arrow.trianglehead.counterclockwise")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(VColor.textMuted)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Regenerate response")


### PR DESCRIPTION
## Summary
- Add 24x24 frame and contentShape to the regenerate button so the `.help()` tooltip reliably appears on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
