### PR TITLE
refactor: route chat name generation through configured provider

### DIFF
--- a/assistant/src/daemon/session-usage.ts
+++ b/assistant/src/daemon/session-usage.ts
@@ -1,4 +1,3 @@
-import Anthropic from '@anthropic-ai/sdk';
 import type { ServerMessage, UsageStats } from './ipc-protocol.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { estimateCost, resolvePricingWithOverrides } from '../util/pricing.js';
@@ -73,28 +72,3 @@ export function recordUsage(
   }
 }
 
-export async function generateTitle(conversationId: string, userMessage: string, assistantResponse: string): Promise<void> {
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) return;
-
-  const client = new Anthropic({ apiKey });
-  const response = await client.messages.create({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 20,
-    messages: [{
-      role: 'user',
-      content: `Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.\n\nUser: ${userMessage.slice(0, 200)}\nAssistant: ${assistantResponse.slice(0, 200)}`,
-    }],
-  });
-
-  const textBlock = response.content.find((b) => b.type === 'text');
-  if (textBlock && textBlock.type === 'text') {
-    let title = textBlock.text.trim().replace(/^["']|["']$/g, '');
-    const words = title.split(/\s+/);
-    if (words.length > 5) title = words.slice(0, 5).join(' ');
-    if (title.length > 40) title = title.slice(0, 40).trimEnd();
-    conversationStore.updateConversationTitle(conversationId, title);
-    log.info({ conversationId, title }, 'Auto-generated conversation title');
-  }
-}

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -77,7 +77,7 @@ import {
   regenerate as regenerateImpl,
   type HistorySessionContext,
 } from './session-history.js';
-import { recordUsage, generateTitle } from './session-usage.js';
+import { recordUsage } from './session-usage.js';
 import { isProviderOrderingError } from './session-slash.js';
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from './session-workspace.js';
 import type { UsageActor } from '../usage/actors.js';
@@ -1230,7 +1230,22 @@ export class Session {
   }
 
   private async generateTitle(userMessage: string, assistantResponse: string): Promise<void> {
-    return generateTitle(this.conversationId, userMessage, assistantResponse);
+    const prompt = `Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.\n\nUser: ${userMessage.slice(0, 200)}\nAssistant: ${assistantResponse.slice(0, 200)}`;
+    const response = await this.provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
+      [], // no tools
+      undefined, // no system prompt
+    );
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    if (textBlock && textBlock.type === 'text') {
+      let title = textBlock.text.trim().replace(/^["']|["']$/g, '');
+      const words = title.split(/\s+/);
+      if (words.length > 5) title = words.slice(0, 5).join(' ');
+      if (title.length > 40) title = title.slice(0, 40).trimEnd();
+      conversationStore.updateConversationTitle(this.conversationId, title);
+      log.info({ conversationId: this.conversationId, title }, 'Auto-generated conversation title');
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- Chat name generation now uses the session's configured provider/model instead of a hardcoded Anthropic SDK call with `claude-haiku-4-5-20251001`
- No tools, no memory storage, no system prompt — just a simple title generation call through the same provider the assistant uses
- Removed standalone `generateTitle` from `session-usage.ts` and its `@anthropic-ai/sdk` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
