### PR TITLE
fix: soften composer border and fix overlapping placeholder text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -122,6 +122,7 @@ struct ComposerView: View {
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
         .animation(VAnimation.fast, value: editorContentHeight)
+        .animation(VAnimation.fast, value: isComposerExpanded)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear { composerFocusRequestID += 1 }
     }
@@ -179,10 +180,14 @@ struct ComposerView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onChange(of: inputText) {
-            if inputText.isEmpty { isComposerExpanded = false }
+            if inputText.isEmpty {
+                withAnimation(VAnimation.fast) { isComposerExpanded = false }
+            }
         }
         .onChange(of: editorContentHeight) {
-            if editorContentHeight > composerCompactHeight { isComposerExpanded = true }
+            if editorContentHeight > composerCompactHeight && !isComposerExpanded {
+                withAnimation(VAnimation.fast) { isComposerExpanded = true }
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -107,13 +107,13 @@ struct ComposerView: View {
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(
-                    isComposerFocused ? VColor.accent.opacity(0.68) : VColor.surfaceBorder.opacity(0.95),
+                    isComposerFocused ? VColor.surfaceBorder : VColor.surfaceBorder.opacity(0.95),
                     lineWidth: isComposerFocused ? 1.5 : 1
                 )
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.accent.opacity(isComposerFocused ? 0.14 : 0), lineWidth: 3)
+                .stroke(VColor.surfaceBorder.opacity(isComposerFocused ? 0.12 : 0), lineWidth: 3)
         )
         .shadow(color: VColor.textPrimary.opacity(0.06), radius: 8, x: 0, y: 2)
         .padding(.horizontal, VSpacing.lg)
@@ -222,7 +222,7 @@ struct ComposerView: View {
                     } label: {
                         ZStack {
                             Circle()
-                                .fill(VColor.accent)
+                                .fill(VColor.accent.opacity(0.55))
                                 .frame(width: 30, height: 30)
                             Image(systemName: "arrow.up")
                                 .font(.system(size: 13, weight: .semibold))
@@ -479,9 +479,16 @@ private struct ComposerTextView: NSViewRepresentable {
         guard let textView = context.coordinator.textView else { return }
 
         textView.isEditable = isEnabled
+        let oldPlaceholder = textView.placeholderText
+        let oldGhostSuffix = textView.hasGhostSuffix
         textView.placeholderText = placeholder
         textView.placeholderColor = NSColor(VColor.textSecondary).withAlphaComponent(0.92)
         textView.hasGhostSuffix = hasGhostSuffix
+
+        // Force redraw when placeholder or ghost suffix state changes so stale text doesn't persist
+        if oldPlaceholder != placeholder || oldGhostSuffix != hasGhostSuffix {
+            textView.needsDisplay = true
+        }
 
         if context.coordinator.isWritingFromView == false, textView.string != text {
             textView.string = text
@@ -566,6 +573,7 @@ private final class ComposerNativeTextView: NSTextView {
         super.draw(dirtyRect)
 
         guard string.isEmpty,
+              !hasGhostSuffix,
               let placeholderText,
               !placeholderText.isEmpty else { return }
 


### PR DESCRIPTION
## Summary
- Replace the violet accent border on the chat composer with a neutral `surfaceBorder` tone, and soften the send button fill to `accent.opacity(0.55)`
- Fix a bug where the native NSTextView placeholder ("What would you like to do?") and the SwiftUI ghost-suffix overlay (suggestion text) could render simultaneously, causing overlapping text in the composer
  - `draw()` now checks `hasGhostSuffix` to skip native placeholder when ghost text is active
  - `updateNSView` forces `needsDisplay` when placeholder or ghost suffix state changes

## Test plan
- [ ] Verify focused composer border is a subtle grey, not purple
- [ ] Verify send button is a lighter purple, not saturated
- [ ] Open an app in workspace mode → go back to chat → confirm no overlapping placeholder text
- [ ] Type in composer → delete all text → confirm placeholder reappears cleanly
- [ ] Trigger a suggestion (ghost text) → confirm placeholder disappears and only ghost text shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
