### PR TITLE
feat: gateway-level Telegram webhook dedup cache

### DIFF
--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { DedupCache } from "../dedup-cache.js";
+
+describe("DedupCache", () => {
+  let cache: DedupCache;
+
+  beforeEach(() => {
+    cache = new DedupCache(5_000, 100);
+  });
+
+  test("returns undefined for unseen update_id", () => {
+    expect(cache.get(123)).toBeUndefined();
+  });
+
+  test("returns cached entry after set", () => {
+    cache.set(100, '{"ok":true}', 200);
+    const hit = cache.get(100);
+    expect(hit).toEqual({ body: '{"ok":true}', status: 200 });
+  });
+
+  test("different update_ids are independent", () => {
+    cache.set(1, '{"a":1}', 200);
+    cache.set(2, '{"a":2}', 201);
+    expect(cache.get(1)?.body).toBe('{"a":1}');
+    expect(cache.get(2)?.body).toBe('{"a":2}');
+    expect(cache.get(3)).toBeUndefined();
+  });
+
+  test("expired entries are not returned", () => {
+    // Use a 1ms TTL so entries expire immediately
+    const shortCache = new DedupCache(1, 100);
+    shortCache.set(42, '{"ok":true}', 200);
+
+    // Wait for the entry to expire
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait
+    }
+
+    expect(shortCache.get(42)).toBeUndefined();
+  });
+
+  test("evicts oldest entry when at max capacity", () => {
+    const tinyCache = new DedupCache(60_000, 3);
+    tinyCache.set(1, "a", 200);
+    tinyCache.set(2, "b", 200);
+    tinyCache.set(3, "c", 200);
+    expect(tinyCache.size).toBe(3);
+
+    // Adding a 4th should evict the oldest (1)
+    tinyCache.set(4, "d", 200);
+    expect(tinyCache.size).toBe(3);
+    expect(tinyCache.get(1)).toBeUndefined();
+    expect(tinyCache.get(4)?.body).toBe("d");
+  });
+
+  test("size reflects current entries", () => {
+    expect(cache.size).toBe(0);
+    cache.set(1, "x", 200);
+    expect(cache.size).toBe(1);
+    cache.set(2, "y", 200);
+    expect(cache.size).toBe(2);
+  });
+});

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -1,0 +1,75 @@
+import { getLogger } from "./logger.js";
+
+const log = getLogger("dedup-cache");
+
+interface CacheEntry {
+  body: string;
+  status: number;
+  expiresAt: number;
+}
+
+/**
+ * In-memory TTL cache for Telegram update_id deduplication.
+ * Prevents redundant normalization, routing, attachment downloads,
+ * and runtime forwarding when Telegram retries a webhook on timeout.
+ */
+export class DedupCache {
+  private cache = new Map<number, CacheEntry>();
+  private readonly ttlMs: number;
+  private readonly maxSize: number;
+
+  constructor(ttlMs = 5 * 60_000, maxSize = 10_000) {
+    this.ttlMs = ttlMs;
+    this.maxSize = maxSize;
+  }
+
+  /** Returns the cached response body+status if the update_id was already seen. */
+  get(updateId: number): { body: string; status: number } | undefined {
+    const entry = this.cache.get(updateId);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(updateId);
+      return undefined;
+    }
+    return { body: entry.body, status: entry.status };
+  }
+
+  /** Store a response for the given update_id. */
+  set(updateId: number, body: string, status: number): void {
+    // Evict expired entries if we're at capacity
+    if (this.cache.size >= this.maxSize) {
+      this.evictExpired();
+    }
+    // If still at capacity after eviction, drop the oldest entry
+    if (this.cache.size >= this.maxSize) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) {
+        this.cache.delete(oldest);
+      }
+    }
+
+    this.cache.set(updateId, {
+      body,
+      status,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  private evictExpired(): void {
+    const now = Date.now();
+    let evicted = 0;
+    for (const [key, entry] of this.cache) {
+      if (now > entry.expiresAt) {
+        this.cache.delete(key);
+        evicted++;
+      }
+    }
+    if (evicted > 0) {
+      log.debug({ evicted }, "Evicted expired dedup cache entries");
+    }
+  }
+}

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../../config.js";
+import { DedupCache } from "../../dedup-cache.js";
 import { handleInbound, type InboundResult } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
@@ -36,6 +37,8 @@ export function createTelegramWebhookHandler(
   config: GatewayConfig,
   onReply?: OnReply,
 ) {
+  const dedupCache = new DedupCache();
+
   return async (req: Request): Promise<Response> => {
     if (req.method !== "POST") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
@@ -73,10 +76,35 @@ export function createTelegramWebhookHandler(
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
+    // Dedup check — short-circuit retried webhooks before doing any real work
+    const updateId = typeof payload.update_id === "number" ? payload.update_id : undefined;
+    if (updateId !== undefined) {
+      const cached = dedupCache.get(updateId);
+      if (cached) {
+        log.info({ updateId }, "Duplicate update_id, returning cached response");
+        return new Response(cached.body, {
+          status: cached.status,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    }
+
+    // Helper: build a JSON response and cache it for this update_id
+    const respond = (body: Record<string, unknown>, status = 200): Response => {
+      const json = JSON.stringify(body);
+      if (updateId !== undefined) {
+        dedupCache.set(updateId, json, status);
+      }
+      return new Response(json, {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
     // Normalize the update
     const normalized = normalizeTelegramUpdate(payload);
     if (!normalized) {
-      return Response.json({ ok: true });
+      return respond({ ok: true });
     }
 
     // Handle /new command — reset conversation before it reaches the runtime
@@ -106,7 +134,7 @@ export function createTelegramWebhookHandler(
         }
       }
 
-      return Response.json({ ok: true });
+      return respond({ ok: true });
     }
 
     // Check routing early so we can gate attachments and typing indicator
@@ -199,6 +227,6 @@ export function createTelegramWebhookHandler(
       });
     }
 
-    return Response.json({ ok: true });
+    return respond({ ok: true });
   };
 }


### PR DESCRIPTION
## Summary
- Adds an in-memory TTL cache (`DedupCache`) keyed by Telegram `update_id` to the gateway webhook handler
- On retried webhooks, short-circuits before normalization, routing, attachment processing, typing indicators, and runtime forwarding
- Cache has a 5-minute TTL and 10k entry cap with LRU-style eviction
- Includes unit tests for the cache (expiry, eviction, size tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
