### PR TITLE
fix: clean up refinement preview properties in all completion paths

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -997,15 +997,16 @@ public final class ChatViewModel: ObservableObject {
                     let text = refinementTextBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !text.isEmpty {
                         refinementStreamingText = text
-                        // Keep refinementFailureText for backward compat (M3 will remove usage)
                         refinementFailureText = text
-                        refinementFailureDismissTask?.cancel()
-                        refinementFailureDismissTask = Task { [weak self] in
-                            try? await Task.sleep(nanoseconds: 8_000_000_000)
-                            guard let self, !Task.isCancelled else { return }
-                            self.refinementFailureText = nil
-                        }
+                    } else {
+                        // Buffer was only whitespace — clean up
+                        refinementMessagePreview = nil
+                        refinementStreamingText = nil
                     }
+                } else {
+                    // No surface update and no text — clean up
+                    refinementMessagePreview = nil
+                    refinementStreamingText = nil
                 }
                 refinementTextBuffer = ""
                 refinementReceivedSurfaceUpdate = false


### PR DESCRIPTION
## Summary
- Ensures `refinementMessagePreview` and `refinementStreamingText` are cleared in all `messageComplete` paths for refinements
- Adds `else` branch for whitespace-only text buffer to clean up preview properties
- Adds fallthrough `else` branch for no-text-no-surface-update case
- Removes stale 8-second auto-dismiss task that only cleared `refinementFailureText` but not the preview properties

Addresses feedback on #3298.

## Test plan
- [x] Build compiles successfully
- [ ] Verify refinement completion with surface update auto-dismisses preview after 2s
- [ ] Verify refinement completion with empty/whitespace text clears preview immediately
- [ ] Verify refinement completion with no text and no surface update clears preview immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
