### PR TITLE
fix: use emitted UUID in status observer to avoid willSet timing bug

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1001,8 +1001,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // Subscribe to active ChatViewModel's objectWillChange so menu bar icon
         // updates when isThinking or errorText changes, even though SwiftUI
         // views now use ActiveChatViewWrapper for their own observation.
+        //
+        // Use the emitted UUID directly (not activeViewModel) because $activeThreadId
+        // fires during willSet — at that point activeThreadId still holds the old value,
+        // so activeViewModel would resolve to the previous thread's view model.
         statusIconCancellable = mainWindow?.threadManager.$activeThreadId
-            .compactMap { [weak mainWindow] _ in mainWindow?.threadManager.activeViewModel }
+            .compactMap { [weak mainWindow] id in
+                guard let id else { return nil }
+                return mainWindow?.threadManager.chatViewModel(for: id)
+            }
             .handleEvents(receiveOutput: { [weak self] _ in
                 // Update immediately when switching threads
                 self?.updateMenuBarIcon()


### PR DESCRIPTION
## Summary
- Fixed a timing bug in `observeAssistantStatus()` where `$activeThreadId` (a `@Published` property) emits during `willSet`, before the property is actually updated
- The `compactMap` closure was reading `activeViewModel` which internally reads `self.activeThreadId` — still holding the **old** value — causing `switchToLatest` to subscribe to the wrong thread's `objectWillChange`
- Now uses the emitted UUID value directly and resolves the view model via `chatViewModel(for:)`, which already exists on `ThreadManager`

Addresses feedback from PR #3225.

## Test plan
- [x] Verify the `chatViewModel(for:)` method exists on ThreadManager (it does — line 233, part of `ThreadRestorerDelegate` conformance)
- [ ] Switch threads rapidly and confirm the menu bar icon reflects the correct thread's status (thinking/error/idle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
