### PR TITLE
fix: renumber duplicate rule in Home Base workspace context

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -78,7 +78,7 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
 
     if (ctx.html.includes('data-vellum-home-base="v1"')) {
       lines.push(
-        '6. This is the prebuilt Home Base scaffold. Preserve layout anchors:',
+        '9. This is the prebuilt Home Base scaffold. Preserve layout anchors:',
         '   `home-base-root`, `home-base-onboarding-lane`, and `home-base-starter-lane`.',
       );
     }


### PR DESCRIPTION
Addresses review feedback from PR #3328. The Home Base scaffold preservation rule was numbered '6.' which conflicted with existing rule 6 (NEVER respond with only text). Renumbered to 9.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
