### PR TITLE
feat: add weather skill script wrapper and enable through dynamic pipeline

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -1111,3 +1111,42 @@ describe('bundled skill: claude-code', () => {
     expect(result.allowedToolNames.has('claude_code')).toBe(false);
   });
 });
+
+describe('bundled skill: weather', () => {
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection();
+  });
+
+  test('weather skill activation produces get_weather tool definition', () => {
+    mockCatalog = [makeSkill('weather', '/path/to/bundled-skills/weather')];
+    mockManifests = { weather: makeManifest(['get_weather']) };
+
+    const history: Message[] = [
+      toolResultMsg('<loaded_skill id="weather" />'),
+    ];
+
+    const result = projectSkillTools(history);
+
+    expect(result.toolDefinitions).toHaveLength(1);
+    expect(result.toolDefinitions[0].name).toBe('get_weather');
+    expect(result.allowedToolNames).toEqual(new Set(['get_weather']));
+  });
+
+  test('get_weather tool is absent when weather skill is not active', () => {
+    mockCatalog = [makeSkill('weather', '/path/to/bundled-skills/weather')];
+    mockManifests = { weather: makeManifest(['get_weather']) };
+
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ];
+
+    const result = projectSkillTools(history);
+
+    expect(result.toolDefinitions).toHaveLength(0);
+    expect(result.allowedToolNames.has('get_weather')).toBe(false);
+  });
+});

--- a/assistant/src/config/bundled-skills/weather/tools/get-weather.ts
+++ b/assistant/src/config/bundled-skills/weather/tools/get-weather.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeGetWeather } from '../../../../tools/weather/service.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeGetWeather(input, globalThis.fetch, context.proxyToolResolver);
+}


### PR DESCRIPTION
## Summary
- Creates the weather skill executor wrapper at `assistant/src/config/bundled-skills/weather/tools/get-weather.ts`, delegating to the existing `executeGetWeather` service with proper `proxyToolResolver` passthrough
- Adds integration tests to `session-skill-tools.test.ts` proving the dynamic skill tool pipeline correctly discovers and projects the `get_weather` tool when the weather skill is activated
- Adds a negative test confirming the `get_weather` tool is excluded when the skill is not in the active context

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/session-skill-tools.test.ts` — 34 tests pass
- [x] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
