### PR TITLE
fix: limit placeholder injection to assistant turns with dropped unknown blocks

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -577,6 +577,33 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
     expect(sent[1].content[1].text).toBe('More valid text');
   });
 
+  test('assistant message with only whitespace text does not get placeholder', async () => {
+    const messages: Message[] = [
+      userMsg('Start'),
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: '   ' },
+          { type: 'text', text: '\n\t' },
+        ],
+      },
+      userMsg('Continue'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    }>;
+
+    // Whitespace-only assistant messages should be dropped entirely, not replaced with placeholder
+    expect(sent).toHaveLength(2);
+    expect(sent[0].role).toBe('user');
+    expect(sent[0].content[0].text).toBe('Start');
+    expect(sent[1].role).toBe('user');
+    expect(sent[1].content[0].text).toBe('Continue');
+  });
+
   // -----------------------------------------------------------------------
   // Workspace context injection + cache control
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -337,15 +337,24 @@ export class AnthropicProvider implements Provider {
     let sentMessages: Anthropic.MessageParam[] | undefined;
     try {
       const formatted = messages.map((m) => {
+        // Track whether an unknown block was dropped during filtering
+        let droppedUnknownBlock = false;
+
         const content = m.content
-          .map((block) => this.toAnthropicBlockSafe(block))
+          .map((block) => {
+            const result = this.toAnthropicBlockSafe(block);
+            if (result === null) {
+              droppedUnknownBlock = true;
+            }
+            return result;
+          })
           .filter((block): block is Anthropic.ContentBlockParam => block !== null)
           .filter((block) => !(block.type === 'text' && !(block as { text?: string }).text?.trim()));
 
         // Preserve assistant turns that would otherwise become empty after filtering
         // unknown block types (e.g. ui_surface). Dropping these messages can violate
         // Anthropic's role alternation requirement.
-        if (content.length === 0 && m.role === 'assistant') {
+        if (content.length === 0 && m.role === 'assistant' && droppedUnknownBlock) {
           return {
             role: m.role,
             content: [{ type: 'text' as const, text: '[internal blocks omitted]' }],


### PR DESCRIPTION
Addresses Codex P2 feedback on https://github.com/vellum-ai/vellum-assistant/pull/3189

## What changed

Previously, the `[internal blocks omitted]` placeholder was injected for ANY empty assistant message after filtering, including messages that only contained whitespace text blocks. This created synthetic content unnecessarily.

Now tracks whether an unknown block (e.g., `ui_surface`) was specifically dropped during filtering via `toAnthropicBlockSafe` returning `null`, and only injects the placeholder when that flag is true.

## Files modified

- `/Users/sidd/vocify/vellum-wt-swarm-task-1/assistant/src/providers/anthropic/client.ts` — Added `droppedUnknownBlock` flag to gate placeholder injection
- `/Users/sidd/vocify/vellum-wt-swarm-task-1/assistant/src/__tests__/anthropic-provider.test.ts` — Added test to verify whitespace-only assistant messages are dropped without placeholder
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
