### PR TITLE
feat: include top-level files in workspace context prompt

### DIFF
--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -110,7 +110,7 @@ mock.module('../workspace/top-level-scanner.js', () => ({
   MAX_TOP_LEVEL_ENTRIES: 120,
   scanTopLevelDirectories: (rootPath: string) => {
     scanCallCount++;
-    return { rootPath, directories: ['src', 'tests', 'docs'], truncated: false };
+    return { rootPath, directories: ['src', 'tests', 'docs'], files: ['README.md', 'package.json'], truncated: false };
   },
 }));
 

--- a/assistant/src/__tests__/top-level-renderer.test.ts
+++ b/assistant/src/__tests__/top-level-renderer.test.ts
@@ -3,10 +3,11 @@ import { renderWorkspaceTopLevelContext } from '../workspace/top-level-renderer.
 import type { TopLevelSnapshot } from '../workspace/top-level-scanner.js';
 
 describe('renderWorkspaceTopLevelContext', () => {
-  test('renders basic snapshot with directories', () => {
+  test('renders basic snapshot with directories and files', () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: '/sandbox',
       directories: ['lib', 'src', 'tests'],
+      files: ['README.md', 'package.json'],
       truncated: false,
     };
 
@@ -15,6 +16,7 @@ describe('renderWorkspaceTopLevelContext', () => {
       '<workspace_top_level>',
       'Root: /sandbox',
       'Directories: lib, src, tests',
+      'Files: README.md, package.json',
       '</workspace_top_level>',
     ].join('\n'));
   });
@@ -23,18 +25,21 @@ describe('renderWorkspaceTopLevelContext', () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: '/sandbox',
       directories: ['a', 'b'],
+      files: ['c.txt'],
       truncated: true,
     };
 
     const result = renderWorkspaceTopLevelContext(snapshot);
-    expect(result).toContain('(list truncated — more directories exist)');
+    expect(result).toContain('(list truncated — more entries exist)');
     expect(result).toContain('Directories: a, b');
+    expect(result).toContain('Files: c.txt');
   });
 
   test('does not include truncation note when not truncated', () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: '/sandbox',
       directories: ['src'],
+      files: ['index.ts'],
       truncated: false,
     };
 
@@ -42,10 +47,11 @@ describe('renderWorkspaceTopLevelContext', () => {
     expect(result).not.toContain('truncated');
   });
 
-  test('renders empty directory list', () => {
+  test('renders empty directory and file lists', () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: '/empty',
       directories: [],
+      files: [],
       truncated: false,
     };
 
@@ -54,6 +60,7 @@ describe('renderWorkspaceTopLevelContext', () => {
       '<workspace_top_level>',
       'Root: /empty',
       'Directories: ',
+      'Files: ',
       '</workspace_top_level>',
     ].join('\n'));
   });
@@ -62,6 +69,7 @@ describe('renderWorkspaceTopLevelContext', () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: '/sandbox',
       directories: ['alpha', 'beta', 'gamma'],
+      files: ['config.json'],
       truncated: false,
     };
 
@@ -74,6 +82,7 @@ describe('renderWorkspaceTopLevelContext', () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: '/test',
       directories: ['src'],
+      files: [],
       truncated: false,
     };
 
@@ -86,6 +95,7 @@ describe('renderWorkspaceTopLevelContext', () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: '/project',
       directories: ['.git', '.vscode', 'src'],
+      files: ['.gitignore'],
       truncated: false,
     };
 
@@ -93,5 +103,19 @@ describe('renderWorkspaceTopLevelContext', () => {
     expect(result).toContain('.git');
     expect(result).toContain('.vscode');
     expect(result).toContain('src');
+    expect(result).toContain('.gitignore');
+  });
+
+  test('renders files-only snapshot (no directories)', () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: '/flat',
+      directories: [],
+      files: ['a.txt', 'b.txt'],
+      truncated: false,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot);
+    expect(result).toContain('Directories: ');
+    expect(result).toContain('Files: a.txt, b.txt');
   });
 });

