### PR TITLE
test: add context-derived deactivation regression tests

### DIFF
--- a/assistant/src/__tests__/active-skill-tools.test.ts
+++ b/assistant/src/__tests__/active-skill-tools.test.ts
@@ -129,3 +129,80 @@ describe('deriveActiveSkillIds', () => {
     expect(deriveActiveSkillIds(messages)).toEqual(['visible']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Context-derived deactivation regression tests
+// ---------------------------------------------------------------------------
+
+describe('deriveActiveSkillIds — deactivation when marker leaves history', () => {
+  test('marker present → skill ID returned; marker removed → empty', () => {
+    const withMarker: Message[] = [
+      toolResultMsg('t1', '<loaded_skill id="deploy" />'),
+    ];
+    expect(deriveActiveSkillIds(withMarker)).toEqual(['deploy']);
+
+    // Simulate history truncation: the message containing the marker is gone
+    const withoutMarker: Message[] = [];
+    expect(deriveActiveSkillIds(withoutMarker)).toEqual([]);
+  });
+
+  test('one of two markers removed → only surviving skill returned', () => {
+    const bothPresent: Message[] = [
+      toolResultMsg('t1', '<loaded_skill id="deploy" />'),
+      toolResultMsg('t2', '<loaded_skill id="oncall" />'),
+    ];
+    expect(deriveActiveSkillIds(bothPresent)).toEqual(['deploy', 'oncall']);
+
+    // History truncated to remove the deploy marker
+    const onlyOncall: Message[] = [
+      toolResultMsg('t2', '<loaded_skill id="oncall" />'),
+    ];
+    expect(deriveActiveSkillIds(onlyOncall)).toEqual(['oncall']);
+  });
+
+  test('all markers removed from multi-message history → empty', () => {
+    const withMarkers: Message[] = [
+      textMsg('user', 'Hello'),
+      toolResultMsg('t1', '<loaded_skill id="alpha" />'),
+      textMsg('assistant', 'Done'),
+      toolResultMsg('t2', '<loaded_skill id="beta" />'),
+    ];
+    expect(deriveActiveSkillIds(withMarkers)).toEqual(['alpha', 'beta']);
+
+    // History truncated to only keep non-marker messages
+    const noMarkers: Message[] = [
+      textMsg('user', 'Hello'),
+      textMsg('assistant', 'Done'),
+    ];
+    expect(deriveActiveSkillIds(noMarkers)).toEqual([]);
+  });
+
+  test('marker replaced by different content in same position → skill gone', () => {
+    const original: Message[] = [
+      toolResultMsg('t1', '<loaded_skill id="deploy" />'),
+    ];
+    expect(deriveActiveSkillIds(original)).toEqual(['deploy']);
+
+    // Same structure but marker text replaced (e.g. message edited/summarized)
+    const replaced: Message[] = [
+      toolResultMsg('t1', 'Deployment complete.'),
+    ];
+    expect(deriveActiveSkillIds(replaced)).toEqual([]);
+  });
+
+  test('derive is stateless — consecutive calls with different histories are independent', () => {
+    const history1: Message[] = [
+      toolResultMsg('t1', '<loaded_skill id="deploy" />'),
+    ];
+    expect(deriveActiveSkillIds(history1)).toEqual(['deploy']);
+
+    // Calling with a completely different history does not carry over state
+    const history2: Message[] = [
+      toolResultMsg('t2', '<loaded_skill id="oncall" />'),
+    ];
+    expect(deriveActiveSkillIds(history2)).toEqual(['oncall']);
+
+    // Empty history returns empty, confirming no leaked state
+    expect(deriveActiveSkillIds([])).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -736,3 +736,200 @@ describe('mid-run skill tool activation (end-to-end)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Context-derived deactivation regression tests
+// ---------------------------------------------------------------------------
+
+describe('context-derived deactivation regression', () => {
+  const baseToolDefs: ToolDefinition[] = [
+    { name: 'file_read', description: 'Read a file', input_schema: { type: 'object', properties: {} } },
+    { name: 'bash', description: 'Run a shell command', input_schema: { type: 'object', properties: {} } },
+  ];
+
+  const CORE_TOOL_NAMES = new Set(['bash', 'file_read', 'file_write', 'file_edit']);
+
+  function makeResolveTools(base: ToolDefinition[]) {
+    return (history: Message[]) => {
+      const projection = projectSkillTools(history);
+      return {
+        toolDefinitions: [...base, ...projection.toolDefinitions],
+        allowedToolNames: new Set([...CORE_TOOL_NAMES, ...projection.allowedToolNames]),
+      };
+    };
+  }
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection();
+  });
+
+  test('tool definitions shrink when skill load marker is removed from history', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page', 'oncall_ack']),
+    };
+
+    const resolveTools = makeResolveTools(baseToolDefs);
+
+    // Turn 1: both skills active
+    const history1: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+      toolResultMsg('<loaded_skill id="oncall" />'),
+    ];
+    const result1 = resolveTools(history1);
+    expect(result1.toolDefinitions).toHaveLength(5); // 2 base + 3 skill tools
+    expect(result1.toolDefinitions.map((d) => d.name)).toContain('oncall_page');
+    expect(result1.toolDefinitions.map((d) => d.name)).toContain('oncall_ack');
+
+    // Turn 2: oncall marker removed from history (truncated)
+    const history2: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+    ];
+    const result2 = resolveTools(history2);
+
+    // Tool definitions should only have base + deploy tools
+    expect(result2.toolDefinitions).toHaveLength(3); // 2 base + 1 skill tool
+    expect(result2.toolDefinitions.map((d) => d.name)).not.toContain('oncall_page');
+    expect(result2.toolDefinitions.map((d) => d.name)).not.toContain('oncall_ack');
+    expect(result2.toolDefinitions.map((d) => d.name)).toContain('deploy_run');
+  });
+
+  test('executor blocks the tool after deactivation — allowedToolNames excludes it', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+
+    const resolveTools = makeResolveTools(baseToolDefs);
+
+    // Turn 1: both skills active, both tools allowed
+    const history1: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+      toolResultMsg('<loaded_skill id="oncall" />'),
+    ];
+    const result1 = resolveTools(history1);
+    expect(result1.allowedToolNames.has('oncall_page')).toBe(true);
+    expect(result1.allowedToolNames.has('deploy_run')).toBe(true);
+
+    // Turn 2: oncall marker gone — its tool should be blocked
+    const history2: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+    ];
+    const result2 = resolveTools(history2);
+
+    // oncall_page is no longer in allowedToolNames — executor would block it
+    expect(result2.allowedToolNames.has('oncall_page')).toBe(false);
+    // deploy_run remains allowed
+    expect(result2.allowedToolNames.has('deploy_run')).toBe(true);
+    // Core tools remain allowed
+    for (const core of CORE_TOOL_NAMES) {
+      expect(result2.allowedToolNames.has(core)).toBe(true);
+    }
+  });
+
+  test('unregisterSkillTools is called for deactivated skill', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+
+    // Turn 1: both active
+    const history1: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+      toolResultMsg('<loaded_skill id="oncall" />'),
+    ];
+    projectSkillTools(history1);
+
+    // Clear tracking before turn 2
+    mockUnregisteredSkillIds = [];
+
+    // Turn 2: deploy marker gone
+    const history2: Message[] = [
+      toolResultMsg('<loaded_skill id="oncall" />'),
+    ];
+    projectSkillTools(history2);
+
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+    expect(mockUnregisteredSkillIds).not.toContain('oncall');
+  });
+
+  test('all skills deactivate when all markers leave history', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+
+    const resolveTools = makeResolveTools(baseToolDefs);
+
+    // Turn 1: both skills active
+    const history1: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+      toolResultMsg('<loaded_skill id="oncall" />'),
+    ];
+    const result1 = resolveTools(history1);
+    expect(result1.toolDefinitions).toHaveLength(4); // 2 base + 2 skill
+
+    // Clear tracking before turn 2
+    mockUnregisteredSkillIds = [];
+
+    // Turn 2: all markers gone (e.g. context window fully truncated)
+    const history2: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Continue working' }] },
+    ];
+    const result2 = resolveTools(history2);
+
+    // Only base tools remain
+    expect(result2.toolDefinitions).toHaveLength(2);
+    expect(result2.toolDefinitions.map((d) => d.name)).toEqual(['file_read', 'bash']);
+
+    // Both skills were unregistered
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+    expect(mockUnregisteredSkillIds).toContain('oncall');
+
+    // No skill tools in allowed set
+    expect(result2.allowedToolNames.has('deploy_run')).toBe(false);
+    expect(result2.allowedToolNames.has('oncall_page')).toBe(false);
+
+    // Core tools still present
+    for (const core of CORE_TOOL_NAMES) {
+      expect(result2.allowedToolNames.has(core)).toBe(true);
+    }
+  });
+
+  test('skill can reactivate after deactivation', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+    };
+
+    const resolveTools = makeResolveTools(baseToolDefs);
+
+    // Turn 1: deploy active
+    const history1: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+    ];
+    const result1 = resolveTools(history1);
+    expect(result1.allowedToolNames.has('deploy_run')).toBe(true);
+
+    // Turn 2: marker gone — deactivated
+    const history2: Message[] = [];
+    const result2 = resolveTools(history2);
+    expect(result2.allowedToolNames.has('deploy_run')).toBe(false);
+
+    // Turn 3: marker reappears — reactivated
+    const history3: Message[] = [
+      toolResultMsg('<loaded_skill id="deploy" />'),
+    ];
+    const result3 = resolveTools(history3);
+    expect(result3.allowedToolNames.has('deploy_run')).toBe(true);
+    expect(result3.toolDefinitions.map((d) => d.name)).toContain('deploy_run');
+  });
+});


### PR DESCRIPTION
## Summary
- Proves tools deactivate when skill load marker leaves active history
- Tests active skill set shrinks when markers are removed
- Verifies executor blocks deactivated tools via allowedToolNames

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
