### PR TITLE
feat: add Identity panel with avatar, constellation view, and bootstrap gate

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/icon.svg
+++ b/assistant/src/config/bundled-skills/gmail/icon.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<rect width="16" height="16" fill="#f5f5f5"/>
+<rect x="2" y="3" width="12" height="10" fill="none" stroke="#d32f2f" stroke-width="1"/>
+<rect x="2" y="3" width="12" height="2" fill="#d32f2f"/>
+<line x1="2" y1="3" x2="8" y2="8" stroke="#d32f2f" stroke-width="1"/>
+<line x1="14" y1="3" x2="8" y2="8" stroke="#d32f2f" stroke-width="1"/>
+<rect x="3" y="5" width="10" height="1" fill="#666"/>
+<rect x="3" y="7" width="9" height="1" fill="#999"/>
+<rect x="3" y="9" width="8" height="1" fill="#999"/>
+<rect x="3" y="11" width="7" height="1" fill="#ccc"/>
+</svg>

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -1,13 +1,19 @@
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceSkillsDir } from '../util/platform.js';
 
 const log = getLogger('clawhub');
 
-// Managed skills directory
+// Managed skills directory — where installed skill folders live
 function getManagedSkillsDir(): string {
   return getWorkspaceSkillsDir();
+}
+
+// ClaWHub project root — clawhub creates a `skills/` subdir inside its cwd,
+// so we use the parent of the managed skills dir as the project root.
+function getClawhubProjectRoot(): string {
+  return dirname(getWorkspaceSkillsDir());
 }
 
 // Validate slug format (alphanumeric, hyphens, dots, underscores; optional namespace with single slash)
@@ -177,7 +183,7 @@ export interface ClawhubUpdateCheckItem {
 
 // Helper to run clawhub commands
 async function runClawhub(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const cwd = opts?.cwd ?? getManagedSkillsDir();
+  const cwd = opts?.cwd ?? getClawhubProjectRoot();
   const timeout = opts?.timeout ?? 60000;
 
   // Ensure managed skills dir exists

--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Codable, Equatable, Sendable {
-    case chat, threadList, activity, settings, agent, debug, doctor, directory, generated
+    case chat, threadList, activity, settings, agent, debug, doctor, directory, generated, identity
 }
 
 public enum SlotContent: Equatable, Sendable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -414,7 +414,15 @@ struct MainWindowView: View {
             NewConversationButton(action: { windowState.activePanel = nil; threadManager.createThread() })
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.top, VSpacing.md)
-                .padding(.bottom, VSpacing.xl)
+                .padding(.bottom, VSpacing.sm)
+
+            IdentityDrawerButton(
+                isActive: windowState.activePanel == .identity,
+                isDisabled: isBootstrapOnboardingActive,
+                action: { windowState.togglePanel(.identity) }
+            )
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.bottom, VSpacing.xl)
 
             Text("Recents")
                 .font(.system(size: 11))
@@ -585,6 +593,8 @@ struct MainWindowView: View {
             )
         case .threadList:
             threadDrawerView
+        case .identity:
+            IdentityPanel(onClose: { windowState.activePanel = nil }, daemonClient: daemonClient)
         }
     }
 
@@ -729,6 +739,8 @@ struct MainWindowView: View {
             )
         case .doctor:
             DoctorPanel(onClose: { windowState.activePanel = nil })
+        case .identity:
+            IdentityPanel(onClose: { windowState.activePanel = nil }, daemonClient: daemonClient)
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;
             // if we reach here, isDynamicExpanded is false — clear activePanel so
