### PR TITLE
fix: unreserve dedup cache on error paths to allow Telegram retries

### DIFF
--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -55,6 +55,14 @@ export class DedupCache {
     return true;
   }
 
+  /** Remove a reserved entry so Telegram can retry. */
+  unreserve(updateId: number): void {
+    const entry = this.cache.get(updateId);
+    if (entry?.processing) {
+      this.cache.delete(updateId);
+    }
+  }
+
   /** Store a response for the given update_id. */
   set(updateId: number, body: string, status: number): void {
     // Evict expired entries if we're at capacity

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -236,6 +236,7 @@ export function createTelegramWebhookHandler(
       });
     } catch (err) {
       log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
+      if (updateId !== undefined) dedupCache.unreserve(updateId);
       return Response.json({ error: "Internal error" }, { status: 500 });
     } finally {
       clearTyping();
@@ -243,6 +244,7 @@ export function createTelegramWebhookHandler(
 
     if (!result.forwarded && !result.rejected) {
       log.error({ updateId: payload.update_id }, "Failed to forward inbound event");
+      if (updateId !== undefined) dedupCache.unreserve(updateId);
       return Response.json({ error: "Internal error" }, { status: 500 });
     }
 


### PR DESCRIPTION
## Summary

When `handleInbound` throws or fails to forward, the dedup cache sentinel was left in place for the full 5-minute TTL. On retry, Telegram would hit the sentinel and receive `{"ok":true}` with status 200 — silently dropping the user's message.

**Changes:**
- Added `unreserve()` method to `DedupCache` that removes a processing sentinel entry
- Called `dedupCache.unreserve(updateId)` at both error-path returns in the telegram webhook handler (handleInbound exception and forward failure)

This ensures Telegram can retry the update when processing fails, rather than receiving a cached success response.

Addresses review feedback on #3409.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
