### PR TITLE
fix: always finish subscriber continuations in DaemonClient deinit

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -260,11 +260,19 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // We must finish subscriber continuations to prevent hanging `for await` loops.
         // deinit is nonisolated in Swift 5.9+, so we check if we're on the main thread.
         // If we are, we can safely access the @MainActor-isolated subscribers.
-        // If not, we skip cleanup here since disconnect() should have already handled it.
+        // If not, dispatch synchronously to the main thread to access them safely.
         if Thread.isMainThread {
             MainActor.assumeIsolated {
                 for continuation in subscribers.values {
                     continuation.finish()
+                }
+            }
+        } else {
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated {
+                    for continuation in self.subscribers.values {
+                        continuation.finish()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #3224 from both Codex and Devin.

When `DaemonClient.deinit` runs off the main thread, subscriber continuations were silently leaked because the `Thread.isMainThread` guard skipped cleanup entirely. Since `disconnect()` is not guaranteed to be called before deallocation, any `for await` loops consuming those streams would hang indefinitely.

## Changes

- Added an `else` branch to the `deinit` method that uses `DispatchQueue.main.sync` to safely access the `@MainActor`-isolated `subscribers` dictionary when deinit runs off the main thread
- Continuations are now always finished regardless of which thread deinit executes on

## Test plan

- [x] Verified the fix matches the approach recommended by both Codex and Devin reviewers
- [ ] Build verification via CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
