### PR TITLE
feat: MIME allowlist and dangerous extension validation for attachments

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -44,6 +44,7 @@ import {
   getAttachmentsForMessage,
   getAttachmentsForMessageUnscoped,
   deleteOrphanAttachments,
+  validateAttachmentUpload,
 } from '../memory/attachments-store.js';
 import { createConversation, addMessage } from '../memory/conversation-store.js';
 
@@ -343,5 +344,79 @@ describe('deleteOrphanAttachments', () => {
     // The unrelated attachment should still exist
     const fetched = getAttachmentById('ast-1', unrelated.id);
     expect(fetched).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAttachmentUpload
+// ---------------------------------------------------------------------------
+
+describe('validateAttachmentUpload', () => {
+  test('accepts common image MIME types', () => {
+    expect(validateAttachmentUpload('photo.png', 'image/png').ok).toBe(true);
+    expect(validateAttachmentUpload('pic.jpg', 'image/jpeg').ok).toBe(true);
+    expect(validateAttachmentUpload('anim.gif', 'image/gif').ok).toBe(true);
+    expect(validateAttachmentUpload('sticker.webp', 'image/webp').ok).toBe(true);
+  });
+
+  test('accepts document MIME types', () => {
+    expect(validateAttachmentUpload('doc.pdf', 'application/pdf').ok).toBe(true);
+    expect(validateAttachmentUpload('notes.txt', 'text/plain').ok).toBe(true);
+    expect(validateAttachmentUpload('data.csv', 'text/csv').ok).toBe(true);
+    expect(validateAttachmentUpload('config.json', 'application/json').ok).toBe(true);
+  });
+
+  test('accepts audio and video MIME types', () => {
+    expect(validateAttachmentUpload('voice.ogg', 'audio/ogg').ok).toBe(true);
+    expect(validateAttachmentUpload('song.mp3', 'audio/mpeg').ok).toBe(true);
+    expect(validateAttachmentUpload('clip.mp4', 'video/mp4').ok).toBe(true);
+  });
+
+  test('accepts application/octet-stream fallback', () => {
+    expect(validateAttachmentUpload('data.bin', 'application/octet-stream').ok).toBe(true);
+  });
+
+  test('rejects dangerous file extensions', () => {
+    const exeResult = validateAttachmentUpload('malware.exe', 'application/octet-stream');
+    expect(exeResult.ok).toBe(false);
+    if (!exeResult.ok) expect(exeResult.error).toContain('.exe');
+
+    const shResult = validateAttachmentUpload('script.sh', 'text/plain');
+    expect(shResult.ok).toBe(false);
+    if (!shResult.ok) expect(shResult.error).toContain('.sh');
+
+    const isoResult = validateAttachmentUpload('disk.iso', 'application/octet-stream');
+    expect(isoResult.ok).toBe(false);
+    if (!isoResult.ok) expect(isoResult.error).toContain('.iso');
+  });
+
+  test('rejects dangerous extensions regardless of claimed MIME type', () => {
+    // .exe disguised as image/png
+    const result = validateAttachmentUpload('payload.exe', 'image/png');
+    expect(result.ok).toBe(false);
+  });
+
+  test('extension check is case-insensitive', () => {
+    expect(validateAttachmentUpload('PROGRAM.EXE', 'application/octet-stream').ok).toBe(false);
+    expect(validateAttachmentUpload('script.SH', 'text/plain').ok).toBe(false);
+  });
+
+  test('rejects unsupported MIME types', () => {
+    const result = validateAttachmentUpload('file.unknown', 'application/x-msdownload');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('Unsupported MIME type');
+  });
+
+  test('handles filenames without extensions', () => {
+    // No extension — only MIME check applies
+    expect(validateAttachmentUpload('Makefile', 'text/plain').ok).toBe(true);
+    expect(validateAttachmentUpload('Makefile', 'application/x-evil').ok).toBe(false);
+  });
+
+  test('rejects all dangerous extension variants', () => {
+    for (const ext of ['bat', 'cmd', 'com', 'msi', 'dmg', 'app', 'scr', 'pif', 'vbs', 'ps1', 'jar']) {
+      const result = validateAttachmentUpload(`file.${ext}`, 'application/octet-stream');
+      expect(result.ok).toBe(false);
+    }
   });
 });

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -25,6 +25,85 @@ function classifyKind(mimeType: string): string {
   return 'document';
 }
 
+// ---------------------------------------------------------------------------
+// Inbound attachment MIME validation
+// ---------------------------------------------------------------------------
+
+/**
+ * MIME types accepted for inbound attachment uploads.
+ * Files with types not on this list are rejected at the API boundary.
+ */
+const ALLOWED_MIME_TYPES = new Set([
+  // Images
+  'image/png', 'image/jpeg', 'image/gif', 'image/webp',
+  'image/svg+xml', 'image/bmp', 'image/tiff', 'image/x-icon',
+  // Audio
+  'audio/mpeg', 'audio/ogg', 'audio/wav', 'audio/flac',
+  'audio/aac', 'audio/x-m4a', 'audio/mp4',
+  // Video
+  'video/mp4', 'video/webm', 'video/quicktime', 'video/mpeg',
+  // Documents
+  'application/pdf', 'text/plain', 'text/csv', 'text/markdown',
+  'text/html', 'text/css', 'application/json', 'application/xml', 'text/xml',
+  // Source code
+  'text/javascript', 'text/typescript',
+  // Archives
+  'application/zip', 'application/gzip', 'application/x-tar',
+  'application/x-7z-compressed',
+  // Office
+  'application/msword', 'application/vnd.ms-excel', 'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  // Fallback for unknown-but-not-dangerous files (Telegram often uses this)
+  'application/octet-stream',
+]);
+
+/**
+ * File extensions that are always rejected regardless of claimed MIME type.
+ */
+const DANGEROUS_EXTENSIONS = new Set([
+  'exe', 'sh', 'bat', 'cmd', 'com', 'msi', 'iso',
+  'dmg', 'app', 'scr', 'pif', 'vbs', 'ps1', 'jar',
+  'cpl', 'inf', 'reg', 'hta', 'wsf', 'wsh',
+]);
+
+export type AttachmentValidationResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Validate a filename + MIME type pair for inbound attachment uploads.
+ *
+ * Rejects files whose extension is in the dangerous blocklist or whose
+ * MIME type is not on the allowlist.
+ */
+export function validateAttachmentUpload(
+  filename: string,
+  mimeType: string,
+): AttachmentValidationResult {
+  const dot = filename.lastIndexOf('.');
+  if (dot !== -1) {
+    const ext = filename.slice(dot + 1).toLowerCase();
+    if (DANGEROUS_EXTENSIONS.has(ext)) {
+      return {
+        ok: false,
+        error: `Dangerous file type rejected: .${ext} files are not allowed`,
+      };
+    }
+  }
+
+  const normalised = mimeType.toLowerCase().trim();
+  if (!ALLOWED_MIME_TYPES.has(normalised)) {
+    return {
+      ok: false,
+      error: `Unsupported MIME type: ${mimeType}`,
+    };
+  }
+
+  return { ok: true };
+}
+
 export function uploadAttachment(
   assistantId: string,
   filename: string,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -16,6 +16,7 @@ import {
 } from '../memory/conversation-key-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
+import { validateAttachmentUpload } from '../memory/attachments-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 import { getConfig } from '../config/loader.js';
@@ -768,6 +769,14 @@ export class RuntimeHttpServer {
       return Response.json(
         { error: 'data (base64) is required' },
         { status: 400 },
+      );
+    }
+
+    const validation = validateAttachmentUpload(filename, mimeType);
+    if (!validation.ok) {
+      return Response.json(
+        { error: validation.error },
+        { status: 415 },
       );
     }
 


### PR DESCRIPTION
## Summary
- Add a MIME type allowlist for inbound attachment uploads — rejects files with unsupported MIME types (HTTP 415)
- Add a dangerous file extension blocklist (.exe, .sh, .iso, .bat, .cmd, .msi, .dmg, .scr, .vbs, .ps1, .jar, etc.) — rejects regardless of claimed MIME type
- Extension check is case-insensitive; MIME allowlist covers images, audio, video, documents, archives, and Office formats
- Includes comprehensive test coverage (10 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
