### PR TITLE
fix: improve attachment MIME type and filename validation

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -82,9 +82,13 @@ export function validateAttachmentUpload(
   filename: string,
   mimeType: string,
 ): AttachmentValidationResult {
-  const dot = filename.lastIndexOf('.');
+  // Normalize filename: trim whitespace and strip trailing dots to prevent
+  // bypasses like "payload.exe " or "payload.exe."
+  const normalizedFilename = filename.trim().replace(/\.+$/, '');
+
+  const dot = normalizedFilename.lastIndexOf('.');
   if (dot !== -1) {
-    const ext = filename.slice(dot + 1).toLowerCase();
+    const ext = normalizedFilename.slice(dot + 1).toLowerCase();
     if (DANGEROUS_EXTENSIONS.has(ext)) {
       return {
         ok: false,
@@ -93,7 +97,8 @@ export function validateAttachmentUpload(
     }
   }
 
-  const normalised = mimeType.toLowerCase().trim();
+  // Strip MIME parameters (e.g. "text/plain; charset=utf-8" → "text/plain")
+  const normalised = mimeType.toLowerCase().trim().split(';')[0].trim();
   if (!ALLOWED_MIME_TYPES.has(normalised)) {
     return {
       ok: false,

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -166,10 +166,11 @@ export function createTelegramWebhookHandler(
           return true;
         });
 
-        // Process with bounded concurrency
+        // Process with bounded concurrency, skipping individual failures
+        // so that an unsupported attachment doesn't drop the user's message.
         for (let i = 0; i < eligible.length; i += config.maxAttachmentConcurrency) {
           const batch = eligible.slice(i, i + config.maxAttachmentConcurrency);
-          const results = await Promise.all(
+          const results = await Promise.allSettled(
             batch.map(async (att) => {
               const downloaded = await downloadTelegramFile(config, att.fileId, {
                 fileName: att.fileName,
@@ -178,13 +179,16 @@ export function createTelegramWebhookHandler(
               return uploadAttachment(config, routing.assistantId, downloaded);
             }),
           );
-          for (const uploaded of results) {
-            attachmentIds.push(uploaded.id);
+          for (const result of results) {
+            if (result.status === 'fulfilled') {
+              attachmentIds.push(result.value.id);
+            } else {
+              log.warn({ err: result.reason }, "Skipping attachment that failed to upload");
+            }
           }
         }
       } catch (err) {
         log.error({ err }, "Failed to process attachments");
-        return Response.json({ error: "Failed to process attachments" }, { status: 500 });
       }
     }
 


### PR DESCRIPTION
Strips MIME parameters before allowlist check, gracefully skips unsupported attachments instead of throwing, and normalizes filenames before extension matching.

**Changes:**
- `assistant/src/memory/attachments-store.ts`: Strip MIME parameters (e.g. `text/plain; charset=utf-8` → `text/plain`) before checking the allowlist. Normalize filenames by trimming whitespace and trailing dots before extension matching to prevent bypasses.
- `gateway/src/http/routes/telegram-webhook.ts`: Use `Promise.allSettled` so a single attachment upload failure skips that attachment instead of aborting the entire inbound webhook with a 500.

Addresses feedback from #3371.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
