### PR TITLE
fix: only apply diff line coloring when result contains unified diff

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -206,8 +206,15 @@ struct ActivityStepView: View {
         return "\(mins)m \(secs)s"
     }
 
+    /// Whether the result text looks like a unified diff (contains @@ hunk headers).
+    private var resultIsDiff: Bool {
+        guard let result = toolCall.result else { return false }
+        return result.contains("@@") && result.contains("---") && result.contains("+++")
+    }
+
     private func diffLineColor(_ line: String) -> Color {
         if toolCall.isError { return VColor.error }
+        guard resultIsDiff else { return VColor.textSecondary }
         if line.hasPrefix("+") { return Emerald._400 }
         if line.hasPrefix("-") { return Rose._400 }
         if line.hasPrefix("@@") { return VColor.textMuted }


### PR DESCRIPTION
Addresses feedback on #3497.

`diffLineColor` applied red/green coloring to all tool results unconditionally. Lines from `ls -la` output starting with `-` would be colored red, and any `+` prefix would be green.

**Fix:** Added `resultIsDiff` computed property that checks for `@@`/`---`/`+++` markers. Diff coloring only applies when the result actually contains unified diff content; all other results use the default `VColor.textSecondary`.

**File modified:** `clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
