### PR TITLE
feat: polish activity panel with collapsed steps and light mode colors

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -13,32 +13,17 @@ struct ActivityPanel: View {
     var body: some View {
         VSidePanel(title: "Activity", onClose: onClose) {
             ScrollViewReader { proxy in
-                ZStack(alignment: .leading) {
-                    // Vertical timeline line aligned with center of status circles
-                    Rectangle()
-                        .fill(VColor.surfaceBorder)
-                        .frame(width: 1)
-                        .padding(.leading, 11) // center of 24pt circle
-
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
-                            ActivityStepView(toolCall: toolCall)
-                                .id(toolCall.id)
-                                .padding(.vertical, VSpacing.sm)
-                                .transition(.asymmetric(
-                                    insertion: .move(edge: .top).combined(with: .opacity),
-                                    removal: .opacity
-                                ))
-
-                            if index < toolCalls.count - 1 {
-                                Divider()
-                                    .background(VColor.surfaceBorder)
-                                    .padding(.leading, 32)
-                            }
-                        }
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    ForEach(toolCalls, id: \.id) { toolCall in
+                        ActivityStepView(toolCall: toolCall)
+                            .id(toolCall.id)
+                            .transition(.asymmetric(
+                                insertion: .move(edge: .top).combined(with: .opacity),
+                                removal: .opacity
+                            ))
                     }
-                    .animation(VAnimation.standard, value: toolCalls.count)
                 }
+                .animation(VAnimation.standard, value: toolCalls.count)
                 .onChange(of: toolCalls.count) {
                     if let lastId = toolCalls.last?.id {
                         withAnimation(VAnimation.standard) {
@@ -53,139 +38,122 @@ struct ActivityPanel: View {
 
 struct ActivityStepView: View {
     let toolCall: ToolCallData
-    @State private var isResultExpanded = true
+    @State private var isExpanded = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Step header with icon
-            HStack(spacing: VSpacing.sm) {
-                // Status icon
-                ZStack {
-                    Circle()
-                        .fill(statusColor.opacity(0.15))
-                        .frame(width: 24, height: 24)
-
-                    if toolCall.isComplete {
-                        if toolCall.isError {
-                            Image(systemName: "xmark")
-                                .font(.system(size: 10, weight: .bold))
-                                .foregroundColor(VColor.error)
-                        } else {
-                            Image(systemName: toolIcon)
-                                .font(.system(size: 10, weight: .bold))
-                                .foregroundColor(VColor.accent)
-                        }
-                    } else {
-                        ProgressView()
-                            .scaleEffect(0.5)
-                            .tint(VColor.accent)
-                    }
+        VStack(alignment: .leading, spacing: 0) {
+            // Collapsed row — always visible, clickable to expand
+            Button(action: {
+                withAnimation(VAnimation.fast) {
+                    isExpanded.toggle()
                 }
+            }) {
+                HStack(spacing: VSpacing.sm) {
+                    // Status icon
+                    ZStack {
+                        Circle()
+                            .fill(statusColor.opacity(0.15))
+                            .frame(width: 24, height: 24)
 
-                // Step name
-                Text(toolCall.toolName)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
+                        if toolCall.isComplete {
+                            if toolCall.isError {
+                                Image(systemName: "xmark")
+                                    .font(.system(size: 10, weight: .bold))
+                                    .foregroundColor(VColor.error)
+                            } else {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 10, weight: .bold))
+                                    .foregroundColor(VColor.accent)
+                            }
+                        } else {
+                            ProgressView()
+                                .scaleEffect(0.5)
+                                .tint(VColor.accent)
+                        }
+                    }
 
-                Spacer()
+                    // Tool name + input summary
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text(toolCall.toolName)
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.textPrimary)
 
-                // Duration
-                if toolCall.isComplete, let started = toolCall.startedAt, let completed = toolCall.completedAt {
-                    let duration = completed.timeIntervalSince(started)
-                    Text(formatDuration(duration))
-                        .font(VFont.small)
-                        .foregroundColor(VColor.textMuted)
-                } else if !toolCall.isComplete, let started = toolCall.startedAt {
-                    TimelineView(.animation(minimumInterval: 0.5)) { context in
-                        let elapsed = context.date.timeIntervalSince(started)
-                        Text(formatDuration(elapsed))
+                        if !toolCall.inputSummary.isEmpty {
+                            Text(toolCall.inputSummary)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+
+                    Spacer()
+
+                    // Duration
+                    if toolCall.isComplete, let started = toolCall.startedAt, let completed = toolCall.completedAt {
+                        let duration = completed.timeIntervalSince(started)
+                        Text(formatDuration(duration))
                             .font(VFont.small)
                             .foregroundColor(VColor.textMuted)
-                    }
-                }
-            }
-
-            // Input summary
-            if !toolCall.inputSummary.isEmpty {
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: toolIcon)
-                        .font(.system(size: 11))
-                        .foregroundColor(VColor.textMuted)
-
-                    Text(toolCall.inputSummary)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                        .lineLimit(2)
-                }
-                .padding(.leading, 32) // Align with text after icon
-            }
-
-            // Screenshot
-            if let cachedImage = toolCall.cachedImage {
-                Image(nsImage: cachedImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: .infinity)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                    .padding(.leading, 32)
-            }
-
-            // Result
-            if let result = toolCall.result, !result.isEmpty {
-                let accentColor = toolCall.isError ? VColor.error : VColor.accent
-
-                VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                    Text(result)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(toolCall.isError ? VColor.error : VColor.textSecondary)
-                        .lineLimit(isResultExpanded ? nil : 3)
-                        .textSelection(.enabled)
-
-                    // Show more/less button if text is long
-                    if result.count > 80 || result.components(separatedBy: "\n").count > 3 {
-                        Button(action: {
-                            withAnimation(VAnimation.fast) {
-                                isResultExpanded.toggle()
-                            }
-                        }) {
-                            HStack(spacing: VSpacing.xxs) {
-                                Text(isResultExpanded ? "Show less" : "Show more")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.accent)
-                                Image(systemName: isResultExpanded ? "chevron.up" : "chevron.down")
-                                    .font(.system(size: 9, weight: .semibold))
-                                    .foregroundColor(VColor.accent)
-                            }
+                    } else if !toolCall.isComplete, let started = toolCall.startedAt {
+                        TimelineView(.animation(minimumInterval: 0.5)) { context in
+                            let elapsed = context.date.timeIntervalSince(started)
+                            Text(formatDuration(elapsed))
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
                         }
-                        .buttonStyle(.plain)
-                        .padding(.top, VSpacing.xxs)
+                    }
+
+                    // Chevron
+                    if hasExpandableContent {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(VColor.textMuted)
+                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(VSpacing.sm)
-                .background(Slate._900)
-                .overlay(alignment: .leading) {
-                    Rectangle()
-                        .fill(accentColor)
-                        .frame(width: 2)
+                .padding(.vertical, VSpacing.sm)
+                .padding(.horizontal, VSpacing.md)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            // Expanded details
+            if isExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    // Screenshot
+                    if let cachedImage = toolCall.cachedImage {
+                        Image(nsImage: cachedImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+
+                    // Result
+                    if let result = toolCall.result, !result.isEmpty {
+                        Text(result)
+                            .font(VFont.monoSmall)
+                            .foregroundColor(toolCall.isError ? VColor.error : VColor.textSecondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(VSpacing.sm)
+                            .background(VColor.backgroundSubtle.opacity(0.5))
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
                 }
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
-                .padding(.leading, 32)
-                .transition(.opacity)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.leading, 24 + VSpacing.sm) // align with text after icon
+                .padding(.bottom, VSpacing.sm)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
+        .animation(VAnimation.fast, value: isExpanded)
         .animation(VAnimation.fast, value: toolCall.isComplete)
     }
 
-    private var toolIcon: String {
-        let name = toolCall.toolName.lowercased()
-        if name.contains("search") { return "magnifyingglass" }
-        if name.contains("navigate") || name.contains("fetch") { return "globe" }
-        if name.contains("screenshot") { return "camera.viewfinder" }
-        if name.contains("click") { return "cursorarrow.click.2" }
-        if name.contains("read") || name.contains("edit") || name.contains("write") { return "doc.text" }
-        if name.contains("command") || name.contains("bash") || name.contains("shell") { return "terminal" }
-        return "terminal"
+    private var hasExpandableContent: Bool {
+        (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true)) || toolCall.cachedImage != nil
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {
@@ -200,8 +168,6 @@ struct ActivityStepView: View {
     private var statusColor: Color {
         if toolCall.isError {
             return VColor.error
-        } else if toolCall.isComplete {
-            return VColor.accent
         } else {
             return VColor.accent
         }
@@ -217,7 +183,6 @@ struct ActivityPanel_Previews: PreviewProvider {
         let viewModel = ChatViewModel(daemonClient: dc)
         let messageId = UUID()
 
-        // Add a message with tool calls to the view model
         viewModel.messages = [
             ChatMessage(
                 id: messageId,
@@ -233,7 +198,7 @@ struct ActivityPanel_Previews: PreviewProvider {
                     ToolCallData(
                         toolName: "Browser Navigate",
                         inputSummary: "https://www.google.com/travel/flights",
-                        result: "Navigated successfully",
+                        result: "Requested URL: https://www.google.com/travel/flights\nFinal URL: https://www.google.com/travel/flights\nStatus: 200\nTitle: Google Flights",
                         isComplete: true
                     ),
                     ToolCallData(


### PR DESCRIPTION
## Summary
- Tool calls are now collapsed by default, showing only title + input summary; click to expand details
- Removed divider lines between items, using spacing instead for a cleaner look
- Expanded code block uses `VColor.backgroundSubtle` for proper light mode adaptation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
