### PR TITLE
fix: ensure assistant responds with text after tool execution

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -69,6 +69,7 @@ export class AgentLoop {
   ): Promise<Message[]> {
     const history = [...messages];
     let toolUseTurns = 0;
+    let nudgedForEmptyResponse = false;
     const debug = isDebug();
     const rlog = requestId ? log.child({ requestId }) : log;
 
@@ -192,6 +193,29 @@ export class AgentLoop {
         );
 
         if (toolUseBlocks.length === 0 || !this.toolExecutor) {
+          // Check if the LLM returned no text after tool results — nudge it to respond
+          const hasTextBlock = response.content.some(
+            (block) => block.type === 'text' && block.text.trim().length > 0,
+          );
+          const lastUserMsg = history.length >= 2 ? history[history.length - 2] : undefined;
+          const lastWasToolResult =
+            lastUserMsg?.role === 'user' &&
+            lastUserMsg.content.some((block) => block.type === 'tool_result');
+
+          if (!hasTextBlock && lastWasToolResult && !nudgedForEmptyResponse) {
+            nudgedForEmptyResponse = true;
+            history.push({
+              role: 'user',
+              content: [
+                {
+                  type: 'text',
+                  text: '<system_notice>You executed tools but didn\'t tell the user what happened. Provide a brief, conversational summary of the results.</system_notice>',
+                },
+              ],
+            });
+            continue;
+          }
+
           // No tool calls or no executor — done
           break;
         }

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -62,6 +62,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildSystemPermissionSection());
   parts.push(buildSwarmGuidanceSection());
   parts.push(buildWorkspaceReflectionSection());
+  parts.push(buildPostToolResponseSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
 }
