### PR TITLE
fix: prevent cascade deletion of shared deduplicated attachments

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -158,6 +158,44 @@ describe('deleteAttachment', () => {
     const fetched = getAttachmentById('ast-owner', stored.id);
     expect(fetched).not.toBeNull();
   });
+
+  test('preserves shared attachment when other messages still reference it', () => {
+    const conv = createConversation();
+    const msg1 = addMessage(conv.id, 'user', 'First upload');
+    const msg2 = addMessage(conv.id, 'user', 'Duplicate upload');
+
+    // Dedup: both uploads return the same attachment row
+    const first = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHARED_CONTENT');
+    const second = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHARED_CONTENT');
+    expect(second.id).toBe(first.id);
+
+    linkAttachmentToMessage(msg1.id, first.id, 0);
+    linkAttachmentToMessage(msg2.id, second.id, 0);
+
+    // Delete should succeed but NOT remove the attachment row
+    const result = deleteAttachment('ast-1', first.id);
+    expect(result).toBe(true);
+
+    // Attachment row still exists because messages reference it
+    const fetched = getAttachmentById('ast-1', first.id);
+    expect(fetched).not.toBeNull();
+
+    // Both messages still see the attachment
+    const linked1 = getAttachmentsForMessage(msg1.id, 'ast-1');
+    expect(linked1).toHaveLength(1);
+    const linked2 = getAttachmentsForMessage(msg2.id, 'ast-1');
+    expect(linked2).toHaveLength(1);
+  });
+
+  test('deletes attachment when no messages reference it', () => {
+    const stored = uploadAttachment('ast-1', 'lonely.txt', 'text/plain', 'UNREFERENCED');
+    // No linkAttachmentToMessage call — zero references
+    const result = deleteAttachment('ast-1', stored.id);
+    expect(result).toBe(true);
+
+    const fetched = getAttachmentById('ast-1', stored.id);
+    expect(fetched).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -196,9 +196,21 @@ export function deleteAttachment(assistantId: string, attachmentId: string): boo
 
   if (!existing) return false;
 
-  db.delete(attachments)
-    .where(eq(attachments.id, attachmentId))
-    .run();
+  // With content-hash deduplication, multiple messages may reference the same
+  // attachment row. Only delete the attachment (and cascade its links) when no
+  // message_attachments rows still point to it.
+  const refCount = db
+    .select({ id: messageAttachments.id })
+    .from(messageAttachments)
+    .where(eq(messageAttachments.attachmentId, attachmentId))
+    .all()
+    .length;
+
+  if (refCount === 0) {
+    db.delete(attachments)
+      .where(eq(attachments.id, attachmentId))
+      .run();
+  }
 
   return true;
 }


### PR DESCRIPTION
## Summary

Fixes a data integrity regression introduced by content-hash deduplication (#3392).

- `deleteAttachment` now checks for remaining `message_attachments` references before deleting the attachment row
- If other messages still reference the deduplicated attachment, the row is preserved (no cascade)
- Only deletes the attachment when zero `message_attachments` links remain

## Context

With dedup, multiple `message_attachments` rows can reference the same attachment. The old `deleteAttachment` unconditionally deleted the attachment row, triggering `ON DELETE CASCADE` which silently removed links from all referencing messages — not just the caller's.

## Test plan

- [x] Added test: shared attachment preserved when messages still reference it
- [x] Added test: unreferenced attachment is deleted normally
- [x] All 42 attachment store tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)

Addresses feedback from #3392.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
