### PR TITLE
fix(test): update system-prompt test to match workspace dir behavior

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -160,9 +160,9 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('swarm_delegate');
   });
 
-  test('config section uses /workspace when Docker sandbox is enabled', () => {
+  test('config section uses workspace directory from platform util', () => {
     const result = buildSystemPrompt();
-    expect(result).toContain('Your configuration directory is `/workspace/`');
+    expect(result).toContain(`Your configuration directory is \`${TEST_DIR}/\``);
   });
 
   test('omits user skills from catalog when none are configured', () => {


### PR DESCRIPTION
Updates the system-prompt test assertion to check for the mocked workspace directory path instead of the hardcoded /workspace/ path. This matches the production code behavior which now uses getWorkspaceDir().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
