### PR TITLE
fix: invalidate embedding backend cache on API key change

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -10,6 +10,7 @@ import { getConfig, invalidateConfigCache } from '../config/loader.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import { resetAllowlist } from '../security/secret-allowlist.js';
+import { clearEmbeddingBackendCache } from '../memory/embedding-backend.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session } from './session.js';
@@ -325,6 +326,7 @@ export class DaemonServer {
    */
   private refreshConfigFromSources(): boolean {
     invalidateConfigCache();
+    clearEmbeddingBackendCache();
     const config = getConfig();
     const fingerprint = this.configFingerprint(config);
     if (fingerprint === this.lastConfigFingerprint) {

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -10,6 +10,11 @@ const log = getLogger('memory-embeddings');
 /** Global cache of embedding backend instances, keyed by "provider:model". */
 const backendCache = new Map<string, EmbeddingBackend>();
 
+/** Clear cached embedding backends so new instances pick up fresh credentials. */
+export function clearEmbeddingBackendCache(): void {
+  backendCache.clear();
+}
+
 function cacheKey(provider: string, model: string): string {
   return `${provider}:${model}`;
 }


### PR DESCRIPTION
Cached embedding backends captured API keys at construction time. After key rotation via `refreshConfigFromSources`, the stale instances would keep using old credentials until process restart, causing authentication failures.

This adds a `clearEmbeddingBackendCache()` function and calls it during config reload, following the same pattern as `clearTrustCache`.

Addresses feedback from #3390.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
