### PR TITLE
fix: address review feedback on PR 3065

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -410,9 +410,11 @@ export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistor
             if (resultEntry.imageData) unresolved.imageData = resultEntry.imageData;
           }
         }
+        // Only suppress this internal user message if we successfully merged into a preceding assistant message
+        continue;
       }
-      // Suppress this internal user message from the visible history
-      continue;
+      // If there's no preceding assistant message to merge into, preserve the tool_result message
+      // so the results aren't lost (e.g., cancellation/error/handoff before follow-up assistant turn)
     }
 
     result.push({ ...msg, toolCalls: msg.toolCalls.map((tc) => ({ ...tc })) });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1302,12 +1302,26 @@ export class Session {
     const firstAssistantMsg = messagesToConsolidate[0];
     conversationStore.updateMessageContent(firstAssistantMsg.id, JSON.stringify(consolidatedContent));
 
-    // Delete the other assistant messages and internal tool_result messages
+    // Delete the other assistant messages and internal tool_result messages,
+    // and collect IDs for vector cleanup
+    const allSegmentIds: string[] = [];
+    const allOrphanedItemIds: string[] = [];
     for (let i = 1; i < messagesToConsolidate.length; i++) {
-      conversationStore.deleteMessageById(messagesToConsolidate[i].id);
+      const deleted = conversationStore.deleteMessageById(messagesToConsolidate[i].id);
+      allSegmentIds.push(...deleted.segmentIds);
+      allOrphanedItemIds.push(...deleted.orphanedItemIds);
     }
     for (const id of messagesToDelete) {
-      conversationStore.deleteMessageById(id);
+      const deleted = conversationStore.deleteMessageById(id);
+      allSegmentIds.push(...deleted.segmentIds);
+      allOrphanedItemIds.push(...deleted.orphanedItemIds);
+    }
+
+    // Clean up Qdrant vectors (fire-and-forget)
+    if (allSegmentIds.length > 0 || allOrphanedItemIds.length > 0) {
+      this.cleanupQdrantVectors(allSegmentIds, allOrphanedItemIds).catch((err) => {
+        log.warn({ err, conversationId: this.conversationId }, 'Qdrant cleanup after consolidation failed (non-fatal)');
+      });
     }
 
     log.info({


### PR DESCRIPTION
## Summary
- Preserve tool_result blocks when no preceding assistant message exists
- Collect vector cleanup IDs during message consolidation

## Details

This PR addresses two remaining issues from the automated review of PR #3065. Three other issues (runOnce missing notifySchedule argument, history response missing message id, and contentOrder not updated for history surfaces) were already fixed in recent commits to main.

### 1. Preserve tool_result blocks when no preceding assistant message
The `mergeToolResults` function was suppressing tool_result user messages even when there was no preceding assistant message to merge them into. This caused tool results to be lost in edge cases like cancellation/error/handoff before a follow-up assistant turn.

**Fixed in:** `assistant/src/daemon/handlers/shared.ts`

### 2. Collect vector cleanup IDs during consolidation
The consolidation path was ignoring the return values from `deleteMessageById`, leaving stale vector entries in Qdrant for deleted messages. Now collects segment and orphaned item IDs and triggers Qdrant cleanup.

**Fixed in:** `assistant/src/daemon/session.ts`

## Test plan
- [ ] Verify tool results are preserved when conversation ends before next assistant turn
- [ ] Verify Qdrant vectors are cleaned up during message consolidation

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
