### PR TITLE
fix: cap output tokens for title generation

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1235,6 +1235,7 @@ export class Session {
       [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
       [], // no tools
       undefined, // no system prompt
+      { config: { max_tokens: 30 } },
     );
 
     const textBlock = response.content.find((b) => b.type === 'text');


### PR DESCRIPTION
## Summary

Addresses review feedback on #3401: the refactored `generateTitle` method lost the `max_tokens` cap that the previous Anthropic-specific code path enforced (`max_tokens: 20`). Without it, title generation defaults to the provider's full token budget (e.g. 64,000 for Anthropic), wasting tokens on what should be a 5-word title.

- Pass `max_tokens: 30` via `options.config` when calling `sendMessage` for title generation
- All three providers (Anthropic, OpenAI, Gemini) already read `max_tokens` from `options.config` and apply it correctly

## Changed files
- `assistant/src/daemon/session.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
