### PR TITLE
feat: replace owl icon with shield icon in Control Center

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -841,9 +841,8 @@ private struct ControlCenterMenuButton: View {
             }
         } label: {
             HStack(spacing: VSpacing.md) {
-                Image("OwlIcon")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
+                Image(systemName: "shield.lefthalf.filled")
+                    .font(.system(size: 16))
                     .foregroundColor(VColor.textSecondary)
                     .frame(width: 20, height: 20)
 


### PR DESCRIPTION
## Summary
- Replaced the custom `OwlIcon` asset with SF Symbol `shield.lefthalf.filled` for the Control Center button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
