### PR TITLE
fix: clamp numeric Retry-After seconds to prevent setTimeout overflow

### DIFF
--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -23,7 +23,8 @@ function computeDelay(
     // Try parsing as numeric seconds first (e.g., "120")
     const seconds = Number(retryAfterHeader);
     if (Number.isFinite(seconds) && seconds > 0) {
-      return seconds * 1000;
+      // Clamp to max 32-bit signed int to prevent setTimeout overflow
+      return Math.min(seconds * 1000, 2_147_483_647);
     }
 
     // Fall back to HTTP-date format (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")


### PR DESCRIPTION
## Summary

- Adds `Math.min(seconds * 1000, 2_147_483_647)` clamp to the numeric seconds code path in `computeDelay()`
- PR #3227 only clamped the HTTP-date path but missed the numeric seconds path
- A `Retry-After: 2200000` header produces 2,200,000,000 ms which exceeds the 32-bit signed integer limit, causing `setTimeout` to fire immediately

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- Verify that numeric Retry-After values exceeding ~2,147,483 seconds are clamped to `2_147_483_647` ms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
