### PR TITLE
fix: clear streaming code preview on cancel/error, fix JSON extraction

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -801,7 +801,7 @@ private struct ChatBubble: View {
             && message.toolCalls.allSatisfy({ $0.isComplete }) && message.isStreaming
         let hasInProgressTools = !message.toolCalls.isEmpty && !hideToolCalls && !allToolCallsComplete
         let hasPermission = decidedConfirmation != nil
-        let hasStreamingCode = message.streamingCodePreview != nil && !(message.streamingCodePreview?.isEmpty ?? true)
+        let hasStreamingCode = message.isStreaming && message.streamingCodePreview != nil && !(message.streamingCodePreview?.isEmpty ?? true)
 
         if hasStreamingCode {
             let rawName = message.streamingCodeToolName ?? ""

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -76,23 +76,46 @@ extension ChatViewModel {
         let isAppTool = toolName == "app_create" || toolName == "app_update"
         guard isAppTool else { return nil }
 
-        // Show the HTML code as it streams in
+        // Find the html JSON string value by locating the opening quote
         let markers = ["\"html\": \"", "\"html\":\""]
         for marker in markers {
-            if let range = accumulatedJson.range(of: marker) {
-                var html = String(accumulatedJson[range.upperBound...])
-                if html.hasSuffix("\"}") {
-                    html = String(html.dropLast(2))
-                } else if html.hasSuffix("\"") {
-                    html = String(html.dropLast(1))
+            guard let range = accumulatedJson.range(of: marker) else { continue }
+            let afterMarker = accumulatedJson[range.upperBound...]
+
+            // Scan for the closing unescaped quote of the JSON string value
+            var result: [Character] = []
+            var i = afterMarker.startIndex
+            while i < afterMarker.endIndex {
+                let ch = afterMarker[i]
+                if ch == "\\" {
+                    let next = afterMarker.index(after: i)
+                    if next < afterMarker.endIndex {
+                        // Single-pass unescape: handle the pair
+                        switch afterMarker[next] {
+                        case "n": result.append("\n")
+                        case "t": result.append("\t")
+                        case "\"": result.append("\"")
+                        case "\\": result.append("\\")
+                        default:
+                            result.append(ch)
+                            result.append(afterMarker[next])
+                        }
+                        i = afterMarker.index(after: next)
+                    } else {
+                        // Trailing backslash (incomplete escape at end of stream)
+                        break
+                    }
+                } else if ch == "\"" {
+                    // Found the closing quote — stop
+                    break
+                } else {
+                    result.append(ch)
+                    i = afterMarker.index(after: i)
                 }
-                html = html
-                    .replacingOccurrences(of: "\\n", with: "\n")
-                    .replacingOccurrences(of: "\\t", with: "\t")
-                    .replacingOccurrences(of: "\\\"", with: "\"")
-                    .replacingOccurrences(of: "\\\\", with: "\\")
-                return html.isEmpty ? nil : html
             }
+
+            let html = String(result)
+            return html.isEmpty ? nil : html
         }
 
         return nil
@@ -368,6 +391,8 @@ extension ChatViewModel {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                messages[index].streamingCodePreview = nil
+                messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
@@ -418,6 +443,8 @@ extension ChatViewModel {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                messages[index].streamingCodePreview = nil
+                messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
@@ -442,6 +469,8 @@ extension ChatViewModel {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                messages[index].streamingCodePreview = nil
+                messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
@@ -723,6 +752,8 @@ extension ChatViewModel {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                messages[index].streamingCodePreview = nil
+                messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -399,6 +399,8 @@ public final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                messages[index].streamingCodePreview = nil
+                messages[index].streamingCodeToolName = nil
                 for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
                     messages[index].toolCalls[j].isComplete = true
                     messages[index].toolCalls[j].completedAt = Date()
@@ -438,6 +440,8 @@ public final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                messages[index].streamingCodePreview = nil
+                messages[index].streamingCodeToolName = nil
                 for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
                     messages[index].toolCalls[j].isComplete = true
                     messages[index].toolCalls[j].completedAt = Date()
@@ -474,6 +478,8 @@ public final class ChatViewModel: ObservableObject {
         if let existingId = currentAssistantMessageId,
            let index = messages.firstIndex(where: { $0.id == existingId }) {
             messages[index].isStreaming = false
+            messages[index].streamingCodePreview = nil
+            messages[index].streamingCodeToolName = nil
             for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
                 messages[index].toolCalls[j].isComplete = true
                 messages[index].toolCalls[j].completedAt = Date()


### PR DESCRIPTION
## Summary
- Gates `hasStreamingCode` to `message.isStreaming` so the code preview hides when streaming ends via any path
- Clears `streamingCodePreview`/`streamingCodeToolName` in all termination handlers (generationCancelled, generationHandoff, error, sessionError, cancel paths) to prevent stale "Building your app" indicator
- Replaces naive HTML extraction (everything after `"html":` marker) with proper JSON string value parsing that scans for the closing unescaped `"`, preventing trailing JSON fields from leaking into the preview
- Replaces sequential `replacingOccurrences` unescape with single-pass character-by-character unescape to fix `\\n` corruption
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
