### PR TITLE
feat: handle Telegram edited_message for context correction

### DIFF
--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -54,7 +54,7 @@ export default async (input: { token: string; url: string; secret: string }) => 
     body: JSON.stringify({
       url: input.url,
       secret_token: input.secret,
-      allowed_updates: ['message'],
+      allowed_updates: ['message', 'edited_message'],
     }),
   });
   return res.json();

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -19,6 +19,10 @@ export interface InboundResult {
   duplicate: boolean;
 }
 
+export interface RecordInboundOptions {
+  sourceMessageId?: string;
+}
+
 /**
  * Record an inbound channel event. Returns `duplicate: true` if this
  * exact (assistant, channel, chat, message) combination was already seen.
@@ -28,6 +32,7 @@ export function recordInbound(
   sourceChannel: string,
   externalChatId: string,
   externalMessageId: string,
+  options?: RecordInboundOptions,
 ): InboundResult {
   const db = getDb();
 
@@ -73,6 +78,7 @@ export function recordInbound(
         sourceChannel,
         externalChatId,
         externalMessageId,
+        sourceMessageId: options?.sourceMessageId ?? null,
         conversationId: mapping.conversationId,
         deliveryStatus: 'pending',
         createdAt: now,
@@ -87,6 +93,49 @@ export function recordInbound(
     conversationId: mapping.conversationId,
     duplicate: false,
   };
+}
+
+/**
+ * Link an inbound event to the user message it created, so edits can
+ * later find the correct message by source_message_id → message_id.
+ */
+export function linkMessage(eventId: string, messageId: string): void {
+  const db = getDb();
+  db.update(channelInboundEvents)
+    .set({ messageId, updatedAt: Date.now() })
+    .where(eq(channelInboundEvents.id, eventId))
+    .run();
+}
+
+/**
+ * Find the message ID linked to the original inbound event for a given
+ * platform-level message identifier (e.g. Telegram message_id).
+ */
+export function findMessageBySourceId(
+  assistantId: string,
+  sourceChannel: string,
+  externalChatId: string,
+  sourceMessageId: string,
+): { messageId: string; conversationId: string } | null {
+  const db = getDb();
+  const row = db
+    .select({
+      messageId: channelInboundEvents.messageId,
+      conversationId: channelInboundEvents.conversationId,
+    })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.assistantId, assistantId),
+        eq(channelInboundEvents.sourceChannel, sourceChannel),
+        eq(channelInboundEvents.externalChatId, externalChatId),
+        eq(channelInboundEvents.sourceMessageId, sourceMessageId),
+      ),
+    )
+    .get();
+
+  if (!row || !row.messageId) return null;
+  return { messageId: row.messageId, conversationId: row.conversationId };
 }
 
 /**

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -466,6 +466,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_summaries ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_segments ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN source_message_id TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
@@ -514,6 +515,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_attachment_id ON message_attachments(attachment_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_lookup ON channel_inbound_events(assistant_id, source_channel, external_chat_id, external_message_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_conversation ON channel_inbound_events(conversation_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_source_msg ON channel_inbound_events(assistant_id, source_channel, external_chat_id, source_message_id)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_assistant_status ON message_runs(assistant_id, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_conversation ON message_runs(conversation_id)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -182,6 +182,7 @@ export const channelInboundEvents = sqliteTable('channel_inbound_events', {
   sourceChannel: text('source_channel').notNull(),
   externalChatId: text('external_chat_id').notNull(),
   externalMessageId: text('external_message_id').notNull(),
+  sourceMessageId: text('source_message_id'),
   conversationId: text('conversation_id')
     .notNull()
     .references(() => conversations.id, { onDelete: 'cascade' }),

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -47,6 +47,7 @@ export async function handleChannelInbound(
     externalChatId?: string;
     externalMessageId?: string;
     content?: string;
+    isEdit?: boolean;
     senderName?: string;
     attachmentIds?: string[];
     senderExternalUserId?: string;
@@ -59,6 +60,7 @@ export async function handleChannelInbound(
     externalChatId,
     externalMessageId,
     content,
+    isEdit,
     attachmentIds,
     sourceMetadata,
   } = body;
@@ -97,11 +99,63 @@ export async function handleChannelInbound(
     }
   }
 
+  const sourceMessageId = typeof sourceMetadata?.messageId === 'string'
+    ? sourceMetadata.messageId
+    : undefined;
+
+  // ── Edit path: update existing message content, no new agent loop ──
+  if (isEdit && sourceMessageId) {
+    // Dedup the edit event itself (retried edited_message webhooks)
+    const editResult = channelDeliveryStore.recordInbound(
+      assistantId,
+      sourceChannel,
+      externalChatId,
+      externalMessageId,
+      { sourceMessageId },
+    );
+
+    if (editResult.duplicate) {
+      return Response.json({
+        accepted: true,
+        duplicate: true,
+        eventId: editResult.eventId,
+      });
+    }
+
+    const original = channelDeliveryStore.findMessageBySourceId(
+      assistantId,
+      sourceChannel,
+      externalChatId,
+      sourceMessageId,
+    );
+
+    if (original) {
+      conversationStore.updateMessageContent(original.messageId, content ?? '');
+      log.info(
+        { assistantId, sourceMessageId, messageId: original.messageId },
+        'Updated message content from edited_message',
+      );
+    } else {
+      log.warn(
+        { assistantId, sourceChannel, externalChatId, sourceMessageId },
+        'Could not find original message for edit, ignoring',
+      );
+    }
+
+    return Response.json({
+      accepted: true,
+      duplicate: false,
+      eventId: editResult.eventId,
+    });
+  }
+
+  // ── New message path ──
   const result = channelDeliveryStore.recordInbound(
     assistantId,
     sourceChannel,
     externalChatId,
     externalMessageId,
+    { sourceMessageId },
   );
 
   const metadataHintsRaw = sourceMetadata?.hints;
@@ -116,7 +170,7 @@ export async function handleChannelInbound(
   let processingSucceeded = false;
   if (!result.duplicate && processMessage) {
     try {
-      await processMessage(
+      const { messageId: userMessageId } = await processMessage(
         assistantId,
         result.conversationId,
         content ?? '',
@@ -129,6 +183,8 @@ export async function handleChannelInbound(
           },
         },
       );
+      // Link the user message to the inbound event so edits can find it later
+      channelDeliveryStore.linkMessage(result.eventId, userMessageId);
       processingSucceeded = true;
     } catch (err) {
       console.error(`[runtime-http] Processing failed`, err);

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -68,7 +68,7 @@ v1 uses deterministic settings-based routing (no database):
 After deploying the gateway, register the webhook with Telegram using the `setWebhook` API method. Pass:
 - `url` — your gateway URL, e.g. `https://your-host/webhooks/telegram`
 - The verify value matching your `TELEGRAM_WEBHOOK_SECRET` env var
-- `allowed_updates` — `["message"]`
+- `allowed_updates` — `["message", "edited_message"]`
 
 See the [Telegram Bot API docs](https://core.telegram.org/bots/api#setwebhook) for the full API reference.
 

--- a/gateway/src/__tests__/telegram-normalize.test.ts
+++ b/gateway/src/__tests__/telegram-normalize.test.ts
@@ -197,6 +197,87 @@ describe("normalizeTelegramUpdate", () => {
     };
     expect(normalizeTelegramUpdate(payload)).toBeNull();
   });
+
+  test("normalizes an edited_message update with isEdit flag", () => {
+    const payload = {
+      update_id: 200,
+      edited_message: {
+        message_id: 42,
+        text: "Hello bot (edited)",
+        chat: { id: 99001, type: "private" },
+        from: {
+          id: 55001,
+          is_bot: false,
+          username: "testuser",
+          first_name: "Test",
+        },
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.isEdit).toBe(true);
+    expect(result!.message.content).toBe("Hello bot (edited)");
+    expect(result!.message.externalChatId).toBe("99001");
+    expect(result!.message.externalMessageId).toBe("200");
+    expect(result!.source.updateId).toBe("200");
+    expect(result!.source.messageId).toBe("42");
+    expect(result!.sender.externalUserId).toBe("55001");
+  });
+
+  test("prefers message over edited_message when both are present", () => {
+    const payload = {
+      update_id: 300,
+      message: {
+        message_id: 50,
+        text: "Original",
+        chat: { id: 99001, type: "private" },
+        from: { id: 55001, is_bot: false },
+      },
+      edited_message: {
+        message_id: 50,
+        text: "Edited",
+        chat: { id: 99001, type: "private" },
+        from: { id: 55001, is_bot: false },
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.isEdit).toBeUndefined();
+    expect(result!.message.content).toBe("Original");
+  });
+
+  test("sets isEdit for edited_message with photo", () => {
+    const payload = {
+      update_id: 400,
+      edited_message: {
+        message_id: 60,
+        chat: { id: 200, type: "private" },
+        from: { id: 300, is_bot: false },
+        photo: [
+          { file_id: "edited_photo", file_unique_id: "ep1", width: 800, height: 800 },
+        ],
+        caption: "Updated caption",
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.isEdit).toBe(true);
+    expect(result!.message.content).toBe("Updated caption");
+    expect(result!.message.attachments).toHaveLength(1);
+  });
+
+  test("returns null for edited_message in group chat", () => {
+    const payload = {
+      update_id: 500,
+      edited_message: {
+        message_id: 70,
+        text: "Edited group msg",
+        chat: { id: 99001, type: "group" },
+        from: { id: 55001, is_bot: false },
+      },
+    };
+    expect(normalizeTelegramUpdate(payload)).toBeNull();
+  });
 });
 
 describe("verifyWebhookSecret", () => {

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -66,6 +66,7 @@ export async function handleInbound(
       externalChatId: event.message.externalChatId,
       externalMessageId: event.message.externalMessageId,
       content: event.message.content,
+      ...(event.message.isEdit ? { isEdit: true } : {}),
       senderName: displayName,
       senderExternalUserId: event.sender.externalUserId,
       senderUsername: event.sender.username,

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -188,7 +188,10 @@ export function createTelegramWebhookHandler(
       }
     }
 
-    // Start typing indicator only for routable chats.
+    // Edits don't produce a new reply, so skip typing indicator
+    const isEdit = !!normalized.message.isEdit;
+
+    // Start typing indicator only for routable chats with new messages.
     // A safety timeout ensures the interval is cleared even if handleInbound hangs.
     // Cancel early if the Telegram API fails repeatedly (MAX_TYPING_FAILURES consecutive).
     let typingInterval: ReturnType<typeof setInterval> | undefined;
@@ -197,7 +200,7 @@ export function createTelegramWebhookHandler(
       clearInterval(typingInterval);
       clearTimeout(typingTimeout);
     };
-    if (routable) {
+    if (routable && !isEdit) {
       let consecutiveFailures = 0;
       sendTypingIndicator(config, chatId).then((ok) => {
         if (!ok) consecutiveFailures++;

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -8,6 +8,7 @@ export type RuntimeInboundPayload = {
   externalChatId: string;
   externalMessageId: string;
   content: string;
+  isEdit?: boolean;
   senderName?: string;
   senderExternalUserId?: string;
   senderUsername?: string;

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -36,6 +36,7 @@ interface TelegramMessage {
 interface TelegramUpdate {
   update_id?: number;
   message?: TelegramMessage;
+  edited_message?: TelegramMessage;
 }
 
 /**
@@ -46,7 +47,8 @@ export function normalizeTelegramUpdate(
   payload: Record<string, unknown>,
 ): Omit<GatewayInboundEventV1, "routing"> | null {
   const update = payload as TelegramUpdate;
-  const message = update.message;
+  const isEdit = !update.message && !!update.edited_message;
+  const message = update.message ?? update.edited_message;
   const updateId = update.update_id;
 
   const hasContent = !!(message?.text || message?.photo || message?.document);
@@ -95,6 +97,7 @@ export function normalizeTelegramUpdate(
       externalChatId: String(message.chat.id),
       externalMessageId: String(updateId),
       ...(attachments.length > 0 ? { attachments } : {}),
+      ...(isEdit ? { isEdit: true } : {}),
     },
     sender: {
       externalUserId,

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -10,6 +10,7 @@ export type GatewayInboundEventV1 = {
     content: string;
     externalChatId: string;
     externalMessageId: string;
+    isEdit?: boolean;
     attachments?: {
       type: "photo" | "document";
       fileId: string;


### PR DESCRIPTION
## Summary
- Gateway now normalizes `edited_message` Telegram updates alongside regular `message` updates, setting an `isEdit` flag
- Runtime looks up the original user message via a new `source_message_id` column on `channel_inbound_events` and updates its content in-place (no new agent loop)
- New messages are linked to their inbound events via the existing `message_id` FK so edits can find them later

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
