### PR TITLE
fix: auto-authenticate clients on overridden socket paths

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, chmodSync, writeFileSync, unlinkSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
 import { getSocketPath, getSessionTokenPath, getRootDir, getWorkspaceDir, getWorkspaceSkillsDir, getSandboxWorkingDir, removeSocketFile } from '../util/platform.js';
+import { hasSocketOverride } from './connection-policy.js';
 import { getLogger } from '../util/logger.js';
 import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -480,6 +481,20 @@ export class DaemonServer {
     log.info('Client connected');
     this.connectedSockets.add(socket);
     const parser = createMessageParser({ maxLineSize: MAX_LINE_SIZE });
+
+    // When the daemon is listening on a custom/forwarded socket
+    // (VELLUM_DAEMON_SOCKET), clients may not have access to the local
+    // session token file (e.g. SSH-forwarded connections). Auto-authenticate
+    // these connections so they aren't disconnected by the auth timeout.
+    // Clients that DO have a token will still send an auth message which
+    // is accepted normally via the auth gate below.
+    if (hasSocketOverride()) {
+      this.authenticatedSockets.add(socket);
+      log.info('Auto-authenticated client on overridden socket path');
+      this.sendInitialSession(socket).catch((err) => {
+        log.error({ err }, 'Failed to send initial session info after auto-auth');
+      });
+    }
 
     // Require authentication before sending session info or accepting
     // commands. Clients must send { type: 'auth', token } as their


### PR DESCRIPTION
## Summary

When `VELLUM_DAEMON_SOCKET` is set (e.g. SSH-forwarded sockets), the CLI skips sending an `auth` message if no local session token is found. However, the server had no corresponding logic — it always required auth within 5 seconds (`AUTH_TIMEOUT_MS`), causing an infinite reconnect loop.

This fix adds server-side detection of `hasSocketOverride()` in `handleConnection`. When true, incoming connections are auto-authenticated immediately, bypassing the auth timeout. Clients that DO have a token still send `auth` normally, and the message is harmlessly ignored since the socket is already authenticated.

**Modified files:**
- `assistant/src/daemon/server.ts` — import `hasSocketOverride`, auto-authenticate in `handleConnection`

Addresses feedback from codex and devin on #3410.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
