### PR TITLE
fix: differentiate workspace paths for shell vs file tools in system prompt

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -333,18 +333,23 @@ function buildConfigSection(): string {
   // which would trigger approval prompts for routine workspace updates.
   const hostWorkspaceDir = getWorkspaceDir();
 
-  // When Docker sandbox is active the workspace is mounted at /workspace inside
-  // the container. The assistant should prefer the local path for all operations
-  // (shell commands, file reads, file_edit, etc.).
   const config = getConfig();
-  const localWorkspaceDir =
-    config.sandbox.enabled && config.sandbox.backend === 'docker'
-      ? '/workspace'
-      : hostWorkspaceDir;
+  const dockerSandboxActive =
+    config.sandbox.enabled && config.sandbox.backend === 'docker';
+  const localWorkspaceDir = dockerSandboxActive
+    ? '/workspace'
+    : hostWorkspaceDir;
+
+  // When Docker sandbox is active, shell commands run inside the container
+  // (use /workspace/) but file_edit/file_read/file_write run on the host
+  // (use the host path). Without Docker, both use the same path.
+  const configPreamble = dockerSandboxActive
+    ? `Your workspace is mounted at \`${localWorkspaceDir}/\` inside the Docker sandbox (host path: \`${hostWorkspaceDir}/\`). For **bash/shell commands** (which run inside Docker), use \`${localWorkspaceDir}/\`. For **file_edit, file_read, and file_write** tools (which run on the host), use the host path \`${hostWorkspaceDir}/\` or relative paths.`
+    : `Your configuration directory is \`${hostWorkspaceDir}/\`.`;
 
   return [
     '## Configuration',
-    `Your configuration directory is \`${localWorkspaceDir}/\` (host path: \`${hostWorkspaceDir}/\`). Prefer the local path for all operations. Key files you may read or edit include but are not limited to:`,
+    `${configPreamble} Key files you may read or edit include but are not limited to:`,
     '',
     '- `IDENTITY.md` — Your name, nature, vibe, and emoji. Updated during the first-run ritual.',
     '- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.',


### PR DESCRIPTION
## Summary
- When Docker sandbox is active, the system prompt now correctly instructs the assistant to use `/workspace/` paths only for bash/shell commands (which run inside Docker)
- For `file_edit`, `file_read`, and `file_write` tools (which run on the host), the prompt instructs using the host path to avoid out-of-bounds validation errors
- Fixes the issue identified by both Codex and Devin on PR #3286

## Test plan
- [x] Verify type-check passes
- [ ] Review the system prompt output with sandbox enabled vs disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
