### PR TITLE
fix: address review feedback on file-based app PRs (#3271-#3274)

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -76,10 +76,12 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
       '8. Keep your text response to 1 brief sentence confirming what you changed.',
     );
 
-    // File tree with sizes
+    // File tree with sizes (capped at 50 files to bound prompt size)
     const files = ctx.appFiles ?? listAppFiles(ctx.appId);
+    const MAX_FILE_TREE_ENTRIES = 50;
+    const displayFiles = files.slice(0, MAX_FILE_TREE_ENTRIES);
     lines.push('', 'App files:');
-    for (const filePath of files) {
+    for (const filePath of displayFiles) {
       let sizeLabel: string;
       try {
         const bytes = statSync(join(getAppsDir(), ctx.appId, filePath)).size;
@@ -88,6 +90,9 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
         sizeLabel = '? KB';
       }
       lines.push(`  ${filePath} (${sizeLabel})`);
+    }
+    if (files.length > MAX_FILE_TREE_ENTRIES) {
+      lines.push(`  ... and ${files.length - MAX_FILE_TREE_ENTRIES} more files`);
     }
 
     // Schema metadata
@@ -112,7 +117,8 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
 
     // Line-numbered current file content
     const schemaSize = schema ? Math.min(schema.length, MAX_SCHEMA_LENGTH) : 0;
-    let mainBudget = MAX_CONTEXT_LENGTH - schemaSize;
+    // Reduce budget by 15% to account for line-number prefix overhead (~7 chars/line)
+    let mainBudget = Math.floor((MAX_CONTEXT_LENGTH - schemaSize) * 0.85);
     const additionalPageBlocks: string[] = [];
 
     // Build additional page content (all pages except the primary one)

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -257,7 +257,7 @@ export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string,
       ...data,
       html: app.htmlDefinition,
       ...(opts?.fileChange ? { reloadGeneration: (data.reloadGeneration ?? 0) + 1 } : {}),
-      status: opts?.status,
+      ...(opts?.status !== undefined ? { status: opts.status } : {}),
     };
     stored.data = updatedData;
 

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -242,6 +242,15 @@ export function updateApp(
     writeFileSync(join(appDir, 'index.html'), htmlUpdate, 'utf-8');
   }
 
+  // Backfill migration: if index.html doesn't exist yet (pre-migration app), write it
+  // before stripping htmlDefinition from JSON to prevent data loss on metadata-only updates.
+  const indexPath = join(getAppsDir(), id, 'index.html');
+  if (!existsSync(indexPath) && updated.htmlDefinition) {
+    const appDir = join(getAppsDir(), id);
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(indexPath, updated.htmlDefinition, 'utf-8');
+  }
+
   // Don't persist htmlDefinition or pages in the JSON file — they live as separate files
   const { pages: _existingPages, htmlDefinition: _html, ...jsonDef } = updated;
   writeFileSync(join(getAppsDir(), `${id}.json`), JSON.stringify(jsonDef, null, 2));

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -502,6 +502,10 @@ export const appFileEditTool: Tool = {
     const newString = input.new_string as string;
     const replaceAll = (input.replace_all as boolean | undefined) ?? false;
 
+    if (!oldString) {
+      return { content: 'old_string must not be empty', isError: true };
+    }
+
     const result = appStore.editAppFile(appId, path, oldString, newString, replaceAll);
     return { content: JSON.stringify(result), isError: false };
   },
@@ -552,6 +556,11 @@ export const appFileWriteTool: Tool = {
     const appId = input.app_id as string;
     const path = input.path as string;
     const content = input.content as string;
+
+    const app = appStore.getApp(appId);
+    if (!app) {
+      return { content: `App not found: ${appId}`, isError: true };
+    }
 
     appStore.writeAppFile(appId, path, content);
     return { content: JSON.stringify({ written: true, path }), isError: false };


### PR DESCRIPTION
## Summary
- Backfills `index.html` for pre-migration apps during `updateApp()` to prevent HTML data loss
- Guards against empty `old_string` in `app_file_edit` to prevent file corruption
- Validates app existence in `app_file_write` to prevent orphan files
- Fixes `status` field in surface refresh to only set when provided (not unconditionally undefined)
- Caps file-tree context at 50 files and accounts for line-number formatting overhead in budget

Addresses review feedback on PRs #3271, #3272, #3273, #3274.

## Test plan
- [ ] TypeScript builds cleanly (`npm run typecheck`)
- [ ] `updateApp()` with metadata-only update preserves HTML for pre-migration apps
- [ ] `app_file_edit` with empty `old_string` returns error
- [ ] `app_file_write` with invalid app_id returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
