### PR TITLE
fix: prevent text overlap in interleaved chat messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1143,6 +1143,7 @@ private struct ChatBubble: View {
                             .foregroundColor(VColor.textPrimary)
                             .tint(VColor.accent)
                             .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
                             .frame(maxWidth: 520, alignment: .leading)
                     case .table(let headers, let rows):
                         MarkdownTableView(headers: headers, rows: rows)
@@ -1160,6 +1161,7 @@ private struct ChatBubble: View {
                 .foregroundColor(VColor.textPrimary)
                 .tint(VColor.accent)
                 .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: 520, alignment: .leading)
         }
     }


### PR DESCRIPTION
## Summary
- Added `.fixedSize(horizontal: false, vertical: true)` to Text views in the `textBubble` function (interleaved content path)
- The `bubbleContent` path already had this modifier, but `textBubble` was missing it, causing SwiftUI's LazyVStack to miscalculate text height and overlap the "Used X tools" chip over message text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
