### PR TITLE
fix: remove incorrect relatedViewModel binding in computer_use sessions

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -268,8 +268,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             skipSessionCreate: true,
             notificationService: self.services.activityNotificationService
         )
-        // Wire relatedViewModel to enable tool call extraction for notifications
-        session.relatedViewModel = mainWindow?.threadManager.activeViewModel
+        // Don't bind relatedViewModel for escalated sessions — the active view model
+        // may be unrelated if the user switched threads. Tool calls for escalated
+        // sessions are tracked by the daemon session, not by ChatViewModel.
         self.currentSession = session
 
         let overlay = SessionOverlayWindow(session: session)
@@ -1167,8 +1168,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     skipSessionCreate: true,
                     notificationService: self.services.activityNotificationService
                 )
-                // Wire relatedViewModel to enable tool call extraction for notifications
-                session.relatedViewModel = self.mainWindow?.threadManager.activeViewModel
+                // Don't bind relatedViewModel — sessions started via startSession() don't
+                // originate from a chat thread, so there's no ChatViewModel to extract
+                // tool calls from. Tool calls are tracked by the daemon session itself.
                 self.currentSession = session
                 let overlay = SessionOverlayWindow(session: session)
                 overlay.show()


### PR DESCRIPTION
## Summary

Addresses feedback on PR #2948 by removing the incorrect `relatedViewModel` binding for computer_use sessions started via `startSession()` and escalation paths.

## Problem

Setting `session.relatedViewModel = mainWindow?.threadManager.activeViewModel` in the escalation path (line 272) and the regular computer_use path (line 1172) caused two issues:

1. **Wrong thread binding**: The `activeViewModel` could be an unrelated chat thread if the user switched conversations after starting the session
2. **Incorrect tool extraction**: `extractToolCalls()` would flatten ALL assistant tool calls from that view model without session/turn filtering, potentially showing stale tools from the active thread in completion notifications instead of the actual tools used by the session

## Solution

Remove `relatedViewModel` binding for sessions that don't originate from chat threads:
- Sessions started via `startSession()` (voice input, ambient agent)
- Sessions created via escalation from text_qa to computer_use

These sessions communicate directly with the daemon via `CuActionMessage`, not through `ChatViewModel`. Tool calls are tracked by the daemon session itself, not by ChatViewModel messages.

## Changes

- `AppDelegate.swift`: Remove `relatedViewModel` binding in `handleEscalationToComputerUse()` and `startSession()` computer_use case
- Added explanatory comments for why `relatedViewModel` should remain nil in these paths

## Test Plan

- [x] TypeScript type-check passes
- [ ] Build succeeds
- [ ] Verify completion notifications no longer show stale tools from unrelated threads

Fixes feedback on #2948

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
