### PR TITLE
feat: add summary text in permission details section

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -46,6 +46,40 @@ public struct ToolConfirmationData: Equatable {
         return normalized
     }
 
+    /// Short third-person summary shown above the code snippet in the details disclosure.
+    public var detailsSummary: String {
+        switch toolName {
+        case "bash", "host_bash":
+            return "The assistant wants to run a command"
+        case "file_write", "host_file_write":
+            let path = (input["path"]?.value as? String) ?? ""
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            return name.isEmpty ? "The assistant wants to write a file" : "The assistant wants to write to \(name)"
+        case "file_edit", "host_file_edit":
+            let path = (input["path"]?.value as? String) ?? ""
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            return name.isEmpty ? "The assistant wants to edit a file" : "The assistant wants to edit \(name)"
+        case "file_read", "host_file_read":
+            let path = (input["path"]?.value as? String) ?? ""
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            return name.isEmpty ? "The assistant wants to read a file" : "The assistant wants to read \(name)"
+        case "web_fetch":
+            let url = (input["url"]?.value as? String) ?? ""
+            if let host = URL(string: url)?.host {
+                return "The assistant wants to fetch data from \(host)"
+            }
+            return "The assistant wants to fetch a URL"
+        case "browser_navigate":
+            let url = (input["url"]?.value as? String) ?? ""
+            if let host = URL(string: url)?.host {
+                return "The assistant wants to open \(host)"
+            }
+            return "The assistant wants to open a page"
+        default:
+            return "The assistant wants to use \(toolName)"
+        }
+    }
+
     /// Human-readable preview of the tool input (e.g. the bash command or file path).
     public var commandPreview: String {
         switch toolName {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -203,17 +203,23 @@ public struct ToolConfirmationBubble: View {
         }
 
         if showDetails, let preview = detailsPreview {
-            Text(preview)
-                .font(VFont.mono)
-                .foregroundColor(VColor.textSecondary)
-                .padding(VSpacing.sm)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(VColor.backgroundSubtle)
-                )
-                .textSelection(.enabled)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text(confirmation.detailsSummary)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+
+                Text(preview)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textSecondary)
+                    .padding(VSpacing.sm)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill(VColor.backgroundSubtle)
+                    )
+                    .textSelection(.enabled)
+            }
+            .transition(.opacity.combined(with: .move(edge: .top)))
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a short human-readable summary (e.g. "The assistant wants to run a command") above the code snippet in the permission details disclosure
- New `detailsSummary` computed property on `ToolConfirmationData` generates context-aware summaries for bash, file, web, and other tool types
- Details section now shows the summary in caption font before the monospace code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
