### PR TITLE
fix: use file_edit instead of host_file_edit in config section prompt

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -276,7 +276,7 @@ function buildConfigSection(configDir: string): string {
     '',
     '### Proactive Workspace Editing',
     '',
-    'You should actively update your workspace files as you learn. You don\'t need to ask the user whether it\'s okay — just briefly explain what you\'re updating, then use `host_file_edit` to make targeted edits.',
+    'You should actively update your workspace files as you learn. You don\'t need to ask the user whether it\'s okay — just briefly explain what you\'re updating, then use `file_edit` to make targeted edits.',
     '',
     '**USER.md** — update when you learn:',
     '- Their name, pronouns, timezone, or what they prefer to be called',


### PR DESCRIPTION
## Summary
- Updated `buildConfigSection` to reference `file_edit` instead of `host_file_edit` for workspace file edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
