### PR TITLE
feat: remove hardcoded Weather registration

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -169,7 +169,7 @@ describe('tool manifest', () => {
   });
 
   test('eager module list contains expected count', () => {
-    expect(eagerModules.length).toBe(16);
+    expect(eagerModules.length).toBe(15);
   });
 
   test('explicit tools list includes memory, credential, and timer tools', () => {
@@ -207,15 +207,14 @@ describe('baseline characterization: hardcoded tool loading', () => {
     expect(eagerModules).toContain('./gmail/executors.js');
   });
 
-  test('weather tool is registered via eager module after initializeTools()', async () => {
+  test('weather tool is NOT in global registry after initializeTools()', async () => {
     await initializeTools();
     const tool = getTool('get_weather');
-    expect(tool).toBeDefined();
-    expect(tool?.category).toBe('weather');
+    expect(tool).toBeUndefined();
   });
 
-  test('weather eager module is in eagerModules manifest', () => {
-    expect(eagerModules).toContain('./weather/get-weather.js');
+  test('weather eager module is NOT in eagerModules manifest', () => {
+    expect(eagerModules).not.toContain('./weather/get-weather.js');
   });
 
   test('claude_code is registered via lazy descriptor after initializeTools()', async () => {

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -29,7 +29,6 @@ export const eagerModules: string[] = [
   './skills/scaffold-managed.js',
   './skills/delete-managed.js',
   './browser/headless-browser.js',
-  './weather/get-weather.js',
   './system/request-permission.js',
   './schedule/create.js',
   './schedule/list.js',


### PR DESCRIPTION
## Summary
- Removes `./weather/get-weather.js` from eager module list in tool-manifest.ts
- Weather tool is now only available through dynamic skill activation
- Updates registry tests to reflect new baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
