### PR TITLE
fix: only clear embedding backend cache when config changes

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -327,12 +327,12 @@ export class DaemonServer {
    */
   private refreshConfigFromSources(): boolean {
     invalidateConfigCache();
-    clearEmbeddingBackendCache();
     const config = getConfig();
     const fingerprint = this.configFingerprint(config);
     if (fingerprint === this.lastConfigFingerprint) {
       return false;
     }
+    clearEmbeddingBackendCache();
     const isFirstInit = this.lastConfigFingerprint === '';
     initializeProviders(config);
     this.lastConfigFingerprint = fingerprint;


### PR DESCRIPTION
## Summary

Moves `clearEmbeddingBackendCache()` after the config fingerprint comparison in `refreshConfigFromSources()`, so cached embedding backends are only destroyed when the config has actually changed.

Previously, `clearEmbeddingBackendCache()` was called before the fingerprint check, meaning every periodic config refresh (~every 30 seconds via `dispatchMessage`) would destroy all cached embedding backend instances — even when the config was unchanged. This is especially costly for `LocalEmbeddingBackend`, which lazily initializes an ONNX model pipeline.

Addresses review feedback on #3413.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
