### PR TITLE
feat: contextual tool pill labels with file/command details

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -845,43 +845,103 @@ private struct ChatBubble: View {
         }
     }
 
-    /// Maps raw tool names to user-friendly past-tense labels.
-    private static func friendlyToolLabel(_ toolName: String) -> String {
-        switch toolName.lowercased() {
-        case "host bash", "bash":          return "Ran a terminal command"
-        case "host file read", "file read": return "Read a file"
-        case "host file write", "file write": return "Wrote a file"
-        case "host file edit", "file edit": return "Edited a file"
-        case "web search":                 return "Searched the web"
-        case "web fetch":                  return "Fetched a webpage"
-        case "browser navigate":           return "Opened a page"
-        case "browser click":              return "Clicked on the page"
-        case "browser screenshot":         return "Took a screenshot"
-        default:                           return "Used \(toolName)"
+    /// Maps tool names to user-friendly past-tense labels.
+    /// When `inputSummary` is provided, produces contextual labels like "Read config.json".
+    private static func friendlyToolLabel(_ toolName: String, inputSummary: String = "") -> String {
+        let name = toolName.lowercased()
+        let summary = inputSummary.trimmingCharacters(in: .whitespaces)
+
+        // Extract just the filename from a file path.
+        let fileName: String? = {
+            guard !summary.isEmpty else { return nil }
+            let last = (summary as NSString).lastPathComponent
+            guard !last.isEmpty, last != "." else { return nil }
+            return last
+        }()
+
+        switch name {
+        case "run command":
+            if !summary.isEmpty {
+                let display = summary.count > 30 ? String(summary.prefix(27)) + "..." : summary
+                return "Ran `\(display)`"
+            }
+            return "Ran a command"
+        case "read file":
+            if let f = fileName { return "Read \(f)" }
+            return "Read a file"
+        case "write file":
+            if let f = fileName { return "Wrote \(f)" }
+            return "Wrote a file"
+        case "edit file":
+            if let f = fileName { return "Edited \(f)" }
+            return "Edited a file"
+        case "search files":
+            if !summary.isEmpty {
+                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
+                return "Searched for '\(display)'"
+            }
+            return "Searched files"
+        case "find files":
+            if !summary.isEmpty {
+                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
+                return "Searched for \(display)"
+            }
+            return "Found files"
+        case "web search":
+            if !summary.isEmpty {
+                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
+                return "Searched '\(display)'"
+            }
+            return "Searched the web"
+        case "fetch url":              return "Fetched a webpage"
+        case "browser navigate":       return "Opened a page"
+        case "browser click":          return "Clicked on the page"
+        case "browser screenshot":     return "Took a screenshot"
+        default:                       return "Used \(toolName)"
         }
     }
 
-    /// Maps raw tool names to user-friendly present-tense labels for the running state.
+    /// Plural past-tense labels for multiple tool calls of the same type.
+    private static func friendlyToolLabelPlural(_ toolName: String, count: Int) -> String {
+        switch toolName.lowercased() {
+        case "run command":        return "Ran \(count) commands"
+        case "read file":          return "Read \(count) files"
+        case "write file":         return "Wrote \(count) files"
+        case "edit file":          return "Edited \(count) files"
+        case "search files":       return "Ran \(count) searches"
+        case "find files":         return "Ran \(count) searches"
+        case "web search":         return "Searched the web \(count) times"
+        case "fetch url":          return "Fetched \(count) webpages"
+        case "browser navigate":   return "Opened \(count) pages"
+        case "browser click":      return "Clicked \(count) times"
+        case "browser screenshot":  return "Took \(count) screenshots"
+        default:                   return "Used \(toolName) \(count) times"
+        }
+    }
+
+    /// Maps tool names to user-friendly present-tense labels for the running state.
     private static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil) -> String {
         switch toolName.lowercased() {
-        case "host bash", "bash":                           return "Running a terminal command"
-        case "host file read", "file read":                 return "Reading a file"
-        case "host file write", "file write":               return "Writing a file"
-        case "host file edit", "file edit":                 return "Editing a file"
-        case "web search":                                  return "Searching the web"
-        case "web fetch":                                   return "Fetching a webpage"
-        case "browser navigate":                            return "Opening a page"
-        case "browser click":                               return "Clicking on the page"
-        case "browser screenshot":                          return "Taking a screenshot"
-        case "app create":                                  return "Building your app"
-        case "app update":                                  return "Updating your app"
+        case "run command":            return "Running a command"
+        case "read file":              return "Reading a file"
+        case "write file":             return "Writing a file"
+        case "edit file":              return "Editing a file"
+        case "search files":           return "Searching files"
+        case "find files":             return "Finding files"
+        case "web search":             return "Searching the web"
+        case "fetch url":              return "Fetching a webpage"
+        case "browser navigate":       return "Opening a page"
+        case "browser click":          return "Clicking on the page"
+        case "browser screenshot":     return "Taking a screenshot"
+        case "app create":             return "Building your app"
+        case "app update":             return "Updating your app"
         case "skill load":
             if let name = inputSummary, !name.isEmpty {
                 let display = name.replacingOccurrences(of: "-", with: " ").replacingOccurrences(of: "_", with: " ")
                 return "Loading \(display)"
             }
             return "Loading a skill"
-        default:                                            return "Running \(toolName)"
+        default:                       return "Running \(toolName)"
         }
     }
 
@@ -913,12 +973,12 @@ private struct ChatBubble: View {
     /// Icon for a tool category.
     private static func friendlyToolIcon(_ toolName: String) -> String {
         switch toolName.lowercased() {
-        case "host bash", "bash":                           return "terminal"
-        case "host file read", "file read":                 return "doc.text"
-        case "host file write", "file write":               return "doc.badge.plus"
-        case "host file edit", "file edit":                 return "pencil"
-        case "web search":                                  return "magnifyingglass"
-        case "web fetch":                                   return "globe"
+        case "run command":                                 return "terminal"
+        case "read file":                                   return "doc.text"
+        case "write file":                                  return "doc.badge.plus"
+        case "edit file":                                   return "pencil"
+        case "search files", "find files", "web search":    return "magnifyingglass"
+        case "fetch url":                                   return "globe"
         case "browser navigate", "browser click":           return "safari"
         case "browser screenshot":                          return "camera"
         default:                                            return "gearshape"
@@ -939,16 +999,12 @@ private struct ChatBubble: View {
 
                 let label: String = {
                     if uniqueNames.count == 1 {
-                        let base = Self.friendlyToolLabel(primary)
-                        if message.toolCalls.count > 1 {
-                            // e.g. "Ran 3 terminal commands"
-                            return base
-                                .replacingOccurrences(of: "a terminal command", with: "\(message.toolCalls.count) terminal commands")
-                                .replacingOccurrences(of: "a file", with: "\(message.toolCalls.count) files")
-                                .replacingOccurrences(of: "a page", with: "\(message.toolCalls.count) pages")
-                                .replacingOccurrences(of: "a webpage", with: "\(message.toolCalls.count) webpages")
+                        if message.toolCalls.count == 1, let first = message.toolCalls.first {
+                            // Single tool: contextual label with details
+                            return Self.friendlyToolLabel(primary, inputSummary: first.inputSummary)
                         }
-                        return base
+                        // Multiple of the same tool: count-based
+                        return Self.friendlyToolLabelPlural(primary, count: message.toolCalls.count)
                     }
                     return "Used \(message.toolCalls.count) tools"
                 }()


### PR DESCRIPTION
## Summary
- Fix tool label case matching — old cases (`"host bash"`, `"file read"`) never matched actual display names (`"Run Command"`, `"Read File"`), so all pills showed generic `"Used Read File"` labels
- Make completed-tool pills contextual by incorporating input summaries: `"Read config.json"`, `` "Ran `git status`" ``, `"Searched for 'useState'"` instead of generic labels
- Add proper plural labels for multi-tool messages (`"Read 3 files"`, `"Ran 4 commands"`) replacing fragile string replacement approach
- Fix icon matching to use correct display names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
