### PR TITLE
fix: latch daemon restart guard after max crash limit

### DIFF
--- a/clients/macos/vellum-assistant/App/DaemonLauncher.swift
+++ b/clients/macos/vellum-assistant/App/DaemonLauncher.swift
@@ -47,6 +47,9 @@ final class DaemonLauncher {
     private var consecutiveCrashes = 0
     private var lastLaunchTime: Date?
 
+    /// Once set, prevents any further automatic restart attempts.
+    private var hasGivenUp = false
+
     /// If the daemon exits within this many seconds of being launched it
     /// counts as a crash for backoff purposes.
     private static let crashThreshold: TimeInterval = 10.0
@@ -156,6 +159,7 @@ final class DaemonLauncher {
 
     private func restartDaemon() async {
         guard let binaryURL = daemonBinaryURL else { return }
+        guard !hasGivenUp else { return }
 
         // Track consecutive rapid crashes for backoff
         if let lastLaunch = lastLaunchTime,
@@ -167,6 +171,7 @@ final class DaemonLauncher {
 
         if consecutiveCrashes >= Self.maxConsecutiveCrashes {
             log.error("Daemon crashed \(Self.maxConsecutiveCrashes) times in quick succession — giving up automatic restart")
+            hasGivenUp = true
             return
         }
 


### PR DESCRIPTION
## Summary
- Adds a permanent `hasGivenUp` flag to `DaemonLauncher` that prevents further automatic restart attempts once `maxConsecutiveCrashes` (5) is reached
- Previously, if enough time passed (>10s) after hitting the crash limit, the `else` branch in `restartDaemon()` would reset `consecutiveCrashes` to 0, allowing infinite restart cycles
- The flag is checked at the top of `restartDaemon()` and set alongside the existing error log when the limit is hit

Addresses feedback from #3361.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
