### PR TITLE
fix: move animation modifier outside conditional for tooltip fade-out

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -812,10 +812,10 @@ private struct ChatBubble: View {
                     .fixedSize()
                     .offset(y: -28)
                     .transition(.opacity)
-                    .animation(VAnimation.fast, value: isRegenerateHovered)
                     .allowsHitTesting(false)
             }
         }
+        .animation(VAnimation.fast, value: isRegenerateHovered)
     }
 
     /// Whether the permission was denied, meaning incomplete tools were blocked (not running).


### PR DESCRIPTION
## Summary
- Moved `.animation(VAnimation.fast, value: isRegenerateHovered)` from inside the `if isRegenerateHovered` block to after the `.overlay(alignment: .top)` closure
- This ensures the animation modifier persists in the view tree during both insertion and removal, allowing the tooltip to fade out smoothly instead of vanishing instantly

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3485
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
