### PR TITLE
fix: improve telegram edit handling race conditions

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -11,7 +11,7 @@
  * and a replay endpoint allows manual recovery of dead-lettered ones.
  */
 
-import { eq, and, lte } from 'drizzle-orm';
+import { eq, and, lte, isNotNull } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { channelInboundEvents, conversations } from './schema.js';
@@ -140,6 +140,7 @@ export function findMessageBySourceId(
         eq(channelInboundEvents.sourceChannel, sourceChannel),
         eq(channelInboundEvents.externalChatId, externalChatId),
         eq(channelInboundEvents.sourceMessageId, sourceMessageId),
+        isNotNull(channelInboundEvents.messageId),
       ),
     )
     .get();

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -122,12 +122,29 @@ export async function handleChannelInbound(
       });
     }
 
-    const original = channelDeliveryStore.findMessageBySourceId(
-      assistantId,
-      sourceChannel,
-      externalChatId,
-      sourceMessageId,
-    );
+    // Retry lookup a few times — the original message may still be processing
+    // (linkMessage hasn't been called yet). Short backoff avoids losing edits
+    // that arrive while the original agent loop is in progress.
+    const EDIT_LOOKUP_RETRIES = 5;
+    const EDIT_LOOKUP_DELAY_MS = 2000;
+
+    let original: { messageId: string; conversationId: string } | null = null;
+    for (let attempt = 0; attempt <= EDIT_LOOKUP_RETRIES; attempt++) {
+      original = channelDeliveryStore.findMessageBySourceId(
+        assistantId,
+        sourceChannel,
+        externalChatId,
+        sourceMessageId,
+      );
+      if (original) break;
+      if (attempt < EDIT_LOOKUP_RETRIES) {
+        log.info(
+          { assistantId, sourceMessageId, attempt: attempt + 1, maxAttempts: EDIT_LOOKUP_RETRIES },
+          'Original message not linked yet, retrying edit lookup',
+        );
+        await new Promise((resolve) => setTimeout(resolve, EDIT_LOOKUP_DELAY_MS));
+      }
+    }
 
     if (original) {
       conversationStore.updateMessageContent(original.messageId, content ?? '');
@@ -138,7 +155,7 @@ export async function handleChannelInbound(
     } else {
       log.warn(
         { assistantId, sourceChannel, externalChatId, sourceMessageId },
-        'Could not find original message for edit, ignoring',
+        'Could not find original message for edit after retries, ignoring',
       );
     }
 

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -140,6 +140,9 @@ export function createTelegramWebhookHandler(
       return respond({ ok: true });
     }
 
+    // Edits don't produce a new reply, so skip typing indicator and attachments
+    const isEdit = !!normalized.message.isEdit;
+
     // Check routing early so we can gate attachments and typing indicator
     const chatId = normalized.message.externalChatId;
     const routing = resolveAssistant(
@@ -149,10 +152,11 @@ export function createTelegramWebhookHandler(
     );
     const routable = !isRejection(routing);
 
-    // Download and upload attachments if present
+    // Download and upload attachments if present (skip for edits — the runtime
+    // edit path only updates text content and doesn't link new attachments)
     let attachmentIds: string[] | undefined;
     const eventAttachments = normalized.message.attachments;
-    if (eventAttachments && eventAttachments.length > 0 && routable) {
+    if (eventAttachments && eventAttachments.length > 0 && routable && !isEdit) {
       try {
         attachmentIds = [];
 
@@ -193,9 +197,6 @@ export function createTelegramWebhookHandler(
         log.error({ err }, "Failed to process attachments");
       }
     }
-
-    // Edits don't produce a new reply, so skip typing indicator
-    const isEdit = !!normalized.message.isEdit;
 
     // Start typing indicator only for routable chats with new messages.
     // A safety timeout ensures the interval is cleared even if handleInbound hangs.


### PR DESCRIPTION
## Summary

Addresses review feedback from #3383:

- **Skip attachment ingestion for edits** (Codex P2): Move `isEdit` check before attachment processing in the gateway so edited photo/document updates don't trigger unnecessary downloads and uploads.
- **Retry edit lookup when original isn't linked yet** (Codex P1): Add a retry loop (5 attempts, 2s delay) in the edit path so edits arriving while the original message is still processing aren't silently dropped.
- **Filter `message_id IS NOT NULL` in findMessageBySourceId** (Devin): Prevent the query from non-deterministically matching the just-inserted edit event row (which has `message_id = NULL`) instead of the linked original.

## Files changed

- `gateway/src/http/routes/telegram-webhook.ts` — moved `isEdit` above attachment block, gated attachments on `!isEdit`
- `assistant/src/memory/channel-delivery-store.ts` — added `isNotNull(messageId)` filter
- `assistant/src/runtime/routes/channel-routes.ts` — added retry loop for edit lookup

## Test plan

- [ ] Send a photo message, then immediately edit its caption — verify the edit updates the message content and no duplicate attachments are created
- [ ] Send a message and edit it before the assistant replies — verify the edit is applied after retry
- [ ] Type-check passes for both assistant and gateway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
