### PR TITLE
fix: link appId on deduplicated publish requests

### DIFF
--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -2,7 +2,7 @@ import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 import { createHash } from 'node:crypto';
 import { deployHtmlToVercel, deleteVercelDeployment } from '../../services/vercel-deploy.js';
-import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedPageByDeploymentId } from '../../memory/published-pages-store.js';
+import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedPageByDeploymentId, updatePublishedPage } from '../../memory/published-pages-store.js';
 import { setSecureKey } from '../../security/secure-keys.js';
 import { upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { credentialBroker } from '../../tools/credentials/broker.js';
@@ -24,6 +24,10 @@ export async function handlePublishPage(
     // Check if already published (no credential needed)
     const existing = getPublishedPageByHash(htmlHash);
     if (existing) {
+      // Link the existing deployment to this app if not already linked
+      if (msg.appId && !existing.appId) {
+        updatePublishedPage(existing.id, { appId: msg.appId });
+      }
       ctx.send(socket, {
         type: 'publish_page_response',
         success: true,

--- a/assistant/src/memory/published-pages-store.ts
+++ b/assistant/src/memory/published-pages-store.ts
@@ -126,6 +126,7 @@ export function updatePublishedPage(
     publicUrl?: string;
     htmlHash?: string;
     publishedAt?: number;
+    appId?: string;
   },
 ): void {
   const db = getDb();


### PR DESCRIPTION
Addresses feedback on #3337. When an identical HTML hash already exists in published_pages, update the existing record's appId if the request includes one. Also adds appId to the updatePublishedPage updates type.

## Changes
- `assistant/src/daemon/handlers/publish.ts`: Import `updatePublishedPage` and call it in the dedup early-return path when `msg.appId` is present but the existing record lacks one.
- `assistant/src/memory/published-pages-store.ts`: Add `appId?: string` to the `updates` parameter type of `updatePublishedPage`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
