### PR TITLE
fix: add missing requestId to signing IPC response inits

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -885,6 +885,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             let publicKey = try SigningIdentityManager.shared.getPublicKey()
 
             try send(SignBundlePayloadResponseMessage(
+                requestId: msg.requestId,
                 signature: signature.base64EncodedString(),
                 keyId: keyId,
                 publicKey: publicKey.rawRepresentation.base64EncodedString()
@@ -895,12 +896,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Handle a get_signing_identity request from the daemon.
-    private func handleGetSigningIdentity() {
+    private func handleGetSigningIdentity(_ msg: GetSigningIdentityMessage) {
         do {
             let keyId = try SigningIdentityManager.shared.getKeyId()
             let publicKey = try SigningIdentityManager.shared.getPublicKey()
 
             try send(GetSigningIdentityResponseMessage(
+                requestId: msg.requestId,
                 keyId: keyId,
                 publicKey: publicKey.rawRepresentation.base64EncodedString()
             ))
@@ -1132,8 +1134,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #if os(macOS)
         case .signBundlePayload(let msg):
             handleSignBundlePayload(msg)
-        case .getSigningIdentity:
-            handleGetSigningIdentity()
+        case .getSigningIdentity(let msg):
+            handleGetSigningIdentity(msg)
         #elseif os(iOS)
         case .signBundlePayload:
             log.error("Received sign_bundle_payload request on iOS - signing operations are not supported on iOS due to sandboxing restrictions")

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -615,8 +615,8 @@ extension IPCSkillsInspectRequest {
 public typealias SignBundlePayloadResponseMessage = IPCSignBundlePayloadResponse
 
 extension IPCSignBundlePayloadResponse {
-    public init(signature: String, keyId: String, publicKey: String) {
-        self.init(type: "sign_bundle_payload_response", signature: signature, keyId: keyId, publicKey: publicKey)
+    public init(requestId: String, signature: String, keyId: String, publicKey: String) {
+        self.init(type: "sign_bundle_payload_response", requestId: requestId, signature: signature, keyId: keyId, publicKey: publicKey)
     }
 }
 
@@ -625,8 +625,8 @@ extension IPCSignBundlePayloadResponse {
 public typealias GetSigningIdentityResponseMessage = IPCGetSigningIdentityResponse
 
 extension IPCGetSigningIdentityResponse {
-    public init(keyId: String, publicKey: String) {
-        self.init(type: "get_signing_identity_response", keyId: keyId, publicKey: publicKey)
+    public init(requestId: String, keyId: String, publicKey: String) {
+        self.init(type: "get_signing_identity_response", requestId: requestId, keyId: keyId, publicKey: publicKey)
     }
 }
 
@@ -1162,6 +1162,10 @@ public typealias BundleAppResponseMessage = IPCBundleAppResponse
 /// Backed by generated `IPCSignBundlePayloadRequest`.
 public typealias SignBundlePayloadMessage = IPCSignBundlePayloadRequest
 
+/// Request from daemon to get the signing identity.
+/// Backed by generated `IPCGetSigningIdentityRequest`.
+public typealias GetSigningIdentityMessage = IPCGetSigningIdentityRequest
+
 /// Blob probe request sent after connecting to verify filesystem reachability.
 /// Backed by generated `IPCIpcBlobProbe`.
 public typealias IpcBlobProbeMessage = IPCIpcBlobProbe
@@ -1547,7 +1551,7 @@ public enum ServerMessage: Decodable, Sendable {
     case integrationListResponse(IPCIntegrationListResponse)
     case integrationConnectResult(IPCIntegrationConnectResult)
     case appFilesChanged(AppFilesChangedMessage)
-    case getSigningIdentity
+    case getSigningIdentity(GetSigningIdentityMessage)
     case pong
     case unknown(String)
 
@@ -1747,7 +1751,8 @@ public enum ServerMessage: Decodable, Sendable {
             let message = try OpenUrlMessage(from: decoder)
             self = .openUrl(message)
         case "get_signing_identity":
-            self = .getSigningIdentity
+            let message = try GetSigningIdentityMessage(from: decoder)
+            self = .getSigningIdentity(message)
         case "daemon_status":
             let message = try DaemonStatusMessage(from: decoder)
             self = .daemonStatus(message)


### PR DESCRIPTION
## Summary
- Added `requestId` parameter to `IPCSignBundlePayloadResponse` and `IPCGetSigningIdentityResponse` convenience inits to match the generated struct signatures
- Updated `DaemonClient` call sites to forward `requestId` from the request messages
- Changed `getSigningIdentity` enum case to carry the request message so `requestId` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
