### PR TITLE
fix: address review feedback on notification PRs (#3313, #3314)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -389,15 +389,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                             requestId: msg.requestId,
                             decision: decision
                         )
+                        // Only sync the inline message state if the IPC send succeeded.
+                        self.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
+                            requestId: msg.requestId,
+                            decision: decision
+                        )
                     } catch {
                         log.error("Failed to send confirmation response: \(error.localizedDescription)")
                     }
-                    // Sync the inline message state across ALL ChatViewModels so the
-                    // originating thread is updated even if the user switched threads.
-                    self.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
-                        requestId: msg.requestId,
-                        decision: decision
-                    )
                 }
             }
         }
@@ -968,6 +967,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let main = MainWindow(services: services)
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
+        }
+        main.threadManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
+            guard let self else { return }
+            // Resume the notification service continuation so it doesn't hang
+            // (no-op if no pending request for this requestId).
+            self.toolConfirmationNotificationService.handleResponse(requestId: requestId, decision: decision)
+            // Remove the delivered notification from Notification Center
+            UNUserNotificationCenter.current().removeDeliveredNotifications(
+                withIdentifiers: ["tool-confirm-\(requestId)"]
+            )
         }
         main.show()
         mainWindow = main

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -239,6 +239,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         chatViewModels.removeValue(forKey: threadId)
     }
 
+    /// Called when the user responds to a confirmation via the inline chat UI.
+    /// The app layer uses this to dismiss the native notification and resume
+    /// the notification service continuation. Receives (requestId, decision).
+    var onInlineConfirmationResponse: ((String, String) -> Void)?
+
     /// The ambient agent instance, set by the app layer so watch session callbacks
     /// can create and manage WatchSession objects.
     weak var ambientAgent: AmbientAgent?
@@ -264,6 +269,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.shouldAcceptConfirmation = { [weak self, weak viewModel] in
             guard let self, let viewModel else { return false }
             return self.isLatestToolUseRecipient(viewModel)
+        }
+        viewModel.onInlineConfirmationResponse = { [weak self] requestId, decision in
+            // The decision was already sent to the daemon by ChatViewModel.
+            // Forward to the app layer so it can dismiss the native notification
+            // and resume the notification service continuation.
+            self?.onInlineConfirmationResponse?(requestId, decision)
         }
         viewModel.onWatchStarted = { [weak self] msg, client in
             guard let self else { return }

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -43,6 +43,13 @@ public final class ToolConfirmationNotificationService {
             return "deny"
         }
 
+        // If a continuation already exists for this requestId (e.g. daemon re-sent
+        // the request), resume it with "deny" to avoid a leaked continuation crash.
+        if let existing = pendingRequests.removeValue(forKey: message.requestId) {
+            log.warning("Duplicate requestId=\(message.requestId, privacy: .public), denying previous")
+            existing.resume(returning: "deny")
+        }
+
         return await withCheckedContinuation { continuation in
             pendingRequests[message.requestId] = continuation
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -179,7 +179,8 @@ public final class ChatViewModel: ObservableObject {
     public var lastToolUseReceivedAt: Date?
 
     /// Called when an inline confirmation is responded to, so the floating panel can be dismissed.
-    public var onInlineConfirmationResponse: ((String) -> Void)?
+    /// Parameters: (requestId, decision)
+    public var onInlineConfirmationResponse: ((String, String) -> Void)?
 
     /// Called to determine whether this ChatViewModel should accept a `confirmationRequest`.
     /// Set by ThreadManager to coordinate routing when multiple ChatViewModels are active.
@@ -1797,8 +1798,8 @@ public final class ChatViewModel: ObservableObject {
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             messages[index].confirmation?.state = decision == "allow" ? .approved : .denied
         }
-        // Dismiss the corresponding floating panel if one exists
-        onInlineConfirmationResponse?(requestId)
+        // Dismiss the corresponding floating panel / native notification if one exists
+        onInlineConfirmationResponse?(requestId, decision)
     }
 
     /// Update the inline confirmation message state without sending a response to the daemon.


### PR DESCRIPTION
## Summary
- Fix duplicate requestId crash: resume existing continuation before storing new one
- Skip UI update when IPC send fails in setupToolConfirmationNotifications
- Dismiss native notification when user responds via inline chat UI by wiring up onInlineConfirmationResponse through ThreadManager to AppDelegate

## Test plan
- [ ] Verify duplicate requestId no longer crashes (previous continuation is denied and cleaned up)
- [ ] Verify that inline confirmation state is not updated when daemon IPC send fails
- [ ] Verify that responding to a confirmation via inline chat UI removes the native notification from Notification Center

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
