### PR TITLE
fix: sidebar drag-to-resize not working

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -187,7 +187,7 @@ struct MainWindowView: View {
                     HStack(spacing: 0) {
                         // Left: Full-height sidebar (always rendered, width collapses to 0)
                         threadDrawerView
-                            .frame(width: sidebarOpen && windowState.layoutConfig.left.visible ? (windowState.layoutConfig.left.width ?? threadDrawerWidth) : 0, alignment: .leading)
+                            .frame(width: sidebarOpen && windowState.layoutConfig.left.visible ? threadDrawerWidth : 0, alignment: .leading)
                             .clipped()
                             .allowsHitTesting(sidebarOpen && windowState.layoutConfig.left.visible)
                             .animation(isDrawerDragging ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: sidebarOpen)


### PR DESCRIPTION
## Summary
- The sidebar frame width was always reading from `layoutConfig.left.width` (hardcoded to 240 in the default LayoutConfig), ignoring the user-controlled `threadDrawerWidth` that the drag gesture updates
- Removed the `layoutConfig.left.width ??` override so the sidebar uses `threadDrawerWidth` directly in drawer mode, making drag-to-resize work again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
