### PR TITLE
fix: guard activity panel row expansion for non-expandable items

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -44,6 +44,7 @@ struct ActivityStepView: View {
         VStack(alignment: .leading, spacing: 0) {
             // Collapsed row — always visible, clickable to expand
             Button(action: {
+                guard hasExpandableContent else { return }
                 withAnimation(VAnimation.fast) {
                     isExpanded.toggle()
                 }


### PR DESCRIPTION
When a tool call has no result and no screenshot, clicking the row still toggled `isExpanded`, creating empty padding space below the row. The chevron was already hidden for these rows, but the button action still fired.

Added `guard hasExpandableContent else { return }` to the button action so rows without expandable content are no longer interactive.

Addresses feedback on #3215.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
