### PR TITLE
fix: break up MainWindowView body to fix Swift type-checker timeout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -150,6 +150,36 @@ struct MainWindowView: View {
     }
 
     var body: some View {
+        coreLayoutView
+            .onChange(of: windowState.isDynamicExpanded) { _, expanded in
+                threadManager.activeViewModel?.activeSurfaceId = expanded ? windowState.activeDynamicSurface?.surfaceId : nil
+            }
+            .onChange(of: windowState.activeDynamicSurface?.surfaceId) { _, surfaceId in
+                if windowState.isDynamicExpanded {
+                    threadManager.activeViewModel?.activeSurfaceId = surfaceId
+                }
+            }
+            .onChange(of: threadManager.activeViewModel?.messages.count) { _, _ in
+                // Close activity panel if the referenced message no longer exists
+                // (e.g., after regenerate, undo, or message rebuild flows)
+                if let messageId = windowState.activityMessageId,
+                   windowState.activePanel == .activity,
+                   let viewModel = threadManager.activeViewModel {
+                    let messageExists = viewModel.messages.contains(where: { $0.id == messageId })
+                    if !messageExists {
+                        windowState.activePanel = nil
+                        windowState.activityMessageId = nil
+                    }
+                }
+            }
+            .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
+            .onReceive(DistributedNotificationCenter.default().publisher(for: Notification.Name("AppleInterfaceThemeChangedNotification"))) { _ in
+                systemIsDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            }
+    }
+
+    /// Core layout extracted to break up type-checker complexity.
+    private var coreLayoutView: some View {
         GeometryReader { geometry in
             Group {
                 if useThreadDrawer {
@@ -302,31 +332,6 @@ struct MainWindowView: View {
                 windowState.activeDynamicSurface = nil
                 windowState.activeDynamicParsedSurface = nil
             }
-        }
-        .onChange(of: windowState.isDynamicExpanded) { _, expanded in
-            threadManager.activeViewModel?.activeSurfaceId = expanded ? windowState.activeDynamicSurface?.surfaceId : nil
-        }
-        .onChange(of: windowState.activeDynamicSurface?.surfaceId) { _, surfaceId in
-            if windowState.isDynamicExpanded {
-                threadManager.activeViewModel?.activeSurfaceId = surfaceId
-            }
-        }
-        .onChange(of: threadManager.activeViewModel?.messages) { _, _ in
-            // Close activity panel if the referenced message no longer exists
-            // (e.g., after regenerate, undo, or message rebuild flows)
-            if let messageId = windowState.activityMessageId,
-               windowState.activePanel == .activity,
-               let viewModel = threadManager.activeViewModel {
-                let messageExists = viewModel.messages.contains(where: { $0.id == messageId })
-                if !messageExists {
-                    windowState.activePanel = nil
-                    windowState.activityMessageId = nil
-                }
-            }
-        }
-        .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
-        .onReceive(DistributedNotificationCenter.default().publisher(for: Notification.Name("AppleInterfaceThemeChangedNotification"))) { _ in
-            systemIsDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         }
     }
 


### PR DESCRIPTION
## Summary
- Split `MainWindowView.body` into `body` + `coreLayoutView` to fix the Swift compiler error: "unable to type-check this expression in reasonable time" caused by 18 chained modifiers on a single expression
- Fixed hidden `Equatable` conformance error: `.onChange(of: messages)` required `ChatMessage: Equatable` — changed to observe `.messages.count` instead

## Test plan
- [x] `./build.sh release` succeeds locally
- [ ] PR macOS Build Check passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
