### PR TITLE
test: Claude Code dynamic regression coverage

### DIFF
--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect, mock } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing modules that use them
+// ---------------------------------------------------------------------------
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: () => ({
+    async *[Symbol.asyncIterator]() {
+      yield { type: 'result' as const, session_id: 's', subtype: 'success' as const, result: 'ok' };
+    },
+  }),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    apiKeys: { anthropic: 'test-key' },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { claudeCodeTool } from '../tools/claude-code/claude-code.js';
+
+// ---------------------------------------------------------------------------
+// Locate the bundled skill directory relative to the test file
+// ---------------------------------------------------------------------------
+
+const SKILL_DIR = path.resolve(
+  import.meta.dirname ?? __dirname,
+  '../config/bundled-skills/claude-code',
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Claude Code skill migration regression', () => {
+  test('skill script wrapper exports a `run` function', async () => {
+    const wrapperPath = path.join(SKILL_DIR, 'tools/claude-code.ts');
+    // The wrapper module must exist and export `run`
+    const mod = await import(wrapperPath);
+    expect(typeof mod.run).toBe('function');
+  });
+
+  test('TOOLS.json manifest lists claude_code as the tool name', () => {
+    const manifestPath = path.join(SKILL_DIR, 'TOOLS.json');
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const manifest = JSON.parse(raw);
+
+    expect(manifest.version).toBe(1);
+    expect(Array.isArray(manifest.tools)).toBe(true);
+
+    const toolNames = manifest.tools.map((t: { name: string }) => t.name);
+    expect(toolNames).toContain('claude_code');
+  });
+
+  test('TOOLS.json input_schema matches claudeCodeTool.getDefinition()', () => {
+    const manifestPath = path.join(SKILL_DIR, 'TOOLS.json');
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const manifest = JSON.parse(raw);
+
+    const manifestTool = manifest.tools.find(
+      (t: { name: string }) => t.name === 'claude_code',
+    );
+    expect(manifestTool).toBeDefined();
+
+    const runtimeDef = claudeCodeTool.getDefinition();
+
+    // The input_schema declared in the static manifest must match the
+    // runtime definition. Drift here would mean the model sees a different
+    // schema than the executor actually supports.
+    expect(manifestTool.input_schema).toEqual(runtimeDef.input_schema);
+  });
+
+  test('TOOLS.json description matches claudeCodeTool.getDefinition()', () => {
+    const manifestPath = path.join(SKILL_DIR, 'TOOLS.json');
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const manifest = JSON.parse(raw);
+
+    const manifestTool = manifest.tools.find(
+      (t: { name: string }) => t.name === 'claude_code',
+    );
+    expect(manifestTool).toBeDefined();
+
+    const runtimeDef = claudeCodeTool.getDefinition();
+
+    // Description parity guards against a manifest edit that diverges from
+    // the canonical tool description.
+    expect(manifestTool.description).toBe(runtimeDef.description);
+  });
+
+  test('wrapper run() delegates to claudeCodeTool.execute()', async () => {
+    // Verifies the wrapper is not a stale stub but actually calls through
+    // to the canonical execute method.
+    const wrapperPath = path.join(SKILL_DIR, 'tools/claude-code.ts');
+    const mod = await import(wrapperPath);
+
+    const ctx = {
+      sessionId: 'test',
+      workingDir: '/tmp',
+      onOutput: () => {},
+    };
+
+    // Calling with a valid profile should succeed (SDK mock returns success)
+    const result = await mod.run({ prompt: 'hello' }, ctx);
+    expect(result.isError).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds regression tests for Claude Code skill migration to verify behavior parity
- Verifies the skill script wrapper at `bundled-skills/claude-code/tools/claude-code.ts` exports a `run` function and delegates to the canonical tool
- Confirms TOOLS.json manifest lists `claude_code` as the tool name with matching input_schema and description from `claudeCodeTool.getDefinition()`
- Inactive skill gating test skipped (already covered in `session-skill-tools.test.ts`)

## Test plan
- [x] `bun test src/__tests__/claude-code-skill-regression.test.ts` — 5 tests pass
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run lint` — clean
- [x] Existing `claude-code-tool-profiles.test.ts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
