### PR TITLE
fix: bypass dedup cache for transient attachment 500 responses

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -202,8 +202,11 @@ export function createTelegramWebhookHandler(
         }
       } catch (err) {
         // Transient attachment failure — return 500 so Telegram retries.
+        // Use Response.json() instead of respond() to bypass the dedup cache,
+        // otherwise the cached 500 prevents Telegram retries from being processed.
         log.error({ err }, "Attachment processing failed with transient error");
-        return respond({ error: "Attachment processing failed" }, 500);
+        if (updateId !== undefined) dedupCache.unreserve(updateId);
+        return Response.json({ error: "Attachment processing failed" }, { status: 500 });
       }
     }
 


### PR DESCRIPTION
## Summary
- Uses `Response.json()` instead of `respond()` for transient attachment failures so the 500 response isn't cached in the dedup cache
- Calls `dedupCache.unreserve()` to clear the reservation, matching the pattern used by other 500 error paths (lines 248-249, 256-257)
- This allows Telegram to retry the webhook delivery successfully when the transient error clears

Addresses feedback from codex and devin on #3432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
