### PR TITLE
fix: use catch (err: unknown) for type safety

### DIFF
--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -62,8 +62,8 @@ try {
 try {
   const result = await fn(input);
   console.log(JSON.stringify({ __eval_result: result }));
-} catch (err: any) {
-  console.error(err?.stack ?? String(err));
+} catch (err: unknown) {
+  console.error(err instanceof Error ? err.stack : String(err));
   process.exit(1);
 }
 `;


### PR DESCRIPTION
## Summary
- Replace `catch (err: any)` with `catch (err: unknown)` in `evaluate-typescript.ts`
- Use `instanceof Error` check instead of optional chaining on untyped `any`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
