### PR TITLE
fix: validate stored hash format before v1 migration in integrity check

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -104,13 +104,24 @@ function verifyAndRecordSkillHash(slug: string): void {
 
   if (existing) {
     const storedHash = existing.sha256;
-    // Detect v1 hash (no "v2:" prefix) and treat as format migration
-    const isV1Hash = !storedHash.startsWith('v2:');
 
-    if (isV1Hash) {
+    // Guard against corrupted manifest entries where sha256 is not a string
+    if (typeof storedHash !== 'string') {
+      log.warn(
+        { slug },
+        'Integrity manifest entry has non-string sha256 — re-recording hash',
+      );
+    } else if (/^[0-9a-f]{64}$/.test(storedHash)) {
+      // Legacy v1 hash: plain hex SHA-256, no version prefix — silently migrate
       log.info(
         { slug },
         'Migrating skill integrity hash from v1 to v2 format (silent re-record)',
+      );
+    } else if (!storedHash.startsWith('v2:')) {
+      // Unknown format (not v1 hex, not v2: prefix) — warn about integrity mismatch
+      log.warn(
+        { slug, stored: storedHash, actual: hash },
+        'Stored hash has unrecognized format — possible integrity mismatch. Re-recording.',
       );
     } else if (storedHash !== hash) {
       log.warn(


### PR DESCRIPTION
## Summary
Addresses Codex review feedback from PR #3218:

- **P1**: Only migrate hashes that match the legacy v1 format (64-char lowercase hex SHA-256). Previously, any non-`v2:` hash was treated as v1 and silently re-recorded. Now unknown formats (e.g. `v3:...` or malformed values) trigger a warning about a possible integrity mismatch before re-recording.
- **P2**: Guard `storedHash` with a `typeof` string check before calling `.startsWith()`. Since `loadIntegrityManifest()` casts parsed JSON without runtime validation, a corrupted or hand-edited manifest could have a non-string `sha256` value, which would throw at runtime.

## Test plan
- [ ] Verify v2-prefixed hashes continue to match correctly (no false warnings)
- [ ] Verify legacy v1 hex hashes (64-char lowercase hex) are silently migrated to v2
- [ ] Verify unknown format hashes (e.g. `v3:abc`, `garbage`) produce a warning log
- [ ] Verify non-string sha256 values (e.g. `null`, `123`) produce a warning log instead of throwing

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
