### PR TITLE
fix: restrict retry button to send failures and preserve queue bookkeeping

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1750,4 +1750,121 @@ final class ChatViewModelTests: XCTestCase {
         // Legacy fallback: tools before text
         XCTAssertEqual(msg.contentOrder, [.toolCall(0), .text(0)])
     }
+
+    // MARK: - Retry Button Visibility (Send-Only Errors)
+
+    func testIsRetryableErrorRequiresSendFailure() {
+        // A non-send error (e.g. confirmation failure) should NOT make the
+        // retry button visible even if lastFailedMessageText is cached from
+        // a prior send failure.
+        viewModel.sessionId = "sess-1"
+
+        // Simulate a prior send failure that cached the message
+        viewModel.inputText = "Hello"
+        daemonClient.isConnected = false
+        viewModel.sendMessage()
+        XCTAssertTrue(viewModel.isRetryableError,
+                       "Send failure should make error retryable")
+
+        // User dismisses the error
+        viewModel.dismissError()
+        XCTAssertFalse(viewModel.isRetryableError)
+
+        // Now a non-send error occurs (e.g. confirmation response failure)
+        daemonClient.isConnected = true
+        viewModel.errorText = "Failed to send confirmation response."
+        XCTAssertFalse(viewModel.isRetryableError,
+                        "Non-send error should not show retry button")
+    }
+
+    func testRetryButtonAppearsOnlySendFailures() {
+        viewModel.sessionId = "sess-1"
+        daemonClient.isConnected = false
+
+        viewModel.inputText = "Test message"
+        viewModel.sendMessage()
+
+        // Send failure should set both lastFailedSendError and lastFailedMessageText
+        XCTAssertTrue(viewModel.isRetryableError,
+                       "Send failure should show retry button")
+        XCTAssertNotNil(viewModel.errorText)
+    }
+
+    func testRetryButtonNotShownForRegenerateFailure() {
+        viewModel.sessionId = "sess-1"
+        daemonClient.isConnected = false
+
+        // First, simulate a send failure to cache a message
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        XCTAssertTrue(viewModel.isRetryableError)
+
+        // Now dismiss and reconnect
+        viewModel.dismissError()
+        daemonClient.isConnected = true
+
+        // Regenerate failure sets errorText but should not trigger retry
+        // for the old cached message
+        viewModel.regenerateLastMessage()
+        // regenerateLastMessage() will fail in the catch block setting errorText
+        // but lastFailedSendError is already nil from dismissError()
+        XCTAssertFalse(viewModel.isRetryableError,
+                        "Regenerate failure should not offer to retry a stale send")
+    }
+
+    // MARK: - Retry Queue Bookkeeping
+
+    func testRetryWhileSendingTracksMessageInQueue() {
+        viewModel.sessionId = "sess-1"
+
+        // Send message A successfully
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        XCTAssertTrue(viewModel.isSending)
+
+        // Simulate a send failure for message B (disconnect, then reconnect)
+        daemonClient.isConnected = false
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+        // Message B is in messages[1] but failed to send
+        XCTAssertNotNil(viewModel.lastFailedMessageText)
+        XCTAssertEqual(viewModel.messages.count, 2)
+
+        // Reconnect and retry while A is still in progress
+        daemonClient.isConnected = true
+        viewModel.isSending = true  // A is still in progress
+        viewModel.retryLastMessage()
+
+        // The retried message should be tracked in pendingMessageIds
+        XCTAssertEqual(viewModel.pendingMessageIds.count, 1,
+                        "Retried message should be tracked in pendingMessageIds")
+        XCTAssertEqual(viewModel.pendingMessageIds.first, viewModel.messages[1].id,
+                        "Pending message ID should match the retried message")
+
+        // The message should have queued status
+        if case .queued = viewModel.messages[1].status {
+            // expected
+        } else {
+            XCTFail("Retried message should have queued status when another send is in progress")
+        }
+    }
+
+    func testRetryWhenNotSendingDoesNotTrackInQueue() {
+        viewModel.sessionId = "sess-1"
+
+        // Send a message that fails
+        daemonClient.isConnected = false
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        XCTAssertNotNil(viewModel.lastFailedMessageText)
+
+        // Reconnect and retry when NOT sending (no active turn)
+        daemonClient.isConnected = true
+        viewModel.isSending = false
+        viewModel.retryLastMessage()
+
+        // Should not be tracked in pendingMessageIds since it's sent directly
+        XCTAssertEqual(viewModel.pendingMessageIds.count, 0,
+                        "Retried message should not be tracked when no other send is in progress")
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -60,6 +60,11 @@ public final class ChatViewModel: ObservableObject {
     /// Stores the last user message that failed to send, enabling retry.
     private(set) var lastFailedMessageText: String?
     private(set) var lastFailedMessageAttachments: [IPCAttachment]?
+    /// Set only when a send operation (bootstrapSession or sendUserMessage) fails.
+    /// Used by `isRetryableError` to ensure the retry button only appears for
+    /// actual send failures, not for unrelated errors (attachment validation,
+    /// confirmation response failures, regenerate errors, etc.).
+    private(set) var lastFailedSendError: String?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?
@@ -202,6 +207,7 @@ public final class ChatViewModel: ObservableObject {
         sessionError = nil
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
+        lastFailedSendError = nil
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
@@ -239,9 +245,10 @@ public final class ChatViewModel: ObservableObject {
                     self.bootstrapCorrelationId = nil
                     self.lastFailedMessageText = self.pendingUserMessage
                     self.lastFailedMessageAttachments = self.pendingUserAttachments
+                    self.lastFailedSendError = "Cannot connect to daemon. Please ensure it's running."
                     self.pendingUserMessage = nil
                     self.pendingUserAttachments = nil
-                    self.errorText = "Cannot connect to daemon. Please ensure it's running."
+                    self.errorText = self.lastFailedSendError
                     return
                 }
             }
@@ -259,9 +266,10 @@ public final class ChatViewModel: ObservableObject {
                 self.bootstrapCorrelationId = nil
                 self.lastFailedMessageText = self.pendingUserMessage
                 self.lastFailedMessageAttachments = self.pendingUserAttachments
+                self.lastFailedSendError = "Failed to create session."
                 self.pendingUserMessage = nil
                 self.pendingUserAttachments = nil
-                self.errorText = "Failed to create session."
+                self.errorText = self.lastFailedSendError
             }
         }
     }
