### PR TITLE
feat: add tool execution profiling with per-request summary

### DIFF
--- a/assistant/src/__tests__/tool-profiling-listener.test.ts
+++ b/assistant/src/__tests__/tool-profiling-listener.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { EventBus } from '../events/bus.js';
+import type { AssistantDomainEvents } from '../events/domain-events.js';
+import { ToolProfiler, registerToolProfilingListener } from '../events/tool-profiling-listener.js';
+import type { TraceEmitter, TraceEmitOptions } from '../daemon/trace-emitter.js';
+import type { TraceEventKind } from '../daemon/ipc-protocol.js';
+
+interface EmittedTrace {
+  kind: TraceEventKind;
+  summary: string;
+  opts?: TraceEmitOptions;
+}
+
+let traces: EmittedTrace[];
+
+function createMockTraceEmitter(): TraceEmitter {
+  return {
+    emit(kind: TraceEventKind, summary: string, opts?: TraceEmitOptions) {
+      traces.push({ kind, summary, opts });
+    },
+  } as TraceEmitter;
+}
+
+describe('ToolProfiler', () => {
+  let profiler: ToolProfiler;
+
+  beforeEach(() => {
+    traces = [];
+    profiler = new ToolProfiler();
+  });
+
+  test('tracks single tool completion', () => {
+    profiler.startRequest();
+    profiler.recordToolCompletion('file_read', 42, false);
+
+    const summary = profiler.getSummary();
+    expect(summary.toolCount).toBe(1);
+    expect(summary.totalToolTimeMs).toBe(42);
+    expect(summary.tools['file_read']).toEqual({
+      count: 1,
+      totalMs: 42,
+      maxMs: 42,
+      errors: 0,
+    });
+  });
+
+  test('accumulates multiple invocations of the same tool', () => {
+    profiler.startRequest();
+    profiler.recordToolCompletion('bash', 100, false);
+    profiler.recordToolCompletion('bash', 200, false);
+    profiler.recordToolCompletion('bash', 50, true);
+
+    const summary = profiler.getSummary();
+    expect(summary.toolCount).toBe(3);
+    expect(summary.totalToolTimeMs).toBe(350);
+    expect(summary.tools['bash']).toEqual({
+      count: 3,
+      totalMs: 350,
+      maxMs: 200,
+      errors: 1,
+    });
+  });
+
+  test('tracks multiple different tools', () => {
+    profiler.startRequest();
+    profiler.recordToolCompletion('file_read', 10, false);
+    profiler.recordToolCompletion('bash', 500, false);
+    profiler.recordToolCompletion('file_write', 30, false);
+
+    const summary = profiler.getSummary();
+    expect(summary.toolCount).toBe(3);
+    expect(summary.totalToolTimeMs).toBe(540);
+    expect(Object.keys(summary.tools)).toHaveLength(3);
+  });
+
+  test('wallClockMs tracks elapsed time since startRequest', async () => {
+    profiler.startRequest();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const summary = profiler.getSummary();
+    expect(summary.wallClockMs).toBeGreaterThanOrEqual(40);
+  });
+
+  test('startRequest resets previous state', () => {
+    profiler.startRequest();
+    profiler.recordToolCompletion('bash', 100, false);
+    expect(profiler.getSummary().toolCount).toBe(1);
+
+    profiler.startRequest();
+    expect(profiler.getSummary().toolCount).toBe(0);
+    expect(profiler.getSummary().totalToolTimeMs).toBe(0);
+  });
+
+  test('tracks RSS memory', () => {
+    profiler.startRequest();
+    profiler.recordToolCompletion('bash', 10, false);
+
+    const summary = profiler.getSummary();
+    expect(summary.peakRssMb).toBeGreaterThan(0);
+    expect(typeof summary.rssDeltaMb).toBe('number');
+  });
+
+  test('emitSummary does nothing when no tools were called', () => {
+    const emitter = createMockTraceEmitter();
+    profiler.startRequest();
+    profiler.emitSummary(emitter, 'req-1');
+
+    expect(traces).toHaveLength(0);
+  });
+
+  test('emitSummary emits tool_profiling_summary trace', () => {
+    const emitter = createMockTraceEmitter();
+    profiler.startRequest();
+    profiler.recordToolCompletion('file_read', 10, false);
+    profiler.recordToolCompletion('bash', 200, false);
+    profiler.recordToolCompletion('bash', 50, true);
+
+    profiler.emitSummary(emitter, 'req-1');
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].kind).toBe('tool_profiling_summary');
+    expect(traces[0].opts?.requestId).toBe('req-1');
+    expect(traces[0].opts?.status).toBe('info');
+    expect(traces[0].opts?.attributes?.toolCount).toBe(3);
+    expect(traces[0].opts?.attributes?.totalToolTimeMs).toBe(260);
+    expect(traces[0].opts?.attributes?.slowestTool).toBe('bash');
+    expect(traces[0].opts?.attributes?.slowestToolMaxMs).toBe(200);
+  });
+
+  test('emitSummary summary text includes key metrics', () => {
+    const emitter = createMockTraceEmitter();
+    profiler.startRequest();
+    profiler.recordToolCompletion('bash', 100, false);
+
+    profiler.emitSummary(emitter);
+
+    expect(traces[0].summary).toContain('1 tool calls');
+    expect(traces[0].summary).toContain('tool time: 100ms');
+    expect(traces[0].summary).toContain('slowest: bash 100ms');
+  });
+});
+
+describe('registerToolProfilingListener', () => {
+  let bus: EventBus<AssistantDomainEvents>;
+  let profiler: ToolProfiler;
+
+  beforeEach(() => {
+    bus = new EventBus<AssistantDomainEvents>();
+    profiler = new ToolProfiler();
+    profiler.startRequest();
+    registerToolProfilingListener(bus, profiler);
+  });
+
+  test('records tool.execution.finished events', async () => {
+    await bus.emit('tool.execution.finished', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-1',
+      toolName: 'file_read',
+      decision: 'allow',
+      riskLevel: 'low',
+      isError: false,
+      durationMs: 42,
+      finishedAtMs: 4042,
+    });
+
+    const summary = profiler.getSummary();
+    expect(summary.toolCount).toBe(1);
+    expect(summary.tools['file_read']).toEqual({
+      count: 1,
+      totalMs: 42,
+      maxMs: 42,
+      errors: 0,
+    });
+  });
+
+  test('records tool.execution.finished with isError=true', async () => {
+    await bus.emit('tool.execution.finished', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'bash',
+      decision: 'allow',
+      riskLevel: 'low',
+      isError: true,
+      durationMs: 55,
+      finishedAtMs: 4055,
+    });
+
+    expect(profiler.getSummary().tools['bash'].errors).toBe(1);
+  });
+
+  test('records tool.execution.failed events as errors', async () => {
+    await bus.emit('tool.execution.failed', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-2',
+      toolName: 'bash',
+      decision: 'allow',
+      riskLevel: 'high',
+      durationMs: 100,
+      error: 'Command not found',
+      isExpected: false,
+      failedAtMs: 5100,
+    });
+
+    const summary = profiler.getSummary();
+    expect(summary.toolCount).toBe(1);
+    expect(summary.tools['bash']).toEqual({
+      count: 1,
+      totalMs: 100,
+      maxMs: 100,
+      errors: 1,
+    });
+  });
+
+  test('ignores non-completion events', async () => {
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'file_read',
+      input: {},
+      startedAtMs: 1000,
+    });
+
+    await bus.emit('tool.permission.requested', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'bash',
+      riskLevel: 'high',
+      requestedAtMs: 2000,
+    });
+
+    expect(profiler.getSummary().toolCount).toBe(0);
+  });
+
+  test('subscription can be disposed', async () => {
+    bus.dispose();
+    bus = new EventBus<AssistantDomainEvents>();
+    const subscription = registerToolProfilingListener(bus, profiler);
+
+    await bus.emit('tool.execution.finished', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'file_read',
+      decision: 'allow',
+      riskLevel: 'low',
+      isError: false,
+      durationMs: 10,
+      finishedAtMs: 3010,
+    });
+    expect(profiler.getSummary().toolCount).toBe(1);
+
+    subscription.dispose();
+    profiler.startRequest(); // reset
+
+    await bus.emit('tool.execution.finished', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'file_read',
+      decision: 'allow',
+      riskLevel: 'low',
+      isError: false,
+      durationMs: 10,
+      finishedAtMs: 4010,
+    });
+    expect(profiler.getSummary().toolCount).toBe(0);
+  });
+});

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1370,7 +1370,8 @@ export type TraceEventKind =
   | 'generation_handoff'
   | 'message_complete'
   | 'generation_cancelled'
