### PR TITLE
feat: surface TOOLS.json manifest in skill catalog

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -223,3 +223,102 @@ describe('workspace skills', () => {
     expect(result.skill!.source).toBe('workspace');
   });
 });
+
+describe('tool manifest detection', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('attaches toolManifest metadata when valid TOOLS.json is present', () => {
+    writeSkill('with-tools', 'Tool Skill', 'Skill with tools');
+    const toolsJson = {
+      version: 1,
+      tools: [
+        {
+          name: 'run-lint',
+          description: 'Runs linting',
+          category: 'quality',
+          risk: 'low',
+          input_schema: { type: 'object', properties: {} },
+          executor: 'lint.sh',
+          execution_target: 'host',
+        },
+        {
+          name: 'run-test',
+          description: 'Runs tests',
+          category: 'quality',
+          risk: 'medium',
+          input_schema: { type: 'object', properties: {} },
+          executor: 'test.sh',
+          execution_target: 'sandbox',
+        },
+      ],
+    };
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'with-tools', 'TOOLS.json'),
+      JSON.stringify(toolsJson),
+    );
+
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'with-tools');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toEqual({
+      present: true,
+      valid: true,
+      toolCount: 2,
+      toolNames: ['run-lint', 'run-test'],
+    });
+  });
+
+  test('marks toolManifest as invalid when TOOLS.json fails to parse', () => {
+    writeSkill('bad-tools', 'Bad Tool Skill', 'Skill with invalid tools');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'bad-tools', 'TOOLS.json'),
+      '{ not valid json !!!',
+    );
+
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'bad-tools');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toEqual({
+      present: true,
+      valid: false,
+      toolCount: 0,
+      toolNames: [],
+    });
+  });
+
+  test('marks toolManifest as invalid when TOOLS.json has schema errors', () => {
+    writeSkill('schema-error', 'Schema Error Skill', 'Skill with schema errors');
+    // Valid JSON but missing required fields
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'schema-error', 'TOOLS.json'),
+      JSON.stringify({ version: 1, tools: [{ name: 'incomplete' }] }),
+    );
+
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'schema-error');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toEqual({
+      present: true,
+      valid: false,
+      toolCount: 0,
+      toolNames: [],
+    });
+  });
+
+  test('does not set toolManifest when TOOLS.json is absent', () => {
+    writeSkill('no-tools', 'No Tool Skill', 'Skill without tools');
+
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'no-tools');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toBeUndefined();
+  });
+});

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -5,6 +5,7 @@ import { getConfig } from './loader.js';
 import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { stripCommentLines } from './system-prompt.js';
+import { parseToolManifestFile } from '../skills/tool-manifest.js';
 
 const log = getLogger('skills');
 
@@ -310,6 +311,38 @@ function isOutsideSkillsRoot(skillsDir: string, candidatePath: string): boolean 
   return relativePath.startsWith('..') || isAbsolute(relativePath);
 }
 
+// ─── Tool manifest detection ─────────────────────────────────────────────────
+
+/**
+ * Detect and parse a TOOLS.json manifest in a skill directory.
+ * Returns the manifest metadata if the file exists, or undefined if it doesn't.
+ * On parse failure, returns a degraded metadata object (present but invalid).
+ */
+function detectToolManifest(directoryPath: string): SkillToolManifestMeta | undefined {
+  const manifestPath = join(directoryPath, 'TOOLS.json');
+  if (!existsSync(manifestPath)) {
+    return undefined;
+  }
+
+  try {
+    const manifest = parseToolManifestFile(manifestPath);
+    return {
+      present: true,
+      valid: true,
+      toolCount: manifest.tools.length,
+      toolNames: manifest.tools.map((t) => t.name),
+    };
+  } catch (err) {
+    log.warn({ err, manifestPath }, 'Failed to parse TOOLS.json manifest');
+    return {
+      present: true,
+      valid: false,
+      toolCount: 0,
+      toolNames: [],
+    };
+  }
+}
+
 // ─── Skill reading ───────────────────────────────────────────────────────────
 
 function readSkillFromDirectory(directoryPath: string, skillsDir: string, source: SkillSource): SkillDefinition | null {
@@ -353,6 +386,7 @@ function readSkillFromDirectory(directoryPath: string, skillsDir: string, source
       disableModelInvocation: parsed.disableModelInvocation,
       source,
       metadata: parsed.metadata,
+      toolManifest: detectToolManifest(directoryPath),
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, 'Failed to read skill file');
@@ -392,6 +426,7 @@ function readBundledSkillFromDirectory(directoryPath: string): SkillDefinition |
       disableModelInvocation: parsed.disableModelInvocation,
       source: 'bundled',
       metadata: parsed.metadata,
+      toolManifest: detectToolManifest(directoryPath),
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, 'Failed to read bundled skill file');
@@ -444,6 +479,7 @@ function loadBundledSkills(): SkillSummary[] {
       disableModelInvocation: skill.disableModelInvocation,
       source: 'bundled',
       metadata: skill.metadata,
+      toolManifest: skill.toolManifest,
     });
   }
 
@@ -562,6 +598,7 @@ function skillSummaryFromDefinition(skill: SkillDefinition, source: SkillSource)
     disableModelInvocation: skill.disableModelInvocation,
     source,
     metadata: skill.metadata,
+    toolManifest: skill.toolManifest,
   };
 }
 
@@ -605,6 +642,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
             disableModelInvocation: parsed.disableModelInvocation,
             source: 'extra',
             metadata: parsed.metadata,
+            toolManifest: detectToolManifest(directory),
           });
         } catch (err) {
           log.warn({ err, directory }, 'Failed to read skill from extraDirs');
@@ -685,6 +723,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
           disableModelInvocation: parsed.disableModelInvocation,
           source: 'workspace',
           metadata: parsed.metadata,
+          toolManifest: detectToolManifest(directory),
         };
 
         if (seenIds.has(id)) {


### PR DESCRIPTION
## Summary
- Detect and parse TOOLS.json when loading skill directories
- Attach SkillToolManifestMeta to SkillSummary for valid manifests
- Gracefully degrade on invalid manifests (mark present but invalid)
- Add tests for manifest detection in skill catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
