### PR TITLE
feat: broadcast app_files_changed for cross-session webview reload

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -955,6 +955,10 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     success: true,
     accountInfo: 'user@gmail.com',
   },
+  app_files_changed: {
+    type: 'app_files_changed',
+    appId: 'app-001',
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -609,6 +609,11 @@ export interface UnpublishPageResponse {
   error?: string;
 }
 
+export interface AppFilesChanged {
+  type: 'app_files_changed';
+  appId: string;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -1499,7 +1504,8 @@ export type ServerMessage =
   | IntegrationConnectResult
   | AppUpdatePreviewResponse
   | PublishPageResponse
-  | UnpublishPageResponse;
+  | UnpublishPageResponse
+  | AppFilesChanged;
 
 // === Contract schema ===
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -603,6 +603,7 @@ export class DaemonServer {
           maxTokens,
           rebindClient ? sendToClient : () => {},
           workingDir,
+          (msg) => this.broadcast(msg),
         );
         // When created without a socket (HTTP path), mark the session
         // so interactive prompts (e.g. host attachment reads) can fail

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -107,6 +107,8 @@ export class Session {
   private executor: ToolExecutor;
   /** @internal — exposed for session-surfaces.ts module functions. */
   sendToClient: (msg: ServerMessage) => void;
+  /** Broadcast a message to all connected sockets (not just this session's client). */
+  private broadcastToAllClients?: (msg: ServerMessage) => void;
   private eventBus = new EventBus<AssistantDomainEvents>();
   private workingDir: string;
   private sandboxOverride?: boolean;
@@ -149,12 +151,14 @@ export class Session {
     maxTokens: number,
     sendToClient: (msg: ServerMessage) => void,
     workingDir: string,
+    broadcastToAllClients?: (msg: ServerMessage) => void,
   ) {
     this.conversationId = conversationId;
     this.systemPrompt = systemPrompt;
     this.provider = provider;
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
+    this.broadcastToAllClients = broadcastToAllClients;
     this.traceEmitter = new TraceEmitter(conversationId, sendToClient);
     this.prompter = new PermissionPrompter(sendToClient);
     this.secretPrompter = new SecretPrompter(sendToClient);
@@ -281,6 +285,7 @@ export class Session {
         const appId = input.app_id as string | undefined;
         if (appId) {
           refreshSurfacesForApp(this, appId);
+          this.broadcastToAllClients?.({ type: 'app_files_changed', appId });
         }
       }
 
@@ -290,6 +295,7 @@ export class Session {
         const status = input.status as string | undefined;
         if (appId) {
           refreshSurfacesForApp(this, appId, { fileChange: true, status });
+          this.broadcastToAllClients?.({ type: 'app_files_changed', appId });
         }
       }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -312,6 +312,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.surfaceManager.dismissSurface(msg)
         }
 
+        // Reload webviews for surfaces whose app files changed (cross-session broadcast)
+        daemonClient.onAppFilesChanged = { [weak self] appId in
+            guard let self else { return }
+            for (surfaceId, appSurfaceId) in self.surfaceManager.surfaceAppIds {
+                guard appSurfaceId == appId else { continue }
+                self.surfaceManager.surfaceCoordinators[surfaceId]?.webView?.reload()
+            }
+        }
+
         // Wire SurfaceManager action callback to DaemonClient
         surfaceManager.onAction = { [weak self] sessionId, surfaceId, actionId, data in
             guard let self else { return }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -80,6 +80,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `ui_surface_complete` message.
     public var onSurfaceComplete: ((UiSurfaceCompleteMessage) -> Void)?
 
+    /// Called when the daemon sends an `app_files_changed` broadcast.
+    public var onAppFilesChanged: ((String) -> Void)?
+
     /// Called when the daemon sends an `app_data_response` message.
     public var onAppDataResponse: ((AppDataResponseMessage) -> Void)?
 
@@ -917,6 +920,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSurfaceComplete?(msg)
         case .uiLayoutConfig(let msg):
             onLayoutConfig?(msg)
+        case .appFilesChanged(let msg):
+            onAppFilesChanged?(msg.appId)
         case .appDataResponse(let msg):
             onAppDataResponse?(msg)
         case .messageQueued(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -37,6 +37,11 @@ public struct IPCAppDataResponse: Codable, Sendable {
     public let error: String?
 }
 
+public struct IPCAppFilesChanged: Codable, Sendable {
+    public let type: String
+    public let appId: String
+}
+
 public struct IPCAppOpenRequest: Codable, Sendable {
     public let type: String
     public let appId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1464,6 +1464,7 @@ public enum ServerMessage: Decodable, Sendable {
     case openUrl(OpenUrlMessage)
     case integrationListResponse(IPCIntegrationListResponse)
     case integrationConnectResult(IPCIntegrationConnectResult)
+    case appFilesChanged(AppFilesChangedMessage)
     case getSigningIdentity
     case pong
     case unknown(String)
@@ -1671,6 +1672,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "integration_connect_result":
             let message = try IPCIntegrationConnectResult(from: decoder)
             self = .integrationConnectResult(message)
+        case "app_files_changed":
+            let message = try AppFilesChangedMessage(from: decoder)
+            self = .appFilesChanged(message)
         case "pong":
             self = .pong
         default:
@@ -1678,6 +1682,10 @@ public enum ServerMessage: Decodable, Sendable {
         }
     }
 }
+
+// MARK: - App Files Changed
+
+public typealias AppFilesChangedMessage = IPCAppFilesChanged
 
 // MARK: - Layout Config Wire Types
 // Defined here temporarily; canonical home is LayoutConfig.swift (M1 / #2973)


### PR DESCRIPTION
## Summary
- Add `app_files_changed` server message type across the IPC stack (TS contract, Swift codegen, IPC messages)
- When a session writes/deploys app files, broadcast to all connected clients (not just the originating session)
- macOS client reloads webviews for matching app surfaces on receipt, enabling live cross-session hot-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
