### PR TITLE
feat: auto-redeploy published apps on content change

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -84,6 +84,7 @@ import {
   surfaceProxyResolver,
 } from './session-surfaces.js';
 import { prepareMemoryContext } from './session-memory.js';
+import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
 import {
   approveHostAttachmentRead,
   formatAttachmentWarnings,
@@ -286,6 +287,7 @@ export class Session {
         if (appId) {
           refreshSurfacesForApp(this, appId);
           this.broadcastToAllClients?.({ type: 'app_files_changed', appId });
+          void updatePublishedAppDeployment(appId);
         }
       }
 
@@ -296,6 +298,7 @@ export class Session {
         if (appId) {
           refreshSurfacesForApp(this, appId, { fileChange: true, status });
           this.broadcastToAllClients?.({ type: 'app_files_changed', appId });
+          void updatePublishedAppDeployment(appId);
         }
       }
 

--- a/assistant/src/services/published-app-updater.ts
+++ b/assistant/src/services/published-app-updater.ts
@@ -1,0 +1,69 @@
+/**
+ * Background service that auto-redeploys published apps when their content changes.
+ */
+
+import { createHash } from 'node:crypto';
+import { getLogger } from '../util/logger.js';
+import { getActivePublishedPageByAppId, updatePublishedPage } from '../memory/published-pages-store.js';
+import { getApp } from '../memory/app-store.js';
+import { deployHtmlToVercel } from './vercel-deploy.js';
+import { credentialBroker } from '../tools/credentials/broker.js';
+
+const log = getLogger('published-app-updater');
+
+export async function updatePublishedAppDeployment(appId: string): Promise<void> {
+  try {
+    // 1. Check if this app has an active published deployment
+    const publishedPage = getActivePublishedPageByAppId(appId);
+    if (!publishedPage) return;
+
+    // 2. Load the app to get current HTML
+    const app = getApp(appId);
+    if (!app || !app.htmlDefinition) {
+      log.warn({ appId }, 'Published app not found or has no HTML');
+      return;
+    }
+
+    // 3. Hash the current HTML and check if it changed
+    const newHash = createHash('sha256').update(app.htmlDefinition).digest('hex');
+    if (newHash === publishedPage.htmlHash) return; // No change
+
+    // 4. Get Vercel token — don't prompt, just skip if unavailable
+    const slug = publishedPage.projectSlug ?? `vellum-page-${Date.now()}`;
+
+    const useResult = await credentialBroker.serverUse({
+      service: 'vercel',
+      field: 'api_token',
+      toolName: 'publish_page',
+      execute: async (token) => {
+        // 5. Deploy updated HTML using the same project slug
+        const result = await deployHtmlToVercel({
+          html: app.htmlDefinition,
+          name: slug,
+          token,
+        });
+
+        // 6. Update the published page record
+        updatePublishedPage(publishedPage.id, {
+          deploymentId: result.deploymentId,
+          publicUrl: result.url,
+          htmlHash: newHash,
+          publishedAt: Date.now(),
+        });
+
+        log.info(
+          { appId, deploymentId: result.deploymentId, url: result.url },
+          'Auto-updated published app deployment',
+        );
+
+        return result;
+      },
+    });
+
+    if (!useResult.success) {
+      log.warn({ appId, reason: useResult.reason }, 'Could not auto-update published app — no Vercel credential available');
+    }
+  } catch (err) {
+    log.error({ err, appId }, 'Failed to auto-update published app deployment');
+  }
+}


### PR DESCRIPTION
Part of #3324.

## Summary
- Creates `published-app-updater.ts` service that auto-redeploys to Vercel when a published app's HTML changes
- Hashes current HTML and compares against the stored hash to skip no-op deploys
- Reuses the stored `projectSlug` so the public URL stays stable across redeploys
- Triggered from `app_update`, `app_file_edit`, and `app_file_write` handlers in `session.ts`
- Gracefully skips if no Vercel credential is available (no user prompt)

## Test plan
- [ ] Publish an app, edit its HTML via `app_file_edit`, verify Vercel redeploy fires
- [ ] Confirm unchanged HTML does not trigger a redeploy (hash match)
- [ ] Confirm missing Vercel credential logs a warning instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
