### PR TITLE
fix: close activity panel when message disappears or thread switches

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -35,7 +35,7 @@ struct ChatView: View {
     let onCopyDebugInfo: () -> Void
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
-    let onOpenActivity: ([ToolCallData]) -> Void
+    let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
@@ -541,7 +541,7 @@ private struct ChatBubble: View {
     /// When true, tool call chips are suppressed because a nearby message has inline surfaces.
     let hideToolCalls: Bool
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
-    let onOpenActivity: ([ToolCallData]) -> Void
+    let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
 
     private var isUser: Bool { message.role == .user }
@@ -648,7 +648,7 @@ private struct ChatBubble: View {
                 isActivityPanelOpen: isActivityPanelOpen,
                 isStreaming: message.isStreaming
             ) {
-                onOpenActivity(calls)
+                onOpenActivity(message.id)
             }
             .frame(maxWidth: 520, alignment: .leading)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -11,19 +11,20 @@ final class MainWindowState: ObservableObject {
     @Published var activeDynamicParsedSurface: Surface?
     @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
-    @Published var activityToolCalls: [ToolCallData] = []
+    @Published var activityMessageId: UUID?
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey
     }
 
-    func toggleActivityPanel(with toolCalls: [ToolCallData]) {
-        if activePanel == .activity {
-            // Close if already open
+    func toggleActivityPanel(with messageId: UUID) {
+        if activePanel == .activity && activityMessageId == messageId {
+            // Close if already open with the same message
             activePanel = nil
+            activityMessageId = nil
         } else {
-            // Open with new tool calls
-            self.activityToolCalls = toolCalls
+            // Open with new message or update to different message
+            self.activityMessageId = messageId
             self.activePanel = .activity
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -498,9 +498,9 @@ struct MainWindowView: View {
                         onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
                         watchSession: ambientAgent.activeWatchSession,
                         onStopWatch: { viewModel.stopWatchSession() },
-                        onOpenActivity: { toolCalls in
-                            print("DEBUG: onOpenActivity called with \(toolCalls.count) tool calls")
-                            windowState.toggleActivityPanel(with: toolCalls)
+                        onOpenActivity: { messageId in
+                            print("DEBUG: onOpenActivity called with message ID: \(messageId)")
+                            windowState.toggleActivityPanel(with: messageId)
                             print("DEBUG: activePanel is now \(String(describing: windowState.activePanel))")
                         },
                         isActivityPanelOpen: windowState.activePanel == .activity
@@ -869,10 +869,17 @@ struct MainWindowView: View {
             case .doctor:
                 DoctorPanel(onClose: { windowState.activePanel = nil })
             case .activity:
-                ActivityPanel(
-                    toolCalls: windowState.activityToolCalls,
-                    onClose: { windowState.activePanel = nil }
-                )
+                if let viewModel = threadManager.activeViewModel,
+                   let messageId = windowState.activityMessageId {
+                    ActivityPanel(
+                        viewModel: viewModel,
+                        messageId: messageId,
+                        onClose: { windowState.activePanel = nil }
+                    )
+                } else {
+                    Color.clear.frame(width: 0, height: 0)
+                        .onAppear { windowState.activePanel = nil }
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -209,6 +209,12 @@ struct MainWindowView: View {
                 threadManager.clearActiveSurface(threadId: oldId)
             }
             threadManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
+
+            // Close activity panel on thread switch to prevent showing stale data from previous thread
+            if windowState.activePanel == .activity {
+                windowState.activePanel = nil
+                windowState.activityMessageId = nil
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
@@ -253,6 +259,18 @@ struct MainWindowView: View {
         .onChange(of: windowState.activeDynamicSurface?.surfaceId) { _, surfaceId in
             if windowState.isDynamicExpanded {
                 threadManager.activeViewModel?.activeSurfaceId = surfaceId
+            }
+        }
+        .onChange(of: threadManager.activeViewModel?.messages) { _, _ in
+            // Close activity panel if the referenced message no longer exists
+            if let messageId = windowState.activityMessageId,
+               windowState.activePanel == .activity,
+               let viewModel = threadManager.activeViewModel {
+                let messageExists = viewModel.messages.contains(where: { $0.id == messageId })
+                if !messageExists {
+                    windowState.activePanel = nil
+                    windowState.activityMessageId = nil
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -2,8 +2,13 @@ import SwiftUI
 import VellumAssistantShared
 
 struct ActivityPanel: View {
-    let toolCalls: [ToolCallData]
+    @ObservedObject var viewModel: ChatViewModel
+    let messageId: UUID
     let onClose: () -> Void
+
+    private var toolCalls: [ToolCallData] {
+        viewModel.messages.first(where: { $0.id == messageId })?.toolCalls ?? []
+    }
 
     var body: some View {
         VSidePanel(title: "Activity", onClose: onClose) {
@@ -208,31 +213,46 @@ struct ActivityStepView: View {
 #if DEBUG
 struct ActivityPanel_Previews: PreviewProvider {
     static var previews: some View {
-        ActivityPanel(
-            toolCalls: [
-                ToolCallData(
-                    toolName: "Web Search",
-                    inputSummary: "flights from New York to London next week",
-                    result: "Found 5 search results",
-                    isComplete: true
-                ),
-                ToolCallData(
-                    toolName: "Browser Navigate",
-                    inputSummary: "https://www.google.com/travel/flights",
-                    result: "Navigated successfully",
-                    isComplete: true
-                ),
-                ToolCallData(
-                    toolName: "Browser Screenshot",
-                    inputSummary: "",
-                    isComplete: true
-                ),
-                ToolCallData(
-                    toolName: "Browser Click",
-                    inputSummary: "[aria-label=\"Departure\"]",
-                    isComplete: false
-                )
-            ],
+        let dc = DaemonClient()
+        let viewModel = ChatViewModel(daemonClient: dc)
+        let messageId = UUID()
+
+        // Add a message with tool calls to the view model
+        viewModel.messages = [
+            ChatMessage(
+                id: messageId,
+                role: .assistant,
+                text: "Finding flights for you",
+                toolCalls: [
+                    ToolCallData(
+                        toolName: "Web Search",
+                        inputSummary: "flights from New York to London next week",
+                        result: "Found 5 search results",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Navigate",
+                        inputSummary: "https://www.google.com/travel/flights",
+                        result: "Navigated successfully",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Screenshot",
+                        inputSummary: "",
+                        isComplete: true
+                    ),
+                    ToolCallData(
+                        toolName: "Browser Click",
+                        inputSummary: "[aria-label=\"Departure\"]",
+                        isComplete: false
+                    )
+                ]
+            )
+        ]
+
+        return ActivityPanel(
+            viewModel: viewModel,
+            messageId: messageId,
             onClose: {}
         )
         .frame(height: 600)

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -78,11 +78,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-<<<<<<< HEAD
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, currentHTML: data.html, sandboxMode: sandboxMode)
-=======
         Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
->>>>>>> 96cab3e0 (feat: add vellum.openLink JS bridge and coordinator handler)
     }
 
     func makeNSView(context: Context) -> WKWebView {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -78,8 +78,8 @@ struct SurfaceContainerView: View {
                     appId: viewModel.appId,
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
-                    sandboxMode: viewModel.sandboxMode,
-                    onLinkOpen: viewModel.onLinkOpen
+                    onLinkOpen: viewModel.onLinkOpen,
+                    sandboxMode: viewModel.sandboxMode
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):


### PR DESCRIPTION
## Summary

Addresses [feedback on PR #2949](https://github.com/vellum-ai/vellum-assistant/pull/2949) where the Activity panel could remain open with empty/stale content after message deletions or thread switches.

## Changes

Added two automatic panel-close behaviors to prevent the confusing UX of a blank activity panel:

1. **Close on message deletion**: Added `onChange(of: messages)` handler that closes the activity panel when the referenced message no longer exists (e.g., after regenerate, undo, or message rebuild flows)

2. **Close on thread switch**: Enhanced existing `onChange(of: activeThreadId)` handler to also close the activity panel, preventing stale data from the previous thread

## Technical Details

**Before:**
- Activity panel used `messageId` reference to derive live tool calls
- But panel could stay open when message was deleted → showed empty `[]` fallback
- Users had to manually close and reopen from a chip to see new activity

**After:**
- Panel automatically closes when message disappears or thread switches
- Users won't see blank activity views
- Maintains reactivity for normal flows (tool results streaming in)

## Files Modified

- `MainWindowView.swift` — Added message existence check and thread switch cleanup

## Related

Addresses feedback from chatgpt-codex-connector on #2949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
