### PR TITLE
fix: wire up IPC signing orchestration for bundle packaging

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -18,7 +18,7 @@ import type {
   AppUpdatePreviewRequest,
   UiSurfaceShow,
 } from '../ipc-protocol.js';
-import { log, compareSemver, type HandlerContext } from './shared.js';
+import { log, compareSemver, createSigningCallback, type HandlerContext } from './shared.js';
 
 export function handleAppDataRequest(
   msg: AppDataRequest,
@@ -338,7 +338,7 @@ export async function handleShareAppCloud(
   ctx: HandlerContext,
 ): Promise<void> {
   try {
-    const result = await packageApp(msg.appId);
+    const result = await packageApp(msg.appId, createSigningCallback(socket, ctx));
     const bundleData = readFileSync(result.bundlePath);
     const { shareToken } = createSharedAppLink(bundleData, result.manifest);
 
@@ -370,7 +370,7 @@ export async function handleBundleApp(
   ctx: HandlerContext,
 ): Promise<void> {
   try {
-    const result = await packageApp(msg.appId);
+    const result = await packageApp(msg.appId, createSigningCallback(socket, ctx));
     ctx.send(socket, {
       type: 'bundle_app_response',
       bundlePath: result.bundlePath,

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -4,7 +4,7 @@ import type { IntegrationConnectRequest, IntegrationDisconnectRequest } from '..
 import { handleRideShotgunStart } from '../ride-shotgun-handler.js';
 import { handleWatchObservation } from '../watch-handler.js';
 import { handleOpenBundle } from './open-bundle-handler.js';
-import { log, type HandlerContext } from './shared.js';
+import { log, pendingSignBundlePayload, pendingSigningIdentity, type HandlerContext } from './shared.js';
 
 import {
   handleUserMessage,
@@ -171,15 +171,25 @@ const handlers: DispatchMap = {
   shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
   shared_app_delete: handleSharedAppDelete,
   fork_shared_app: handleForkSharedApp,
-  sign_bundle_payload_response: (_msg, _socket, _ctx) => {
-    // TODO(signing): Route to pending promise resolution once the daemon-driven
-    // IPC signing orchestration is wired up. Currently a no-op placeholder to
-    // satisfy the exhaustive dispatch map; signing is invoked via SigningCallback.
+  sign_bundle_payload_response: (msg, socket) => {
+    const pending = pendingSignBundlePayload.get(socket);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pendingSignBundlePayload.delete(socket);
+      pending.resolve({ signature: msg.signature, keyId: msg.keyId, publicKey: msg.publicKey });
+    } else {
+      log.warn('Received sign_bundle_payload_response with no pending request');
+    }
   },
-  get_signing_identity_response: (_msg, _socket, _ctx) => {
-    // TODO(signing): Route to pending promise resolution once the daemon-driven
-    // IPC signing orchestration is wired up. Currently a no-op placeholder to
-    // satisfy the exhaustive dispatch map; signing is invoked via SigningCallback.
+  get_signing_identity_response: (msg, socket) => {
+    const pending = pendingSigningIdentity.get(socket);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pendingSigningIdentity.delete(socket);
+      pending.resolve({ keyId: msg.keyId, publicKey: msg.publicKey });
+    } else {
+      log.warn('Received get_signing_identity_response with no pending request');
+    }
   },
   gallery_list: (_msg, socket, ctx) => handleGalleryList(socket, ctx),
   gallery_install: handleGalleryInstall,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -20,6 +20,21 @@ let cachedScreenDims: { width: number; height: number } | null = null;
 // Module-level map for non-session secret prompts (e.g. publish_page)
 export const pendingStandaloneSecrets = new Map<string, { resolve: (result: SecretPromptResult) => void; timer: ReturnType<typeof setTimeout> }>();
 
+// Pending IPC signing responses (bundle signing orchestration)
+interface PendingSigningResolve {
+  resolve: (result: { signature: string; keyId: string; publicKey: string }) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+export const pendingSignBundlePayload = new Map<net.Socket, PendingSigningResolve>();
+
+interface PendingIdentityResolve {
+  resolve: (result: { keyId: string; publicKey: string }) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+export const pendingSigningIdentity = new Map<net.Socket, PendingIdentityResolve>();
+
 export interface HistoryToolCall {
   name: string;
   input: Record<string, unknown>;
@@ -451,6 +466,27 @@ export function requestSecretStandalone(
       allowedTools: params.allowedTools,
     });
   });
+}
+
+const SIGNING_TIMEOUT_MS = 30_000;
+
+/**
+ * Create a SigningCallback that sends `sign_bundle_payload` to the Swift client
+ * over IPC and waits for the `sign_bundle_payload_response`.
+ */
+export function createSigningCallback(
+  socket: net.Socket,
+  ctx: HandlerContext,
+): (payload: string) => Promise<{ signature: string; keyId: string; publicKey: string }> {
+  return (payload: string) =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingSignBundlePayload.delete(socket);
+        reject(new Error('Signing request timed out'));
+      }, SIGNING_TIMEOUT_MS);
+      pendingSignBundlePayload.set(socket, { resolve, reject, timer });
+      ctx.send(socket, { type: 'sign_bundle_payload', payload });
+    });
 }
 
 /** Get or create the skill entry object for a given skill name, creating intermediate objects as needed.


### PR DESCRIPTION
## Summary
- Resolves both `TODO(signing)` placeholders in `daemon/handlers/index.ts`
- Adds pending-promise maps and a `createSigningCallback` factory to `shared.ts` that sends `sign_bundle_payload` requests to the Swift client and waits for responses (with 30s timeout)
- Wires response handlers (`sign_bundle_payload_response`, `get_signing_identity_response`) to resolve pending promises
- Passes the signing callback to `packageApp` in `handleShareAppCloud` and `handleBundleApp`, enabling signed bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
