### PR TITLE
feat: add bundled Claude Code skill skeleton

### DIFF
--- a/assistant/src/config/bundled-skills/claude-code/SKILL.md
+++ b/assistant/src/config/bundled-skills/claude-code/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: "Claude Code"
+description: "Delegate coding tasks to Claude Code, an AI-powered coding agent"
+user-invocable: true
+metadata: {"vellum": {"emoji": "💻"}}
+---
+
+You are delegating a coding task to Claude Code, an autonomous AI coding agent. Use this skill when the user needs hands-on software engineering work done.
+
+## Capabilities
+
+Claude Code can:
+- Read, write, and edit files across a codebase
+- Run shell commands (build, test, lint, deploy scripts)
+- Perform multi-step engineering tasks autonomously (refactoring, implementing features, debugging)
+- Search codebases for patterns, definitions, and usage
+- Work with git repositories (commits, branches, diffs)
+
+## When to Delegate
+
+Delegate to Claude Code when the task involves:
+- Writing or modifying source code
+- Running build/test/lint commands and iterating on failures
+- Exploring a codebase to answer architectural questions
+- Multi-file refactors or migrations
+- Debugging issues that require reading code and running tests
+- Any task that benefits from direct filesystem and shell access
+
+Do NOT delegate when:
+- The user just wants a conversational answer or explanation
+- The task is pure information retrieval with no code changes needed
+- The user explicitly wants to discuss an approach before implementation
+
+## Guardrails
+
+- Claude Code runs in a sandboxed environment with approval flows for destructive actions
+- File writes, edits, and shell commands that modify state require user confirmation (unless auto-approved by trust rules)
+- Read-only operations (file reads, searches, web fetches) are auto-approved
+- The working directory defaults to the current session's working directory but can be overridden
+
+## Worker Profiles
+
+Claude Code supports scoped worker profiles that restrict tool access:
+
+- **general** (default) — Full access to all tools. Backward-compatible with existing behavior.
+- **researcher** — Read-only access. Can search, read files, and browse the web but cannot write or execute commands.
+- **coder** — Full read/write/execute access optimized for implementation tasks.
+- **reviewer** — Read-only access tailored for code review, with emphasis on analysis and feedback.
+
+Select the profile that best matches the task to enforce least-privilege access.

--- a/assistant/src/config/bundled-skills/claude-code/TOOLS.json
+++ b/assistant/src/config/bundled-skills/claude-code/TOOLS.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "claude_code",
+      "description": "Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.",
+      "category": "coding",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "The coding task or question for Claude Code to work on"
+          },
+          "working_dir": {
+            "type": "string",
+            "description": "Working directory for Claude Code (defaults to session working directory)"
+          },
+          "resume": {
+            "type": "string",
+            "description": "Claude Code session ID to resume a previous session"
+          },
+          "model": {
+            "type": "string",
+            "description": "Model to use (defaults to claude-sonnet-4-5-20250929)"
+          },
+          "profile": {
+            "type": "string",
+            "enum": ["general", "researcher", "coder", "reviewer"],
+            "description": "Worker profile that scopes tool access. Defaults to general (backward compatible)."
+          }
+        },
+        "required": ["prompt"]
+      },
+      "executor": "tools/claude-code.ts",
+      "execution_target": "host"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `assistant/src/config/bundled-skills/claude-code/SKILL.md` with operating guidance (capabilities, delegation criteria, guardrails, worker profiles)
- Adds `assistant/src/config/bundled-skills/claude-code/TOOLS.json` with claude_code tool definition matching the existing runtime tool
- No runtime changes — skeleton only for upcoming dynamic tool loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
