### PR TITLE
fix: update menu bar icon immediately on thread switch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1003,7 +1003,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // views now use ActiveChatViewWrapper for their own observation.
         statusIconCancellable = mainWindow?.threadManager.$activeThreadId
             .compactMap { [weak mainWindow] _ in mainWindow?.threadManager.activeViewModel }
-            .flatMap { $0.objectWillChange }
+            .handleEvents(receiveOutput: { [weak self] _ in
+                // Update immediately when switching threads
+                self?.updateMenuBarIcon()
+            })
+            .map { $0.objectWillChange }
+            .switchToLatest()
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.updateMenuBarIcon()


### PR DESCRIPTION
Addresses feedback from PR #3204 (Codex P2 and Devin reviews).

## Changes

1. **Immediate menu bar icon update on thread switch** - Added `handleEvents(receiveOutput:)` before `switchToLatest()` to immediately call `updateMenuBarIcon()` when `activeThreadId` changes
2. **Fixed subscription accumulation** - Replaced `.flatMap { $0.objectWillChange }` with `.map { $0.objectWillChange }.switchToLatest()` to properly cancel old subscriptions when switching threads

## Technical details

The previous implementation using `flatMap` would accumulate inner subscriptions, meaning each thread switch would create a new subscription to the new ChatViewModel's `objectWillChange` without canceling the previous one. This could lead to stale updates and memory leaks.

The new implementation using `map + switchToLatest` properly cancels the previous inner subscription when switching threads, ensuring only one active subscription at a time.

The `handleEvents` operator ensures the menu bar icon updates immediately upon thread switch, before even setting up the new subscription.

## Files modified
- `clients/macos/vellum-assistant/App/AppDelegate.swift:1000-1011`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
