### PR TITLE
fix: update system-prompt test to match Docker sandbox wording

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -162,7 +162,7 @@ describe('buildSystemPrompt', () => {
 
   test('config section uses workspace directory from platform util', () => {
     const result = buildSystemPrompt();
-    expect(result).toContain(`Your configuration directory is \`/workspace/\` (host path: \`${TEST_DIR}/\`)`);
+    expect(result).toContain(`Your workspace is mounted at \`/workspace/\` inside the Docker sandbox (host path: \`${TEST_DIR}/\`)`);
   });
 
   test('omits user skills from catalog when none are configured', () => {


### PR DESCRIPTION
## Summary
- The `system-prompt.test.ts` config section test was asserting the old wording (`"Your configuration directory is..."`) but the source was updated to `"Your workspace is mounted at..."` for Docker sandbox mode
- Updated the test expectation to match the current implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
