### PR TITLE
fix: prevent typing indicator failure counter race condition

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -208,9 +208,9 @@ export function createTelegramWebhookHandler(
     };
     if (routable && !isEdit) {
       let consecutiveFailures = 0;
-      sendTypingIndicator(config, chatId).then((ok) => {
-        if (!ok) consecutiveFailures++;
-      });
+      // Fire-and-forget: don't track the initial call's result to avoid
+      // race conditions with the interval's consecutiveFailures counter.
+      sendTypingIndicator(config, chatId);
       typingInterval = setInterval(async () => {
         const ok = await sendTypingIndicator(config, chatId);
         if (ok) {


### PR DESCRIPTION
Fixes race condition where the fire-and-forget initial `sendTypingIndicator` call shared the `consecutiveFailures` counter with the interval callbacks. When the initial call resolved out-of-order (e.g., after a slow retry taking up to ~60s), it could corrupt the counter by incrementing it after a successful interval tick had already reset it to 0 — causing the typing indicator to cancel earlier than the intended 3-consecutive-failure threshold.

Additionally, a delayed success on the initial call never reset the failure streak, so subsequent interval failures appeared "consecutive" even though a success occurred in between.

**Fix:** Stop tracking the initial call's result entirely. The interval handles all failure counting, keeping the counter's "consecutive" invariant intact.

Addresses feedback from #3376.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
