### PR TITLE
fix: add platform guard for PointingHandCursorView in shared modifier

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
@@ -38,6 +38,7 @@ public struct InlineWidgetCardModifier: ViewModifier {
                 }
                 .allowsHitTesting(false)
             )
+            #if os(macOS)
             .onHover { hovering in
                 guard interactive else { return }
                 isHovered = hovering
@@ -50,6 +51,7 @@ public struct InlineWidgetCardModifier: ViewModifier {
                 }
                 .allowsHitTesting(false)
             )
+            #endif
             .animation(VAnimation.fast, value: isHovered)
     }
 }


### PR DESCRIPTION
Addresses feedback on #3209.

InlineWidgetCardModifier in the shared target references `PointingHandCursorView()` and `.onHover` without `#if os(macOS)` guards, but `PointingHandCursorView` is only defined inside a `#if os(macOS)` block. This would cause iOS compilation errors.

**Changes:**
- Wrapped `.onHover` and `PointingHandCursorView()` overlay with `#if os(macOS)` / `#endif` guards

**File modified:** `clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
