### PR TITLE
refactor: make ConversationBubble and BouncingDots internal

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -163,19 +163,6 @@ private struct MessageBubble: View {
     }
 }
 
-// MARK: - Conditional Modifier
-
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}
-
 // MARK: - Typing Indicator
 
 private struct TypingIndicator: View {

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -252,7 +252,7 @@ struct TextResponseView: View {
 
 // MARK: - Conversation Bubble
 
-private struct ConversationBubble: View {
+struct ConversationBubble: View {
     let message: ConversationMessage
 
     private var isAssistant: Bool { message.role == .assistant }
@@ -319,7 +319,7 @@ private struct ConversationBubble: View {
 
 // MARK: - Bouncing Dots
 
-private struct BouncingDots: View {
+struct BouncingDots: View {
     @State private var phase: Int = 0
     @State private var timer: Timer?
 
@@ -347,7 +347,7 @@ private struct BouncingDots: View {
 
 // MARK: - Conditional Modifier
 
-private extension View {
+extension View {
     @ViewBuilder
     func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
         if condition {


### PR DESCRIPTION
Part of #3291. Makes ConversationBubble, BouncingDots, and the View.if modifier internal (was private) so they can be reused by WorkspaceActivityFeed. Also removes the duplicate View.if extension from InterviewChatView. Closes #3292.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
