### PR TITLE
fix: keep browser_navigate with private network at medium risk

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -199,7 +199,10 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'web_fetch') {
     return input.allow_private_network === true ? RiskLevel.Medium : RiskLevel.Low;
   }
-  // All browser tools are low risk — the browser is sandboxed and user-visible.
+  if (toolName === 'browser_navigate') {
+    return input.allow_private_network === true ? RiskLevel.Medium : RiskLevel.Low;
+  }
+  // All other browser tools are low risk — the browser is sandboxed and user-visible.
   if (toolName.startsWith('browser_')) return RiskLevel.Low;
   if (toolName === 'skill_load') return RiskLevel.Low;
 


### PR DESCRIPTION
## Summary
- Restores the `allow_private_network` check for `browser_navigate` so it requires user approval (Medium risk) when accessing private/internal network addresses
- Keeps all other browser tools at Low risk via the `browser_` prefix catch-all
- Makes `browser_navigate` consistent with `web_fetch` behavior for private network access

Addresses feedback from #3359.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
