### PR TITLE
fix: compute lexical score for direct item search results

### DIFF
--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -163,21 +163,31 @@ export function directItemSearch(query: string, limit: number, scopeIds?: string
     return [];
   }
 
-  return rows.map((row) => ({
-    key: `item:${row.id}`,
-    type: 'item' as CandidateType,
-    id: row.id,
-    source: 'item_direct',
-    text: `${row.subject}: ${row.statement}`,
-    kind: row.kind,
-    confidence: row.confidence,
-    importance: row.importance ?? 0.5,
-    createdAt: row.last_seen_at,
-    lexical: 0,
-    semantic: 0,
-    recency: computeRecencyScore(row.last_seen_at),
-    finalScore: 0,
-  }));
+  return rows.map((row) => {
+    // Compute lexical score based on token match coverage: fraction of query
+    // tokens that appear in subject or statement. Direct items are keyword
+    // matches so this score reflects query-match relevance (unlike confidence,
+    // which reflects extraction certainty).
+    const textLower = `${row.subject} ${row.statement}`.toLowerCase();
+    const matchedTokens = tokens.filter((t) => textLower.includes(t)).length;
+    const lexical = tokens.length > 0 ? matchedTokens / tokens.length : 0;
+
+    return {
+      key: `item:${row.id}`,
+      type: 'item' as CandidateType,
+      id: row.id,
+      source: 'item_direct',
+      text: `${row.subject}: ${row.statement}`,
+      kind: row.kind,
+      confidence: row.confidence,
+      importance: row.importance ?? 0.5,
+      createdAt: row.last_seen_at,
+      lexical,
+      semantic: 0,
+      recency: computeRecencyScore(row.last_seen_at),
+      finalScore: 0,
+    };
+  });
 }
 
 export function lexicalRankToScore(rank: number, minRank: number, maxRank: number): number {


### PR DESCRIPTION
Direct item results were assigned `lexical: 0`, preventing them from counting toward the early termination high-relevance threshold even when they were highly relevant matches. Now compute lexical score as the fraction of query tokens found in the item's subject/statement, providing a meaningful query-match relevance signal.

Fixes Codex P2 feedback on #3201.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
