### PR TITLE
feat: deduplicate inbound attachment uploads across webhook retries

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -102,6 +102,30 @@ describe('uploadAttachment', () => {
     const stored = uploadAttachment('ast-1', 'hello.txt', 'text/plain', 'aGVsbG8=');
     expect(stored.sizeBytes).toBe(5);
   });
+
+  test('deduplicates by content hash within the same assistant', () => {
+    const first = uploadAttachment('ast-1', 'photo.png', 'image/png', 'iVBORw0KGgoAAAANSUh');
+    const second = uploadAttachment('ast-1', 'photo.png', 'image/png', 'iVBORw0KGgoAAAANSUh');
+    expect(second.id).toBe(first.id);
+  });
+
+  test('deduplicates even when filenames differ', () => {
+    const first = uploadAttachment('ast-1', 'original.png', 'image/png', 'DUPECONTENT123');
+    const second = uploadAttachment('ast-1', 'renamed.png', 'image/png', 'DUPECONTENT123');
+    expect(second.id).toBe(first.id);
+  });
+
+  test('does not deduplicate across different assistants', () => {
+    const first = uploadAttachment('ast-1', 'file.txt', 'text/plain', 'CROSSASSISTANT');
+    const second = uploadAttachment('ast-2', 'file.txt', 'text/plain', 'CROSSASSISTANT');
+    expect(second.id).not.toBe(first.id);
+  });
+
+  test('does not deduplicate different content', () => {
+    const first = uploadAttachment('ast-1', 'a.txt', 'text/plain', 'CONTENT_A');
+    const second = uploadAttachment('ast-1', 'b.txt', 'text/plain', 'CONTENT_B');
+    expect(second.id).not.toBe(first.id);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -104,6 +104,14 @@ export function validateAttachmentUpload(
   return { ok: true };
 }
 
+/**
+ * Compute a content hash for deduplication. Uses Bun.hash (wyhash) for speed,
+ * encoded as base-36 for compact storage.
+ */
+function computeContentHash(dataBase64: string): string {
+  return Bun.hash(dataBase64).toString(36);
+}
+
 export function uploadAttachment(
   assistantId: string,
   filename: string,
@@ -111,6 +119,33 @@ export function uploadAttachment(
   dataBase64: string,
 ): StoredAttachment {
   const db = getDb();
+  const contentHash = computeContentHash(dataBase64);
+
+  // Dedup: if an attachment with the same content already exists for this
+  // assistant, return it instead of storing a duplicate.
+  const existing = db
+    .select({
+      id: attachments.id,
+      assistantId: attachments.assistantId,
+      originalFilename: attachments.originalFilename,
+      mimeType: attachments.mimeType,
+      sizeBytes: attachments.sizeBytes,
+      kind: attachments.kind,
+      createdAt: attachments.createdAt,
+    })
+    .from(attachments)
+    .where(
+      and(
+        eq(attachments.assistantId, assistantId),
+        eq(attachments.contentHash, contentHash),
+      ),
+    )
+    .get();
+
+  if (existing) {
+    return existing;
+  }
+
   const now = Date.now();
   const padding = dataBase64.endsWith('==') ? 2 : (dataBase64.endsWith('=') ? 1 : 0);
   const sizeBytes = Math.max(0, Math.floor((dataBase64.length * 3) / 4) - padding);
@@ -124,6 +159,7 @@ export function uploadAttachment(
     sizeBytes,
     kind,
     dataBase64,
+    contentHash,
     createdAt: now,
   };
 

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -467,6 +467,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE memory_summaries ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_segments ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN source_message_id TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
@@ -511,6 +512,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_id ON memory_summaries(scope_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_keys_assistant_key ON conversation_keys(assistant_id, conversation_key)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_attachments_assistant_id ON attachments(assistant_id)`);
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_content_dedup ON attachments(assistant_id, content_hash) WHERE content_hash IS NOT NULL`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_message_id ON message_attachments(message_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_attachment_id ON message_attachments(attachment_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_lookup ON channel_inbound_events(assistant_id, source_channel, external_chat_id, external_message_id)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -161,6 +161,7 @@ export const attachments = sqliteTable('attachments', {
   sizeBytes: integer('size_bytes').notNull(),
   kind: text('kind').notNull(),
   dataBase64: text('data_base64').notNull(),
+  contentHash: text('content_hash'),
   createdAt: integer('created_at').notNull(),
 });
 


### PR DESCRIPTION
## Summary
- Adds content-hash based deduplication to attachment uploads so that webhook retries (gateway re-uploading the same file) return the existing attachment instead of creating duplicate rows
- Uses `Bun.hash` (wyhash) for fast content hashing with a partial unique index on `(assistant_id, content_hash)` for efficient lookups
- Backward-compatible: existing attachments without a hash continue to work; only new uploads participate in deduplication

## Test plan
- [x] New tests verify same-content uploads return the same attachment ID
- [x] Cross-assistant isolation preserved (same content, different assistants → different IDs)
- [x] Different content still produces distinct attachments
- [x] All 40 existing + new attachment store tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
