### PR TITLE
feat: channel inbound dead-letter queue + replay

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -4,13 +4,23 @@
  * Ensures duplicate channel messages (e.g. Telegram webhook retries)
  * don't produce duplicate replies. Tracks delivery acknowledgement
  * so the runtime owns the full lifecycle instead of web Postgres.
+ *
+ * Dead-letter support: when processMessage fails, the event is marked
+ * with processing_status='failed' (retryable) or 'dead_letter' (fatal
+ * or max attempts exceeded). A periodic sweep retries failed events,
+ * and a replay endpoint allows manual recovery of dead-lettered ones.
  */
 
-import { eq, and } from 'drizzle-orm';
+import { eq, and, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { channelInboundEvents, conversations } from './schema.js';
 import { getOrCreateConversation } from './conversation-key-store.js';
+import {
+  classifyError,
+  retryDelayForAttempt,
+  RETRY_MAX_ATTEMPTS,
+} from './job-utils.js';
 
 export interface InboundResult {
   accepted: boolean;
@@ -174,4 +184,171 @@ export function acknowledgeDelivery(
     .run();
 
   return true;
+}
+
+// ── Dead-letter queue helpers ───────────────────────────────────────
+
+/**
+ * Store the raw request payload on an inbound event so it can be
+ * replayed later if processing fails.
+ */
+export function storePayload(eventId: string, payload: Record<string, unknown>): void {
+  const db = getDb();
+  db.update(channelInboundEvents)
+    .set({ rawPayload: JSON.stringify(payload), updatedAt: Date.now() })
+    .where(eq(channelInboundEvents.id, eventId))
+    .run();
+}
+
+/** Mark an event as successfully processed. */
+export function markProcessed(eventId: string): void {
+  const db = getDb();
+  db.update(channelInboundEvents)
+    .set({ processingStatus: 'processed', updatedAt: Date.now() })
+    .where(eq(channelInboundEvents.id, eventId))
+    .run();
+}
+
+/**
+ * Record a processing failure. Classifies the error to decide whether
+ * the event should be retried (status='failed') or dead-lettered
+ * (status='dead_letter') when the error is fatal or max attempts
+ * are exhausted.
+ */
+export function recordProcessingFailure(eventId: string, err: unknown): void {
+  const db = getDb();
+  const now = Date.now();
+
+  const row = db
+    .select({ attempts: channelInboundEvents.processingAttempts })
+    .from(channelInboundEvents)
+    .where(eq(channelInboundEvents.id, eventId))
+    .get();
+
+  const attempts = (row?.attempts ?? 0) + 1;
+  const category = classifyError(err);
+  const errorMsg = err instanceof Error ? err.message : String(err);
+
+  if (category === 'fatal' || attempts >= RETRY_MAX_ATTEMPTS) {
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: 'dead_letter',
+        processingAttempts: attempts,
+        lastProcessingError: errorMsg,
+        retryAfter: null,
+        updatedAt: now,
+      })
+      .where(eq(channelInboundEvents.id, eventId))
+      .run();
+  } else {
+    const delay = retryDelayForAttempt(attempts);
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: 'failed',
+        processingAttempts: attempts,
+        lastProcessingError: errorMsg,
+        retryAfter: now + delay,
+        updatedAt: now,
+      })
+      .where(eq(channelInboundEvents.id, eventId))
+      .run();
+  }
+}
+
+/** Fetch events eligible for automatic retry (failed + past their backoff). */
+export function getRetryableEvents(limit = 20): Array<{
+  id: string;
+  assistantId: string;
+  conversationId: string;
+  processingAttempts: number;
+  rawPayload: string | null;
+}> {
+  const db = getDb();
+  const now = Date.now();
+  return db
+    .select({
+      id: channelInboundEvents.id,
+      assistantId: channelInboundEvents.assistantId,
+      conversationId: channelInboundEvents.conversationId,
+      processingAttempts: channelInboundEvents.processingAttempts,
+      rawPayload: channelInboundEvents.rawPayload,
+    })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.processingStatus, 'failed'),
+        lte(channelInboundEvents.retryAfter, now),
+      ),
+    )
+    .limit(limit)
+    .all();
+}
+
+/** Fetch dead-lettered events for an assistant. */
+export function getDeadLetterEvents(assistantId: string): Array<{
+  id: string;
+  sourceChannel: string;
+  externalChatId: string;
+  externalMessageId: string;
+  conversationId: string;
+  processingAttempts: number;
+  lastProcessingError: string | null;
+  createdAt: number;
+}> {
+  const db = getDb();
+  return db
+    .select({
+      id: channelInboundEvents.id,
+      sourceChannel: channelInboundEvents.sourceChannel,
+      externalChatId: channelInboundEvents.externalChatId,
+      externalMessageId: channelInboundEvents.externalMessageId,
+      conversationId: channelInboundEvents.conversationId,
+      processingAttempts: channelInboundEvents.processingAttempts,
+      lastProcessingError: channelInboundEvents.lastProcessingError,
+      createdAt: channelInboundEvents.createdAt,
+    })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.assistantId, assistantId),
+        eq(channelInboundEvents.processingStatus, 'dead_letter'),
+      ),
+    )
+    .all();
+}
+
+/**
+ * Reset dead-lettered events back to 'failed' so the sweep can retry
+ * them. Resets attempt counter and sets an immediate retry_after.
+ */
+export function replayDeadLetters(eventIds: string[]): number {
+  const db = getDb();
+  const now = Date.now();
+  let count = 0;
+  for (const id of eventIds) {
+    const existing = db
+      .select({ id: channelInboundEvents.id })
+      .from(channelInboundEvents)
+      .where(
+        and(
+          eq(channelInboundEvents.id, id),
+          eq(channelInboundEvents.processingStatus, 'dead_letter'),
+        ),
+      )
+      .get();
+    if (!existing) continue;
+
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: 'failed',
+        processingAttempts: 0,
+        lastProcessingError: null,
+        retryAfter: now,
+        updatedAt: now,
+      })
+      .where(eq(channelInboundEvents.id, id))
+      .run();
+    count++;
+  }
+  return count;
 }

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -468,6 +468,11 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE memory_segments ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN source_message_id TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN processing_status TEXT NOT NULL DEFAULT 'pending'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN processing_attempts INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN last_processing_error TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN retry_after INTEGER`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN raw_payload TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
@@ -518,6 +523,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_lookup ON channel_inbound_events(assistant_id, source_channel, external_chat_id, external_message_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_conversation ON channel_inbound_events(conversation_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_source_msg ON channel_inbound_events(assistant_id, source_channel, external_chat_id, source_message_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_processing_retry ON channel_inbound_events(processing_status, retry_after)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_assistant_status ON message_runs(assistant_id, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_conversation ON message_runs(conversation_id)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -190,6 +190,11 @@ export const channelInboundEvents = sqliteTable('channel_inbound_events', {
   messageId: text('message_id')
     .references(() => messages.id, { onDelete: 'cascade' }),
   deliveryStatus: text('delivery_status').notNull().default('pending'),
+  processingStatus: text('processing_status').notNull().default('pending'),
+  processingAttempts: integer('processing_attempts').notNull().default(0),
+  lastProcessingError: text('last_processing_error'),
+  retryAfter: integer('retry_after'),
+  rawPayload: text('raw_payload'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -31,7 +31,10 @@ import {
   handleDeleteConversation,
   handleChannelInbound,
   handleChannelDeliveryAck,
+  handleListDeadLetters,
+  handleReplayDeadLetters,
 } from './routes/channel-routes.js';
+import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import {
   handleServePage,
   handleShareApp,
@@ -68,6 +71,7 @@ export class RuntimeHttpServer {
   private interfacesDir: string | null;
   private suggestionCache = new Map<string, string>();
   private suggestionInFlight = new Map<string, Promise<string | null>>();
+  private retrySweepTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
@@ -83,10 +87,19 @@ export class RuntimeHttpServer {
       fetch: (req) => this.handleRequest(req),
     });
 
+    // Sweep failed channel inbound events for retry every 30 seconds
+    if (this.processMessage) {
+      this.retrySweepTimer = setInterval(() => this.sweepFailedEvents(), 30_000);
+    }
+
     log.info({ port: this.port }, 'Runtime HTTP server listening');
   }
 
   async stop(): Promise<void> {
+    if (this.retrySweepTimer) {
+      clearInterval(this.retrySweepTimer);
+      this.retrySweepTimer = null;
+    }
     if (this.server) {
       this.server.stop(true);
       this.server = null;
@@ -245,10 +258,88 @@ export class RuntimeHttpServer {
         return await handleChannelDeliveryAck(assistantId, req);
       }
 
+      if (endpoint === 'channels/dead-letters' && req.method === 'GET') {
+        return handleListDeadLetters(assistantId);
+      }
+
+      if (endpoint === 'channels/replay' && req.method === 'POST') {
+        return await handleReplayDeadLetters(assistantId, req);
+      }
+
       return Response.json({ error: 'Not found' }, { status: 404 });
     } catch (err) {
       log.error({ err, endpoint, assistantId }, 'Runtime HTTP handler error');
       return Response.json({ error: 'Internal server error' }, { status: 500 });
+    }
+  }
+
+  /**
+   * Periodically retry failed channel inbound events that have passed
+   * their exponential backoff delay.
+   */
+  private async sweepFailedEvents(): Promise<void> {
+    if (!this.processMessage) return;
+
+    const events = channelDeliveryStore.getRetryableEvents();
+    if (events.length === 0) return;
+
+    log.info({ count: events.length }, 'Retrying failed channel inbound events');
+
+    for (const event of events) {
+      if (!event.rawPayload) {
+        // No payload stored — can't replay, move to dead letter
+        channelDeliveryStore.recordProcessingFailure(
+          event.id,
+          new Error('No raw payload stored for replay'),
+        );
+        continue;
+      }
+
+      let payload: Record<string, unknown>;
+      try {
+        payload = JSON.parse(event.rawPayload) as Record<string, unknown>;
+      } catch {
+        channelDeliveryStore.recordProcessingFailure(
+          event.id,
+          new Error('Failed to parse stored raw payload'),
+        );
+        continue;
+      }
+
+      const content = typeof payload.content === 'string' ? payload.content.trim() : '';
+      const attachmentIds = Array.isArray(payload.attachmentIds) ? payload.attachmentIds as string[] : undefined;
+      const sourceChannel = payload.sourceChannel as string;
+      const sourceMetadata = payload.sourceMetadata as Record<string, unknown> | undefined;
+
+      const metadataHintsRaw = sourceMetadata?.hints;
+      const metadataHints = Array.isArray(metadataHintsRaw)
+        ? metadataHintsRaw.filter((h): h is string => typeof h === 'string' && h.trim().length > 0)
+        : [];
+      const metadataUxBrief = typeof sourceMetadata?.uxBrief === 'string' && sourceMetadata.uxBrief.trim().length > 0
+        ? sourceMetadata.uxBrief.trim()
+        : undefined;
+
+      try {
+        const { messageId: userMessageId } = await this.processMessage(
+          event.assistantId,
+          event.conversationId,
+          content,
+          attachmentIds,
+          {
+            transport: {
+              channelId: sourceChannel,
+              hints: metadataHints.length > 0 ? metadataHints : undefined,
+              uxBrief: metadataUxBrief,
+            },
+          },
+        );
+        channelDeliveryStore.linkMessage(event.id, userMessageId);
+        channelDeliveryStore.markProcessed(event.id);
+        log.info({ eventId: event.id }, 'Successfully replayed failed channel event');
+      } catch (err) {
+        log.error({ err, eventId: event.id }, 'Retry failed for channel event');
+        channelDeliveryStore.recordProcessingFailure(event.id, err);
+      }
     }
   }
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -169,6 +169,15 @@ export async function handleChannelInbound(
   // For new (non-duplicate) messages, run the agent loop to generate a reply.
   let processingSucceeded = false;
   if (!result.duplicate && processMessage) {
+    // Persist the raw payload so the event can be replayed on failure
+    channelDeliveryStore.storePayload(result.eventId, {
+      sourceChannel, externalChatId, externalMessageId, content,
+      attachmentIds, sourceMetadata: body.sourceMetadata,
+      senderName: body.senderName,
+      senderExternalUserId: body.senderExternalUserId,
+      senderUsername: body.senderUsername,
+    });
+
     try {
       const { messageId: userMessageId } = await processMessage(
         assistantId,
@@ -185,10 +194,12 @@ export async function handleChannelInbound(
       );
       // Link the user message to the inbound event so edits can find it later
       channelDeliveryStore.linkMessage(result.eventId, userMessageId);
+      channelDeliveryStore.markProcessed(result.eventId);
       processingSucceeded = true;
     } catch (err) {
       console.error(`[runtime-http] Processing failed`, err);
       log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
+      channelDeliveryStore.recordProcessingFailure(result.eventId, err);
     }
   }
 
@@ -234,6 +245,23 @@ export async function handleChannelInbound(
     eventId: result.eventId,
     ...(assistantMessage ? { assistantMessage } : {}),
   });
+}
+
+export function handleListDeadLetters(assistantId: string): Response {
+  const events = channelDeliveryStore.getDeadLetterEvents(assistantId);
+  return Response.json({ events });
+}
+
+export async function handleReplayDeadLetters(assistantId: string, req: Request): Promise<Response> {
+  const body = await req.json() as { eventIds?: string[] };
+  const eventIds = body.eventIds;
+
+  if (!Array.isArray(eventIds) || eventIds.length === 0) {
+    return Response.json({ error: 'eventIds array is required' }, { status: 400 });
+  }
+
+  const replayed = channelDeliveryStore.replayDeadLetters(eventIds);
+  return Response.json({ replayed });
 }
 
 export async function handleChannelDeliveryAck(assistantId: string, req: Request): Promise<Response> {


### PR DESCRIPTION
## Summary
- When `processMessage` fails on a channel webhook, the raw payload and error are now persisted on the inbound event instead of being silently dropped
- Errors are classified (retryable vs fatal) using existing `job-utils` logic — retryable errors get exponential backoff retries via a 30s sweep timer, fatal errors or exhausted retries go to dead-letter
- New HTTP endpoints: `GET channels/dead-letters` to list dead-lettered events, `POST channels/replay` to reset them for retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
