### PR TITLE
feat: remove hardcoded Gmail registration

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -169,7 +169,7 @@ describe('tool manifest', () => {
   });
 
   test('eager module list contains expected count', () => {
-    expect(eagerModules.length).toBe(16);
+    expect(eagerModules.length).toBe(15);
   });
 
   test('explicit tools list includes memory, credential, and timer tools', () => {
@@ -190,7 +190,7 @@ describe('tool manifest', () => {
 });
 
 describe('baseline characterization: hardcoded tool loading', () => {
-  test('gmail tools are registered via eager module after initializeTools()', async () => {
+  test('gmail tools are NOT registered in the global registry after initializeTools()', async () => {
     await initializeTools();
     const allTools = getAllTools();
     const toolNames = allTools.map(t => t.name);
@@ -199,12 +199,12 @@ describe('baseline characterization: hardcoded tool loading', () => {
       'gmail_draft', 'gmail_archive', 'gmail_batch_archive', 'gmail_label', 'gmail_batch_label',
       'gmail_trash', 'gmail_send', 'gmail_unsubscribe'];
     for (const name of gmailTools) {
-      expect(toolNames).toContain(name);
+      expect(toolNames).not.toContain(name);
     }
   });
 
-  test('gmail eager module is in eagerModules manifest', () => {
-    expect(eagerModules).toContain('./gmail/executors.js');
+  test('gmail eager module is NOT in eagerModules manifest', () => {
+    expect(eagerModules).not.toContain('./gmail/executors.js');
   });
 
   test('weather tool is registered via eager module after initializeTools()', async () => {

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -35,7 +35,6 @@ export const eagerModules: string[] = [
   './schedule/list.js',
   './schedule/update.js',
   './schedule/delete.js',
-  './gmail/executors.js',
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removes `./gmail/executors.js` from eager module list in tool-manifest.ts
- Gmail tools are now only available through dynamic skill activation
- Updates registry tests to reflect new baseline (eager module count 16 -> 15, Gmail assertions flipped to negative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
