### PR TITLE
feat: auto-enable skills on install and default managed skills to enabled

### DIFF
--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -33,8 +33,8 @@ export function resolveSkillStates(
     if (entry && typeof entry.enabled === 'boolean') {
       isEnabled = entry.enabled;
     } else {
-      // Default: bundled skills are enabled, others are disabled
-      isEnabled = skill.source === 'bundled';
+      // Default: bundled and managed (user-installed) skills are enabled, others are disabled
+      isEnabled = skill.source === 'bundled' || skill.source === 'managed';
     }
 
     if (!isEnabled) {

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -209,6 +209,28 @@ export async function handleSkillsInstall(
     // Reload skill catalog so the newly installed skill is picked up
     loadSkillCatalog();
 
+    // Auto-enable the newly installed skill so it's immediately usable
+    const skillId = result.skillName ?? msg.slug;
+    try {
+      const raw = loadRawConfig();
+      ensureSkillEntry(raw, skillId).enabled = true;
+      ctx.setSuppressConfigReload(true);
+      try {
+        saveRawConfig(raw);
+      } catch (err) {
+        ctx.setSuppressConfigReload(false);
+        throw err;
+      }
+      invalidateConfigCache();
+      const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
+      if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
+      const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+      ctx.debounceTimers.set('__suppress_reset__', resetTimer);
+      ctx.updateConfigFingerprint();
+    } catch (err) {
+      log.warn({ err, skillId }, 'Failed to auto-enable installed skill');
+    }
+
     ctx.send(socket, {
       type: 'skills_operation_response',
       operation: 'install',
@@ -216,8 +238,8 @@ export async function handleSkillsInstall(
     });
     ctx.broadcast({
       type: 'skills_state_changed',
-      name: result.skillName ?? msg.slug,
-      state: 'installed',
+      name: skillId,
+      state: 'enabled',
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Managed (user-installed) skills now default to enabled alongside bundled skills
- Newly installed skills are auto-enabled immediately after install so they're usable without manual toggle
- Install broadcast state changed from 'installed' to 'enabled' to reflect the auto-enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
