### PR TITLE
feat: add retry button for failed message sends

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -64,6 +64,8 @@ struct ChatView: View {
     let onSend: () -> Void
     let onStop: () -> Void
     let onDismissError: () -> Void
+    let isRetryableError: Bool
+    let onRetryError: () -> Void
     let onAcceptSuggestion: () -> Void
     let onAttach: () -> Void
     let onRemoveAttachment: (String) -> Void
@@ -458,6 +460,19 @@ struct ChatView: View {
                 .lineLimit(2)
 
             Spacer()
+
+            if isRetryableError {
+                Button(action: onRetryError) {
+                    Text("Retry")
+                        .font(VFont.captionMedium)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(Color.white.opacity(0.2))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Retry sending message")
+            }
 
             Button {
                 onDismissError()
@@ -1758,6 +1773,8 @@ private struct ChatViewPreviewWrapper: View {
                 onSend: {},
                 onStop: {},
                 onDismissError: {},
+                isRetryableError: false,
+                onRetryError: {},
                 onAcceptSuggestion: {},
                 onAttach: {},
                 onRemoveAttachment: { _ in },

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -991,6 +991,8 @@ private struct ActiveChatViewWrapper: View {
             onSend: viewModel.sendMessage,
             onStop: viewModel.stopGenerating,
             onDismissError: viewModel.dismissError,
+            isRetryableError: viewModel.isRetryableError,
+            onRetryError: { viewModel.retryLastMessage() },
             onAcceptSuggestion: viewModel.acceptSuggestion,
             onAttach: { openFilePicker(viewModel: viewModel) },
             onRemoveAttachment: { viewModel.removeAttachment(id: $0) },

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -57,6 +57,9 @@ public final class ChatViewModel: ObservableObject {
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
     var pendingUserAttachments: [IPCAttachment]?
+    /// Stores the last user message that failed to send, enabling retry.
+    private(set) var lastFailedMessageText: String?
+    private(set) var lastFailedMessageAttachments: [IPCAttachment]?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?
@@ -197,6 +200,8 @@ public final class ChatViewModel: ObservableObject {
         pendingSuggestionRequestId = nil
         errorText = nil
         sessionError = nil
+        lastFailedMessageText = nil
+        lastFailedMessageAttachments = nil
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
@@ -232,6 +237,10 @@ public final class ChatViewModel: ObservableObject {
                     self.isThinking = false
                     self.isSending = false
                     self.bootstrapCorrelationId = nil
+                    self.lastFailedMessageText = self.pendingUserMessage
+                    self.lastFailedMessageAttachments = self.pendingUserAttachments
+                    self.pendingUserMessage = nil
+                    self.pendingUserAttachments = nil
                     self.errorText = "Cannot connect to daemon. Please ensure it's running."
                     return
                 }
@@ -248,6 +257,10 @@ public final class ChatViewModel: ObservableObject {
                 self.isThinking = false
                 self.isSending = false
                 self.bootstrapCorrelationId = nil
+                self.lastFailedMessageText = self.pendingUserMessage
+                self.lastFailedMessageAttachments = self.pendingUserAttachments
+                self.pendingUserMessage = nil
+                self.pendingUserAttachments = nil
                 self.errorText = "Failed to create session."
             }
         }
@@ -261,6 +274,8 @@ public final class ChatViewModel: ObservableObject {
         // daemon has disconnected between turns.
         guard daemonClient.isConnected else {
             log.error("Cannot send user_message: daemon not connected")
+            lastFailedMessageText = text
+            lastFailedMessageAttachments = attachments
             errorText = "Cannot connect to daemon. Please ensure it's running."
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
@@ -289,6 +304,8 @@ public final class ChatViewModel: ObservableObject {
             log.error("Failed to send user_message: \(error.localizedDescription)")
             isSending = false
             isThinking = false
+            lastFailedMessageText = text
+            lastFailedMessageAttachments = attachments
             errorText = "Failed to send message."
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
@@ -547,6 +564,8 @@ public final class ChatViewModel: ObservableObject {
     public func dismissError() {
         sessionError = nil
         errorText = nil
+        lastFailedMessageText = nil
+        lastFailedMessageAttachments = nil
     }
 
     /// Dismiss the typed session error state. Clears both the typed error
@@ -595,6 +614,28 @@ public final class ChatViewModel: ObservableObject {
         }
         dismissSessionError()
         regenerateLastMessage()
+    }
+
+    /// Whether the current error has a failed user message that can be retried.
+    public var isRetryableError: Bool {
+        lastFailedMessageText != nil && errorText != nil
+    }
+
+    /// Retry sending the last user message that failed (e.g. due to daemon disconnection).
+    public func retryLastMessage() {
+        guard let text = lastFailedMessageText else { return }
+        let attachments = lastFailedMessageAttachments
+
+        // Clear failed message state and error
+        lastFailedMessageText = nil
+        lastFailedMessageAttachments = nil
+        errorText = nil
+
+        if sessionId == nil {
+            bootstrapSession(userMessage: text, attachments: attachments)
+        } else {
+            sendUserMessage(text, attachments: attachments)
+        }
     }
 
     /// Respond to a tool confirmation request displayed inline in the chat.


### PR DESCRIPTION
## Summary
- When a message fails to send (daemon disconnected, session creation failure, etc.), the error banner now shows a **Retry** button that resends the last user message
- Tracks the failed message text and attachments in `ChatViewModel` so they can be retried without the user needing to retype
- Clears failed message state on dismiss, new send, or successful retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
