### PR TITLE
fix: guard against undefined htmlDefinition in isPrebuiltHomeBaseApp

### DIFF
--- a/assistant/src/home-base/prebuilt-home-base-updater.ts
+++ b/assistant/src/home-base/prebuilt-home-base-updater.ts
@@ -12,7 +12,7 @@ export function isPrebuiltHomeBaseApp(app: Pick<AppDefinition, 'name' | 'descrip
   if (app.description?.startsWith(HOME_BASE_PREBUILT_DESCRIPTION_PREFIX)) {
     return true;
   }
-  return app.htmlDefinition.includes('data-vellum-home-base="v1"');
+  return app.htmlDefinition?.includes('data-vellum-home-base="v1"') ?? false;
 }
 
 export function validatePrebuiltHomeBaseHtml(html: string): { valid: boolean; missingAnchors: string[] } {


### PR DESCRIPTION
## Summary
- Adds a null guard (`?.` + `?? false`) to `isPrebuiltHomeBaseApp` to prevent `TypeError` when `htmlDefinition` is `undefined`
- This happens when `listApps()` returns metadata-only objects without loading HTML from disk

## Context
Addresses review feedback from PR #3328.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] Verified the fix handles `undefined` htmlDefinition gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
