### PR TITLE
fix: clamp Retry-After delays to prevent setTimeout overflow

### DIFF
--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -31,7 +31,8 @@ function computeDelay(
     if (Number.isFinite(targetTime)) {
       const delayMs = targetTime - Date.now();
       if (delayMs > 0) {
-        return delayMs;
+        // Clamp to max 32-bit signed int to prevent setTimeout overflow
+        return Math.min(delayMs, 2_147_483_647);
       }
     }
   }


### PR DESCRIPTION
Addresses Codex feedback on PR #3198.

When Retry-After is an HTTP-date far in the future, delayMs can exceed the 32-bit signed integer timer limit (2,147,483,647 ms), causing Bun's setTimeout to overflow and execute immediately instead of waiting.

This change clamps delayMs to the maximum 32-bit signed integer value to prevent overflow behavior while still respecting reasonable retry-after values.

**Changed:**
- `gateway/src/telegram/api.ts`: Added `Math.min(delayMs, 2_147_483_647)` clamp on line 35
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
