### PR TITLE
feat: /model command, model picker in settings, slash highlight

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -349,6 +349,7 @@ function buildConfigSection(): string {
 
   return [
     '## Configuration',
+    `- **Active model**: \`${config.model}\` (provider: ${config.provider})`,
     `${configPreamble} Key files you may read or edit include but are not limited to:`,
     '',
     '- `IDENTITY.md` — Your name, nature, vibe, and emoji. Updated during the first-run ritual.',

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -1,4 +1,6 @@
-import { getConfig } from '../config/loader.js';
+import { readFileSync, existsSync } from 'node:fs';
+import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
+import { initializeProviders } from '../providers/registry.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
 import {
@@ -6,16 +8,119 @@ import {
   resolveSlashSkillCommand,
   rewriteKnownSlashCommandPrompt,
 } from '../skills/slash-commands.js';
+import { getWorkspacePromptPath } from '../util/platform.js';
 
 export type SlashResolution =
   | { kind: 'passthrough' | 'rewritten'; content: string }
   | { kind: 'unknown'; message: string };
+
+// ── /model command ───────────────────────────────────────────────────
+
+const AVAILABLE_MODELS = [
+  'claude-opus-4-6',
+  'claude-sonnet-4-5-20250929',
+  'claude-haiku-4-5-20251001',
+] as const;
+
+const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  'claude-opus-4-6': 'Claude Opus 4.6',
+  'claude-sonnet-4-5-20250929': 'Claude Sonnet 4.5',
+  'claude-haiku-4-5-20251001': 'Claude Haiku 4.5',
+};
+
+/** Read the assistant's name from IDENTITY.md for personalized responses. */
+function getAssistantName(): string | null {
+  try {
+    const path = getWorkspacePromptPath('IDENTITY.md');
+    if (!existsSync(path)) return null;
+    const content = readFileSync(path, 'utf-8');
+    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
+    return match?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Partial-match a user input like "opus", "sonnet", "haiku" to a full model ID. */
+function matchModel(input: string): string | undefined {
+  const lower = input.toLowerCase().trim();
+  // Exact match first
+  const exact = AVAILABLE_MODELS.find((m) => m === lower);
+  if (exact) return exact;
+  // Partial match (e.g. "opus" → "claude-opus-4-6")
+  return AVAILABLE_MODELS.find((m) => m.includes(lower));
+}
+
+function resolveModelCommand(content: string): SlashResolution | null {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith('/model')) return null;
+  // Ensure it's exactly "/model" or "/model " (not "/modelsomething")
+  if (trimmed.length > 6 && trimmed[6] !== ' ') return null;
+
+  const args = trimmed.slice(6).trim();
+  const name = getAssistantName();
+
+  if (!args) {
+    // Show current model
+    const config = getConfig();
+    const displayName = MODEL_DISPLAY_NAMES[config.model] ?? config.model;
+    const prefix = name ? `${name} is running on` : `Currently using`;
+    return {
+      kind: 'unknown',
+      message: `${prefix} **${displayName}** (\`${config.model}\`).`,
+    };
+  }
+
+  // Try to match the model name
+  const matched = matchModel(args);
+  if (!matched) {
+    const available = AVAILABLE_MODELS.map(
+      (m) => `- **${MODEL_DISPLAY_NAMES[m]}** (\`${m}\`)`,
+    ).join('\n');
+    return {
+      kind: 'unknown',
+      message: `Hmm, "${args}" doesn't match any available model. Here's what you can pick from:\n${available}`,
+    };
+  }
+
+  // Check if already using this model
+  const currentConfig = getConfig();
+  if (currentConfig.model === matched) {
+    const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
+    const alreadyMsg = name
+      ? `${name} is already running on **${displayName}**.`
+      : `Already on **${displayName}**.`;
+    return {
+      kind: 'unknown',
+      message: alreadyMsg,
+    };
+  }
+
+  // Change model: save config and re-initialize providers
+  const raw = loadRawConfig();
+  raw.model = matched;
+  saveRawConfig(raw);
+  const config = getConfig();
+  initializeProviders(config);
+
+  const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
+  const switchedMsg = name
+    ? `Switched ${name} to **${displayName}**. New conversations will use this model.`
+    : `Switched to **${displayName}**. New conversations will use this model.`;
+  return {
+    kind: 'unknown',
+    message: switchedMsg,
+  };
+}
 
 /**
  * Resolve slash commands against the current skill catalog.
  * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
  */
 export function resolveSlash(content: string): SlashResolution {
+  // Handle /model before skill resolution
+  const modelResult = resolveModelCommand(content);
+  if (modelResult) return modelResult;
   const config = getConfig();
   const catalog = loadSkillCatalog();
   const resolved = resolveSkillStates(catalog, config);

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1428,8 +1428,17 @@ private struct ChatBubble: View {
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
-        let parsed = (try? AttributedString(markdown: trimmed, options: options))
+        var parsed = (try? AttributedString(markdown: trimmed, options: options))
             ?? AttributedString(trimmed)
+
+        // Highlight slash command token (e.g. /model) in blue
+        if let slashMatch = trimmed.range(of: #"^/\w+"#, options: .regularExpression) {
+            let offset = trimmed.distance(from: trimmed.startIndex, to: slashMatch.lowerBound)
+            let length = trimmed.distance(from: slashMatch.lowerBound, to: slashMatch.upperBound)
+            let attrStart = parsed.index(parsed.startIndex, offsetByCharacters: offset)
+            let attrEnd = parsed.index(attrStart, offsetByCharacters: length)
+            parsed[attrStart..<attrEnd].foregroundColor = Indigo._500
+        }
 
         // Store in cache (with size limit to prevent unbounded growth)
         if Self.markdownCache.count >= Self.maxCacheSize {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -617,6 +617,29 @@ private final class ComposerNativeTextView: NSTextView {
     override func didChangeText() {
         super.didChangeText()
         needsDisplay = true
+        highlightSlashCommand()
+    }
+
+    private func highlightSlashCommand() {
+        guard let layoutManager = layoutManager, let textStorage = textStorage else { return }
+        let fullRange = NSRange(location: 0, length: textStorage.length)
+        guard fullRange.length > 0 else { return }
+
+        // Reset to default text color
+        layoutManager.addTemporaryAttributes(
+            [.foregroundColor: NSColor(VColor.textPrimary)],
+            forCharacterRange: fullRange
+        )
+
+        // Highlight slash command token (e.g. /model, /help)
+        let text = textStorage.string
+        if let match = text.range(of: #"^/\w+"#, options: .regularExpression) {
+            let nsRange = NSRange(match, in: text)
+            layoutManager.addTemporaryAttributes(
+                [.foregroundColor: NSColor(Indigo._500)],
+                forCharacterRange: nsRange
+            )
+        }
     }
 
     override func keyDown(with event: NSEvent) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -77,6 +77,35 @@ struct SettingsPanel: View {
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
 
+                // MODEL section (only when API key is configured)
+                if store.hasKey {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("MODEL")
+                            .font(VFont.sectionTitle)
+                            .foregroundColor(VColor.textPrimary)
+
+                        HStack {
+                            Text("Active Model")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Spacer()
+                            Picker("", selection: $store.selectedModel) {
+                                ForEach(SettingsStore.availableModels, id: \.self) { model in
+                                    Text(SettingsStore.modelDisplayNames[model] ?? model)
+                                        .tag(model)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .frame(maxWidth: 200)
+                        }
+                        .onChange(of: store.selectedModel) { _, newValue in
+                            store.setModel(newValue)
+                        }
+                    }
+                    .padding(VSpacing.lg)
+                    .vCard(background: VColor.surfaceSubtle)
+                }
+
                 // BRAVE SEARCH section
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     Text("BRAVE SEARCH")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -14,6 +14,22 @@ public final class SettingsStore: ObservableObject {
     @Published var maskedKey: String = ""
     @Published var maskedBraveKey: String = ""
 
+    // MARK: - Model Selection
+
+    @Published var selectedModel: String = "claude-opus-4-6"
+
+    static let availableModels: [String] = [
+        "claude-opus-4-6",
+        "claude-sonnet-4-5-20250929",
+        "claude-haiku-4-5-20251001",
+    ]
+
+    static let modelDisplayNames: [String: String] = [
+        "claude-opus-4-6": "Claude Opus 4.6",
+        "claude-sonnet-4-5-20250929": "Claude Sonnet 4.5",
+        "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+    ]
+
     // MARK: - Settings Values
 
     @Published var maxSteps: Double {
@@ -73,8 +89,17 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
+        // Wire up model info IPC response
+        daemonClient?.onModelInfo = { [weak self] response in
+            guard let self else { return }
+            self.selectedModel = response.model
+        }
+
         // Refresh Vercel key state on init
         refreshVercelKeyState()
+
+        // Fetch current model from daemon
+        try? daemonClient?.sendModelGet()
     }
 
     // MARK: - API Key Actions
@@ -143,5 +168,11 @@ public final class SettingsStore: ObservableObject {
 
     func refreshVercelKeyState() {
         try? daemonClient?.sendVercelApiConfig(action: "get")
+    }
+
+    // MARK: - Model Actions
+
+    func setModel(_ model: String) {
+        try? daemonClient?.sendModelSet(model: model)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -62,6 +62,20 @@ public struct SettingsView: View {
                 }
             }
 
+            if store.hasKey {
+                Section("Model") {
+                    Picker("Active model", selection: $store.selectedModel) {
+                        ForEach(SettingsStore.availableModels, id: \.self) { model in
+                            Text(SettingsStore.modelDisplayNames[model] ?? model)
+                                .tag(model)
+                        }
+                    }
+                    .onChange(of: store.selectedModel) { _, newValue in
+                        store.setModel(newValue)
+                    }
+                }
+            }
+
             Section("Brave Search API Key") {
                 if store.hasBraveKey {
                     HStack(spacing: 6) {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -196,6 +196,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `vercel_api_config_response` message.
     public var onVercelApiConfigResponse: ((VercelApiConfigResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `model_info` message.
+    public var onModelInfo: ((ModelInfoMessage) -> Void)?
+
+    /// The currently active model ID, populated via `model_info` responses.
+    @Published public var currentModel: String?
+
     /// Called when the daemon sends a `publish_page_response` message.
     public var onPublishPageResponse: ((PublishPageResponseMessage) -> Void)?
 
@@ -849,6 +855,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(UnpublishPageRequestMessage(deploymentId: deploymentId))
     }
 
+    // MARK: - Model Config
+
+    /// Request the current model/provider configuration from the daemon.
+    public func sendModelGet() throws {
+        try send(ModelGetRequestMessage())
+    }
+
+    /// Set the active model on the daemon.
+    public func sendModelSet(model: String) throws {
+        try send(ModelSetRequestMessage(model: model))
+    }
+
     // MARK: - Integrations
 
     /// Request the list of registered integrations and their connection status.
@@ -1119,6 +1137,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSlackWebhookConfigResponse?(msg)
         case .vercelApiConfigResponse(let msg):
             onVercelApiConfigResponse?(msg)
+        case .modelInfo(let msg):
+            currentModel = msg.model
+            onModelInfo?(msg)
         case .publishPageResponse(let msg):
             onPublishPageResponse?(msg)
         case .openUrl(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1456,6 +1456,32 @@ public struct SlackWebhookConfigResponseMessage: Decodable, Sendable {
     public let error: String?
 }
 
+// MARK: - Model Config Messages
+
+/// Request the current model/provider configuration.
+/// Backed by generated `IPCModelGetRequest`.
+public typealias ModelGetRequestMessage = IPCModelGetRequest
+
+extension IPCModelGetRequest {
+    public init() {
+        self.init(type: "model_get")
+    }
+}
+
+/// Set the active model.
+/// Backed by generated `IPCModelSetRequest`.
+public typealias ModelSetRequestMessage = IPCModelSetRequest
+
+extension IPCModelSetRequest {
+    public init(model: String) {
+        self.init(type: "model_set", model: model)
+    }
+}
+
+/// Response containing the current model/provider info.
+/// Backed by generated `IPCModelInfo`.
+public typealias ModelInfoMessage = IPCModelInfo
+
 // MARK: - Vercel API Config Messages
 
 /// Sent to get/set/delete the Vercel API token.
@@ -1538,6 +1564,7 @@ public enum ServerMessage: Decodable, Sendable {
     case shareToSlackResponse(ShareToSlackResponseMessage)
     case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
     case vercelApiConfigResponse(VercelApiConfigResponseMessage)
+    case modelInfo(ModelInfoMessage)
     case publishPageResponse(PublishPageResponseMessage)
     case unpublishPageResponse(UnpublishPageResponseMessage)
     case uiSurfaceUndoResult(UiSurfaceUndoResultMessage)
@@ -1734,6 +1761,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "vercel_api_config_response":
             let message = try VercelApiConfigResponseMessage(from: decoder)
             self = .vercelApiConfigResponse(message)
+        case "model_info":
+            let message = try ModelInfoMessage(from: decoder)
+            self = .modelInfo(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
## Summary
- Add `/model` slash command to view/switch between Claude models (Opus 4.6, Sonnet 4.5, Haiku 4.5) with partial matching and personalized responses
- Add model picker dropdown to both Settings panel and Settings view, backed by new IPC model_get/model_set messages
- Highlight slash command tokens in indigo in the composer input field and chat message bubbles
- Show active model/provider in system prompt configuration section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
