### PR TITLE
fix: check path.isEmpty instead of name.isEmpty in detailsSummary

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -53,16 +53,19 @@ public struct ToolConfirmationData: Equatable {
             return "The assistant wants to run a command"
         case "file_write", "host_file_write":
             let path = (input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "The assistant wants to write a file" }
             let name = URL(fileURLWithPath: path).lastPathComponent
-            return name.isEmpty ? "The assistant wants to write a file" : "The assistant wants to write to \(name)"
+            return "The assistant wants to write to \(name)"
         case "file_edit", "host_file_edit":
             let path = (input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "The assistant wants to edit a file" }
             let name = URL(fileURLWithPath: path).lastPathComponent
-            return name.isEmpty ? "The assistant wants to edit a file" : "The assistant wants to edit \(name)"
+            return "The assistant wants to edit \(name)"
         case "file_read", "host_file_read":
             let path = (input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "The assistant wants to read a file" }
             let name = URL(fileURLWithPath: path).lastPathComponent
-            return name.isEmpty ? "The assistant wants to read a file" : "The assistant wants to read \(name)"
+            return "The assistant wants to read \(name)"
         case "web_fetch":
             let url = (input["url"]?.value as? String) ?? ""
             if let host = URL(string: url)?.host {


### PR DESCRIPTION
Addresses feedback on #3472.

`URL(fileURLWithPath: "").lastPathComponent` returns the CWD name (not empty), so the `name.isEmpty` fallback in `detailsSummary` never triggers. Users see misleading text like "write to myproject" instead of the generic fallback.

**Fix:** Check `path.isEmpty` before constructing the URL for all three file tool cases (file_write, file_edit, file_read).

**File modified:** `clients/shared/Features/Chat/ChatMessage.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
