### PR TITLE
fix: stabilize memory test suites by mocking ONNX local embedding backend

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -31,6 +31,19 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+// Stub the local embedding backend so the real ONNX model (2.5 GB RSS) never
+// loads — avoids a Bun v1.3.9 panic on process exit.
+mock.module('../memory/embedding-local.js', () => ({
+  LocalEmbeddingBackend: class {
+    readonly provider = 'local' as const;
+    readonly model: string;
+    constructor(model: string) { this.model = model; }
+    async embed(texts: string[]): Promise<number[][]> {
+      return texts.map(() => new Array(384).fill(0));
+    }
+  },
+}));
+
 // Mock Qdrant client so semantic search returns empty results instead of
 // throwing "Qdrant client not initialized" (which would discard lexical results
 // due to the single try-catch in buildMemoryRecall).

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -23,6 +23,30 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+// Stub the local embedding backend so the real ONNX model (2.5 GB RSS) never
+// loads — avoids a Bun v1.3.9 panic on process exit.
+mock.module('../memory/embedding-local.js', () => ({
+  LocalEmbeddingBackend: class {
+    readonly provider = 'local' as const;
+    readonly model: string;
+    constructor(model: string) { this.model = model; }
+    async embed(texts: string[]): Promise<number[][]> {
+      return texts.map(() => new Array(384).fill(0));
+    }
+  },
+}));
+
+// Mock Qdrant client so semantic search returns empty results instead of
+// throwing "Qdrant client not initialized".
+mock.module('../memory/qdrant-client.js', () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+}));
+
 import { and, eq } from 'drizzle-orm';
 import { DEFAULT_CONFIG } from '../config/defaults.js';
 


### PR DESCRIPTION
## Summary
- Mock `LocalEmbeddingBackend` (ONNX/Transformers.js) in `memory-recall-quality.test.ts` and `memory-regressions.test.ts` with a lightweight stub returning zero-vectors — prevents loading the real Xenova/bge-small-en-v1.5 model (~2.5 GB RSS) that triggers a Bun v1.3.9 C++ panic on process exit
- Add Qdrant client mock to `memory-regressions.test.ts` to suppress noisy "Qdrant client not initialized" warnings during test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
