### PR TITLE
fix: remove sensitive screen content from info-level logs

### DIFF
--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -263,7 +263,7 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
 
     log.info(
-      { watchId: session.watchId, summaryLength: summaryText.length, summaryPreview: summaryText.substring(0, 150) },
+      { watchId: session.watchId, summaryLength: summaryText.length },
       '[SHOTGUN-DEBUG] Summary result from Sonnet',
     );
 

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -122,7 +122,7 @@ public final class AmbientAgent: ObservableObject {
             progressWindow = nil
             let hasSession = currentSession != nil
             let summary = currentSession?.summary ?? ""
-            log.info("[SHOTGUN-DEBUG] Session complete: hasSession=\(hasSession) summaryLength=\(summary.count) summaryPreview=\(summary.prefix(200))")
+            log.info("[SHOTGUN-DEBUG] Session complete: hasSession=\(hasSession) summaryLength=\(summary.count)")
             showSummary(summary.isEmpty
                 ? "I watched your screen but wasn't able to generate a report. This can happen if the analysis timed out or there was an API error."
                 : summary)

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -144,7 +144,7 @@ public final class RideShotgunSession: ObservableObject {
         observationCount = result.observationCount
         state = .complete
 
-        log.info("[SHOTGUN-DEBUG] Ride shotgun session complete: \(result.observationCount) observations, summary=\(result.summary.prefix(150))")
+        log.info("[SHOTGUN-DEBUG] Ride shotgun session complete: \(result.observationCount) observations")
         cleanup()
     }
 


### PR DESCRIPTION
## Summary
- Removed `summaryPreview` from ride-shotgun log statements in `watch-handler.ts`, `AmbientAgent.swift`, and `RideShotgunSession.swift`
- OCR-derived screen content could contain sensitive data (messages, credentials, documents) and should not be persisted to log files at info level

Addresses feedback on https://github.com/vellum-ai/vellum-assistant/pull/3302
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
