### PR TITLE
fix: add fallback for undefined err.stack in TypeScript eval

### DIFF
--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -63,7 +63,7 @@ try {
   const result = await fn(input);
   console.log(JSON.stringify({ __eval_result: result }));
 } catch (err: unknown) {
-  console.error(err instanceof Error ? err.stack : String(err));
+  console.error(err instanceof Error ? err.stack ?? String(err) : String(err));
   process.exit(1);
 }
 `;


### PR DESCRIPTION
Adds `?? String(err)` fallback when `err.stack` is undefined for Error instances in the generated TypeScript eval runner.

`err.stack` can be `undefined` per the ECMAScript spec even for Error instances. Without the fallback, `console.error` would output `"undefined"` instead of a useful error message.

Addresses review feedback from #3370.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
