### PR TITLE
feat: pass appId and projectSlug through publish flow

### DIFF
--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -47,6 +47,8 @@ export async function handlePublishPage(
         publicUrl: result.url,
         pageTitle: msg.title,
         htmlHash,
+        appId: msg.appId,
+        projectSlug: name,
       });
 
       return { url: result.url, deploymentId: result.deploymentId };

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -588,6 +588,7 @@ export interface PublishPageRequest {
   type: 'publish_page';
   html: string;
   title?: string;
+  appId?: string;
 }
 
 export interface PublishPageResponse {


### PR DESCRIPTION
Part of #3324. Adds appId to PublishPageRequest and passes both appId and projectSlug to createPublishedPage so deployments are linked to their source app.

## Changes
- Added optional `appId` field to `PublishPageRequest` interface in `ipc-contract.ts`
- Updated `handlePublishPage` in `publish.ts` to forward `msg.appId` and the computed `name` slug to `createPublishedPage`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
