### PR TITLE
feat: WebView scheme handler + Swift IPC for file-based apps (#3269)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -372,9 +372,15 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         onCoordinatorReady?(context.coordinator)
         // Use a per-app origin so localStorage/sessionStorage work natively,
         // isolated per app. Non-app surfaces get a shared fallback origin.
-        let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
-        webView.loadHTMLString(data.html, baseURL: URL(string: origin))
-
+        if let appId = appId {
+            // App-backed surface — serve from disk via scheme handler
+            let schemeURL = URL(string: "vellumapp://\(appId)/index.html")!
+            webView.load(URLRequest(url: schemeURL))
+        } else {
+            // Ephemeral surface — inline HTML
+            let origin = "https://surface.vellum.local/"
+            webView.loadHTMLString(data.html, baseURL: URL(string: origin))
+        }
         return webView
     }
 
@@ -404,6 +410,13 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         // Update the snapshot callback so navigating between surfaces picks up the new closure.
         context.coordinator.onSnapshotCaptured = onSnapshotCaptured
 
+
+        // For file-based apps, reload on generation change (picks up CSS/JS/HTML edits)
+        if let gen = data.reloadGeneration, gen != context.coordinator.lastReloadGeneration {
+            context.coordinator.lastReloadGeneration = gen
+            context.coordinator.hasCapturedSnapshot = false
+            webView.reload()
+        }
         // Reload if the HTML content has changed.
         if data.html != context.coordinator.currentHTML {
             let previousHTML = context.coordinator.currentHTML
@@ -465,8 +478,33 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 """
             webView.evaluateJavaScript(js, completionHandler: nil)
         }
-    }
 
+        // Show transient status pill overlay
+        if let status = data.status {
+            let escapedStatus = status
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: " ")
+            let js = """
+                (function() {
+                    var existing = document.getElementById('vellum-status-pill');
+                    if (existing) existing.remove();
+                    var pill = document.createElement('div');
+                    pill.id = 'vellum-status-pill';
+                    pill.setAttribute('data-vellum-injected', '1');
+                    pill.textContent = '\(escapedStatus)';
+                    pill.style.cssText = 'position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.75);color:#fff;font-size:12px;padding:6px 14px;border-radius:20px;z-index:100000;pointer-events:none;opacity:0;transition:opacity 0.3s ease;backdrop-filter:blur(8px);font-family:-apple-system,BlinkMacSystemFont,sans-serif;';
+                    document.body.appendChild(pill);
+                    requestAnimationFrame(function() { pill.style.opacity = '1'; });
+                    setTimeout(function() {
+                        pill.style.opacity = '0';
+                        setTimeout(function() { if (pill.parentNode) pill.remove(); }, 300);
+                    }, 3000);
+                })();
+                """
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
+    }
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "vellumBridge")
     }
@@ -492,7 +530,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var pendingScrollRestore: String?
         var hasCapturedSnapshot = false
         var morphGeneration: Int = 0
-
+        var lastReloadGeneration: Int = 0
         init(
             onAction: @escaping (String, Any?) -> Void,
             onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,

--- a/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
@@ -14,10 +14,15 @@ final class VellumAppSchemeHandler: NSObject, WKURLSchemeHandler {
     /// Base directory for shared app content.
     private let baseDirectory: URL
 
+    /// Base directory for user-created app content.
+    static var userAppsDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum/workspace/data/apps")
+    }
+
     init(baseDirectory: URL = BundleSandbox.sharedAppsDirectory) {
         self.baseDirectory = baseDirectory
     }
-
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
         guard let url = urlSchemeTask.request.url else {
             fail(urlSchemeTask, statusCode: 400, message: "No URL in request")
@@ -33,29 +38,45 @@ final class VellumAppSchemeHandler: NSObject, WKURLSchemeHandler {
         let uuid = host
         let resourcePath = url.path.hasPrefix("/") ? String(url.path.dropFirst()) : url.path
 
-        // Resolve the file path in the sandbox
-        let appDir = baseDirectory.appendingPathComponent(uuid)
-        let filePath = resourcePath.isEmpty
-            ? appDir
-            : appDir.appendingPathComponent(resourcePath)
+        // Resolve file path — try user apps directory first, then shared apps.
+        let candidateDirs = [
+            Self.userAppsDirectory.appendingPathComponent(uuid),
+            baseDirectory.appendingPathComponent(uuid)
+        ]
 
-        // Security: ensure the resolved path is within the app directory.
-        // Append "/" to appDirPath so that a sibling like "<uuid>-meta.json"
-        // doesn't match via simple string prefix comparison.
-        let resolvedPath = filePath.standardizedFileURL.path
-        let appDirPath = appDir.standardizedFileURL.path
-        guard resolvedPath == appDirPath || resolvedPath.hasPrefix(appDirPath + "/") else {
-            log.error("Path traversal attempt: \(resolvedPath) outside \(appDirPath)")
-            fail(urlSchemeTask, statusCode: 403, message: "Access denied")
-            return
+        func resolveFile(in appDir: URL) -> (path: String, appDirPath: String)? {
+            let filePath = resourcePath.isEmpty
+                ? appDir
+                : appDir.appendingPathComponent(resourcePath)
+            let resolvedPath = filePath.standardizedFileURL.path
+            let appDirPath = appDir.standardizedFileURL.path
+            // Security: ensure the resolved path is within the app directory.
+            guard resolvedPath == appDirPath || resolvedPath.hasPrefix(appDirPath + "/") else {
+                return nil
+            }
+            guard FileManager.default.fileExists(atPath: resolvedPath) else {
+                return nil
+            }
+            return (resolvedPath, appDirPath)
         }
 
-        // Read the file
-        guard FileManager.default.fileExists(atPath: resolvedPath) else {
+        guard let resolved = candidateDirs.lazy.compactMap({ resolveFile(in: $0) }).first else {
+            // Check if any candidate had a path traversal issue
+            for appDir in candidateDirs {
+                let filePath = resourcePath.isEmpty ? appDir : appDir.appendingPathComponent(resourcePath)
+                let resolvedPath = filePath.standardizedFileURL.path
+                let appDirPath = appDir.standardizedFileURL.path
+                if resolvedPath != appDirPath && !resolvedPath.hasPrefix(appDirPath + "/") {
+                    log.error("Path traversal attempt: \(resolvedPath) outside \(appDirPath)")
+                    fail(urlSchemeTask, statusCode: 403, message: "Access denied")
+                    return
+                }
+            }
             fail(urlSchemeTask, statusCode: 404, message: "File not found: \(resourcePath)")
             return
         }
 
+        let resolvedPath = resolved.path
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: resolvedPath)) else {
             fail(urlSchemeTask, statusCode: 500, message: "Failed to read file")
             return

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -240,14 +240,18 @@ public struct DynamicPageSurfaceData: Sendable {
     public let appId: String?
     public let appType: String?
     public let preview: DynamicPagePreview?
+    public let reloadGeneration: Int?
+    public let status: String?
 
-    public init(html: String, width: Int? = nil, height: Int? = nil, appId: String? = nil, appType: String? = nil, preview: DynamicPagePreview? = nil) {
+    public init(html: String, width: Int? = nil, height: Int? = nil, appId: String? = nil, appType: String? = nil, preview: DynamicPagePreview? = nil, reloadGeneration: Int? = nil, status: String? = nil) {
         self.html = html
         self.width = width
         self.height = height
         self.appId = appId
         self.appType = appType
         self.preview = preview
+        self.reloadGeneration = reloadGeneration
+        self.status = status
     }
 }
 
@@ -596,9 +600,10 @@ public extension Surface {
         let preview: DynamicPagePreview? = update.keys.contains("preview")
             ? parseDynamicPagePreview(update["preview"] as? [String: Any?])
             : existing.preview
-        return DynamicPageSurfaceData(html: html, width: width, height: height, appId: appId, appType: appType, preview: preview)
+        let reloadGeneration: Int? = update.keys.contains("reloadGeneration") ? (update["reloadGeneration"] as? Int) : existing.reloadGeneration
+        let status: String? = update.keys.contains("status") ? (update["status"] as? String) : existing.status
+        return DynamicPageSurfaceData(html: html, width: width, height: height, appId: appId, appType: appType, preview: preview, reloadGeneration: reloadGeneration, status: status)
     }
-
     // MARK: - Field Parsing Helpers
 
     private static func parseFormFields(_ fieldsArray: [[String: Any?]]) -> [FormField] {
@@ -759,10 +764,11 @@ public extension Surface {
             height: dict["height"] as? Int,
             appId: dict["appId"] as? String,
             appType: dict["appType"] as? String,
-            preview: parseDynamicPagePreview(dict["preview"] as? [String: Any?])
+            preview: parseDynamicPagePreview(dict["preview"] as? [String: Any?]),
+            reloadGeneration: dict["reloadGeneration"] as? Int,
+            status: dict["status"] as? String
         )
     }
-
     private static func parseDynamicPagePreview(_ dict: [String: Any?]?) -> DynamicPagePreview? {
         guard let dict = dict, let title = dict["title"] as? String else { return nil }
         var metrics: [(label: String, value: String)]?


### PR DESCRIPTION
## Summary
- Extends `VellumAppSchemeHandler` to serve files from both shared apps and user-created apps (`~/.vellum/workspace/data/apps/`)
- Adds `reloadGeneration` and `status` fields to `DynamicPageSurfaceData` for live reload and progress display
- Loads app-backed surfaces via `vellumapp://` scheme URL instead of inline HTML
- Shows transient status pill overlay when the assistant is editing app files

Closes #3269

## Test plan
- [ ] Build passes (`./build.sh`)
- [ ] Create an app → loads via `vellumapp://` scheme
- [ ] Edit app files → WebView reloads on `reloadGeneration` change
- [ ] Status messages appear as floating pill at bottom of WebView

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
