### PR TITLE
feat: add sandbox skill script runner

### DIFF
--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -1,0 +1,220 @@
+import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the module under test is imported
+// ---------------------------------------------------------------------------
+
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  sandbox: { enabled: false },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: true, action: 'warn' as const, entropyThreshold: 4.0 },
+  auditLog: { retentionDays: 0 },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Pass through without actual sandboxing so tests can run bun directly
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: (command: string, _workingDir: string, _config: unknown) => ({
+    command: 'bash',
+    args: ['-c', '--', command],
+    sandboxed: false,
+  }),
+}));
+
+import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';
+import type { ToolContext } from '../tools/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'skill-sandbox-test-'));
+
+  // 1. A script that returns a successful result using input.
+  await writeFile(
+    join(tempDir, 'success.ts'),
+    `export async function run(input: any, context: any) {
+  return { content: 'sandbox hello from ' + input.name, isError: false };
+}`,
+    'utf-8',
+  );
+
+  // 2. A script that does NOT export a run function.
+  await writeFile(
+    join(tempDir, 'no-run.ts'),
+    `export const version = 1;`,
+    'utf-8',
+  );
+
+  // 3. A script whose run function throws an error.
+  await writeFile(
+    join(tempDir, 'throws.ts'),
+    `export async function run() {
+  throw new Error('sandbox kaboom');
+}`,
+    'utf-8',
+  );
+
+  // 4. A script that echoes input and context back for inspection.
+  await writeFile(
+    join(tempDir, 'echo.ts'),
+    `export async function run(input: any, context: any) {
+  return {
+    content: JSON.stringify({ input, workingDir: context.workingDir, sessionId: context.sessionId }),
+    isError: false,
+  };
+}`,
+    'utf-8',
+  );
+
+  // 5. A script that sleeps forever (for timeout testing).
+  await writeFile(
+    join(tempDir, 'hang.ts'),
+    `export async function run() {
+  await new Promise(resolve => setTimeout(resolve, 120_000));
+  return { content: 'should not reach', isError: false };
+}`,
+    'utf-8',
+  );
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Success cases
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript sandbox — success', () => {
+  test('executes a valid script and returns its result', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', { name: 'world' }, makeContext(), { target: 'sandbox' },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('sandbox hello from world');
+  }, 15_000);
+
+  test('passes input and context through to the script', async () => {
+    const ctx = makeContext({ workingDir: '/my/project', sessionId: 'sess-42' });
+    const result = await runSkillToolScript(
+      tempDir, 'echo.ts', { foo: 'bar' }, ctx, { target: 'sandbox' },
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.input).toEqual({ foo: 'bar' });
+    expect(parsed.workingDir).toBe('/my/project');
+    expect(parsed.sessionId).toBe('sess-42');
+  }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript sandbox — errors', () => {
+  test('returns error when script does not export a run function', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'no-run.ts', {}, makeContext(), { target: 'sandbox' },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('does not export a "run" function');
+  }, 15_000);
+
+  test('returns error when script throws during execution', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'throws.ts', {}, makeContext(), { target: 'sandbox' },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('sandbox kaboom');
+  }, 15_000);
+
+  test('returns error when script file does not exist', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'nonexistent.ts', {}, makeContext(), { target: 'sandbox' },
+    );
+
+    expect(result.isError).toBe(true);
+    // The subprocess will fail to import the nonexistent file
+  }, 15_000);
+
+  test('times out and returns error for long-running scripts', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'hang.ts', {}, makeContext(), { target: 'sandbox', timeoutMs: 1_500 },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('timed out');
+    expect(result.status).toBe('timeout');
+  }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// Routing — default target is host (in-process)
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript routing', () => {
+  test('defaults to host execution when no target is specified', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', { name: 'host' }, makeContext(),
+    );
+
+    // Host path uses dynamic import, so the script runs in-process
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('sandbox hello from host');
+  });
+
+  test('explicit target=host uses in-process execution', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', { name: 'explicit' }, makeContext(), { target: 'host' },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('sandbox hello from explicit');
+  });
+});

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -1,0 +1,249 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { ToolExecutionResult, ToolContext } from '../types.js';
+import { getConfig } from '../../config/loader.js';
+import { wrapCommand } from '../terminal/sandbox.js';
+import { buildSanitizedEnv } from '../terminal/safe-env.js';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_CHARS = 50_000;
+
+/**
+ * Wrapper script that imports the target skill tool script, feeds it
+ * JSON input via an env var, and prints the ToolExecutionResult as JSON
+ * to stdout. This runs inside the sandbox subprocess.
+ */
+function buildRunnerSource(scriptPath: string): string {
+  return `
+const mod = await import(${JSON.stringify(scriptPath)});
+
+if (typeof mod.run !== 'function') {
+  console.log(JSON.stringify({ __skill_error: 'Script does not export a "run" function' }));
+  process.exit(1);
+}
+
+let input;
+try {
+  input = JSON.parse(process.env.__SKILL_INPUT_JSON ?? '{}');
+} catch {
+  console.log(JSON.stringify({ __skill_error: 'Invalid JSON in __SKILL_INPUT_JSON' }));
+  process.exit(1);
+}
+
+let context;
+try {
+  context = JSON.parse(process.env.__SKILL_CONTEXT_JSON ?? '{}');
+} catch {
+  context = {};
+}
+
+try {
+  const result = await mod.run(input, context);
+  console.log(JSON.stringify({ __skill_result: result }));
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.log(JSON.stringify({ __skill_result: { content: 'Script threw an error: ' + message, isError: true } }));
+}
+`;
+}
+
+/**
+ * Execute a skill tool script in a sandboxed subprocess.
+ *
+ * Follows the same subprocess isolation pattern used by the
+ * evaluate_typescript_code tool: writes a runner script to a temp dir,
+ * spawns it via the sandbox backend, passes input through env vars,
+ * and reads a structured JSON result from stdout.
+ */
+export async function runSkillToolScriptSandbox(
+  skillDir: string,
+  executorPath: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+  options?: { timeoutMs?: number },
+): Promise<ToolExecutionResult> {
+  const scriptPath = join(skillDir, executorPath);
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const runDir = join(skillDir, '.vellum-skill-run', randomUUID());
+
+  try {
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, '__skill_runner.ts'), buildRunnerSource(scriptPath), 'utf-8');
+
+    return await spawnRunner(runDir, input, context, timeoutMs, executorPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: `Failed to run skill tool script "${executorPath}" in sandbox: ${message}`, isError: true };
+  } finally {
+    try {
+      rmSync(runDir, { recursive: true, force: true });
+    } catch {
+      // best effort cleanup
+    }
+  }
+}
+
+function spawnRunner(
+  runDir: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+  timeoutMs: number,
+  executorPath: string,
+): Promise<ToolExecutionResult> {
+  return new Promise<ToolExecutionResult>((resolve) => {
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let timedOut = false;
+
+    const config = getConfig();
+    const sandboxConfig = context.sandboxOverride != null
+      ? { ...config.sandbox, enabled: context.sandboxOverride }
+      : config.sandbox;
+
+    const bunRunCmd = 'bun run __skill_runner.ts';
+    const wrapped = wrapCommand(bunRunCmd, runDir, sandboxConfig);
+
+    const env = buildSanitizedEnv();
+    env.__SKILL_INPUT_JSON = JSON.stringify(input);
+    // Pass a serializable subset of context to the subprocess
+    env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      workingDir: context.workingDir,
+      sessionId: context.sessionId,
+      conversationId: context.conversationId,
+    });
+
+    const child = spawn(wrapped.command, wrapped.args, {
+      cwd: runDir,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+
+    // Cooperative cancellation via AbortSignal
+    const onAbort = () => {
+      child.kill('SIGKILL');
+    };
+    if (context.signal) {
+      if (context.signal.aborted) {
+        child.kill('SIGKILL');
+      } else {
+        context.signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+
+    child.stdout.on('data', (data: Buffer) => stdoutChunks.push(data));
+    child.stderr.on('data', (data: Buffer) => stderrChunks.push(data));
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      context.signal?.removeEventListener('abort', onAbort);
+
+      if (timedOut) {
+        resolve({
+          content: `Skill tool script "${executorPath}" timed out after ${timeoutMs}ms`,
+          isError: true,
+          status: 'timeout',
+        });
+        return;
+      }
+
+      const stdout = Buffer.concat(stdoutChunks).toString();
+      const stderr = Buffer.concat(stderrChunks).toString();
+
+      // Parse structured result from stdout
+      const result = parseSkillResult(stdout, executorPath);
+      if (result) {
+        resolve(result);
+        return;
+      }
+
+      // No structured result — fall back to raw output
+      if (code !== 0) {
+        const truncatedStderr = stderr.length > MAX_OUTPUT_CHARS
+          ? stderr.slice(0, MAX_OUTPUT_CHARS) + '\n[stderr truncated]'
+          : stderr;
+        resolve({
+          content: `Skill tool script "${executorPath}" exited with code ${code}:\n${truncatedStderr}`,
+          isError: true,
+        });
+        return;
+      }
+
+      const truncatedStdout = stdout.length > MAX_OUTPUT_CHARS
+        ? stdout.slice(0, MAX_OUTPUT_CHARS) + '\n[stdout truncated]'
+        : stdout;
+      resolve({ content: truncatedStdout, isError: false });
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      context.signal?.removeEventListener('abort', onAbort);
+      resolve({
+        content: `Failed to spawn skill tool script "${executorPath}": ${err.message}`,
+        isError: true,
+      });
+    });
+  });
+}
+
+/**
+ * Scan stdout for the last occurrence of our structured result marker.
+ * Uses the same backward-scanning approach as evaluate-typescript.
+ */
+function parseSkillResult(stdout: string, executorPath: string): ToolExecutionResult | null {
+  let searchFrom = stdout.length;
+  while (searchFrom > 0) {
+    const markerIdx = stdout.lastIndexOf('__skill_result', searchFrom - 1);
+    if (markerIdx === -1) break;
+
+    const lineStart = stdout.lastIndexOf('\n', markerIdx) + 1;
+    const lineEnd = stdout.indexOf('\n', markerIdx);
+    const line = stdout.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === 'object' && '__skill_result' in parsed) {
+        const result = parsed.__skill_result;
+        if (result && typeof result === 'object' && 'content' in result) {
+          return result as ToolExecutionResult;
+        }
+      }
+    } catch {
+      // malformed line — keep scanning
+    }
+    searchFrom = lineStart;
+  }
+
+  // Check for error marker
+  searchFrom = stdout.length;
+  while (searchFrom > 0) {
+    const markerIdx = stdout.lastIndexOf('__skill_error', searchFrom - 1);
+    if (markerIdx === -1) break;
+
+    const lineStart = stdout.lastIndexOf('\n', markerIdx) + 1;
+    const lineEnd = stdout.indexOf('\n', markerIdx);
+    const line = stdout.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === 'object' && '__skill_error' in parsed) {
+        return {
+          content: `Skill tool script "${executorPath}": ${parsed.__skill_error}`,
+          isError: true,
+        };
+      }
+    } catch {
+      // malformed line — keep scanning
+    }
+    searchFrom = lineStart;
+  }
+
+  return null;
+}

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -1,6 +1,14 @@
-import type { ToolExecutionResult, ToolContext } from '../types.js';
+import type { ToolExecutionResult, ToolContext, ExecutionTarget } from '../types.js';
 import type { SkillToolScript } from './script-contract.js';
 import { join } from 'node:path';
