### PR TITLE
fix: prevent crash in DaemonClient deinit with Thread.isMainThread check

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -258,14 +258,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // NWConnection.cancel() are safe from any thread.
         //
         // We must finish subscriber continuations to prevent hanging `for await` loops.
-        // To safely access the @MainActor-isolated `subscribers` dictionary from deinit,
-        // we use MainActor.assumeIsolated, which is safe here because:
-        // 1. deinit only runs when the last reference is released
-        // 2. No other code can be concurrently accessing this instance's isolated state
-        // 3. The class is marked @MainActor, so all references must be released from MainActor
-        MainActor.assumeIsolated {
-            for continuation in subscribers.values {
-                continuation.finish()
+        // deinit is nonisolated in Swift 5.9+, so we check if we're on the main thread.
+        // If we are, we can safely access the @MainActor-isolated subscribers.
+        // If not, we skip cleanup here since disconnect() should have already handled it.
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                for continuation in subscribers.values {
+                    continuation.finish()
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Replace bare `MainActor.assumeIsolated` in `DaemonClient.deinit` with a `Thread.isMainThread` guard to prevent crashes when deinit runs off the main thread.

## Changes
- Add `Thread.isMainThread` check before `MainActor.assumeIsolated` in deinit
- Skip subscriber cleanup if not on main thread (disconnect() should have already handled it)

## Context
`deinit` is nonisolated in Swift 5.9+, so `MainActor.assumeIsolated` will trap/crash if deinit runs off the main thread. This addresses feedback from Codex P1 and Devin on PR #3203.

## Files Modified
- `clients/shared/IPC/DaemonClient.swift` (lines 260-276)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
