### PR TITLE
feat: pass turn-specific allowed tool set from session projection

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -437,3 +437,113 @@ describe('resolveTools callback (session wiring)', () => {
     expect(names).toContain('oncall_ack');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — allowed tool set merging with core tools
+// ---------------------------------------------------------------------------
+
+describe('allowed tool set merging', () => {
+  const CORE_TOOL_NAMES = new Set(['bash', 'file_read', 'file_write', 'file_edit']);
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection();
+  });
+
+  /**
+   * Simulates the merging logic from session.ts:
+   * union of core tool names + projected skill tool names.
+   */
+  function buildAllowedSet(projection: { allowedToolNames: Set<string> }): Set<string> {
+    const merged = new Set(CORE_TOOL_NAMES);
+    for (const name of projection.allowedToolNames) {
+      merged.add(name);
+    }
+    return merged;
+  }
+
+  test('core tools are always included even with no active skills', () => {
+    const projection = projectSkillTools([]);
+    const allowed = buildAllowedSet(projection);
+
+    for (const core of CORE_TOOL_NAMES) {
+      expect(allowed.has(core)).toBe(true);
+    }
+  });
+
+  test('active skill tools are included alongside core tools', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run', 'deploy_status']) };
+
+    const history: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+    ];
+
+    const projection = projectSkillTools(history);
+    const allowed = buildAllowedSet(projection);
+
+    // Core tools present
+    for (const core of CORE_TOOL_NAMES) {
+      expect(allowed.has(core)).toBe(true);
+    }
+    // Active skill tools present
+    expect(allowed.has('deploy_run')).toBe(true);
+    expect(allowed.has('deploy_status')).toBe(true);
+  });
+
+  test('inactive skill tools are NOT in the allowed set', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+
+    // Only deploy is active
+    const history: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+    ];
+
+    const projection = projectSkillTools(history);
+    const allowed = buildAllowedSet(projection);
+
+    expect(allowed.has('deploy_run')).toBe(true);
+    // oncall_page is not active — not in projection, not in allowed set
+    expect(allowed.has('oncall_page')).toBe(false);
+  });
+
+  test('allowed set updates when skills activate and deactivate', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+
+    // Turn 1: both active
+    const history1: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+      toolResultMsg('<loaded_skill id="oncall" />'),
+    ];
+    const projection1 = projectSkillTools(history1);
+    const allowed1 = buildAllowedSet(projection1);
+
+    expect(allowed1.has('deploy_run')).toBe(true);
+    expect(allowed1.has('oncall_page')).toBe(true);
+
+    // Turn 2: only deploy remains
+    const history2: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+    ];
+    const projection2 = projectSkillTools(history2);
+    const allowed2 = buildAllowedSet(projection2);
+
+    expect(allowed2.has('deploy_run')).toBe(true);
+    expect(allowed2.has('oncall_page')).toBe(false);
+    // Core tools still present
+    for (const core of CORE_TOOL_NAMES) {
+      expect(allowed2.has(core)).toBe(true);
+    }
+  });
+});

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -38,6 +38,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   workingDir: string;
   sandboxOverride?: boolean;
   abortController: AbortController | null;
+  /** When set, only tools in this set may execute during the current turn. */
+  allowedToolNames?: Set<string>;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -82,6 +84,7 @@ export function createToolExecutor(
       onOutput,
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,
+      allowedToolNames: ctx.allowedToolNames,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),
       requestSecret: async (params) => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -122,6 +122,10 @@ export class Session {
   workingDir: string;
   /** @internal — exposed for session-tool-setup.ts module functions. */
   sandboxOverride?: boolean;
+  /** @internal — per-turn allowed tool set, read by the tool executor closure. */
+  allowedToolNames?: Set<string>;
+  /** Core tool names (computed once in constructor), always allowed regardless of skill state. */
+  private coreToolNames: Set<string>;
   /** @internal — exposed for session-usage.ts module functions. */
   usageStats: UsageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
   private readonly systemPrompt: string;
@@ -237,6 +241,7 @@ export class Session {
     };
 
     const toolDefs = buildToolDefinitions();
+    this.coreToolNames = new Set(toolDefs.map((d) => d.name));
     const toolExecutor = createToolExecutor(
       this.executor,
       this.prompter,
@@ -731,6 +736,15 @@ export class Session {
         workspaceTopLevelContext: this.workspaceTopLevelContext,
       });
 
+      // Project skill tools for this turn and build the allowed tool set.
+      // Core tools are always included so they're never gated.
+      const skillProjection = projectSkillTools(runMessages);
+      const turnAllowed = new Set(this.coreToolNames);
+      for (const name of skillProjection.allowedToolNames) {
+        turnAllowed.add(name);
+      }
+      this.allowedToolNames = turnAllowed;
+
       // Pre-run repair: fix any message ordering issues before sending to provider.
       // Keep a reference to the original (un-repaired) messages so we can
       // reconstruct this.messages after the agent loop without leaking synthetic
@@ -1154,6 +1168,7 @@ export class Session {
       this.processing = false;
       this.currentRequestId = undefined;
       this.currentActiveSurfaceId = undefined;
+      this.allowedToolNames = undefined;
 
       // Consolidate consecutive assistant messages from this agent loop run
       if (userMessageId) {


### PR DESCRIPTION
## Summary
- Captures `allowedToolNames` from skill tool projection per turn
- Passes through `ToolContext` so executor can gate inactive skill tools
- Core tools are always included in the allowed set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
