### PR TITLE
fix: preserve stderr output for daemon startup errors

### DIFF
--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -2,14 +2,15 @@
 import '../instrument.js';
 import * as Sentry from '@sentry/node';
 import { runDaemon } from './lifecycle.js';
-import { getLogger } from '../util/logger.js';
 
-const log = getLogger('daemon');
-
+// Use console.error instead of the structured logger here because
+// startDaemon() captures the child process's stderr to surface error
+// details to the parent process. The structured logger writes to a file
+// by default, so these messages would be lost from stderr.
 runDaemon().catch(async (err) => {
   Sentry.captureException(err);
   await Sentry.flush(2000);
-  log.error({ err }, 'Failed to start daemon');
-  log.error('Troubleshooting: check if another daemon is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/workspace/data/logs/');
+  console.error('Failed to start daemon:', err);
+  console.error('Troubleshooting: check if another daemon is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/workspace/data/logs/');
   process.exit(1);
 });


### PR DESCRIPTION
Reverts structured logging (`log.error`) back to `console.error` for daemon startup error paths that need to be captured via stderr by the parent process.

`startDaemon()` spawns the daemon child with `stdio: ['ignore', 'ignore', 'pipe']` and captures stderr chunks. When the child crashes, those chunks are included in the thrown `DaemonError`. The structured logger writes to a file by default, so using `log.error()` here caused error details to be lost from stderr, making daemon startup failures harder to diagnose.

Addresses feedback from #3381.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
