### PR TITLE
fix: add full jitter to provider and memory job retry backoff

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -114,9 +114,10 @@ function classifyError(err: unknown): ErrorCategory {
   return 'fatal';
 }
 
-/** Exponential backoff delay: base * 2^(attempt-1), capped. */
+/** Exponential backoff with full jitter: uniform random in [0, cap]. */
 function retryDelayForAttempt(attempts: number): number {
-  return Math.min(RETRY_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempts - 1)), RETRY_MAX_DELAY_MS);
+  const cap = Math.min(RETRY_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempts - 1)), RETRY_MAX_DELAY_MS);
+  return Math.random() * cap;
 }
 
 const BACKFILL_CHECKPOINT_KEY = 'memory:backfill:last_created_at';

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -32,9 +32,10 @@ function isRetryableError(error: unknown): boolean {
 }
 
 function getRetryDelay(attempt: number): number {
-  const exponential = BASE_DELAY_MS * Math.pow(2, attempt);
-  const jitter = Math.random() * BASE_DELAY_MS;
-  return exponential + jitter;
+  // Full jitter: uniform random in [0, exponential cap] prevents synchronized
+  // retry storms when many sessions hit the same transient failure.
+  const cap = BASE_DELAY_MS * Math.pow(2, attempt);
+  return Math.random() * cap;
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Switched provider retry (`retry.ts`) from fixed-window additive jitter (0–1s) to full jitter (uniform random in [0, exponential cap])
- Added full jitter to memory jobs retry (`jobs-worker.ts`) which previously had no jitter at all (pure exponential backoff)
- Prevents synchronized retry storms (thundering herd) when multiple concurrent sessions hit the same transient failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
