### PR TITLE
feat: extend slash resolution to return preactivation skill ID

### DIFF
--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -311,7 +311,7 @@ describe('Session slash command — known', () => {
 // ---------------------------------------------------------------------------
 
 describe('resolveSlash — direct characterization', () => {
-  test('known slash returns {kind: "rewritten"} with model-facing content', () => {
+  test('known slash returns {kind: "rewritten"} with model-facing content and skillId', () => {
     const result = resolveSlash('/start-the-day');
     expect(result.kind).toBe('rewritten');
     if (result.kind !== 'rewritten') throw new Error('unreachable');
@@ -322,20 +322,24 @@ describe('resolveSlash — direct characterization', () => {
     expect(result.content).toContain('ID: start-the-day');
     // It is NOT the raw user input
     expect(result.content).not.toBe('/start-the-day');
+    // The skillId matches the owning skill's canonical ID
+    expect(result.skillId).toBe('start-the-day');
   });
 
-  test('known slash with trailing args includes args in rewritten content', () => {
+  test('known slash with trailing args includes args in rewritten content and skillId', () => {
     const result = resolveSlash('/start-the-day check emails and calendar');
     expect(result.kind).toBe('rewritten');
     if (result.kind !== 'rewritten') throw new Error('unreachable');
     expect(result.content).toContain('User arguments: check emails and calendar');
+    expect(result.skillId).toBe('start-the-day');
   });
 
-  test('normal text returns {kind: "passthrough"} with content unchanged', () => {
+  test('normal text returns {kind: "passthrough"} with content unchanged and no skillId', () => {
     const result = resolveSlash('hello world');
     expect(result.kind).toBe('passthrough');
     if (result.kind !== 'passthrough') throw new Error('unreachable');
     expect(result.content).toBe('hello world');
+    expect('skillId' in result).toBe(false);
   });
 
   test('path-like input returns passthrough (not treated as slash)', () => {
@@ -345,18 +349,20 @@ describe('resolveSlash — direct characterization', () => {
     expect(result.content).toBe('/tmp/some-file.txt');
   });
 
-  test('unknown slash returns {kind: "unknown"} with message listing available commands', () => {
+  test('unknown slash returns {kind: "unknown"} with message and no skillId', () => {
     const result = resolveSlash('/does-not-exist');
     expect(result.kind).toBe('unknown');
     if (result.kind !== 'unknown') throw new Error('unreachable');
     expect(result.message).toContain('Unknown command `/does-not-exist`');
     expect(result.message).toContain('/start-the-day');
+    expect('skillId' in result).toBe(false);
   });
 
-  test('empty input returns passthrough', () => {
+  test('empty input returns passthrough with no skillId', () => {
     const result = resolveSlash('');
     expect(result.kind).toBe('passthrough');
     if (result.kind !== 'passthrough') throw new Error('unreachable');
     expect(result.content).toBe('');
+    expect('skillId' in result).toBe(false);
   });
 });

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -11,7 +11,8 @@ import {
 import { getWorkspacePromptPath } from '../util/platform.js';
 
 export type SlashResolution =
-  | { kind: 'passthrough' | 'rewritten'; content: string }
+  | { kind: 'passthrough'; content: string }
+  | { kind: 'rewritten'; content: string; skillId: string }
   | { kind: 'unknown'; message: string };
 
 // ── /model command ───────────────────────────────────────────────────
@@ -137,6 +138,7 @@ export function resolveSlash(content: string): SlashResolution {
         skillName: skill?.name ?? resolution.skillId,
         trailingArgs: resolution.trailingArgs,
       }),
+      skillId: resolution.skillId,
     };
   }
 


### PR DESCRIPTION
## Summary
- Extends slash resolution result for known commands with `skillId` metadata
- Enables session pipeline to preactivate skill tools before first model call
- Preserves existing passthrough/unknown behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
