### PR TITLE
fix: update Swift client for computer_use tool name rename

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -556,18 +556,18 @@ final class ComputerUseSession: ObservableObject {
 
     private func mapToAgentAction(_ msg: CuActionMessage) -> AgentAction {
         let type: ActionType = switch msg.toolName {
-        case "cu_click": .click
-        case "cu_double_click": .doubleClick
-        case "cu_right_click": .rightClick
-        case "cu_type_text": .type
-        case "cu_key": .key
-        case "cu_scroll": .scroll
-        case "cu_wait": .wait
-        case "cu_drag": .drag
-        case "cu_open_app": .openApp
-        case "cu_run_applescript": .runAppleScript
-        case "cu_done": .done
-        case "cu_respond": .respond
+        case "computer_use_click", "cu_click": .click
+        case "computer_use_double_click", "cu_double_click": .doubleClick
+        case "computer_use_right_click", "cu_right_click": .rightClick
+        case "computer_use_type_text", "cu_type_text": .type
+        case "computer_use_key", "cu_key": .key
+        case "computer_use_scroll", "cu_scroll": .scroll
+        case "computer_use_wait", "cu_wait": .wait
+        case "computer_use_drag", "cu_drag": .drag
+        case "computer_use_open_app", "cu_open_app": .openApp
+        case "computer_use_run_applescript", "cu_run_applescript": .runAppleScript
+        case "computer_use_done", "cu_done": .done
+        case "computer_use_respond", "cu_respond": .respond
         default: .done
         }
 


### PR DESCRIPTION
## Summary
- Updates the Swift client's `mapToAgentAction` switch statement in `Session.swift` to recognize both new `computer_use_*` and legacy `cu_*` tool names
- PR #3389 renamed tool names from `cu_*` to `computer_use_*` in the daemon but didn't update the Swift client, causing all computer-use actions to fall through to `.done`
- Adds backwards compatibility so both old and new tool names are handled correctly

Addresses feedback from #3389.

## Test plan
- [ ] Build the macOS client with `./build.sh`
- [ ] Run a computer-use session and verify actions (click, type, scroll, etc.) execute correctly
- [ ] Verify terminal actions (done, respond) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
