### PR TITLE
refactor: replace [SHOTGUN-DEBUG] prefixes with debug-level logging

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -37,31 +37,31 @@ export async function handleRideShotgunStart(
   };
 
   watchSessions.set(watchId, session);
-  log.info(
+  log.debug(
     { watchId, sessionId, durationSeconds, intervalSeconds },
-    '[SHOTGUN-DEBUG] Session created and stored in watchSessions map',
+    'Session created and stored in watchSessions map',
   );
 
   // Set timeout for duration expiry — generate summary before firing notifier
   session.timeoutHandle = setTimeout(async () => {
     session.status = 'completing';
     session.timeoutHandle = undefined;
-    log.info(
+    log.debug(
       { watchId, sessionId, observationCount: session.observations.length },
-      '[SHOTGUN-DEBUG] Duration timer fired — session completing. Generating summary...',
+      'Duration timer fired — session completing. Generating summary...',
     );
     await generateSummary(session);
     session.status = 'completed';
-    log.info(
+    log.debug(
       { watchId, sessionId, hasSummary: lastSummaryBySession.has(sessionId) },
-      '[SHOTGUN-DEBUG] generateSummary returned. Checking if completion notifier needs fallback fire.',
+      'generateSummary returned — checking if completion notifier needs fallback fire',
     );
     // Fallback: if generateSummary failed or returned empty, fire notifier
     // anyway so the client always receives a response
     if (!lastSummaryBySession.has(sessionId)) {
       log.warn(
         { watchId, sessionId },
-        '[SHOTGUN-DEBUG] No summary in map — firing completion notifier as fallback (will send empty summary)',
+        'No summary in map — firing completion notifier as fallback (will send empty summary)',
       );
       fireWatchCompletionNotifier(sessionId, session);
     }
@@ -72,9 +72,9 @@ export async function handleRideShotgunStart(
     const summary = lastSummaryBySession.get(sessionId) ?? '';
     const observationCount = _completedSession.observations.length;
 
-    log.info(
+    log.debug(
       { watchId, sessionId, observationCount, summaryLength: summary.length, socketDestroyed: socket.destroyed },
-      '[SHOTGUN-DEBUG] Completion notifier firing — sending ride_shotgun_result to client',
+      'Completion notifier firing — sending ride_shotgun_result to client',
     );
 
     ctx.send(socket, {
@@ -87,16 +87,16 @@ export async function handleRideShotgunStart(
 
     unregisterWatchCompletionNotifier(sessionId);
     lastSummaryBySession.delete(sessionId);
-    log.info({ watchId, sessionId, observationCount }, '[SHOTGUN-DEBUG] Ride shotgun result sent successfully');
+    log.debug({ watchId, sessionId, observationCount }, 'Ride shotgun result sent successfully');
   });
 
   // Fire start notifier
   fireWatchStartNotifier(sessionId, session);
 
   // Send watch_started so the Swift client knows the watchId/sessionId
-  log.info(
+  log.debug(
     { watchId, sessionId, socketDestroyed: socket.destroyed },
-    '[SHOTGUN-DEBUG] Sending watch_started to client',
+    'Sending watch_started to client',
   );
   ctx.send(socket, {
     type: 'watch_started',
@@ -106,5 +106,5 @@ export async function handleRideShotgunStart(
     intervalSeconds,
   });
 
-  log.info({ watchId, sessionId, durationSeconds, intervalSeconds }, '[SHOTGUN-DEBUG] Ride shotgun session started — waiting for observations');
+  log.debug({ watchId, sessionId, durationSeconds, intervalSeconds }, 'Ride shotgun session started — waiting for observations');
 }

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -27,9 +27,9 @@ export async function handleWatchObservation(
   _ctx: HandlerContext,
 ): Promise<void> {
   try {
-    log.info(
+    log.debug(
       { watchId: msg.watchId, captureIndex: msg.captureIndex, appName: msg.appName, ocrLen: msg.ocrText?.length ?? 0 },
-      '[SHOTGUN-DEBUG] Received watch_observation from client',
+      'Received watch_observation from client',
     );
 
     // 1. Find the WatchSession by watchId
@@ -39,12 +39,12 @@ export async function handleWatchObservation(
     if (!session) {
       log.warn(
         { watchId: msg.watchId, knownWatchIds: [...watchSessions.keys()] },
-        '[SHOTGUN-DEBUG] Watch session not found for observation — known watchIds listed',
+        'Watch session not found for observation',
       );
       return;
     }
     if (session.status !== 'active' && session.status !== 'completing') {
-      log.warn({ watchId: msg.watchId, status: session.status }, '[SHOTGUN-DEBUG] Watch session not active');
+      log.warn({ watchId: msg.watchId, status: session.status }, 'Watch session not active');
       return;
     }
 
@@ -58,37 +58,37 @@ export async function handleWatchObservation(
       captureIndex: msg.captureIndex,
     };
     addObservation(msg.watchId, entry);
-    log.info(
+    log.debug(
       { watchId: msg.watchId, totalObservations: session.observations.length, status: session.status },
-      '[SHOTGUN-DEBUG] Observation added to session',
+      'Observation added to session',
     );
 
     // 4. Every 3 observations: call Haiku for live commentary
     if (session.observations.length % 3 === 0) {
-      log.info(
+      log.debug(
         { watchId: msg.watchId, observationCount: session.observations.length },
-        '[SHOTGUN-DEBUG] Triggering commentary generation (every 3rd observation)',
+        'Triggering commentary generation (every 3rd observation)',
       );
       await generateCommentary(session);
     }
 
     // 5. If session is completing, generate final summary
     if (session.status === 'completing') {
-      log.info({ watchId: msg.watchId }, '[SHOTGUN-DEBUG] Session is completing — generating summary from observation handler');
+      log.debug({ watchId: msg.watchId }, 'Session is completing — generating summary from observation handler');
       session.status = 'completed';
       await generateSummary(session);
     }
   } catch (err) {
-    log.error({ err, watchId: msg.watchId }, '[SHOTGUN-DEBUG] Error handling watch observation');
+    log.error({ err, watchId: msg.watchId }, 'Error handling watch observation');
   }
 }
 
 async function generateCommentary(session: WatchSession): Promise<void> {
   try {
-    log.info({ watchId: session.watchId, sessionId: session.sessionId }, '[SHOTGUN-DEBUG] generateCommentary starting — calling Haiku');
+    log.debug({ watchId: session.watchId, sessionId: session.sessionId }, 'generateCommentary starting — calling Haiku');
     const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
-      log.warn({ watchId: session.watchId }, '[SHOTGUN-DEBUG] No Anthropic API key available for commentary generation');
+      log.warn({ watchId: session.watchId }, 'No Anthropic API key available for commentary generation');
       return;
     }
     const client = new Anthropic({ apiKey });
@@ -136,42 +136,42 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       messages: [{ role: 'user', content: userContent }],
     });
 
-    log.info({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Haiku API call completed successfully');
+    log.debug({ watchId: session.watchId }, 'Haiku API call completed successfully');
 
     const textBlock = response.content.find((b) => b.type === 'text');
     const commentaryText =
       textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
 
-    log.info(
+    log.debug(
       { watchId: session.watchId, commentaryLength: commentaryText.length, isSkip: commentaryText === 'SKIP' },
-      '[SHOTGUN-DEBUG] Commentary result from Haiku',
+      'Commentary result from Haiku',
     );
 
     if (commentaryText && commentaryText !== 'SKIP') {
       lastCommentaryBySession.set(session.sessionId, commentaryText);
       fireWatchCommentaryNotifier(session.sessionId, session);
       session.commentaryCount++;
-      log.info(
+      log.debug(
         { watchId: session.watchId, commentaryCount: session.commentaryCount },
-        '[SHOTGUN-DEBUG] Commentary notifier fired',
+        'Commentary notifier fired',
       );
     } else {
-      log.info({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Commentary skipped (empty or SKIP)');
+      log.debug({ watchId: session.watchId }, 'Commentary skipped (empty or SKIP)');
     }
   } catch (err) {
-    log.error({ err, watchId: session.watchId }, '[SHOTGUN-DEBUG] Error generating watch commentary — API call failed');
+    log.error({ err, watchId: session.watchId }, 'Error generating watch commentary — API call failed');
   }
 }
 
 export async function generateSummary(session: WatchSession): Promise<void> {
   try {
-    log.info(
+    log.debug(
       { watchId: session.watchId, sessionId: session.sessionId, observationCount: session.observations.length, commentaryCount: session.commentaryCount },
-      '[SHOTGUN-DEBUG] generateSummary starting — calling Sonnet',
+      'generateSummary starting — calling Sonnet',
     );
     const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
-      log.warn({ watchId: session.watchId }, '[SHOTGUN-DEBUG] No Anthropic API key available for summary generation');
+      log.warn({ watchId: session.watchId }, 'No Anthropic API key available for summary generation');
       return;
     }
     const client = new Anthropic({ apiKey });
@@ -256,25 +256,25 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       messages: [{ role: 'user', content: userContent }],
     });
 
-    log.info({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Sonnet API call completed successfully');
+    log.debug({ watchId: session.watchId }, 'Sonnet API call completed successfully');
 
     const textBlock = response.content.find((b) => b.type === 'text');
     const summaryText =
       textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
 
-    log.info(
+    log.debug(
       { watchId: session.watchId, summaryLength: summaryText.length },
-      '[SHOTGUN-DEBUG] Summary result from Sonnet',
+      'Summary result from Sonnet',
     );
 
     if (summaryText) {
       lastSummaryBySession.set(session.sessionId, summaryText);
-      log.info({ watchId: session.watchId, sessionId: session.sessionId }, '[SHOTGUN-DEBUG] Firing completion notifier with summary');
+      log.debug({ watchId: session.watchId, sessionId: session.sessionId }, 'Firing completion notifier with summary');
       fireWatchCompletionNotifier(session.sessionId, session);
     } else {
-      log.warn({ watchId: session.watchId }, '[SHOTGUN-DEBUG] Summary was empty — completion notifier NOT fired');
+      log.warn({ watchId: session.watchId }, 'Summary was empty — completion notifier NOT fired');
     }
   } catch (err) {
-    log.error({ err, watchId: session.watchId }, '[SHOTGUN-DEBUG] Error generating watch summary — Sonnet API call failed');
+    log.error({ err, watchId: session.watchId }, 'Error generating watch summary — Sonnet API call failed');
   }
 }

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -134,14 +134,14 @@ public final class AmbientAgent: ObservableObject {
     }
 
     private func handleSessionStateChange(_ state: RideShotgunSession.State) {
-        log.info("[SHOTGUN-DEBUG] handleSessionStateChange: \(String(describing: state))")
+        log.debug("handleSessionStateChange: \(String(describing: state))")
         switch state {
         case .complete:
             progressWindow?.close()
             progressWindow = nil
             let hasSession = currentSession != nil
             let summary = currentSession?.summary ?? ""
-            log.info("[SHOTGUN-DEBUG] Session complete: hasSession=\(hasSession) summaryLength=\(summary.count)")
+            log.debug("Session complete: hasSession=\(hasSession) summaryLength=\(summary.count)")
             showSummary(summary.isEmpty
                 ? "I watched your screen but wasn't able to generate a report. This can happen if the analysis timed out or there was an API error."
                 : summary)

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -67,14 +67,14 @@ public final class RideShotgunSession: ObservableObject {
 
         // Send ride_shotgun_start to daemon
         do {
-            log.info("[SHOTGUN-DEBUG] Sending ride_shotgun_start to daemon")
+            log.debug("Sending ride_shotgun_start to daemon")
             try daemonClient.send(RideShotgunStartMessage(
                 durationSeconds: Double(durationSeconds),
                 intervalSeconds: Double(intervalSeconds)
             ))
-            log.info("[SHOTGUN-DEBUG] ride_shotgun_start sent successfully")
+            log.debug("ride_shotgun_start sent successfully")
         } catch {
-            log.error("[SHOTGUN-DEBUG] Failed to send ride_shotgun_start: \(error.localizedDescription)")
+            log.error("Failed to send ride_shotgun_start: \(error.localizedDescription)")
             state = .failed("Failed to start session")
             cleanup()
         }
@@ -91,11 +91,11 @@ public final class RideShotgunSession: ObservableObject {
 
     private func handleWatchStarted(_ message: WatchStartedMessage, daemonClient: DaemonClient) {
         guard state == .starting else {
-            log.warning("[SHOTGUN-DEBUG] Received watch_started but state is \(String(describing: self.state)), ignoring")
+            log.warning("Received watch_started but state is \(String(describing: self.state)), ignoring")
             return
         }
 
-        log.info("[SHOTGUN-DEBUG] Received watch_started: watchId=\(message.watchId) sessionId=\(message.sessionId)")
+        log.debug("Received watch_started: watchId=\(message.watchId) sessionId=\(message.sessionId)")
         expectedWatchId = message.watchId
 
         let session = WatchSession(
@@ -130,13 +130,13 @@ public final class RideShotgunSession: ObservableObject {
     }
 
     private func handleRideShotgunResult(_ result: RideShotgunResultMessage) {
-        log.info("[SHOTGUN-DEBUG] Received ride_shotgun_result: watchId=\(result.watchId) observationCount=\(result.observationCount) summaryLength=\(result.summary.count)")
+        log.debug("Received ride_shotgun_result: watchId=\(result.watchId) observationCount=\(result.observationCount) summaryLength=\(result.summary.count)")
         guard state == .capturing || state == .summarizing else {
-            log.warning("[SHOTGUN-DEBUG] Ignoring ride_shotgun_result — state is \(String(describing: self.state)), expected capturing or summarizing")
+            log.warning("Ignoring ride_shotgun_result — state is \(String(describing: self.state)), expected capturing or summarizing")
             return
         }
         guard result.watchId == expectedWatchId else {
-            log.warning("[SHOTGUN-DEBUG] Ignoring ride_shotgun_result — watchId mismatch: got \(result.watchId), expected \(self.expectedWatchId ?? "nil")")
+            log.warning("Ignoring ride_shotgun_result — watchId mismatch: got \(result.watchId), expected \(self.expectedWatchId ?? "nil")")
             return
         }
 
@@ -144,7 +144,7 @@ public final class RideShotgunSession: ObservableObject {
         observationCount = result.observationCount
         state = .complete
 
-        log.info("[SHOTGUN-DEBUG] Ride shotgun session complete: \(result.observationCount) observations")
+        log.debug("Ride shotgun session complete: \(result.observationCount) observations")
         cleanup()
     }
 

--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -105,7 +105,7 @@ public final class WatchSession: ObservableObject {
 
             // Skip empty content
             guard !screenContent.isEmpty else {
-                log.info("[SHOTGUN-DEBUG] Screen content empty — skipping observation")
+                log.debug("Screen content empty — skipping observation")
                 try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
                 continue
             }
@@ -113,11 +113,11 @@ public final class WatchSession: ObservableObject {
             // Similarity check - skip if >85% similar to previous capture
             let similarity = ScreenOCR.similarity(screenContent, previousOcrText)
             if similarity > 0.85 {
-                log.info("[SHOTGUN-DEBUG] Screen unchanged (similarity=\(String(format: "%.2f", similarity))) — skipping observation \(appName)")
+                log.debug("Screen unchanged (similarity=\(String(format: "%.2f", similarity))) — skipping observation \(appName)")
                 try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
                 continue
             }
-            log.info("[SHOTGUN-DEBUG] Screen changed (similarity=\(String(format: "%.2f", similarity))) — will send observation for \(appName)")
+            log.debug("Screen changed (similarity=\(String(format: "%.2f", similarity))) — will send observation for \(appName)")
             previousOcrText = screenContent
 
             captureCount += 1
@@ -137,11 +137,11 @@ public final class WatchSession: ObservableObject {
 
             do {
                 let hasDaemon = daemonClient != nil
-                log.info("[SHOTGUN-DEBUG] Sending observation \(self.captureCount)/\(self.totalExpected) watchId=\(self.watchId) hasDaemon=\(hasDaemon) ocrLen=\(screenContent.count)")
+                log.debug("Sending observation \(self.captureCount)/\(self.totalExpected) watchId=\(self.watchId) hasDaemon=\(hasDaemon) ocrLen=\(screenContent.count)")
                 try daemonClient?.send(observation)
-                log.info("[SHOTGUN-DEBUG] Observation \(self.captureCount) sent successfully for \(appName)")
+                log.debug("Observation \(self.captureCount) sent successfully for \(appName)")
             } catch {
-                log.error("[SHOTGUN-DEBUG] Failed to send watch observation: \(error.localizedDescription)")
+                log.error("Failed to send watch observation: \(error.localizedDescription)")
             }
 
             try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)


### PR DESCRIPTION
## Summary
- Removed all 46 `[SHOTGUN-DEBUG]` log prefixes across 5 files (2 TypeScript, 3 Swift)
- Downgraded info-level debug traces to proper `log.debug()` calls so they're silent in production
- Kept `warn` and `error` calls at their original severity, just removed the prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
