### PR TITLE
fix: send auth_result for auto-authenticated sockets

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -491,6 +491,7 @@ export class DaemonServer {
     if (hasSocketOverride()) {
       this.authenticatedSockets.add(socket);
       log.info('Auto-authenticated client on overridden socket path');
+      this.send(socket, { type: 'auth_result', success: true });
       this.sendInitialSession(socket).catch((err) => {
         log.error({ err }, 'Failed to send initial session info after auto-auth');
       });
@@ -576,6 +577,14 @@ export class DaemonServer {
           this.send(socket, { type: 'error', message: 'Authentication required' });
           socket.destroy();
           return;
+        }
+
+        // If an already-authenticated socket sends an auth message (e.g.
+        // auto-auth'd client that also has a local token), respond with
+        // auth_result so the client doesn't hang waiting for the handshake.
+        if (result.message.type === 'auth') {
+          this.send(socket, { type: 'auth_result', success: true });
+          continue;
         }
 
         this.dispatchMessage(result.message, socket);


### PR DESCRIPTION
## Summary
When `hasSocketOverride()` auto-authenticates a connection, the server now sends `auth_result` so clients with session tokens don't hang waiting for the auth handshake. Also handles the case where an already-authenticated socket sends an `auth` message by responding with `auth_result` instead of silently dropping it.

Addresses feedback from codex and devin on #3431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
