### PR TITLE
feat: add bundled Gmail skill skeleton

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: "Gmail"
+description: "Read, search, draft, send, and manage Gmail messages"
+user-invocable: true
+metadata: {"vellum": {"emoji": "📧"}}
+---
+
+You are a Gmail assistant with full access to the user's inbox. Use the Gmail tools to help them read, search, organize, draft, and send email.
+
+## Capabilities
+
+- **Search & Read**: Find messages using Gmail search syntax, list recent messages, and read full message content.
+- **Draft & Send**: Compose draft emails for user review or send messages directly (with confirmation).
+- **Organize**: Archive, label, trash, and batch-process messages.
+- **Unsubscribe**: Automatically unsubscribe from mailing lists via the List-Unsubscribe header.
+
+## Gmail Search Syntax
+
+When using `gmail_search`, leverage Gmail's powerful query operators:
+
+| Operator | Example | What it finds |
+|---|---|---|
+| `from:` | `from:alice@example.com` | Messages from a specific sender |
+| `to:` | `to:bob@example.com` | Messages sent to a specific recipient |
+| `subject:` | `subject:meeting` | Messages with a word in the subject |
+| `newer_than:` | `newer_than:7d` | Messages from the last 7 days |
+| `older_than:` | `older_than:30d` | Messages older than 30 days |
+| `is:unread` | `is:unread` | Unread messages |
+| `is:starred` | `is:starred` | Starred messages |
+| `has:attachment` | `has:attachment` | Messages with attachments |
+| `label:` | `label:work` | Messages with a specific label |
+| `in:` | `in:inbox` | Messages in a specific mailbox |
+| `{...}` | `{from:a from:b}` | OR grouping |
+| `-` | `-from:noreply` | Exclude matches |
+
+Operators can be combined: `from:boss@company.com newer_than:2d is:unread`
+
+## Drafting vs Sending
+
+- Use `gmail_draft` when the user wants to compose a message for review. The draft appears in Gmail's Drafts folder.
+- Use `gmail_send` only when the user explicitly wants to send immediately. This is a medium-risk action that requires confidence.
+- When uncertain, always default to drafting.
+
+## Batch Operations
+
+- `gmail_batch_archive` and `gmail_batch_label` accept arrays of message IDs for bulk processing.
+- First search or list messages to collect IDs, then apply batch actions.
+- Always confirm with the user before batch-archiving or batch-labeling large numbers of messages.
+
+## Confidence Scores
+
+Medium-risk tools (archive, label, trash, send, unsubscribe) require a confidence score between 0 and 1. Set this based on how certain you are the action matches the user's intent:
+
+- **0.9-1.0**: User explicitly requested this exact action
+- **0.7-0.8**: Action is strongly implied by context
+- **0.5-0.6**: Reasonable inference but some ambiguity
+- **Below 0.5**: Ask the user to confirm before proceeding

--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -1,0 +1,243 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "gmail_search",
+      "description": "Search emails using Gmail search syntax. Returns message IDs and metadata.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string", "description": "Gmail search query (e.g. \"from:user@example.com newer_than:7d\")" },
+          "max_results": { "type": "number", "description": "Maximum number of results to return (default 20, max 200)" },
+          "format": { "type": "string", "enum": ["minimal", "metadata", "full"], "description": "Message format to return (default \"metadata\")" },
+          "metadata_headers": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Headers to include when format is \"metadata\" (e.g. [\"From\", \"Subject\", \"List-Unsubscribe\"])"
+          }
+        },
+        "required": ["query"]
+      },
+      "executor": "tools/gmail-search.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_list_messages",
+      "description": "List recent messages from the inbox. Returns message IDs and metadata.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "max_results": { "type": "number", "description": "Maximum number of results (default 20, max 200)" },
+          "label_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Filter by label IDs (e.g. [\"INBOX\", \"UNREAD\"])"
+          },
+          "page_token": { "type": "string", "description": "Token for the next page of results" }
+        }
+      },
+      "executor": "tools/gmail-list-messages.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_get_message",
+      "description": "Get the full content of a single email message by its ID.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "The Gmail message ID" },
+          "format": { "type": "string", "enum": ["minimal", "metadata", "full"], "description": "Message format (default \"full\")" }
+        },
+        "required": ["message_id"]
+      },
+      "executor": "tools/gmail-get-message.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_mark_read",
+      "description": "Mark one or more messages as read.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Message IDs to mark as read"
+          }
+        },
+        "required": ["message_ids"]
+      },
+      "executor": "tools/gmail-mark-read.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_draft",
+      "description": "Create a draft email. The draft will appear in Gmail Drafts for user review.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "to": { "type": "string", "description": "Recipient email address" },
+          "subject": { "type": "string", "description": "Email subject line" },
+          "body": { "type": "string", "description": "Email body (plain text)" },
+          "in_reply_to": { "type": "string", "description": "Message-ID header of the email being replied to" }
+        },
+        "required": ["to", "subject", "body"]
+      },
+      "executor": "tools/gmail-draft.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_archive",
+      "description": "Archive a message (remove from inbox). Include a confidence score (0-1) indicating how certain you are this action is correct.",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "Message ID to archive" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-archive.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_batch_archive",
+      "description": "Archive multiple messages at once. Include a confidence score (0-1) indicating how certain you are this action is correct.",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Message IDs to archive"
+          },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message_ids", "confidence"]
+      },
+      "executor": "tools/gmail-batch-archive.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_label",
+      "description": "Add or remove labels on a message. Include a confidence score (0-1) indicating how certain you are this action is correct.",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "Message ID" },
+          "add_label_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Label IDs to add"
+          },
+          "remove_label_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Label IDs to remove"
+          },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-label.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_batch_label",
+      "description": "Add or remove labels on multiple messages. Include a confidence score (0-1) indicating how certain you are this action is correct.",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Message IDs"
+          },
+          "add_label_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Label IDs to add"
+          },
+          "remove_label_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Label IDs to remove"
+          },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message_ids", "confidence"]
+      },
+      "executor": "tools/gmail-batch-label.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_trash",
+      "description": "Move a message to trash. Include a confidence score (0-1) indicating how certain you are this action is correct.",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "Message ID to trash" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-trash.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_send",
+      "description": "Send an email. This is a medium-risk action that defaults to requiring user approval (overridable via trust rules). Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "to": { "type": "string", "description": "Recipient email address" },
+          "subject": { "type": "string", "description": "Email subject line" },
+          "body": { "type": "string", "description": "Email body (plain text)" },
+          "in_reply_to": { "type": "string", "description": "Message-ID header for replies" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["to", "subject", "body", "confidence"]
+      },
+      "executor": "tools/gmail-send.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_unsubscribe",
+      "description": "Unsubscribe from a mailing list by following the List-Unsubscribe header. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "A message ID from the mailing list to unsubscribe from" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-unsubscribe.ts",
+      "execution_target": "host"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `assistant/src/config/bundled-skills/gmail/SKILL.md` with usage instructions
- Adds `assistant/src/config/bundled-skills/gmail/TOOLS.json` listing all 12 Gmail tools
- No runtime changes — skeleton only for upcoming dynamic tool loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
