### PR TITLE
fix: reject edit requests missing sourceMetadata.messageId

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -103,6 +103,10 @@ export async function handleChannelInbound(
     ? sourceMetadata.messageId
     : undefined;
 
+  if (isEdit && !sourceMessageId) {
+    return Response.json({ error: 'sourceMetadata.messageId is required for edits' }, { status: 400 });
+  }
+
   // ── Edit path: update existing message content, no new agent loop ──
   if (isEdit && sourceMessageId) {
     // Dedup the edit event itself (retried edited_message webhooks)


### PR DESCRIPTION
## Summary
Adds a guard to reject isEdit requests that lack sourceMetadata.messageId, preventing them from falling through to the new-message path with empty content. This tightens the validation relaxation from #3433 to only allow edits with a valid source message reference.

Addresses feedback from codex and devin on #3433 and #3437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
