### PR TITLE
fix: theme switcher applies changes immediately

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -162,21 +162,35 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         default:
             appearance = nil // follow system
         }
-        NSApp.appearance = appearance
-        // Propagate to all existing windows so the change takes effect immediately
-        for window in NSApp.windows {
-            window.appearance = appearance
-            window.invalidateShadow()
-            window.contentView?.needsDisplay = true
-            window.displayIfNeeded()
-        }
-        // Force SwiftUI to re-evaluate adaptive colors by toggling the appearance
-        DispatchQueue.main.async {
+
+        if appearance == nil {
+            // When switching back to "system", explicitly set the current system
+            // appearance first so windows see an immediate change, then clear the
+            // override on the next run loop so future system changes propagate.
+            let systemAppearance = NSAppearance(named:
+                NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? .darkAqua : .aqua)
+            NSApp.appearance = systemAppearance
             for window in NSApp.windows {
-                window.contentView?.effectiveAppearance.performAsCurrentDrawingAppearance {
-                    window.contentView?.needsLayout = true
+                window.appearance = systemAppearance
+                window.invalidateShadow()
+                window.contentView?.needsDisplay = true
+            }
+            DispatchQueue.main.async {
+                NSApp.appearance = nil
+                for window in NSApp.windows {
+                    window.appearance = nil
+                    window.invalidateShadow()
                     window.contentView?.needsDisplay = true
                 }
+            }
+        } else {
+            NSApp.appearance = appearance
+            for window in NSApp.windows {
+                window.appearance = appearance
+                window.invalidateShadow()
+                window.contentView?.needsDisplay = true
+                window.displayIfNeeded()
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -163,41 +163,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             appearance = nil // follow system
         }
 
-        if appearance == nil {
-            // When switching back to "system", clear the override first so
-            // effectiveAppearance reflects the actual system appearance, then
-            // snapshot it and apply explicitly so windows see an immediate change.
-            NSApp.appearance = nil
-            let systemAppearance = NSAppearance(named:
-                NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                    ? .darkAqua : .aqua)
-            NSApp.appearance = systemAppearance
-            for window in NSApp.windows {
-                window.appearance = systemAppearance
-                window.invalidateShadow()
-                window.contentView?.needsDisplay = true
-            }
-            // Clear the explicit override on the next run loop so future system
-            // appearance changes propagate. Guard against races where the user
-            // picks a different theme before this block fires.
-            DispatchQueue.main.async {
-                let current = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
-                guard current == "system" else { return }
-                NSApp.appearance = nil
-                for window in NSApp.windows {
-                    window.appearance = nil
-                    window.invalidateShadow()
-                    window.contentView?.needsDisplay = true
-                }
-            }
-        } else {
-            NSApp.appearance = appearance
-            for window in NSApp.windows {
-                window.appearance = appearance
-                window.invalidateShadow()
-                window.contentView?.needsDisplay = true
-                window.displayIfNeeded()
-            }
+        NSApp.appearance = appearance
+        for window in NSApp.windows {
+            window.appearance = appearance
+            window.invalidateShadow()
+            window.contentView?.needsDisplay = true
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -164,9 +164,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if appearance == nil {
-            // When switching back to "system", explicitly set the current system
-            // appearance first so windows see an immediate change, then clear the
-            // override on the next run loop so future system changes propagate.
+            // When switching back to "system", clear the override first so
+            // effectiveAppearance reflects the actual system appearance, then
+            // snapshot it and apply explicitly so windows see an immediate change.
+            NSApp.appearance = nil
             let systemAppearance = NSAppearance(named:
                 NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
                     ? .darkAqua : .aqua)
@@ -176,7 +177,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 window.invalidateShadow()
                 window.contentView?.needsDisplay = true
             }
+            // Clear the explicit override on the next run loop so future system
+            // appearance changes propagate. Guard against races where the user
+            // picks a different theme before this block fires.
             DispatchQueue.main.async {
+                let current = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
+                guard current == "system" else { return }
                 NSApp.appearance = nil
                 for window in NSApp.windows {
                     window.appearance = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -19,6 +19,7 @@ struct MainWindowView: View {
 
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
     @AppStorage("sidebarOpen") private var sidebarOpen: Bool = false
+    @AppStorage("themePreference") private var themePreference: String = "system"
     @AppStorage("threadDrawerWidth") private var threadDrawerWidth: Double = 240
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     @State private var drawerDragStartWidth: Double?
@@ -272,6 +273,7 @@ struct MainWindowView: View {
                 threadManager.activeViewModel?.activeSurfaceId = surfaceId
             }
         }
+        .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : nil)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -20,6 +20,7 @@ struct MainWindowView: View {
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
     @AppStorage("sidebarOpen") private var sidebarOpen: Bool = false
     @AppStorage("themePreference") private var themePreference: String = "system"
+    @State private var systemIsDark: Bool = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     @AppStorage("threadDrawerWidth") private var threadDrawerWidth: Double = 240
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     @State private var drawerDragStartWidth: Double?
@@ -273,7 +274,10 @@ struct MainWindowView: View {
                 threadManager.activeViewModel?.activeSurfaceId = surfaceId
             }
         }
-        .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : nil)
+        .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
+        .onReceive(DistributedNotificationCenter.default().publisher(for: Notification.Name("AppleInterfaceThemeChangedNotification"))) { _ in
+            systemIsDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        }
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -203,8 +203,6 @@ struct SettingsPanel: View {
                             get: { themePreference },
                             set: { newValue in
                                 themePreference = newValue
-                                UserDefaults.standard.set(newValue, forKey: "themePreference")
-                                UserDefaults.standard.synchronize()
                                 if let delegate = NSApp.delegate as? AppDelegate {
                                     delegate.applyThemePreference()
                                 }


### PR DESCRIPTION
## Summary
- Add `.preferredColorScheme()` to `MainWindowView` root so SwiftUI's `colorScheme` environment updates reliably on theme change
- Fix `applyThemePreference()` to force immediate window re-evaluation when switching back to "system" by briefly setting the resolved system appearance before clearing the override
- Remove redundant `UserDefaults.standard.set()` and `.synchronize()` from the settings picker (already handled by `@AppStorage`)

## Test plan
- [ ] Open Settings, switch theme to Light — UI updates immediately
- [ ] Switch to Dark — UI updates immediately
- [ ] Switch back to System — UI updates immediately (previously required app switch)
- [ ] Change macOS system appearance while set to System — app follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
