### PR TITLE
Fix data race in ChatTimestampTimeZone notification observer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -24,7 +24,7 @@ private enum ChatTimestampTimeZone {
             observer = NotificationCenter.default.addObserver(
                 forName: NSNotification.Name.NSSystemTimeZoneDidChange,
                 object: nil,
-                queue: nil
+                queue: .main
             ) { _ in
                 cachedZone = nil
                 cacheTimestamp = nil


### PR DESCRIPTION
Fixes the data race on static mutable state in `ChatTimestampTimeZone.resolve()`.

## What Changed
- Changed `queue: nil` to `queue: .main` in the `NotificationCenter.default.addObserver` call
- This ensures the cache invalidation closure always runs on the main thread, matching where `resolve()` is called from SwiftUI view body evaluations

## Why
The notification observer was using `queue: nil`, which allows the closure to run on any thread. Since the closure mutates static mutable state (`cachedZone` and `cacheTimestamp`), this could cause a data race when `resolve()` is called from SwiftUI (main thread) while the notification fires on a background thread.

## Test Plan
- Built successfully with no errors
- The change ensures thread safety while maintaining the same functional behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
