### PR TITLE
fix: restore vertical padding in composer overflow mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -464,7 +464,7 @@ private struct ComposerTextView: NSViewRepresentable {
         textView.font = NSFont(name: "Inter", size: 13) ?? NSFont.systemFont(ofSize: 13)
         textView.textColor = NSColor(VColor.textPrimary)
         textView.insertionPointColor = NSColor(VColor.accent)
-        textView.textContainerInset = NSSize(width: 0, height: 0)
+        textView.textContainerInset = NSSize(width: 0, height: 8)
         textView.string = text
 
         if let container = textView.textContainer {
@@ -702,7 +702,11 @@ private final class CenteringClipView: NSClipView {
            let layoutManager = textView.layoutManager,
            let textContainer = textView.textContainer {
             layoutManager.ensureLayout(for: textContainer)
-            let contentHeight = layoutManager.usedRect(for: textContainer).height
+            let usedHeight = layoutManager.usedRect(for: textContainer).height
+            // Include the textContainerInset in the total content height so
+            // centering accounts for the top/bottom padding the text view adds.
+            let insetHeight = textView.textContainerInset.height * 2
+            let contentHeight = usedHeight + insetHeight
             if contentHeight < bounds.height {
                 rect.origin.y = ceil((contentHeight - bounds.height) / 2)
             }


### PR DESCRIPTION
## Summary
- Restored `textContainerInset.height = 8` on the composer text view so that when text overflows (long prompts at max composer height), the first and last lines have proper breathing room instead of sitting flush against the edges
- Updated `CenteringClipView.constrainBoundsRect` to include the text container inset in the content height calculation, so centering remains accurate for short content

Addresses feedback from #3425.

## Test plan
- [ ] Type a short message in the composer -- text should still be vertically centered
- [ ] Type a long multi-line message that exceeds the composer max height (200pt) -- text should have ~8pt padding at top and bottom, not flush against edges
- [ ] Verify placeholder text alignment is correct
- [ ] Verify cursor alignment with text (including emoji)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
