### PR TITLE
feat: add TOOLS.json parser for skill tool manifests

### DIFF
--- a/assistant/src/__tests__/skill-tool-manifest.test.ts
+++ b/assistant/src/__tests__/skill-tool-manifest.test.ts
@@ -1,0 +1,205 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseToolManifest, parseToolManifestFile } from '../skills/tool-manifest.js';
+import type { SkillToolManifest } from '../config/skills.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToolEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'test-tool',
+    description: 'A test tool',
+    category: 'testing',
+    risk: 'low',
+    input_schema: { type: 'object', properties: {} },
+    executor: 'tools/run.ts',
+    execution_target: 'host',
+    ...overrides,
+  };
+}
+
+function makeManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    tools: [makeToolEntry()],
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'skill-tool-manifest-test-'));
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// parseToolManifest — happy path
+// ---------------------------------------------------------------------------
+
+describe('parseToolManifest', () => {
+  test('parses a valid manifest with one tool', () => {
+    const raw = makeManifest();
+    const result = parseToolManifest(raw);
+
+    expect(result.version).toBe(1);
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe('test-tool');
+    expect(result.tools[0].description).toBe('A test tool');
+    expect(result.tools[0].category).toBe('testing');
+    expect(result.tools[0].risk).toBe('low');
+    expect(result.tools[0].input_schema).toEqual({ type: 'object', properties: {} });
+    expect(result.tools[0].executor).toBe('tools/run.ts');
+    expect(result.tools[0].execution_target).toBe('host');
+  });
+
+  test('preserves all fields exactly', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'The URL to fetch' },
+        timeout: { type: 'number', description: 'Timeout in ms' },
+      },
+      required: ['url'],
+    };
+    const raw = makeManifest({
+      tools: [makeToolEntry({
+        name: 'web-fetch',
+        description: 'Fetch content from a URL',
+        category: 'network',
+        risk: 'medium',
+        input_schema: schema,
+        executor: 'tools/web-fetch.ts',
+        execution_target: 'sandbox',
+      })],
+    });
+
+    const result = parseToolManifest(raw);
+    const tool = result.tools[0];
+
+    expect(tool.name).toBe('web-fetch');
+    expect(tool.description).toBe('Fetch content from a URL');
+    expect(tool.category).toBe('network');
+    expect(tool.risk).toBe('medium');
+    expect(tool.input_schema).toEqual(schema);
+    expect(tool.executor).toBe('tools/web-fetch.ts');
+    expect(tool.execution_target).toBe('sandbox');
+  });
+
+  test('parses a manifest with multiple tools', () => {
+    const raw = makeManifest({
+      tools: [
+        makeToolEntry({ name: 'tool-a', risk: 'low' }),
+        makeToolEntry({ name: 'tool-b', risk: 'medium' }),
+        makeToolEntry({ name: 'tool-c', risk: 'high' }),
+      ],
+    });
+
+    const result = parseToolManifest(raw);
+    expect(result.tools).toHaveLength(3);
+    expect(result.tools.map((t) => t.name)).toEqual(['tool-a', 'tool-b', 'tool-c']);
+    expect(result.tools.map((t) => t.risk)).toEqual(['low', 'medium', 'high']);
+  });
+
+  test('accepts executor with ./ prefix', () => {
+    const raw = makeManifest({
+      tools: [makeToolEntry({ executor: './tools/run.ts' })],
+    });
+
+    const result = parseToolManifest(raw);
+    expect(result.tools[0].executor).toBe('./tools/run.ts');
+  });
+
+  test('accepts deeply nested executor paths', () => {
+    const raw = makeManifest({
+      tools: [makeToolEntry({ executor: 'src/tools/impl/run.ts' })],
+    });
+
+    const result = parseToolManifest(raw);
+    expect(result.tools[0].executor).toBe('src/tools/impl/run.ts');
+  });
+
+  test('accepts all valid risk levels', () => {
+    for (const risk of ['low', 'medium', 'high'] as const) {
+      const raw = makeManifest({
+        tools: [makeToolEntry({ name: `tool-${risk}`, risk })],
+      });
+      const result = parseToolManifest(raw);
+      expect(result.tools[0].risk).toBe(risk);
+    }
+  });
+
+  test('accepts both execution targets', () => {
+    for (const target of ['host', 'sandbox'] as const) {
+      const raw = makeManifest({
+        tools: [makeToolEntry({ name: `tool-${target}`, execution_target: target })],
+      });
+      const result = parseToolManifest(raw);
+      expect(result.tools[0].execution_target).toBe(target);
+    }
+  });
+
+  test('accepts an empty input_schema object', () => {
+    const raw = makeManifest({
+      tools: [makeToolEntry({ input_schema: {} })],
+    });
+
+    const result = parseToolManifest(raw);
+    expect(result.tools[0].input_schema).toEqual({});
+  });
+
+  test('returns a typed SkillToolManifest', () => {
+    const raw = makeManifest();
+    const result: SkillToolManifest = parseToolManifest(raw);
+
+    // Type assertion is the test — if this compiles, the return type is correct
+    expect(result).toBeDefined();
+    expect(result.version).toBe(1);
+    expect(Array.isArray(result.tools)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseToolManifestFile — happy path
+// ---------------------------------------------------------------------------
+
+describe('parseToolManifestFile', () => {
+  test('reads and parses a valid TOOLS.json file', async () => {
+    const manifest = makeManifest({
+      tools: [
+        makeToolEntry({ name: 'file-tool', executor: 'tools/file.ts' }),
+      ],
+    });
+    const filePath = join(tempDir, 'valid-TOOLS.json');
+    await writeFile(filePath, JSON.stringify(manifest, null, 2), 'utf-8');
+
+    const result = parseToolManifestFile(filePath);
+    expect(result.version).toBe(1);
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe('file-tool');
+    expect(result.tools[0].executor).toBe('tools/file.ts');
+  });
+
+  test('parses a file with multiple tools', async () => {
+    const manifest = makeManifest({
+      tools: [
+        makeToolEntry({ name: 'alpha', risk: 'low', execution_target: 'host' }),
+        makeToolEntry({ name: 'beta', risk: 'high', execution_target: 'sandbox' }),
+      ],
+    });
+    const filePath = join(tempDir, 'multi-TOOLS.json');
+    await writeFile(filePath, JSON.stringify(manifest), 'utf-8');
+
+    const result = parseToolManifestFile(filePath);
+    expect(result.tools).toHaveLength(2);
+    expect(result.tools[0].name).toBe('alpha');
+    expect(result.tools[1].name).toBe('beta');
+  });
+});

--- a/assistant/src/skills/tool-manifest.ts
+++ b/assistant/src/skills/tool-manifest.ts
@@ -1,0 +1,165 @@
+import { readFileSync } from 'node:fs';
+import type { SkillToolManifest, SkillToolEntry } from '../config/skills.js';
+
+const VALID_RISK_LEVELS = new Set(['low', 'medium', 'high']);
+const VALID_EXECUTION_TARGETS = new Set(['host', 'sandbox']);
+
+/**
+ * Parse and validate a raw TOOLS.json payload into a typed SkillToolManifest.
+ * Throws descriptive errors for any validation failure.
+ */
+export function parseToolManifest(raw: unknown): SkillToolManifest {
+  if (raw === null || raw === undefined || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('TOOLS.json must be a JSON object');
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // Validate version
+  if (!('version' in obj)) {
+    throw new Error('TOOLS.json is missing required field "version"');
+  }
+  if (obj.version !== 1) {
+    throw new Error(`TOOLS.json "version" must be 1, got: ${JSON.stringify(obj.version)}`);
+  }
+
+  // Validate tools array
+  if (!('tools' in obj)) {
+    throw new Error('TOOLS.json is missing required field "tools"');
+  }
+  if (!Array.isArray(obj.tools)) {
+    throw new Error('TOOLS.json "tools" must be an array');
+  }
+  if (obj.tools.length === 0) {
+    throw new Error('TOOLS.json "tools" must contain at least one tool entry');
+  }
+
+  const tools: SkillToolEntry[] = [];
+  const seenNames = new Set<string>();
+
+  for (let i = 0; i < obj.tools.length; i++) {
+    const entry = obj.tools[i];
+    const prefix = `TOOLS.json tools[${i}]`;
+    const tool = parseToolEntry(entry, prefix);
+
+    if (seenNames.has(tool.name)) {
+      throw new Error(`${prefix}: duplicate tool name "${tool.name}"`);
+    }
+    seenNames.add(tool.name);
+
+    tools.push(tool);
+  }
+
+  return { version: 1, tools };
+}
+
+function parseToolEntry(raw: unknown, prefix: string): SkillToolEntry {
+  if (raw === null || raw === undefined || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${prefix}: each tool entry must be a JSON object`);
+  }
+
+  const entry = raw as Record<string, unknown>;
+
+  // name
+  if (!('name' in entry) || typeof entry.name !== 'string') {
+    throw new Error(`${prefix}: missing or non-string "name"`);
+  }
+  const name = entry.name.trim();
+  if (name.length === 0) {
+    throw new Error(`${prefix}: "name" must be a non-empty string`);
+  }
+
+  // description
+  if (!('description' in entry) || typeof entry.description !== 'string') {
+    throw new Error(`${prefix}: missing or non-string "description"`);
+  }
+  const description = entry.description.trim();
+  if (description.length === 0) {
+    throw new Error(`${prefix}: "description" must be a non-empty string`);
+  }
+
+  // category
+  if (!('category' in entry) || typeof entry.category !== 'string') {
+    throw new Error(`${prefix}: missing or non-string "category"`);
+  }
+  const category = entry.category.trim();
+  if (category.length === 0) {
+    throw new Error(`${prefix}: "category" must be a non-empty string`);
+  }
+
+  // risk
+  if (!('risk' in entry) || typeof entry.risk !== 'string') {
+    throw new Error(`${prefix}: missing or non-string "risk"`);
+  }
+  if (!VALID_RISK_LEVELS.has(entry.risk)) {
+    throw new Error(`${prefix}: "risk" must be one of "low", "medium", "high", got: "${entry.risk}"`);
+  }
+  const risk = entry.risk as SkillToolEntry['risk'];
+
+  // input_schema
+  if (!('input_schema' in entry) || entry.input_schema === null || typeof entry.input_schema !== 'object' || Array.isArray(entry.input_schema)) {
+    throw new Error(`${prefix}: missing or non-object "input_schema"`);
+  }
+  const input_schema = entry.input_schema as Record<string, unknown>;
+
+  // executor
+  if (!('executor' in entry) || typeof entry.executor !== 'string') {
+    throw new Error(`${prefix}: missing or non-string "executor"`);
+  }
+  const executor = entry.executor;
+  if (executor.length === 0) {
+    throw new Error(`${prefix}: "executor" must be a non-empty string`);
+  }
+  validateExecutorPath(executor, prefix);
+
+  // execution_target
+  if (!('execution_target' in entry) || typeof entry.execution_target !== 'string') {
+    throw new Error(`${prefix}: missing or non-string "execution_target"`);
+  }
+  if (!VALID_EXECUTION_TARGETS.has(entry.execution_target)) {
+    throw new Error(`${prefix}: "execution_target" must be one of "host", "sandbox", got: "${entry.execution_target}"`);
+  }
+  const execution_target = entry.execution_target as SkillToolEntry['execution_target'];
+
+  return { name, description, category, risk, input_schema, executor, execution_target };
+}
+
+/**
+ * Enforce that executor paths are relative and don't escape the skill directory.
+ * Rejects absolute paths and paths containing `../`.
+ */
+function validateExecutorPath(executor: string, prefix: string): void {
+  if (executor.startsWith('/')) {
+    throw new Error(`${prefix}: "executor" must be a relative path, got absolute path: "${executor}"`);
+  }
+  // Reject path traversal sequences
+  const segments = executor.split('/');
+  for (const segment of segments) {
+    if (segment === '..') {
+      throw new Error(`${prefix}: "executor" must not contain ".." path segments: "${executor}"`);
+    }
+  }
+}
+
+/**
+ * Read and parse a TOOLS.json file from disk.
+ */
+export function parseToolManifestFile(filePath: string): SkillToolManifest {
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read TOOLS.json at "${filePath}": ${message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse TOOLS.json at "${filePath}" as JSON: ${message}`);
+  }
+
+  return parseToolManifest(parsed);
+}


### PR DESCRIPTION
## Summary
- Add `parseToolManifest()` and `parseToolManifestFile()` in `skills/tool-manifest.ts`
- Validates version, required tool fields, risk levels, execution targets, and executor paths
- Happy-path tests for valid manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
