### PR TITLE
fix: guard ancestor directory walk against relative paths

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -388,11 +388,13 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
     let dir = dirname(filePath);
     const maxLevels = 3;
     let levels = 0;
-    while (dir && dir !== '/' && levels < maxLevels) {
+    while (dir && dir !== '/' && dir !== '.' && levels < maxLevels) {
       const dirName = friendlyBasename(dir);
       options.push({ label: `${dir}/**`, description: `Anything in ${dirName}/`, pattern: `${toolName}:${dir}/**` });
       if (dir === home) break;
-      dir = dirname(dir);
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
       levels++;
     }
 


### PR DESCRIPTION
The purpose of this PR is to fix a bug in the ancestor directory walk where relative file paths would cause an infinite loop producing duplicate `./**` entries.

## Changes Made
- Add `dir !== '.'` guard to stop the while loop when `dirname` returns `.` for relative paths
- Add `parent === dir` check to break when `dirname` can no longer walk further up

## Testing
- Typechecks pass
- Manual review of edge cases: relative paths (`src/file.ts`, `README.md`) and absolute paths

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