--- a/assistant/src/__tests__/top-level-scanner.test.ts
+++ b/assistant/src/__tests__/top-level-scanner.test.ts
@@ -16,14 +16,15 @@ describe('scanTopLevelDirectories', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  test('returns empty array for empty directory', () => {
+  test('returns empty arrays for empty directory', () => {
     const result = scanTopLevelDirectories(tempDir);
     expect(result.rootPath).toBe(tempDir);
     expect(result.directories).toEqual([]);
+    expect(result.files).toEqual([]);
     expect(result.truncated).toBe(false);
   });
 
-  test('returns only directories, not files', () => {
+  test('separates directories and files', () => {
     mkdirSync(join(tempDir, 'src'));
     mkdirSync(join(tempDir, 'lib'));
     writeFileSync(join(tempDir, 'README.md'), 'hello');
@@ -31,6 +32,7 @@ describe('scanTopLevelDirectories', () => {
 
     const result = scanTopLevelDirectories(tempDir);
     expect(result.directories).toEqual(['lib', 'src']);
+    expect(result.files).toEqual(['README.md', 'package.json']);
     expect(result.truncated).toBe(false);
   });
 
@@ -43,6 +45,15 @@ describe('scanTopLevelDirectories', () => {
     expect(result.directories).toEqual(['alpha', 'middle', 'zebra']);
   });
 
+  test('sorts files lexicographically', () => {
+    writeFileSync(join(tempDir, 'z.txt'), '');
+    writeFileSync(join(tempDir, 'a.txt'), '');
+    writeFileSync(join(tempDir, 'm.txt'), '');
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.files).toEqual(['a.txt', 'm.txt', 'z.txt']);
+  });
+
   test('includes hidden directories', () => {
     mkdirSync(join(tempDir, '.git'));
     mkdirSync(join(tempDir, '.vscode'));
@@ -52,49 +63,79 @@ describe('scanTopLevelDirectories', () => {
     expect(result.directories).toEqual(['.git', '.vscode', 'src']);
   });
 
+  test('includes hidden files', () => {
+    writeFileSync(join(tempDir, '.gitignore'), '');
+    writeFileSync(join(tempDir, '.env'), '');
+    writeFileSync(join(tempDir, 'index.ts'), '');
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.files).toEqual(['.env', '.gitignore', 'index.ts']);
+  });
+
   test('is non-recursive — does not descend into subdirectories', () => {
     mkdirSync(join(tempDir, 'src'));
     mkdirSync(join(tempDir, 'src', 'nested'));
     mkdirSync(join(tempDir, 'src', 'nested', 'deep'));
+    writeFileSync(join(tempDir, 'src', 'index.ts'), '');
 
     const result = scanTopLevelDirectories(tempDir);
     expect(result.directories).toEqual(['src']);
+    expect(result.files).toEqual([]);
   });
 
   test('is deterministic — same input produces same output', () => {
     mkdirSync(join(tempDir, 'b'));
     mkdirSync(join(tempDir, 'a'));
     mkdirSync(join(tempDir, 'c'));
+    writeFileSync(join(tempDir, 'x.txt'), '');
 
     const r1 = scanTopLevelDirectories(tempDir);
     const r2 = scanTopLevelDirectories(tempDir);
     expect(r1).toEqual(r2);
   });
 
-  test('returns truncated=true when exceeding MAX_TOP_LEVEL_ENTRIES', () => {
-    for (let i = 0; i < MAX_TOP_LEVEL_ENTRIES + 5; i++) {
+  test('returns truncated=true when total entries exceed MAX_TOP_LEVEL_ENTRIES', () => {
+    for (let i = 0; i < MAX_TOP_LEVEL_ENTRIES; i++) {
       mkdirSync(join(tempDir, `dir-${String(i).padStart(4, '0')}`));
     }
+    writeFileSync(join(tempDir, 'extra.txt'), '');
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.truncated).toBe(true);
+    expect(result.directories.length + result.files.length).toBeLessThanOrEqual(MAX_TOP_LEVEL_ENTRIES);
+  });
+
+  test('returns truncated=false at exactly MAX_TOP_LEVEL_ENTRIES total', () => {
+    const dirCount = MAX_TOP_LEVEL_ENTRIES - 2;
+    for (let i = 0; i < dirCount; i++) {
+      mkdirSync(join(tempDir, `dir-${String(i).padStart(4, '0')}`));
+    }
+    writeFileSync(join(tempDir, 'a.txt'), '');
+    writeFileSync(join(tempDir, 'b.txt'), '');
+
+    const result = scanTopLevelDirectories(tempDir);
+    expect(result.truncated).toBe(false);
+    expect(result.directories).toHaveLength(dirCount);
+    expect(result.files).toHaveLength(2);
+  });
+
+  test('prioritizes directories over files when truncating', () => {
+    for (let i = 0; i < MAX_TOP_LEVEL_ENTRIES; i++) {
+      mkdirSync(join(tempDir, `dir-${String(i).padStart(4, '0')}`));
+    }
+    writeFileSync(join(tempDir, 'file.txt'), '');
 
     const result = scanTopLevelDirectories(tempDir);
     expect(result.truncated).toBe(true);
     expect(result.directories).toHaveLength(MAX_TOP_LEVEL_ENTRIES);
-  });
-
-  test('returns truncated=false at exactly MAX_TOP_LEVEL_ENTRIES', () => {
-    for (let i = 0; i < MAX_TOP_LEVEL_ENTRIES; i++) {
-      mkdirSync(join(tempDir, `dir-${String(i).padStart(4, '0')}`));
-    }
-
-    const result = scanTopLevelDirectories(tempDir);
-    expect(result.truncated).toBe(false);
-    expect(result.directories).toHaveLength(MAX_TOP_LEVEL_ENTRIES);
+    expect(result.files).toHaveLength(0);
   });
 
   test('handles non-existent rootPath gracefully', () => {
     const result = scanTopLevelDirectories('/tmp/non-existent-path-abc123');
     expect(result.rootPath).toBe('/tmp/non-existent-path-abc123');
     expect(result.directories).toEqual([]);
+    expect(result.files).toEqual([]);
     expect(result.truncated).toBe(false);
   });
 });

--- a/assistant/src/workspace/top-level-renderer.ts
+++ b/assistant/src/workspace/top-level-renderer.ts
@@ -10,8 +10,9 @@ export function renderWorkspaceTopLevelContext(snapshot: TopLevelSnapshot): stri
   const lines: string[] = ['<workspace_top_level>'];
   lines.push(`Root: ${snapshot.rootPath}`);
   lines.push(`Directories: ${snapshot.directories.join(', ')}`);
+  lines.push(`Files: ${snapshot.files.join(', ')}`);
   if (snapshot.truncated) {
-    lines.push('(list truncated — more directories exist)');
+    lines.push('(list truncated — more entries exist)');
   }
   lines.push('</workspace_top_level>');
   return lines.join('\n');

--- a/assistant/src/workspace/top-level-scanner.ts
+++ b/assistant/src/workspace/top-level-scanner.ts
@@ -6,6 +6,7 @@ export const MAX_TOP_LEVEL_ENTRIES = 120;
 export interface TopLevelSnapshot {
   rootPath: string;
   directories: string[];
+  files: string[];
   truncated: boolean;
 }
 
@@ -15,20 +16,26 @@ export interface TopLevelSnapshot {
  * is sorted lexicographically.
  */
 export function scanTopLevelDirectories(rootPath: string): TopLevelSnapshot {
-  let entries: string[];
+  let dirEntries: string[];
+  let fileEntries: string[];
   try {
-    entries = readdirSync(rootPath, { withFileTypes: true })
-      .filter((d) => d.isDirectory())
-      .map((d) => d.name)
-      .sort();
+    const all = readdirSync(rootPath, { withFileTypes: true });
+    dirEntries = all.filter((d) => d.isDirectory()).map((d) => d.name).sort();
+    fileEntries = all.filter((d) => d.isFile()).map((d) => d.name).sort();
   } catch {
-    return { rootPath, directories: [], truncated: false };
+    return { rootPath, directories: [], files: [], truncated: false };
   }
 
-  const truncated = entries.length > MAX_TOP_LEVEL_ENTRIES;
-  return {
-    rootPath,
-    directories: truncated ? entries.slice(0, MAX_TOP_LEVEL_ENTRIES) : entries,
-    truncated,
-  };
+  const totalEntries = dirEntries.length + fileEntries.length;
+  const truncated = totalEntries > MAX_TOP_LEVEL_ENTRIES;
+
+  if (truncated) {
+    // Directories first, then fill remaining budget with files
+    const dirs = dirEntries.slice(0, MAX_TOP_LEVEL_ENTRIES);
+    const remaining = Math.max(0, MAX_TOP_LEVEL_ENTRIES - dirs.length);
+    const files = fileEntries.slice(0, remaining);
+    return { rootPath, directories: dirs, files, truncated };
+  }
+
+  return { rootPath, directories: dirEntries, files: fileEntries, truncated };
 }


### PR DESCRIPTION
## Summary
- The `<workspace_top_level>` block injected into user messages previously only listed directories
- Added a `Files:` line so the model also sees top-level files (README.md, package.json, etc.)
- Truncation budget prioritizes directories, then fills remaining slots with files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
