### PR TITLE
fix: defer status pill injection after webView reload (#3282 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -415,6 +415,11 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         if let gen = data.reloadGeneration, gen != context.coordinator.lastReloadGeneration {
             context.coordinator.lastReloadGeneration = gen
             context.coordinator.hasCapturedSnapshot = false
+            // Stash any simultaneous status change for injection after reload completes
+            if let status = data.status, status != context.coordinator.lastStatus {
+                context.coordinator.pendingStatus = status
+                context.coordinator.lastStatus = status
+            }
             webView.reload()
             return
         }
@@ -537,6 +542,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var morphGeneration: Int = 0
         var lastReloadGeneration: Int = 0
         var lastStatus: String?
+        /// Status message to inject after the next page reload completes.
+        var pendingStatus: String?
         init(
             onAction: @escaping (String, Any?) -> Void,
             onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,
@@ -814,6 +821,34 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     })();
                     """
                 webView.evaluateJavaScript(js, completionHandler: nil)
+            }
+
+            // Inject deferred status pill that was stashed during a reload.
+            if let status = pendingStatus {
+                pendingStatus = nil
+                let escapedStatus = status
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "'", with: "\\'")
+                    .replacingOccurrences(of: "\n", with: " ")
+                    .replacingOccurrences(of: "\r", with: " ")
+                let pillJS = """
+                    (function() {
+                        var existing = document.getElementById('vellum-status-pill');
+                        if (existing) existing.remove();
+                        var pill = document.createElement('div');
+                        pill.id = 'vellum-status-pill';
+                        pill.setAttribute('data-vellum-injected', '1');
+                        pill.textContent = '\(escapedStatus)';
+                        pill.style.cssText = 'position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.75);color:#fff;font-size:12px;padding:6px 14px;border-radius:20px;z-index:100000;pointer-events:none;opacity:0;transition:opacity 0.3s ease;backdrop-filter:blur(8px);font-family:-apple-system,BlinkMacSystemFont,sans-serif;';
+                        document.body.appendChild(pill);
+                        requestAnimationFrame(function() { pill.style.opacity = '1'; });
+                        setTimeout(function() {
+                            pill.style.opacity = '0';
+                            setTimeout(function() { if (pill.parentNode) pill.remove(); }, 300);
+                        }, 3000);
+                    })();
+                    """
+                webView.evaluateJavaScript(pillJS, completionHandler: nil)
             }
 
             // Detect page changes from URL-based navigation (e.g. <a href="settings.html">).


### PR DESCRIPTION
## Summary
When `reloadGeneration` and `status` change simultaneously (e.g., after `app_file_edit`), the early return after `webView.reload()` skipped status pill injection, silently dropping the status message.

Fix: stash the pending status in the Coordinator and inject it in `didFinish` after the reload completes.

- Added `pendingStatus` property to Coordinator
- On reload with simultaneous status change, store status as pending
- In `webView(_:didFinish:)`, inject the status pill from pending status

## Test plan
- [ ] Edit a file-based app (triggers both reloadGeneration bump and status)
- [ ] Verify status pill appears after the page reloads
- [ ] Verify status pill still auto-dismisses after 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
