### PR TITLE
feat: build skill tool factory from manifest entries

### DIFF
--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createSkillTool, createSkillToolsFromManifest } from '../tools/skills/skill-tool-factory.js';
+import { RiskLevel } from '../permissions/types.js';
+import type { SkillToolEntry } from '../config/skills.js';
+import type { ToolContext } from '../tools/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<SkillToolEntry> = {}): SkillToolEntry {
+  return {
+    name: 'test_tool',
+    description: 'A test tool',
+    category: 'testing',
+    risk: 'medium',
+    input_schema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    },
+    executor: 'scripts/run.ts',
+    execution_target: 'host',
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Temp dir for execute tests that need real scripts
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'skill-tool-factory-test-'));
+
+  await writeFile(
+    join(tempDir, 'echo.ts'),
+    `export async function run(input, context) {
+  return {
+    content: JSON.stringify({ input, workingDir: context.workingDir }),
+    isError: false,
+  };
+}`,
+    'utf-8',
+  );
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// createSkillTool — metadata
+// ---------------------------------------------------------------------------
+
+describe('createSkillTool', () => {
+  test('produces a tool with correct name, description, and category', () => {
+    const tool = createSkillTool(makeEntry(), 'my-skill', '/skills/my-skill');
+
+    expect(tool.name).toBe('test_tool');
+    expect(tool.description).toBe('A test tool');
+    expect(tool.category).toBe('testing');
+  });
+
+  test('sets origin to skill and ownerSkillId', () => {
+    const tool = createSkillTool(makeEntry(), 'weather-skill', '/skills/weather');
+
+    expect(tool.origin).toBe('skill');
+    expect(tool.ownerSkillId).toBe('weather-skill');
+  });
+
+  test.each([
+    ['low', RiskLevel.Low],
+    ['medium', RiskLevel.Medium],
+    ['high', RiskLevel.High],
+  ] as const)('maps risk "%s" to RiskLevel.%s', (risk, expected) => {
+    const tool = createSkillTool(makeEntry({ risk }), 'sk', '/skills/sk');
+
+    expect(tool.defaultRiskLevel).toBe(expected);
+  });
+
+  // ---------------------------------------------------------------------------
+  // getDefinition
+  // ---------------------------------------------------------------------------
+
+  test('getDefinition() returns correct ToolDefinition with input_schema', () => {
+    const schema = {
+      type: 'object',
+      properties: { url: { type: 'string' }, depth: { type: 'number' } },
+      required: ['url'],
+    };
+    const tool = createSkillTool(
+      makeEntry({ name: 'web_scrape', description: 'Scrape a URL', input_schema: schema }),
+      'scraper',
+      '/skills/scraper',
+    );
+
+    const def = tool.getDefinition();
+
+    expect(def.name).toBe('web_scrape');
+    expect(def.description).toBe('Scrape a URL');
+    expect(def.input_schema).toEqual(schema);
+  });
+
+  // ---------------------------------------------------------------------------
+  // execute — integration with real script
+  // ---------------------------------------------------------------------------
+
+  test('execute() routes through runSkillToolScript to the executor', async () => {
+    const tool = createSkillTool(
+      makeEntry({ executor: 'echo.ts' }),
+      'my-skill',
+      tempDir,
+    );
+    const ctx = makeContext({ workingDir: '/my/project' });
+    const input = { query: 'hello' };
+
+    const result = await tool.execute(input, ctx);
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.input).toEqual({ query: 'hello' });
+    expect(parsed.workingDir).toBe('/my/project');
+  });
+
+  test('execute() returns error when executor script is missing', async () => {
+    const tool = createSkillTool(
+      makeEntry({ executor: 'nonexistent.ts' }),
+      'my-skill',
+      tempDir,
+    );
+
+    const result = await tool.execute({}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Failed to load skill tool script');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSkillToolsFromManifest
+// ---------------------------------------------------------------------------
+
+describe('createSkillToolsFromManifest', () => {
+  test('creates a tool for each manifest entry', () => {
+    const entries: SkillToolEntry[] = [
+      makeEntry({ name: 'tool_a', description: 'Tool A', risk: 'low' }),
+      makeEntry({ name: 'tool_b', description: 'Tool B', risk: 'high' }),
+      makeEntry({ name: 'tool_c', description: 'Tool C', risk: 'medium' }),
+    ];
+
+    const tools = createSkillToolsFromManifest(entries, 'multi-skill', '/skills/multi');
+
+    expect(tools).toHaveLength(3);
+    expect(tools.map(t => t.name)).toEqual(['tool_a', 'tool_b', 'tool_c']);
+    expect(tools.map(t => t.defaultRiskLevel)).toEqual([
+      RiskLevel.Low,
+      RiskLevel.High,
+      RiskLevel.Medium,
+    ]);
+  });
+
+  test('all created tools share the same skillId and origin', () => {
+    const entries: SkillToolEntry[] = [
+      makeEntry({ name: 'alpha' }),
+      makeEntry({ name: 'beta' }),
+    ];
+
+    const tools = createSkillToolsFromManifest(entries, 'shared-skill', '/skills/shared');
+
+    for (const tool of tools) {
+      expect(tool.origin).toBe('skill');
+      expect(tool.ownerSkillId).toBe('shared-skill');
+    }
+  });
+
+  test('returns an empty array when given no entries', () => {
+    const tools = createSkillToolsFromManifest([], 'empty-skill', '/skills/empty');
+
+    expect(tools).toEqual([]);
+  });
+});

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -1,0 +1,54 @@
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { SkillToolEntry } from '../../config/skills.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { RiskLevel } from '../../permissions/types.js';
+import { runSkillToolScript } from './skill-script-runner.js';
+
+const riskMap: Record<SkillToolEntry['risk'], RiskLevel> = {
+  low: RiskLevel.Low,
+  medium: RiskLevel.Medium,
+  high: RiskLevel.High,
+};
+
+/**
+ * Create a runtime Tool object from a manifest entry.
+ * Maps SkillToolEntry metadata to the Tool interface and routes execution
+ * through the skill script runner.
+ */
+export function createSkillTool(
+  entry: SkillToolEntry,
+  skillId: string,
+  skillDir: string,
+): Tool {
+  return {
+    name: entry.name,
+    description: entry.description,
+    category: entry.category,
+    defaultRiskLevel: riskMap[entry.risk],
+    origin: 'skill',
+    ownerSkillId: skillId,
+
+    getDefinition(): ToolDefinition {
+      return {
+        name: entry.name,
+        description: entry.description,
+        input_schema: entry.input_schema as ToolDefinition['input_schema'],
+      };
+    },
+
+    async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+      return runSkillToolScript(skillDir, entry.executor, input, context);
+    },
+  };
+}
+
+/**
+ * Create runtime Tool objects from all entries in a manifest.
+ */
+export function createSkillToolsFromManifest(
+  entries: SkillToolEntry[],
+  skillId: string,
+  skillDir: string,
+): Tool[] {
+  return entries.map(entry => createSkillTool(entry, skillId, skillDir));
+}


### PR DESCRIPTION
## Summary
- Add `createSkillTool()` and `createSkillToolsFromManifest()` in `skill-tool-factory.ts`
- Maps `SkillToolEntry` to runtime `Tool` with `origin`/`ownerSkillId` metadata
- Routes execution through the skill script runner
- Tests for tool creation, metadata, risk level mapping, definitions, execute delegation, and batch creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
