### PR TITLE
feat: add active skill derivation from runtime message history

### DIFF
--- a/assistant/src/__tests__/active-skill-tools.test.ts
+++ b/assistant/src/__tests__/active-skill-tools.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect } from 'bun:test';
+import { deriveActiveSkillIds } from '../skills/active-skill-tools.js';
+import type { Message } from '../providers/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convenience: build a user message with a single tool_result block. */
+function toolResultMsg(toolUseId: string, content: string): Message {
+  return {
+    role: 'user',
+    content: [{ type: 'tool_result', tool_use_id: toolUseId, content }],
+  };
+}
+
+/** Convenience: build a user message with a plain text block. */
+function textMsg(role: 'user' | 'assistant', text: string): Message {
+  return { role, content: [{ type: 'text', text }] };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('deriveActiveSkillIds', () => {
+  test('empty history returns empty array', () => {
+    expect(deriveActiveSkillIds([])).toEqual([]);
+  });
+
+  test('no markers returns empty array', () => {
+    const messages: Message[] = [
+      textMsg('user', 'Hello'),
+      textMsg('assistant', 'Hi there!'),
+      toolResultMsg('t1', 'Some tool output with no markers'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual([]);
+  });
+
+  test('single marker extraction from tool result', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', 'Skill loaded.\n\n<loaded_skill id="deploy" />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['deploy']);
+  });
+
+  test('multiple markers from different tool results', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', 'Loaded\n\n<loaded_skill id="deploy" />'),
+      toolResultMsg('t2', 'Loaded\n\n<loaded_skill id="oncall" />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['deploy', 'oncall']);
+  });
+
+  test('duplicate markers are deduplicated with order preserved', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', '<loaded_skill id="deploy" />'),
+      toolResultMsg('t2', '<loaded_skill id="oncall" />'),
+      toolResultMsg('t3', '<loaded_skill id="deploy" />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['deploy', 'oncall']);
+  });
+
+  test('malformed markers are ignored — missing id attribute', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', '<loaded_skill />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual([]);
+  });
+
+  test('malformed markers are ignored — unclosed tag', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', '<loaded_skill id="deploy">'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual([]);
+  });
+
+  test('malformed markers are ignored — wrong tag name', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', '<loaded_tool id="deploy" />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual([]);
+  });
+
+  test('markers in assistant text content are found', () => {
+    const messages: Message[] = [
+      textMsg('assistant', 'I loaded a skill: <loaded_skill id="review" />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['review']);
+  });
+
+  test('markers in user text content are found', () => {
+    const messages: Message[] = [
+      textMsg('user', 'Context: <loaded_skill id="debug" />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['debug']);
+  });
+
+  test('mixed valid and invalid markers', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', [
+        '<loaded_skill id="alpha" />',
+        '<loaded_skill />',
+        '<loaded_skill id="beta" />',
+        '<loaded_tool id="gamma" />',
+        '<loaded_skill id="alpha" />',
+      ].join('\n')),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['alpha', 'beta']);
+  });
+
+  test('multiple markers in a single content string', () => {
+    const messages: Message[] = [
+      toolResultMsg('t1', '<loaded_skill id="a" />\n<loaded_skill id="b" />'),
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['a', 'b']);
+  });
+
+  test('ignores non-text, non-tool-result blocks', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '<loaded_skill id="hidden" />', signature: 'sig' },
+          { type: 'text', text: '<loaded_skill id="visible" />' },
+        ],
+      },
+    ];
+    expect(deriveActiveSkillIds(messages)).toEqual(['visible']);
+  });
+});

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';

--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/assistant/src/skills/active-skill-tools.ts
+++ b/assistant/src/skills/active-skill-tools.ts
@@ -1,0 +1,38 @@
+import type { Message } from '../providers/types.js';
+
+const LOADED_SKILL_RE = /<loaded_skill\s+id="([^"]+)"\s*\/>/g;
+
+/**
+ * Scans conversation history for `<loaded_skill id="..." />` markers and
+ * returns an ordered, deduplicated list of active skill IDs.  The function is
+ * intentionally pure — no caching or side-effects — so callers can invoke it on
+ * every turn without worrying about stale state.
+ */
+export function deriveActiveSkillIds(messages: Message[]): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+
+  for (const msg of messages) {
+    for (const block of msg.content) {
+      let text: string | undefined;
+
+      if (block.type === 'text') {
+        text = block.text;
+      } else if (block.type === 'tool_result') {
+        text = block.content;
+      }
+
+      if (!text) continue;
+
+      for (const match of text.matchAll(LOADED_SKILL_RE)) {
+        const id = match[1];
+        if (!seen.has(id)) {
+          seen.add(id);
+          ids.push(id);
+        }
+      }
+    }
+  }
+
+  return ids;
+}


### PR DESCRIPTION
## Summary
- Adds `deriveActiveSkillIds()` pure function to scan message history for `<loaded_skill>` markers
- Returns ordered deduplicated active skill IDs for dynamic tool projection
- Fixes pre-existing unused import lint errors in script runner tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
