### PR TITLE
fix: use deterministic fallback slug in published-app-updater

### DIFF
--- a/assistant/src/services/published-app-updater.ts
+++ b/assistant/src/services/published-app-updater.ts
@@ -29,7 +29,7 @@ export async function updatePublishedAppDeployment(appId: string): Promise<void>
     if (newHash === publishedPage.htmlHash) return; // No change
 
     // 4. Get Vercel token — don't prompt, just skip if unavailable
-    const slug = publishedPage.projectSlug ?? `vellum-page-${Date.now()}`;
+    const slug = publishedPage.projectSlug ?? `vellum-app-${appId.slice(0, 8)}`;
 
     const useResult = await credentialBroker.serverUse({
       service: 'vercel',


### PR DESCRIPTION
Addresses feedback on #3339. Changes the fallback slug from `Date.now()` to a deterministic slug based on `appId`, so legacy records without a `projectSlug` still map to the same Vercel project on every redeploy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
