### PR TITLE
feat: allow granting file permissions on ancestor directories

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -383,10 +383,18 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
     // Exact file
     options.push({ label: filePath, description: `This file only`, pattern: `${toolName}:${filePath}` });
 
-    // Directory wildcard
-    const dir = dirname(filePath);
-    const dirName = friendlyBasename(dir);
-    options.push({ label: `${dir}/*`, description: `Any file in ${dirName}/`, pattern: `${toolName}:${dir}/*` });
+    // Ancestor directory wildcards — walk up from immediate parent, stop at home dir or /
+    const home = homedir();
+    let dir = dirname(filePath);
+    const maxLevels = 3;
+    let levels = 0;
+    while (dir && dir !== '/' && levels < maxLevels) {
+      const dirName = friendlyBasename(dir);
+      options.push({ label: `${dir}/**`, description: `Anything in ${dirName}/`, pattern: `${toolName}:${dir}/**` });
+      if (dir === home) break;
+      dir = dirname(dir);
+      levels++;
+    }
 
     // Tool wildcard
     options.push({ label: `${toolName}:*`, description: `All ${toolLabel}`, pattern: `${toolName}:*` });

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -149,13 +149,33 @@ public struct ToolConfirmationBubble: View {
             }
 
             if hasRuleOptions {
-                VButton(label: "Always Allow", style: .ghost) {
-                    let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
-                    let scope = confirmation.scopeOptions.first?.scope ?? ""
-                    if !pattern.isEmpty && !scope.isEmpty {
-                        _ = onAddTrustRule(confirmation.toolName, pattern, scope, "allow")
+                if confirmation.allowlistOptions.count > 2 {
+                    Menu {
+                        ForEach(confirmation.allowlistOptions, id: \.pattern) { option in
+                            Button(option.description) {
+                                let scope = confirmation.scopeOptions.first?.scope ?? ""
+                                if !option.pattern.isEmpty && !scope.isEmpty {
+                                    _ = onAddTrustRule(confirmation.toolName, option.pattern, scope, "allow")
+                                }
+                                onAllow()
+                            }
+                        }
+                    } label: {
+                        Text("Always Allow")
+                            .font(VFont.bodyMedium)
+                            .foregroundStyle(VColor.textSecondary)
                     }
-                    onAllow()
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                } else {
+                    VButton(label: "Always Allow", style: .ghost) {
+                        let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
+                        let scope = confirmation.scopeOptions.first?.scope ?? ""
+                        if !pattern.isEmpty && !scope.isEmpty {
+                            _ = onAddTrustRule(confirmation.toolName, pattern, scope, "allow")
+                        }
+                        onAllow()
+                    }
                 }
             }
 


### PR DESCRIPTION
The purpose of this PR is to let users grant file write permissions to an entire project directory (not just a single file or its immediate parent) when prompted for tool confirmation.

## Changes Made
- **Backend (`checker.ts`)**: Replace the single parent-directory wildcard option with up to 3 ancestor directory options using `**` glob patterns, stopping at the home directory
- **Frontend (`ToolConfirmationBubble.swift`)**: When multiple directory options exist, replace the "Always Allow" button with a dropdown `Menu` showing each ancestor directory option

## Testing
- TypeScript typechecks pass
- Manual testing: trigger a file write permission prompt and verify the "Always Allow" button shows a menu with directory-level options

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
