### PR TITLE
fix: use collision-safe placeholder sentinels and cover both placeholder types (#3239 feedback)

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -55,7 +55,7 @@ mock.module('@anthropic-ai/sdk', () => ({
 }));
 
 // Import after mocking
-import { AnthropicProvider } from '../providers/anthropic/client.js';
+import { AnthropicProvider, PLACEHOLDER_EMPTY_TURN, PLACEHOLDER_BLOCKS_OMITTED } from '../providers/anthropic/client.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -546,7 +546,7 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
     expect(sent[1].role).toBe('assistant');
     expect(sent[1].content).toHaveLength(1);
     expect(sent[1].content[0].type).toBe('text');
-    expect(sent[1].content[0].text).toBe('[internal blocks omitted]');
+    expect(sent[1].content[0].text).toBe(PLACEHOLDER_BLOCKS_OMITTED);
     expect(sent[2].role).toBe('user');
   });
 
@@ -604,9 +604,39 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
     expect(sent[1].role).toBe('assistant');
     expect(sent[1].content).toHaveLength(1);
     expect(sent[1].content[0].type).toBe('text');
-    expect(sent[1].content[0].text).toBe('[empty assistant turn]');
+    expect(sent[1].content[0].text).toBe(PLACEHOLDER_EMPTY_TURN);
     expect(sent[2].role).toBe('user');
     expect(sent[2].content[0].text).toBe('Continue');
+  });
+
+  test('unknown-blocks-only assistant followed by empty user does not produce consecutive same-role messages', async () => {
+    // Same edge case as the empty-assistant test below, but triggered by an
+    // assistant turn whose blocks are all unknown (e.g. ui_surface). The turn
+    // becomes a [internal blocks omitted] placeholder which must also be
+    // removed when adjacent to a real assistant message.
+    const messages: Message[] = [
+      userMsg('Start'),
+      {
+        role: 'assistant',
+        content: [{ type: 'ui_surface' as 'text', text: 'invisible' }], // unknown → placeholder
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: '  \n  ' }], // whitespace-only → empty after filtering
+      },
+      assistantMsg('Real response'),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    }>;
+
+    // Verify strict role alternation: no two adjacent messages share the same role
+    for (let i = 1; i < sent.length; i++) {
+      expect(sent[i].role).not.toBe(sent[i - 1].role);
+    }
   });
 
   test('empty assistant followed by empty user does not produce consecutive same-role messages', async () => {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -27,6 +27,11 @@ function sanitizeToolId(id: string): string {
 
 const SYNTHETIC_RESULT = '<synthesized_result>tool result missing from history</synthesized_result>';
 
+// Null-byte prefix makes these placeholders impossible to produce via normal
+// model output or user input, preventing false positives in isPlaceholder().
+export const PLACEHOLDER_EMPTY_TURN = '\x00__PLACEHOLDER__[empty assistant turn]';
+export const PLACEHOLDER_BLOCKS_OMITTED = '\x00__PLACEHOLDER__[internal blocks omitted]';
+
 /** Type-guard for tool_use blocks in Anthropic-formatted content. */
 function isToolUseBlock(block: unknown): block is Anthropic.ToolUseBlockParam {
   return typeof block === 'object' && block !== null && (block as { type: string }).type === 'tool_use';
@@ -357,7 +362,7 @@ export class AnthropicProvider implements Provider {
         if (content.length === 0 && m.role === 'assistant' && droppedUnknownBlock) {
           return {
             role: m.role as 'assistant',
-            content: [{ type: 'text' as const, text: '[internal blocks omitted]' }],
+            content: [{ type: 'text' as const, text: PLACEHOLDER_BLOCKS_OMITTED }],
           };
         }
 
@@ -377,7 +382,7 @@ export class AnthropicProvider implements Provider {
         if (m.role === 'assistant' && prev && prev.role !== 'assistant') {
           acc.push({
             role: 'assistant' as const,
-            content: [{ type: 'text' as const, text: '[empty assistant turn]' }],
+            content: [{ type: 'text' as const, text: PLACEHOLDER_EMPTY_TURN }],
           });
         }
         return acc;
@@ -394,9 +399,11 @@ export class AnthropicProvider implements Provider {
         if (formatted[i].role === 'assistant') {
           const iContent = Array.isArray(formatted[i].content) ? formatted[i].content : [];
           const prevContent = Array.isArray(formatted[i - 1].content) ? formatted[i - 1].content : [];
-          const isPlaceholder = (c: typeof iContent) =>
-            c.length === 1 && typeof c[0] !== 'string' && c[0].type === 'text' &&
-            (c[0] as { text?: string }).text === '[empty assistant turn]';
+          const isPlaceholder = (c: typeof iContent) => {
+            if (c.length !== 1 || typeof c[0] === 'string' || c[0].type !== 'text') return false;
+            const text = (c[0] as { text?: string }).text;
+            return text === PLACEHOLDER_EMPTY_TURN || text === PLACEHOLDER_BLOCKS_OMITTED;
+          };
           if (isPlaceholder(iContent)) {
             formatted.splice(i, 1);
           } else if (isPlaceholder(prevContent)) {


### PR DESCRIPTION
## Summary

Addresses review feedback on #3239:

- **Codex P2 — sentinel collision guard:** Placeholder strings (`[empty assistant turn]`, `[internal blocks omitted]`) could match legitimate assistant text. Now prefixed with a null byte (`\x00__PLACEHOLDER__...`) making them impossible to produce via model output or user input.

- **Devin P1 — incomplete isPlaceholder coverage:** The post-processing `isPlaceholder()` only checked for `[empty assistant turn]` but ignored the `[internal blocks omitted]` placeholder, leaving a path to consecutive assistant-role violations. Now checks both constants.

## Changes
- `assistant/src/providers/anthropic/client.ts`: Added exported `PLACEHOLDER_EMPTY_TURN` and `PLACEHOLDER_BLOCKS_OMITTED` constants with null-byte prefix; updated both injection sites and `isPlaceholder()` to use them.
- `assistant/src/__tests__/anthropic-provider.test.ts`: Added test for unknown-blocks-only assistant followed by empty user; updated assertions to use exported constants.

## Test plan
- [x] All 27 existing tests pass
- [x] New test: unknown-blocks-only assistant + empty user maintains role alternation
- [x] Type-check passes (only pre-existing react/ink/dotenv errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
