### PR TITLE
feat: add green checkmark icon next to configured API keys

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -29,7 +29,10 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textPrimary)
 
                     if store.hasKey {
-                        HStack {
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(VColor.success)
+                                .font(.system(size: 14))
                             Text(store.maskedKey)
                                 .font(VFont.body)
                                 .foregroundColor(VColor.textSecondary)
@@ -81,7 +84,10 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textPrimary)
 
                     if store.hasBraveKey {
-                        HStack {
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(VColor.success)
+                                .font(.system(size: 14))
                             Text(store.maskedBraveKey)
                                 .font(VFont.body)
                                 .foregroundColor(VColor.textSecondary)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -32,7 +32,10 @@ public struct SettingsView: View {
         Form {
             Section("Anthropic API Key") {
                 if store.hasKey {
-                    HStack {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.system(size: 14))
                         Text(store.maskedKey)
                             .foregroundStyle(.secondary)
                         Spacer()
@@ -61,7 +64,10 @@ public struct SettingsView: View {
 
             Section("Brave Search API Key") {
                 if store.hasBraveKey {
-                    HStack {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.system(size: 14))
                         Text(store.maskedBraveKey)
                             .foregroundStyle(.secondary)
                         Spacer()


### PR DESCRIPTION
## Summary
- Add a green `checkmark.circle.fill` SF Symbol icon next to each masked API key in both SettingsPanel and SettingsView
- Provides clear visual confirmation that a key is configured without needing "configured" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
