### PR TITLE
chore: regenerate IPC Swift bindings

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -280,6 +280,8 @@ public struct IPCDynamicPageSurfaceData: Codable, Sendable {
     public let height: Int?
     public let appId: String?
     public let appType: String?
+    public let reloadGeneration: Double?
+    public let status: String?
     public let preview: IPCDynamicPagePreview?
 }
 


### PR DESCRIPTION
## Summary
- Regenerated `IPCContractGenerated.swift` to include `reloadGeneration` and `status` fields on `IPCDynamicPageSurfaceData`
- These fields were added to the TypeScript IPC contract in recent PRs but the Swift bindings were not regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
