### PR TITLE
fix: context budget for line-number overhead and file-tree cap (#3274/#3278 feedback)

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -143,7 +143,7 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
       if (additionalSize + primaryContent.length > MAX_CONTEXT_LENGTH - schemaSize) {
         additionalPageBlocks.length = 0;
       } else {
-        mainBudget = MAX_CONTEXT_LENGTH - schemaSize - additionalSize;
+        mainBudget = Math.floor((MAX_CONTEXT_LENGTH - schemaSize - additionalSize) * 0.85);
       }
     }
 


### PR DESCRIPTION
## Summary
- Apply the 0.85 line-number overhead factor consistently when `mainBudget` is reassigned for additional pages (line 146). Previously only the initial assignment (line 121) applied the factor, meaning multi-page apps could exceed the intended context budget.
- File-tree cap (50 entries) was already addressed in PR #3278 — no additional change needed there.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm multi-page app context stays within budget when additional pages are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
