### PR TITLE
fix: clarify onboarding button labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -124,7 +124,7 @@ struct APIKeyStepView: View {
                         saveKeyAndShowModels()
                     }
                 }) {
-                    Text(showModelSelector ? "Save & Continue" : "Select a model")
+                    Text(showModelSelector ? "Select model" : "Save API key")
                         .font(.system(size: 15, weight: .medium))
                         .foregroundColor(adaptiveColor(light: .white, dark: .white))
                         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- API key entry page button: "Select a model" → "Save API key"
- Model selection page button: "Save & Continue" → "Select model"

🤖 Generated with [Claude Code](https://claude.com/claude-code)