### PR TITLE
refactor: replace stray print() calls with structured os.Logger

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -1,6 +1,12 @@
 #if canImport(UIKit)
+import os
 import SwiftUI
 import VellumAssistantShared
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "InputBarView"
+)
 
 struct InputBarView: View {
     @Binding var text: String
@@ -49,7 +55,7 @@ struct InputBarView_Previews: PreviewProvider {
                     text: $text,
                     isInputFocused: $isFocused,
                     isGenerating: false,
-                    onSend: { print("Send tapped") }
+                    onSend: { log.debug("Send tapped") }
                 )
             }
             .background(VColor.background)

--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -1,6 +1,12 @@
 #if canImport(UIKit)
+import os
 import SwiftUI
 import VellumAssistantShared
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "MessageBubbleView"
+)
 
 struct MessageBubbleView: View {
     let message: ChatMessage
@@ -25,7 +31,7 @@ struct MessageBubbleView: View {
                             onConfirmationResponse?(confirmation.requestId, "deny")
                         },
                         onAddTrustRule: { _, _, _, _ in
-                            print("iOS: Add trust rule not yet implemented")
+                            log.debug("Add trust rule not yet implemented")
                             return false
                         }
                     )
@@ -236,7 +242,7 @@ struct MessageBubbleView: View {
                 toolCalls: []
             ),
             onConfirmationResponse: { requestId, decision in
-                print("Preview: Confirmation \(decision) for \(requestId)")
+                log.debug("Preview: Confirmation \(decision) for \(requestId)")
             },
             onSurfaceAction: nil
         )

--- a/clients/macos/vellum-assistant/Logging/SessionLogger.swift
+++ b/clients/macos/vellum-assistant/Logging/SessionLogger.swift
@@ -1,4 +1,10 @@
 import Foundation
+import os
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "SessionLogger"
+)
 
 struct TurnLog: Codable {
     let step: Int
@@ -92,7 +98,7 @@ final class SessionLogger {
             let data = try encoder.encode(log)
             try data.write(to: fileURL)
         } catch {
-            print("Failed to save session log: \(error)")
+            log.error("Failed to save session log: \(error.localizedDescription)")
         }
     }
 }

--- a/clients/shared/Features/Chat/CurrentStepIndicator.swift
+++ b/clients/shared/Features/Chat/CurrentStepIndicator.swift
@@ -1,4 +1,10 @@
+import os
 import SwiftUI
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "CurrentStepIndicator"
+)
 
 /// A simple indicator showing the current step being executed.
 /// Clicking it opens the Activity sidebar with all step details.
@@ -102,7 +108,7 @@ public struct CurrentStepIndicator: View {
             }
             .contentShape(Rectangle())
             .onTapGesture {
-                print("DEBUG: CurrentStepIndicator tapped")
+                log.debug("CurrentStepIndicator tapped")
                 onTap()
             }
             .padding(.top, VSpacing.md)


### PR DESCRIPTION
## Summary
- Replaced 5 stray `print(...)` debug calls across 4 Swift files with structured `os.Logger` calls
- Added `import os` and file-scoped `Logger` instances following the existing codebase convention (subsystem + category)
- Used appropriate log levels: `.debug()` for tap/interaction traces, `.error()` for failure paths (SessionLogger)
- Left `generate-background.swift` alone — its `print()` is intentional CLI stdout output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