+import { runSkillToolScriptSandbox } from './sandbox-runner.js';
+
+export interface RunSkillToolScriptOptions {
+  /** Where to execute: 'host' runs in-process, 'sandbox' runs in an isolated subprocess. */
+  target?: ExecutionTarget;
+  /** Timeout in ms for sandbox execution. Ignored for host execution. */
+  timeoutMs?: number;
+}
 
 /**
  * Execute a skill tool script on the host backend.
@@ -11,7 +19,14 @@ export async function runSkillToolScript(
   executorPath: string,
   input: Record<string, unknown>,
   context: ToolContext,
+  options?: RunSkillToolScriptOptions,
 ): Promise<ToolExecutionResult> {
+  if (options?.target === 'sandbox') {
+    return runSkillToolScriptSandbox(skillDir, executorPath, input, context, {
+      timeoutMs: options.timeoutMs,
+    });
+  }
+
   const scriptPath = join(skillDir, executorPath);
 
   let module: SkillToolScript;


### PR DESCRIPTION
## Summary
- Add `sandbox-runner.ts` with subprocess-based isolation for skill tool scripts
- Uses the same patterns as `evaluate-typescript` tool: temp runner script, `spawn` via sandbox backend, JSON stdin/stdout contract
- Passes input and serializable context via environment variables
- Timeout and cooperative cancellation (AbortSignal) support
- Backward-scanning stdout parser for structured JSON result extraction
- Update `skill-script-runner.ts` with unified routing: `target: 'sandbox'` routes to subprocess, default/host uses in-process dynamic import
- 8 tests covering success, error, timeout, and routing scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
