### PR TITLE
feat: plumb slash preactivation through session processing

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -737,7 +737,6 @@ describe('mid-run skill tool activation (end-to-end)', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
 // Context-derived deactivation regression tests
 // ---------------------------------------------------------------------------
 
@@ -931,5 +930,83 @@ describe('context-derived deactivation regression', () => {
     const result3 = resolveTools(history3);
     expect(result3.allowedToolNames.has('deploy_run')).toBe(true);
     expect(result3.toolDefinitions.map((d) => d.name)).toContain('deploy_run');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slash preactivation tests
+// ---------------------------------------------------------------------------
+
+describe('slash preactivation through session processing', () => {
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection();
+  });
+
+  test('slash-known skill has its tools available on first projection (turn-0)', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run', 'deploy_status']) };
+
+    // Empty history — no loaded_skill markers yet. The skill is preactivated
+    // via slash resolution, so its tools should be available immediately.
+    const emptyHistory: Message[] = [];
+
+    const result = projectSkillTools(emptyHistory, {
+      preactivatedSkillIds: ['deploy'],
+    });
+
+    expect(result.toolDefinitions).toHaveLength(2);
+    expect(result.toolDefinitions.map((d) => d.name)).toEqual([
+      'deploy_run',
+      'deploy_status',
+    ]);
+    expect(result.allowedToolNames).toEqual(
+      new Set(['deploy_run', 'deploy_status']),
+    );
+  });
+
+  test('preactivation is request-scoped — does not persist to unrelated runs', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+
+    // First request: preactivated via slash command
+    const result1 = projectSkillTools([], {
+      preactivatedSkillIds: ['deploy'],
+    });
+    expect(result1.toolDefinitions).toHaveLength(1);
+    expect(result1.allowedToolNames.has('deploy_run')).toBe(true);
+
+    // Second request: no preactivation, no history markers.
+    // Without preactivated IDs, the skill should not appear.
+    const result2 = projectSkillTools([]);
+
+    expect(result2.toolDefinitions).toHaveLength(0);
+    expect(result2.allowedToolNames.has('deploy_run')).toBe(false);
+  });
+
+  test('preactivated skill tools merge with history-derived skills on turn-0', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+
+    // History has an oncall marker from a previous exchange
+    const history: Message[] = [
+      toolResultMsg('<loaded_skill id="oncall" />'),
+    ];
+
+    // deploy is preactivated via slash, oncall is from history
+    const result = projectSkillTools(history, {
+      preactivatedSkillIds: ['deploy'],
+    });
+
+    expect(result.toolDefinitions).toHaveLength(2);
+    expect(result.allowedToolNames).toEqual(
+      new Set(['deploy_run', 'oncall_page']),
+    );
   });
 });

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -33,6 +33,8 @@ export interface ProcessSessionContext {
   readonly traceEmitter: TraceEmitter;
   currentActiveSurfaceId?: string;
   currentPage?: string;
+  /** Request-scoped skill IDs preactivated via slash resolution. */
+  preactivatedSkillIds?: string[];
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string): string;
   runAgentLoop(
     content: string,
@@ -116,6 +118,11 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   }
 
   const resolvedContent = slashResult.content;
+
+  // Preactivate skill tools when slash resolution identifies a known skill
+  if (slashResult.kind === 'rewritten') {
+    session.preactivatedSkillIds = [slashResult.skillId];
+  }
 
   // Try to persist and run the dequeued message. If persistUserMessage
   // succeeds, runAgentLoop is called and its finally block will drain
@@ -203,6 +210,11 @@ export async function processMessage(
   }
 
   const resolvedContent = slashResult.content;
+
+  // Preactivate skill tools when slash resolution identifies a known skill
+  if (slashResult.kind === 'rewritten') {
+    session.preactivatedSkillIds = [slashResult.skillId];
+  }
 
   let userMessageId: string;
   try {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -124,6 +124,8 @@ export class Session {
   sandboxOverride?: boolean;
   /** @internal — per-turn allowed tool set, read by the tool executor closure. */
   allowedToolNames?: Set<string>;
+  /** @internal — request-scoped skill IDs preactivated via slash resolution. */
+  preactivatedSkillIds?: string[];
   /** Core tool names (computed once in constructor), always allowed regardless of skill state. */
   private coreToolNames: Set<string>;
   /** @internal — exposed for session-usage.ts module functions. */
@@ -256,7 +258,9 @@ export class Session {
     // dynamically projected skill tools on each agent turn.
     const resolveTools = toolDefs.length > 0
       ? (history: Message[]) => {
-          const projection = projectSkillTools(history);
+          const projection = projectSkillTools(history, {
+            preactivatedSkillIds: this.preactivatedSkillIds,
+          });
           return [...toolDefs, ...projection.toolDefinitions];
         }
       : undefined;
@@ -738,7 +742,9 @@ export class Session {
 
       // Project skill tools for this turn and build the allowed tool set.
       // Core tools are always included so they're never gated.
-      const skillProjection = projectSkillTools(runMessages);
+      const skillProjection = projectSkillTools(runMessages, {
+        preactivatedSkillIds: this.preactivatedSkillIds,
+      });
       const turnAllowed = new Set(this.coreToolNames);
       for (const name of skillProjection.allowedToolNames) {
         turnAllowed.add(name);
@@ -1169,6 +1175,7 @@ export class Session {
       this.currentRequestId = undefined;
       this.currentActiveSurfaceId = undefined;
       this.allowedToolNames = undefined;
+      this.preactivatedSkillIds = undefined;
 
       // Consolidate consecutive assistant messages from this agent loop run
       if (userMessageId) {


### PR DESCRIPTION
## Summary
- Captures skill ID from slash resolution and passes as preactivated ID
- Skill tools are available on turn-0 for known slash commands
- Preactivation scope is request-local

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
