### PR TITLE
fix: create parent directory before writing model config during onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -318,6 +318,9 @@ struct APIKeyStepView: View {
         let configURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".vellum/workspace/config.json")
 
+        let dirURL = configURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
         do {
             let data = try Data(contentsOf: configURL)
             if var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {


### PR DESCRIPTION
Addresses feedback on #3457.

On first launch, `~/.vellum/workspace/` may not exist yet when `saveModelToConfig` is called during onboarding. The `try? data.write(to: configURL)` silently fails, and the user's model selection is lost.

**Fix:** Added `FileManager.createDirectory(at: dirURL, withIntermediateDirectories: true)` before the write, matching the pattern used by `writeVellumIdentityFile` in `AppDelegate.swift`.

**File modified:** `clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
