### PR TITLE
feat: extend Tool interface with skill-origin metadata

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -5,7 +5,7 @@ import type { ToolDefinition } from '../providers/types.js';
 
 // We cannot import the private LazyTool class directly, so we test through
 // registerLazyTool + getTool which exercise the same code path.
-import { registerLazyTool, getTool, getAllTools, getAllToolDefinitions, initializeTools } from '../tools/registry.js';
+import { registerTool, registerLazyTool, getTool, getAllTools, getAllToolDefinitions, initializeTools } from '../tools/registry.js';
 import { eagerModules, explicitTools, lazyTools } from '../tools/tool-manifest.js';
 
 function makeFakeTool(name: string): Tool {
@@ -209,5 +209,31 @@ describe('baseline characterization: hardcoded tool loading', () => {
   test('claude_code lazy descriptor is in lazyTools manifest', () => {
     const lazyNames = lazyTools.map(t => t.name);
     expect(lazyNames).toContain('claude_code');
+  });
+});
+
+describe('tool origin metadata', () => {
+  test('registers a skill-origin tool and preserves metadata via getTool()', () => {
+    const skillTool: Tool = {
+      ...makeFakeTool('test-skill-origin-tool'),
+      origin: 'skill',
+      ownerSkillId: 'test-skill',
+    };
+
+    registerTool(skillTool);
+
+    const retrieved = getTool('test-skill-origin-tool');
+    expect(retrieved).toBeDefined();
+    expect(retrieved?.origin).toBe('skill');
+    expect(retrieved?.ownerSkillId).toBe('test-skill');
+  });
+
+  test('core tools default to no origin metadata (undefined)', async () => {
+    await initializeTools();
+
+    const coreTool = getTool('host_file_read');
+    expect(coreTool).toBeDefined();
+    expect(coreTool?.origin).toBeUndefined();
+    expect(coreTool?.ownerSkillId).toBeUndefined();
   });
 });

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -138,6 +138,10 @@ export interface Tool {
   defaultRiskLevel: RiskLevel;
   /** When set to 'proxy', the tool is forwarded to a connected client rather than executed locally. */
   executionMode?: 'local' | 'proxy';
+  /** Whether this tool is a core built-in or provided by a skill. */
+  origin?: 'core' | 'skill';
+  /** If origin is 'skill', the ID of the owning skill. */
+  ownerSkillId?: string;
   getDefinition(): ToolDefinition;
   execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult>;
 }


### PR DESCRIPTION
## Summary
- Add optional `origin` ('core' | 'skill') and `ownerSkillId` fields to the `Tool` interface in `types.ts`
- Registry preserves metadata as-is (stores Tool objects by reference)
- Add tests verifying skill-origin tool registration and core-tool defaults

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All 19 registry tests pass including 2 new origin-metadata tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
