### PR TITLE
fix: log JSON parse errors in habit tracker catch blocks

### DIFF
--- a/assistant/src/gallery/default-gallery.ts
+++ b/assistant/src/gallery/default-gallery.ts
@@ -383,7 +383,7 @@ const habitTrackerHtml = `<!DOCTYPE html>
     var html = '';
     habits.forEach(function(record) {
       var completedDates = [];
-      try { completedDates = JSON.parse(record.data.completedDates || '[]'); } catch(e) {}
+      try { completedDates = JSON.parse(record.data.completedDates || '[]'); } catch(e) { console.error('Failed to parse completedDates for habit ' + record.id + ':', e); }
       html += '<div class="habit-row">';
       html += '<div style="display:flex;align-items:center;gap:8px">';
       html += '<span class="habit-name">' + escapeHtml(record.data.name) + '</span>';
@@ -421,7 +421,7 @@ const habitTrackerHtml = `<!DOCTYPE html>
     var record = habits.find(function(h) { return h.id === recordId; });
     if (!record) return;
     var completedDates = [];
-    try { completedDates = JSON.parse(record.data.completedDates || '[]'); } catch(e) {}
+    try { completedDates = JSON.parse(record.data.completedDates || '[]'); } catch(e) { console.error('Failed to parse completedDates for habit ' + record.id + ':', e); }
     var idx = completedDates.indexOf(date);
     if (idx === -1) { completedDates.push(date); } else { completedDates.splice(idx, 1); }
     vellum.data.update(recordId, {


### PR DESCRIPTION
## Summary
- Both bare `catch(e) {}` blocks in `default-gallery.ts` (render and toggleDate) now log the error with the habit record ID via `console.error`
- Makes data corruption in `completedDates` visible instead of silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