@@ -817,6 +829,47 @@ private struct NewConversationButton: View {
         }
         .buttonStyle(.plain)
         .onHover { hovering in
+            withAnimation(VAnimation.fast) {
+                isHovered = hovering
+            }
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+}
+
+private struct IdentityDrawerButton: View {
+    let isActive: Bool
+    var isDisabled: Bool = false
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: "person.crop.circle")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(isActive ? Violet._400 : (isHovered ? VColor.textPrimary : VColor.textMuted))
+                    .frame(width: 22, height: 22)
+                    .overlay(
+                        Circle()
+                            .stroke(isActive ? Violet._400 : (isHovered ? VColor.textMuted : VColor.textMuted.opacity(0.5)), lineWidth: 1)
+                    )
+                Text("Identity")
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .foregroundColor(isActive ? Violet._400 : VColor.textPrimary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.sm)
+            .background(isActive ? Violet._400.opacity(0.08) : (isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.4 : 1.0)
+        .onHover { hovering in
+            guard !isDisabled else { return }
             withAnimation(VAnimation.fast) {
                 isHovered = hovering
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavBar.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct NavBar: View {
+    @Binding var sidebarOpen: Bool
+    let sidebarVisible: Bool
+    let onSettings: () -> Void
+
+    /// Leading padding to account for macOS traffic light buttons.
+    private let trafficLightPadding: CGFloat = 78
+
+    var body: some View {
+        ZStack {
+            // Center: title
+            Text("Vellum")
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.textSecondary)
+
+            HStack(spacing: VSpacing.xs) {
+                // Left group
+                if sidebarVisible {
+                    VIconButton(label: "Threads", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true) {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                            sidebarOpen.toggle()
+                        }
+                    }
+                }
+
+                Spacer()
+
+                // Right group
+                VIconButton(label: "Settings", icon: "gearshape", iconOnly: true) {
+                    onSettings()
+                }
+            }
+            .padding(.leading, trafficLightPadding)
+            .padding(.trailing, VSpacing.lg)
+        }
+        .frame(height: 36)
+        .background(VColor.background)
+        .shadow(color: .black.opacity(0.08), radius: 3, y: 2)
+    }
+}
+
+#if DEBUG
+struct NavBar_Preview: PreviewProvider {
+    static var previews: some View {
+        NavBarPreviewWrapper()
+            .frame(width: 700)
+            .previewDisplayName("NavBar")
+    }
+}
+
+private struct NavBarPreviewWrapper: View {
+    @State private var sidebarOpen = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            NavBar(
+                sidebarOpen: $sidebarOpen,
+                sidebarVisible: true,
+                onSettings: {}
+            )
+            Spacer()
+        }
+        .background(VColor.backgroundSubtle)
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarSpriteBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarSpriteBuilder.swift
@@ -1,0 +1,581 @@
+import AppKit
+import SceneKit
+
+/// Generates procedural 3D voxel dino characters seeded from a string.
+/// Native Swift port of the voxeldino Python package (github.com/avareed-assistant/voxeldino).
+/// Each unique seed produces a deterministic dino with randomized clothing/accessories.
+enum DinoVoxelGenerator {
+
+    // MARK: - Types
+
+    struct RGB: Hashable {
+        let r: UInt8, g: UInt8, b: UInt8
+
+        init(_ r: UInt8, _ g: UInt8, _ b: UInt8) {
+            self.r = r; self.g = g; self.b = b
+        }
+
+        var nsColor: NSColor {
+            NSColor(
+                red: CGFloat(r) / 255.0,
+                green: CGFloat(g) / 255.0,
+                blue: CGFloat(b) / 255.0,
+                alpha: 1.0
+            )
+        }
+    }
+
+    struct VoxelPos: Hashable {
+        let x: Int, y: Int, z: Int
+    }
+
+    // MARK: - Color Palette
+
+    private static let dinoGreen = RGB(76, 175, 80)
+    private static let dinoLight = RGB(129, 199, 132)
+    private static let dinoBelly = RGB(200, 230, 201)
+    private static let dinoDark  = RGB(56, 142, 60)
+    private static let eyeWhite  = RGB(255, 255, 255)
+    private static let eyeBlack  = RGB(33, 33, 33)
+    private static let cheekPink = RGB(255, 160, 170)
+
+    private static let palette: [String: RGB] = [
+        "red": RGB(244, 67, 54),
+        "blue": RGB(33, 150, 243),
+        "yellow": RGB(255, 235, 59),
+        "purple": RGB(156, 39, 176),
+        "orange": RGB(255, 152, 0),
+        "pink": RGB(233, 30, 99),
+        "cyan": RGB(0, 188, 212),
+        "brown": RGB(121, 85, 72),
+        "black": RGB(33, 33, 33),
+        "white": RGB(250, 250, 250),
+        "gold": RGB(255, 215, 0),
+        "silver": RGB(192, 192, 192),
+        "glasses_black": RGB(20, 20, 20),
+        "glasses_gold": RGB(212, 175, 55),
+        "wood": RGB(139, 90, 43),
+        "metal": RGB(158, 158, 158),
+    ]
+
+    // MARK: - Clothing Definitions
+
+    private struct ClothingDef {
+        let positions: [VoxelPos]
+        let defaultColor: String
+    }
+
+    // Hat options — head top is y=22, crown at y=21
+    private static let hatNames = ["none", "top_hat", "crown", "cap", "beanie", "wizard_hat", "cowboy_hat"]
+
+    private static let hatDefs: [String: ClothingDef] = [
+        "top_hat": ClothingDef(
+            positions: box(x: 4...11, y: 22...22, z: 4...11) +
+                       box(x: 5...10, y: 23...27, z: 5...10),
+            defaultColor: "black"
+        ),
+        "crown": ClothingDef(
+            positions: box(x: 4...11, y: 22...22, z: 4...11) +
+                [4, 7, 11].flatMap { x in [4, 7, 11].map { z in VoxelPos(x: x, y: 23, z: z) } },
+            defaultColor: "gold"
+        ),
+        "cap": ClothingDef(
+            positions: box(x: 4...11, y: 22...24, z: 4...11) +
+                       box(x: 5...10, y: 22...22, z: 12...14),
+            defaultColor: "red"
+        ),
+        "beanie": ClothingDef(
+            positions: box(x: 4...11, y: 22...25, z: 4...11),
+            defaultColor: "blue"
+        ),
+        "wizard_hat": ClothingDef(
+            positions: box(x: 4...11, y: 22...22, z: 4...11) +
+                       box(x: 5...10, y: 23...25, z: 5...10) +
+                       box(x: 6...9, y: 26...28, z: 6...9),
+            defaultColor: "purple"
+        ),
+        "cowboy_hat": ClothingDef(
+            positions: box(x: 2...13, y: 22...22, z: 2...13) +
+                       box(x: 5...10, y: 23...25, z: 5...10),
+            defaultColor: "brown"
+        ),
+    ]
+
+    // Shirt options — body y=6-12
+    private static let shirtNames = ["none", "tshirt", "suit", "hoodie", "tank_top", "sweater"]
+
+    private static let shirtDefs: [String: ClothingDef] = [
+        "tshirt": ClothingDef(
+            positions: box(x: 4...11, y: 8...12, z: 5...10, excluding: { x, _, z in
+                (6...9).contains(x) && z >= 9
+            }),
+            defaultColor: "blue"
+        ),
+        "suit": ClothingDef(
+            positions: box(x: 4...11, y: 6...12, z: 5...10),
+            defaultColor: "black"
+        ),
+        "hoodie": ClothingDef(
+            positions: box(x: 4...11, y: 6...13, z: 4...10),
+            defaultColor: "purple"
+        ),
+        "tank_top": ClothingDef(
+            positions: box(x: 5...10, y: 8...12, z: 5...10),
+            defaultColor: "white"
+        ),
+        "sweater": ClothingDef(
+            positions: box(x: 4...11, y: 6...12, z: 5...10) +
+                [4, 11].flatMap { x in box(x: x...x, y: 9...11, z: 7...9) },
+            defaultColor: "orange"
+        ),
+    ]
+
+    // Accessory options — face z=12, neck y=12-13
+    private static let accessoryNames = ["none", "sunglasses", "monocle", "bowtie", "necklace", "scarf", "cape"]
+
+    private static let accessoryDefs: [String: ClothingDef] = [
+        "sunglasses": ClothingDef(
+            positions: (4...11).map { VoxelPos(x: $0, y: 18, z: 12) } +
+                (4...7).map { VoxelPos(x: $0, y: 17, z: 12) } +
+                (8...11).map { VoxelPos(x: $0, y: 17, z: 12) },
+            defaultColor: "glasses_black"
+        ),
+        "monocle": ClothingDef(
+            positions: box(x: 8...11, y: 17...19, z: 12...12),
+            defaultColor: "glasses_gold"
+        ),
+        "bowtie": ClothingDef(
+            positions: [6, 7, 8, 9].map { VoxelPos(x: $0, y: 12, z: 11) },
+            defaultColor: "red"
+        ),
+        "necklace": ClothingDef(
+            positions: (5...10).map { VoxelPos(x: $0, y: 12, z: 11) },
+            defaultColor: "gold"
+        ),
+        "scarf": ClothingDef(
+            positions: box(x: 4...11, y: 12...13, z: 9...12) +
+                (8...12).map { VoxelPos(x: 5, y: $0, z: 12) },
+            defaultColor: "cyan"
+        ),
+        "cape": ClothingDef(
+            positions: box(x: 4...11, y: 3...13, z: 3...3) +
+                       box(x: 5...10, y: 4...12, z: 4...4),
+            defaultColor: "red"
+        ),
+    ]
+
+    // Held item options — arm at x=3-4 / x=11-12
+    private static let heldItemNames = ["none", "sword", "staff", "shield", "balloon"]
+
+    private static let heldItemDefs: [String: ClothingDef] = [
+        "sword": ClothingDef(
+            positions: (9...18).map { VoxelPos(x: 3, y: $0, z: 8) } +
+                [VoxelPos(x: 3, y: 19, z: 8), VoxelPos(x: 3, y: 19, z: 9)],
+            defaultColor: "silver"
+        ),
+        "staff": ClothingDef(
+            positions: (7...22).map { VoxelPos(x: 3, y: $0, z: 8) } +
+                [VoxelPos(x: 3, y: 23, z: 8), VoxelPos(x: 3, y: 23, z: 9)],
+            defaultColor: "wood"
+        ),
+        "shield": ClothingDef(
+            positions: box(x: 12...12, y: 7...12, z: 5...10),
+            defaultColor: "metal"
+        ),
+        "balloon": ClothingDef(
+            positions: (14...22).map { VoxelPos(x: 2, y: $0, z: 8) } +
+                       box(x: 1...3, y: 23...26, z: 7...9),
+            defaultColor: "red"
+        ),
+    ]
+
+    private static let clothingColorNames = ["red", "blue", "yellow", "purple", "orange", "pink", "cyan", "brown", "black", "white", "gold", "silver"]
+
+    // MARK: - Box Helper
+
+    private static func box(
+        x xr: ClosedRange<Int>, y yr: ClosedRange<Int>, z zr: ClosedRange<Int>,
+        excluding: ((Int, Int, Int) -> Bool)? = nil
+    ) -> [VoxelPos] {
+        var positions: [VoxelPos] = []
+        for x in xr {
+            for y in yr {
+                for z in zr {
+                    if let exclude = excluding, exclude(x, y, z) { continue }
+                    positions.append(VoxelPos(x: x, y: y, z: z))
+                }
+            }
+        }
+        return positions
+    }
+
+    // MARK: - Base Dino (chibi proportions)
+
+    private static func createBaseDino() -> [VoxelPos: RGB] {
+        var voxels: [VoxelPos: RGB] = [:]
+
+        func set(_ x: Int, _ y: Int, _ z: Int, _ color: RGB) {
+            voxels[VoxelPos(x: x, y: y, z: z)] = color
+        }
+
+        // === HEAD (y=13-22) — big rounded cube ===
+
+        // Bottom jaw (y=13): tapered 8×8
+        for x in 4...11 {
+            for z in 4...11 {
+                let edgeX = (x == 4 || x == 11)
+                let edgeZ = (z == 4 || z == 11)
+                if edgeX && edgeZ { continue }
+                set(x, 13, z, dinoGreen)
+            }
+        }
+
+        // Main head (y=14-20): 10×10 with rounded corners
+        for y in 14...20 {
+            for x in 3...12 {
+                for z in 3...12 {
+                    let edgeX = (x == 3 || x == 12)
+                    let edgeZ = (z == 3 || z == 12)
+                    if edgeX && edgeZ { continue }
+                    set(x, y, z, dinoGreen)
+                }
+            }
+        }
+
+        // Upper head (y=21): tapered 8×8
+        for x in 4...11 {
+            for z in 4...11 {
+                let edgeX = (x == 4 || x == 11)
+                let edgeZ = (z == 4 || z == 11)
+                if edgeX && edgeZ { continue }
+                set(x, 21, z, dinoGreen)
+            }
+        }
+
+        // Top cap (y=22): small 6×6
+        for x in 5...10 { for z in 5...10 { set(x, 22, z, dinoGreen) } }
+
+        // === SNOUT (protruding forward, lighter color) ===
+        for x in 5...10 {
+            for y in 14...17 {
+                for z in 12...14 {
+                    set(x, y, z, dinoLight)
+                }
+            }
+        }
+
+        // Nostrils (dark dots on snout front)
+        set(6, 16, 14, dinoDark)
+        set(9, 16, 14, dinoDark)
+
+        // Mouth line
+        for x in 6...9 { set(x, 14, 14, dinoDark) }
+
+        // === EYES (4×3 each, big & expressive) ===
+
+        // Left eye white (x=4-7, y=17-19, z=12)
+        for x in 4...7 { for y in 17...19 { set(x, y, 12, eyeWhite) } }
+        // Left pupil (2×2, centered-inner)
+        set(5, 17, 12, eyeBlack)
+        set(6, 17, 12, eyeBlack)
+        set(5, 18, 12, eyeBlack)
+        set(6, 18, 12, eyeBlack)
+
+        // Right eye white (x=8-11, y=17-19, z=12)
+        for x in 8...11 { for y in 17...19 { set(x, y, 12, eyeWhite) } }
+        // Right pupil (2×2, centered-inner)
+        set(9, 17, 12, eyeBlack)
+        set(10, 17, 12, eyeBlack)
+        set(9, 18, 12, eyeBlack)
+        set(10, 18, 12, eyeBlack)
+
+        // Rosy cheeks (below and outside each eye)
+        set(4, 16, 12, cheekPink)
+        set(3, 16, 12, cheekPink)
+        set(11, 16, 12, cheekPink)
+        set(12, 16, 12, cheekPink)
+
+        // === BODY (y=6-12) ===
+        for x in 5...10 {
+            for y in 6...12 {
+                for z in 5...10 {
+                    if z >= 9 {
+                        set(x, y, z, dinoBelly)
+                    } else {
+                        set(x, y, z, dinoGreen)
+                    }
+                }
+            }
+        }
+
+        // === ARMS (tiny T-rex style, y=9-11) ===
+        for y in 9...11 {
+            for z in 7...9 {
+                set(4, y, z, dinoGreen)
+                set(11, y, z, dinoGreen)
+            }
+        }
+
+        // === LEGS (y=1-5, two stumpy legs) ===
+        for y in 1...5 {
+            for z in 6...9 {
+                set(5, y, z, dinoGreen)
+                set(6, y, z, dinoGreen)
+                set(9, y, z, dinoGreen)
+                set(10, y, z, dinoGreen)
+            }
+        }
+
+        // === FEET (y=0, wider than legs for cute look) ===
+        for z in 5...10 {
+            for x in 4...7 { set(x, 0, z, dinoGreen) }
+            for x in 8...11 { set(x, 0, z, dinoGreen) }
+        }
+
+        // === TAIL (extends behind, tapering) ===
+        for i in 0..<6 {
+            let z = 4 - i
+            if z < 0 { continue }
+            let width = max(2, 4 - i)
+            let startX = 8 - width / 2
+            for dx in 0..<width {
+                set(startX + dx, 7, z, dinoGreen)
+                if i < 3 { set(startX + dx, 8, z, dinoGreen) }
+            }
+        }
+        set(7, 7, 0, dinoDark)
+
+        // === SPIKES (along back of head) ===
+        for spikeY in [15, 18, 21] {
+            set(7, spikeY, 2, dinoLight)
+            set(8, spikeY, 2, dinoLight)
+            set(7, spikeY + 1, 2, dinoLight)
+            set(8, spikeY + 1, 2, dinoLight)
+        }
+
+        return voxels
+    }
+
+    // MARK: - Clothing Application
+
+    private static func applyClothing(
+        _ voxels: inout [VoxelPos: RGB],
+        hatName: String, shirtName: String, accessoryName: String, heldItemName: String,
+        hatColor: String, shirtColor: String, accessoryColor: String
+    ) {
+        func applyItem(_ def: ClothingDef?, colorOverride: String) {
+            guard let def else { return }
+            let color = palette[colorOverride] ?? palette[def.defaultColor] ?? dinoGreen
+            for pos in def.positions {
+                guard pos.x >= 0, pos.x < 16, pos.y >= 0, pos.y < 30, pos.z >= 0, pos.z < 16 else { continue }
+                voxels[pos] = color
+            }
+        }
+
+        applyItem(shirtDefs[shirtName], colorOverride: shirtColor)
+        applyItem(hatDefs[hatName], colorOverride: hatColor)
+        applyItem(accessoryDefs[accessoryName], colorOverride: accessoryColor)
+        applyItem(heldItemDefs[heldItemName], colorOverride: accessoryColor)
+    }
+
+    // MARK: - Seeded Hash
+
+    private static func hashSeed(_ seed: String) -> UInt64 {
+        var hash: UInt64 = 5381
+        for byte in seed.utf8 {
+            hash = hash &* 33 &+ UInt64(byte)
+        }
+        return hash
+    }
+
+    private static func pick<T>(_ array: [T], hash: UInt64, shift: inout Int) -> T {
+        let count = UInt64(array.count)
+        let value = (hash >> shift) % count
+        shift += Int(count.bitWidth - count.leadingZeroBitCount) + 1
+        return array[Int(value)]
+    }
+
+    // MARK: - Public API
+
+    static func generate(seed: String) -> [VoxelPos: RGB] {
+        let hash = hashSeed(seed)
+        var shift = 0
+
+        let hat = pick(hatNames, hash: hash, shift: &shift)
+        let shirt = pick(shirtNames, hash: hash, shift: &shift)
+        let accessory = pick(accessoryNames, hash: hash, shift: &shift)
+        let heldItem = pick(heldItemNames, hash: hash, shift: &shift)
+        let hatColor = pick(clothingColorNames, hash: hash, shift: &shift)
+        let shirtColor = pick(clothingColorNames, hash: hash, shift: &shift)
+        let accColor = pick(clothingColorNames, hash: hash, shift: &shift)
+
+        var model = createBaseDino()
+        applyClothing(
+            &model,
+            hatName: hat, shirtName: shirt, accessoryName: accessory, heldItemName: heldItem,
+            hatColor: hatColor, shirtColor: shirtColor, accessoryColor: accColor
+        )
+        return model
+    }
+
+    /// Builds a SceneKit scene from a voxel model for 3D rendering.
+    static func buildScene(seed: String) -> SCNScene {
+        let voxels = generate(seed: seed)
+        let scene = SCNScene()
+
+        let modelNode = SCNNode()
+        var materialCache: [RGB: SCNMaterial] = [:]
+
+        for (pos, color) in voxels {
+            let box = SCNBox(width: 1, height: 1, length: 1, chamferRadius: 0)
+
+            if materialCache[color] == nil {
+                let mat = SCNMaterial()
+                mat.diffuse.contents = color.nsColor
+                mat.roughness.contents = NSNumber(value: 0.8)
+                materialCache[color] = mat
+            }
+            box.firstMaterial = materialCache[color]
+
+            let node = SCNNode(geometry: box)
+            node.position = SCNVector3(
+                Float(pos.x) - 8,
+                Float(pos.y) - 11,
+                Float(pos.z) - 8
+            )
+            modelNode.addChildNode(node)
+        }
+
+        let optimized = modelNode.flattenedClone()
+
+        // Gentle floating bob
+        let bob = SCNAction.repeatForever(
+            SCNAction.sequence([
+                SCNAction.moveBy(x: 0, y: 0.6, z: 0, duration: 1.8),
+                SCNAction.moveBy(x: 0, y: -0.6, z: 0, duration: 1.8),
+            ])
+        )
+        bob.timingMode = .easeInEaseOut
+        optimized.runAction(bob)
+        scene.rootNode.addChildNode(optimized)
+
+        // Camera — front-on orthographic
+        let camera = SCNCamera()
+        camera.fieldOfView = 45
+        camera.zNear = 1
+        camera.zFar = 200
+        camera.usesOrthographicProjection = true
+        camera.orthographicScale = 16
+        let cameraNode = SCNNode()
+        cameraNode.camera = camera
+        cameraNode.position = SCNVector3(10, 4, 38)
+        cameraNode.look(at: SCNVector3(0, 2, 0))
+        scene.rootNode.addChildNode(cameraNode)
+
+        // Ambient light
+        let ambientLight = SCNLight()
+        ambientLight.type = .ambient
+        ambientLight.color = NSColor(white: 0.5, alpha: 1)
+        let ambientNode = SCNNode()
+        ambientNode.light = ambientLight
+        scene.rootNode.addChildNode(ambientNode)
+
+        // Directional light — front-above
+        let directionalLight = SCNLight()
+        directionalLight.type = .directional
+        directionalLight.color = NSColor(white: 0.7, alpha: 1)
+        let lightNode = SCNNode()
+        lightNode.light = directionalLight
+        lightNode.position = SCNVector3(0, 20, 30)
+        lightNode.look(at: SCNVector3(0, 0, 0))
+        scene.rootNode.addChildNode(lightNode)
+
+        scene.background.contents = NSColor.clear
+
+        return scene
+    }
+
+    /// Builds a SceneKit scene showing only the dino's face/head (y >= 12).
+    static func buildFaceScene(seed: String) -> SCNScene {
+        let allVoxels = generate(seed: seed)
+        let scene = SCNScene()
+
+        // Filter to head region only (y >= 12 captures neck, head, hat, spikes)
+        let headVoxels = allVoxels.filter { $0.key.y >= 12 }
+
+        let modelNode = SCNNode()
+        var materialCache: [RGB: SCNMaterial] = [:]
+
+        // Center the head: head spans roughly y=12-28, x=3-12, z=2-14
+        let centerY: Float = 17.5 // midpoint of head
+        let centerX: Float = 7.5
+        let centerZ: Float = 7.5
+
+        for (pos, color) in headVoxels {
+            let box = SCNBox(width: 1, height: 1, length: 1, chamferRadius: 0)
+
+            if materialCache[color] == nil {
+                let mat = SCNMaterial()
+                mat.diffuse.contents = color.nsColor
+                mat.roughness.contents = NSNumber(value: 0.8)
+                materialCache[color] = mat
+            }
+            box.firstMaterial = materialCache[color]
+
+            let node = SCNNode(geometry: box)
+            node.position = SCNVector3(
+                Float(pos.x) - centerX,
+                Float(pos.y) - centerY,
+                Float(pos.z) - centerZ
+            )
+            modelNode.addChildNode(node)
+        }
+
+        let optimized = modelNode.flattenedClone()
+
+        // Gentle floating bob
+        let bob = SCNAction.repeatForever(
+            SCNAction.sequence([
+                SCNAction.moveBy(x: 0, y: 0.4, z: 0, duration: 2.0),
+                SCNAction.moveBy(x: 0, y: -0.4, z: 0, duration: 2.0),
+            ])
+        )
+        bob.timingMode = .easeInEaseOut
+        optimized.runAction(bob)
+        scene.rootNode.addChildNode(optimized)
+
+        // Camera — slight angle, tighter framing for face
+        let camera = SCNCamera()
+        camera.zNear = 1
+        camera.zFar = 200
+        camera.usesOrthographicProjection = true
+        camera.orthographicScale = 9
+        let cameraNode = SCNNode()
+        cameraNode.camera = camera
+        cameraNode.position = SCNVector3(5, 2, 30)
+        cameraNode.look(at: SCNVector3(0, 1, 0))
+        scene.rootNode.addChildNode(cameraNode)
+
+        // Ambient light
+        let ambientLight = SCNLight()
+        ambientLight.type = .ambient
+        ambientLight.color = NSColor(white: 0.5, alpha: 1)
+        let ambientNode = SCNNode()
+        ambientNode.light = ambientLight
+        scene.rootNode.addChildNode(ambientNode)
+
+        // Directional light — front-above
+        let directionalLight = SCNLight()
+        directionalLight.type = .directional
+        directionalLight.color = NSColor(white: 0.7, alpha: 1)
+        let lightNode = SCNNode()
+        lightNode.light = directionalLight
+        lightNode.position = SCNVector3(0, 15, 25)
+        lightNode.look(at: SCNVector3(0, 0, 0))
+        scene.rootNode.addChildNode(lightNode)
+
+        scene.background.contents = NSColor.clear
+
+        return scene
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import SceneKit
+
+/// 3D voxel dino avatar that the user can rotate by dragging.
+/// Seeded from a string so the same name always produces the same dino.
+struct DinoSceneView: NSViewRepresentable {
+    let seed: String
+
+    final class Coordinator {
+        var currentSeed: String = ""
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> SCNView {
+        let scnView = PointerSCNView()
+        scnView.backgroundColor = .clear
+        scnView.allowsCameraControl = true
+        scnView.antialiasingMode = .multisampling4X
+        scnView.scene = DinoVoxelGenerator.buildScene(seed: seed)
+        context.coordinator.currentSeed = seed
+        return scnView
+    }
+
+    func updateNSView(_ nsView: SCNView, context: Context) {
+        guard context.coordinator.currentSeed != seed else { return }
+        context.coordinator.currentSeed = seed
+        nsView.scene = DinoVoxelGenerator.buildScene(seed: seed)
+    }
+}
+
+/// 3D voxel dino face only — head cropped from the full model.
+struct DinoFaceView: NSViewRepresentable {
+    let seed: String
+
+    final class Coordinator {
+        var currentSeed: String = ""
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.backgroundColor = .clear
+        scnView.allowsCameraControl = true
+        scnView.antialiasingMode = .multisampling4X
+        scnView.scene = DinoVoxelGenerator.buildFaceScene(seed: seed)
+        context.coordinator.currentSeed = seed
+        return scnView
+    }
+
+    func updateNSView(_ nsView: SCNView, context: Context) {
+        guard context.coordinator.currentSeed != seed else { return }
+        context.coordinator.currentSeed = seed
+        nsView.scene = DinoVoxelGenerator.buildFaceScene(seed: seed)
+    }
+}
+
+/// SCNView subclass that shows a pointing-hand cursor on hover.
+private final class PointerSCNView: SCNView {
+    private var trackingArea: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = trackingArea {
+            removeTrackingArea(existing)
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInActiveApp],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        NSCursor.pointingHand.push()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        NSCursor.pop()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct ConstellationView: View {
+    let identity: IdentityInfo?
+    let skills: [SkillInfo]
+    let workspaceFiles: [WorkspaceFileNode]
+
+    @State private var nodesVisible = false
+
+    private var existingFiles: [WorkspaceFileNode] {
+        workspaceFiles.filter { $0.exists }
+    }
+
+    /// All items merged into one orbit ring.
+    private var allItems: [OrbitItem] {
+        let fileItems = existingFiles.map { node in
+            OrbitItem(label: node.label, icon: "doc.text.fill", emoji: nil, color: Amber._400)
+        }
+        let skillItems = skills.map { skill in
+            OrbitItem(label: skill.name, icon: "wand.and.stars", emoji: skill.emoji, color: Violet._400)
+        }
+        return fileItems + skillItems
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let center = CGPoint(x: geometry.size.width / 2, y: geometry.size.height / 2)
+            let orbitRadius = min(geometry.size.width, geometry.size.height) * 0.38
+
+            ZStack {
+                // Background glow
+                RadialGradient(
+                    colors: [Violet._600.opacity(0.06), Color.clear],
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: min(geometry.size.width, geometry.size.height) * 0.5
+                )
+                .ignoresSafeArea()
+
+                // Orbiting pills
+                ForEach(Array(allItems.enumerated()), id: \.offset) { index, item in
+                    let pos = orbitPosition(
+                        center: center,
+                        radius: orbitRadius,
+                        index: index,
+                        total: allItems.count
+                    )
+                    ConstellationPill(label: item.label, icon: item.icon, emoji: item.emoji, color: item.color)
+                        .position(pos)
+                        .scaleEffect(nodesVisible ? 1 : 0.4)
+                        .opacity(nodesVisible ? 1 : 0)
+                        .animation(
+                            .spring(response: 0.5, dampingFraction: 0.7)
+                                .delay(0.15 + Double(index) * 0.06),
+                            value: nodesVisible
+                        )
+                }
+
+                // Center dino face
+                DinoFaceView(seed: identity?.name ?? "default")
+                    .frame(width: 100, height: 100)
+                    .position(center)
+                    .scaleEffect(nodesVisible ? 1 : 0.6)
+                    .opacity(nodesVisible ? 1 : 0)
+                    .animation(.spring(response: 0.5, dampingFraction: 0.7).delay(0.05), value: nodesVisible)
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                nodesVisible = true
+            }
+        }
+    }
+
+    // MARK: - Orbit Layout
+
+    /// Places items evenly around a circle, starting from the top.
+    private func orbitPosition(center: CGPoint, radius: CGFloat, index: Int, total: Int) -> CGPoint {
+        guard total > 0 else { return center }
+        let angle = (2 * .pi * Double(index) / Double(total)) - .pi / 2 // start at top
+        return CGPoint(
+            x: center.x + radius * CGFloat(Darwin.cos(angle)),
+            y: center.y + radius * CGFloat(Darwin.sin(angle))
+        )
+    }
+}
+
+// MARK: - Orbit Item
+
+private struct OrbitItem {
+    let label: String
+    let icon: String
+    let emoji: String?
+    let color: Color
+}
+
+// MARK: - Polished Pill
+
+private struct ConstellationPill: View {
+    let label: String
+    let icon: String
+    let emoji: String?
+    let color: Color
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            // Icon: show emoji if available, otherwise SF Symbol
+            if let emoji, !emoji.isEmpty {
+                Text(emoji)
+                    .font(.system(size: 13))
+                    .frame(width: 24, height: 24)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill(color.opacity(0.12))
+                    )
+            } else {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(color)
+                    .frame(width: 24, height: 24)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill(color.opacity(0.12))
+                    )
+            }
+
+            Text(label)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textPrimary)
+                .lineLimit(1)
+        }
+        .padding(.leading, VSpacing.xs)
+        .padding(.trailing, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surface.opacity(isHovered ? 1 : 0.9))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(
+                            isHovered ? color.opacity(0.4) : VColor.surfaceBorder.opacity(0.6),
+                            lineWidth: 1
+                        )
+                )
+                .shadow(color: Color.black.opacity(isHovered ? 0.3 : 0.15), radius: isHovered ? 8 : 4, y: 2)
+        )
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Identity Info (parsed from IDENTITY.md)
+
+struct IdentityInfo {
+    let name: String
+    let role: String
+    let vibe: String
+    let emoji: String
+
+    static func load() -> IdentityInfo? {
+        let path = NSHomeDirectory() + "/.vellum/workspace/IDENTITY.md"
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+
+        var name = ""
+        var role = ""
+        var vibe = ""
+        var emoji = ""
+
+        for line in content.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.lowercased().hasPrefix("- **name:**") {
+                name = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
+            } else if trimmed.lowercased().hasPrefix("- **role:**") {
+                role = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
+            } else if trimmed.lowercased().hasPrefix("- **vibe:**") {
+                vibe = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
+            } else if trimmed.lowercased().hasPrefix("- **emoji:**") {
+                emoji = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
+            }
+        }
+
+        guard !name.isEmpty else { return nil }
+        return IdentityInfo(name: name, role: role, vibe: vibe, emoji: emoji)
+    }
+
+    /// Deterministic 8-character hex agent ID derived from the identity name.
+    var agentID: String {
+        var hash: UInt64 = 0xcbf29ce484222325 // FNV-1a offset basis
+        for byte in name.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3 // FNV prime
+        }
+        return String(format: "%08X", UInt32(truncatingIfNeeded: hash))
+    }
+}
+
+// MARK: - Assistant Metadata
+
+struct AssistantMetadata {
+    let version: String
+    let createdAt: Date?
+    let originSystem: String
+
+    static func load() -> AssistantMetadata {
+        let identityPath = NSHomeDirectory() + "/.vellum/workspace/IDENTITY.md"
+        let fm = FileManager.default
+
+        // Version from IDENTITY.md modified date count (simple lineage)
+        let version = "v1.0"
+
+        // Created at = IDENTITY.md creation date
+        let createdAt: Date?
+        if let attrs = try? fm.attributesOfItem(atPath: identityPath),
+           let date = attrs[.creationDate] as? Date {
+            createdAt = date
+        } else {
+            createdAt = nil
+        }
+
+        // Origin system
+        let originSystem = Host.current().localizedName ?? "local"
+
+        return AssistantMetadata(version: version, createdAt: createdAt, originSystem: originSystem)
+    }
+}
+
+// MARK: - Workspace File Node (checks file existence)
+
+struct WorkspaceFileNode: Identifiable {
+    let id = UUID()
+    let label: String
+    let path: String
+    let exists: Bool
+
+    static func scan() -> [WorkspaceFileNode] {
+        let base = NSHomeDirectory() + "/.vellum/workspace"
+        let fm = FileManager.default
+        return [
+            WorkspaceFileNode(label: "IDENTITY.md", path: base + "/IDENTITY.md", exists: fm.fileExists(atPath: base + "/IDENTITY.md")),
+            WorkspaceFileNode(label: "SOUL.md", path: base + "/SOUL.md", exists: fm.fileExists(atPath: base + "/SOUL.md")),
+            WorkspaceFileNode(label: "USER.md", path: base + "/USER.md", exists: fm.fileExists(atPath: base + "/USER.md")),
+            WorkspaceFileNode(label: "skills/", path: base + "/skills", exists: fm.fileExists(atPath: base + "/skills")),
+        ]
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct IdentityPanel: View {
+    let onClose: () -> Void
+    let daemonClient: DaemonClient
+
+    @State private var identity: IdentityInfo?
+    @State private var metadata: AssistantMetadata?
+    @State private var workspaceFiles: [WorkspaceFileNode] = []
+    @State private var skills: [SkillInfo] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text("Assistant ID")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close Assistant ID")
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.lg)
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            ScrollView {
+                VStack(spacing: VSpacing.xl) {
+                    // Avatar + ID card side by side
+                    HStack(alignment: .center, spacing: VSpacing.lg) {
+                        DinoSceneView(seed: identity?.name ?? "default")
+                            .frame(width: 180, height: 200)
+
+                        if let identity {
+                            idCardSection(identity: identity)
+                        }
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+
+                    Divider()
+                        .background(VColor.surfaceBorder)
+                        .padding(.horizontal, VSpacing.lg)
+
+                    // Constellation
+                    ConstellationView(
+                        identity: identity,
+                        skills: skills,
+                        workspaceFiles: workspaceFiles
+                    )
+                    .frame(height: 400)
+                }
+                .padding(.vertical, VSpacing.lg)
+            }
+        }
+        .background(VColor.backgroundSubtle)
+        .onAppear {
+            identity = IdentityInfo.load()
+            metadata = AssistantMetadata.load()
+            workspaceFiles = WorkspaceFileNode.scan()
+            fetchSkills()
+        }
+    }
+
+    // MARK: - Skills
+
+    private func fetchSkills() {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.send(SkillsListRequestMessage())
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .skillsListResponse(let response) = message {
+                    skills = response.skills.filter { $0.state == "enabled" }
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - ID Card
+
+    @ViewBuilder
+    private func idCardSection(identity: IdentityInfo) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            idRow(label: "Agent ID", value: identity.agentID, mono: true)
+            idRow(label: "Given name", value: identity.name)
+
+            if !identity.role.isEmpty {
+                idRow(label: "Role", value: identity.role)
+            }
+
+            if !identity.vibe.isEmpty {
+                idRow(label: "Vibe", value: identity.vibe)
+            }
+
+            idRow(label: "Version", value: metadata?.version ?? "v1.0")
+
+            if let date = metadata?.createdAt {
+                idRow(label: "Created at", value: formatDate(date))
+            }
+
+            idRow(label: "Origin system", value: metadata?.originSystem ?? "local")
+        }
+    }
+
+    private func idRow(label: String, value: String, mono: Bool = false) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 100, alignment: .leading)
+
+            Text(value)
+                .font(mono ? VFont.mono : VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+
+            Spacer()
+        }
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -6,6 +6,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case debug
     case doctor
     case activity
+    case identity
 
     init?(rawValue: String) {
         switch rawValue {
@@ -16,6 +17,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "debug": self = .debug
         case "doctor": self = .doctor
         case "activity": self = .activity
+        case "identity": self = .identity
         default: return nil
         }
     }


### PR DESCRIPTION
## Summary
- Add Identity panel with avatar sprite builder, constellation background, and identity data parsed from IDENTITY.md
- Gate the Identity tab on bootstrap onboarding completion — disabled with reduced opacity while BOOTSTRAP.md exists
- Fix clawhub cwd to use project root instead of skills subdirectory
- Add gmail skill icon SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
