### PR TITLE
fix: use full appId in fallback slug to avoid collision risk

### DIFF
--- a/assistant/src/services/published-app-updater.ts
+++ b/assistant/src/services/published-app-updater.ts
@@ -29,7 +29,7 @@ export async function updatePublishedAppDeployment(appId: string): Promise<void>
     if (newHash === publishedPage.htmlHash) return; // No change
 
     // 4. Get Vercel token — don't prompt, just skip if unavailable
-    const slug = publishedPage.projectSlug ?? `vellum-app-${appId.slice(0, 8)}`;
+    const slug = publishedPage.projectSlug ?? `vellum-app-${appId}`;
 
     const useResult = await credentialBroker.serverUse({
       service: 'vercel',


### PR DESCRIPTION
## Summary
- Addresses Codex review feedback on #3342: the fallback slug `vellum-app-${appId.slice(0, 8)}` truncated the UUID, creating a theoretical collision risk for legacy records without `projectSlug`
- Uses the full `appId` in the fallback slug instead, eliminating any possibility of cross-app collision

## Test plan
- [ ] Verify published app auto-redeploy still works when `projectSlug` is missing (fallback path)
- [ ] Confirm the Vercel project name uses the full UUID format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
