### PR TITLE
feat: surface refresh for file edits with reloadGeneration (#3267)

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -500,6 +500,8 @@ export interface DynamicPageSurfaceData {
   height?: number;
   appId?: string;
   appType?: string;
+  reloadGeneration?: number;
+  status?: string;
   preview?: DynamicPagePreview;
 }
 

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -240,7 +240,7 @@ export function handleSurfaceAction(ctx: SurfaceSessionContext, surfaceId: strin
 /**
  * After an app_update, refresh any active surface that displays the updated app.
  */
-export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string): void {
+export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string, opts?: { fileChange?: boolean; status?: string }): void {
   const app = getApp(appId);
   if (!app) return;
 
@@ -253,7 +253,12 @@ export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string)
     pushUndoState(ctx.surfaceUndoStacks, surfaceId, data.html);
 
     // Update in-memory surface state so the next refinement gets fresh HTML
-    const updatedData: DynamicPageSurfaceData = { ...data, html: app.htmlDefinition };
+    const updatedData: DynamicPageSurfaceData = {
+      ...data,
+      html: app.htmlDefinition,
+      ...(opts?.fileChange ? { reloadGeneration: (data.reloadGeneration ?? 0) + 1 } : {}),
+      status: opts?.status,
+    };
     stored.data = updatedData;
 
     // Push the update to the client

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -284,6 +284,15 @@ export class Session {
         }
       }
 
+      // Auto-refresh workspace surfaces when app files are edited
+      if ((name === 'app_file_edit' || name === 'app_file_write') && !result.isError) {
+        const appId = input.app_id as string | undefined;
+        const status = input.status as string | undefined;
+        if (appId) {
+          refreshSurfacesForApp(this, appId, { fileChange: true, status });
+        }
+      }
+
       return result;
     };
 


### PR DESCRIPTION
Part of #3264

## Changes
- Added reloadGeneration and status fields to DynamicPageSurfaceData in ipc-contract
- Extended post-tool hook in session.ts to trigger on app_file_edit and app_file_write
- Modified refreshSurfacesForApp() to accept options for file changes and status
- reloadGeneration increments on file edits so Swift can detect CSS/JS changes and reload

Closes #3267
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
