### PR TITLE
feat: add model selector step to onboarding flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -11,7 +11,15 @@ struct APIKeyStepView: View {
     @State private var showIcon = false
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showModelSelector = false
+    @State private var selectedModel = "claude-sonnet-4-5-20250929"
     @FocusState private var keyFieldFocused: Bool
+
+    private static let models: [(id: String, name: String, detail: String)] = [
+        ("claude-opus-4-6", "Opus 4.6", "Most capable"),
+        ("claude-sonnet-4-5-20250929", "Sonnet 4.5", "Balanced"),
+        ("claude-haiku-4-5-20251001", "Haiku 4.5", "Fastest"),
+    ]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -38,90 +46,111 @@ struct APIKeyStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
             // Title
-            Text("Add your API key")
+            Text(showModelSelector ? "Choose your model" : "Add your API key")
                 .font(.system(size: 32, weight: .regular, design: .serif))
                 .foregroundColor(VColor.textPrimary)
                 .opacity(showTitle ? 1 : 0)
                 .offset(y: showTitle ? 0 : 8)
                 .padding(.bottom, VSpacing.md)
+                .animation(.easeInOut(duration: 0.3), value: showModelSelector)
 
             // Subtitle
-            Text("Enter your Anthropic API key to get started.")
+            Text(showModelSelector
+                 ? "Pick the model that powers your assistant."
+                 : "Enter your Anthropic API key to get started.")
                 .font(.system(size: 16))
                 .foregroundColor(VColor.textSecondary)
                 .opacity(showTitle ? 1 : 0)
                 .offset(y: showTitle ? 0 : 8)
+                .animation(.easeInOut(duration: 0.3), value: showModelSelector)
 
             Spacer()
 
             // Content
             VStack(spacing: VSpacing.md) {
-                    if hasExistingKey && !isEditing {
-                        // Show masked key: first 4 chars + dots + last 3 chars
-                        Text(maskedKey)
-                            .font(.system(size: 16, weight: .medium, design: .monospaced))
-                            .foregroundColor(VColor.textPrimary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-                            )
-                            .onTapGesture {
-                                isEditing = true
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                    keyFieldFocused = true
+                if showModelSelector {
+                    // Model selection cards
+                    VStack(spacing: VSpacing.sm) {
+                        ForEach(Self.models, id: \.id) { model in
+                            modelCard(id: model.id, name: model.name, detail: model.detail)
+                        }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+                } else {
+                    Group {
+                        if hasExistingKey && !isEditing {
+                            Text(maskedKey)
+                                .font(.system(size: 16, weight: .medium, design: .monospaced))
+                                .foregroundColor(VColor.textPrimary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, VSpacing.lg)
+                                .background(
+                                    RoundedRectangle(cornerRadius: VRadius.lg)
+                                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                )
+                                .onTapGesture {
+                                    isEditing = true
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                        keyFieldFocused = true
+                                    }
                                 }
-                            }
+                        } else {
+                            SecureField("sk-ant-\u{2026}", text: $apiKey)
+                                .textFieldStyle(.plain)
+                                .font(.system(size: 16, weight: .medium, design: .monospaced))
+                                .foregroundColor(VColor.textPrimary)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, VSpacing.lg)
+                                .background(
+                                    RoundedRectangle(cornerRadius: VRadius.lg)
+                                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                )
+                                .focused($keyFieldFocused)
+                                .onSubmit {
+                                    saveKeyAndShowModels()
+                                }
+                        }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .leading)))
+                }
+
+                // Primary button
+                Button(action: {
+                    if showModelSelector {
+                        saveModelAndContinue()
                     } else {
-                        SecureField("sk-ant-\u{2026}", text: $apiKey)
-                            .textFieldStyle(.plain)
-                            .font(.system(size: 16, weight: .medium, design: .monospaced))
-                            .foregroundColor(VColor.textPrimary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-                            )
-                            .focused($keyFieldFocused)
-                            .onSubmit {
-                                saveAndContinue()
-                            }
+                        saveKeyAndShowModels()
                     }
-
-                    Button(action: { saveAndContinue() }) {
-                        Text("Save & Continue")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundColor(adaptiveColor(
-                                light: .white,
-                                dark: .white
-                            ))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .fill(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                                        ? adaptiveColor(
-                                            light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 0.3)),
-                                            dark: Violet._600.opacity(0.3)
-                                        )
-                                        : adaptiveColor(
-                                            light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
-                                            dark: Violet._600
-                                        )
+                }) {
+                    Text(showModelSelector ? "Save & Continue" : "Select a model")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(adaptiveColor(light: .white, dark: .white))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, VSpacing.lg)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .fill(primaryButtonDisabled
+                                    ? adaptiveColor(
+                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 0.3)),
+                                        dark: Violet._600.opacity(0.3)
                                     )
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
+                                    : adaptiveColor(
+                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                        dark: Violet._600
+                                    )
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(primaryButtonDisabled)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
 
