### PR TITLE
fix: address review feedback on PR 3065

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -307,6 +307,11 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
   for (const block of content) {
     if (!isRecord(block) || typeof block.type !== 'string') continue;
 
+    // Skip ui_surface blocks - they're handled separately
+    if (block.type === 'ui_surface') {
+      continue;
+    }
+
     if (block.type === 'text' && typeof block.text === 'string') {
       textParts.push(block.text);
       ensureSegment();
@@ -896,6 +901,9 @@ function handleHistoryRequest(
       toolCallsBeforeText = rendered.toolCallsBeforeText;
       textSegments = rendered.textSegments;
       contentOrder = rendered.contentOrder;
+      if (m.role === 'assistant' && toolCalls.length > 0) {
+        log.info({ messageId: m.id, toolCallCount: toolCalls.length, text: text.substring(0, 100) }, 'History message with tool calls');
+      }
     } catch (err) {
       log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
       text = m.content;
@@ -934,23 +942,57 @@ function handleHistoryRequest(
     };
   });
   ctx.send(socket, { type: 'history_response', sessionId: msg.sessionId, messages: historyMessages });
+
+  // Emit ui_surface_show for any persisted surfaces in the messages
+  for (const dbMsg of dbMessages) {
+    try {
+      const content = JSON.parse(dbMsg.content);
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (isRecord(block) && block.type === 'ui_surface') {
+            log.info({
+              surfaceId: block.surfaceId,
+              surfaceType: block.surfaceType,
+              messageId: dbMsg.id,
+              sessionId: msg.sessionId
+            }, 'Emitting ui_surface_show from history');
+            ctx.send(socket, {
+              type: 'ui_surface_show',
+              sessionId: msg.sessionId,
+              surfaceId: block.surfaceId as string,
+              surfaceType: block.surfaceType as SurfaceType,
+              title: block.title as string | undefined,
+              data: block.data as SurfaceData,
+              actions: block.actions as Array<{ id: string; label: string; style?: string }> | undefined,
+              display: block.display as string | undefined,
+              messageId: dbMsg.id,  // Add messageId so client can match surface to message
+            });
+          }
+        }
+      }
+    } catch (err) {
+      log.warn({ err, messageId: dbMsg.id }, 'Failed to emit ui_surface from history');
+    }
+  }
 }
 
 export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistoryMessage[] {
+  // Note: We no longer merge consecutive assistant messages at load time since
+  // they are now consolidated when saved. This function only handles legacy
+  // conversations that haven't been consolidated yet, and continues to merge
+  // tool_result blocks into their preceding assistant messages.
   const result: ParsedHistoryMessage[] = [];
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
 
     // If this is a user message whose only content is tool_result blocks,
     // merge those results into the preceding assistant message's toolCalls.
+    // This should rarely happen now since consolidation removes these messages,
+    // but we keep it for backwards compatibility with old data.
     if (msg.role === 'user' && msg.text.trim() === '' && msg.toolCalls.length > 0) {
       const prev = result.length > 0 ? result[result.length - 1] : null;
       if (prev && prev.role === 'assistant' && prev.toolCalls.length > 0) {
-        // Build a lookup from tool name → result for this user message's tool_results
         for (const resultEntry of msg.toolCalls) {
-          // Match by tool_use_id pairing: tool_results are ordered to match
-          // the tool_uses in the preceding assistant message, so pair by index
-          // of unresolved entries, or fall back to name matching.
           const unresolved = prev.toolCalls.find(
             (tc) => tc.result === undefined,
           );

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -932,6 +932,7 @@ function handleHistoryRequest(
       }
     }
     return {
+      ...(m.id ? { id: m.id } : {}),
       role: m.role,
       text: m.text,
       timestamp: m.timestamp,
@@ -1002,9 +1003,11 @@ export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistor
             if (resultEntry.imageData) unresolved.imageData = resultEntry.imageData;
           }
         }
+        // Only suppress this internal user message if we successfully merged into a preceding assistant message
+        continue;
       }
-      // Suppress this internal user message from the visible history
-      continue;
+      // If there's no preceding assistant message to merge into, preserve the tool_result message
+      // so the results aren't lost (e.g., cancellation/error/handoff before follow-up assistant turn)
     }
 
     result.push({ ...msg, toolCalls: msg.toolCalls.map((tc) => ({ ...tc })) });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -769,6 +769,7 @@ export interface HistoryResponse {
   type: 'history_response';
   sessionId: string;
   messages: Array<{
+    id?: string;  // Database message ID (for matching surfaces)
     role: string;
     text: string;
     timestamp: number;
@@ -1217,6 +1218,12 @@ export interface ReminderFired {
   message: string;
 }
 
+export interface ScheduleComplete {
+  type: 'schedule_complete';
+  scheduleId: string;
+  name: string;
+}
+
 export interface WatchStarted {
   type: 'watch_started';
   sessionId: string;
@@ -1270,6 +1277,8 @@ interface UiSurfaceShowBase {
   title?: string;
   actions?: SurfaceAction[];
   display?: 'inline' | 'panel';
+  /** The message ID that this surface belongs to (for history loading). */
+  messageId?: string;
 }
 
 export interface UiSurfaceShowCard extends UiSurfaceShowBase {
@@ -1384,6 +1393,7 @@ export type ServerMessage =
   | MessageQueued
   | MessageDequeued
   | ReminderFired
+  | ScheduleComplete
   | WatchStarted
   | WatchCompleteRequest
   | TrustRulesListResponse

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -241,6 +241,13 @@ export async function runDaemon(): Promise<void> {
         message: reminder.message,
       });
     },
+    (schedule) => {
+      server.broadcast({
+        type: 'schedule_complete',
+        scheduleId: schedule.id,
+        name: schedule.name,
+      });
+    },
   );
 
   // Start optional runtime HTTP server when RUNTIME_HTTP_PORT is set

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -130,6 +130,8 @@ export class Session {
   /** Per-surface undo stack: stores previous HTML strings for workspace refinement undo. */
   private surfaceUndoStacks = new Map<string, string[]>();
   private static readonly MAX_UNDO_DEPTH = 10;
+  /** Surfaces created during the current agent loop turn, to be persisted with the message. */
+  private currentTurnSurfaces: Array<{ surfaceId: string; surfaceType: SurfaceType; title?: string; data: SurfaceData; actions?: Array<{ id: string; label: string; style?: string }>; display?: string }> = [];
   private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => boolean;
   private workspaceTopLevelContext: string | null = null;
   private workspaceTopLevelDirty = true;
@@ -1027,13 +1029,30 @@ export class Session {
             accumulatedDirectives.push(...msgDirectives);
             directiveWarnings.push(...msgWarnings);
 
-            // Save assistant message with cleaned content (tags stripped)
+            // Add surface blocks to content for persistence
+            const contentWithSurfaces: ContentBlock[] = [...cleanedContent];
+            for (const surface of this.currentTurnSurfaces) {
+              contentWithSurfaces.push({
+                type: 'ui_surface' as any,
+                surfaceId: surface.surfaceId,
+                surfaceType: surface.surfaceType,
+                title: surface.title,
+                data: surface.data,
+                actions: surface.actions,
+                display: surface.display,
+              } as any);
+            }
+
+            // Save assistant message with cleaned content (tags stripped) plus surfaces
             const assistantMsg = conversationStore.addMessage(
               this.conversationId,
               'assistant',
-              JSON.stringify(cleanedContent),
+              JSON.stringify(contentWithSurfaces),
             );
             lastAssistantMessageId = assistantMsg.id;
+
+            // Clear surfaces for next turn
+            this.currentTurnSurfaces = [];
 
             // Emit assistant_message trace with content metrics.
             // Char count only includes text blocks; thinking blocks are
@@ -1324,9 +1343,124 @@ export class Session {
       this.currentRequestId = undefined;
       this.currentActiveSurfaceId = undefined;
 
+      // Consolidate consecutive assistant messages from this agent loop run
+      if (userMessageId) {
+        this.consolidateAssistantMessages(userMessageId);
+      }
+
       // Drain the next queued message, if any
       this.drainQueue(yieldedForHandoff ? 'checkpoint_handoff' : 'loop_complete');
     }
+  }
+
+  /**
+   * Consolidate consecutive assistant messages created during an agent loop.
+   * After the loop completes, merge all assistant messages that came after
+   * the user message into a single message, and delete the internal tool_result
+   * user messages. This ensures the database matches what the client sees
+   * during streaming (one consolidated message per user request).
+   */
+  private consolidateAssistantMessages(userMessageId: string): void {
+    const allMessages = conversationStore.getMessages(this.conversationId);
+    const userMsgIndex = allMessages.findIndex((m) => m.id === userMessageId);
+    if (userMsgIndex === -1) return;
+
+    const messagesToConsolidate: typeof allMessages = [];
+    const internalToolResultMessages: typeof allMessages = [];
+    const messagesToDelete: string[] = [];
+
+    // Collect all assistant messages and internal tool_result user messages after this user message
+    for (let i = userMsgIndex + 1; i < allMessages.length; i++) {
+      const msg = allMessages[i];
+      if (msg.role === 'assistant') {
+        messagesToConsolidate.push(msg);
+      } else if (msg.role === 'user') {
+        // Check if this is an internal tool_result message (no text, only tool_result blocks)
+        try {
+          const content = JSON.parse(msg.content);
+          const isToolResultOnly = Array.isArray(content) &&
+            content.every((block) => block.type === 'tool_result') &&
+            content.length > 0;
+          if (isToolResultOnly) {
+            internalToolResultMessages.push(msg);
+            messagesToDelete.push(msg.id);
+          } else {
+            // Hit a real user message, stop consolidating
+            break;
+          }
+        } catch {
+          // Can't parse, assume it's a real user message
+          break;
+        }
+      }
+    }
+
+    // Only consolidate if there are multiple assistant messages
+    if (messagesToConsolidate.length <= 1) {
+      // Still delete internal tool_result messages even if only one assistant message
+      for (const id of messagesToDelete) {
+        conversationStore.deleteMessageById(id);
+      }
+      return;
+    }
+
+    log.info({
+      conversationId: this.conversationId,
+      userMessageId,
+      assistantCount: messagesToConsolidate.length,
+      internalMessageCount: messagesToDelete.length,
+    }, 'Consolidating assistant messages');
+
+    // Merge all content blocks from all assistant messages AND tool_result blocks from internal user messages
+    const consolidatedContent: ContentBlock[] = [];
+    for (const msg of messagesToConsolidate) {
+      try {
+        const content = JSON.parse(msg.content);
+        if (Array.isArray(content)) {
+          const toolUseBlocks = content.filter((b: any) => b.type === 'tool_use');
+          log.info({ messageId: msg.id, blockCount: content.length, toolUseCount: toolUseBlocks.length }, 'Consolidating assistant message content');
+          consolidatedContent.push(...content);
+        }
+      } catch (err) {
+        log.warn({ err, messageId: msg.id }, 'Failed to parse message content during consolidation');
+      }
+    }
+
+    // Also merge tool_result blocks from internal user messages
+    for (const msg of internalToolResultMessages) {
+      try {
+        const content = JSON.parse(msg.content);
+        if (Array.isArray(content)) {
+          const toolResultBlocks = content.filter((b: any) => b.type === 'tool_result');
+          log.info({ messageId: msg.id, blockCount: content.length, toolResultCount: toolResultBlocks.length }, 'Merging tool_result blocks from internal user message');
+          consolidatedContent.push(...content);
+        }
+      } catch (err) {
+        log.warn({ err, messageId: msg.id }, 'Failed to parse internal tool_result message during consolidation');
+      }
+    }
+
+    const toolUseBlocksInConsolidated = consolidatedContent.filter((b: any) => b.type === 'tool_use').length;
+    const toolResultBlocksInConsolidated = consolidatedContent.filter((b: any) => b.type === 'tool_result').length;
+    log.info({ totalBlocks: consolidatedContent.length, toolUseBlocks: toolUseBlocksInConsolidated, toolResultBlocks: toolResultBlocksInConsolidated }, 'Final consolidated content');
+
+    // Update the first assistant message with all content
+    const firstAssistantMsg = messagesToConsolidate[0];
+    conversationStore.updateMessageContent(firstAssistantMsg.id, JSON.stringify(consolidatedContent));
+
+    // Delete the other assistant messages and internal tool_result messages
+    for (let i = 1; i < messagesToConsolidate.length; i++) {
+      conversationStore.deleteMessageById(messagesToConsolidate[i].id);
+    }
+    for (const id of messagesToDelete) {
+      conversationStore.deleteMessageById(id);
+    }
+
+    log.info({
+      conversationId: this.conversationId,
+      consolidatedMessageId: firstAssistantMsg.id,
+      deletedCount: messagesToConsolidate.length - 1 + messagesToDelete.length,
+    }, 'Assistant messages consolidated');
   }
 
   /**
@@ -1981,6 +2115,14 @@ export class Session {
         data,
       } as UiSurfaceShow);
 
+      // Track surface for persistence
+      this.currentTurnSurfaces.push({
+        surfaceId,
+        surfaceType: 'file_upload',
+        title: 'File Request',
+        data,
+      });
+
       // Non-blocking: return immediately, user action arrives as follow-up message
       this.pendingSurfaceActions.set(surfaceId, { surfaceType: 'file_upload' as SurfaceType });
       return {
@@ -2016,6 +2158,8 @@ export class Session {
 
       const display = (input.display as string) === 'panel' ? 'panel' : 'inline';
 
+      const mappedActions = actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' }));
+
       this.sendToClient({
         type: 'ui_surface_show',
         sessionId: this.conversationId,
@@ -2023,9 +2167,19 @@ export class Session {
         surfaceType,
         title,
         data,
-        actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
+        actions: mappedActions,
         display,
       } as unknown as UiSurfaceShow);
+
+      // Track surface for persistence with the message
+      this.currentTurnSurfaces.push({
+        surfaceId,
+        surfaceType,
+        title,
+        data,
+        actions: mappedActions,
+        display,
+      });
 
       if (awaitAction) {
         this.pendingSurfaceActions.set(surfaceId, { surfaceType });
@@ -2124,6 +2278,14 @@ export class Session {
         title: app.name,
         data: surfaceData,
       } as UiSurfaceShow);
+
+      // Track surface for persistence
+      this.currentTurnSurfaces.push({
+        surfaceId,
+        surfaceType: 'dynamic_page',
+        title: app.name,
+        data: surfaceData,
+      });
 
       return { content: JSON.stringify({ surfaceId, appId }), isError: false };
     }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1448,12 +1448,26 @@ export class Session {
     const firstAssistantMsg = messagesToConsolidate[0];
     conversationStore.updateMessageContent(firstAssistantMsg.id, JSON.stringify(consolidatedContent));
 
-    // Delete the other assistant messages and internal tool_result messages
+    // Delete the other assistant messages and internal tool_result messages,
+    // and collect IDs for vector cleanup
+    const allSegmentIds: string[] = [];
+    const allOrphanedItemIds: string[] = [];
     for (let i = 1; i < messagesToConsolidate.length; i++) {
-      conversationStore.deleteMessageById(messagesToConsolidate[i].id);
+      const deleted = conversationStore.deleteMessageById(messagesToConsolidate[i].id);
+      allSegmentIds.push(...deleted.segmentIds);
+      allOrphanedItemIds.push(...deleted.orphanedItemIds);
     }
     for (const id of messagesToDelete) {
-      conversationStore.deleteMessageById(id);
+      const deleted = conversationStore.deleteMessageById(id);
+      allSegmentIds.push(...deleted.segmentIds);
+      allOrphanedItemIds.push(...deleted.orphanedItemIds);
+    }
+
+    // Clean up Qdrant vectors (fire-and-forget)
+    if (allSegmentIds.length > 0 || allOrphanedItemIds.length > 0) {
+      this.cleanupQdrantVectors(allSegmentIds, allOrphanedItemIds).catch((err) => {
+        log.warn({ err, conversationId: this.conversationId }, 'Qdrant cleanup after consolidation failed (non-fatal)');
+      });
     }
 
     log.info({

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -285,6 +285,18 @@ export interface DeletedMemoryIds {
 }
 
 /**
+ * Update the content of an existing message. Used when consolidating
+ * multiple assistant messages into one.
+ */
+export function updateMessageContent(messageId: string, newContent: string): void {
+  const db = getDb();
+  db.update(messages)
+    .set({ content: newContent })
+    .where(eq(messages.id, messageId))
+    .run();
+}
+
+/**
  * Delete a single message by ID without cascading to message_runs or
  * channel_inbound_events. Nullable FK columns in those tables are set to
  * NULL before the message row is removed, so associated run and event

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -16,6 +16,8 @@ export type ScheduleMessageProcessor = (
 
 export type ReminderNotifier = (reminder: { id: string; label: string; message: string }) => void;
 
+export type ScheduleNotifier = (schedule: { id: string; name: string }) => void;
+
 export interface SchedulerHandle {
   runOnce(): Promise<number>;
   stop(): void;
@@ -26,6 +28,7 @@ const TICK_INTERVAL_MS = 15_000;
 export function startScheduler(
   processMessage: ScheduleMessageProcessor,
   notifyReminder: ReminderNotifier,
+  notifySchedule: ScheduleNotifier,
 ): SchedulerHandle {
   let stopped = false;
   let tickRunning = false;
@@ -34,7 +37,7 @@ export function startScheduler(
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
-      await runScheduleOnce(processMessage, notifyReminder);
+      await runScheduleOnce(processMessage, notifyReminder, notifySchedule);
     } catch (err) {
       log.error({ err }, 'Schedule tick failed');
     } finally {
@@ -60,6 +63,7 @@ export function startScheduler(
 async function runScheduleOnce(
   processMessage: ScheduleMessageProcessor,
   notifyReminder: ReminderNotifier,
+  notifySchedule: ScheduleNotifier,
 ): Promise<number> {
   const now = Date.now();
   let processed = 0;
@@ -74,6 +78,7 @@ async function runScheduleOnce(
       log.info({ jobId: job.id, name: job.name, conversationId: conversation.id }, 'Executing schedule');
       await processMessage(conversation.id, job.message);
       completeScheduleRun(runId, { status: 'ok' });
+      notifySchedule({ id: job.id, name: job.name });
       processed += 1;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -51,7 +51,7 @@ export function startScheduler(
 
   return {
     async runOnce(): Promise<number> {
-      return runScheduleOnce(processMessage, notifyReminder);
+      return runScheduleOnce(processMessage, notifyReminder, notifySchedule);
     },
     stop(): void {
       stopped = true;

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -201,6 +201,23 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        daemonClient.onScheduleComplete = { msg in
+            let content = UNMutableNotificationContent()
+            content.title = msg.name
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: "schedule-\(msg.scheduleId)",
+                content: content,
+                trigger: nil
+            )
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error {
+                    log.error("Failed to post schedule notification: \(error.localizedDescription)")
+                }
+            }
+        }
+
         // Handle open_bundle_response from the daemon
         daemonClient.onOpenBundleResponse = { [weak self] response in
             guard let self else { return }
@@ -1358,7 +1375,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                         title: manifest.name,
                         data: AnyCodable(["html": html]),
                         actions: nil,
-                        display: "panel"
+                        display: "panel",
+                        messageId: nil
                     )
                     self.surfaceManager.showSurface(surfaceMsg)
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -349,11 +349,10 @@ struct ChatView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isThinking)
-            .onChange(of: messages.count) {
-                withAnimation(VAnimation.standard) {
-                    if let lastMessage = messages.last {
-                        proxy.scrollTo(lastMessage.id, anchor: .bottom)
-                    }
+            .onAppear {
+                // Scroll to bottom on initial load
+                if let lastMessage = messages.last {
+                    proxy.scrollTo(lastMessage.id, anchor: .bottom)
                 }
             }
             .onChange(of: isThinking) {
@@ -580,6 +579,10 @@ private struct ChatBubble: View {
     let isActivityPanelOpen: Bool
 
     private var isUser: Bool { message.role == .user }
+
+    @State private var isExpanded = false
+    private let truncationLimit = 2000  // Character limit before truncation
+    private let lineLimit = 50  // Maximum lines before truncation
 
     private var statusLabel: String? {
         switch message.status {
@@ -1031,6 +1034,42 @@ private struct ChatBubble: View {
         !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    private var shouldTruncate: Bool {
+        if isExpanded { return false }
+        let charCount = message.text.count
+        let lineCount = message.text.components(separatedBy: .newlines).count
+        return charCount > truncationLimit || lineCount > lineLimit
+    }
+
+    private var displayText: String {
+        if shouldTruncate {
+            let lines = message.text.components(separatedBy: .newlines)
+            if lines.count > lineLimit {
+                // Truncate by line count
+                let truncatedLines = lines.prefix(lineLimit)
+                return truncatedLines.joined(separator: "\n")
+            } else {
+                // Truncate by character count
+                return String(message.text.prefix(truncationLimit))
+            }
+        }
+        return message.text
+    }
+
+    private var truncationMessage: String {
+        let charCount = message.text.count
+        let lineCount = message.text.components(separatedBy: .newlines).count
+
+        if lineCount > lineLimit {
+            let hiddenLines = lineCount - lineLimit
+            return "Show more (\(hiddenLines) more lines)"
+        } else if charCount > truncationLimit {
+            let hiddenChars = charCount - truncationLimit
+            return "Show more (\(hiddenChars) more characters)"
+        }
+        return "Show more"
+    }
+
     private var attachmentSummary: String {
         let count = message.attachments.count
         if count == 1 {
@@ -1062,11 +1101,38 @@ private struct ChatBubble: View {
             }
 
             if hasText {
-                Text(markdownText)
-                    .font(.system(size: 13))
-                    .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                    .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                    .textSelection(.enabled)
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    if isExpanded && message.text.count > truncationLimit {
+                        // For expanded long messages, use a scrollable container with fixed height
+                        ScrollView {
+                            Text(markdownText)
+                                .font(.system(size: 13))
+                                .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
+                                .tint(isUser ? VColor.userBubbleText : VColor.accent)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .frame(height: 400)
+                        .background(Color.black.opacity(0.1))
+                        .cornerRadius(4)
+                    } else {
+                        Text(markdownText)
+                            .font(.system(size: 13))
+                            .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
+                            .tint(isUser ? VColor.userBubbleText : VColor.accent)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    if shouldTruncate || (isExpanded && (message.text.count > truncationLimit || message.text.components(separatedBy: .newlines).count > lineLimit)) {
+                        Button(action: { isExpanded.toggle() }) {
+                            Text(isExpanded ? "Show less" : truncationMessage)
+                                .font(VFont.caption)
+                                .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.accent)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
             } else if !message.attachments.isEmpty {
                 Text(attachmentSummary)
                     .font(VFont.caption)
@@ -1181,13 +1247,38 @@ private struct ChatBubble: View {
         return String(format: "%.1f MB", mb)
     }
 
+    /// Cached markdown parser to avoid re-parsing on every render.
+    /// Uses the message text hash as the cache key.
+    private static var markdownCache = [Int: AttributedString]()
+    private static let maxCacheSize = 100
+
     private var markdownText: AttributedString {
-        let trimmed = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let textToRender = displayText
+        let trimmed = textToRender.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cacheKey = trimmed.hashValue
+
+        // Return cached value if available
+        if let cached = Self.markdownCache[cacheKey] {
+            return cached
+        }
+
+        // Parse markdown
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
-        return (try? AttributedString(markdown: trimmed, options: options))
+        let parsed = (try? AttributedString(markdown: trimmed, options: options))
             ?? AttributedString(trimmed)
+
+        // Store in cache (with size limit to prevent unbounded growth)
+        if Self.markdownCache.count >= Self.maxCacheSize {
+            // Simple FIFO eviction - remove first entry
+            if let firstKey = Self.markdownCache.keys.first {
+                Self.markdownCache.removeValue(forKey: firstKey)
+            }
+        }
+        Self.markdownCache[cacheKey] = parsed
+
+        return parsed
     }
 
     private func ordinal(_ n: Int) -> String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -323,7 +323,8 @@ struct AppDirectoryView: View {
                 title: item.name,
                 data: AnyCodable(["html": html]),
                 actions: nil,
-                display: "panel"
+                display: "panel",
+                messageId: nil
             )
             onOpenApp(surfaceMsg)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -592,7 +592,8 @@ struct GeneratedPanel: View {
                 title: item.name,
                 data: AnyCodable(["html": html]),
                 actions: nil,
-                display: "panel"
+                display: "panel",
+                messageId: nil
             )
             if let onOpenApp {
                 onOpenApp(surfaceMsg)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -126,6 +126,9 @@ public final class ChatViewModel: ObservableObject {
 
     /// Maximum file size per attachment (20 MB).
     private static let maxFileSize = 20 * 1024 * 1024
+    /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
+    /// Anthropic has a 5MB limit per image; base64 encoding adds ~33% overhead.
+    private static let maxImageSize = 4 * 1024 * 1024
     /// Maximum number of attachments per message.
     private static let maxAttachments = 5
 
@@ -263,12 +266,40 @@ public final class ChatViewModel: ObservableObject {
         }
 
         let filename = url.lastPathComponent
-        let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
-        let base64 = data.base64EncodedString()
+        var mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+
+        // Compress images if needed
+        var finalData = data
+        var wasCompressed = false
+        if let utType = UTType(filenameExtension: url.pathExtension), utType.conforms(to: .image) {
+            let (compressedData, didCompress) = Self.compressImageIfNeeded(data: data, maxSize: Self.maxImageSize)
+            finalData = compressedData
+            wasCompressed = didCompress
+
+            // Update MIME type if compression changed format
+            if wasCompressed && finalData.count < data.count {
+                // Detect format from magic bytes
+                let header = [UInt8](finalData.prefix(4))
+                if header[0] == 0xFF && header[1] == 0xD8 {
+                    mimeType = "image/jpeg"
+                } else if header == [0x89, 0x50, 0x4E, 0x47] {
+                    mimeType = "image/png"
+                }
+            }
+        }
+
+        let base64 = finalData.base64EncodedString()
 
         var thumbnail: Data?
         if let utType = UTType(filenameExtension: url.pathExtension), utType.conforms(to: .image) {
-            thumbnail = Self.generateThumbnail(from: data, maxDimension: 120)
+            thumbnail = Self.generateThumbnail(from: finalData, maxDimension: 120)
+        }
+
+        // Inform user if image was compressed
+        if wasCompressed {
+            let originalMB = Double(data.count) / (1024 * 1024)
+            let compressedMB = Double(finalData.count) / (1024 * 1024)
+            log.info("Image compressed: \(String(format: "%.1f", originalMB))MB → \(String(format: "%.1f", compressedMB))MB")
         }
 
         #if os(macOS)
@@ -383,8 +414,27 @@ public final class ChatViewModel: ObservableObject {
             return
         }
 
-        let base64 = pngData.base64EncodedString()
-        let thumbnail = Self.generateThumbnail(from: pngData, maxDimension: 120)
+        // Compress image if needed
+        let (finalData, wasCompressed) = Self.compressImageIfNeeded(data: pngData, maxSize: Self.maxImageSize)
+
+        // Inform user if image was compressed
+        if wasCompressed {
+            let originalMB = Double(pngData.count) / (1024 * 1024)
+            let compressedMB = Double(finalData.count) / (1024 * 1024)
+            log.info("Image compressed: \(String(format: "%.1f", originalMB))MB → \(String(format: "%.1f", compressedMB))MB")
+        }
+
+        let base64 = finalData.base64EncodedString()
+        let thumbnail = Self.generateThumbnail(from: finalData, maxDimension: 120)
+
+        // Detect MIME type from compressed data
+        var mimeType = "image/png"
+        if wasCompressed {
+            let header = [UInt8](finalData.prefix(4))
+            if header[0] == 0xFF && header[1] == 0xD8 {
+                mimeType = "image/jpeg"
+            }
+        }
 
         #if os(macOS)
         let thumbnailImage = thumbnail.flatMap { NSImage(data: $0) }
@@ -397,7 +447,7 @@ public final class ChatViewModel: ObservableObject {
         let attachment = ChatAttachment(
             id: UUID().uuidString,
             filename: filename,
-            mimeType: "image/png",
+            mimeType: mimeType,
             data: base64,
             thumbnailData: thumbnail,
             dataLength: base64.count,
@@ -435,6 +485,140 @@ public final class ChatViewModel: ObservableObject {
         let resized = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return resized?.pngData()
+        #else
+        #error("Unsupported platform")
+        #endif
+    }
+
+    /// Compress image data if it exceeds the size limit.
+    /// Returns (compressedData, wasCompressed) tuple.
+    private static func compressImageIfNeeded(data: Data, maxSize: Int) -> (Data, Bool) {
+        // Check if compression is needed
+        guard data.count > maxSize else {
+            return (data, false)
+        }
+
+        #if os(macOS)
+        guard let image = NSImage(data: data),
+              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            // Not a valid image, return as-is
+            return (data, false)
+        }
+
+        let originalWidth = CGFloat(cgImage.width)
+        let originalHeight = CGFloat(cgImage.height)
+        guard originalWidth > 0 && originalHeight > 0 else {
+            return (data, false)
+        }
+
+        // Calculate scale factor needed to reduce file size
+        // Rough heuristic: file size scales roughly with pixel count
+        let sizeReduction = Double(maxSize) / Double(data.count)
+        let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% of max for safety margin
+        let scale = min(CGFloat(pixelReduction), 1.0)
+
+        let newWidth = Int(originalWidth * scale)
+        let newHeight = Int(originalHeight * scale)
+
+        // Create bitmap context for resizing
+        guard let colorSpace = cgImage.colorSpace,
+              let context = CGContext(
+                data: nil,
+                width: newWidth,
+                height: newHeight,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            return (data, false)
+        }
+
+        // Draw scaled image
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+
+        guard let scaledCGImage = context.makeImage() else {
+            return (data, false)
+        }
+
+        let scaledImage = NSImage(cgImage: scaledCGImage, size: NSSize(width: newWidth, height: newHeight))
+
+        // Try JPEG compression first (better for photos)
+        if let tiffData = scaledImage.tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiffData),
+           let jpeg = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.75]) {
+            if jpeg.count <= maxSize {
+                log.info("Compressed image from \(data.count) to \(jpeg.count) bytes (JPEG, \(newWidth)×\(newHeight))")
+                return (jpeg, true)
+            }
+        }
+
+        // Fallback: try PNG
+        if let tiffData = scaledImage.tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiffData),
+           let png = bitmap.representation(using: .png, properties: [:]) {
+            if png.count <= maxSize {
+                log.info("Compressed image from \(data.count) to \(png.count) bytes (PNG, \(newWidth)×\(newHeight))")
+                return (png, true)
+            }
+        }
+
+        // If still too large, warn and return original
+        log.warning("Failed to compress image to \(maxSize) bytes, final size: \(data.count)")
+        return (data, false)
+
+        #elseif os(iOS)
+        guard let image = UIImage(data: data) else {
+            return (data, false)
+        }
+
+        let originalSize = image.size
+        guard originalSize.width > 0 && originalSize.height > 0 else {
+            return (data, false)
+        }
+
+        // Calculate scale factor
+        let sizeReduction = Double(maxSize) / Double(data.count)
+        let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% for safety margin
+        let scale = min(CGFloat(pixelReduction), 1.0)
+
+        let newSize = CGSize(
+            width: originalSize.width * scale,
+            height: originalSize.height * scale
+        )
+
+        // Resize image
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 0.0)
+        image.draw(in: CGRect(origin: .zero, size: newSize))
+        let resized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        guard let resized = resized else {
+            return (data, false)
+        }
+
+        // Try JPEG compression
+        if let jpeg = resized.jpegData(compressionQuality: 0.75) {
+            if jpeg.count <= maxSize {
+                let dimensions = "\(Int(newSize.width))×\(Int(newSize.height))"
+                log.info("Compressed image from \(data.count) to \(jpeg.count) bytes (JPEG, \(dimensions))")
+                return (jpeg, true)
+            }
+        }
+
+        // Fallback: try PNG
+        if let png = resized.pngData() {
+            if png.count <= maxSize {
+                let dimensions = "\(Int(newSize.width))×\(Int(newSize.height))"
+                log.info("Compressed image from \(data.count) to \(png.count) bytes (PNG, \(dimensions))")
+                return (png, true)
+            }
+        }
+
+        // If still too large, warn and return original
+        log.warning("Failed to compress image to \(maxSize) bytes, final size: \(data.count)")
+        return (data, false)
         #else
         #error("Unsupported platform")
         #endif
@@ -1047,9 +1231,20 @@ public final class ChatViewModel: ObservableObject {
             }
 
         case .uiSurfaceShow(let msg):
-            guard belongsToSession(msg.sessionId) else { return }
-            guard msg.display == nil || msg.display == "inline" || msg.display == "panel" else { break }
-            guard let surface = Surface.from(msg) else { break }
+            log.info("Received ui_surface_show: surfaceId=\(msg.surfaceId), messageId=\(msg.messageId ?? "nil"), display=\(msg.display ?? "nil")")
+            log.info("Current messages count: \(self.messages.count), IDs: \(self.messages.map { $0.id.uuidString }.joined(separator: ", "))")
+            guard belongsToSession(msg.sessionId) else {
+                log.info("Skipping surface - wrong session")
+                return
+            }
+            guard msg.display == nil || msg.display == "inline" || msg.display == "panel" else {
+                log.info("Skipping surface - display mode is '\(msg.display ?? "nil")'")
+                break
+            }
+            guard let surface = Surface.from(msg) else {
+                log.info("Skipping surface - failed to create Surface from message")
+                break
+            }
 
             // On macOS, dynamic pages with no explicit display mode (or "panel")
             // are routed to the workspace by SurfaceManager. If the dynamic page
@@ -1059,7 +1254,10 @@ public final class ChatViewModel: ObservableObject {
             if case .dynamicPage(let dpData) = surface.data, msg.display == nil || msg.display == "panel" {
                 isThinking = false
                 // Only render inline preview if the dynamic page has preview metadata
-                guard dpData.preview != nil else { break }
+                guard dpData.preview != nil else {
+                    log.info("Skipping inline surface - no preview metadata")
+                    break
+                }
             }
             #endif
 
@@ -1072,8 +1270,16 @@ public final class ChatViewModel: ObservableObject {
                 actions: surface.actions,
                 surfaceMessage: msg
             )
-            if let existingId = currentAssistantMessageId,
+
+            // If messageId is provided (from history loading), attach to that specific message
+            if let messageId = msg.messageId,
+               let messageUUID = UUID(uuidString: messageId),
+               let index = messages.firstIndex(where: { $0.id == messageUUID }) {
+                log.info("Attaching surface to message by messageId: \(messageId)")
+                messages[index].inlineSurfaces.append(inlineSurface)
+            } else if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
+                log.info("Attaching surface to currentAssistantMessage: \(existingId)")
                 let surfIdx = messages[index].inlineSurfaces.count
                 messages[index].inlineSurfaces.append(inlineSurface)
                 messages[index].contentOrder.append(.surface(surfIdx))
@@ -1082,11 +1288,13 @@ public final class ChatViewModel: ObservableObject {
                       let idx = messages[lastUserIndex...].lastIndex(where: { $0.role == .assistant }) {
                 // Scope to the current turn so we never attach to an assistant message
                 // from a previous conversation turn.
+                log.info("Attaching surface to last assistant message in current turn")
                 let surfIdx = messages[idx].inlineSurfaces.count
                 messages[idx].inlineSurfaces.append(inlineSurface)
                 messages[idx].contentOrder.append(.surface(surfIdx))
                 lastContentWasToolCall = true
             } else {
+                log.info("Creating new assistant message for surface")
                 var newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
                 newMsg.contentOrder = [.surface(0)]
                 currentAssistantMessageId = newMsg.id
@@ -1645,13 +1853,28 @@ public final class ChatViewModel: ObservableObject {
             // Skip empty messages (internal tool-result-only turns already filtered by daemon)
             if item.text.isEmpty && toolCalls.isEmpty && attachments.isEmpty { continue }
             let timestamp = Date(timeIntervalSince1970: TimeInterval(item.timestamp) / 1000.0)
-            var chatMsg = ChatMessage(
-                role: role,
-                text: item.text,
-                timestamp: timestamp,
-                attachments: attachments,
-                toolCalls: toolCalls
-            )
+
+            // Use the database message ID if available (for matching surfaces)
+            var chatMsg: ChatMessage
+            if let dbId = item.id, let uuid = UUID(uuidString: dbId) {
+                chatMsg = ChatMessage(
+                    id: uuid,
+                    role: role,
+                    text: item.text,
+                    timestamp: timestamp,
+                    attachments: attachments,
+                    toolCalls: toolCalls
+                )
+            } else {
+                chatMsg = ChatMessage(
+                    role: role,
+                    text: item.text,
+                    timestamp: timestamp,
+                    attachments: attachments,
+                    toolCalls: toolCalls
+                )
+            }
+
             // Use daemon-provided segments/order when available; fall back to legacy
             if let segments = item.textSegments, let orderStrings = item.contentOrder, !segments.isEmpty {
                 chatMsg.textSegments = segments

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1276,7 +1276,9 @@ public final class ChatViewModel: ObservableObject {
                let messageUUID = UUID(uuidString: messageId),
                let index = messages.firstIndex(where: { $0.id == messageUUID }) {
                 log.info("Attaching surface to message by messageId: \(messageId)")
+                let surfIdx = messages[index].inlineSurfaces.count
                 messages[index].inlineSurfaces.append(inlineSurface)
+                messages[index].contentOrder.append(.surface(surfIdx))
             } else if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 log.info("Attaching surface to currentAssistantMessage: \(existingId)")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -101,6 +101,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when a reminder fires.
     public var onReminderFired: ((ReminderFiredMessage) -> Void)?
 
+    /// Called when a scheduled task completes.
+    public var onScheduleComplete: ((ScheduleCompleteMessage) -> Void)?
+
     /// Called when the daemon sends a `trust_rules_list_response` message.
     public var onTrustRulesListResponse: (([TrustRuleItem]) -> Void)?
 
@@ -908,6 +911,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onTaskRouted?(msg)
         case .reminderFired(let msg):
             onReminderFired?(msg)
+        case .scheduleComplete(let msg):
+            onScheduleComplete?(msg)
         case .trustRulesListResponse(let msg):
             onTrustRulesListResponse?(msg.rules)
         case .schedulesListResponse(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -411,6 +411,7 @@ public struct IPCHistoryResponse: Codable, Sendable {
 }
 
 public struct IPCHistoryResponseMessage: Codable, Sendable {
+    public let id: String?
     public let role: String
     public let text: String
     public let timestamp: Double
@@ -678,6 +679,12 @@ public struct IPCRideShotgunStart: Codable, Sendable {
 public struct IPCSandboxSetRequest: Codable, Sendable {
     public let type: String
     public let enabled: Bool
+}
+
+public struct IPCScheduleComplete: Codable, Sendable {
+    public let type: String
+    public let scheduleId: String
+    public let name: String
 }
 
 public struct IPCScheduleRemove: Codable, Sendable {
@@ -1174,6 +1181,8 @@ public struct IPCUiSurfaceShowCard: Codable, Sendable {
     public let title: String?
     public let actions: [IPCSurfaceAction]?
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 }
 
 public struct IPCUiSurfaceShowConfirmation: Codable, Sendable {
@@ -1185,6 +1194,8 @@ public struct IPCUiSurfaceShowConfirmation: Codable, Sendable {
     public let title: String?
     public let actions: [IPCSurfaceAction]?
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 }
 
 public struct IPCUiSurfaceShowDynamicPage: Codable, Sendable {
@@ -1196,6 +1207,8 @@ public struct IPCUiSurfaceShowDynamicPage: Codable, Sendable {
     public let title: String?
     public let actions: [IPCSurfaceAction]?
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 }
 
 public struct IPCUiSurfaceShowFileUpload: Codable, Sendable {
@@ -1207,6 +1220,8 @@ public struct IPCUiSurfaceShowFileUpload: Codable, Sendable {
     public let title: String?
     public let actions: [IPCSurfaceAction]?
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 }
 
 public struct IPCUiSurfaceShowForm: Codable, Sendable {
@@ -1218,6 +1233,8 @@ public struct IPCUiSurfaceShowForm: Codable, Sendable {
     public let title: String?
     public let actions: [IPCSurfaceAction]?
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 }
 
 public struct IPCUiSurfaceShowList: Codable, Sendable {
@@ -1229,6 +1246,8 @@ public struct IPCUiSurfaceShowList: Codable, Sendable {
     public let title: String?
     public let actions: [IPCSurfaceAction]?
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 }
 
 public struct IPCUiSurfaceShowTable: Codable, Sendable {
@@ -1240,6 +1259,8 @@ public struct IPCUiSurfaceShowTable: Codable, Sendable {
     public let title: String?
     public let actions: [IPCSurfaceAction]?
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 }
 
 public struct IPCUiSurfaceUndoRequest: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -707,8 +707,10 @@ public struct UiSurfaceShowMessage: Decodable, Sendable {
     public let actions: [SurfaceActionData]?
     /// `"inline"` embeds in chat, `"panel"` shows a floating window.
     public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
 
-    public init(sessionId: String, surfaceId: String, surfaceType: String, title: String?, data: AnyCodable, actions: [SurfaceActionData]?, display: String?) {
+    public init(sessionId: String, surfaceId: String, surfaceType: String, title: String?, data: AnyCodable, actions: [SurfaceActionData]?, display: String?, messageId: String?) {
         self.sessionId = sessionId
         self.surfaceId = surfaceId
         self.surfaceType = surfaceType
@@ -716,6 +718,7 @@ public struct UiSurfaceShowMessage: Decodable, Sendable {
         self.data = data
         self.actions = actions
         self.display = display
+        self.messageId = messageId
     }
 }
 
@@ -1142,6 +1145,10 @@ public struct SessionErrorMessage: Decodable, Sendable {
 /// Backed by generated `IPCReminderFired`.
 public typealias ReminderFiredMessage = IPCReminderFired
 
+/// Schedule complete notification from daemon.
+/// Backed by generated `IPCScheduleComplete`.
+public typealias ScheduleCompleteMessage = IPCScheduleComplete
+
 /// Watch session started notification from daemon.
 /// Backed by generated `IPCWatchStarted`.
 public typealias WatchStartedMessage = IPCWatchStarted
@@ -1413,6 +1420,7 @@ public enum ServerMessage: Decodable, Sendable {
     case toolOutputChunk(ToolOutputChunkMessage)
     case toolResult(ToolResultMessage)
     case reminderFired(ReminderFiredMessage)
+    case scheduleComplete(ScheduleCompleteMessage)
     case watchStarted(WatchStartedMessage)
     case watchCompleteRequest(WatchCompleteRequestMessage)
     case traceEvent(TraceEventMessage)
@@ -1557,6 +1565,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "reminder_fired":
             let message = try ReminderFiredMessage(from: decoder)
             self = .reminderFired(message)
+        case "schedule_complete":
+            let message = try ScheduleCompleteMessage(from: decoder)
+            self = .scheduleComplete(message)
         case "watch_started":
             let message = try WatchStartedMessage(from: decoder)
             self = .watchStarted(message)

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -957,7 +957,7 @@ extension IPCHistoryResponse {
 extension IPCHistoryResponseMessage {
     /// Backward-compatible init without textSegments/contentOrder (added in later IPC version).
     public init(role: String, text: String, timestamp: Double, toolCalls: [IPCHistoryResponseToolCall]?, toolCallsBeforeText: Bool?, attachments: [IPCUserMessageAttachment]?) {
-        self.init(role: role, text: text, timestamp: timestamp, toolCalls: toolCalls, toolCallsBeforeText: toolCallsBeforeText, attachments: attachments, textSegments: nil, contentOrder: nil)
+        self.init(id: nil, role: role, text: text, timestamp: timestamp, toolCalls: toolCalls, toolCallsBeforeText: toolCallsBeforeText, attachments: attachments, textSegments: nil, contentOrder: nil)
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix `runOnce()` missing `notifySchedule` argument in scheduler
- Include message `id` in history response for surface-to-message matching
- Append surface order when binding history surfaces by `messageId`
- Preserve tool_result blocks when no preceding assistant message exists
- Collect vector cleanup IDs during message consolidation

## Details

This PR addresses five critical issues identified in the automated review of PR #3065:

### 1. Fix scheduler runOnce() crash
The `runOnce` method was calling `runScheduleOnce` with only 2 arguments instead of the required 3, which would cause a `TypeError: notifySchedule is not a function` when schedule jobs complete.

**Fixed in:** `assistant/src/schedule/scheduler.ts`

### 2. Include message id in history response
The `handleHistoryRequest` function was dropping the message `id` field during the final mapping to the wire format, preventing UI surfaces from being correctly matched to their originating messages during history reload.

**Fixed in:** `assistant/src/daemon/handlers.ts`

### 3. Append surface to contentOrder when binding by messageId
When attaching surfaces via `messageId` during history loading, only `inlineSurfaces` was updated but `contentOrder` was not appended. This caused surfaces to disappear after reload for messages using interleaved rendering.

**Fixed in:** `clients/shared/Features/Chat/ChatViewModel.swift`

### 4. Preserve tool_result blocks when no preceding assistant message
The `mergeToolResults` function was suppressing tool_result user messages even when there was no preceding assistant message to merge them into. This caused tool results to be lost in edge cases like cancellation/error/handoff before a follow-up assistant turn.

**Fixed in:** `assistant/src/daemon/handlers.ts`

### 5. Collect vector cleanup IDs during consolidation
The consolidation path was ignoring the return values from `deleteMessageById`, leaving stale vector entries in Qdrant for deleted messages.

**Fixed in:** `assistant/src/daemon/session.ts`

## Test plan
- [ ] Verify scheduler `runOnce()` doesn't crash when completing jobs
- [ ] Verify UI surfaces are correctly matched to messages after history reload
- [ ] Verify surfaces appear correctly in interleaved message content after reload
- [ ] Verify tool results are preserved when conversation ends before next assistant turn
- [ ] Verify Qdrant vectors are cleaned up during message consolidation

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
