### PR TITLE
fix: deduplicate query tokens in directItemSearch lexical scoring

### DIFF
--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -125,10 +125,10 @@ export function recencySearch(conversationId: string, limit: number, excludedMes
  */
 export function directItemSearch(query: string, limit: number, scopeIds?: string[]): Candidate[] {
   const db = getDb();
-  const tokens = query
+  const tokens = [...new Set(query
     .toLowerCase()
     .split(/[^a-z0-9_.-]+/g)
-    .filter((t) => t.length >= 2);
+    .filter((t) => t.length >= 2))];
   if (tokens.length === 0) return [];
 
   const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;


### PR DESCRIPTION
## Summary
- Deduplicate query tokens in `directItemSearch` before computing lexical relevance scores
- Repeated words in a query (e.g. "dark dark dark dark mode") were counted multiple times in the `matchedTokens / tokens.length` ratio, inflating the lexical score (0.8 instead of 0.5 for matching 1 of 2 unique terms)
- This could satisfy early-termination gating in `buildRetrievalCandidates` and skip semantic/entity search even though key query terms are missing

## Changes
- Wrapped the token array in `directItemSearch` with `new Set()` to deduplicate before scoring and before generating SQL LIKE clauses

Addresses feedback from PR #3226.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