-                    HStack(spacing: VSpacing.lg) {
+                HStack(spacing: VSpacing.lg) {
+                    if !showModelSelector {
                         Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
                             Text("Get an API key")
                                 .font(.system(size: 13))
@@ -130,18 +159,19 @@ struct APIKeyStepView: View {
                         .onHover { hovering in
                             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                         }
-
-                        Button(action: { goBack() }) {
-                            Text("Back")
-                                .font(.system(size: 13))
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        .buttonStyle(.plain)
-                        .onHover { hovering in
-                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
                     }
-                    .padding(.top, VSpacing.xs)
+
+                    Button(action: { goBack() }) {
+                        Text("Back")
+                            .font(.system(size: 13))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
+                }
+                .padding(.top, VSpacing.xs)
             }
             .padding(.horizontal, VSpacing.xxl)
             .padding(.bottom, VSpacing.xxl)
@@ -198,6 +228,58 @@ struct APIKeyStepView: View {
         }
     }
 
+    // MARK: - Model Card
+
+    private func modelCard(id: String, name: String, detail: String) -> some View {
+        let isSelected = selectedModel == id
+        return Button(action: { selectedModel = id }) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(name)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(VColor.textPrimary)
+                    Text(detail)
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.textSecondary)
+                }
+                Spacer()
+                Circle()
+                    .fill(isSelected ? Violet._600 : Color.clear)
+                    .overlay(
+                        Circle().stroke(isSelected ? Violet._600 : VColor.surfaceBorder, lineWidth: 1.5)
+                    )
+                    .overlay(
+                        isSelected
+                            ? Circle().fill(Color.white).frame(width: 6, height: 6)
+                            : nil
+                    )
+                    .frame(width: 18, height: 18)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isSelected ? Violet._600.opacity(0.1) : Color.clear)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(isSelected ? Violet._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var primaryButtonDisabled: Bool {
+        if showModelSelector { return false }
+        return apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     private var maskedKey: String {
         guard apiKey.count > 7 else { return String(repeating: "\u{2022}", count: apiKey.count) }
         let prefix = String(apiKey.prefix(4))
@@ -207,16 +289,48 @@ struct APIKeyStepView: View {
     }
 
     private func goBack() {
-        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
-            state.currentStep = 0
+        if showModelSelector {
+            withAnimation(.spring(duration: 0.4, bounce: 0.1)) {
+                showModelSelector = false
+            }
+        } else {
+            withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                state.currentStep = 0
+            }
         }
     }
 
-    private func saveAndContinue() {
+    private func saveKeyAndShowModels() {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         APIKeyManager.setKey(trimmed)
+        withAnimation(.spring(duration: 0.4, bounce: 0.1)) {
+            showModelSelector = true
+        }
+    }
+
+    private func saveModelAndContinue() {
+        saveModelToConfig(selectedModel)
         state.advance()
+    }
+
+    private func saveModelToConfig(_ model: String) {
+        let configURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum/workspace/config.json")
+
+        do {
+            let data = try Data(contentsOf: configURL)
+            if var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                json["model"] = model
+                let updated = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
+                try updated.write(to: configURL)
+            }
+        } catch {
+            let json: [String: Any] = ["model": model]
+            if let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) {
+                try? data.write(to: configURL)
+            }
+        }
     }
 }
 
@@ -229,5 +343,5 @@ struct APIKeyStepView: View {
             return s
         }())
     }
-    .frame(width: 460, height: 520)
+    .frame(width: 460, height: 620)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -40,7 +40,7 @@ final class OnboardingWindow {
         let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 520),
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 620),
             styleMask: [.titled, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -53,10 +53,10 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
 
-        window.contentMinSize = NSSize(width: 420, height: 480)
+        window.contentMinSize = NSSize(width: 420, height: 580)
 
         let startWidth: CGFloat = 460
-        let startHeight: CGFloat = 520
+        let startHeight: CGFloat = 620
         if let visibleFrame = Self.visibleScreenFrame() {
             let x = visibleFrame.midX - startWidth / 2
             let y = visibleFrame.midY - startHeight / 2


### PR DESCRIPTION
## Summary
- After entering API key, users now select a model (Opus 4.6, Sonnet 4.5, or Haiku 4.5) before continuing onboarding
- Model cards with radio-button styling, animated transitions between API key and model selector phases
- Increased onboarding window height from 520 to 620 to accommodate the model selector content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
