### PR TITLE
fix: pass API key to Anthropic client in ride-shotgun watch handler

### DIFF
--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -143,7 +143,7 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
 
     log.info(
-      { watchId: session.watchId, commentaryText: commentaryText.substring(0, 100), isSkip: commentaryText === 'SKIP' },
+      { watchId: session.watchId, commentaryLength: commentaryText.length, isSkip: commentaryText === 'SKIP' },
       '[SHOTGUN-DEBUG] Commentary result from Haiku',
     );
 

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -2,6 +2,7 @@ import Foundation
 import VellumAssistantShared
 import AppKit
 import Combine
+import UserNotifications
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientAgent")
@@ -19,7 +20,6 @@ public final class AmbientAgent: ObservableObject {
     let rideShotgunTrigger = RideShotgunTrigger()
     @Published var currentSession: RideShotgunSession?
 
-    private var invitationWindow: RideShotgunInvitationWindow?
     private var progressWindow: RideShotgunProgressWindow?
     private var summaryWindow: RideShotgunSummaryWindow?
     private var triggerCancellable: AnyCancellable?
@@ -35,7 +35,9 @@ public final class AmbientAgent: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] shouldShow in
                 if shouldShow {
-                    self?.showInvitation()
+                    Task { @MainActor in
+                        await self?.showInvitation()
+                    }
                 }
             }
         rideShotgunTrigger.start()
@@ -53,7 +55,7 @@ public final class AmbientAgent: ObservableObject {
         rideShotgunTrigger.stop()
         currentSession?.cancel()
         currentSession = nil
-        invitationWindow?.close()
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ["ride-shotgun-invitation"])
         progressWindow?.close()
         summaryWindow?.close()
         triggerCancellable?.cancel()
@@ -62,21 +64,38 @@ public final class AmbientAgent: ObservableObject {
 
     // MARK: - Ride Shotgun Flow
 
-    func showInvitation() {
-        guard invitationWindow == nil else { return }
+    func showInvitation() async {
+        // Check notification authorization; fall back to starting session directly
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        guard settings.authorizationStatus == .authorized else {
+            log.warning("Notifications not authorized; falling back to direct ride shotgun session")
+            startRideShotgun(durationSeconds: 60)
+            return
+        }
 
-        let window = RideShotgunInvitationWindow(
-            onAccept: { [weak self] durationSeconds in
-                self?.invitationWindow = nil
-                self?.startRideShotgun(durationSeconds: durationSeconds)
-            },
-            onDecline: { [weak self] in
-                self?.invitationWindow = nil
-                self?.rideShotgunTrigger.recordDeclined()
-            }
+        let content = UNMutableNotificationContent()
+        content.title = "Ride Shotgun"
+        content.body = """
+        I'll watch your screen briefly to learn how you work:
+        • Pick up patterns in your workflow
+        • Spot where I can save you time
+        • Get context so my suggestions are relevant
+        """
+        content.categoryIdentifier = "RIDE_SHOTGUN"
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "ride-shotgun-invitation",
+            content: content,
+            trigger: nil
         )
-        invitationWindow = window
-        window.show()
+
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+            log.info("Posted ride shotgun invitation notification")
+        } catch {
+            log.error("Failed to post ride shotgun notification: \(error.localizedDescription)")
+        }
     }
 
     func startRideShotgun(durationSeconds: Int) {

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -2,7 +2,6 @@ import Foundation
 import VellumAssistantShared
 import AppKit
 import Combine
-import UserNotifications
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientAgent")
@@ -20,6 +19,7 @@ public final class AmbientAgent: ObservableObject {
     let rideShotgunTrigger = RideShotgunTrigger()
     @Published var currentSession: RideShotgunSession?
 
+    private var invitationWindow: RideShotgunInvitationWindow?
     private var progressWindow: RideShotgunProgressWindow?
     private var summaryWindow: RideShotgunSummaryWindow?
     private var triggerCancellable: AnyCancellable?
@@ -35,9 +35,7 @@ public final class AmbientAgent: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] shouldShow in
                 if shouldShow {
-                    Task { @MainActor in
-                        await self?.showInvitation()
-                    }
+                    self?.showInvitation()
                 }
             }
         rideShotgunTrigger.start()
@@ -55,7 +53,7 @@ public final class AmbientAgent: ObservableObject {
         rideShotgunTrigger.stop()
         currentSession?.cancel()
         currentSession = nil
-        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ["ride-shotgun-invitation"])
+        invitationWindow?.close()
         progressWindow?.close()
         summaryWindow?.close()
         triggerCancellable?.cancel()
@@ -64,38 +62,21 @@ public final class AmbientAgent: ObservableObject {
 
     // MARK: - Ride Shotgun Flow
 
-    func showInvitation() async {
-        // Check notification authorization; fall back to starting session directly
-        let settings = await UNUserNotificationCenter.current().notificationSettings()
-        guard settings.authorizationStatus == .authorized else {
-            log.warning("Notifications not authorized; falling back to direct ride shotgun session")
-            startRideShotgun(durationSeconds: 60)
-            return
-        }
+    func showInvitation() {
+        guard invitationWindow == nil else { return }
 
-        let content = UNMutableNotificationContent()
-        content.title = "Ride Shotgun"
-        content.body = """
-        I'll watch your screen briefly to learn how you work:
-        • Pick up patterns in your workflow
-        • Spot where I can save you time
-        • Get context so my suggestions are relevant
-        """
-        content.categoryIdentifier = "RIDE_SHOTGUN"
-        content.sound = .default
-
-        let request = UNNotificationRequest(
-            identifier: "ride-shotgun-invitation",
-            content: content,
-            trigger: nil
+        let window = RideShotgunInvitationWindow(
+            onAccept: { [weak self] durationSeconds in
+                self?.invitationWindow = nil
+                self?.startRideShotgun(durationSeconds: durationSeconds)
+            },
+            onDecline: { [weak self] in
+                self?.invitationWindow = nil
+                self?.rideShotgunTrigger.recordDeclined()
+            }
         )
-
-        do {
-            try await UNUserNotificationCenter.current().add(request)
-            log.info("Posted ride shotgun invitation notification")
-        } catch {
-            log.error("Failed to post ride shotgun notification: \(error.localizedDescription)")
-        }
+        invitationWindow = window
+        window.show()
     }
 
     func startRideShotgun(durationSeconds: Int) {


### PR DESCRIPTION
## Summary
- **Root cause**: `watch-handler.ts` created Anthropic clients with `new Anthropic()` (no API key), while the daemon stores keys in its config system — not in env vars. This caused both Haiku (commentary) and Sonnet (summary) API calls to fail silently with "Could not resolve authentication method" errors.
- **Fix**: Import `getConfig()` and pass `apiKey` explicitly to both `new Anthropic({ apiKey })` calls, matching the pattern used everywhere else in the daemon.
- **Diagnostic logging**: Added `[SHOTGUN-DEBUG]` tagged logging throughout the ride-shotgun pipeline (daemon handler, watch handler, Swift client session, ambient agent) to trace observations, API calls, and state transitions.

## Test plan
- [ ] Start a ride-shotgun session and verify the summary window shows actual content instead of the empty fallback
- [ ] Check daemon logs (`~/.vellum/workspace/data/logs/vellum.log`) for `[SHOTGUN-DEBUG]` entries confirming API calls succeed
- [ ] Verify commentary generation (Haiku) fires every 3 observations
- [ ] Verify summary generation (Sonnet) fires when the session duration expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
