### PR TITLE
fix: restore suggestion max_tokens cap and provider availability guard

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -173,7 +173,7 @@ export async function handleSuggestionRequest(
 
     // Try LLM suggestion using the configured provider
     const config = getConfig();
-    if (listProviders().length > 0) {
+    if (listProviders().includes(config.provider)) {
       try {
         const provider = getFailoverProvider(config.provider, config.providerOrder);
         let promise = suggestionInFlight.get(m.id);
@@ -221,6 +221,8 @@ async function generateSuggestion(provider: Provider, assistantText: string): Pr
   const response = await provider.sendMessage(
     [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
     [], // no tools
+    undefined, // no system prompt
+    { config: { max_tokens: 30 } },
   );
 
   const textBlock = response.content.find((b) => b.type === 'text');

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -217,6 +217,8 @@ async function generateLlmSuggestion(provider: Provider, assistantText: string):
   const response = await provider.sendMessage(
     [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
     [], // no tools
+    undefined, // no system prompt
+    { config: { max_tokens: 30 } },
   );
 
   const textBlock = response.content.find((b) => b.type === 'text');
@@ -304,7 +306,7 @@ export async function handleGetSuggestion(
 
     // Try LLM suggestion using the configured provider
     const config = getConfig();
-    if (listProviders().length > 0) {
+    if (listProviders().includes(config.provider)) {
       try {
         const provider = getFailoverProvider(config.provider, config.providerOrder);
         // Deduplicate concurrent requests


### PR DESCRIPTION
## Summary

Addresses review feedback on #3417:

1. **Restore max_tokens cap for suggestions** (Codex P2): The refactored suggestion handler dropped the explicit `max_tokens: 30` limit. Now suggestion generation inherits each provider's default output budget (e.g. Anthropic defaults to 64000). This adds `options.config.max_tokens = 30` to `sendMessage` calls in both the IPC handler (`misc.ts`) and the HTTP handler (`conversation-routes.ts`).

2. **Fix provider availability guard** (Devin): Both handlers checked `listProviders().length > 0` but then called `getFailoverProvider(config.provider, ...)` which internally calls `getProvider(primaryName)` and throws `ConfigError` if the primary provider isn't registered. Changed the guard to `listProviders().includes(config.provider)` to ensure the configured primary provider is actually available.

## Changed files
- `assistant/src/daemon/handlers/misc.ts`
- `assistant/src/runtime/routes/conversation-routes.ts`

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify suggestions still generate correctly with a registered provider
- [ ] Verify no crash when `config.provider` is not in the registry (graceful no-suggestion)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
