### PR TITLE
feat: add skill tool manifest types (no runtime behavior)

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -51,6 +51,8 @@ export interface SkillSummary {
   disableModelInvocation: boolean;
   source: SkillSource;
   metadata?: VellumMetadata;
+  /** Parsed tool manifest metadata, if the skill has a valid TOOLS.json. */
+  toolManifest?: SkillToolManifestMeta;
 }
 
 export interface SkillDefinition extends SkillSummary {
@@ -65,6 +67,52 @@ export interface SkillLookupResult {
 export interface SkillSelectorResult {
   skill?: SkillSummary;
   error?: string;
+}
+
+// ─── Skill Tool Manifest Types ────────────────────────────────────────────────
+
+/**
+ * Schema for a skill's TOOLS.json manifest file.
+ * Declares which tools a skill provides and how they should be executed.
+ */
+export interface SkillToolManifest {
+  version: 1;
+  tools: SkillToolEntry[];
+}
+
+/**
+ * A single tool entry within a skill's TOOLS.json manifest.
+ */
+export interface SkillToolEntry {
+  /** Unique tool name (must not collide with core tool names). */
+  name: string;
+  /** Human-readable description shown to the model. */
+  description: string;
+  /** Tool category for grouping/display. */
+  category: string;
+  /** Default risk level for permission checks. */
+  risk: 'low' | 'medium' | 'high';
+  /** JSON Schema for the tool's input parameters. */
+  input_schema: Record<string, unknown>;
+  /** Relative path to the executor script within the skill directory. */
+  executor: string;
+  /** Where the tool script runs. */
+  execution_target: 'host' | 'sandbox';
+}
+
+/**
+ * Lightweight metadata about a skill's tool manifest, attached to SkillSummary
+ * without loading the full manifest at catalog time.
+ */
+export interface SkillToolManifestMeta {
+  /** Whether the skill has a TOOLS.json file. */
+  present: boolean;
+  /** Whether the manifest parsed successfully. */
+  valid: boolean;
+  /** Number of tools declared in the manifest (0 if invalid). */
+  toolCount: number;
+  /** Tool names declared in the manifest (empty if invalid). */
+  toolNames: string[];
 }
 
 // ─── Requirements check ──────────────────────────────────────────────────────


### PR DESCRIPTION
PR 3/44 of skill-tools plan. Introduces TypeScript contracts for skill-local tool manifests without any runtime behavior changes.

## Changes

- `SkillToolManifest`: schema for a skill's `TOOLS.json` manifest file (version + tools array)
- `SkillToolEntry`: individual tool declaration (name, description, category, risk level, input schema, executor path, execution target)
- `SkillToolManifestMeta`: lightweight metadata (present, valid, toolCount, toolNames) attached to `SkillSummary` at catalog time
- Adds optional `toolManifest` field to the existing `SkillSummary` interface

All existing tests pass unchanged — the new field is optional, so no existing code is affected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
