### PR TITLE
docs: document TOOLS.json format in skills docs

### DIFF
--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -48,6 +48,65 @@ description: "Run pre-release validation and deployment checks."
 
 Skills missing valid frontmatter are skipped.
 
+## `TOOLS.json` Manifest
+
+A skill can declare custom tools by placing a `TOOLS.json` file in its directory alongside `SKILL.md`:
+
+```
+~/.vellum/workspace/skills/<skill-id>/TOOLS.json
+```
+
+### Format
+
+```json
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "run-lint",
+      "description": "Run the project linter and return results.",
+      "category": "code-quality",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string", "description": "Directory to lint" }
+        },
+        "required": ["path"]
+      },
+      "executor": "tools/run-lint.ts",
+      "execution_target": "host"
+    }
+  ]
+}
+```
+
+### Fields
+
+All fields on each tool entry are **required**.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `1` | Manifest schema version. Must be `1`. |
+| `tools` | array | One or more tool entries. Must not be empty. |
+| `tools[].name` | string | Unique tool name. Duplicate names within the same manifest are rejected. |
+| `tools[].description` | string | Human-readable description shown to the model. |
+| `tools[].category` | string | Grouping label for display purposes. |
+| `tools[].risk` | `"low"` \| `"medium"` \| `"high"` | Default risk level for permission checks. `low` tools are auto-allowed, `medium` tools check trust rules before prompting, `high` tools always prompt. |
+| `tools[].input_schema` | object | JSON Schema describing the tool's input parameters. |
+| `tools[].executor` | string | Relative path to the executor script within the skill directory. |
+| `tools[].execution_target` | `"host"` \| `"sandbox"` | Where the tool script runs. `host` runs directly on the user's machine; `sandbox` runs in an isolated environment. |
+
+### Security Constraints
+
+- **Relative paths only**: The `executor` field must be a relative path. Absolute paths (starting with `/`) are rejected.
+- **No path traversal**: Executor paths must not contain `..` segments. The script must reside within the skill directory.
+- **Skill-root confinement**: These constraints ensure a skill can only reference executors inside its own `~/.vellum/workspace/skills/<skill-id>/` subtree.
+
+### Detection
+
+When the skill catalog is built, each skill directory is checked for a `TOOLS.json` file. If present, its metadata (tool count, validity) is surfaced in the skill summary without loading the full manifest until the skill is activated.
+
 ## Runtime Behavior
 
 - System prompt appends a **Skills Catalog** with skill id, name, and description.


### PR DESCRIPTION
## Summary
- Add TOOLS.json format documentation to skills docs
- Document all required fields, security constraints, and execution backends
- Include a practical example manifest

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
