### PR TITLE
test: enable Gmail skill tools through dynamic pipeline

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -1010,3 +1010,65 @@ describe('slash preactivation through session processing', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bundled skill pipeline integration tests
+// ---------------------------------------------------------------------------
+
+const GMAIL_TOOL_NAMES = [
+  'gmail_search',
+  'gmail_list_messages',
+  'gmail_get_message',
+  'gmail_mark_read',
+  'gmail_draft',
+  'gmail_archive',
+  'gmail_batch_archive',
+  'gmail_label',
+  'gmail_batch_label',
+  'gmail_trash',
+  'gmail_send',
+  'gmail_unsubscribe',
+] as const;
+
+describe('bundled skill: gmail', () => {
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection();
+  });
+
+  test('gmail skill activation via loaded_skill marker projects all 12 tool definitions', () => {
+    mockCatalog = [makeSkill('gmail', '/path/to/bundled-skills/gmail')];
+    mockManifests = { gmail: makeManifest([...GMAIL_TOOL_NAMES]) };
+
+    const history: Message[] = [
+      toolResultMsg('<loaded_skill id="gmail" />'),
+    ];
+
+    const result = projectSkillTools(history);
+
+    expect(result.toolDefinitions).toHaveLength(12);
+    expect(result.toolDefinitions.map((d) => d.name)).toEqual([...GMAIL_TOOL_NAMES]);
+    expect(result.allowedToolNames).toEqual(new Set(GMAIL_TOOL_NAMES));
+  });
+
+  test('gmail tools are NOT available when gmail skill is not in active context', () => {
+    mockCatalog = [makeSkill('gmail', '/path/to/bundled-skills/gmail')];
+    mockManifests = { gmail: makeManifest([...GMAIL_TOOL_NAMES]) };
+
+    // No loaded_skill marker for gmail in history
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ];
+
+    const result = projectSkillTools(history);
+
+    expect(result.toolDefinitions).toHaveLength(0);
+    expect(result.allowedToolNames.size).toBe(0);
+    for (const name of GMAIL_TOOL_NAMES) {
+      expect(result.allowedToolNames.has(name)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds integration tests to `session-skill-tools.test.ts` proving the dynamic skill tool pipeline correctly discovers and projects all 12 Gmail tools (`gmail_search`, `gmail_list_messages`, `gmail_get_message`, `gmail_mark_read`, `gmail_draft`, `gmail_archive`, `gmail_batch_archive`, `gmail_label`, `gmail_batch_label`, `gmail_trash`, `gmail_send`, `gmail_unsubscribe`) when the Gmail skill is activated via a `loaded_skill` marker
- Adds a negative test confirming Gmail tools are excluded when the skill is not in the active context

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/session-skill-tools.test.ts` — 30 tests pass
- [x] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
