### PR TITLE
fix: show confirmation panel in workspace mode

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -367,12 +367,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupToolConfirmationManager() {
         daemonClient.onConfirmationRequest = { [weak self] msg in
-            // Only suppress the floating panel when the main chat window is visible
-            // AND the app is active (frontmost). NSWindow.isVisible returns true even
-            // when the window is behind other apps, so we must also check NSApp.isActive
-            // to avoid silently dropping confirmations when the user can't see the inline UI.
-            guard self?.mainWindow?.isVisible != true || !NSApp.isActive else { return }
-            self?.toolConfirmationManager.showConfirmation(msg)
+            guard let self else { return }
+            let mainWindowVisible = self.mainWindow?.isVisible == true && NSApp.isActive
+            let workspaceExpanded = self.mainWindow?.windowState.isDynamicExpanded == true
+            // Show floating panel when window not visible OR workspace is expanded
+            // (in workspace mode the chat is hidden behind the surface)
+            if !mainWindowVisible || workspaceExpanded {
+                self.toolConfirmationManager.showConfirmation(msg)
+            }
         }
         toolConfirmationManager.onResponse = { [weak self] requestId, decision in
             guard let self else { return false }


### PR DESCRIPTION
Part of #3291. The floating confirmation panel was suppressed when the main window was visible, but in workspace mode the chat (where inline confirmations appear) is hidden behind the surface. Now also shows the floating panel when workspace is expanded. Closes #3295.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
