### PR TITLE
fix: revert queued status when retry send fails

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1616,8 +1616,8 @@ final class ChatViewModelTests: XCTestCase {
             data: "iVBORw0KGgo=", extractedText: nil
         )
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
-            IPCHistoryResponseMessage(role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil),
-            IPCHistoryResponseMessage(role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment]),
+            IPCHistoryResponseMessage(id: nil, role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil),
+            IPCHistoryResponseMessage(id: nil, role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil),
         ]
 
         viewModel.populateFromHistory(historyItems)
@@ -1635,7 +1635,7 @@ final class ChatViewModelTests: XCTestCase {
             data: "JVBER", extractedText: nil
         )
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
-            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment]),
+            IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil),
         ]
 
         viewModel.populateFromHistory(historyItems)
@@ -1649,7 +1649,7 @@ final class ChatViewModelTests: XCTestCase {
 
     func testPopulateFromHistorySkipsEmptyMessagesWithNoAttachments() {
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
-            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil),
+            IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil),
         ]
 
         viewModel.populateFromHistory(historyItems)
@@ -1711,6 +1711,7 @@ final class ChatViewModelTests: XCTestCase {
         let toolCall = IPCHistoryResponseToolCall(name: "memory_save", input: ["key": AnyCodable("task")], result: "saved", isError: nil, imageData: nil)
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
             IPCHistoryResponseMessage(
+                id: nil,
                 role: "assistant",
                 text: "What are you working on?Saved that to memory.",
                 timestamp: 1000,
@@ -1718,7 +1719,8 @@ final class ChatViewModelTests: XCTestCase {
                 toolCallsBeforeText: nil,
                 attachments: nil,
                 textSegments: ["What are you working on?", "Saved that to memory."],
-                contentOrder: ["text:0", "tool:0", "text:1"]
+                contentOrder: ["text:0", "tool:0", "text:1"],
+                surfaces: nil
             ),
         ]
 
@@ -1734,12 +1736,16 @@ final class ChatViewModelTests: XCTestCase {
         let toolCall = IPCHistoryResponseToolCall(name: "bash", input: ["command": AnyCodable("ls")], result: "file.txt", isError: nil, imageData: nil)
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
             IPCHistoryResponseMessage(
+                id: nil,
                 role: "assistant",
                 text: "Here are the files.",
                 timestamp: 1000,
                 toolCalls: [toolCall],
                 toolCallsBeforeText: true,
-                attachments: nil
+                attachments: nil,
+                textSegments: nil,
+                contentOrder: nil,
+                surfaces: nil
             ),
         ]
 
@@ -1847,6 +1853,64 @@ final class ChatViewModelTests: XCTestCase {
         } else {
             XCTFail("Retried message should have queued status when another send is in progress")
         }
+    }
+
+    func testRetryWhileSendingRevertsQueuedStatusOnDisconnect() {
+        viewModel.sessionId = "sess-1"
+
+        // Send message A successfully
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        XCTAssertTrue(viewModel.isSending)
+
+        // Send message B which fails (disconnect)
+        daemonClient.isConnected = false
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messages.count, 2)
+
+        // Reconnect and retry while A is still in progress
+        daemonClient.isConnected = true
+        viewModel.isSending = true
+
+        // Now disconnect again so the retry fails at the connectivity check
+        daemonClient.isConnected = false
+        viewModel.retryLastMessage()
+
+        // The message status should be reverted from .queued back to .sent
+        XCTAssertEqual(viewModel.messages[1].status, .sent,
+                        "Queued status should be reverted to .sent when retry send fails due to disconnect")
+        // pendingMessageIds should be cleaned up
+        XCTAssertEqual(viewModel.pendingMessageIds.count, 0,
+                        "pendingMessageIds should be cleaned up on retry failure")
+    }
+
+    func testRetryWhileSendingRevertsQueuedStatusOnSendThrow() {
+        viewModel.sessionId = "sess-1"
+
+        // Send message A successfully
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        XCTAssertTrue(viewModel.isSending)
+
+        // Send message B which fails (disconnect)
+        daemonClient.isConnected = false
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messages.count, 2)
+
+        // Reconnect and retry while A is still in progress, but make send throw
+        daemonClient.isConnected = true
+        viewModel.isSending = true
+        daemonClient.sendOverride = { _ in throw NSError(domain: "test", code: 1) }
+        viewModel.retryLastMessage()
+
+        // The message status should be reverted from .queued back to .sent
+        XCTAssertEqual(viewModel.messages[1].status, .sent,
+                        "Queued status should be reverted to .sent when retry send throws")
+        // pendingMessageIds should be cleaned up
+        XCTAssertEqual(viewModel.pendingMessageIds.count, 0,
+                        "pendingMessageIds should be cleaned up on retry send failure")
     }
 
     func testRetryWhenNotSendingDoesNotTrackInQueue() {

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -51,6 +51,10 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
     func isSessionArchived(_ sessionId: String) -> Bool {
         archivedSessionIds.contains(sessionId)
     }
+
+    func restoreLastActiveThread() {
+        // no-op for tests
+    }
 }
 
 // MARK: - Helpers

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -289,6 +289,10 @@ public final class ChatViewModel: ObservableObject {
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
                 pendingMessageIds.removeAll { $0 == queuedMessageId }
+                // Revert status so the message doesn't appear permanently queued
+                if let idx = messages.firstIndex(where: { $0.id == queuedMessageId }) {
+                    messages[idx].status = .sent
+                }
             }
             return
         }
@@ -320,6 +324,10 @@ public final class ChatViewModel: ObservableObject {
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
                 pendingMessageIds.removeAll { $0 == queuedMessageId }
+                // Revert status so the message doesn't appear permanently queued
+                if let idx = messages.firstIndex(where: { $0.id == queuedMessageId }) {
+                    messages[idx].status = .sent
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
When `sendUserMessage` fails during a retry while another turn is active, the message status is now reverted from `.queued` back to `.sent`. Previously only `pendingMessageIds` was cleaned up, leaving the message permanently showing as "queued" in the UI.

- Added status reversion in both error paths of `sendUserMessage` (daemon disconnected and send throws)
- Added two new tests covering both failure scenarios
- Fixed pre-existing test compilation issues (missing mock method and updated init params)

Addresses feedback from codex on #3434.

## Test plan
- [x] `testRetryWhileSendingRevertsQueuedStatusOnDisconnect` — verifies status reverts when daemon is disconnected
- [x] `testRetryWhileSendingRevertsQueuedStatusOnSendThrow` — verifies status reverts when send throws
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
