### PR TITLE
fix: close identity panel when switching conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -289,6 +289,8 @@ struct MainWindowView: View {
             if windowState.activePanel == .activity {
                 windowState.activePanel = nil
                 windowState.activityMessageId = nil
+            } else if windowState.activePanel == .identity {
+                windowState.activePanel = nil
             }
             // Clear stale activeSurfaceId on the old thread and sync the new one
             if let oldId {
@@ -349,7 +351,7 @@ struct MainWindowView: View {
         HStack(spacing: 0) {
             Button(action: {
                 threadManager.selectThread(id: thread.id)
-                if windowState.activePanel == .directory {
+                if windowState.activePanel == .directory || windowState.activePanel == .identity {
                     windowState.activePanel = nil
                 }
             }) {


### PR DESCRIPTION
## Summary
- Close the Identity (Assistant ID) panel when clicking a conversation in the sidebar or when the active thread changes
- Adds `.identity` to the existing panel-close checks alongside `.directory` and `.activity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
