### PR TITLE
fix: add minimum delay floor to jitter retry strategy

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -70,10 +70,12 @@ export function classifyError(err: unknown): ErrorCategory {
   return 'fatal';
 }
 
-/** Exponential backoff with full jitter: uniform random in [0, cap]. */
+/** Equal jitter backoff: floor of cap/2 plus random in [0, cap/2].
+ *  Prevents retry delays from collapsing to 0ms while still avoiding thundering herds. */
 export function retryDelayForAttempt(attempts: number): number {
   const cap = Math.min(RETRY_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempts - 1)), RETRY_MAX_DELAY_MS);
-  return Math.random() * cap;
+  const half = cap / 2;
+  return half + Math.random() * half;
 }
 
 // ── Payload extraction helpers ─────────────────────────────────────

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -32,10 +32,11 @@ function isRetryableError(error: unknown): boolean {
 }
 
 function getRetryDelay(attempt: number): number {
-  // Full jitter: uniform random in [0, exponential cap] prevents synchronized
-  // retry storms when many sessions hit the same transient failure.
+  // Equal jitter: guaranteed floor of cap/2 plus random in [0, cap/2].
+  // Prevents retry storms while ensuring retries never collapse to 0ms.
   const cap = BASE_DELAY_MS * Math.pow(2, attempt);
-  return Math.random() * cap;
+  const half = cap / 2;
+  return half + Math.random() * half;
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
Prevents retry delays from collapsing to 0ms by switching from full jitter (`Math.random() * cap`) to equal jitter (`cap/2 + Math.random() * cap/2`). This guarantees at least half the base delay on every retry attempt.

**Changes:**
- `assistant/src/providers/retry.ts`: Provider retry delay now uses equal jitter
- `assistant/src/memory/job-utils.ts`: Memory job retry delay now uses equal jitter

Addresses feedback from #3368.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
