### PR TITLE
fix: add timeout guard to AX tree scanning

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
@@ -27,6 +27,9 @@ enum AmbientAXCapture {
     private static let maxDepth = 4
     private static let maxElements = 50
 
+    /// Timeout for AX API calls — prevents blocking if the target app is unresponsive.
+    private static let axMessagingTimeoutSeconds: Float = 5.0
+
     /// Roles to skip — they add noise without meaningful content.
     private static let decorationRoles: Set<String> = [
         "AXScrollBar", "AXSplitter", "AXGrowArea", "AXRuler",
@@ -59,6 +62,7 @@ enum AmbientAXCapture {
         let bundleId = frontApp.bundleIdentifier
         let appName = frontApp.localizedName ?? "Unknown"
         let appElement = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(appElement, axMessagingTimeoutSeconds)
 
         // Get focused window
         var windowValue: CFTypeRef?

--- a/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
@@ -41,6 +41,11 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
     /// Maximum elements to enumerate before bailing out (protects against circular refs)
     private let maxElementsPerEnumeration = 10000
 
+    /// Timeout (in seconds) for AX API calls to a target app. If an app is
+    /// unresponsive, individual AXUIElementCopyAttributeValue calls will return
+    /// kAXErrorCannotComplete after this duration instead of blocking indefinitely.
+    private static let axMessagingTimeoutSeconds: Float = 5.0
+
     static let interactiveRoles: Set<String> = [
         "AXButton", "AXTextField", "AXTextArea", "AXCheckBox", "AXRadioButton",
         "AXPopUpButton", "AXComboBox", "AXSlider", "AXLink", "AXMenuItem",
@@ -116,6 +121,7 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
         let pid = frontApp.processIdentifier
         let appName = frontApp.localizedName ?? "Unknown"
         let appElement = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(appElement, Self.axMessagingTimeoutSeconds)
 
         // Tell apps (especially Chrome, Electron) to expose full web content AX tree.
         // This is what real assistive technologies do.
@@ -187,6 +193,7 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
     /// Returns nil if the app has no focused window or yields no elements.
     private func enumerateAppByPID(_ pid: pid_t) -> (elements: [AXElement], windowTitle: String, appName: String, pid: pid_t)? {
         let appElement = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(appElement, Self.axMessagingTimeoutSeconds)
 
         if !Self.enhancedAXEnabled.contains(pid) {
             AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
@@ -231,6 +238,7 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
             guard results.count < maxWindows else { break }
             let pid = app.processIdentifier
             let appElement = AXUIElementCreateApplication(pid)
+            AXUIElementSetMessagingTimeout(appElement, Self.axMessagingTimeoutSeconds)
 
             if !Self.enhancedAXEnabled.contains(pid) {
                 AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)


### PR DESCRIPTION
## Summary
- Adds a 5-second `AXUIElementSetMessagingTimeout` on every AX application element before querying it
- Covers all entry points: `enumerateCurrentWindow()`, `enumerateAppByPID()`, `enumerateSecondaryWindows()`, and `AmbientAXCapture.capture()`
- If a target app is unresponsive, individual AX API calls now return `kAXErrorCannotComplete` after 5s instead of blocking the main thread indefinitely (the system default timeout is ~120s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
