### PR TITLE
fix: resolve build error from SessionLog shadowing Logger

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -326,14 +326,6 @@ struct ChatView: View {
 
                         if let confirmation = message.confirmation {
                             if confirmation.state == .pending {
-                                // Check if the preceding assistant message has text
-                                let prevHasText: Bool = {
-                                    guard index > 0 else { return false }
-                                    let prev = messages[index - 1]
-                                    return prev.role == .assistant
-                                        && !prev.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                                }()
-
                                 // Show pending confirmations as inline buttons
                                 ToolConfirmationBubble(
                                     confirmation: confirmation,

--- a/clients/macos/vellum-assistant/Logging/SessionLogger.swift
+++ b/clients/macos/vellum-assistant/Logging/SessionLogger.swift
@@ -69,7 +69,7 @@ final class SessionLogger {
     }
 
     func finishSession(result: String) {
-        let log = SessionLog(
+        let sessionLog = SessionLog(
             task: task,
             startTime: startTime,
             endTime: Date(),
@@ -95,7 +95,7 @@ final class SessionLogger {
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(log)
+            let data = try encoder.encode(sessionLog)
             try data.write(to: fileURL)
         } catch {
             log.error("Failed to save session log: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary
- Rename local `log` variable to `sessionLog` in `SessionLogger.finishSession()` to avoid shadowing the module-level `os.Logger`, which caused a build error (`SessionLog has no member 'error'`)
- Remove unused `prevHasText` variable in `ChatView` to eliminate compiler warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
