### PR TITLE
feat: add TTL + LRU session eviction with memory pressure monitoring

### DIFF
--- a/assistant/src/__tests__/session-evictor.test.ts
+++ b/assistant/src/__tests__/session-evictor.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { SessionEvictor, type EvictableSession } from '../daemon/session-evictor.js';
+
+function createMockSession(processing = false): EvictableSession & { disposed: boolean } {
+  return {
+    disposed: false,
+    isProcessing() { return processing; },
+    dispose() { this.disposed = true; },
+  };
+}
+
+describe('SessionEvictor', () => {
+  let sessions: Map<string, EvictableSession & { disposed: boolean }>;
+  let evictor: SessionEvictor;
+
+  beforeEach(() => {
+    sessions = new Map();
+    evictor = new SessionEvictor(sessions as Map<string, EvictableSession>, {
+      ttlMs: 1000,
+      maxSessions: 3,
+      memoryThresholdBytes: Number.MAX_SAFE_INTEGER, // disable memory pressure for most tests
+      sweepIntervalMs: 60_000,
+    });
+  });
+
+  describe('TTL eviction', () => {
+    test('evicts sessions that have exceeded TTL', () => {
+      const s1 = createMockSession();
+      const s2 = createMockSession();
+      sessions.set('a', s1);
+      sessions.set('b', s2);
+
+      // Touch both, then backdate one beyond TTL
+      evictor.touch('a');
+      evictor.touch('b');
+
+      // Simulate time passing — set last access to 2 seconds ago (TTL is 1s)
+      (evictor as unknown as { lastAccess: Map<string, number> }).lastAccess.set('a', Date.now() - 2000);
+
+      const result = evictor.sweep();
+
+      expect(result.ttlEvicted).toBe(1);
+      expect(sessions.has('a')).toBe(false);
+      expect(sessions.has('b')).toBe(true);
+      expect(s1.disposed).toBe(true);
+      expect(s2.disposed).toBe(false);
+    });
+
+    test('evicts sessions that were never touched (lastAccess = 0)', () => {
+      const s1 = createMockSession();
+      sessions.set('a', s1);
+      // Never call evictor.touch('a')
+
+      const result = evictor.sweep();
+
+      expect(result.ttlEvicted).toBe(1);
+      expect(sessions.has('a')).toBe(false);
+      expect(s1.disposed).toBe(true);
+    });
+
+    test('skips processing sessions', () => {
+      const s1 = createMockSession(true); // processing
+      sessions.set('a', s1);
+
+      const result = evictor.sweep();
+
+      expect(result.ttlEvicted).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(sessions.has('a')).toBe(true);
+      expect(s1.disposed).toBe(false);
+    });
+  });
+
+  describe('LRU eviction', () => {
+    test('evicts least-recently-used sessions when over maxSessions', () => {
+      // maxSessions = 3, add 5 sessions
+      const allSessions: Array<EvictableSession & { disposed: boolean }> = [];
+      for (let i = 0; i < 5; i++) {
+        const s = createMockSession();
+        sessions.set(`s${i}`, s);
+        allSessions.push(s);
+        evictor.touch(`s${i}`);
+      }
+
+      // Make s0 and s1 the oldest, keep s2-s4 fresh
+      const now = Date.now();
+      const lastAccess = (evictor as unknown as { lastAccess: Map<string, number> }).lastAccess;
+      lastAccess.set('s0', now - 100); // oldest
+      lastAccess.set('s1', now - 90);  // second oldest
+      // s2, s3, s4 remain at ~now (within TTL)
+
+      const result = evictor.sweep();
+
+      expect(result.lruEvicted).toBe(2); // need to remove 2 to get from 5 to 3
+      expect(sessions.size).toBe(3);
+      expect(sessions.has('s0')).toBe(false);
+      expect(sessions.has('s1')).toBe(false);
+      expect(sessions.has('s2')).toBe(true);
+      expect(sessions.has('s3')).toBe(true);
+      expect(sessions.has('s4')).toBe(true);
+    });
+
+    test('skips processing sessions during LRU eviction', () => {
+      // maxSessions = 3, add 4 sessions, one processing
+      const s0 = createMockSession(true); // processing — should not be evicted
+      const s1 = createMockSession();
+      const s2 = createMockSession();
+      const s3 = createMockSession();
+      sessions.set('s0', s0);
+      sessions.set('s1', s1);
+      sessions.set('s2', s2);
+      sessions.set('s3', s3);
+
+      const now = Date.now();
+      const lastAccess = (evictor as unknown as { lastAccess: Map<string, number> }).lastAccess;
+      lastAccess.set('s0', now - 50); // old but processing
+      lastAccess.set('s1', now - 40);
+      lastAccess.set('s2', now);
+      lastAccess.set('s3', now);
+
+      const result = evictor.sweep();
+
+      // s1 is the LRU non-processing session, gets evicted
+      expect(result.lruEvicted).toBe(1);
+      expect(sessions.has('s0')).toBe(true); // kept: processing
+      expect(sessions.has('s1')).toBe(false); // evicted: LRU
+      expect(s0.disposed).toBe(false);
+      expect(s1.disposed).toBe(true);
+    });
+  });
+
+  describe('onEvict callback', () => {
+    test('calls onEvict for each evicted session', () => {
+      const evicted: string[] = [];
+      evictor.onEvict = (id) => evicted.push(id);
+
+      const s1 = createMockSession();
+      sessions.set('a', s1);
+      // Never touched — will be TTL evicted
+
+      evictor.sweep();
+
+      expect(evicted).toEqual(['a']);
+    });
+  });
+
+  describe('remove()', () => {
+    test('cleans up tracking for externally removed sessions', () => {
+      const s1 = createMockSession();
+      sessions.set('a', s1);
+      evictor.touch('a');
+
+      expect(evictor.trackedCount).toBe(1);
+
+      evictor.remove('a');
+      expect(evictor.trackedCount).toBe(0);
+    });
+  });
+
+  describe('stale lastAccess cleanup', () => {
+    test('removes lastAccess entries for sessions no longer in the map', () => {
+      const s1 = createMockSession();
+      sessions.set('a', s1);
+      evictor.touch('a');
+      evictor.touch('phantom'); // tracked but no session in map
+
+      expect(evictor.trackedCount).toBe(2);
+
+      // Backdate 'a' so it's evicted by TTL, 'phantom' cleaned by stale check
+      (evictor as unknown as { lastAccess: Map<string, number> }).lastAccess.set('a', Date.now() - 2000);
+
+      evictor.sweep();
+
+      expect(evictor.trackedCount).toBe(0);
+    });
+  });
+
+  describe('start/stop', () => {
+    test('stop clears tracking state', () => {
+      evictor.touch('a');
+      evictor.touch('b');
+      expect(evictor.trackedCount).toBe(2);
+
+      evictor.stop();
+      expect(evictor.trackedCount).toBe(0);
+    });
+  });
+});

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -25,6 +25,7 @@ import { handleMessage, type HandlerContext, type SessionCreateOptions } from '.
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
 import { ensureBlobDir, sweepStaleBlobs } from './ipc-blob-store.js';
 import { bootstrapHomeBaseAppLink } from '../home-base/bootstrap.js';
