### PR TITLE
fix: use request ID for signing IPC to prevent concurrent request collision

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -420,6 +420,7 @@ exports[`IPC message snapshots ClientMessage types sign_bundle_payload_response 
 {
   "keyId": "abc123",
   "publicKey": "dGVzdA==",
+  "requestId": "req-sign-001",
   "signature": "dGVzdC1zaWduYXR1cmU=",
   "type": "sign_bundle_payload_response",
 }
@@ -429,6 +430,7 @@ exports[`IPC message snapshots ClientMessage types get_signing_identity_response
 {
   "keyId": "abc123",
   "publicKey": "dGVzdA==",
+  "requestId": "req-identity-001",
   "type": "get_signing_identity_response",
 }
 `;
@@ -1393,12 +1395,14 @@ exports[`IPC message snapshots ServerMessage types open_bundle_response serializ
 exports[`IPC message snapshots ServerMessage types sign_bundle_payload serializes to expected JSON 1`] = `
 {
   "payload": "{"content_hashes":{},"manifest":{}}",
+  "requestId": "req-sign-001",
   "type": "sign_bundle_payload",
 }
 `;
 
 exports[`IPC message snapshots ServerMessage types get_signing_identity serializes to expected JSON 1`] = `
 {
+  "requestId": "req-identity-001",
   "type": "get_signing_identity",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -271,12 +271,14 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   },
   sign_bundle_payload_response: {
     type: 'sign_bundle_payload_response',
+    requestId: 'req-sign-001',
     signature: 'dGVzdC1zaWduYXR1cmU=',
     keyId: 'abc123',
     publicKey: 'dGVzdA==',
   },
   get_signing_identity_response: {
     type: 'get_signing_identity_response',
+    requestId: 'req-identity-001',
     keyId: 'abc123',
     publicKey: 'dGVzdA==',
   },
@@ -894,10 +896,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   sign_bundle_payload: {
     type: 'sign_bundle_payload',
+    requestId: 'req-sign-001',
     payload: '{"content_hashes":{},"manifest":{}}',
   },
   get_signing_identity: {
     type: 'get_signing_identity',
+    requestId: 'req-identity-001',
   },
   session_error: {
     type: 'session_error',

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -171,24 +171,24 @@ const handlers: DispatchMap = {
   shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
   shared_app_delete: handleSharedAppDelete,
   fork_shared_app: handleForkSharedApp,
-  sign_bundle_payload_response: (msg, socket) => {
-    const pending = pendingSignBundlePayload.get(socket);
+  sign_bundle_payload_response: (msg) => {
+    const pending = pendingSignBundlePayload.get(msg.requestId);
     if (pending) {
       clearTimeout(pending.timer);
-      pendingSignBundlePayload.delete(socket);
+      pendingSignBundlePayload.delete(msg.requestId);
       pending.resolve({ signature: msg.signature, keyId: msg.keyId, publicKey: msg.publicKey });
     } else {
-      log.warn('Received sign_bundle_payload_response with no pending request');
+      log.warn({ requestId: msg.requestId }, 'Received sign_bundle_payload_response with no pending request');
     }
   },
-  get_signing_identity_response: (msg, socket) => {
-    const pending = pendingSigningIdentity.get(socket);
+  get_signing_identity_response: (msg) => {
+    const pending = pendingSigningIdentity.get(msg.requestId);
     if (pending) {
       clearTimeout(pending.timer);
-      pendingSigningIdentity.delete(socket);
+      pendingSigningIdentity.delete(msg.requestId);
       pending.resolve({ keyId: msg.keyId, publicKey: msg.publicKey });
     } else {
-      log.warn('Received get_signing_identity_response with no pending request');
+      log.warn({ requestId: msg.requestId }, 'Received get_signing_identity_response with no pending request');
     }
   },
   gallery_list: (_msg, socket, ctx) => handleGalleryList(socket, ctx),

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -20,20 +20,20 @@ let cachedScreenDims: { width: number; height: number } | null = null;
 // Module-level map for non-session secret prompts (e.g. publish_page)
 export const pendingStandaloneSecrets = new Map<string, { resolve: (result: SecretPromptResult) => void; timer: ReturnType<typeof setTimeout> }>();
 
-// Pending IPC signing responses (bundle signing orchestration)
+// Pending IPC signing responses (bundle signing orchestration), keyed by unique requestId
 interface PendingSigningResolve {
   resolve: (result: { signature: string; keyId: string; publicKey: string }) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
 }
-export const pendingSignBundlePayload = new Map<net.Socket, PendingSigningResolve>();
+export const pendingSignBundlePayload = new Map<string, PendingSigningResolve>();
 
 interface PendingIdentityResolve {
   resolve: (result: { keyId: string; publicKey: string }) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
 }
-export const pendingSigningIdentity = new Map<net.Socket, PendingIdentityResolve>();
+export const pendingSigningIdentity = new Map<string, PendingIdentityResolve>();
 
 export interface HistoryToolCall {
   name: string;
@@ -482,12 +482,13 @@ export function createSigningCallback(
 ): (payload: string) => Promise<{ signature: string; keyId: string; publicKey: string }> {
   return (payload: string) =>
     new Promise((resolve, reject) => {
+      const requestId = uuid();
       const timer = setTimeout(() => {
-        pendingSignBundlePayload.delete(socket);
+        pendingSignBundlePayload.delete(requestId);
         reject(new Error('Signing request timed out'));
       }, SIGNING_TIMEOUT_MS);
-      pendingSignBundlePayload.set(socket, { resolve, reject, timer });
-      ctx.send(socket, { type: 'sign_bundle_payload', payload });
+      pendingSignBundlePayload.set(requestId, { resolve, reject, timer });
+      ctx.send(socket, { type: 'sign_bundle_payload', requestId, payload });
     });
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -378,6 +378,7 @@ export interface OpenBundleRequest {
 
 export interface SignBundlePayloadResponse {
   type: 'sign_bundle_payload_response';
+  requestId: string;
   signature: string;
   keyId: string;
   publicKey: string;
@@ -385,6 +386,7 @@ export interface SignBundlePayloadResponse {
 
 export interface GetSigningIdentityResponse {
   type: 'get_signing_identity_response';
+  requestId: string;
   keyId: string;
   publicKey: string;
 }
@@ -1284,11 +1286,13 @@ export interface OpenBundleResponse {
 
 export interface SignBundlePayloadRequest {
   type: 'sign_bundle_payload';
+  requestId: string;
   payload: string;
 }
 
 export interface GetSigningIdentityRequest {
   type: 'get_signing_identity';
+  requestId: string;
 }
 
 export interface ShareAppCloudResponse {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -424,10 +424,12 @@ public struct IPCGenerationHandoff: Codable, Sendable {
 
 public struct IPCGetSigningIdentityRequest: Codable, Sendable {
     public let type: String
+    public let requestId: String
 }
 
 public struct IPCGetSigningIdentityResponse: Codable, Sendable {
     public let type: String
+    public let requestId: String
     public let keyId: String
     public let publicKey: String
 }
@@ -996,11 +998,13 @@ public struct IPCShareToSlackResponse: Codable, Sendable {
 
 public struct IPCSignBundlePayloadRequest: Codable, Sendable {
     public let type: String
+    public let requestId: String
     public let payload: String
 }
 
 public struct IPCSignBundlePayloadResponse: Codable, Sendable {
     public let type: String
+    public let requestId: String
     public let signature: String
     public let keyId: String
     public let publicKey: String


### PR DESCRIPTION
Replaces socket-based map key for `pendingSignBundlePayload` and `pendingSigningIdentity` with unique request IDs (UUIDs) to safely handle concurrent signing operations on the same connection.

**Problem:** Using `net.Socket` as the sole map key meant concurrent signing requests on the same socket would overwrite each other, causing promise leaks and cross-request interference. A second request would overwrite the first's pending promise, and the first's timeout timer would then delete the second's entry.

**Fix:** Generate a unique `requestId` (UUID) for each signing request and use it as the map key instead of the socket reference. The `requestId` is included in the IPC message to the Swift client and echoed back in the response, allowing correct correlation. This mirrors the existing `pendingStandaloneSecrets` pattern.

Addresses feedback from #3380.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
