### PR TITLE
feat: instant Try again tooltip on regenerate button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -669,6 +669,8 @@ private struct ChatBubble: View {
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
 
+    @State private var isRegenerateHovered = false
+
     private var isUser: Bool { message.role == .user }
 
     private var statusLabel: String? {
@@ -789,8 +791,31 @@ private struct ChatBubble: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Regenerate response")
-        .help("Regenerate response")
+        .accessibilityLabel("Try again")
+        .onHover { isRegenerateHovered = $0 }
+        .overlay(alignment: .top) {
+            if isRegenerateHovered {
+                Text("Try again")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill(VColor.surface)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                    .vShadow(VShadow.sm)
+                    .fixedSize()
+                    .offset(y: -28)
+                    .transition(.opacity)
+                    .animation(VAnimation.fast, value: isRegenerateHovered)
+                    .allowsHitTesting(false)
+            }
+        }
     }
 
     /// Whether the permission was denied, meaning incomplete tools were blocked (not running).


### PR DESCRIPTION
## Summary
- Replaced the slow native macOS `.help()` tooltip on the regenerate button with a custom overlay tooltip that appears instantly on hover
- Styled with the app's design system (VFont.caption, VColor.surface, VShadow.sm)
- Label changed from "Regenerate response" to "Try again"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
