### PR TITLE
fix: cancel typing indicator after repeated Telegram API failures

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -12,6 +12,7 @@ import { verifyWebhookSecret } from "../../telegram/verify.js";
 const log = getLogger("telegram-webhook");
 
 const MAX_TYPING_DURATION_MS = 60_000;
+const MAX_TYPING_FAILURES = 3;
 export const TELEGRAM_CHANNEL_TRANSPORT_HINTS = [
   "chat-first-medium",
   "channel-safe-onboarding",
@@ -189,6 +190,7 @@ export function createTelegramWebhookHandler(
 
     // Start typing indicator only for routable chats.
     // A safety timeout ensures the interval is cleared even if handleInbound hangs.
+    // Cancel early if the Telegram API fails repeatedly (MAX_TYPING_FAILURES consecutive).
     let typingInterval: ReturnType<typeof setInterval> | undefined;
     let typingTimeout: ReturnType<typeof setTimeout> | undefined;
     const clearTyping = () => {
@@ -196,8 +198,22 @@ export function createTelegramWebhookHandler(
       clearTimeout(typingTimeout);
     };
     if (routable) {
-      sendTypingIndicator(config, chatId);
-      typingInterval = setInterval(() => sendTypingIndicator(config, chatId), 5000);
+      let consecutiveFailures = 0;
+      sendTypingIndicator(config, chatId).then((ok) => {
+        if (!ok) consecutiveFailures++;
+      });
+      typingInterval = setInterval(async () => {
+        const ok = await sendTypingIndicator(config, chatId);
+        if (ok) {
+          consecutiveFailures = 0;
+        } else {
+          consecutiveFailures++;
+          if (consecutiveFailures >= MAX_TYPING_FAILURES) {
+            log.warn({ chatId, consecutiveFailures }, "Typing indicator cancelled after repeated failures");
+            clearTyping();
+          }
+        }
+      }, 5000);
       typingTimeout = setTimeout(clearTyping, MAX_TYPING_DURATION_MS);
     }
 

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -94,11 +94,13 @@ export async function sendTelegramAttachments(
   }
 }
 
-export async function sendTypingIndicator(config: GatewayConfig, chatId: string): Promise<void> {
+export async function sendTypingIndicator(config: GatewayConfig, chatId: string): Promise<boolean> {
   try {
     await callTelegramApi(config, "sendChatAction", { chat_id: chatId, action: "typing" });
+    return true;
   } catch (err) {
     log.debug({ err, chatId }, "Failed to send typing indicator");
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
- `sendTypingIndicator` now returns `boolean` success/failure instead of swallowing errors silently
- Typing interval tracks consecutive failures and cancels after 3 consecutive API failures (previously ran for the full 60s timeout even when every call was failing)
- Logs a warning when the typing indicator is cancelled due to repeated failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