-  | 'request_error';
+  | 'request_error'
+  | 'tool_profiling_summary';
 
 export interface TraceEvent {
   type: 'trace_event';

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -40,6 +40,7 @@ import { registerToolMetricsLoggingListener } from '../events/tool-metrics-liste
 import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
 import { registerToolTraceListener } from '../events/tool-trace-listener.js';
 import { createToolAuditListener } from '../events/tool-audit-listener.js';
+import { ToolProfiler, registerToolProfilingListener } from '../events/tool-profiling-listener.js';
 import {
   ContextWindowManager,
   createContextSummaryMessage,
@@ -110,6 +111,7 @@ export class Session {
   private prompter: PermissionPrompter;
   private secretPrompter: SecretPrompter;
   private executor: ToolExecutor;
+  private profiler: ToolProfiler;
   /** @internal — exposed for session-surfaces.ts module functions. */
   sendToClient: (msg: ServerMessage) => void;
   /** Broadcast a message to all connected sockets (not just this session's client). */
@@ -217,9 +219,11 @@ export class Session {
     });
 
     this.executor = new ToolExecutor(this.prompter);
+    this.profiler = new ToolProfiler();
     registerToolMetricsLoggingListener(this.eventBus);
     registerToolNotificationListener(this.eventBus, (msg) => this.sendToClient(msg));
     registerToolTraceListener(this.eventBus, this.traceEmitter);
+    registerToolProfilingListener(this.eventBus, this.profiler);
     const auditToolLifecycleEvent = createToolAuditListener();
     const publishToolDomainEvent = createToolDomainEventPublisher(this.eventBus);
     const handleToolLifecycleEvent: ToolLifecycleEventHandler = (event) => {
@@ -643,6 +647,8 @@ export class Session {
     // from a prior successful run.
     this.lastAssistantAttachments = [];
     this.lastAttachmentWarnings = [];
+
+    this.profiler.startRequest();
 
     try {
       const preMessageResult = await getHookManager().trigger('pre-message', {
@@ -1205,6 +1211,8 @@ export class Session {
         });
       }
     } finally {
+      this.profiler.emitSummary(this.traceEmitter, reqId);
+
       this.abortController = null;
       this.processing = false;
       this.currentRequestId = undefined;

--- a/assistant/src/events/tool-profiling-listener.ts
+++ b/assistant/src/events/tool-profiling-listener.ts
@@ -1,0 +1,150 @@
+import type { EventBus, Subscription } from './bus.js';
+import type { AssistantDomainEvents } from './domain-events.js';
+import type { TraceEmitter } from '../daemon/trace-emitter.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('tool-profiler');
+
+export interface ToolStats {
+  count: number;
+  totalMs: number;
+  maxMs: number;
+  errors: number;
+}
+
+export interface ToolProfilingSummary {
+  toolCount: number;
+  totalToolTimeMs: number;
+  wallClockMs: number;
+  tools: Record<string, ToolStats>;
+  peakRssMb: number;
+  rssDeltaMb: number;
+}
+
+/**
+ * Accumulates per-tool timing and resource stats across a request.
+ * Call `startRequest()` at the beginning and `emitSummary()` at the end.
+ */
+export class ToolProfiler {
+  private tools = new Map<string, ToolStats>();
+  private requestStartMs = 0;
+  private rssStartBytes = 0;
+  private peakRssBytes = 0;
+
+  startRequest(): void {
+    this.tools.clear();
+    this.requestStartMs = Date.now();
+    const rss = process.memoryUsage().rss;
+    this.rssStartBytes = rss;
+    this.peakRssBytes = rss;
+  }
+
+  recordToolCompletion(toolName: string, durationMs: number, isError: boolean): void {
+    let stats = this.tools.get(toolName);
+    if (!stats) {
+      stats = { count: 0, totalMs: 0, maxMs: 0, errors: 0 };
+      this.tools.set(toolName, stats);
+    }
+    stats.count++;
+    stats.totalMs += durationMs;
+    if (durationMs > stats.maxMs) stats.maxMs = durationMs;
+    if (isError) stats.errors++;
+
+    const currentRss = process.memoryUsage().rss;
+    if (currentRss > this.peakRssBytes) this.peakRssBytes = currentRss;
+  }
+
+  getSummary(): ToolProfilingSummary {
+    let totalToolTimeMs = 0;
+    let toolCount = 0;
+    const tools: Record<string, ToolStats> = {};
+
+    for (const [name, stats] of this.tools) {
+      tools[name] = { ...stats };
+      totalToolTimeMs += stats.totalMs;
+      toolCount += stats.count;
+    }
+
+    const peakRssMb = Math.round(this.peakRssBytes / 1024 / 1024);
+    const rssDeltaMb = Math.round((this.peakRssBytes - this.rssStartBytes) / 1024 / 1024);
+
+    return {
+      toolCount,
+      totalToolTimeMs,
+      wallClockMs: this.requestStartMs > 0 ? Date.now() - this.requestStartMs : 0,
+      tools,
+      peakRssMb,
+      rssDeltaMb,
+    };
+  }
+
+  emitSummary(traceEmitter: TraceEmitter, requestId?: string): void {
+    const summary = this.getSummary();
+    if (summary.toolCount === 0) return;
+
+    // Find the slowest individual tool invocation
+    let slowestTool = '';
+    let slowestMs = 0;
+    for (const [name, stats] of Object.entries(summary.tools)) {
+      if (stats.maxMs > slowestMs) {
+        slowestMs = stats.maxMs;
+        slowestTool = name;
+      }
+    }
+
+    log.info({
+      toolCount: summary.toolCount,
+      totalToolTimeMs: summary.totalToolTimeMs,
+      wallClockMs: summary.wallClockMs,
+      peakRssMb: summary.peakRssMb,
+      rssDeltaMb: summary.rssDeltaMb,
+      slowestTool,
+      slowestToolMaxMs: slowestMs,
+      tools: summary.tools,
+    }, 'Tool execution profiling summary');
+
+    traceEmitter.emit(
+      'tool_profiling_summary',
+      `${summary.toolCount} tool calls in ${summary.wallClockMs}ms (tool time: ${summary.totalToolTimeMs}ms, slowest: ${slowestTool} ${slowestMs}ms)`,
+      {
+        requestId,
+        status: 'info',
+        attributes: {
+          toolCount: summary.toolCount,
+          totalToolTimeMs: summary.totalToolTimeMs,
+          wallClockMs: summary.wallClockMs,
+          slowestTool,
+          slowestToolMaxMs: slowestMs,
+          peakRssMb: summary.peakRssMb,
+          rssDeltaMb: summary.rssDeltaMb,
+        },
+      },
+    );
+  }
+}
+
+export function registerToolProfilingListener(
+  eventBus: EventBus<AssistantDomainEvents>,
+  profiler: ToolProfiler,
+): Subscription {
+  return eventBus.onAny((event) => {
+    switch (event.type) {
+      case 'tool.execution.finished':
+        profiler.recordToolCompletion(
+          event.payload.toolName,
+          event.payload.durationMs,
+          event.payload.isError,
+        );
+        return;
+      case 'tool.execution.failed':
+        profiler.recordToolCompletion(
+          event.payload.toolName,
+          event.payload.durationMs,
+          true,
+        );
+        return;
+      default:
+        return;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `ToolProfiler` class and `registerToolProfilingListener` that listen to `tool.execution.finished` / `tool.execution.failed` domain events and accumulate per-tool stats (invocation count, total/max duration, error count) plus RSS memory tracking
- Emits a `tool_profiling_summary` trace event at the end of each request in the session's `finally` block, surfacing the slowest tool, total tool time vs wall clock time, and memory delta for debugging slow turns
- Adds `tool_profiling_summary` to `TraceEventKind` and includes 14 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
