### PR TITLE
fix: correct attachment strip height in chat inset

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -152,7 +152,7 @@ struct ChatView: View {
         let topPad: CGFloat = expanded ? VSpacing.lg : VSpacing.sm
         let buttonRow: CGFloat = expanded ? 28 + VSpacing.xs : 0
         let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + VSpacing.sm + contentHeight + buttonRow
-        let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 44
+        let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = sessionError != nil ? 60 : (errorText != nil ? 36 : 0)
         let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0
         return base + attachments + error + queue


### PR DESCRIPTION
## Summary

Fixes the `composerReservedHeight` calculation in `ChatView.swift` where the attachment strip height constant was 44pt but the actual rendered height is 48pt.

The attachment strip in `ComposerView` renders as:
- `.padding(.top, VSpacing.sm)` = 8pt
- 36pt chip row (28pt icon + 8pt vertical padding)
- `.padding(.bottom, VSpacing.xs)` = 4pt
- **Total: 48pt**

This mismatch caused the last message to be partially clipped behind the composer when file attachments were pending.

Addresses feedback from PR #3202.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
