### PR TITLE
fix: round only top-left corner of side panel

### DIFF
--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -36,7 +36,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                         .frame(width: panelWidth)
                         .animation(nil, value: panelWidth)  // Disable animation on width changes
                         .background(VColor.backgroundSubtle)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.lg))
                         .padding([.bottom, .trailing], VSpacing.xs)
                         .transition(.move(edge: .trailing))
                 }


### PR DESCRIPTION
## Summary
- Changed the VSplitView side panel clip shape from `RoundedRectangle` (all corners) to `UnevenRoundedRectangle(topLeadingRadius:)` so only the top-left corner is rounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
