### PR TITLE
fix: defer web search API key check to execution time

### DIFF
--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -200,8 +200,4 @@ class WebSearchTool implements Tool {
   }
 }
 
-// Only register when a Brave API key is available — avoids exposing a
-// non-functional tool to the model when no key is configured.
-if (getApiKey()) {
-  registerTool(new WebSearchTool());
-}
+registerTool(new WebSearchTool());


### PR DESCRIPTION
Moves Brave API key check from tool registration time to execution time, allowing users to configure the key mid-session without restarting the daemon.

Previously, `registerTool(new WebSearchTool())` was guarded by `if (getApiKey())`, meaning the tool was only available if a key existed at daemon startup. The `execute()` method already checks for the key and returns a helpful error, so the registration guard was unnecessary and prevented mid-session key configuration.

Addresses feedback from #3386.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
