### PR TITLE
feat: add Claude Code skill script wrapper

### DIFF
--- a/assistant/src/config/bundled-skills/claude-code/tools/claude-code.ts
+++ b/assistant/src/config/bundled-skills/claude-code/tools/claude-code.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { claudeCodeTool } from '../../../../tools/claude-code/claude-code.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return claudeCodeTool.execute(input, context);
+}


### PR DESCRIPTION
## Summary
- Creates skill tool script at `bundled-skills/claude-code/tools/claude-code.ts`
- Thin wrapper that delegates to existing `claudeCodeTool.execute()`
- Preserves all behavior: profile validation, confirmation flows, model selection
- No runtime behavior changes — will be wired through dynamic pipeline in PR 33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
