### PR TITLE
fix: populate dedup cache before processing telegram updates

### DIFF
--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -61,4 +61,41 @@ describe("DedupCache", () => {
     cache.set(2, "y", 200);
     expect(cache.size).toBe(2);
   });
+
+  test("reserve returns true for unseen update_id and populates cache", () => {
+    expect(cache.reserve(50)).toBe(true);
+    expect(cache.size).toBe(1);
+    const hit = cache.get(50);
+    expect(hit).toBeDefined();
+    expect(hit!.status).toBe(200);
+  });
+
+  test("reserve returns false for already-reserved update_id", () => {
+    cache.reserve(60);
+    expect(cache.reserve(60)).toBe(false);
+  });
+
+  test("reserve returns false for already-cached update_id", () => {
+    cache.set(70, '{"done":true}', 200);
+    expect(cache.reserve(70)).toBe(false);
+  });
+
+  test("set overwrites a reserved entry with the final response", () => {
+    cache.reserve(80);
+    cache.set(80, '{"final":true}', 201);
+    const hit = cache.get(80);
+    expect(hit).toEqual({ body: '{"final":true}', status: 201 });
+  });
+
+  test("reserve succeeds after a reserved entry expires", () => {
+    const shortCache = new DedupCache(1, 100);
+    shortCache.reserve(90);
+
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait for expiry
+    }
+
+    expect(shortCache.reserve(90)).toBe(true);
+  });
 });

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -6,6 +6,8 @@ interface CacheEntry {
   body: string;
   status: number;
   expiresAt: number;
+  /** When true, the first handler is still processing this update_id. */
+  processing?: boolean;
 }
 
 /**
@@ -32,6 +34,25 @@ export class DedupCache {
       return undefined;
     }
     return { body: entry.body, status: entry.status };
+  }
+
+  /**
+   * Checks whether this update_id is already reserved or cached.
+   * If not, immediately reserves it with a "processing" sentinel so that
+   * concurrent retries are blocked before the handler finishes.
+   * Returns true if a new reservation was created (caller should proceed),
+   * false if the update_id was already present (caller should short-circuit).
+   */
+  reserve(updateId: number): boolean {
+    const existing = this.cache.get(updateId);
+    if (existing && Date.now() <= existing.expiresAt) {
+      return false;
+    }
+    // Clean up expired entry if present
+    if (existing) this.cache.delete(updateId);
+    this.set(updateId, '{"ok":true}', 200);
+    this.cache.get(updateId)!.processing = true;
+    return true;
   }
 
   /** Store a response for the given update_id. */

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -77,12 +77,14 @@ export function createTelegramWebhookHandler(
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    // Dedup check — short-circuit retried webhooks before doing any real work
+    // Dedup check — reserve the update_id immediately so concurrent retries
+    // are blocked even while the first request is still processing.
     const updateId = typeof payload.update_id === "number" ? payload.update_id : undefined;
     if (updateId !== undefined) {
-      const cached = dedupCache.get(updateId);
-      if (cached) {
+      const reserved = dedupCache.reserve(updateId);
+      if (!reserved) {
         log.info({ updateId }, "Duplicate update_id, returning cached response");
+        const cached = dedupCache.get(updateId)!;
         return new Response(cached.body, {
           status: cached.status,
           headers: { "content-type": "application/json" },
@@ -90,7 +92,7 @@ export function createTelegramWebhookHandler(
       }
     }
 
-    // Helper: build a JSON response and cache it for this update_id
+    // Helper: build a JSON response and update the cache with the final result
     const respond = (body: Record<string, unknown>, status = 200): Response => {
       const json = JSON.stringify(body);
       if (updateId !== undefined) {


### PR DESCRIPTION
Moves deduplication cache population to immediately after reading update_id, preventing concurrent retries from both executing the full pipeline. Addresses feedback from #3367.

## Changes

- Added `reserve()` method to `DedupCache` that immediately claims an `update_id` with a sentinel entry before processing begins
- Updated `telegram-webhook.ts` to call `reserve()` instead of the previous `get()` check — concurrent retries now find the reservation and short-circuit
- The sentinel is overwritten with the actual response once `respond()` is called
- Added 5 tests for the new `reserve()` behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
