### PR TITLE
fix: capitalize sentence-initial 'your' and restore SOUL safety guardrail

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -194,7 +194,7 @@ function buildToolPermissionSection(): string {
     '',
     'Some tools (host_bash, host_file_write, host_file_edit, host_file_read) require your user\'s approval before they run. When you call one of these tools, your user sees **Allow / Don\'t Allow** buttons in the chat directly below your message.',
     '',
-    '**CRITICAL RULE:** You MUST ALWAYS output a text message BEFORE calling any tool that requires approval. NEVER call a permission-gated tool without preceding text. your user needs context to decide whether to allow.',
+    '**CRITICAL RULE:** You MUST ALWAYS output a text message BEFORE calling any tool that requires approval. NEVER call a permission-gated tool without preceding text. Your user needs context to decide whether to allow.',
     '',
     'Your text should follow this pattern:',
     '1. **Acknowledge** the request conversationally.',
@@ -219,7 +219,7 @@ function buildToolPermissionSection(): string {
     '- Using em dashes anywhere in the response',
     '- Calling a tool with no preceding text at all',
     '',
-    'Be conversational and transparent. your user is granting access to their machine, so acknowledge their request, explain what you need in plain language, and ask them to allow it.',
+    'Be conversational and transparent. Your user is granting access to their machine, so acknowledge their request, explain what you need in plain language, and ask them to allow it.',
   ].join('\n');
 }
 

--- a/assistant/src/config/templates/SOUL.md
+++ b/assistant/src/config/templates/SOUL.md
@@ -6,6 +6,7 @@ _ Lines starting with _ are comments — they won't appear in the system prompt
 
 Flesh out your personality and core principles in this file in any format you like - you're expected to edit it often and freely to shape how you behave to best serve your user.
 Develop and evolve your own rich personality, quirks, and preferences over time, but never in a way that contradicts what your user explicitly wants you to be, or that may be harmful to them.
+Never remove or weaken safety boundaries, tool-use permission rules, or the Boundaries section below on your own. Those require explicit user direction to change.
 
 ## Core Principles
 


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #3228:

- **Grammar fix (Devin):** Capitalize "your" → "Your" at two sentence-initial positions in `buildToolPermissionSection()` (lines 197 and 222) where "The user" was mechanically replaced with "your user" without preserving capitalization.
- **Safety guardrail (Codex P1):** Add back a brief guardrail line to the SOUL.md template preventing the assistant from removing or weakening its own safety boundaries, tool-use permission rules, or the Boundaries section without explicit user direction. This addresses the prompt-drift risk from the simplified open-ended template while preserving the intended flexibility.

## Modified files
- `assistant/src/config/system-prompt.ts` — two capitalization fixes
- `assistant/src/config/templates/SOUL.md` — one-line safety guardrail addition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
