### PR TITLE
fix: use threadDrawerWidth for inner sidebar frame too

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -437,7 +437,7 @@ struct MainWindowView: View {
                 onDoctor: { windowState.togglePanel(.doctor) }
             )
         }
-        .frame(width: windowState.layoutConfig.left.width ?? threadDrawerWidth)
+        .frame(width: threadDrawerWidth)
         .background(VColor.backgroundSubtle)
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to #3363 — the inner `threadDrawerView` content frame still used `layoutConfig.left.width`, creating a width mismatch with the outer container frame (which now uses `threadDrawerWidth`)
- This mismatch caused the sidebar to disappear due to conflicting layout constraints
- Now both inner and outer frames consistently use `threadDrawerWidth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
