### PR TITLE
Fix composer text clipping on multi-line input

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -222,7 +222,7 @@ struct ComposerView: View {
         }
         .onChange(of: editorContentHeight) {
             syncComposerScrollPosition(proxy)
-            if editorContentHeight > 28 { isComposerExpanded = true }
+            if editorContentHeight > 40 { isComposerExpanded = true }
         }
         .onKeyPress(.tab, phases: .down) { keyPress in
             if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 struct ComposerView: View {
-    private let composerVerticalTextInset: CGFloat = 2
+    private let composerVerticalTextInset: CGFloat = 8
 
     @Binding var inputText: String
     let hasAPIKey: Bool


### PR DESCRIPTION
## Summary
- Increases `composerVerticalTextInset` from 2pt to 8pt in the composer text field
- Fixes multi-line text being cut off at the bottom of the chat input bar
- Compensates for AppKit's multiline TextField under-reporting its rendered height

## Test plan
- [ ] Type a long message that wraps to 2+ lines in the composer
- [ ] Verify the full text is visible without clipping at the bottom
- [ ] Verify single-line input still looks correct
- [ ] Verify the composer expands smoothly when text wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