@@ -258,6 +259,16 @@ function buildWorkspaceReflectionSection(): string {
     '- Did you adapt your style in a way that worked well and should persist?',
     '',
     'If yes, briefly explain what you\'re updating, then update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response.',
+  ].join('\n');
+}
+
+function buildPostToolResponseSection(): string {
+  return [
+    '## Post-Tool Response',
+    '',
+    'After executing tools, ALWAYS provide a brief text response to the user summarizing what you found or did.',
+    'Never end your turn with only tool calls and no text. The user needs to know what happened.',
+    'Keep your summary concise and conversational.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -37,17 +37,32 @@ export async function handleRideShotgunStart(
   };
 
   watchSessions.set(watchId, session);
+  log.info(
+    { watchId, sessionId, durationSeconds, intervalSeconds },
+    '[SHOTGUN-DEBUG] Session created and stored in watchSessions map',
+  );
 
   // Set timeout for duration expiry — generate summary before firing notifier
   session.timeoutHandle = setTimeout(async () => {
     session.status = 'completing';
     session.timeoutHandle = undefined;
-    log.info({ watchId }, 'Ride shotgun session duration expired, generating summary');
+    log.info(
+      { watchId, sessionId, observationCount: session.observations.length },
+      '[SHOTGUN-DEBUG] Duration timer fired — session completing. Generating summary...',
+    );
     await generateSummary(session);
     session.status = 'completed';
+    log.info(
+      { watchId, sessionId, hasSummary: lastSummaryBySession.has(sessionId) },
+      '[SHOTGUN-DEBUG] generateSummary returned. Checking if completion notifier needs fallback fire.',
+    );
     // Fallback: if generateSummary failed or returned empty, fire notifier
     // anyway so the client always receives a response
     if (!lastSummaryBySession.has(sessionId)) {
+      log.warn(
+        { watchId, sessionId },
+        '[SHOTGUN-DEBUG] No summary in map — firing completion notifier as fallback (will send empty summary)',
+      );
       fireWatchCompletionNotifier(sessionId, session);
     }
   }, durationSeconds * 1000);
@@ -56,6 +71,11 @@ export async function handleRideShotgunStart(
   registerWatchCompletionNotifier(sessionId, (_completedSession: WatchSession) => {
     const summary = lastSummaryBySession.get(sessionId) ?? '';
     const observationCount = _completedSession.observations.length;
+
+    log.info(
+      { watchId, sessionId, observationCount, summaryLength: summary.length, socketDestroyed: socket.destroyed },
+      '[SHOTGUN-DEBUG] Completion notifier firing — sending ride_shotgun_result to client',
+    );
 
     ctx.send(socket, {
       type: 'ride_shotgun_result',
@@ -67,13 +87,17 @@ export async function handleRideShotgunStart(
 
     unregisterWatchCompletionNotifier(sessionId);
     lastSummaryBySession.delete(sessionId);
-    log.info({ watchId, sessionId, observationCount }, 'Ride shotgun result sent');
+    log.info({ watchId, sessionId, observationCount }, '[SHOTGUN-DEBUG] Ride shotgun result sent successfully');
   });
 
   // Fire start notifier
   fireWatchStartNotifier(sessionId, session);
 
   // Send watch_started so the Swift client knows the watchId/sessionId
+  log.info(
+    { watchId, sessionId, socketDestroyed: socket.destroyed },
+    '[SHOTGUN-DEBUG] Sending watch_started to client',
+  );
   ctx.send(socket, {
     type: 'watch_started',
     sessionId,
@@ -82,5 +106,5 @@ export async function handleRideShotgunStart(
     intervalSeconds,
   });
 
-  log.info({ watchId, sessionId, durationSeconds, intervalSeconds }, 'Ride shotgun session started');
+  log.info({ watchId, sessionId, durationSeconds, intervalSeconds }, '[SHOTGUN-DEBUG] Ride shotgun session started — waiting for observations');
 }

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -1,5 +1,6 @@
 import type * as net from 'node:net';
 import Anthropic from '@anthropic-ai/sdk';
+import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import type { WatchObservation } from './ipc-protocol.js';
 import type { HandlerContext } from './handlers.js';
@@ -26,16 +27,24 @@ export async function handleWatchObservation(
   _ctx: HandlerContext,
 ): Promise<void> {
   try {
+    log.info(
+      { watchId: msg.watchId, captureIndex: msg.captureIndex, appName: msg.appName, ocrLen: msg.ocrText?.length ?? 0 },
+      '[SHOTGUN-DEBUG] Received watch_observation from client',
+    );
+
     // 1. Find the WatchSession by watchId
     const session = watchSessions.get(msg.watchId);
 
     // 2. If not found or not active (and not completing), log warning and return
     if (!session) {
-      log.warn({ watchId: msg.watchId }, 'Watch session not found for observation');
+      log.warn(
+        { watchId: msg.watchId, knownWatchIds: [...watchSessions.keys()] },
+        '[SHOTGUN-DEBUG] Watch session not found for observation — known watchIds listed',
+      );
       return;
     }
     if (session.status !== 'active' && session.status !== 'completing') {
-      log.warn({ watchId: msg.watchId, status: session.status }, 'Watch session not active');
+      log.warn({ watchId: msg.watchId, status: session.status }, '[SHOTGUN-DEBUG] Watch session not active');
       return;
     }
 
@@ -49,25 +58,40 @@ export async function handleWatchObservation(
       captureIndex: msg.captureIndex,
     };
     addObservation(msg.watchId, entry);
+    log.info(
+      { watchId: msg.watchId, totalObservations: session.observations.length, status: session.status },
+      '[SHOTGUN-DEBUG] Observation added to session',
+    );
 
     // 4. Every 3 observations: call Haiku for live commentary
     if (session.observations.length % 3 === 0) {
+      log.info(
+        { watchId: msg.watchId, observationCount: session.observations.length },
+        '[SHOTGUN-DEBUG] Triggering commentary generation (every 3rd observation)',
+      );
       await generateCommentary(session);
     }
 
     // 5. If session is completing, generate final summary
     if (session.status === 'completing') {
+      log.info({ watchId: msg.watchId }, '[SHOTGUN-DEBUG] Session is completing — generating summary from observation handler');
       session.status = 'completed';
       await generateSummary(session);
     }
   } catch (err) {
-    log.error({ err, watchId: msg.watchId }, 'Error handling watch observation');
+    log.error({ err, watchId: msg.watchId }, '[SHOTGUN-DEBUG] Error handling watch observation');
   }
 }
 
 async function generateCommentary(session: WatchSession): Promise<void> {
   try {
-    const client = new Anthropic();
+    log.info({ watchId: session.watchId, sessionId: session.sessionId }, '[SHOTGUN-DEBUG] generateCommentary starting — calling Haiku');
+    const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      log.warn({ watchId: session.watchId }, '[SHOTGUN-DEBUG] No Anthropic API key available for commentary generation');
+      return;
+    }
+    const client = new Anthropic({ apiKey });
     const lastThree = session.observations.slice(-3);
 
     const previousCommentary = lastCommentaryBySession.get(session.sessionId);
@@ -112,23 +136,45 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       messages: [{ role: 'user', content: userContent }],
     });
 
+    log.info({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Haiku API call completed successfully');
+
     const textBlock = response.content.find((b) => b.type === 'text');
     const commentaryText =
       textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+
+    log.info(
+      { watchId: session.watchId, commentaryText: commentaryText.substring(0, 100), isSkip: commentaryText === 'SKIP' },
+      '[SHOTGUN-DEBUG] Commentary result from Haiku',
+    );
 
     if (commentaryText && commentaryText !== 'SKIP') {
       lastCommentaryBySession.set(session.sessionId, commentaryText);
       fireWatchCommentaryNotifier(session.sessionId, session);
       session.commentaryCount++;
+      log.info(
+        { watchId: session.watchId, commentaryCount: session.commentaryCount },
+        '[SHOTGUN-DEBUG] Commentary notifier fired',
+      );
+    } else {
+      log.info({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Commentary skipped (empty or SKIP)');
     }
   } catch (err) {
-    log.error({ err, watchId: session.watchId }, 'Error generating watch commentary');
+    log.error({ err, watchId: session.watchId }, '[SHOTGUN-DEBUG] Error generating watch commentary — API call failed');
   }
 }
 
 export async function generateSummary(session: WatchSession): Promise<void> {
   try {
-    const client = new Anthropic();
+    log.info(
+      { watchId: session.watchId, sessionId: session.sessionId, observationCount: session.observations.length, commentaryCount: session.commentaryCount },
+      '[SHOTGUN-DEBUG] generateSummary starting — calling Sonnet',
+    );
+    const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      log.warn({ watchId: session.watchId }, '[SHOTGUN-DEBUG] No Anthropic API key available for summary generation');
+      return;
+    }
+    const client = new Anthropic({ apiKey });
 
     // Build observations text with truncation (keep most recent if >50K chars)
     let observations = session.observations;
@@ -210,15 +256,25 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       messages: [{ role: 'user', content: userContent }],
     });
 
+    log.info({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Sonnet API call completed successfully');
+
     const textBlock = response.content.find((b) => b.type === 'text');
     const summaryText =
       textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
 
+    log.info(
+      { watchId: session.watchId, summaryLength: summaryText.length, summaryPreview: summaryText.substring(0, 150) },
+      '[SHOTGUN-DEBUG] Summary result from Sonnet',
+    );
+
     if (summaryText) {
       lastSummaryBySession.set(session.sessionId, summaryText);
+      log.info({ watchId: session.watchId, sessionId: session.sessionId }, '[SHOTGUN-DEBUG] Firing completion notifier with summary');
       fireWatchCompletionNotifier(session.sessionId, session);
+    } else {
+      log.warn({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Summary was empty — completion notifier NOT fired');
     }
   } catch (err) {
-    log.error({ err, watchId: session.watchId }, 'Error generating watch summary');
+    log.error({ err, watchId: session.watchId }, '[SHOTGUN-DEBUG] Error generating watch summary — Sonnet API call failed');
   }
 }

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -115,11 +115,14 @@ public final class AmbientAgent: ObservableObject {
     }
 
     private func handleSessionStateChange(_ state: RideShotgunSession.State) {
+        log.info("[SHOTGUN-DEBUG] handleSessionStateChange: \(String(describing: state))")
         switch state {
         case .complete:
             progressWindow?.close()
             progressWindow = nil
+            let hasSession = currentSession != nil
             let summary = currentSession?.summary ?? ""
+            log.info("[SHOTGUN-DEBUG] Session complete: hasSession=\(hasSession) summaryLength=\(summary.count) summaryPreview=\(summary.prefix(200))")
             showSummary(summary.isEmpty
                 ? "I watched your screen but wasn't able to generate a report. This can happen if the analysis timed out or there was an API error."
                 : summary)

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -67,12 +67,14 @@ public final class RideShotgunSession: ObservableObject {
 
         // Send ride_shotgun_start to daemon
         do {
+            log.info("[SHOTGUN-DEBUG] Sending ride_shotgun_start to daemon")
             try daemonClient.send(RideShotgunStartMessage(
                 durationSeconds: Double(durationSeconds),
                 intervalSeconds: Double(intervalSeconds)
             ))
+            log.info("[SHOTGUN-DEBUG] ride_shotgun_start sent successfully")
         } catch {
-            log.error("Failed to send ride_shotgun_start: \(error.localizedDescription)")
+            log.error("[SHOTGUN-DEBUG] Failed to send ride_shotgun_start: \(error.localizedDescription)")
             state = .failed("Failed to start session")
             cleanup()
         }
@@ -88,8 +90,12 @@ public final class RideShotgunSession: ObservableObject {
     // MARK: - Private
 
     private func handleWatchStarted(_ message: WatchStartedMessage, daemonClient: DaemonClient) {
-        guard state == .starting else { return }
+        guard state == .starting else {
+            log.warning("[SHOTGUN-DEBUG] Received watch_started but state is \(String(describing: self.state)), ignoring")
+            return
+        }
 
+        log.info("[SHOTGUN-DEBUG] Received watch_started: watchId=\(message.watchId) sessionId=\(message.sessionId)")
         expectedWatchId = message.watchId
 
         let session = WatchSession(
@@ -124,9 +130,13 @@ public final class RideShotgunSession: ObservableObject {
     }
 
     private func handleRideShotgunResult(_ result: RideShotgunResultMessage) {
-        guard state == .capturing || state == .summarizing else { return }
+        log.info("[SHOTGUN-DEBUG] Received ride_shotgun_result: watchId=\(result.watchId) observationCount=\(result.observationCount) summaryLength=\(result.summary.count)")
+        guard state == .capturing || state == .summarizing else {
+            log.warning("[SHOTGUN-DEBUG] Ignoring ride_shotgun_result — state is \(String(describing: self.state)), expected capturing or summarizing")
+            return
+        }
         guard result.watchId == expectedWatchId else {
-            log.warning("Ignoring ride_shotgun_result for unexpected watchId=\(result.watchId)")
+            log.warning("[SHOTGUN-DEBUG] Ignoring ride_shotgun_result — watchId mismatch: got \(result.watchId), expected \(self.expectedWatchId ?? "nil")")
             return
         }
 
@@ -134,7 +144,7 @@ public final class RideShotgunSession: ObservableObject {
         observationCount = result.observationCount
         state = .complete
 
-        log.info("Ride shotgun session complete: \(result.observationCount) observations")
+        log.info("[SHOTGUN-DEBUG] Ride shotgun session complete: \(result.observationCount) observations, summary=\(result.summary.prefix(150))")
         cleanup()
     }
 

--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -105,16 +105,19 @@ public final class WatchSession: ObservableObject {
 
             // Skip empty content
             guard !screenContent.isEmpty else {
+                log.info("[SHOTGUN-DEBUG] Screen content empty — skipping observation")
                 try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
                 continue
             }
 
             // Similarity check - skip if >85% similar to previous capture
-            if ScreenOCR.similarity(screenContent, previousOcrText) > 0.85 {
-                log.debug("Screen unchanged (similarity > 0.85) - skipping observation")
+            let similarity = ScreenOCR.similarity(screenContent, previousOcrText)
+            if similarity > 0.85 {
+                log.info("[SHOTGUN-DEBUG] Screen unchanged (similarity=\(String(format: "%.2f", similarity))) — skipping observation \(appName)")
                 try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
                 continue
             }
+            log.info("[SHOTGUN-DEBUG] Screen changed (similarity=\(String(format: "%.2f", similarity))) — will send observation for \(appName)")
             previousOcrText = screenContent
 
             captureCount += 1
@@ -133,10 +136,12 @@ public final class WatchSession: ObservableObject {
             )
 
             do {
+                let hasDaemon = daemonClient != nil
+                log.info("[SHOTGUN-DEBUG] Sending observation \(self.captureCount)/\(self.totalExpected) watchId=\(self.watchId) hasDaemon=\(hasDaemon) ocrLen=\(screenContent.count)")
                 try daemonClient?.send(observation)
-                log.info("Sent watch observation \(self.captureCount)/\(self.totalExpected) for \(appName)")
+                log.info("[SHOTGUN-DEBUG] Observation \(self.captureCount) sent successfully for \(appName)")
             } catch {
-                log.warning("Failed to send watch observation: \(error.localizedDescription)")
+                log.error("[SHOTGUN-DEBUG] Failed to send watch observation: \(error.localizedDescription)")
             }
 
             try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)


### PR DESCRIPTION
## Summary
- Added system prompt instruction requiring the assistant to always provide a text response after using tools
- Added agent loop safety net that detects when the LLM stops after tool results without text and nudges it to respond

Fixes #3300
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
