### PR TITLE
feat: move Gmail execution logic into skill scripts

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -1,0 +1,12 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+
+  return withGmailToken(async (token) => {
+    await gmail.modifyMessage(token, messageId, { removeLabelIds: ['INBOX'] });
+    return ok('Message archived.');
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-archive.ts
@@ -1,0 +1,12 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageIds = input.message_ids as string[];
+
+  return withGmailToken(async (token) => {
+    await gmail.batchModifyMessages(token, messageIds, { removeLabelIds: ['INBOX'] });
+    return ok(`Archived ${messageIds.length} message(s).`);
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-label.ts
@@ -1,0 +1,14 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageIds = input.message_ids as string[];
+  const addLabelIds = input.add_label_ids as string[] | undefined;
+  const removeLabelIds = input.remove_label_ids as string[] | undefined;
+
+  return withGmailToken(async (token) => {
+    await gmail.batchModifyMessages(token, messageIds, { addLabelIds, removeLabelIds });
+    return ok(`Labels updated on ${messageIds.length} message(s).`);
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -1,0 +1,15 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const to = input.to as string;
+  const subject = input.subject as string;
+  const body = input.body as string;
+  const inReplyTo = input.in_reply_to as string | undefined;
+
+  return withGmailToken(async (token) => {
+    const draft = await gmail.createDraft(token, to, subject, body, inReplyTo);
+    return ok(`Draft created (ID: ${draft.id}). It will appear in your Gmail Drafts.`);
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-get-message.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-get-message.ts
@@ -1,0 +1,14 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import type { GmailMessageFormat } from '../../../../integrations/gmail/types.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+  const format = (input.format as GmailMessageFormat) ?? 'full';
+
+  return withGmailToken(async (token) => {
+    const message = await gmail.getMessage(token, messageId, format);
+    return ok(JSON.stringify(message, null, 2));
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -1,0 +1,14 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+  const addLabelIds = input.add_label_ids as string[] | undefined;
+  const removeLabelIds = input.remove_label_ids as string[] | undefined;
+
+  return withGmailToken(async (token) => {
+    await gmail.modifyMessage(token, messageId, { addLabelIds, removeLabelIds });
+    return ok('Labels updated.');
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-list-messages.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-list-messages.ts
@@ -1,0 +1,14 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const maxResults = Math.min((input.max_results as number) ?? 20, 200);
+  const labelIds = input.label_ids as string[] | undefined;
+  const pageToken = input.page_token as string | undefined;
+
+  return withGmailToken(async (token) => {
+    const result = await gmail.listMessages(token, undefined, maxResults, pageToken, labelIds);
+    return ok(JSON.stringify(result, null, 2));
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-mark-read.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-mark-read.ts
@@ -1,0 +1,12 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageIds = input.message_ids as string[];
+
+  return withGmailToken(async (token) => {
+    await gmail.batchModifyMessages(token, messageIds, { removeLabelIds: ['UNREAD'] });
+    return ok(`Marked ${messageIds.length} message(s) as read.`);
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-search.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-search.ts
@@ -1,0 +1,34 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import type { GmailMessageFormat } from '../../../../integrations/gmail/types.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const query = input.query as string;
+  const maxResults = Math.min((input.max_results as number) ?? 20, 200);
+  const format = (input.format as GmailMessageFormat) ?? 'metadata';
+  const metadataHeaders = input.metadata_headers as string[] | undefined;
+
+  return withGmailToken(async (token) => {
+    const listResult = await gmail.listMessages(token, query, maxResults);
+    if (!listResult.messages?.length) {
+      return ok('No messages found.');
+    }
+
+    if (format === 'minimal') {
+      return ok(JSON.stringify(listResult, null, 2));
+    }
+
+    const messages = await gmail.batchGetMessages(
+      token,
+      listResult.messages.map((m) => m.id),
+      format,
+      metadataHeaders,
+    );
+    return ok(JSON.stringify({
+      resultSizeEstimate: listResult.resultSizeEstimate,
+      nextPageToken: listResult.nextPageToken,
+      messages,
+    }, null, 2));
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send.ts
@@ -1,0 +1,15 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const to = input.to as string;
+  const subject = input.subject as string;
+  const body = input.body as string;
+  const inReplyTo = input.in_reply_to as string | undefined;
+
+  return withGmailToken(async (token) => {
+    const message = await gmail.sendMessage(token, to, subject, body, inReplyTo);
+    return ok(`Email sent (ID: ${message.id}).`);
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -1,0 +1,12 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { withGmailToken, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+
+  return withGmailToken(async (token) => {
+    await gmail.trashMessage(token, messageId);
+    return ok('Message moved to trash.');
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -1,0 +1,80 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as gmail from '../../../../integrations/gmail/client.js';
+import { isPrivateOrLocalHost, resolveHostAddresses, resolveRequestAddress } from '../../../../tools/network/url-safety.js';
+import { withGmailToken, ok, err, pinnedHttpsRequest } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+
+  return withGmailToken(async (token) => {
+    // Fetch message to get List-Unsubscribe header
+    const message = await gmail.getMessage(token, messageId, 'metadata', ['List-Unsubscribe', 'List-Unsubscribe-Post']);
+    const headers = message.payload?.headers ?? [];
+    const unsubHeader = headers.find((h) => h.name.toLowerCase() === 'list-unsubscribe')?.value;
+
+    if (!unsubHeader) {
+      return err('No List-Unsubscribe header found. Manual unsubscribe may be required.');
+    }
+
+    // Parse List-Unsubscribe header — can contain mailto: and/or https: URLs
+    const httpsMatch = unsubHeader.match(/<(https:\/\/[^>]+)>/);
+    const mailtoMatch = unsubHeader.match(/<mailto:([^>]+)>/);
+    const postHeader = headers.find((h) => h.name.toLowerCase() === 'list-unsubscribe-post')?.value;
+
+    if (httpsMatch) {
+      const url = httpsMatch[1];
+      // SSRF protection: validate URL against private/internal addresses
+      let parsed: URL;
+      let validatedAddresses: string[];
+      try {
+        parsed = new URL(url);
+        if (parsed.protocol !== 'https:') {
+          return err('Unsubscribe URL must use HTTPS.');
+        }
+        if (isPrivateOrLocalHost(parsed.hostname)) {
+          return err('Unsubscribe URL points to a private or local address.');
+        }
+        // DNS resolution check — reuse validated addresses for the fetch to prevent TOCTOU
+        const { addresses, blockedAddress } = await resolveRequestAddress(parsed.hostname, resolveHostAddresses, false);
+        if (blockedAddress) {
+          return err('Unsubscribe URL resolves to a private or local address.');
+        }
+        if (addresses.length === 0) {
+          return err('Unable to resolve unsubscribe URL hostname.');
+        }
+        validatedAddresses = addresses;
+      } catch {
+        return err('Invalid unsubscribe URL.');
+      }
+
+      // Try each validated address for dual-stack/multi-A reliability
+      const method = postHeader ? 'POST' : 'GET';
+      const reqOpts = postHeader
+        ? { method: 'POST' as const, headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: postHeader }
+        : undefined;
+
+      let lastStatus = 0;
+      for (const address of validatedAddresses) {
+        try {
+          lastStatus = await pinnedHttpsRequest(parsed, address, reqOpts);
+          if (lastStatus >= 200 && lastStatus < 400) {
+            return ok(`Successfully unsubscribed via HTTPS ${method}.`);
+          }
+        } catch {
+          // Try next address
+          continue;
+        }
+      }
+      return err(`Unsubscribe request failed: ${lastStatus}`);
+    }
+
+    if (mailtoMatch) {
+      // Send unsubscribe email
+      const mailtoAddr = mailtoMatch[1].split('?')[0];
+      await gmail.sendMessage(token, mailtoAddr, 'Unsubscribe', 'Unsubscribe');
+      return ok(`Unsubscribe email sent to ${mailtoAddr}.`);
+    }
+
+    return err('No supported unsubscribe method found (requires https: or mailto: URL).');
+  });
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/shared.ts
@@ -1,0 +1,48 @@
+import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from 'node:https';
+import { withValidToken } from '../../../../integrations/token-manager.js';
+import { getIntegration } from '../../../../integrations/registry.js';
+import type { ToolExecutionResult } from '../../../../tools/types.js';
+
+export function getGmailDef() {
+  const def = getIntegration('gmail');
+  if (!def) throw new Error('Gmail integration not registered');
+  return def;
+}
+
+export function ok(content: string): ToolExecutionResult {
+  return { content, isError: false };
+}
+
+export function err(message: string): ToolExecutionResult {
+  return { content: message, isError: true };
+}
+
+export async function withGmailToken<T>(fn: (token: string) => Promise<T>): Promise<T> {
+  const def = getGmailDef();
+  return withValidToken('gmail', def, fn);
+}
+
+/** Make an HTTPS request pinned to a specific resolved IP to prevent DNS rebinding. */
+export function pinnedHttpsRequest(
+  target: URL,
+  resolvedAddress: string,
+  options?: { method?: string; headers?: Record<string, string>; body?: string },
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const reqOpts: HttpsRequestOptions = {
+      method: options?.method ?? 'GET',
+      hostname: resolvedAddress,
+      port: target.port ? Number(target.port) : undefined,
+      path: `${target.pathname}${target.search}`,
+      headers: { host: target.host, ...options?.headers },
+      servername: target.hostname,
+    };
+    const req = httpsRequest(reqOpts, (res) => {
+      res.resume();
+      resolve(res.statusCode ?? 0);
+    });
+    req.once('error', reject);
+    if (options?.body) req.write(options.body);
+    req.end();
+  });
+}


### PR DESCRIPTION
## Summary
- Creates 12 skill tool scripts in `bundled-skills/gmail/tools/`
- Each script exports `run()` and delegates to existing Gmail integration layer
- Adds shared helper module for OAuth token management and result formatting
- No runtime behavior changes — scripts will be wired through dynamic pipeline in PR 28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
