### PR TITLE
fix: allow edit events through validation without content or attachments

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -83,7 +83,7 @@ export async function handleChannelInbound(
   const trimmedContent = typeof content === 'string' ? content.trim() : '';
   const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
 
-  if (trimmedContent.length === 0 && !hasAttachments) {
+  if (trimmedContent.length === 0 && !hasAttachments && !isEdit) {
     return Response.json({ error: 'content or attachmentIds is required' }, { status: 400 });
   }
 


### PR DESCRIPTION
## Summary

Addresses review feedback on #3419 (both Codex P1 and Devin):

When a user edits a photo/document message to remove its caption, the inbound request arrives with `content: ""` and no `attachmentIds`. The validation check at `channel-routes.ts:86` rejected these with a 400 before the edit handling code was reached.

**Fix**: Add `&& !isEdit` to the validation gate so edit events pass through even without content or attachments. The edit path at line 107+ correctly handles empty content by updating the stored message to an empty string.

## Changes

- `assistant/src/runtime/routes/channel-routes.ts`: Relaxed validation to allow edits with empty content and no attachments
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
