### PR TITLE
feat: personalized empty state for new conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -96,21 +96,54 @@ struct ChatView: View {
     @State private var isDropTargeted = false
     @State private var editorContentHeight: CGFloat = 20
     @State private var isComposerExpanded = false
+    @State private var emptyStateTitle: String = emptyStateTitles.randomElement()!
+    @State private var emptyStatePlaceholder: String = placeholderTexts.randomElement()!
+    @State private var emptyStateVisible = false
+    @State private var identity: IdentityInfo? = IdentityInfo.load()
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
+
+    private static let defaultGreetings = [
+        "What are we working on?",
+        "I'm here whenever you need me.",
+        "What's on your mind?",
+        "Let's make something happen.",
+        "Ready when you are.",
+    ]
+
+    private static var emptyStateTitles: [String] {
+        let custom = IdentityInfo.loadGreetings()
+        return custom.isEmpty ? defaultGreetings : custom
+    }
+
+    private static let placeholderTexts = [
+        "Ask me anything...",
+        "Tell me what you need...",
+        "Say the word...",
+        "Go ahead, I'm listening...",
+        "Type or hold Fn to talk...",
+    ]
+
+    private var isEmptyState: Bool {
+        messages.isEmpty && !isThinking
+    }
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 apiKeyBanner
-                ZStack(alignment: .bottom) {
-                    messageList
-                        .safeAreaInset(edge: .bottom) {
-                            Color.clear.frame(height: composerReservedHeight)
-                                .animation(VAnimation.fast, value: editorContentHeight)
-                        }
+                if isEmptyState {
+                    emptyStateView
+                } else {
+                    ZStack(alignment: .bottom) {
+                        messageList
+                            .safeAreaInset(edge: .bottom) {
+                                Color.clear.frame(height: composerReservedHeight)
+                                    .animation(VAnimation.fast, value: editorContentHeight)
+                            }
 
-                    composerOverlay
+                        composerOverlay
+                    }
                 }
             }
             .background(alignment: .bottom) {
@@ -141,8 +174,86 @@ struct ChatView: View {
                     .transition(.opacity)
             }
         }
+        .onChange(of: messages.isEmpty) {
+            if messages.isEmpty {
+                emptyStateTitle = Self.emptyStateTitles.randomElement()!
+                emptyStatePlaceholder = Self.placeholderTexts.randomElement()!
+            }
+        }
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
+        }
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            Spacer()
+
+            DinoFaceView(seed: identity?.name ?? "default")
+                .frame(width: 80, height: 80)
+                .allowsHitTesting(false)
+                .opacity(emptyStateVisible ? 1 : 0)
+                .scaleEffect(emptyStateVisible ? 1 : 0.8)
+                .padding(.bottom, VSpacing.lg)
+
+            Text(emptyStateTitle)
+                .font(.system(size: 28, weight: .medium))
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 500)
+                .opacity(emptyStateVisible ? 1 : 0)
+                .offset(y: emptyStateVisible ? 0 : 8)
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.bottom, VSpacing.xl)
+
+            ComposerView(
+                inputText: $inputText,
+                hasAPIKey: hasAPIKey,
+                isSending: isSending,
+                isRecording: isRecording,
+                suggestion: suggestion,
+                pendingAttachments: pendingAttachments,
+                onSend: onSend,
+                onStop: onStop,
+                onAcceptSuggestion: onAcceptSuggestion,
+                onAttach: onAttach,
+                onRemoveAttachment: onRemoveAttachment,
+                onPaste: onPaste,
+                onMicrophoneToggle: onMicrophoneToggle,
+                placeholderText: emptyStatePlaceholder,
+                editorContentHeight: $editorContentHeight,
+                isComposerExpanded: $isComposerExpanded
+            )
+            .opacity(emptyStateVisible ? 1 : 0)
+            .offset(y: emptyStateVisible ? 0 : 10)
+
+            Spacer()
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RadialGradient(
+                gradient: Gradient(colors: [
+                    VColor.accent.opacity(0.07),
+                    VColor.accent.opacity(0.02),
+                    Color.clear,
+                ]),
+                center: .center,
+                startRadius: 20,
+                endRadius: 350
+            )
+            .offset(y: -40)
+            .opacity(emptyStateVisible ? 1 : 0)
+        )
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.5)) {
+                emptyStateVisible = true
+            }
+        }
+        .onDisappear {
+            emptyStateVisible = false
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -35,6 +35,37 @@ struct IdentityInfo {
         return IdentityInfo(name: name, role: role, vibe: vibe, emoji: emoji)
     }
 
+    /// Parses an optional `## Greetings` section from SOUL.md.
+    /// The assistant is expected to maintain this section as part of its personality.
+    static func loadGreetings() -> [String] {
+        let path = NSHomeDirectory() + "/.vellum/workspace/SOUL.md"
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+
+        var greetings: [String] = []
+        var inGreetingsSection = false
+
+        for line in content.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("## ") || trimmed.hasPrefix("# ") {
+                inGreetingsSection = trimmed.lowercased().contains("greetings")
+                continue
+            }
+            if inGreetingsSection {
+                if trimmed.hasPrefix("- ") {
+                    var greeting = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                    // Strip surrounding quotes if present
+                    if greeting.count >= 2,
+                       (greeting.hasPrefix("\"") && greeting.hasSuffix("\""))
+                        || (greeting.hasPrefix("\u{201C}") && greeting.hasSuffix("\u{201D}")) {
+                        greeting = String(greeting.dropFirst().dropLast())
+                    }
+                    if !greeting.isEmpty { greetings.append(greeting) }
+                }
+            }
+        }
+        return greetings
+    }
+
     /// Deterministic 8-character hex agent ID derived from the identity name.
     var agentID: String {
         var hash: UInt64 = 0xcbf29ce484222325 // FNV-1a offset basis


### PR DESCRIPTION
## Summary
- Show centered avatar, greeting, and composer when a conversation has no messages (instead of blank view)
- Greetings dynamically loaded from assistant's SOUL.md (`## Greetings` section), with hardcoded defaults as fallback
- Composer placeholder text rotates randomly between conversational prompts
- Includes fade-in animation and subtle radial accent glow background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
