### PR TITLE
feat: remove hardcoded Claude Code lazy registration

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -164,7 +164,7 @@ describe('tool manifest', () => {
     const lazyNames = new Set(lazyTools.map((t) => t.name));
     expect(lazyNames.has('bash')).toBe(true);
     expect(lazyNames.has('evaluate_typescript_code')).toBe(true);
-    expect(lazyNames.has('claude_code')).toBe(true);
+    expect(lazyNames.has('claude_code')).toBe(false);
     expect(lazyNames.has('swarm_delegate')).toBe(true);
   });
 
@@ -218,15 +218,15 @@ describe('baseline characterization: hardcoded tool loading', () => {
     expect(eagerModules).toContain('./weather/get-weather.js');
   });
 
-  test('claude_code is registered via lazy descriptor after initializeTools()', async () => {
+  test('claude_code is NOT in global registry after initializeTools()', async () => {
     await initializeTools();
     const tool = getTool('claude_code');
-    expect(tool).toBeDefined();
+    expect(tool).toBeUndefined();
   });
 
-  test('claude_code lazy descriptor is in lazyTools manifest', () => {
+  test('claude_code is NOT in lazyTools manifest', () => {
     const lazyNames = lazyTools.map(t => t.name);
-    expect(lazyNames).toContain('claude_code');
+    expect(lazyNames).not.toContain('claude_code');
   });
 });
 

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -131,47 +131,6 @@ export const lazyTools: LazyToolDescriptor[] = [
     },
   },
   {
-    name: 'claude_code',
-    description: 'Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.',
-    category: 'coding',
-    defaultRiskLevel: RiskLevel.Medium,
-    definition: {
-      name: 'claude_code',
-      description: 'Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.',
-      input_schema: {
-        type: 'object',
-        properties: {
-          prompt: {
-            type: 'string',
-            description: 'The coding task or question for Claude Code to work on',
-          },
-          working_dir: {
-            type: 'string',
-            description: 'Working directory for Claude Code (defaults to session working directory)',
-          },
-          resume: {
-            type: 'string',
-            description: 'Claude Code session ID to resume a previous session',
-          },
-          model: {
-            type: 'string',
-            description: 'Model to use (defaults to claude-sonnet-4-5-20250929)',
-          },
-          profile: {
-            type: 'string',
-            enum: ['general', 'researcher', 'coder', 'reviewer'],
-            description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
-          },
-        },
-        required: ['prompt'],
-      },
-    },
-    loader: async () => {
-      const mod = await import('./claude-code/claude-code.js');
-      return mod.claudeCodeTool;
-    },
-  },
-  {
     name: 'swarm_delegate',
     description: 'Decompose a complex task into parallel specialist subtasks and execute them concurrently.',
     category: 'orchestration',


### PR DESCRIPTION
## Summary
- Removes `claude_code` from lazy tool descriptors in tool-manifest.ts
- Claude Code tool is now only available through dynamic skill activation
- Updates registry tests to reflect new baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
