### PR TITLE
fix: always use file_edit for workspace edits regardless of sandbox mode

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -2,7 +2,6 @@ import { readFileSync, existsSync, copyFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getWorkspaceDir, getWorkspacePromptPath } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
-import { getConfig } from './loader.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 
 const log = getLogger('system-prompt');
@@ -263,14 +262,16 @@ function buildWorkspaceReflectionSection(): string {
 }
 
 function buildConfigSection(): string {
-  // Intentionally use the assistant visible workspace path when possible to avoid prompting your user to edit files using host_file_edit
-  const config = getConfig();
-  const sandboxed = config.sandbox.enabled && config.sandbox.backend === 'docker';
-  const visibleDir = sandboxed ? '/workspace' : getWorkspaceDir();
+  // Always use `file_edit` (not `host_file_edit`) for workspace files — file_edit
+  // handles sandbox path mapping internally, and host_file_edit is permission-gated
+  // which would trigger approval prompts for routine workspace updates.
+  // Always use the real host workspace path — file_edit validates against it, so
+  // container-relative paths like /workspace/ would be rejected as out-of-bounds.
+  const workspaceDir = getWorkspaceDir();
 
   return [
     '## Configuration',
-    `Your configuration directory is \`${visibleDir}/\`. Key files you may read or edit:`,
+    `Your configuration directory is \`${workspaceDir}/\`. Key files you may read or edit:`,
     '',
     '- `IDENTITY.md` — Your name and role. Slim metadata — rarely changes.',
     '- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.',
@@ -279,7 +280,7 @@ function buildConfigSection(): string {
     '',
     '### Proactive Workspace Editing',
     '',
-    `You MUST actively update your workspace files as you learn. You don't need to ask your user whether it's okay — just briefly explain what you're updating, then use \`${sandboxed ? 'file_edit' : 'host_file_edit'}\` to make targeted edits.`,
+    `You MUST actively update your workspace files as you learn. You don't need to ask your user whether it's okay — just briefly explain what you're updating, then use \`file_edit\` to make targeted edits.`,
     '',
     '**USER.md** — update when you learn:',
     '- Their name or what they prefer to be called',


### PR DESCRIPTION
## Summary

Fixes two issues from PR #3220 review feedback:

- **P1**: `buildConfigSection` was telling the model to use `host_file_edit` when sandbox was disabled or backend was native. Since `host_file_edit` is permission-gated by default, routine workspace file updates (USER.md, SOUL.md, IDENTITY.md) were triggering approval prompts. Now always uses `file_edit` which handles sandbox path mapping internally.

- **P2**: In Docker mode, the config referenced `/workspace/` as the directory path, but `file_edit` validates paths against the host workspace root. If the model sent `/workspace/USER.md`, it would be rejected as out-of-bounds. Now always uses the real host workspace path from `getWorkspaceDir()`.

## Changes

- Removed sandbox config branching logic from `buildConfigSection`
- Always use `file_edit` (not `host_file_edit`) for workspace file edits
- Always use `getWorkspaceDir()` for the configuration directory path
- Removed unused `getConfig` import

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] All 34 system-prompt tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
