### PR TITLE
refactor: rename cu_* tool names to computer_use_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bun run src/index.ts daemon start
 - Default tool workspace: `~/.vellum/workspace` (persistent global sandbox filesystem).
 - Sandbox-scoped tools: `file_read`, `file_write`, `file_edit`, and `bash`.
 - Explicit host tools: `host_file_read`, `host_file_write`, `host_file_edit`, and `host_bash` (absolute host paths only for host file tools).
-- Host/computer-use prompts: `host_*`, `request_computer_control`, and `cu_*` default to `ask` unless allowlisted/denylisted in trust rules.
+- Host/computer-use prompts: `host_*`, `request_computer_control`, and `computer_use_*` default to `ask` unless allowlisted/denylisted in trust rules.
 - Runtime override removal: CLI `--no-sandbox` is removed; legacy `sandbox_set` IPC messages are accepted but ignored (deprecated no-op).
 
 ### Sandbox Backend Selection

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -398,11 +398,11 @@ describe('Permission Checker', () => {
       expect(result.decision).toBe('prompt');
     });
 
-    test('cu_click prompts by default via computer-use ask rule', async () => {
-      const result = await check('cu_click', { reasoning: 'Click the save button' }, '/tmp');
+    test('computer_use_click prompts by default via computer-use ask rule', async () => {
+      const result = await check('computer_use_click', { reasoning: 'Click the save button' }, '/tmp');
       expect(result.decision).toBe('prompt');
       expect(result.reason).toContain('ask rule');
-      expect(result.matchedRule?.id).toBe('default:ask-cu_click-global');
+      expect(result.matchedRule?.id).toBe('default:ask-computer_use_click-global');
     });
 
     test('request_computer_control prompts by default via computer-use ask rule', async () => {
@@ -412,17 +412,17 @@ describe('Permission Checker', () => {
       expect(result.matchedRule?.id).toBe('default:ask-request_computer_control-global');
     });
 
-    test('higher-priority allow rule can override default cu ask rule', async () => {
-      addRule('cu_click', 'cu_click:*', 'everywhere', 'allow', 2000);
-      const result = await check('cu_click', { reasoning: 'Click confirm' }, '/tmp');
+    test('higher-priority allow rule can override default computer-use ask rule', async () => {
+      addRule('computer_use_click', 'computer_use_click:*', 'everywhere', 'allow', 2000);
+      const result = await check('computer_use_click', { reasoning: 'Click confirm' }, '/tmp');
       expect(result.decision).toBe('allow');
       expect(result.matchedRule?.decision).toBe('allow');
       expect(result.matchedRule?.priority).toBe(2000);
     });
 
-    test('higher-priority deny rule can override default cu ask rule', async () => {
-      addRule('cu_click', 'cu_click:*', 'everywhere', 'deny', 2001);
-      const result = await check('cu_click', { reasoning: 'Click confirm' }, '/tmp');
+    test('higher-priority deny rule can override default computer-use ask rule', async () => {
+      addRule('computer_use_click', 'computer_use_click:*', 'everywhere', 'deny', 2001);
+      const result = await check('computer_use_click', { reasoning: 'Click confirm' }, '/tmp');
       expect(result.decision).toBe('deny');
       expect(result.matchedRule?.decision).toBe('deny');
       expect(result.matchedRule?.priority).toBe(2001);

--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -20,13 +20,13 @@ function createProvider(responses: ProviderResponse[]): { provider: Provider; ge
 }
 
 describe('ComputerUseSession lifecycle', () => {
-  test('stops provider loop immediately after terminal cu_done tool', async () => {
+  test('stops provider loop immediately after terminal computer_use_done tool', async () => {
     const { provider, getCalls } = createProvider([
       {
         content: [{
           type: 'tool_use',
           id: 'tu-1',
-          name: 'cu_done',
+          name: 'computer_use_done',
           input: { summary: 'Task finished' },
         }],
         model: 'mock-model',
@@ -63,7 +63,7 @@ describe('ComputerUseSession lifecycle', () => {
 
     await session.handleObservation(observation);
 
-    // If cu_done does not abort the loop, we'd see an extra provider call.
+    // If computer_use_done does not abort the loop, we'd see an extra provider call.
     expect(getCalls()).toBe(1);
     expect(session.getState()).toBe('complete');
     expect(terminalCalls).toBe(1);

--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -70,7 +70,7 @@ mock.module('../agent/loop.js', () => ({
     }
 
     async run(_messages: unknown, _onEvent: unknown, _signal?: AbortSignal): Promise<void> {
-      await this.runTool('cu_click', { element_id: 1 });
+      await this.runTool('computer_use_click', { element_id: 1 });
     }
   },
 }));

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -597,16 +597,16 @@ describe('Trust Store', () => {
         .map((r) => r.tool)
         .sort();
       expect(defaultTools).toEqual([
-        'cu_click',
-        'cu_double_click',
-        'cu_drag',
-        'cu_key',
-        'cu_open_app',
-        'cu_right_click',
-        'cu_run_applescript',
-        'cu_scroll',
-        'cu_type_text',
-        'cu_wait',
+        'computer_use_click',
+        'computer_use_double_click',
+        'computer_use_drag',
+        'computer_use_key',
+        'computer_use_open_app',
+        'computer_use_right_click',
+        'computer_use_run_applescript',
+        'computer_use_scroll',
+        'computer_use_type_text',
+        'computer_use_wait',
         'delete_managed_skill',
         'file_edit',
         'file_read',
@@ -725,12 +725,12 @@ describe('Trust Store', () => {
       expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-host_bash-global')!);
     });
 
-    test('findHighestPriorityRule matches default ask for cu_click', () => {
-      const match = findHighestPriorityRule('cu_click', ['cu_click:'], '/tmp');
+    test('findHighestPriorityRule matches default ask for computer_use_click', () => {
+      const match = findHighestPriorityRule('computer_use_click', ['computer_use_click:'], '/tmp');
       expect(match).not.toBeNull();
-      expect(match!.id).toBe('default:ask-cu_click-global');
+      expect(match!.id).toBe('default:ask-computer_use_click-global');
       expect(match!.decision).toBe('ask');
-      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-cu_click-global')!);
+      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-computer_use_click-global')!);
     });
 
     test('findHighestPriorityRule matches default ask for request_computer_control', () => {

--- a/assistant/src/config/computer-use-prompt.ts
+++ b/assistant/src/config/computer-use-prompt.ts
@@ -28,39 +28,39 @@ The screen is ${screenWidth}\u00d7${screenHeight} pixels.
 ACTION EXECUTION HIERARCHY:
 Not all actions require the same execution method. Always prefer the least invasive, most reliable approach. Foreground computer use (clicking, typing, scrolling) takes over the user's cursor and keyboard — it is disruptive and should be your LAST resort, not your first instinct.
 
-  BEST  → cu_respond / ui_show — Answer directly or render a UI surface. No computer control needed.
-  GOOD  → cu_run_applescript — Tell the app to do something through its automation interface. No cursor movement. User keeps working.
-  LAST  → cu_click / cu_type_text / cu_key / cu_scroll / cu_drag — Foreground computer use. Takes over cursor + keyboard. Use only when AppleScript cannot accomplish the task.
+  BEST  → computer_use_respond / ui_show — Answer directly or render a UI surface. No computer control needed.
+  GOOD  → computer_use_run_applescript — Tell the app to do something through its automation interface. No cursor movement. User keeps working.
+  LAST  → computer_use_click / computer_use_type_text / computer_use_key / computer_use_scroll / computer_use_drag — Foreground computer use. Takes over cursor + keyboard. Use only when AppleScript cannot accomplish the task.
 
 Before every action, ask yourself: "Can I do this with AppleScript or a direct response instead of moving the cursor?" If yes, do that instead.
 
 You will receive the current screen state as an accessibility tree. Each interactive element has an [ID] number like [3] or [17]. Use these IDs with element_id to target elements \u2014 this is much more reliable than pixel coordinates.
 
-YOUR AVAILABLE TOOLS ARE: cu_click, cu_double_click, cu_right_click, cu_type_text, cu_key, cu_scroll, cu_drag, cu_wait, cu_open_app, cu_run_applescript, cu_done, cu_respond, ui_show, ui_update, ui_dismiss.
+YOUR AVAILABLE TOOLS ARE: computer_use_click, computer_use_double_click, computer_use_right_click, computer_use_type_text, computer_use_key, computer_use_scroll, computer_use_drag, computer_use_wait, computer_use_open_app, computer_use_run_applescript, computer_use_done, computer_use_respond, ui_show, ui_update, ui_dismiss.
 You MUST only call one tool per turn.
 
-UI SURFACES: When the user asks you to build, create, or display something (an app, dashboard, tracker, etc.), use ui_show with surface_type "dynamic_page" to render custom HTML directly instead of trying to build it with computer-use tools. This is your primary way to create visual applications for the user. After calling ui_show, call cu_done immediately — the surface is already displayed to the user.
+UI SURFACES: When the user asks you to build, create, or display something (an app, dashboard, tracker, etc.), use ui_show with surface_type "dynamic_page" to render custom HTML directly instead of trying to build it with computer-use tools. This is your primary way to create visual applications for the user. After calling ui_show, call computer_use_done immediately — the surface is already displayed to the user.
 
 RULES:
 - Call exactly one tool per turn. After each action, you'll receive the updated screen state.
 - ALWAYS use element_id to target elements from the accessibility tree. Only fall back to x,y coordinates if no tree is available.
-- If the accessibility tree already shows you're in the correct app, do NOT call cu_open_app again \u2014 proceed directly with your intended interaction (e.g., click an element, use a keyboard shortcut).
-- Use the cu_wait tool when you need to pause for UI to update (e.g. after clicking a button that loads content).
-- FORM FIELD WORKFLOW: To fill a text field, first click it (by element_id) to focus it, then call cu_type_text. If a field already shows "FOCUSED", skip the click and type immediately.
+- If the accessibility tree already shows you're in the correct app, do NOT call computer_use_open_app again \u2014 proceed directly with your intended interaction (e.g., click an element, use a keyboard shortcut).
+- Use the computer_use_wait tool when you need to pause for UI to update (e.g. after clicking a button that loads content).
+- FORM FIELD WORKFLOW: To fill a text field, first click it (by element_id) to focus it, then call computer_use_type_text. If a field already shows "FOCUSED", skip the click and type immediately.
 - After typing, verify in the next turn that the text appeared correctly.
 - If something unexpected happens, adapt your approach.
-- If you're stuck (same state after 3+ actions), try a different approach or call cu_done with an explanation.
+- If you're stuck (same state after 3+ actions), try a different approach or call computer_use_done with an explanation.
 - NEVER type passwords, credit card numbers, SSNs, or other sensitive data.
 - When you must use foreground computer use, prefer keyboard shortcuts (cmd+c, cmd+v) over menu navigation.
-- When the task is complete, call the cu_done tool with a summary.
+- When the task is complete, call the computer_use_done tool with a summary.
 - You may receive a "CHANGES SINCE LAST ACTION" section that summarizes what changed in the UI. Use this to confirm your action worked or to adapt.
 - You may see "OTHER VISIBLE WINDOWS" showing elements from other apps. Use this for cross-app tasks (e.g., "copy from Safari, paste into Notes").
-- For drag operations (moving files, resizing, sliders), use the cu_drag tool with source and destination element_ids or coordinates.
+- For drag operations (moving files, resizing, sliders), use the computer_use_drag tool with source and destination element_ids or coordinates.
 
 MULTI-STEP WORKFLOWS:
-- When a task involves multiple apps (e.g., "send a message in Slack"), use cu_open_app to switch apps \u2014 it is much more reliable than cmd+tab.
-- After switching apps with cu_open_app, wait one turn for the UI to update before interacting with the new app's elements.
-- Break cross-app tasks into phases: (1) cu_open_app to switch, (2) wait for UI, (3) interact with the app.
+- When a task involves multiple apps (e.g., "send a message in Slack"), use computer_use_open_app to switch apps \u2014 it is much more reliable than cmd+tab.
+- After switching apps with computer_use_open_app, wait one turn for the UI to update before interacting with the new app's elements.
+- Break cross-app tasks into phases: (1) computer_use_open_app to switch, (2) wait for UI, (3) interact with the app.
 
 APP-SPECIFIC TIPS:
 - Slack: Use cmd+k to quickly jump to a channel or DM by name.
@@ -84,7 +84,7 @@ When you see a CAPTCHA or "verify you are human" challenge on the screen:
 3. Refresh the page and continue
 
 APPLESCRIPT (PREFERRED over clicking/typing):
-- ALWAYS prefer cu_run_applescript over cu_click/cu_type_text when possible \u2014 it does not move the cursor or take over the keyboard.
+- ALWAYS prefer computer_use_run_applescript over computer_use_click/computer_use_type_text when possible \u2014 it does not move the cursor or take over the keyboard.
 - Use it for: setting a browser URL, navigating Finder to a path, querying app state, clicking menus, opening files, sending messages, and any action an app exposes via its scripting dictionary.
 - The script result (if any) is returned to you so you can reason about it.
 - NEVER use "do shell script" inside AppleScript \u2014 it is blocked for security.
@@ -93,5 +93,5 @@ APPLESCRIPT (PREFERRED over clicking/typing):
 
 Today is ${dateStr}.
 
-If the user is asking a question about their schedule or meetings, use the \`cu_respond\` tool to answer directly. Do NOT use computer-control tools to open the Calendar app.`;
+If the user is asking a question about their schedule or meetings, use the \`computer_use_respond\` tool to answer directly. Do NOT use computer-control tools to open the Calendar app.`;
 }

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -348,9 +348,9 @@ export class ComputerUseSession {
       });
 
       // Check for terminal tools
-      if (toolName === 'cu_done' || toolName === 'cu_respond') {
+      if (toolName === 'computer_use_done' || toolName === 'computer_use_respond') {
         const summary =
-          toolName === 'cu_done'
+          toolName === 'computer_use_done'
             ? (typeof input.summary === 'string' ? input.summary : 'Task completed')
             : (typeof input.answer === 'string' ? input.answer : 'No answer provided');
 
@@ -359,7 +359,7 @@ export class ComputerUseSession {
           sessionId: this.sessionId,
           summary,
           stepCount: this.stepCount,
-          isResponse: toolName === 'cu_respond' ? true : undefined,
+          isResponse: toolName === 'computer_use_respond' ? true : undefined,
         });
         this.state = 'complete';
         // Stop AgentLoop immediately so terminal tools cannot trigger extra provider calls.
@@ -439,7 +439,7 @@ export class ComputerUseSession {
         maxTokens: 4096,
         toolChoice: { type: 'any' },
         // Allow MAX_STEPS non-terminal actions plus one terminal turn
-        // (cu_done/cu_respond), since AgentLoop caps tool turns globally.
+        // (computer_use_done/computer_use_respond), since AgentLoop caps tool turns globally.
         maxToolUseTurns: MAX_STEPS + 1,
       },
       toolDefs,
@@ -603,7 +603,7 @@ export class ComputerUseSession {
       parts.push('');
     } else if (hadPreviousAXTree && obs.axTree != null) {
       const lastAction = this.actionHistory[this.actionHistory.length - 1];
-      const wasWait = lastAction?.toolName === 'cu_wait';
+      const wasWait = lastAction?.toolName === 'computer_use_wait';
       if (this.consecutiveUnchangedSteps >= CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD) {
         parts.push(
           `WARNING: ${this.consecutiveUnchangedSteps} consecutive actions had NO VISIBLE EFFECT on the UI. You MUST try a completely different approach.`,
@@ -667,7 +667,7 @@ export class ComputerUseSession {
     } else if (hadPreviousAXTree && obs.axTree != null && this.actionHistory.length > 0) {
       // AX tree unchanged — tell the model its action had no effect
       const lastAction = this.actionHistory[this.actionHistory.length - 1];
-      const wasWait = lastAction?.toolName === 'cu_wait';
+      const wasWait = lastAction?.toolName === 'computer_use_wait';
       textParts.push('CHANGES SINCE LAST ACTION:');
       if (this.consecutiveUnchangedSteps >= CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD) {
         textParts.push(
@@ -753,7 +753,7 @@ export class ComputerUseSession {
       if (allIdentical) {
         textParts.push('');
         textParts.push(
-          `WARNING: You have repeated the exact same action (${recent[0].toolName}) ${LOOP_DETECTION_WINDOW} times in a row. You MUST try a completely different approach or call cu_done with an explanation of why you are stuck.`,
+          `WARNING: You have repeated the exact same action (${recent[0].toolName}) ${LOOP_DETECTION_WINDOW} times in a row. You MUST try a completely different approach or call computer_use_done with an explanation of why you are stuck.`,
         );
       }
     }

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -14,19 +14,20 @@ export interface DefaultRuleTemplate {
 const FILE_TOOLS = ['file_read', 'file_write', 'file_edit'] as const;
 const HOST_FILE_TOOLS = ['host_file_read', 'host_file_write', 'host_file_edit'] as const;
 const COMPUTER_USE_TOOLS = [
-  'cu_click',
-  'cu_double_click',
-  'cu_right_click',
-  'cu_type_text',
-  'cu_key',
-  'cu_scroll',
-  'cu_drag',
-  'cu_wait',
-  'cu_open_app',
-  'cu_run_applescript',
+  'computer_use_click',
+  'computer_use_double_click',
+  'computer_use_right_click',
+  'computer_use_type_text',
+  'computer_use_key',
+  'computer_use_scroll',
+  'computer_use_drag',
+  'computer_use_wait',
+  'computer_use_open_app',
+  'computer_use_run_applescript',
   'request_computer_control',
-  // cu_done and cu_respond are terminal signal tools (RiskLevel.Low) — they
-  // don't perform any computer action, so they should NOT get an 'ask' rule.
+  // computer_use_done and computer_use_respond are terminal signal tools
+  // (RiskLevel.Low) — they don't perform any computer action, so they
+  // should NOT get an 'ask' rule.
 ] as const;
 
 /**

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -60,7 +60,7 @@ function backfillDefaults(rules: TrustRule[]): boolean {
   }
 
   // Remove default rules that are no longer in the template set (e.g.
-  // cu_done/cu_respond were removed from the computer-use ask-rule list
+  // computer_use_done/computer_use_respond were removed from the ask-rule list
   // because they are terminal signal tools that don't need approval).
   const templateIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
   for (let i = rules.length - 1; i >= 0; i--) {

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -2,7 +2,7 @@
  * Computer-use tool definitions.
  *
  * These tools mirror the macOS client's ToolDefinitions.swift schemas, prefixed
- * with `cu_` to avoid collisions with existing daemon tools.  They are all
+ * with `computer_use_` to avoid collisions with existing daemon tools.  They are all
  * proxy tools — execution is forwarded to a connected macOS client and never
  * handled locally by the daemon.
  */
@@ -64,16 +64,16 @@ function makeClickTool(name: string, verb: string): Tool {
 // Click variants
 // ---------------------------------------------------------------------------
 
-export const cuClickTool = makeClickTool('cu_click', 'Click');
-export const cuDoubleClickTool = makeClickTool('cu_double_click', 'Double-click');
-export const cuRightClickTool = makeClickTool('cu_right_click', 'Right-click');
+export const computerUseClickTool = makeClickTool('computer_use_click', 'Click');
+export const computerUseDoubleClickTool = makeClickTool('computer_use_double_click', 'Double-click');
+export const computerUseRightClickTool = makeClickTool('computer_use_right_click', 'Right-click');
 
 // ---------------------------------------------------------------------------
 // type_text
 // ---------------------------------------------------------------------------
 
-export const cuTypeTextTool: Tool = {
-  name: 'cu_type_text',
+export const computerUseTypeTextTool: Tool = {
+  name: 'computer_use_type_text',
   description: 'Type text at the current cursor position. The target field must already be focused (click it first).',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -107,8 +107,8 @@ export const cuTypeTextTool: Tool = {
 // key
 // ---------------------------------------------------------------------------
 
-export const cuKeyTool: Tool = {
-  name: 'cu_key',
+export const computerUseKeyTool: Tool = {
+  name: 'computer_use_key',
   description: 'Press a key or keyboard shortcut. Supported: enter, tab, escape, backspace, delete, up, down, left, right, space, cmd+a, cmd+c, cmd+v, cmd+z, cmd+tab, cmd+w, shift+tab, option+tab',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -142,8 +142,8 @@ export const cuKeyTool: Tool = {
 // scroll
 // ---------------------------------------------------------------------------
 
-export const cuScrollTool: Tool = {
-  name: 'cu_scroll',
+export const computerUseScrollTool: Tool = {
+  name: 'computer_use_scroll',
   description: 'Scroll within an element by its [ID], or at raw screen coordinates as fallback.',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -194,8 +194,8 @@ export const cuScrollTool: Tool = {
 // drag
 // ---------------------------------------------------------------------------
 
-export const cuDragTool: Tool = {
-  name: 'cu_drag',
+export const computerUseDragTool: Tool = {
+  name: 'computer_use_drag',
   description: 'Drag from one element or position to another. Use for moving files, resizing windows, rearranging items, or adjusting sliders.',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -249,8 +249,8 @@ export const cuDragTool: Tool = {
 // wait
 // ---------------------------------------------------------------------------
 
-export const cuWaitTool: Tool = {
-  name: 'cu_wait',
+export const computerUseWaitTool: Tool = {
+  name: 'computer_use_wait',
   description: 'Wait for the UI to update',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -284,8 +284,8 @@ export const cuWaitTool: Tool = {
 // open_app
 // ---------------------------------------------------------------------------
 
-export const cuOpenAppTool: Tool = {
-  name: 'cu_open_app',
+export const computerUseOpenAppTool: Tool = {
+  name: 'computer_use_open_app',
   description: 'Open or switch to a macOS application by name. Preferred over cmd+tab for switching apps — more reliable and explicit.',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -319,8 +319,8 @@ export const cuOpenAppTool: Tool = {
 // run_applescript
 // ---------------------------------------------------------------------------
 
-export const cuRunAppleScriptTool: Tool = {
-  name: 'cu_run_applescript',
+export const computerUseRunAppleScriptTool: Tool = {
+  name: 'computer_use_run_applescript',
   description:
     'Execute an AppleScript to control applications via Apple\'s scripting bridge. ' +
     'Use this for operations that are more reliable through scripting than UI interaction: ' +
@@ -361,8 +361,8 @@ export const cuRunAppleScriptTool: Tool = {
 // done
 // ---------------------------------------------------------------------------
 
-export const cuDoneTool: Tool = {
-  name: 'cu_done',
+export const computerUseDoneTool: Tool = {
+  name: 'computer_use_done',
   description: 'Task is complete',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -392,8 +392,8 @@ export const cuDoneTool: Tool = {
 // respond
 // ---------------------------------------------------------------------------
 
-export const cuRespondTool: Tool = {
-  name: 'cu_respond',
+export const computerUseRespondTool: Tool = {
+  name: 'computer_use_respond',
   description: 'Respond directly to the user with a text answer. Use this when the user is asking a question (about their schedule, meetings, calendar, etc.) rather than asking you to control the computer.',
   category: 'computer-use',
   defaultRiskLevel: RiskLevel.Low,
@@ -428,16 +428,16 @@ export const cuRespondTool: Tool = {
 // ---------------------------------------------------------------------------
 
 export const allComputerUseTools: Tool[] = [
-  cuClickTool,
-  cuDoubleClickTool,
-  cuRightClickTool,
-  cuTypeTextTool,
-  cuKeyTool,
-  cuScrollTool,
-  cuDragTool,
-  cuWaitTool,
-  cuOpenAppTool,
-  cuRunAppleScriptTool,
-  cuDoneTool,
-  cuRespondTool,
+  computerUseClickTool,
+  computerUseDoubleClickTool,
+  computerUseRightClickTool,
+  computerUseTypeTextTool,
+  computerUseKeyTool,
+  computerUseScrollTool,
+  computerUseDragTool,
+  computerUseWaitTool,
+  computerUseOpenAppTool,
+  computerUseRunAppleScriptTool,
+  computerUseDoneTool,
+  computerUseRespondTool,
 ];

--- a/assistant/src/tools/computer-use/registry.ts
+++ b/assistant/src/tools/computer-use/registry.ts
@@ -1,7 +1,7 @@
 /**
  * Registers all computer-use proxy tools with the daemon's tool registry.
  *
- * Call `registerComputerUseTools()` during daemon startup to make the 12 `cu_*`
+ * Call `registerComputerUseTools()` during daemon startup to make the 12 `computer_use_*`
  * tools available for inference.
  */
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -461,7 +461,7 @@ async function executeWithTimeout(
 }
 
 function resolveExecutionTarget(toolName: string): ExecutionTarget {
-  if (toolName.startsWith('host_') || toolName.startsWith('cu_') || toolName === 'request_computer_control') {
+  if (toolName.startsWith('host_') || toolName.startsWith('computer_use_') || toolName === 'request_computer_control') {
     return 'host';
   }
   // Check the tool's executionMode metadata — proxy tools run on the connected

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -95,7 +95,7 @@ export function getAllTools(): Tool[] {
 }
 
 export function getAllToolDefinitions(): ToolDefinition[] {
-  // Exclude proxy tools (e.g. cu_* computer-use tools) — they are only used
+  // Exclude proxy tools (e.g. computer_use_* tools) — they are only used
   // by ComputerUseSession which builds its own tool definitions list.
   return getAllTools()
     .filter((t) => t.executionMode !== 'proxy')


### PR DESCRIPTION
## Summary
- Renamed all 12 computer-use tool names from `cu_*` to `computer_use_*` (e.g. `cu_click` → `computer_use_click`)
- Updated tool definitions, permissions defaults, trust store, executor routing, system prompt, and all affected tests
- IPC message types (`cu_observation`, `cu_action`, `cu_complete`, `cu_error`, `cu_session_create`, `cu_session_abort`) are unchanged — they are part of the wire protocol shared with the Swift client

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
