### PR TITLE
fix: resolve build errors in SessionLogger and IPC signing

### DIFF
--- a/clients/macos/vellum-assistant/Logging/SessionLogger.swift
+++ b/clients/macos/vellum-assistant/Logging/SessionLogger.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let log = Logger(
+private let logger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
     category: "SessionLogger"
 )
@@ -98,7 +98,7 @@ final class SessionLogger {
             let data = try encoder.encode(sessionLog)
             try data.write(to: fileURL)
         } catch {
-            log.error("Failed to save session log: \(error.localizedDescription)")
+            logger.error("Failed to save session log: \(error.localizedDescription)")
         }
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -885,6 +885,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             let publicKey = try SigningIdentityManager.shared.getPublicKey()
 
             try send(SignBundlePayloadResponseMessage(
+                requestId: msg.requestId,
                 signature: signature.base64EncodedString(),
                 keyId: keyId,
                 publicKey: publicKey.rawRepresentation.base64EncodedString()
@@ -895,12 +896,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Handle a get_signing_identity request from the daemon.
-    private func handleGetSigningIdentity() {
+    private func handleGetSigningIdentity(_ msg: IPCGetSigningIdentityRequest) {
         do {
             let keyId = try SigningIdentityManager.shared.getKeyId()
             let publicKey = try SigningIdentityManager.shared.getPublicKey()
 
             try send(GetSigningIdentityResponseMessage(
+                requestId: msg.requestId,
                 keyId: keyId,
                 publicKey: publicKey.rawRepresentation.base64EncodedString()
             ))
@@ -1132,8 +1134,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #if os(macOS)
         case .signBundlePayload(let msg):
             handleSignBundlePayload(msg)
-        case .getSigningIdentity:
-            handleGetSigningIdentity()
+        case .getSigningIdentity(let msg):
+            handleGetSigningIdentity(msg)
         #elseif os(iOS)
         case .signBundlePayload:
             log.error("Received sign_bundle_payload request on iOS - signing operations are not supported on iOS due to sandboxing restrictions")

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -615,8 +615,8 @@ extension IPCSkillsInspectRequest {
 public typealias SignBundlePayloadResponseMessage = IPCSignBundlePayloadResponse
 
 extension IPCSignBundlePayloadResponse {
-    public init(signature: String, keyId: String, publicKey: String) {
-        self.init(type: "sign_bundle_payload_response", signature: signature, keyId: keyId, publicKey: publicKey)
+    public init(requestId: String, signature: String, keyId: String, publicKey: String) {
+        self.init(type: "sign_bundle_payload_response", requestId: requestId, signature: signature, keyId: keyId, publicKey: publicKey)
     }
 }
 
@@ -625,8 +625,8 @@ extension IPCSignBundlePayloadResponse {
 public typealias GetSigningIdentityResponseMessage = IPCGetSigningIdentityResponse
 
 extension IPCGetSigningIdentityResponse {
-    public init(keyId: String, publicKey: String) {
-        self.init(type: "get_signing_identity_response", keyId: keyId, publicKey: publicKey)
+    public init(requestId: String, keyId: String, publicKey: String) {
+        self.init(type: "get_signing_identity_response", requestId: requestId, keyId: keyId, publicKey: publicKey)
     }
 }
 
@@ -1547,7 +1547,7 @@ public enum ServerMessage: Decodable, Sendable {
     case integrationListResponse(IPCIntegrationListResponse)
     case integrationConnectResult(IPCIntegrationConnectResult)
     case appFilesChanged(AppFilesChangedMessage)
-    case getSigningIdentity
+    case getSigningIdentity(IPCGetSigningIdentityRequest)
     case pong
     case unknown(String)
 
@@ -1747,7 +1747,8 @@ public enum ServerMessage: Decodable, Sendable {
             let message = try OpenUrlMessage(from: decoder)
             self = .openUrl(message)
         case "get_signing_identity":
-            self = .getSigningIdentity
+            let message = try IPCGetSigningIdentityRequest(from: decoder)
+            self = .getSigningIdentity(message)
         case "daemon_status":
             let message = try DaemonStatusMessage(from: decoder)
             self = .daemonStatus(message)


### PR DESCRIPTION
## Summary
- Rename file-level `log` to `logger` in `SessionLogger.swift` to fix Swift name resolution collision with the `SessionLog` struct type
- Add missing `requestId` parameter to `IPCSignBundlePayloadResponse` and `IPCGetSigningIdentityResponse` convenience initializers (required after PR #3418 added requestId to generated types)
- Update `getSigningIdentity` enum case to carry the request message for requestId passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
