### PR TITLE
fix: correct app_update field list in SKILL.md (#3275 feedback)

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1200,7 +1200,7 @@ When the user requests changes to an existing app, prefer **`app_file_edit`** ov
 
 #### Metadata vs code changes
 
-- **`app_update`** — use for metadata changes only: `name`, `description`, `icon`, `preview`. Do not use it for code changes.
+- **`app_update`** — use for metadata changes only: `name`, `description`, and `schema_json`. Do not use it for code changes.
 - **`app_file_edit`** / **`app_file_write`** — use for all code changes (HTML, CSS, JS).
 - Call `app_open` after edits to refresh the view.
 - If schema changes affect existing records, mention this.


### PR DESCRIPTION
## Summary
- Removes `icon` and `preview` from `app_update` guidance in SKILL.md
- The `app_update` tool only supports `name`, `description`, and `schema_json` for metadata changes

Addresses review feedback on PR #3275.

## Test plan
- [x] TypeScript typechecks cleanly (`npm run typecheck`)
- [x] SKILL.md accurately reflects `app_update` capabilities per `definitions.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
