### PR TITLE
fix: backfill index.html on metadata-only updateApp (#3271 feedback)

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -235,20 +235,16 @@ export function updateApp(
   };
 
   // Write htmlDefinition to {appId}/index.html if provided in updates
+  const appDir = join(getAppsDir(), id);
   if (htmlUpdate !== undefined) {
     updated.htmlDefinition = htmlUpdate;
-    const appDir = join(getAppsDir(), id);
     mkdirSync(appDir, { recursive: true });
     writeFileSync(join(appDir, 'index.html'), htmlUpdate, 'utf-8');
-  }
-
-  // Backfill migration: if index.html doesn't exist yet (pre-migration app), write it
-  // before stripping htmlDefinition from JSON to prevent data loss on metadata-only updates.
-  const indexPath = join(getAppsDir(), id, 'index.html');
-  if (!existsSync(indexPath) && updated.htmlDefinition) {
-    const appDir = join(getAppsDir(), id);
+  } else if (!existsSync(join(appDir, 'index.html')) && updated.htmlDefinition) {
+    // Backfill: migrate existing htmlDefinition to index.html before stripping from JSON
+    // to prevent data loss on metadata-only updates of pre-migration apps.
     mkdirSync(appDir, { recursive: true });
-    writeFileSync(indexPath, updated.htmlDefinition, 'utf-8');
+    writeFileSync(join(appDir, 'index.html'), updated.htmlDefinition, 'utf-8');
   }
 
   // Don't persist htmlDefinition or pages in the JSON file — they live as separate files


### PR DESCRIPTION
## Summary
- Restructures the backfill migration logic in `updateApp` as an `else if` branch instead of a separate conditional block
- Prevents data loss when `updateApp` is called without `htmlDefinition` on pre-migration apps by migrating existing `htmlDefinition` to `index.html` before stripping it from JSON
- Addresses review feedback on PR #3271

## Test plan
- [ ] Call `updateApp` with only metadata updates (no `htmlDefinition`) on a pre-migration app that has `htmlDefinition` in JSON but no `index.html` file — verify `index.html` is created
- [ ] Call `updateApp` with `htmlDefinition` — verify `index.html` is written as before
- [ ] Call `updateApp` on an app that already has `index.html` — verify no redundant writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
