### PR TITLE
fix: add notification fallback for Ride Shotgun invitation

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -35,7 +35,9 @@ public final class AmbientAgent: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] shouldShow in
                 if shouldShow {
-                    self?.showInvitation()
+                    Task { @MainActor in
+                        await self?.showInvitation()
+                    }
                 }
             }
         rideShotgunTrigger.start()
@@ -62,7 +64,15 @@ public final class AmbientAgent: ObservableObject {
 
     // MARK: - Ride Shotgun Flow
 
-    func showInvitation() {
+    func showInvitation() async {
+        // Check notification authorization; fall back to starting session directly
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        guard settings.authorizationStatus == .authorized else {
+            log.warning("Notifications not authorized; falling back to direct ride shotgun session")
+            startRideShotgun(durationSeconds: 60)
+            return
+        }
+
         let content = UNMutableNotificationContent()
         content.title = "Ride Shotgun"
         content.body = """

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -669,7 +669,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func showRideShotgunInvitation() {
-        ambientAgent.showInvitation()
+        Task { @MainActor in
+            await ambientAgent.showInvitation()
+        }
     }
 
     @objc private func toggleSkill(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary
- Make `showInvitation()` async and check `UNUserNotificationCenter` authorization status before posting the notification
- When notifications are not authorized, fall back to starting a 1-minute ride shotgun session directly since the user explicitly requested it
- Update callers in `AmbientAgent.setupRideShotgun()` and `AppDelegate.showRideShotgunInvitation()` to use `Task { await ... }`

## Test plan
- [ ] Deny notification permissions and click "Ride Shotgun" menu item — verify a 1-minute session starts directly
- [ ] With notifications authorized, verify the invitation notification still appears as before
- [ ] Verify the Combine sink trigger path also works correctly with the async change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
