### PR TITLE
fix: version skill hash format to prevent false tampering warnings

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -61,7 +61,10 @@ function collectFileContents(dir: string, prefix = ''): Array<{ relPath: string;
   return results.sort((a, b) => a.relPath.localeCompare(b.relPath));
 }
 
-/** Compute a SHA-256 hash over all files in a skill directory. */
+/**
+ * Compute a SHA-256 hash over all files in a skill directory.
+ * Returns format: "v2:sha256hex" (version prefix added to support hash format evolution).
+ */
 function computeSkillHash(skillDir: string): string | null {
   if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
 
@@ -77,13 +80,16 @@ function computeSkillHash(skillDir: string): string | null {
     hasher.update(`${file.content.length}:`);
     hasher.update(file.content);
   }
-  return hasher.digest('hex');
+  return `v2:${hasher.digest('hex')}`;
 }
 
 /**
  * Record or verify the content hash of an installed skill.
  * On first install: stores the hash (trust-on-first-use).
  * On subsequent installs: compares with stored hash and warns on mismatch.
+ *
+ * Hash format migration: v1 (legacy, no prefix) → v2 (prefixed "v2:sha256hex").
+ * When stored hash is v1, silently re-record with v2 instead of warning.
  */
 function verifyAndRecordSkillHash(slug: string): void {
   const skillDir = join(getManagedSkillsDir(), slug);
@@ -97,9 +103,18 @@ function verifyAndRecordSkillHash(slug: string): void {
   const existing = manifest[slug];
 
   if (existing) {
-    if (existing.sha256 !== hash) {
+    const storedHash = existing.sha256;
+    // Detect v1 hash (no "v2:" prefix) and treat as format migration
+    const isV1Hash = !storedHash.startsWith('v2:');
+
+    if (isV1Hash) {
+      log.info(
+        { slug },
+        'Migrating skill integrity hash from v1 to v2 format (silent re-record)',
+      );
+    } else if (storedHash !== hash) {
       log.warn(
-        { slug, expected: existing.sha256, actual: hash },
+        { slug, expected: storedHash, actual: hash },
         'Skill content hash changed — content differs from previous install. ' +
           'This is expected for updates but could indicate CDN tampering.',
       );


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback from PR #3192.

The `computeSkillHash()` format was changed to use length-prefixed segments, but without versioning stored hashes from the old format would all mismatch and produce false tampering warnings.

## Changes
- Prefix hash format with `v2:` to support hash format evolution
- When verifying, detect v1 hashes (no prefix) and silently re-record with v2 format (no warning)
- Add documentation explaining the hash format migration behavior

This ensures existing installations migrate gracefully without false positive tampering alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
