### PR TITLE
fix: app_file_edit/write status forwarding, validation (#3272 feedback)

### DIFF
--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -503,11 +503,12 @@ export const appFileEditTool: Tool = {
     const replaceAll = (input.replace_all as boolean | undefined) ?? false;
 
     if (!oldString) {
-      return { content: 'old_string must not be empty', isError: true };
+      return { content: JSON.stringify({ error: 'old_string must not be empty' }), isError: true };
     }
 
+    const status = input.status as string | undefined;
     const result = appStore.editAppFile(appId, path, oldString, newString, replaceAll);
-    return { content: JSON.stringify(result), isError: false };
+    return { content: JSON.stringify(result), isError: false, status };
   },
 };
 
@@ -559,11 +560,12 @@ export const appFileWriteTool: Tool = {
 
     const app = appStore.getApp(appId);
     if (!app) {
-      return { content: `App not found: ${appId}`, isError: true };
+      return { content: JSON.stringify({ error: `App '${appId}' not found` }), isError: true };
     }
 
+    const status = input.status as string | undefined;
     appStore.writeAppFile(appId, path, content);
-    return { content: JSON.stringify({ written: true, path }), isError: false };
+    return { content: JSON.stringify({ written: true, path }), isError: false, status };
   },
 };
 


### PR DESCRIPTION
## Summary
- Forward `status` input param in `ToolExecutionResult` for both `app_file_edit` and `app_file_write`
- Validate app ID exists in `app_file_write` with JSON-formatted error response
- Return JSON-formatted error for empty `old_string` in `app_file_edit`

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify `app_file_edit` returns `status` in result when provided
- [ ] Verify `app_file_write` returns `status` in result when provided
- [ ] Verify `app_file_write` returns error for non-existent app ID
- [ ] Verify `app_file_edit` returns error for empty `old_string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
