### PR TITLE
fix: propagate transient attachment errors instead of silently dropping

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -3,7 +3,7 @@ import { DedupCache } from "../../dedup-cache.js";
 import { handleInbound, type InboundResult } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
-import { resetConversation, uploadAttachment } from "../../runtime/client.js";
+import { AttachmentValidationError, resetConversation, uploadAttachment } from "../../runtime/client.js";
 import { downloadTelegramFile } from "../../telegram/download.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
 import { sendTelegramReply, sendTypingIndicator } from "../../telegram/send.js";
@@ -172,8 +172,11 @@ export function createTelegramWebhookHandler(
           return true;
         });
 
-        // Process with bounded concurrency, skipping individual failures
-        // so that an unsupported attachment doesn't drop the user's message.
+        // Process with bounded concurrency. Validation errors (unsupported
+        // MIME type, dangerous extension) are skipped so that a bad attachment
+        // doesn't drop the user's message. Transient errors (download timeout,
+        // upload 5xx, network failures) are propagated so that Telegram retries
+        // the webhook delivery.
         for (let i = 0; i < eligible.length; i += config.maxAttachmentConcurrency) {
           const batch = eligible.slice(i, i + config.maxAttachmentConcurrency);
           const results = await Promise.allSettled(
@@ -188,13 +191,19 @@ export function createTelegramWebhookHandler(
           for (const result of results) {
             if (result.status === 'fulfilled') {
               attachmentIds.push(result.value.id);
+            } else if (result.reason instanceof AttachmentValidationError) {
+              log.warn({ err: result.reason }, "Skipping attachment with validation error");
             } else {
-              log.warn({ err: result.reason }, "Skipping attachment that failed to upload");
+              // Transient failure — propagate so the webhook returns 500 and
+              // Telegram retries the update delivery.
+              throw result.reason;
             }
           }
         }
       } catch (err) {
-        log.error({ err }, "Failed to process attachments");
+        // Transient attachment failure — return 500 so Telegram retries.
+        log.error({ err }, "Attachment processing failed with transient error");
+        return respond({ error: "Attachment processing failed" }, 500);
       }
     }
 

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -3,6 +3,18 @@ import { getLogger } from "../logger.js";
 
 const log = getLogger("runtime-client");
 
+/**
+ * Thrown when the assistant rejects an attachment for a non-retriable reason
+ * (e.g. unsupported MIME type, dangerous file extension). Callers can use
+ * this to distinguish validation failures from transient errors.
+ */
+export class AttachmentValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AttachmentValidationError";
+  }
+}
+
 export type RuntimeInboundPayload = {
   sourceChannel: string;
   externalChatId: string;
@@ -175,6 +187,14 @@ export async function uploadAttachment(
 
   if (!response.ok) {
     const body = await response.text();
+    // 4xx = non-retriable validation rejection (unsupported MIME, dangerous
+    // extension, missing fields). Distinguish from transient 5xx/network errors
+    // so callers can decide whether to skip or propagate.
+    if (response.status >= 400 && response.status < 500) {
+      throw new AttachmentValidationError(
+        `Attachment rejected (${response.status}): ${body}`,
+      );
+    }
     throw new Error(`Attachment upload failed (${response.status}): ${body}`);
   }
 


### PR DESCRIPTION
## Summary

Addresses feedback from [PR #3412](https://github.com/vellum-ai/vellum-assistant/pull/3412): the attachment processing pipeline was silently dropping **all** failed attachments (via `Promise.allSettled` + filter), including transient failures like Telegram download timeouts and upload 5xx errors. This meant the webhook returned 200 and Telegram never retried the delivery.

### Changes

- **`gateway/src/runtime/client.ts`**: Added `AttachmentValidationError` class. `uploadAttachment` now throws this for 4xx responses (validation rejections like unsupported MIME type or dangerous file extension), while continuing to throw generic `Error` for 5xx/other failures.

- **`gateway/src/http/routes/telegram-webhook.ts`**: Updated the `allSettled` result handler to distinguish error types:
  - `AttachmentValidationError` → silently skipped (non-retriable, user's text message still goes through)
  - Any other error (download timeout, upload 5xx, network failure) → returns 500 so Telegram retries the webhook delivery
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
