### PR TITLE
fix: prevent model_set feedback loop and guard /model by provider

### DIFF
--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -96,6 +96,14 @@ function resolveModelCommand(content: string): SlashResolution | null {
     };
   }
 
+  // Guard: /model only works with the Anthropic provider
+  if (currentConfig.provider && currentConfig.provider !== 'anthropic') {
+    return {
+      kind: 'unknown',
+      message: `Cannot switch models while using the ${currentConfig.provider} provider. Model switching is only available with the Anthropic provider.`,
+    };
+  }
+
   // Change model: save config and re-initialize providers
   const raw = loadRawConfig();
   raw.model = matched;

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -53,6 +53,10 @@ public final class SettingsStore: ObservableObject {
     private weak var daemonClient: DaemonClient?
     private var cancellables = Set<AnyCancellable>()
 
+    /// Last model reported by the daemon — used to skip redundant model_set calls
+    /// that would otherwise reinitialize providers and evict idle sessions.
+    private var lastDaemonModel: String?
+
     init(daemonClient: DaemonClient? = nil) {
         self.daemonClient = daemonClient
 
@@ -92,6 +96,7 @@ public final class SettingsStore: ObservableObject {
         // Wire up model info IPC response
         daemonClient?.onModelInfo = { [weak self] response in
             guard let self else { return }
+            self.lastDaemonModel = response.model
             self.selectedModel = response.model
         }
 
@@ -173,6 +178,7 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Model Actions
 
     func setModel(_ model: String) {
+        guard model != lastDaemonModel else { return }
         try? daemonClient?.sendModelSet(model: model)
     }
 }


### PR DESCRIPTION
Addresses feedback on #3452.

**Issue 1 — model_set feedback loop:** When `SettingsStore` initializes, it sends `model_get` to the daemon. The daemon responds with `model_info`, setting `selectedModel`. If the persisted model differs from the hardcoded default (`claude-opus-4-6`), this triggers `.onChange(of: store.selectedModel)` which calls `setModel()` → `sendModelSet()` back to the daemon, causing it to reinitialize providers and evict idle sessions.

**Fix:** Added `lastDaemonModel` property to `SettingsStore`. The `onModelInfo` callback sets it, and `setModel()` guards against it to skip redundant IPC calls.

**Issue 2 — /model ignores provider:** The `/model` slash command persists Claude model IDs without checking the configured provider. If provider is `openai`/`gemini`/etc., saving a Claude model ID leads to request failures.

**Fix:** Added provider compatibility guard in `resolveModelCommand()` that rejects model switches when provider is not Anthropic.

**Files modified:**
- `clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift`
- `assistant/src/daemon/session-slash.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
