### PR TITLE
fix: move clearTimeout into finally block to prevent timer leak

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -445,16 +445,19 @@ async function executeWithTimeout(
   const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
     timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
   });
-  const result = await Promise.race([promise, timeoutPromise]);
-  clearTimeout(timeoutHandle!);
-  if (result === TIMEOUT_SENTINEL) {
-    const sec = Math.round(timeoutMs / 1000);
-    return {
-      content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,
-      isError: true,
-    };
+  try {
+    const result = await Promise.race([promise, timeoutPromise]);
+    if (result === TIMEOUT_SENTINEL) {
+      const sec = Math.round(timeoutMs / 1000);
+      return {
+        content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,
+        isError: true,
+      };
+    }
+    return result;
+  } finally {
+    clearTimeout(timeoutHandle!);
   }
-  return result;
 }
 
 function resolveExecutionTarget(toolName: string): ExecutionTarget {


### PR DESCRIPTION
Fixes timer leak in tool executor when promises reject. The clearTimeout was previously only reached on successful promise completion, causing a timer leak when the tool promise rejects. Now wrapped in try/finally to ensure cleanup always runs.

Addresses feedback from PR #3190.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
