### PR TITLE
fix: retry web_search on Brave Search 429 rate limit

### DIFF
--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -182,7 +182,26 @@ describe('WebSearchTool', () => {
       expect(result.content).toContain('Invalid or expired');
     });
 
-    test('handles 429 rate limit', async () => {
+    test('retries on 429 and succeeds', async () => {
+      let callCount = 0;
+      globalThis.fetch = (async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return new Response('Too Many Requests', { status: 429 });
+        }
+        return new Response(
+          JSON.stringify({ web: { results: [{ title: 'Result', url: 'https://example.com', description: 'Found it' }] } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }) as any;
+
+      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('Result');
+      expect(callCount).toBe(3);
+    });
+
+    test('returns error after exhausting 429 retries', async () => {
       globalThis.fetch = (async () =>
         new Response('Too Many Requests', { status: 429 })
       ) as any;
@@ -190,6 +209,30 @@ describe('WebSearchTool', () => {
       const result = await executeWebSearch({ query: 'test' }, 'test-key');
       expect(result.isError).toBe(true);
       expect(result.content).toContain('rate limit');
+      expect(result.content).toContain('after retries');
+    });
+
+    test('respects Retry-After header on 429', async () => {
+      let callCount = 0;
+      const callTimestamps: number[] = [];
+      globalThis.fetch = (async () => {
+        callCount++;
+        callTimestamps.push(Date.now());
+        if (callCount === 1) {
+          return new Response('Too Many Requests', {
+            status: 429,
+            headers: { 'Retry-After': '0' },
+          });
+        }
+        return new Response(
+          JSON.stringify({ web: { results: [] } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }) as any;
+
+      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      expect(result.isError).toBe(false);
+      expect(callCount).toBe(2);
     });
 
     test('handles network errors', async () => {
@@ -285,49 +328,67 @@ async function executeWebSearch(
 
   const url = `https://api.search.brave.com/res/v1/web/search?${params.toString()}`;
 
-  try {
-    const response = await fetch(url, {
-      headers: {
-        'Accept': 'application/json',
-        'Accept-Encoding': 'gzip',
-        'X-Subscription-Token': apiKey,
-      },
-    });
+  const MAX_RETRIES = 3;
+  const BASE_DELAY_MS = 1;  // Use 1ms in tests to avoid slow tests
 
-    if (!response.ok) {
+  try {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const response = await fetch(url, {
+        headers: {
+          'Accept': 'application/json',
+          'Accept-Encoding': 'gzip',
+          'X-Subscription-Token': apiKey,
+        },
+      });
+
+      if (response.ok) {
+        const data = await response.json() as any;
+        const results = data.web?.results ?? [];
+
+        if (results.length === 0) {
+          return { content: `No results found for "${query}".`, isError: false };
+        }
+
+        const lines: string[] = [`Web search results for "${query}":\n`];
+        for (let i = 0; i < results.length; i++) {
+          const r = results[i];
+          lines.push(`${i + 1}. ${r.title}`);
+          lines.push(`   URL: ${r.url}`);
+          if (r.description) lines.push(`   ${r.description}`);
+          if (r.age) lines.push(`   Age: ${r.age}`);
+          if (r.extra_snippets && r.extra_snippets.length > 0) {
+            for (const snippet of r.extra_snippets) {
+              lines.push(`   > ${snippet}`);
+            }
+          }
+          lines.push('');
+        }
+
+        return { content: lines.join('\n'), isError: false };
+      }
+
       await response.text();
+
       if (response.status === 401 || response.status === 403) {
         return { content: 'Error: Invalid or expired Brave Search API key', isError: true };
       }
+
+      if (response.status === 429 && attempt < MAX_RETRIES) {
+        const retryAfter = response.headers.get('retry-after');
+        const delayMs = retryAfter && !isNaN(Number(retryAfter))
+          ? Number(retryAfter) * 1000
+          : BASE_DELAY_MS * Math.pow(2, attempt);
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        continue;
+      }
+
       if (response.status === 429) {
-        return { content: 'Error: Brave Search rate limit exceeded. Try again shortly.', isError: true };
+        return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
       }
       return { content: `Error: Brave Search API returned status ${response.status}`, isError: true };
     }
 
-    const data = await response.json() as any;
-    const results = data.web?.results ?? [];
-
-    if (results.length === 0) {
-      return { content: `No results found for "${query}".`, isError: false };
-    }
-
-    const lines: string[] = [`Web search results for "${query}":\n`];
-    for (let i = 0; i < results.length; i++) {
-      const r = results[i];
-      lines.push(`${i + 1}. ${r.title}`);
-      lines.push(`   URL: ${r.url}`);
-      if (r.description) lines.push(`   ${r.description}`);
-      if (r.age) lines.push(`   Age: ${r.age}`);
-      if (r.extra_snippets && r.extra_snippets.length > 0) {
-        for (const snippet of r.extra_snippets) {
-          lines.push(`   > ${snippet}`);
-        }
-      }
-      lines.push('');
-    }
-
-    return { content: lines.join('\n'), isError: false };
+    return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error: Web search failed: ${msg}`, isError: true };

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -9,6 +9,8 @@ import { getLogger } from '../../util/logger.js';
 const log = getLogger('web-search');
 
 const BRAVE_API_URL = 'https://api.search.brave.com/res/v1/web/search';
+const RATE_LIMIT_MAX_RETRIES = 3;
+const RATE_LIMIT_BASE_DELAY_MS = 1000;
 
 interface BraveSearchResult {
   title: string;
@@ -132,34 +134,47 @@ class WebSearchTool implements Tool {
     try {
       log.debug({ query, count, offset }, 'Executing web search');
 
-      const response = await fetch(url, {
-        headers: {
-          'Accept': 'application/json',
-          'Accept-Encoding': 'gzip',
-          'X-Subscription-Token': apiKey,
-        },
-      });
+      let lastBody = '';
+      for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+        const response = await fetch(url, {
+          headers: {
+            'Accept': 'application/json',
+            'Accept-Encoding': 'gzip',
+            'X-Subscription-Token': apiKey,
+          },
+        });
 
-      if (!response.ok) {
-        const body = await response.text();
-        log.warn({ status: response.status, body }, 'Brave Search API error');
+        if (response.ok) {
+          const data = await response.json() as BraveSearchResponse;
+          const results = data.web?.results ?? [];
+          return { content: formatResults(results, query), isError: false };
+        }
+
+        lastBody = await response.text();
 
         if (response.status === 401 || response.status === 403) {
           return { content: 'Error: Invalid or expired Brave Search API key', isError: true };
         }
+
+        if (response.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
+          const retryAfter = response.headers.get('retry-after');
+          const delayMs = retryAfter && !isNaN(Number(retryAfter))
+            ? Number(retryAfter) * 1000
+            : RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
+          log.warn({ attempt: attempt + 1, delayMs }, 'Brave Search rate limited, retrying');
+          await new Promise(resolve => setTimeout(resolve, delayMs));
+          continue;
+        }
+
+        log.warn({ status: response.status, body: lastBody }, 'Brave Search API error');
         if (response.status === 429) {
-          return { content: 'Error: Brave Search rate limit exceeded. Try again shortly.', isError: true };
+          return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
         }
         return { content: `Error: Brave Search API returned status ${response.status}`, isError: true };
       }
 
-      const data = await response.json() as BraveSearchResponse;
-      const results = data.web?.results ?? [];
-
-      return {
-        content: formatResults(results, query),
-        isError: false,
-      };
+      // Should be unreachable, but satisfies TypeScript
+      return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ err }, 'Web search failed');


### PR DESCRIPTION
## Summary
- Add exponential backoff retry (up to 3 attempts) when Brave Search returns HTTP 429 rate limit
- Respects the `Retry-After` header when present, otherwise uses exponential backoff (1s, 2s, 4s)
- Non-429 errors (401, 403, 5xx) still fail immediately without retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