+import { SessionEvictor } from './session-evictor.js';
 
 const log = getLogger('server');
 
@@ -57,6 +58,7 @@ export class DaemonServer {
   private blobSweepTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly CONFIG_REFRESH_INTERVAL_MS = 30_000;
   private static readonly MAX_CONNECTIONS = 50;
+  private evictor: SessionEvictor;
 
   private applyTransportMetadata(_session: Session, options: SessionCreateOptions | undefined): void {
     const transport = options?.transport;
@@ -69,6 +71,7 @@ export class DaemonServer {
 
   constructor() {
     this.socketPath = getSocketPath();
+    this.evictor = new SessionEvictor(this.sessions);
   }
 
   async start(): Promise<void> {
@@ -87,6 +90,8 @@ export class DaemonServer {
     } catch (err) {
       log.warn({ err }, 'Failed to bootstrap Home Base app link at daemon startup');
     }
+
+    this.evictor.start();
 
     ensureBlobDir();
     this.blobSweepTimer = setInterval(() => {
@@ -125,6 +130,7 @@ export class DaemonServer {
   }
 
   async stop(): Promise<void> {
+    this.evictor.stop();
     if (this.blobSweepTimer) {
       clearInterval(this.blobSweepTimer);
       this.blobSweepTimer = null;
@@ -264,6 +270,9 @@ export class DaemonServer {
    */
   clearAllSessions(): number {
     const count = this.sessions.size;
+    for (const id of this.sessions.keys()) {
+      this.evictor.remove(id);
+    }
     for (const session of this.sessions.values()) {
       session.dispose();
     }
@@ -277,6 +286,7 @@ export class DaemonServer {
       if (!session.isProcessing()) {
         session.dispose();
         this.sessions.delete(id);
+        this.evictor.remove(id);
       } else {
         session.markStale();
       }
@@ -643,10 +653,12 @@ export class DaemonServer {
       } finally {
         this.sessionCreating.delete(conversationId);
       }
+      this.evictor.touch(conversationId);
     } else {
       // Rebind to the new socket so IPC goes to the current client.
       maybeBindClient(session);
       this.applyTransportMetadata(session, options);
+      this.evictor.touch(conversationId);
     }
     return session;
   }

--- a/assistant/src/daemon/session-evictor.ts
+++ b/assistant/src/daemon/session-evictor.ts
@@ -1,0 +1,190 @@
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('session-evictor');
+
+/** Minimal interface a session must satisfy to be evictable. */
+export interface EvictableSession {
+  isProcessing(): boolean;
+  dispose(): void;
+}
+
+export interface EvictorOptions {
+  /** Max idle time before a session is eligible for eviction (ms). Default: 30 min. */
+  ttlMs?: number;
+  /** Max number of in-memory sessions before LRU eviction kicks in. Default: 100. */
+  maxSessions?: number;
+  /** RSS threshold (bytes) above which idle sessions are aggressively evicted. Default: 512 MB. */
+  memoryThresholdBytes?: number;
+  /** Interval between periodic sweeps (ms). Default: 60 s. */
+  sweepIntervalMs?: number;
+}
+
+export interface EvictionResult {
+  /** Sessions evicted because they exceeded TTL. */
+  ttlEvicted: number;
+  /** Sessions evicted because pool exceeded maxSessions (LRU order). */
+  lruEvicted: number;
+  /** Sessions evicted due to memory pressure. */
+  memoryEvicted: number;
+  /** Sessions skipped because they were actively processing. */
+  skipped: number;
+}
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const DEFAULT_MAX_SESSIONS = 100;
+const DEFAULT_MEMORY_THRESHOLD_BYTES = 512 * 1024 * 1024; // 512 MB
+const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000; // 60 seconds
+
+export class SessionEvictor {
+  private readonly ttlMs: number;
+  private readonly maxSessions: number;
+  private readonly memoryThresholdBytes: number;
+  private readonly sweepIntervalMs: number;
+
+  /** Tracks last access time per session ID. */
+  private lastAccess = new Map<string, number>();
+
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private sessions: Map<string, EvictableSession>;
+
+  /** Optional hook called for each evicted session (for cleanup in DaemonServer). */
+  onEvict?: (sessionId: string) => void;
+
+  constructor(
+    sessions: Map<string, EvictableSession>,
+    options?: EvictorOptions,
+  ) {
+    this.sessions = sessions;
+    this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxSessions = options?.maxSessions ?? DEFAULT_MAX_SESSIONS;
+    this.memoryThresholdBytes = options?.memoryThresholdBytes ?? DEFAULT_MEMORY_THRESHOLD_BYTES;
+    this.sweepIntervalMs = options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
+  }
+
+  /** Record an access for the given session (resets its idle clock). */
+  touch(sessionId: string): void {
+    this.lastAccess.set(sessionId, Date.now());
+  }
+
+  /** Remove tracking state for a session that was externally removed. */
+  remove(sessionId: string): void {
+    this.lastAccess.delete(sessionId);
+  }
+
+  /** Start the periodic sweep timer. */
+  start(): void {
+    if (this.sweepTimer) return;
+    this.sweepTimer = setInterval(() => {
+      try {
+        const result = this.sweep();
+        const total = result.ttlEvicted + result.lruEvicted + result.memoryEvicted;
+        if (total > 0) {
+          log.info(result, 'Session eviction sweep completed');
+        }
+      } catch (err) {
+        log.error({ err }, 'Session eviction sweep failed');
+      }
+    }, this.sweepIntervalMs);
+  }
+
+  /** Stop the periodic sweep timer. */
+  stop(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    this.lastAccess.clear();
+  }
+
+  /**
+   * Run a single eviction sweep. Safe to call manually (e.g. from tests)
+   * in addition to the periodic timer.
+   */
+  sweep(): EvictionResult {
+    const now = Date.now();
+    const result: EvictionResult = {
+      ttlEvicted: 0,
+      lruEvicted: 0,
+      memoryEvicted: 0,
+      skipped: 0,
+    };
+
+    // Phase 1: TTL eviction — remove sessions idle longer than ttlMs.
+    for (const [id, session] of this.sessions) {
+      const lastAccessTime = this.lastAccess.get(id) ?? 0;
+      if (now - lastAccessTime < this.ttlMs) continue;
+      if (session.isProcessing()) {
+        result.skipped++;
+        continue;
+      }
+      this.evict(id, session);
+      result.ttlEvicted++;
+    }
+
+    // Phase 2: LRU eviction — if still over capacity, evict least-recently-used.
+    if (this.sessions.size > this.maxSessions) {
+      const sorted = this.idleSessionsByLru();
+      for (const [id, session] of sorted) {
+        if (this.sessions.size <= this.maxSessions) break;
+        this.evict(id, session);
+        result.lruEvicted++;
+      }
+    }
+
+    // Phase 3: Memory pressure — if RSS exceeds threshold, evict idle sessions
+    // starting from least-recently-used until we're under the threshold or
+    // no more idle sessions remain.
+    const rss = process.memoryUsage.rss();
+    if (rss > this.memoryThresholdBytes) {
+      log.warn(
+        { rssBytes: rss, thresholdBytes: this.memoryThresholdBytes, sessionCount: this.sessions.size },
+        'Memory pressure detected, evicting idle sessions',
+      );
+      const sorted = this.idleSessionsByLru();
+      for (const [id, session] of sorted) {
+        if (process.memoryUsage.rss() <= this.memoryThresholdBytes) break;
+        this.evict(id, session);
+        result.memoryEvicted++;
+      }
+    }
+
+    // Clean up stale lastAccess entries for sessions that no longer exist
+    // (e.g. removed by clearAllSessions or evictSessionsForReload).
+    for (const id of this.lastAccess.keys()) {
+      if (!this.sessions.has(id)) {
+        this.lastAccess.delete(id);
+      }
+    }
+
+    return result;
+  }
+
+  /** Current number of tracked sessions (for diagnostics). */
+  get trackedCount(): number {
+    return this.lastAccess.size;
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────
+
+  private evict(id: string, session: EvictableSession): void {
+    session.dispose();
+    this.sessions.delete(id);
+    this.lastAccess.delete(id);
+    this.onEvict?.(id);
+    log.debug({ sessionId: id }, 'Evicted idle session');
+  }
+
+  /**
+   * Return idle (non-processing) sessions sorted by last access time
+   * ascending (least recently used first).
+   */
+  private idleSessionsByLru(): Array<[string, EvictableSession]> {
+    const idle: Array<[string, EvictableSession, number]> = [];
+    for (const [id, session] of this.sessions) {
+      if (session.isProcessing()) continue;
+      idle.push([id, session, this.lastAccess.get(id) ?? 0]);
+    }
+    idle.sort((a, b) => a[2] - b[2]);
+    return idle.map(([id, session]) => [id, session]);
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces `SessionEvictor` with three-phase eviction: TTL (30 min idle), LRU (cap at 100 sessions), and memory pressure (512 MB RSS threshold)
- Integrates evictor into `DaemonServer` — sessions are touched on access and tracked through their lifecycle
- Adds 9 unit tests covering TTL, LRU, skip-processing, callbacks, and cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
