### PR TITLE
fix: remove deadlock-prone DispatchQueue.main.sync from DaemonClient deinit

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -258,23 +258,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // NWConnection.cancel() are safe from any thread.
         //
         // We must finish subscriber continuations to prevent hanging `for await` loops.
-        // deinit is nonisolated in Swift 5.9+, so we check if we're on the main thread.
-        // If we are, we can safely access the @MainActor-isolated subscribers.
-        // If not, dispatch synchronously to the main thread to access them safely.
-        if Thread.isMainThread {
-            MainActor.assumeIsolated {
-                for continuation in subscribers.values {
-                    continuation.finish()
-                }
-            }
-        } else {
-            DispatchQueue.main.sync {
-                MainActor.assumeIsolated {
-                    for continuation in self.subscribers.values {
-                        continuation.finish()
-                    }
-                }
-            }
+        // deinit guarantees exclusive access (no other strong references exist), so
+        // direct property access is safe without actor isolation dispatch.
+        let continuations = subscribers.values
+        for continuation in continuations {
+            continuation.finish()
         }
 
         reconnectTask?.cancel()


### PR DESCRIPTION
## Summary

Replaces the `if Thread.isMainThread` / `DispatchQueue.main.sync` pattern in `DaemonClient.deinit` with direct property access.

The previous approach (from #3230) used `DispatchQueue.main.sync` when deinit ran off the main thread. This can deadlock during app termination if the main thread's run loop has already stopped.

Since `deinit` guarantees exclusive access (no other code holds a strong reference to `self`), we can safely access the `@MainActor`-isolated `subscribers` dictionary directly without any dispatch, eliminating the deadlock risk entirely.

## Changes

- **`clients/shared/IPC/DaemonClient.swift`**: Replaced the `if/else` thread-check block with a simple `let continuations = subscribers.values` + iteration.

Addresses review feedback on #3230.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
