### PR TITLE
feat: add appId and projectSlug to published_pages

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -324,6 +324,9 @@ export function initializeDb(): void {
     )
   `);
 
+  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN app_id TEXT`); } catch {}
+  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN project_slug TEXT`); } catch {}
+
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS shared_app_links (
       id TEXT PRIMARY KEY,

--- a/assistant/src/memory/published-pages-store.ts
+++ b/assistant/src/memory/published-pages-store.ts
@@ -17,6 +17,8 @@ export interface PublishedPageRecord {
   htmlHash: string;
   publishedAt: number;
   status: string;
+  appId: string | null;
+  projectSlug: string | null;
 }
 
 export function createPublishedPage(record: {
@@ -25,6 +27,8 @@ export function createPublishedPage(record: {
   publicUrl: string;
   pageTitle?: string;
   htmlHash: string;
+  appId?: string;
+  projectSlug?: string;
 }): void {
   const db = getDb();
   db.insert(publishedPages)
@@ -36,6 +40,8 @@ export function createPublishedPage(record: {
       htmlHash: record.htmlHash,
       publishedAt: Date.now(),
       status: 'active',
+      appId: record.appId ?? null,
+      projectSlug: record.projectSlug ?? null,
     })
     .run();
 }
@@ -96,4 +102,35 @@ export function markDeleted(id: string): boolean {
     .run();
 
   return true;
+}
+
+export function getActivePublishedPageByAppId(appId: string): PublishedPageRecord | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(publishedPages)
+    .where(
+      and(
+        eq(publishedPages.appId, appId),
+        eq(publishedPages.status, 'active'),
+      ),
+    )
+    .get();
+  return row ?? null;
+}
+
+export function updatePublishedPage(
+  id: string,
+  updates: {
+    deploymentId?: string;
+    publicUrl?: string;
+    htmlHash?: string;
+    publishedAt?: number;
+  },
+): void {
+  const db = getDb();
+  db.update(publishedPages)
+    .set(updates)
+    .where(eq(publishedPages.id, id))
+    .run();
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -328,6 +328,8 @@ export const publishedPages = sqliteTable('published_pages', {
   htmlHash: text('html_hash').notNull(),
   publishedAt: integer('published_at').notNull(),
   status: text('status').notNull().default('active'),
+  appId: text('app_id'),
+  projectSlug: text('project_slug'),
 });
 
 export const llmUsageEvents = sqliteTable('llm_usage_events', {


### PR DESCRIPTION
## Summary
- Add `app_id` and `project_slug` nullable columns to the `published_pages` table schema, migration, and store
- Add `getActivePublishedPageByAppId()` query function to look up active deployments by app ID
- Add `updatePublishedPage()` function for updating deployment details on redeployment

Part of #3324.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify migration runs cleanly on existing databases (columns added via ALTER TABLE with try/catch)
- [ ] Verify new store functions work with the updated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
