### PR TITLE
fix: prevent DLQ retry overlap and add assistantId filter to replay

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -322,7 +322,7 @@ export function getDeadLetterEvents(assistantId: string): Array<{
  * Reset dead-lettered events back to 'failed' so the sweep can retry
  * them. Resets attempt counter and sets an immediate retry_after.
  */
-export function replayDeadLetters(eventIds: string[]): number {
+export function replayDeadLetters(assistantId: string, eventIds: string[]): number {
   const db = getDb();
   const now = Date.now();
   let count = 0;
@@ -333,6 +333,7 @@ export function replayDeadLetters(eventIds: string[]): number {
       .where(
         and(
           eq(channelInboundEvents.id, id),
+          eq(channelInboundEvents.assistantId, assistantId),
           eq(channelInboundEvents.processingStatus, 'dead_letter'),
         ),
       )

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -72,6 +72,7 @@ export class RuntimeHttpServer {
   private suggestionCache = new Map<string, string>();
   private suggestionInFlight = new Map<string, Promise<string | null>>();
   private retrySweepTimer: ReturnType<typeof setInterval> | null = null;
+  private sweepInProgress = false;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
@@ -89,7 +90,11 @@ export class RuntimeHttpServer {
 
     // Sweep failed channel inbound events for retry every 30 seconds
     if (this.processMessage) {
-      this.retrySweepTimer = setInterval(() => this.sweepFailedEvents(), 30_000);
+      this.retrySweepTimer = setInterval(() => {
+        if (this.sweepInProgress) return;
+        this.sweepInProgress = true;
+        this.sweepFailedEvents().finally(() => { this.sweepInProgress = false; });
+      }, 30_000);
     }
 
     log.info({ port: this.port }, 'Runtime HTTP server listening');

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -277,7 +277,7 @@ export async function handleReplayDeadLetters(assistantId: string, req: Request)
     return Response.json({ error: 'eventIds array is required' }, { status: 400 });
   }
 
-  const replayed = channelDeliveryStore.replayDeadLetters(eventIds);
+  const replayed = channelDeliveryStore.replayDeadLetters(assistantId, eventIds);
   return Response.json({ replayed });
 }
 


### PR DESCRIPTION
Adds overlap guard to DLQ retry sweep to prevent duplicate processing during slow async operations, and adds assistantId filter to replayDeadLetters for tenant isolation. Addresses feedback from #3393.

## Changes

1. **Sweep overlap guard** (`assistant/src/runtime/http-server.ts`): Added `sweepInProgress` flag so `setInterval` callbacks skip when a previous sweep is still running, preventing duplicate `processMessage` calls for the same failed events.

2. **Tenant isolation for replay** (`assistant/src/memory/channel-delivery-store.ts`): `replayDeadLetters()` now requires an `assistantId` parameter and includes it in the WHERE clause, ensuring events can only be replayed by the assistant that owns them.

3. **Caller update** (`assistant/src/runtime/routes/channel-routes.ts`): Updated `handleReplayDeadLetters` to pass `assistantId` to the store function.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
