### PR TITLE
feat: add dynamic tool resolver support to AgentLoop

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -915,4 +915,120 @@ describe('AgentLoop', () => {
     // History: user, assistant(t1), user(result1), assistant(t2), user(result2)
     expect(history).toHaveLength(5);
   });
+
+  // ---------------------------------------------------------------------------
+  // Dynamic tool resolver (resolveTools) tests
+  // ---------------------------------------------------------------------------
+
+  // 25. Without resolveTools, static tools are used (backward compatible)
+  test('without resolveTools, static tools are passed to provider', async () => {
+    const { provider, calls } = createMockProvider([textResponse('Hi')]);
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools);
+
+    await loop.run([userMessage], () => {});
+
+    expect(calls[0].tools).toEqual(dummyTools);
+  });
+
+  // 26. resolveTools callback is invoked before each provider call
+  test('resolveTools is invoked before each provider call', async () => {
+    const resolverCalls: Message[][] = [];
+    const resolvedTools: ToolDefinition[] = [
+      { name: 'search', description: 'Search files', input_schema: { type: 'object', properties: { query: { type: 'string' } } } },
+    ];
+
+    const { provider } = createMockProvider([
+      toolUseResponse('t1', 'search', { query: 'foo' }),
+      textResponse('Found it'),
+    ]);
+
+    const toolExecutor = async () => ({ content: 'result', isError: false });
+
+    const resolveTools = (history: Message[]): ToolDefinition[] => {
+      resolverCalls.push([...history]);
+      return resolvedTools;
+    };
+
+    const loop = new AgentLoop(provider, 'system', {}, [], toolExecutor, resolveTools);
+    await loop.run([userMessage], () => {});
+
+    // resolveTools should be called once per provider turn (2 turns total)
+    expect(resolverCalls).toHaveLength(2);
+
+    // First call receives just the initial user message
+    expect(resolverCalls[0]).toHaveLength(1);
+    expect(resolverCalls[0][0]).toEqual(userMessage);
+
+    // Second call receives the accumulated history (user + assistant + tool_result)
+    expect(resolverCalls[1].length).toBeGreaterThan(1);
+  });
+
+  // 27. Resolved tool list is passed to the provider
+  test('resolved tools are passed to the provider instead of static tools', async () => {
+    const dynamicTools: ToolDefinition[] = [
+      { name: 'dynamic_tool', description: 'Dynamic', input_schema: { type: 'object' } },
+    ];
+
+    const { provider, calls } = createMockProvider([textResponse('Hi')]);
+
+    const resolveTools = (): ToolDefinition[] => dynamicTools;
+
+    // Pass different static tools to verify they are overridden
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, undefined, resolveTools);
+    await loop.run([userMessage], () => {});
+
+    // Provider should receive the dynamically resolved tools, not the static ones
+    expect(calls[0].tools).toEqual(dynamicTools);
+    expect(calls[0].tools).not.toEqual(dummyTools);
+  });
+
+  // 28. Tool list can change between turns
+  test('resolveTools can return different tools on each turn', async () => {
+    const toolsPerTurn: ToolDefinition[][] = [
+      [{ name: 'tool_a', description: 'Tool A', input_schema: { type: 'object' } }],
+      [
+        { name: 'tool_a', description: 'Tool A', input_schema: { type: 'object' } },
+        { name: 'tool_b', description: 'Tool B', input_schema: { type: 'object' } },
+      ],
+      [{ name: 'tool_c', description: 'Tool C', input_schema: { type: 'object' } }],
+    ];
+
+    let turnIndex = 0;
+    const resolveTools = (): ToolDefinition[] => {
+      const tools = toolsPerTurn[turnIndex] ?? toolsPerTurn[toolsPerTurn.length - 1];
+      turnIndex++;
+      return tools;
+    };
+
+    const { provider, calls } = createMockProvider([
+      toolUseResponse('t1', 'tool_a', {}),
+      toolUseResponse('t2', 'tool_a', {}),
+      textResponse('Done'),
+    ]);
+
+    const toolExecutor = async () => ({ content: 'ok', isError: false });
+    const loop = new AgentLoop(provider, 'system', {}, [], toolExecutor, resolveTools);
+    await loop.run([userMessage], () => {});
+
+    // Provider should have been called 3 times
+    expect(calls).toHaveLength(3);
+
+    // Each call should have received different tools
+    expect(calls[0].tools).toEqual(toolsPerTurn[0]);
+    expect(calls[1].tools).toEqual(toolsPerTurn[1]);
+    expect(calls[2].tools).toEqual(toolsPerTurn[2]);
+  });
+
+  // 29. resolveTools returning empty array means no tools passed to provider
+  test('resolveTools returning empty array sends no tools to provider', async () => {
+    const resolveTools = (): ToolDefinition[] => [];
+
+    const { provider, calls } = createMockProvider([textResponse('No tools available')]);
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, undefined, resolveTools);
+    await loop.run([userMessage], () => {});
+
+    // Empty array should result in undefined tools (same as no-tools behavior)
+    expect(calls[0].tools).toBeUndefined();
+  });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -44,6 +44,7 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
+  private resolveTools: ((history: Message[]) => ToolDefinition[]) | null;
   private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>) | null;
 
   constructor(
@@ -52,11 +53,13 @@ export class AgentLoop {
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
     toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>,
+    resolveTools?: (history: Message[]) => ToolDefinition[],
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.tools = tools ?? [];
+    this.resolveTools = resolveTools ?? null;
     this.toolExecutor = toolExecutor ?? null;
   }
 
@@ -80,6 +83,12 @@ export class AgentLoop {
       let toolUseBlocks: Extract<ContentBlock, { type: 'tool_use' }>[] = [];
 
       try {
+        // Resolve tools for this turn: use the dynamic resolver if provided,
+        // otherwise fall back to the static tool list.
+        const currentTools = this.resolveTools
+          ? this.resolveTools(history)
+          : this.tools;
+
         const providerConfig: Record<string, unknown> = { max_tokens: this.config.maxTokens };
         if (this.config.thinking?.enabled) {
           // Anthropic requires budget_tokens < max_tokens
@@ -104,7 +113,7 @@ export class AgentLoop {
             lastMessage: history.length > 0
               ? summarizeMessage(history[history.length - 1])
               : null,
-            toolCount: this.tools.length,
+            toolCount: currentTools.length,
             config: providerConfig,
           }, 'Sending request to provider');
         }
@@ -112,7 +121,7 @@ export class AgentLoop {
         const preLlmResult = await getHookManager().trigger('pre-llm-call', {
           systemPrompt: this.systemPrompt,
           messages: history,
-          toolCount: this.tools.length,
+          toolCount: currentTools.length,
         });
 
         if (preLlmResult.blocked) {
@@ -124,7 +133,7 @@ export class AgentLoop {
 
         const response = await this.provider.sendMessage(
           history,
-          this.tools.length > 0 ? this.tools : undefined,
+          currentTools.length > 0 ? currentTools : undefined,
           this.systemPrompt,
           {
             config: providerConfig,


### PR DESCRIPTION
## Summary
- Adds optional `resolveTools(history)` callback to AgentLoop constructor
- Before each provider call, resolves current tool list from callback if provided
- Falls back to static tools for existing callers (backward compatible)
- Adds 5 tests covering: static fallback, callback invocation, resolved tools passed to provider, tools changing between turns, empty resolver

## Test plan
- [x] All 35 existing + new agent-loop tests pass
- [x] TypeScript type checking passes (`bunx tsc --noEmit`)
- [x] No new lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
