### PR TITLE
fix: stop recreating BOOTSTRAP.md on every daemon startup

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -381,4 +381,36 @@ describe('ensurePromptFiles', () => {
     // mocking the filesystem, but the important contract is: no throw.
     expect(() => ensurePromptFiles()).not.toThrow();
   });
+
+  test('creates BOOTSTRAP.md on first run when no prompt files exist', () => {
+    ensurePromptFiles();
+
+    const bootstrapPath = join(TEST_DIR, 'BOOTSTRAP.md');
+    expect(existsSync(bootstrapPath)).toBe(true);
+    const content = readFileSync(bootstrapPath, 'utf-8');
+    expect(content.length).toBeGreaterThan(0);
+  });
+
+  test('does not recreate BOOTSTRAP.md when other prompt files already exist', () => {
+    // Simulate a workspace where onboarding completed: core files exist,
+    // BOOTSTRAP.md was deleted by the user.
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'My identity');
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), 'My soul');
+    writeFileSync(join(TEST_DIR, 'USER.md'), 'My user');
+
+    ensurePromptFiles();
+
+    const bootstrapPath = join(TEST_DIR, 'BOOTSTRAP.md');
+    expect(existsSync(bootstrapPath)).toBe(false);
+  });
+
+  test('does not recreate BOOTSTRAP.md when at least one prompt file exists', () => {
+    // Even if only one core file exists, it's not a fresh install.
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'My identity');
+
+    ensurePromptFiles();
+
+    const bootstrapPath = join(TEST_DIR, 'BOOTSTRAP.md');
+    expect(existsSync(bootstrapPath)).toBe(false);
+  });
 });

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -7,14 +7,24 @@ import { getConfig } from './loader.js';
 
 const log = getLogger('system-prompt');
 
-const PROMPT_FILES = ['SOUL.md', 'IDENTITY.md', 'USER.md', 'BOOTSTRAP.md'] as const;
+const PROMPT_FILES = ['SOUL.md', 'IDENTITY.md', 'USER.md'] as const;
 
 /**
  * Copy template prompt files into the data directory if they don't already exist.
  * Called once during daemon startup so users always have discoverable files to edit.
+ *
+ * BOOTSTRAP.md is handled separately: it is only created when *none* of the core
+ * prompt files existed beforehand (a truly fresh install).  This prevents the
+ * daemon from recreating the file on every restart after the user deletes it to
+ * signal that onboarding is complete.
  */
 export function ensurePromptFiles(): void {
   const templatesDir = join(import.meta.dirname ?? __dirname, 'templates');
+
+  // Track whether this is a fresh workspace (no core prompt files exist yet).
+  const isFirstRun = PROMPT_FILES.every(
+    (file) => !existsSync(getWorkspacePromptPath(file)),
+  );
 
   for (const file of PROMPT_FILES) {
     const dest = getWorkspacePromptPath(file);
@@ -30,6 +40,23 @@ export function ensurePromptFiles(): void {
       log.info({ file, dest }, 'Created prompt file from template');
     } catch (err) {
       log.warn({ err, file }, 'Failed to create prompt file from template');
+    }
+  }
+
+  // Only seed BOOTSTRAP.md on a truly fresh install so that deleting it
+  // reliably signals onboarding completion across daemon restarts.
+  if (isFirstRun) {
+    const bootstrapDest = getWorkspacePromptPath('BOOTSTRAP.md');
+    if (!existsSync(bootstrapDest)) {
+      const bootstrapSrc = join(templatesDir, 'BOOTSTRAP.md');
+      try {
+        if (existsSync(bootstrapSrc)) {
+          copyFileSync(bootstrapSrc, bootstrapDest);
+          log.info({ file: 'BOOTSTRAP.md', dest: bootstrapDest }, 'Created BOOTSTRAP.md for first-run onboarding');
+        }
+      } catch (err) {
+        log.warn({ err, file: 'BOOTSTRAP.md' }, 'Failed to create BOOTSTRAP.md from template');
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes `BOOTSTRAP.md` from the `PROMPT_FILES` array so `ensurePromptFiles()` no longer recreates it on every daemon restart
- Adds first-run detection: BOOTSTRAP.md is now only created when none of the core prompt files (SOUL.md, IDENTITY.md, USER.md) exist, indicating a truly fresh install
- Adds 3 new tests covering the first-run creation, non-recreation when all files exist, and non-recreation when at least one file exists

Addresses review feedback from PR #3328.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 37 tests pass including 3 new tests for BOOTSTRAP.md behavior
- [ ] Verify fresh workspace creates BOOTSTRAP.md
- [ ] Verify daemon restart after onboarding completion does not recreate BOOTSTRAP.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
