### PR TITLE
fix: align onboarding buttons and rename Set up to Enable

### DIFF
--- a/assistant/src/home-base/prebuilt/index.html
+++ b/assistant/src/home-base/prebuilt/index.html
@@ -391,7 +391,8 @@
     }
 
     .onboarding-card .task-controls {
-      margin-top: 4px;
+      margin-top: auto;
+      padding-top: 4px;
     }
 
     .onboarding-card .task-button {
@@ -518,7 +519,7 @@
           <div class="task">Ambient mode</div>
           <div class="task-meta">Support while you work.</div>
           <div class="task-controls">
-            <button id="home-base-enable-ambient-start" class="task-button secondary" type="button">Set up</button>
+            <button id="home-base-enable-ambient-start" class="task-button secondary" type="button">Enable</button>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- Align the 3 Enable/Set up buttons in the onboarding cards by using `margin-top: auto` to push them to the bottom of each card
- Rename the Ambient mode "Set up" button to "Enable" for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
