### PR TITLE
fix: preserve elements when accessibility tree has large child counts

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
@@ -302,28 +302,23 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
         var childElements: [AXElement] = []
         var childrenRef: CFTypeRef?
 
-        // Bail early if we've hit the element limit
-        guard totalElementsEnumerated < maxElementsPerEnumeration else {
-            return []
-        }
-
         if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
            let children = childrenRef as? [AXUIElement] {
             // Sanity check: if children array is suspiciously large, it might be corrupted
-            guard children.count < 1000 else {
-                log.warning("Element has \(children.count) children — likely corrupted, skipping")
-                return []
-            }
+            // Skip children enumeration but continue processing current element
+            if children.count >= 1000 {
+                log.warning("Element has \(children.count) children — likely corrupted, skipping children enumeration")
+            } else {
+                for (index, child) in children.enumerated() {
+                    // Stop if we've hit the limit mid-enumeration
+                    guard totalElementsEnumerated < maxElementsPerEnumeration else {
+                        log.warning("Hit element limit while enumerating children (\(index)/\(children.count) processed)")
+                        break
+                    }
 
-            for (index, child) in children.enumerated() {
-                // Stop if we've hit the limit mid-enumeration
-                guard totalElementsEnumerated < maxElementsPerEnumeration else {
-                    log.warning("Hit element limit while enumerating children (\(index)/\(children.count) processed)")
-                    break
+                    // Recursively enumerate with the safe wrapper
+                    childElements.append(contentsOf: enumerateElementSafely(element: child, depth: depth + 1, maxDepth: maxDepth))
                 }
-
-                // Recursively enumerate with the safe wrapper
-                childElements.append(contentsOf: enumerateElementSafely(element: child, depth: depth + 1, maxDepth: maxDepth))
             }
         }
 


### PR DESCRIPTION
## Summary
- Removes redundant element limit guard that incorrectly discarded already-counted elements
- Changes large children guard to skip children enumeration instead of discarding the parent element
- Ensures interactive elements remain visible even when they have 1000+ children or the element limit is reached

## Problem
PR #2965 introduced safety guards to prevent crashes in accessibility tree enumeration for file dialogs. However, two guards were overly aggressive:

1. The guard at lines 306-308 checked `totalElementsEnumerated >= maxElementsPerEnumeration` and returned `[]`, discarding the current element even though it was already counted and its attributes fetched. This was redundant with the checks in `enumerateElementSafely` and the children loop.

2. The guard at lines 313-316 checked `children.count >= 1000` and returned `[]`, discarding both the current element AND its entire subtree. In legitimate cases like file dialogs or tables with 1000+ items, this would remove interactive controls that agents need to target.

## Solution
1. Removed the redundant element limit guard at lines 306-308. The children loop already has protection at line 320, and this guard was incorrectly discarding elements that should be preserved.

2. Changed the large children guard to conditionally skip children enumeration (using `if` instead of `guard`) while allowing the function to continue processing the current element. This preserves interactive elements and their attributes even when they have large child lists.

## Impact
- Interactive elements in large lists/tables remain visible to agents
- Elements that push the counter to `maxElementsPerEnumeration` are correctly processed
- Maintains crash protection while avoiding false positives

Addresses feedback from chatgpt-codex-connector and devin-ai-integration on PR #2965.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
