### PR TITLE
feat: conditionally register web_search tool based on Brave API key

### DIFF
--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -183,4 +183,8 @@ class WebSearchTool implements Tool {
   }
 }
 
-registerTool(new WebSearchTool());
+// Only register when a Brave API key is available — avoids exposing a
+// non-functional tool to the model when no key is configured.
+if (getApiKey()) {
+  registerTool(new WebSearchTool());
+}


### PR DESCRIPTION
## Summary
- The `web_search` tool is now only registered when a Brave API key is available (env var, secure storage, or config)
- Previously the tool was always registered and returned an error at execution time if no key was configured
- This avoids exposing a non-functional tool to the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
