### PR TITLE
feat: inline image/GIF rendering in chat and fix sidebar scroll overlap

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -130,6 +130,14 @@ function buildAttachmentSection(): string {
     '- `mime_type`: Optional MIME type override (inferred from the file extension if omitted).',
     '',
     'Limits: up to 5 attachments per turn, 20 MB each. Tool outputs that produce image or file content blocks are also automatically converted into attachments.',
+    '',
+    '### Inline Images and GIFs',
+    '',
+    'The chat natively renders images and animated GIFs inline in message bubbles. When you have an image or GIF URL (e.g. from Giphy, web search, or any tool), embed it directly in your response text using markdown image syntax:',
+    '',
+    '`![description](https://media.giphy.com/media/example/giphy.gif)`',
+    '',
+    'This renders the image/GIF visually inside the chat bubble with full animation. You can also use `ui_show`, `app_create`, or `vellum-attachment` for images when appropriate. Do NOT wrap image markdown in code fences or it will render as literal text.',
   ].join('\n');
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import AppKit
+import VellumAssistantShared
+
+/// Displays a remote image with animated GIF support.
+///
+/// Uses a two-layer approach:
+/// - SwiftUI `AsyncImage`-style state machine for layout and static images
+/// - `NSViewRepresentable` wrapping `NSImageView` with `animates = true` for GIFs
+///
+/// The Coordinator tracks the current URL to prevent redundant downloads across
+/// streaming re-renders (same pattern as `DinoSceneView` in `AvatarView.swift`).
+struct AnimatedImageView: View {
+    let urlString: String
+
+    @State private var loadedImage: NSImage?
+    @State private var imageData: Data?
+    @State private var isLoading = true
+
+    var body: some View {
+        Group {
+            if let data = imageData, isAnimatedGIF(data) {
+                GIFView(data: data)
+                    .frame(
+                        width: min(imageSize.width, 280),
+                        height: min(imageSize.height, 280)
+                    )
+            } else if let image = loadedImage {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                Image(systemName: "photo")
+                    .font(.system(size: 24))
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 80, height: 60)
+            }
+        }
+        .task(id: urlString) {
+            await loadImage()
+        }
+    }
+
+    private var imageSize: CGSize {
+        guard let image = loadedImage else { return CGSize(width: 280, height: 280) }
+        let size = image.size
+        guard size.width > 0, size.height > 0 else { return CGSize(width: 280, height: 280) }
+        let scale = min(280 / size.width, 280 / size.height, 1.0)
+        return CGSize(width: size.width * scale, height: size.height * scale)
+    }
+
+    private func loadImage() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        // Support local file paths
+        if urlString.hasPrefix("/") || urlString.hasPrefix("file://") {
+            let fileURL = urlString.hasPrefix("file://")
+                ? URL(string: urlString)
+                : URL(fileURLWithPath: urlString)
+            if let fileURL {
+                imageData = try? Data(contentsOf: fileURL)
+                loadedImage = imageData.flatMap { NSImage(data: $0) }
+            }
+            return
+        }
+
+        guard let url = URL(string: urlString) else { return }
+
+        do {
+            let data = try await ImageCache.shared.imageData(for: url)
+            self.imageData = data
+            self.loadedImage = NSImage(data: data)
+        } catch {
+            // Keep placeholder on failure
+        }
+    }
+
+    private func isAnimatedGIF(_ data: Data) -> Bool {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return false }
+        return CGImageSourceGetCount(source) > 1
+    }
+}
+
+/// NSViewRepresentable that renders animated GIF data via NSImageView.
+private struct GIFView: NSViewRepresentable {
+    let data: Data
+
+    func makeNSView(context: Context) -> NSImageView {
+        let imageView = NSImageView()
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.animates = true
+        imageView.isEditable = false
+        imageView.canDrawSubviewsIntoLayer = true
+        if let image = NSImage(data: data) {
+            imageView.image = image
+        }
+        return imageView
+    }
+
+    func updateNSView(_ nsView: NSImageView, context: Context) {
+        // Data is immutable per GIF URL — no updates needed
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1330,15 +1330,17 @@ private struct ChatBubble: View {
         }
     }
 
-    /// Render a single text segment as a styled bubble, with table support.
+    /// Render a single text segment as a styled bubble, with table and image support.
     @ViewBuilder
     private func textBubble(for segmentText: String) -> some View {
         let segments = parseMarkdownSegments(segmentText)
-        let hasTable = segments.contains(where: {
-            if case .table = $0 { return true }; return false
+        let hasRichContent = segments.contains(where: {
+            if case .table = $0 { return true }
+            if case .image = $0 { return true }
+            return false
         })
 
-        if hasTable {
+        if hasRichContent {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
                     switch segment {
@@ -1357,6 +1359,11 @@ private struct ChatBubble: View {
                             .frame(maxWidth: 520, alignment: .leading)
                     case .table(let headers, let rows):
                         MarkdownTableView(headers: headers, rows: rows)
+                    case .image(let alt, let url):
+                        AnimatedImageView(urlString: url)
+                            .frame(maxWidth: 280, maxHeight: 280)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .accessibilityLabel(alt.isEmpty ? "Image" : alt)
                     }
                 }
             }
@@ -1416,12 +1423,14 @@ private struct ChatBubble: View {
 
             if hasText {
                 let segments = parseMarkdownSegments(message.text)
-                let hasTable = segments.contains(where: {
-                    if case .table = $0 { return true }; return false
+                let hasRichContent = segments.contains(where: {
+                    if case .table = $0 { return true }
+                    if case .image = $0 { return true }
+                    return false
                 })
-                VStack(alignment: .leading, spacing: hasTable ? VSpacing.lg : VSpacing.xs) {
+                VStack(alignment: .leading, spacing: hasRichContent ? VSpacing.lg : VSpacing.xs) {
 
-                    if hasTable {
+                    if hasRichContent {
                         ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
                             switch segment {
                             case .text(let text):
@@ -1438,6 +1447,11 @@ private struct ChatBubble: View {
                                     .fixedSize(horizontal: false, vertical: true)
                             case .table(let headers, let rows):
                                 MarkdownTableView(headers: headers, rows: rows)
+                            case .image(let alt, let url):
+                                AnimatedImageView(urlString: url)
+                                    .frame(maxWidth: 280, maxHeight: 280)
+                                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                                    .accessibilityLabel(alt.isEmpty ? "Image" : alt)
                             }
                         }
                     } else {
@@ -1630,6 +1644,7 @@ private struct ChatBubble: View {
 private enum MarkdownSegment {
     case text(String)
     case table(headers: [String], rows: [[String]])
+    case image(alt: String, url: String)
 }
 
 /// Parses message text into segments, extracting pipe-delimited markdown tables.
@@ -1703,6 +1718,58 @@ private func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
         .trimmingCharacters(in: .whitespacesAndNewlines)
     if !remaining.isEmpty {
         segments.append(.text(remaining))
+    }
+
+    // Post-process .text segments to extract inline images.
+    // Code-fenced segments are already opaque from the table pass, so images inside
+    // code blocks remain as literal text.
+    return segments.flatMap { segment -> [MarkdownSegment] in
+        if case .text(let content) = segment {
+            return extractImageSegments(from: content)
+        }
+        return [segment]
+    }
+}
+
+/// Splits text around `![alt](url)` matches, returning mixed `.text` / `.image` segments.
+private func extractImageSegments(from text: String) -> [MarkdownSegment] {
+    let pattern = #"!\[([^\]]*)\]\(([^)]+)\)"#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else {
+        return [.text(text)]
+    }
+
+    let nsText = text as NSString
+    let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+
+    if matches.isEmpty { return [.text(text)] }
+
+    var segments: [MarkdownSegment] = []
+    var lastEnd = 0
+
+    for match in matches {
+        // Text before the image
+        if match.range.location > lastEnd {
+            let before = nsText.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !before.isEmpty {
+                segments.append(.text(before))
+            }
+        }
+
+        let alt = nsText.substring(with: match.range(at: 1))
+        let url = nsText.substring(with: match.range(at: 2))
+        segments.append(.image(alt: alt, url: url))
+
+        lastEnd = match.range.location + match.range.length
+    }
+
+    // Text after the last image
+    if lastEnd < nsText.length {
+        let after = nsText.substring(from: lastEnd)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !after.isEmpty {
+            segments.append(.text(after))
+        }
     }
 
     return segments

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -441,19 +441,24 @@ struct MainWindowView: View {
                 }
             }
             .scrollClipDisabled()
+            .clipped()
 
-            Spacer()
+            Spacer(minLength: 0)
 
             // Control Center
-            VColor.surfaceBorder.frame(height: 1)
+            VStack(spacing: 0) {
+                VColor.surfaceBorder.frame(height: 1)
 
-            ControlCenterMenuButton(
-                onSettings: { windowState.togglePanel(.settings) },
-                onSkills: { windowState.togglePanel(.agent) },
-                onDirectory: { windowState.togglePanel(.directory) },
-                onDebug: { windowState.togglePanel(.debug) },
-                onDoctor: { windowState.togglePanel(.doctor) }
-            )
+                ControlCenterMenuButton(
+                    onSettings: { windowState.togglePanel(.settings) },
+                    onSkills: { windowState.togglePanel(.agent) },
+                    onDirectory: { windowState.togglePanel(.directory) },
+                    onDebug: { windowState.togglePanel(.debug) },
+                    onDoctor: { windowState.togglePanel(.doctor) }
+                )
+            }
+            .background(VColor.backgroundSubtle)
+            .zIndex(1)
         }
         .frame(width: threadDrawerWidth)
         .background(VColor.backgroundSubtle)

--- a/clients/shared/Features/Chat/ImageCache.swift
+++ b/clients/shared/Features/Chat/ImageCache.swift
@@ -1,0 +1,51 @@
+import Foundation
+#if os(macOS)
+import AppKit
+#elseif os(iOS)
+import UIKit
+#endif
+
+/// Thread-safe, NSCache-backed image cache that coalesces duplicate in-flight requests.
+/// Used by ``AnimatedImageView`` to avoid redundant downloads during streaming re-renders.
+public actor ImageCache {
+    public static let shared = ImageCache()
+
+    private let dataCache = NSCache<NSURL, NSData>()
+    private var inFlight: [URL: Task<Data, Error>] = [:]
+
+    private init() {
+        dataCache.countLimit = 50
+    }
+
+    /// Returns raw `Data` for the URL (needed for GIF animation frames).
+    public func imageData(for url: URL) async throws -> Data {
+        let nsURL = url as NSURL
+
+        // Return from cache if available
+        if let cachedData = dataCache.object(forKey: nsURL) {
+            return cachedData as Data
+        }
+
+        // Coalesce duplicate in-flight requests
+        if let existing = inFlight[url] {
+            return try await existing.value
+        }
+
+        let task = Task<Data, Error> {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return data
+        }
+
+        inFlight[url] = task
+
+        do {
+            let data = try await task.value
+            dataCache.setObject(data as NSData, forKey: nsURL)
+            inFlight[url] = nil
+            return data
+        } catch {
+            inFlight[url] = nil
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Parse `![alt](url)` markdown in chat messages and render images/GIFs inline using a new `AnimatedImageView` with shared `ImageCache`
- Update system prompt to instruct the assistant to use inline markdown image syntax for GIFs and images
- Fix conversation list overlapping the Control Center in the sidebar by clipping scroll overflow and raising Control Center z-index

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
