### PR TITLE
feat: activity panel as side panel with auto-close sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -296,6 +296,14 @@ struct MainWindowView: View {
             }
             threadManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
         }
+        .onChange(of: windowState.activePanel) { _, newPanel in
+            // Close the left sidebar when the activity panel opens to avoid crowding
+            if newPanel == .activity && sidebarOpen {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    sidebarOpen = false
+                }
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
                 windowState.activeDynamicSurface = msg
@@ -652,28 +660,29 @@ struct MainWindowView: View {
             fullWindowPanel(panel)
         } else {
             let config = windowState.layoutConfig
+            let showActivity = windowState.activePanel == .activity
+                && threadManager.activeViewModel != nil
+                && windowState.activityMessageId != nil
+            let showConfigPanel = config.right.visible && config.right.content != .empty
 
-            ZStack {
-                VSplitView(
-                    panelWidth: $sidePanelWidth,
-                    showPanel: config.right.visible && config.right.content != .empty,
-                    main: { slotView(for: config.center.content) },
-                    panel: { slotView(for: config.right.content) }
-                )
-
-                if windowState.activePanel == .activity,
-                   let viewModel = threadManager.activeViewModel,
-                   let messageId = windowState.activityMessageId {
-                    ActivityPanel(
-                        viewModel: viewModel,
-                        messageId: messageId,
-                        onClose: { windowState.activePanel = nil }
-                    )
-                    .background(VColor.background)
-                    .transition(.move(edge: .trailing))
-                    .animation(VAnimation.panel, value: windowState.activePanel)
+            VSplitView(
+                panelWidth: $sidePanelWidth,
+                showPanel: showActivity || showConfigPanel,
+                main: { slotView(for: config.center.content) },
+                panel: {
+                    if showActivity,
+                       let viewModel = threadManager.activeViewModel,
+                       let messageId = windowState.activityMessageId {
+                        ActivityPanel(
+                            viewModel: viewModel,
+                            messageId: messageId,
+                            onClose: { windowState.activePanel = nil }
+                        )
+                    } else {
+                        slotView(for: config.right.content)
+                    }
                 }
-            }
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Move Activity panel from a full-window ZStack overlay into the VSplitView right panel slot, so the chat remains visible alongside it
- Auto-close the left thread sidebar (with spring animation) when the activity panel opens to avoid crowding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
