### PR TITLE
fix: restore VStack spacing for non-table messages and skip code fence tables

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1277,11 +1277,11 @@ private struct ChatBubble: View {
             }
 
             if hasText {
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    let segments = parseMarkdownSegments(message.text)
-                    let hasTable = segments.contains(where: {
-                        if case .table = $0 { return true }; return false
-                    })
+                let segments = parseMarkdownSegments(message.text)
+                let hasTable = segments.contains(where: {
+                    if case .table = $0 { return true }; return false
+                })
+                VStack(alignment: .leading, spacing: hasTable ? VSpacing.lg : VSpacing.xs) {
 
                     if hasTable {
                         ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
@@ -1500,10 +1500,20 @@ private func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
     var segments: [MarkdownSegment] = []
     var currentText: [String] = []
     var i = 0
+    var inCodeFence = false
 
     while i < lines.count {
+        // Track fenced code blocks so we don't parse tables inside them
+        if lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+            inCodeFence.toggle()
+            currentText.append(lines[i])
+            i += 1
+            continue
+        }
+
         // Check for table: need header row + separator row + at least one data row
-        if i + 2 < lines.count,
+        if !inCodeFence,
+           i + 2 < lines.count,
            isTableRow(lines[i]),
            isTableSeparator(lines[i + 1]),
            isTableRow(lines[i + 2]) {


### PR DESCRIPTION
Addresses feedback on #3211.

**Issue 1 — VStack spacing regression:** The inner VStack spacing in `bubbleContent` was changed from `VSpacing.xs` (4pt) to `VSpacing.lg` (16pt), affecting all messages including plain text. This created a visually jarring 16pt gap between text and the "Show more/less" truncation button.

**Fix:** Moved `segments`/`hasTable` computation before the VStack so spacing can use a ternary: `hasTable ? VSpacing.lg : VSpacing.xs`. Table messages get the wider spacing; plain text messages keep the original 4pt gap.

**Issue 2 — Tables detected inside code fences:** `parseMarkdownSegments` treats pipe-delimited lines as tables even inside triple-backtick fences, so code examples containing markdown table syntax get rendered as actual tables instead of code.

**Fix:** Added `inCodeFence` tracking that toggles on lines starting with triple backticks. Table detection is skipped while inside a code fence.

**File modified:** `clients/macos/vellum-assistant/Features/Chat/ChatView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
