### PR TITLE
feat: add host skill script runner

### DIFF
--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';
+import type { ToolContext } from '../tools/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'skill-script-runner-test-'));
+
+  // Write test script files that the runner will dynamically import.
+
+  // 1. A script that successfully returns a result.
+  await writeFile(
+    join(tempDir, 'success.ts'),
+    `export async function run(input, context) {
+  return { content: 'hello from ' + input.name, isError: false };
+}`,
+    'utf-8',
+  );
+
+  // 2. A script that does NOT export a run function.
+  await writeFile(
+    join(tempDir, 'no-run.ts'),
+    `export const version = 1;`,
+    'utf-8',
+  );
+
+  // 3. A script whose run function throws an error.
+  await writeFile(
+    join(tempDir, 'throws.ts'),
+    `export async function run() {
+  throw new Error('intentional kaboom');
+}`,
+    'utf-8',
+  );
+
+  // 4. A script that returns the input and context for inspection.
+  await writeFile(
+    join(tempDir, 'echo.ts'),
+    `export async function run(input, context) {
+  return {
+    content: JSON.stringify({ input, workingDir: context.workingDir, sessionId: context.sessionId }),
+    isError: false,
+  };
+}`,
+    'utf-8',
+  );
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Success cases
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript — success', () => {
+  test('executes a valid script and returns its result', async () => {
+    const result = await runSkillToolScript(tempDir, 'success.ts', { name: 'world' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('hello from world');
+  });
+
+  test('passes input and context through to the script', async () => {
+    const ctx = makeContext({ workingDir: '/my/project', sessionId: 'sess-42' });
+    const result = await runSkillToolScript(tempDir, 'echo.ts', { foo: 'bar' }, ctx);
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.input).toEqual({ foo: 'bar' });
+    expect(parsed.workingDir).toBe('/my/project');
+    expect(parsed.sessionId).toBe('sess-42');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript — errors', () => {
+  test('returns error result when script does not export a run function', async () => {
+    const result = await runSkillToolScript(tempDir, 'no-run.ts', {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('does not export a "run" function');
+    expect(result.content).toContain('no-run.ts');
+  });
+
+  test('returns error result when script throws during execution', async () => {
+    const result = await runSkillToolScript(tempDir, 'throws.ts', {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('threw an error');
+    expect(result.content).toContain('intentional kaboom');
+    expect(result.content).toContain('throws.ts');
+  });
+
+  test('returns error result when script file does not exist', async () => {
+    const result = await runSkillToolScript(tempDir, 'nonexistent.ts', {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Failed to load skill tool script');
+    expect(result.content).toContain('nonexistent.ts');
+  });
+});

--- a/assistant/src/tools/skills/script-contract.ts
+++ b/assistant/src/tools/skills/script-contract.ts
@@ -1,0 +1,6 @@
+import type { ToolExecutionResult, ToolContext } from '../types.js';
+
+/** The exported interface a skill tool script must implement. */
+export interface SkillToolScript {
+  run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult>;
+}

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -1,0 +1,35 @@
+import type { ToolExecutionResult, ToolContext } from '../types.js';
+import type { SkillToolScript } from './script-contract.js';
+import { join } from 'node:path';
+
+/**
+ * Execute a skill tool script on the host backend.
+ * Dynamically imports the script file and calls its exported `run()` function.
+ */
+export async function runSkillToolScript(
+  skillDir: string,
+  executorPath: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const scriptPath = join(skillDir, executorPath);
+
+  let module: SkillToolScript;
+  try {
+    module = await import(scriptPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: `Failed to load skill tool script "${executorPath}": ${message}`, isError: true };
+  }
+
+  if (typeof module.run !== 'function') {
+    return { content: `Skill tool script "${executorPath}" does not export a "run" function`, isError: true };
+  }
+
+  try {
+    return await module.run(input, context);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: `Skill tool script "${executorPath}" threw an error: ${message}`, isError: true };
+  }
+}


### PR DESCRIPTION
## Summary
- Define `SkillToolScript` contract interface (exported `run()` function)
- Implement `runSkillToolScript` for host execution via dynamic import
- Normalize output into `ToolExecutionResult` with error handling for missing scripts, missing exports, and thrown exceptions
- Tests cover success path, input/context passthrough, and all three error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
