### PR TITLE
test: enable Claude Code skill tool through dynamic pipeline

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -1072,3 +1072,42 @@ describe('bundled skill: gmail', () => {
     }
   });
 });
+
+describe('bundled skill: claude-code', () => {
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection();
+  });
+
+  test('claude-code skill activation produces claude_code tool definition', () => {
+    mockCatalog = [makeSkill('claude-code', '/path/to/bundled-skills/claude-code')];
+    mockManifests = { 'claude-code': makeManifest(['claude_code']) };
+
+    const history: Message[] = [
+      toolResultMsg('<loaded_skill id="claude-code" />'),
+    ];
+
+    const result = projectSkillTools(history);
+
+    expect(result.toolDefinitions).toHaveLength(1);
+    expect(result.toolDefinitions[0].name).toBe('claude_code');
+    expect(result.allowedToolNames).toEqual(new Set(['claude_code']));
+  });
+
+  test('claude_code tool is absent when claude-code skill is not active', () => {
+    mockCatalog = [makeSkill('claude-code', '/path/to/bundled-skills/claude-code')];
+    mockManifests = { 'claude-code': makeManifest(['claude_code']) };
+
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ];
+
+    const result = projectSkillTools(history);
+
+    expect(result.toolDefinitions).toHaveLength(0);
+    expect(result.allowedToolNames.has('claude_code')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds integration tests to `session-skill-tools.test.ts` proving the dynamic skill tool pipeline correctly discovers and projects the `claude_code` tool when the claude-code skill is activated via a `loaded_skill` marker
- Adds a negative test confirming the `claude_code` tool is excluded when the skill is not in the active context

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/session-skill-tools.test.ts` — 32 tests pass
- [x] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
