### PR TITLE
fix: remove unused vars in session-runtime-assembly

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Message } from '../providers/types.js';
-import { listAppFiles, readAppFile, getAppsDir } from '../memory/app-store.js';
+import { listAppFiles, getAppsDir } from '../memory/app-store.js';
 import { statSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -106,7 +106,6 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
     }
 
     // Determine which file content to show based on the currently viewed page
-    const pageNames = ctx.appPages ? Object.keys(ctx.appPages) : [];
     const viewingPage = ctx.currentPage && ctx.currentPage !== 'index.html' ? ctx.currentPage : null;
     let primaryLabel = 'index.html';
     let primaryContent = ctx.html;


### PR DESCRIPTION
## Summary
- Remove unused `readAppFile` import from `session-runtime-assembly.ts`
- Remove unused `pageNames` variable assignment

Fixes CI lint failure (`@typescript-eslint/no-unused-vars`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
