### PR TITLE
fix: show activity panel as overlay on top of chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -576,16 +576,28 @@ struct MainWindowView: View {
             fullWindowPanel(panel)
         } else {
             let config = windowState.layoutConfig
-            let rightVisible = config.right.visible || windowState.activePanel == .activity
-            let rightContent: SlotContent = windowState.activePanel == .activity
-                ? .native(.activity) : config.right.content
 
-            VSplitView(
-                panelWidth: $sidePanelWidth,
-                showPanel: rightVisible && rightContent != .empty,
-                main: { slotView(for: config.center.content) },
-                panel: { slotView(for: rightContent) }
-            )
+            ZStack {
+                VSplitView(
+                    panelWidth: $sidePanelWidth,
+                    showPanel: config.right.visible && config.right.content != .empty,
+                    main: { slotView(for: config.center.content) },
+                    panel: { slotView(for: config.right.content) }
+                )
+
+                if windowState.activePanel == .activity,
+                   let viewModel = threadManager.activeViewModel,
+                   let messageId = windowState.activityMessageId {
+                    ActivityPanel(
+                        viewModel: viewModel,
+                        messageId: messageId,
+                        onClose: { windowState.activePanel = nil }
+                    )
+                    .background(VColor.background)
+                    .transition(.move(edge: .trailing))
+                    .animation(VAnimation.panel, value: windowState.activePanel)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Changed the Activity panel from rendering as a side panel in `VSplitView` to overlaying the chat using a `ZStack`
- When clicking "View Tools", the Activity panel now covers the chat area instead of pushing it to the side
- Uses `VAnimation.panel` transition for smooth slide-in from the trailing edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
