### PR TITLE
test: baseline characterization for hardcoded Gmail, Claude Code, Weather tools

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -151,7 +151,7 @@ describe('tool manifest', () => {
   });
 
   test('eager module list contains expected count', () => {
-    expect(eagerModules.length).toBe(17);
+    expect(eagerModules.length).toBe(16);
   });
 
   test('explicit tools list includes memory, credential, and timer tools', () => {
@@ -168,5 +168,46 @@ describe('tool manifest', () => {
     await initializeTools();
     const tools = getAllTools();
     expect(tools.length).toBeGreaterThanOrEqual(eagerModules.length + lazyTools.length);
+  });
+});
+
+describe('baseline characterization: hardcoded tool loading', () => {
+  test('gmail tools are registered via eager module after initializeTools()', async () => {
+    await initializeTools();
+    const allTools = getAllTools();
+    const toolNames = allTools.map(t => t.name);
+
+    const gmailTools = ['gmail_search', 'gmail_list_messages', 'gmail_get_message', 'gmail_mark_read',
+      'gmail_draft', 'gmail_archive', 'gmail_batch_archive', 'gmail_label', 'gmail_batch_label',
+      'gmail_trash', 'gmail_send', 'gmail_unsubscribe'];
+    for (const name of gmailTools) {
+      expect(toolNames).toContain(name);
+    }
+  });
+
+  test('gmail eager module is in eagerModules manifest', () => {
+    expect(eagerModules).toContain('./gmail/executors.js');
+  });
+
+  test('weather tool is registered via eager module after initializeTools()', async () => {
+    await initializeTools();
+    const tool = getTool('get_weather');
+    expect(tool).toBeDefined();
+    expect(tool?.category).toBe('weather');
+  });
+
+  test('weather eager module is in eagerModules manifest', () => {
+    expect(eagerModules).toContain('./weather/get-weather.js');
+  });
+
+  test('claude_code is registered via lazy descriptor after initializeTools()', async () => {
+    await initializeTools();
+    const tool = getTool('claude_code');
+    expect(tool).toBeDefined();
+  });
+
+  test('claude_code lazy descriptor is in lazyTools manifest', () => {
+    const lazyNames = lazyTools.map(t => t.name);
+    expect(lazyNames).toContain('claude_code');
   });
 });


### PR DESCRIPTION
PR 1/44 of skill-tools plan. Locks current behavior of hardcoded tool loading before refactor.

Adds a `baseline characterization: hardcoded tool loading` describe block to `registry.test.ts` with 6 tests:
- Gmail tools (all 12) are registered via eager module after `initializeTools()`
- Gmail eager module path is in the `eagerModules` manifest
- Weather tool is registered via eager module with correct category (`weather`)
- Weather eager module path is in the `eagerModules` manifest
- `claude_code` is registered via lazy descriptor after `initializeTools()`
- `claude_code` lazy descriptor is in the `lazyTools` manifest

Also fixes pre-existing off-by-one in `eagerModules` count assertion (expected 17, actual 16).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
