### PR TITLE
fix: refresh session eviction timestamp on all access patterns

### DIFF
--- a/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
+++ b/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
@@ -94,6 +94,7 @@ function createTestContext(sessionId: string): {
     broadcast: () => {},
     clearAllSessions: () => 0,
     getOrCreateSession: () => { throw new Error('not implemented'); },
+    touchSession: () => {},
   };
   return { ctx, sent, observations };
 }

--- a/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
+++ b/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
@@ -71,6 +71,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     broadcast: () => {},
     clearAllSessions: () => 0,
     getOrCreateSession: () => { throw new Error('not implemented'); },
+    touchSession: () => {},
   };
   return { ctx, sent };
 }

--- a/assistant/src/__tests__/handlers-slack-config.test.ts
+++ b/assistant/src/__tests__/handlers-slack-config.test.ts
@@ -101,6 +101,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     broadcast: () => {},
     clearAllSessions: () => 0,
     getOrCreateSession: () => { throw new Error('not implemented'); },
+    touchSession: () => {},
   };
   return { ctx, sent };
 }

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -209,6 +209,7 @@ const handlers: DispatchMap = {
     }
     const session = ctx.sessions.get(msg.sessionId);
     if (session) {
+      ctx.touchSession(msg.sessionId);
       session.handleSurfaceAction(msg.surfaceId, msg.actionId, msg.data);
       return;
     }
@@ -217,6 +218,7 @@ const handlers: DispatchMap = {
   ui_surface_undo: (msg, _socket, ctx) => {
     const session = ctx.sessions.get(msg.sessionId);
     if (session) {
+      ctx.touchSession(msg.sessionId);
       session.handleSurfaceUndo(msg.surfaceId);
       return;
     }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -132,6 +132,7 @@ export function handleConfirmationResponse(
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
     if (session) {
+      ctx.touchSession(sessionId);
       session.handleConfirmationResponse(
         msg.requestId,
         msg.decision as 'allow' | 'always_allow' | 'deny',
@@ -162,6 +163,7 @@ export function handleSecretResponse(
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
     if (session) {
+      ctx.touchSession(sessionId);
       session.handleSecretResponse(msg.requestId, msg.value, msg.delivery);
     }
   }
@@ -241,6 +243,7 @@ export function handleCancel(msg: CancelRequest, socket: net.Socket, ctx: Handle
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
     if (session) {
+      ctx.touchSession(sessionId);
       session.abort();
     }
   }
@@ -327,6 +330,7 @@ export function handleUndo(
     ctx.send(socket, { type: 'error', message: 'No active session' });
     return;
   }
+  ctx.touchSession(msg.sessionId);
   const removedCount = session.undo();
   ctx.send(socket, { type: 'undo_complete', removedCount, sessionId: msg.sessionId });
 }
@@ -341,6 +345,7 @@ export async function handleRegenerate(
     ctx.send(socket, { type: 'error', message: 'No active session' });
     return;
   }
+  ctx.touchSession(msg.sessionId);
 
   const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
   const requestId = uuid();

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -112,6 +112,8 @@ export interface HandlerContext {
     rebindClient?: boolean,
     options?: SessionCreateOptions,
   ): Promise<Session>;
+  /** Refresh the eviction timestamp for a session that was accessed directly. */
+  touchSession(sessionId: string): void;
 }
 
 /**

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -755,6 +755,7 @@ export class DaemonServer {
       clearAllSessions: () => this.clearAllSessions(),
       getOrCreateSession: (id, socket?, rebind?, options?) =>
         this.getOrCreateSession(id, socket, rebind, options),
+      touchSession: (id) => this.evictor.touch(id),
     };
   }
 


### PR DESCRIPTION
Ensures the session eviction clock is updated on direct session access (handleUndo, handleRegenerate, handleCancel, handleConfirmationResponse, handleSecretResponse, ui_surface_action, ui_surface_undo), not just getOrCreateSession.

Previously, sessions accessed via `ctx.sessions.get()` without going through `getOrCreateSession` never refreshed the evictor's `lastAccess` clock. This meant actively-used sessions could be prematurely evicted if the user only interacted through undo, regenerate, cancel, confirmation responses, or surface actions.

**Changes:**
- Added `touchSession(sessionId)` to `HandlerContext` interface, delegating to `evictor.touch()`
- Added `ctx.touchSession()` calls at all 7 direct session access points in handlers
- Updated 3 test mock contexts to include the new method

Addresses feedback from #3366.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