@@ -276,7 +284,8 @@ public final class ChatViewModel: ObservableObject {
             log.error("Cannot send user_message: daemon not connected")
             lastFailedMessageText = text
             lastFailedMessageAttachments = attachments
-            errorText = "Cannot connect to daemon. Please ensure it's running."
+            lastFailedSendError = "Cannot connect to daemon. Please ensure it's running."
+            errorText = lastFailedSendError
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
                 pendingMessageIds.removeAll { $0 == queuedMessageId }
@@ -306,7 +315,8 @@ public final class ChatViewModel: ObservableObject {
             isThinking = false
             lastFailedMessageText = text
             lastFailedMessageAttachments = attachments
-            errorText = "Failed to send message."
+            lastFailedSendError = "Failed to send message."
+            errorText = lastFailedSendError
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
                 pendingMessageIds.removeAll { $0 == queuedMessageId }
@@ -566,6 +576,7 @@ public final class ChatViewModel: ObservableObject {
         errorText = nil
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
+        lastFailedSendError = nil
     }
 
     /// Dismiss the typed session error state. Clears both the typed error
@@ -617,8 +628,12 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Whether the current error has a failed user message that can be retried.
+    /// Only true when `lastFailedSendError` is set, which restricts the retry
+    /// button to actual send failures and prevents unrelated errors (attachment
+    /// validation, confirmation response failures, regenerate errors) from
+    /// offering to resend a stale cached message.
     public var isRetryableError: Bool {
-        lastFailedMessageText != nil && errorText != nil
+        lastFailedMessageText != nil && lastFailedSendError != nil
     }
 
     /// Retry sending the last user message that failed (e.g. due to daemon disconnection).
@@ -629,12 +644,29 @@ public final class ChatViewModel: ObservableObject {
         // Clear failed message state and error
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
+        lastFailedSendError = nil
         errorText = nil
 
         if sessionId == nil {
             bootstrapSession(userMessage: text, attachments: attachments)
         } else {
-            sendUserMessage(text, attachments: attachments)
+            // When retrying while another turn is in progress, the retried
+            // message will be queued by the daemon. Track it in
+            // pendingMessageIds so subsequent messageQueued/messageDequeued
+            // events can update the user message's status correctly.
+            var queuedMessageId: UUID?
+            if isSending {
+                // Find the user message that corresponds to the failed text
+                // (it was already appended to messages[] during the original
+                // sendMessage() call). Use the last user message with matching
+                // text as the queue entry.
+                if let idx = messages.lastIndex(where: { $0.role == .user && $0.text == text }) {
+                    pendingMessageIds.append(messages[idx].id)
+                    queuedMessageId = messages[idx].id
+                    messages[idx].status = .queued(position: 0)
+                }
+            }
+            sendUserMessage(text, attachments: attachments, queuedMessageId: queuedMessageId)
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses code review feedback from Codex on PR #3422 (retry button for failed message sends):

1. **Preserve queue bookkeeping when retrying** (P2): When `retryLastMessage()` is called while another turn is in progress (`isSending == true`), the retried message is now tracked in `pendingMessageIds` and given `.queued` status. This ensures subsequent `messageQueued`/`messageDequeued` events from the daemon can correctly update the user message's status in the UI.

2. **Restrict retry visibility to actual send failures** (P2): Added `lastFailedSendError` flag that is only set when a send operation (`bootstrapSession` or `sendUserMessage`) specifically fails. The `isRetryableError` computed property now checks this flag instead of the generic `errorText`, preventing unrelated errors (confirmation response failures, regenerate failures, attachment validation) from showing a Retry button that would resend an older cached message.

## Modified Files

- `clients/shared/Features/Chat/ChatViewModel.swift` — Added `lastFailedSendError` property, updated `isRetryableError` to use it, enhanced `retryLastMessage()` with queue tracking
- `clients/macos/vellum-assistantTests/ChatViewModelTests.swift` — Added 5 tests covering retry button visibility and queue bookkeeping

## Test Plan

- [x] Library builds successfully (`swift build`)
- [x] New tests verify retry button only appears for send failures
- [x] New tests verify retried messages are tracked in pendingMessageIds when another send is active
- [x] New tests verify no queue tracking when retrying with no active send
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
