### PR TITLE
fix: close activity panel when message disappears due to regenerate/undo

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -274,6 +274,19 @@ struct MainWindowView: View {
                 threadManager.activeViewModel?.activeSurfaceId = surfaceId
             }
         }
+        .onChange(of: threadManager.activeViewModel?.messages) { _, _ in
+            // Close activity panel if the referenced message no longer exists
+            // (e.g., after regenerate, undo, or message rebuild flows)
+            if let messageId = windowState.activityMessageId,
+               windowState.activePanel == .activity,
+               let viewModel = threadManager.activeViewModel {
+                let messageExists = viewModel.messages.contains(where: { $0.id == messageId })
+                if !messageExists {
+                    windowState.activePanel = nil
+                    windowState.activityMessageId = nil
+                }
+            }
+        }
         .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
         .onReceive(DistributedNotificationCenter.default().publisher(for: Notification.Name("AppleInterfaceThemeChangedNotification"))) { _ in
             systemIsDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua


### PR DESCRIPTION
## Summary

Completes the fix for [PR #2949 feedback](https://github.com/vellum-ai/vellum-assistant/pull/2949) where the Activity panel could remain open with empty/stale content after message deletions.

## Context

PR #2949 already added code to close the activity panel on thread switch (lines 220-225 in MainWindowView.swift). However, the bot feedback specifically mentioned another case: when messages are removed/rebuilt **within the same thread** via regenerate, undo, or other message rebuild flows.

## Changes

Added `onChange(of: messages)` handler that watches for changes to the messages array and automatically closes the activity panel if the referenced message no longer exists.

## Technical Details

**Before:**
- Activity panel used `messageId` reference to derive live tool calls
- Panel closed on thread switch ✅
- Panel could stay open when message deleted within same thread ❌ → showed empty `[]` fallback

**After:**
- Panel closes on thread switch ✅
- Panel closes when message is deleted/rebuilt ✅
- Users won't see blank activity views
- Maintains reactivity for normal flows (tool results streaming in)

## Files Modified

- `MainWindowView.swift` — Added message existence check in onChange handler

## Related

Addresses feedback from chatgpt-codex-connector on #2949:
> "Falling back to `[]` when `messageId` is no longer present leaves the Activity panel open but empty, which can happen after flows that remove/rebuild assistant messages (for example regenerate/undo paths)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
