### PR TITLE
fix: normalize multiline command summaries in tool chip labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -890,7 +890,9 @@ private struct ChatBubble: View {
     /// When `inputSummary` is provided, produces contextual labels like "Read config.json".
     private static func friendlyToolLabel(_ toolName: String, inputSummary: String = "") -> String {
         let name = toolName.lowercased()
-        let summary = inputSummary.trimmingCharacters(in: .whitespaces)
+        let summary = inputSummary
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
 
         // Extract just the filename from a file path.
         let fileName: String? = {


### PR DESCRIPTION
Addresses feedback on #3426.

Tool chip labels interpolate `inputSummary` directly, but the summary only trims leading/trailing spaces. Commands containing embedded newlines (heredocs, chained multiline shell snippets) render as multi-line chip text like `Ran \`line1\nline2\``, breaking the compact pill layout and pushing surrounding controls vertically.

**Fix:** Replaced `.trimmingCharacters(in: .whitespaces)` with a regex-based whitespace normalization that collapses all internal newlines and whitespace runs into a single space before truncation.

**File modified:** `clients/macos/vellum-assistant/Features/Chat/ChatView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
