### PR TITLE
fix: return 409 when deleting attachment still referenced by messages

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -135,31 +135,31 @@ describe('uploadAttachment', () => {
 describe('deleteAttachment', () => {
   beforeEach(resetTables);
 
-  test('deletes existing attachment and returns true', () => {
+  test('deletes existing attachment and returns deleted', () => {
     const stored = uploadAttachment('ast-1', 'file.txt', 'text/plain', 'dGVzdA==');
     const result = deleteAttachment('ast-1', stored.id);
-    expect(result).toBe(true);
+    expect(result).toBe('deleted');
 
     const fetched = getAttachmentById('ast-1', stored.id);
     expect(fetched).toBeNull();
   });
 
-  test('returns false for nonexistent attachment', () => {
+  test('returns not_found for nonexistent attachment', () => {
     const result = deleteAttachment('ast-1', 'nonexistent-id');
-    expect(result).toBe(false);
+    expect(result).toBe('not_found');
   });
 
-  test('returns false when assistantId does not match', () => {
+  test('returns not_found when assistantId does not match', () => {
     const stored = uploadAttachment('ast-owner', 'file.txt', 'text/plain', 'dGVzdA==');
     const result = deleteAttachment('ast-other', stored.id);
-    expect(result).toBe(false);
+    expect(result).toBe('not_found');
 
     // Original still exists
     const fetched = getAttachmentById('ast-owner', stored.id);
     expect(fetched).not.toBeNull();
   });
 
-  test('preserves shared attachment when other messages still reference it', () => {
+  test('returns still_referenced when messages reference the attachment', () => {
     const conv = createConversation();
     const msg1 = addMessage(conv.id, 'user', 'First upload');
     const msg2 = addMessage(conv.id, 'user', 'Duplicate upload');
@@ -172,9 +172,9 @@ describe('deleteAttachment', () => {
     linkAttachmentToMessage(msg1.id, first.id, 0);
     linkAttachmentToMessage(msg2.id, second.id, 0);
 
-    // Delete should succeed but NOT remove the attachment row
+    // Delete should return still_referenced and NOT remove the attachment row
     const result = deleteAttachment('ast-1', first.id);
-    expect(result).toBe(true);
+    expect(result).toBe('still_referenced');
 
     // Attachment row still exists because messages reference it
     const fetched = getAttachmentById('ast-1', first.id);
@@ -191,7 +191,7 @@ describe('deleteAttachment', () => {
     const stored = uploadAttachment('ast-1', 'lonely.txt', 'text/plain', 'UNREFERENCED');
     // No linkAttachmentToMessage call — zero references
     const result = deleteAttachment('ast-1', stored.id);
-    expect(result).toBe(true);
+    expect(result).toBe('deleted');
 
     const fetched = getAttachmentById('ast-1', stored.id);
     expect(fetched).toBeNull();

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -181,7 +181,9 @@ export function uploadAttachment(
   };
 }
 
-export function deleteAttachment(assistantId: string, attachmentId: string): boolean {
+export type DeleteAttachmentResult = 'deleted' | 'not_found' | 'still_referenced';
+
+export function deleteAttachment(assistantId: string, attachmentId: string): DeleteAttachmentResult {
   const db = getDb();
   const existing = db
     .select({ id: attachments.id })
@@ -194,7 +196,7 @@ export function deleteAttachment(assistantId: string, attachmentId: string): boo
     )
     .get();
 
-  if (!existing) return false;
+  if (!existing) return 'not_found';
 
   // With content-hash deduplication, multiple messages may reference the same
   // attachment row. Only delete the attachment (and cascade its links) when no
@@ -206,13 +208,13 @@ export function deleteAttachment(assistantId: string, attachmentId: string): boo
     .all()
     .length;
 
-  if (refCount === 0) {
-    db.delete(attachments)
-      .where(eq(attachments.id, attachmentId))
-      .run();
-  }
+  if (refCount > 0) return 'still_referenced';
 
-  return true;
+  db.delete(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .run();
+
+  return 'deleted';
 }
 
 export function getAttachmentsByIds(

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -78,12 +78,19 @@ export async function handleDeleteAttachment(assistantId: string, req: Request):
     );
   }
 
-  const deleted = attachmentsStore.deleteAttachment(assistantId, attachmentId);
+  const result = attachmentsStore.deleteAttachment(assistantId, attachmentId);
 
-  if (!deleted) {
+  if (result === 'not_found') {
     return Response.json(
       { error: 'Attachment not found' },
       { status: 404 },
+    );
+  }
+
+  if (result === 'still_referenced') {
+    return Response.json(
+      { error: 'Attachment is still referenced by one or more messages' },
+      { status: 409 },
     );
   }
 


### PR DESCRIPTION
## Summary

- `deleteAttachment` previously returned `true` even when the attachment had `message_attachments` references and was not actually deleted, causing the HTTP handler to return 204 (misleading the client into thinking deletion succeeded).
- Changed `deleteAttachment` return type from `boolean` to a discriminated string union (`'deleted' | 'not_found' | 'still_referenced'`) for explicit semantics.
- Updated the route handler to return **409 Conflict** with an error message when the attachment is still referenced by messages.
- Updated all existing tests to match the new return value semantics.

Addresses review feedback from PR #3416.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
