### PR TITLE
fix: DynamicPageSurfaceView reload/status fixes (#3273/#3276 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -416,6 +416,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             context.coordinator.lastReloadGeneration = gen
             context.coordinator.hasCapturedSnapshot = false
             webView.reload()
+            return
         }
         // Reload if the HTML content has changed.
         if data.html != context.coordinator.currentHTML {
@@ -480,11 +481,13 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         }
 
         // Show transient status pill overlay
-        if let status = data.status {
+        if let status = data.status, status != context.coordinator.lastStatus {
+            context.coordinator.lastStatus = status
             let escapedStatus = status
                 .replacingOccurrences(of: "\\", with: "\\\\")
                 .replacingOccurrences(of: "'", with: "\\'")
                 .replacingOccurrences(of: "\n", with: " ")
+                .replacingOccurrences(of: "\r", with: " ")
             let js = """
                 (function() {
                     var existing = document.getElementById('vellum-status-pill');
@@ -503,6 +506,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 })();
                 """
             webView.evaluateJavaScript(js, completionHandler: nil)
+        } else if data.status == nil {
+            context.coordinator.lastStatus = nil
         }
     }
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
@@ -531,6 +536,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var hasCapturedSnapshot = false
         var morphGeneration: Int = 0
         var lastReloadGeneration: Int = 0
+        var lastStatus: String?
         init(
             onAction: @escaping (String, Any?) -> Void,
             onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,


### PR DESCRIPTION
## Summary
- **Early return after reload**: When `reloadGeneration` changes and `webView.reload()` fires, add `return` so the inline HTML-diff/morph path doesn't run with the wrong base URL, which breaks asset loading for `vellumapp://` scheme apps.
- **Track `lastStatus` in Coordinator**: Only inject the status pill when the status text actually changes, preventing re-injection on every SwiftUI update cycle and letting the 3-second auto-dismiss timer work correctly.
- **Add `\r` escaping for status pill**: Matches the escaping pattern used everywhere else in the file (confirmId, scrollJSON, callId, error strings).
- **Reset `lastStatus` on nil**: When status is cleared, reset the tracker so the next status change is properly detected.

Note: Items 1 and 5 from the task (adding `reloadGeneration`/`status` to `DynamicPageSurfaceData` and merge handling) were already implemented in the codebase.

## Test plan
- [ ] Verify file-based apps reload correctly without broken asset URLs
- [ ] Verify status pill shows once and auto-dismisses after 3 seconds
- [ ] Verify status pill updates when text changes
- [ ] Verify status pill reappears after being cleared and set again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
