### PR TITLE
fix: remove placeholder assistant turns adjacent to real assistant messages

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -609,6 +609,36 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
     expect(sent[2].content[0].text).toBe('Continue');
   });
 
+  test('empty assistant followed by empty user does not produce consecutive same-role messages', async () => {
+    // Edge case: an empty assistant turn gets a placeholder injected, but if
+    // the following user turn also filters to empty (e.g. whitespace-only),
+    // the user turn is dropped and the placeholder ends up adjacent to the
+    // next real assistant turn — producing consecutive assistant roles.
+    const messages: Message[] = [
+      userMsg('Start'),
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: '   ' }], // whitespace-only → empty after filtering
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: '  \n  ' }], // whitespace-only → empty after filtering
+      },
+      assistantMsg('Real response'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    }>;
+
+    // Verify strict role alternation: no two adjacent messages share the same role
+    for (let i = 1; i < sent.length; i++) {
+      expect(sent[i].role).not.toBe(sent[i - 1].role);
+    }
+  });
+
   // -----------------------------------------------------------------------
   // Workspace context injection + cache control
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -383,6 +383,28 @@ export class AnthropicProvider implements Provider {
         return acc;
       }, []);
 
+      // Post-processing: fix consecutive same-role messages that can arise when
+      // dropping empty messages (e.g. empty assistant followed by empty user).
+      // Remove placeholder assistant messages that ended up adjacent to another
+      // assistant message, since the placeholder is no longer needed.
+      for (let i = formatted.length - 1; i > 0; i--) {
+        if (formatted[i].role !== formatted[i - 1].role) continue;
+        // For consecutive assistant messages, remove whichever one is a
+        // placeholder injected by the reduce above.
+        if (formatted[i].role === 'assistant') {
+          const iContent = Array.isArray(formatted[i].content) ? formatted[i].content : [];
+          const prevContent = Array.isArray(formatted[i - 1].content) ? formatted[i - 1].content : [];
+          const isPlaceholder = (c: typeof iContent) =>
+            c.length === 1 && typeof c[0] !== 'string' && c[0].type === 'text' &&
+            (c[0] as { text?: string }).text === '[empty assistant turn]';
+          if (isPlaceholder(iContent)) {
+            formatted.splice(i, 1);
+          } else if (isPlaceholder(prevContent)) {
+            formatted.splice(i - 1, 1);
+          }
+        }
+      }
+
       sentMessages = ensureToolPairing(formatted);
       const params: Anthropic.MessageCreateParams = {
         model: this.model,


### PR DESCRIPTION
## Summary

Addresses feedback from PR #3236: the `[empty assistant turn]` placeholder injection only checked the previous retained message. If an empty assistant turn was followed by an empty user turn (e.g. whitespace-only text), the user turn was dropped and the placeholder ended up adjacent to the next real assistant turn — producing consecutive `assistant` roles and triggering Anthropic 400 errors.

**Fix:** After the `.reduce()` pass, a post-processing step scans for consecutive same-role assistant messages and removes any `[empty assistant turn]` placeholder that is no longer needed (because it's adjacent to another assistant message rather than separating a user from an assistant).

## Changes
- `assistant/src/providers/anthropic/client.ts`: Added post-reduce loop to remove placeholder assistant messages adjacent to real assistant messages
- `assistant/src/__tests__/anthropic-provider.test.ts`: Added test for the empty-assistant-followed-by-empty-user edge case, verifying strict role alternation

## Test plan
- [x] New test: "empty assistant followed by empty user does not produce consecutive same-role messages"
- [x] All 26 existing tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
