### PR TITLE
fix: exclude originating socket from app_files_changed broadcast

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -511,8 +511,9 @@ export class DaemonServer {
     }
   }
 
-  broadcast(msg: ServerMessage): void {
+  broadcast(msg: ServerMessage, excludeSocket?: net.Socket): void {
     for (const socket of this.connectedSockets) {
+      if (socket === excludeSocket) continue;
       this.send(socket, msg);
     }
   }
@@ -603,7 +604,7 @@ export class DaemonServer {
           maxTokens,
           rebindClient ? sendToClient : () => {},
           workingDir,
-          (msg) => this.broadcast(msg),
+          (msg) => this.broadcast(msg, socket),
         );
         // When created without a socket (HTTP path), mark the session
         // so interactive prompts (e.g. host attachment reads) can fail


### PR DESCRIPTION
## Summary
- Added `excludeSocket` parameter to `DaemonServer.broadcast()` 
- Pass the originating session's socket to the broadcast callback so it's excluded
- Prevents double webview reload (targeted `ui_surface_update` + redundant `app_files_changed` broadcast) on the originating client

Addresses feedback on https://github.com/vellum-ai/vellum-assistant/pull/3304
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
