### PR TITLE
fix: inject placeholder for empty assistant turns to preserve role alternation

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -577,7 +577,7 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
     expect(sent[1].content[1].text).toBe('More valid text');
   });
 
-  test('assistant message with only whitespace text does not get placeholder', async () => {
+  test('assistant message with only whitespace text gets placeholder to preserve alternation', async () => {
     const messages: Message[] = [
       userMsg('Start'),
       {
@@ -596,12 +596,17 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
       content: Array<{ type: string; text?: string }>;
     }>;
 
-    // Whitespace-only assistant messages should be dropped entirely, not replaced with placeholder
-    expect(sent).toHaveLength(2);
+    // Whitespace-only assistant messages between user messages must be preserved
+    // with a placeholder to maintain Anthropic's strict role alternation
+    expect(sent).toHaveLength(3);
     expect(sent[0].role).toBe('user');
     expect(sent[0].content[0].text).toBe('Start');
-    expect(sent[1].role).toBe('user');
-    expect(sent[1].content[0].text).toBe('Continue');
+    expect(sent[1].role).toBe('assistant');
+    expect(sent[1].content).toHaveLength(1);
+    expect(sent[1].content[0].type).toBe('text');
+    expect(sent[1].content[0].text).toBe('[empty assistant turn]');
+    expect(sent[2].role).toBe('user');
+    expect(sent[2].content[0].text).toBe('Continue');
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -356,7 +356,7 @@ export class AnthropicProvider implements Provider {
         // Anthropic's role alternation requirement.
         if (content.length === 0 && m.role === 'assistant' && droppedUnknownBlock) {
           return {
-            role: m.role,
+            role: m.role as 'assistant',
             content: [{ type: 'text' as const, text: '[internal blocks omitted]' }],
           };
         }
@@ -364,8 +364,24 @@ export class AnthropicProvider implements Provider {
         return {
           role: m.role,
           content,
-        };
-      }).filter((m) => m.content.length > 0);
+        } as Anthropic.MessageParam;
+      }).reduce<Anthropic.MessageParam[]>((acc, m) => {
+        if (m.content.length > 0) {
+          acc.push(m);
+          return acc;
+        }
+        // Dropping an empty assistant message between two user messages (or vice
+        // versa) would create consecutive same-role messages, violating
+        // Anthropic's role alternation requirement. Inject a placeholder instead.
+        const prev = acc[acc.length - 1];
+        if (m.role === 'assistant' && prev && prev.role !== 'assistant') {
+          acc.push({
+            role: 'assistant' as const,
+            content: [{ type: 'text' as const, text: '[empty assistant turn]' }],
+          });
+        }
+        return acc;
+      }, []);
 
       sentMessages = ensureToolPairing(formatted);
       const params: Anthropic.MessageCreateParams = {


### PR DESCRIPTION
## Summary

Fixes a bug where whitespace-only assistant messages are dropped, creating consecutive user messages that violate Anthropic's strict role alternation requirement and cause 400 API errors.

- Whitespace text blocks pass `toAnthropicBlockSafe` (not null), so `droppedUnknownBlock` stays false
- The whitespace filter then strips them, leaving content empty
- The existing guard only checks `droppedUnknownBlock`, so no placeholder is injected
- The empty message is dropped by `.filter()`, creating consecutive same-role messages

**Fix:** Replace the post-map `.filter()` with a `.reduce()` that checks whether dropping an empty assistant message would create consecutive same-role neighbors. When it would, injects an `[empty assistant turn]` placeholder instead.

Follows up on #3222.

## Test plan
- [x] Updated test: whitespace-only assistant messages now get placeholder to preserve alternation
- [x] All 25 existing anthropic-provider tests pass
- [x] Type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
