### PR TITLE
fix: use .background instead of .foregroundColor on Divider

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -234,7 +234,7 @@ public struct ToolConfirmationBubble: View {
 
                     if index < confirmation.allowlistOptions.count - 1 {
                         Divider()
-                            .foregroundColor(VColor.divider)
+                            .background(VColor.divider)
                     }
                 }
             }


### PR DESCRIPTION
Addresses feedback on #3477.

SwiftUI's `Divider` ignores `.foregroundColor`. The dropdown divider between "Always Allow" options was rendering with the system default color instead of `VColor.divider`.

**Fix:** Changed `.foregroundColor(VColor.divider)` to `.background(VColor.divider)`, matching the codebase convention used in ~35 other places.

**File modified:** `clients/shared/Features/Chat/ToolConfirmationBubble.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
