### PR TITLE
fix: complete IPC auth for broadcast and SSH-forwarded sockets

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -3,6 +3,7 @@ import * as readline from 'node:readline';
 import { readFileSync, appendFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { getSocketPath, getHistoryPath, readSessionToken } from './util/platform.js';
+import { hasSocketOverride } from './daemon/connection-policy.js';
 import {
   serialize,
   createMessageParser,
@@ -666,6 +667,15 @@ export async function startCli(): Promise<void> {
         // accept any other messages.
         const token = readSessionToken();
         if (!token) {
+          if (hasSocketOverride()) {
+            // SSH-forwarded socket: the token file lives on the remote
+            // host, not locally. Connect without auth and let the server
+            // decide whether to accept the unauthenticated connection.
+            authenticated = true;
+            startHeartbeat();
+            resolve();
+            return;
+          }
           reject(new Error('Session token not found — is the daemon running?'));
           newSocket.destroy();
           return;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -609,7 +609,7 @@ export class DaemonServer {
   }
 
   broadcast(msg: ServerMessage, excludeSocket?: net.Socket): void {
-    for (const socket of this.connectedSockets) {
+    for (const socket of this.authenticatedSockets) {
       if (socket === excludeSocket) continue;
       this.send(socket, msg);
     }


### PR DESCRIPTION
## Summary

Addresses two remaining issues from the IPC auth implementation in #3375:

1. **broadcast() leaked messages to unauthenticated sockets** — During the 5-second auth timeout window, `broadcast()` iterated over all `connectedSockets`, sending messages (like `daemon_status` with `httpPort`, session info, etc.) to sockets that hadn't authenticated yet. Fixed by iterating over `authenticatedSockets` instead.

2. **CLI hard-failed when session token was missing for SSH-forwarded sockets** — The CLI's `connect()` immediately rejected and destroyed the socket when `readSessionToken()` returned null, breaking the SSH-forwarded socket workflow where the token file exists on the remote host, not locally. Fixed by detecting `VELLUM_DAEMON_SOCKET` override and proceeding without auth in that case.

Note: The Swift DaemonClient auth (issue #1 from the feedback) was already implemented — `authenticate()` and `AuthMessage` send are present in `DaemonClient.swift`.

## Files Changed

- `assistant/src/daemon/server.ts` — `broadcast()` uses `authenticatedSockets` instead of `connectedSockets`
- `assistant/src/cli.ts` — Graceful fallback when token missing + socket override is set

## Test Plan

- [ ] Verify broadcast messages are not received by unauthenticated connections
- [ ] Verify SSH-forwarded socket workflow: `VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock vellum` connects without crashing
- [ ] Verify normal local auth flow still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
