### PR TITLE
fix: timer and event listener cleanup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -378,6 +378,7 @@ export async function runDaemon(): Promise<void> {
     memoryWorker.stop();
     await qdrantManager.stop();
     await Sentry.flush(2000);
+    clearTimeout(forceTimer);
     cleanupPidFile();
     process.exit(0);
   };

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -441,7 +441,7 @@ export class DaemonServer {
   private handleConnection(socket: net.Socket): void {
     if (this.connectedSockets.size >= DaemonServer.MAX_CONNECTIONS) {
       log.warn({ current: this.connectedSockets.size, max: DaemonServer.MAX_CONNECTIONS }, 'Connection limit reached, rejecting client');
-      socket.on('error', (err) => {
+      socket.once('error', (err) => {
         log.error({ err }, 'Socket error while rejecting connection');
       });
       socket.write(serialize({ type: 'error', message: `Connection limit reached (max ${DaemonServer.MAX_CONNECTIONS})` }));

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -66,6 +66,7 @@ function getProfileDir(): string {
 class BrowserManager {
   private context: BrowserContext | null = null;
   private contextCreating: Promise<BrowserContext> | null = null;
+  private contextCloseHandler: ((...args: unknown[]) => void) | null = null;
   private pages = new Map<string, Page>();
   private snapshotMaps = new Map<string, Map<string, string>>();
 
@@ -121,14 +122,19 @@ class BrowserManager {
 
       // Listen for browser disconnection so we can reset state
       // instead of leaving a stale context reference.
-      const rawCtx = this.context as unknown as { on?: (event: string, handler: (...args: unknown[]) => void) => void };
+      const rawCtx = this.context as unknown as {
+        on?: (event: string, handler: (...args: unknown[]) => void) => void;
+        off?: (event: string, handler: (...args: unknown[]) => void) => void;
+      };
       if (typeof rawCtx.on === 'function') {
-        rawCtx.on('close', () => {
+        this.contextCloseHandler = () => {
           log.warn('Browser context closed unexpectedly, resetting state');
           this.context = null;
+          this.contextCloseHandler = null;
           this.pages.clear();
           this.snapshotMaps.clear();
-        });
+        };
+        rawCtx.on('close', this.contextCloseHandler);
       }
 
       return this.context;
@@ -178,6 +184,15 @@ class BrowserManager {
     this.snapshotMaps.clear();
 
     if (this.context) {
+      // Remove the close listener before intentional close to avoid
+      // the handler firing and clearing state we're already cleaning up.
+      if (this.contextCloseHandler) {
+        const rawCtx = this.context as unknown as { off?: (event: string, handler: (...args: unknown[]) => void) => void };
+        if (typeof rawCtx.off === 'function') {
+          rawCtx.off('close', this.contextCloseHandler);
+        }
+        this.contextCloseHandler = null;
+      }
       try {
         await this.context.close();
       } catch (err) {


### PR DESCRIPTION
## Summary
- Clear the force-shutdown timer (`forceTimer`) after graceful shutdown completes, preventing it from outliving the cleanup path
- Use `socket.once('error')` instead of `socket.on('error')` for rejected connections that are immediately destroyed
- Track the browser context `close` listener and explicitly remove it on intentional close to prevent listener accumulation when the context is recreated after a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
