### PR TITLE
fix: update lastDaemonModel on setModel to handle rapid toggles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -179,6 +179,7 @@ public final class SettingsStore: ObservableObject {
 
     func setModel(_ model: String) {
         guard model != lastDaemonModel else { return }
+        lastDaemonModel = model
         try? daemonClient?.sendModelSet(model: model)
     }
 }


### PR DESCRIPTION
Addresses feedback on #3474.

When the user quickly toggles models (A→B→A), the second switch is suppressed because `lastDaemonModel` is still A from the daemon's last report. The user ends up stuck on B.

**Fix:** Update `lastDaemonModel` immediately when calling `setModel()` so subsequent switches compare against the pending model, not the stale daemon response.

**File modified:** `clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
