### PR TITLE
fix: remove premature deduplicateBySubject to restore fallback and trust-rank correctness

### DIFF
--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -72,13 +72,9 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
     .filter((row) => TRUST_RANK[row.verificationState] !== undefined)
     .sort((a, b) => compareProfileCandidates(a, b, nowMs));
 
-  // Deduplicate by subject after ranking, keeping highest-scoring entry per subject
-  // with recency as tiebreaker for identical scores
-  const deduped = deduplicateBySubject(trusted, nowMs);
-
   const selectedLines: string[] = [];
   const seenKeys = new Set<string>();
-  for (const candidate of deduped) {
+  for (const candidate of trusted) {
     const subject = normalizeWhitespace(candidate.subject, 80);
     const statement = normalizeWhitespace(candidate.statement, 220);
     if (!subject || !statement) continue;
@@ -130,35 +126,6 @@ function compareProfileCandidates(left: ProfileCandidate, right: ProfileCandidat
   if (confidenceDelta !== 0) return confidenceDelta;
 
   return right.firstSeenAt - left.firstSeenAt;
-}
-
-function deduplicateBySubject(candidates: ProfileCandidate[], nowMs: number): ProfileCandidate[] {
-  const subjectMap = new Map<string, ProfileCandidate>();
-
-  for (const candidate of candidates) {
-    const normalizedSubject = normalizeWhitespace(candidate.subject, 80).toLowerCase();
-    if (!normalizedSubject) continue;
-
-    const dedupeKey = `${candidate.kind}|${normalizedSubject}`;
-    const existing = subjectMap.get(dedupeKey);
-
-    if (!existing) {
-      subjectMap.set(dedupeKey, candidate);
-      continue;
-    }
-
-    // Keep highest-scoring entry; use recency as tiebreaker for identical scores
-    const existingScore = candidateRankScore(existing, nowMs);
-    const candidateScore = candidateRankScore(candidate, nowMs);
-
-    if (candidateScore > existingScore) {
-      subjectMap.set(dedupeKey, candidate);
-    } else if (candidateScore === existingScore && candidate.lastSeenAt > existing.lastSeenAt) {
-      subjectMap.set(dedupeKey, candidate);
-    }
-  }
-
-  return Array.from(subjectMap.values());
 }
 
 function normalizeWhitespace(input: string, maxLength: number): string {


### PR DESCRIPTION
## Summary

Fixes two bugs in `deduplicateBySubject` introduced in PR #3219:

1. **Lost fallback**: Running dedup before the token-budget loop removed lower-ranked candidates, so if the top candidate exceeded the budget, the entire subject was dropped instead of falling back to a shorter alternative.
2. **Trust rank ignored**: The dedup compared candidates using `candidateRankScore` (importance + recency) but ignored trust rank, allowing `assistant_inferred` entries to overwrite `user_confirmed` entries.

**Fix**: Remove `deduplicateBySubject` entirely. The token-budget loop already deduplicates via `seenKeys` — it only marks a `kind|subject` key as seen when a candidate actually fits, so lower-ranked candidates naturally serve as fallbacks. Since candidates are pre-sorted by `compareProfileCandidates` (trust rank first), trust ordering is always respected.

## Test plan

- [x] Existing fallback test (lines 221-247) passes — confirms shorter same-subject candidates are used when the top candidate exceeds budget
- [x] Existing trust-preference test passes — confirms `user_confirmed` beats `assistant_inferred` for same subject
- [x] All 4 profile-compiler tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
