### PR TITLE
feat: fn+shift voice activation with onboarding and push notifications

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -60,7 +60,19 @@ extension AppDelegate {
             options: [.customDismissAction]
         )
 
-        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory])
+        let viewResponseAction = UNNotificationAction(
+            identifier: "VIEW_RESPONSE",
+            title: "View Response",
+            options: .foreground
+        )
+        let voiceResponseCategory = UNNotificationCategory(
+            identifier: "VOICE_RESPONSE_COMPLETE",
+            actions: [viewResponseAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory])
     }
 
     func registerBundledFonts() {
@@ -119,6 +131,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             }
             await MainActor.run {
                 self.toolConfirmationNotificationService.handleResponse(requestId: requestId, decision: decision)
+            }
+            return
+        }
+
+        // Handle voice response complete notifications
+        if categoryId == "VOICE_RESPONSE_COMPLETE" {
+            await MainActor.run {
+                self.showMainWindow()
             }
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -470,10 +470,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.voiceTranscriptionWindow?.close()
             self?.voiceTranscriptionWindow = nil
 
-            // Priority 1: Route to main window ChatView if visible
-            if let mainWindow = self?.mainWindow, mainWindow.isVisible,
+            // Priority 1: Route to main window ChatView if in the foreground
+            if NSApp.isActive,
+               let mainWindow = self?.mainWindow, mainWindow.isVisible,
                let viewModel = mainWindow.activeViewModel {
                 viewModel.inputText = text
+                viewModel.pendingVoiceMessage = true
                 viewModel.sendMessage()
                 return
             }
@@ -489,8 +491,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.startSession(task: text, source: "voice")
         }
         voiceInput?.onPartialTranscription = { [weak self] text in
-            // Priority 1: Route partial text to main window ChatView input if visible
-            if let mainWindow = self?.mainWindow, mainWindow.isVisible,
+            // Priority 1: Route partial text to main window ChatView input if in the foreground
+            if NSApp.isActive,
+               let mainWindow = self?.mainWindow, mainWindow.isVisible,
                let viewModel = mainWindow.activeViewModel {
                 viewModel.inputText = text
                 return
@@ -504,8 +507,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
-            // Check if main window ChatView is the target
-            let mainWindowVisible = self?.mainWindow?.isVisible ?? false
+            // Check if main window is actively in the foreground (not just existing behind other apps)
+            let mainWindowActive = NSApp.isActive && (self?.mainWindow?.isVisible ?? false)
             // If there's an active conversation in ready state, route recording state there
             let hasActiveConvo = self?.currentTextSession?.state == .ready
 
@@ -526,7 +529,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     systemSymbolName: "mic.fill",
                     accessibilityDescription: "Vellum"
                 )
-                if !mainWindowVisible && !hasActiveConvo {
+                if !mainWindowActive && !hasActiveConvo {
                     let window = VoiceTranscriptionWindow()
                     window.show()
                     self?.voiceTranscriptionWindow = window
@@ -611,15 +614,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.setupNotifications()
             self?.setupAutoUpdate()
 
-            self?.showMainWindow()
-
-            // Send an automatic greeting after onboarding completes
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                if let viewModel = self?.mainWindow?.activeViewModel {
-                    viewModel.inputText = "Wake up, my friend"
-                    viewModel.sendMessage()
-                }
-            }
+            self?.showMainWindow(initialMessage: "Wake up, my friend")
         }
         onboarding.show()
         onboardingWindow = onboarding
@@ -683,7 +678,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Main Window
 
-    func showMainWindow() {
+    func showMainWindow(initialMessage: String? = nil) {
         if let existing = mainWindow {
             existing.show()
             return
@@ -702,6 +697,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             UNUserNotificationCenter.current().removeDeliveredNotifications(
                 withIdentifiers: ["tool-confirm-\(requestId)"]
             )
+        }
+        // Send the initial message BEFORE showing the window so SwiftUI never
+        // renders the empty state.
+        if let message = initialMessage, let viewModel = main.activeViewModel {
+            viewModel.inputText = message
+            viewModel.sendMessage()
         }
         main.show()
         mainWindow = main

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -21,10 +21,11 @@ final class VoiceInputManager {
     private var otherKeyPressedDuringHold = false  // True if any other key pressed while holding
     private static let holdDelay: UInt64 = 300_000_000 // 300ms in nanoseconds
 
-    private var activationFlag: NSEvent.ModifierFlags? {
+    private var activationFlags: NSEvent.ModifierFlags? {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
         switch stored {
         case "ctrl": return .control
+        case "fn_shift": return [.function, .shift]
         case "none": return nil
         default: return .function // fn and globe are the same physical key
         }
@@ -99,14 +100,18 @@ final class VoiceInputManager {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        guard let flag = activationFlag else { return }
-        let keyPressed = event.modifierFlags.contains(flag)
+        guard let requiredFlags = activationFlags else { return }
+        let keyPressed = event.modifierFlags.contains(requiredFlags)
         var otherModifiers: NSEvent.ModifierFlags = [.command, .shift, .control, .option, .function]
-        otherModifiers.remove(flag)
+        for flag in [NSEvent.ModifierFlags.command, .shift, .control, .option, .function] {
+            if requiredFlags.contains(flag) {
+                otherModifiers.remove(flag)
+            }
+        }
         let hasOtherModifiers = !event.modifierFlags.intersection(otherModifiers).isEmpty
 
         if keyPressed && !hasOtherModifiers && !isRecording {
-            // Activation key pressed alone - start timer to begin recording while key is held
+            // Activation key(s) pressed alone - start timer to begin recording while held
             holdTask?.cancel()
             otherKeyPressedDuringHold = false
             holdTask = Task { [weak self] in

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 import Foundation
+import UserNotifications
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadManager")
@@ -307,6 +308,25 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.onSessionCreated = { [weak self, weak viewModel] sessionId in
             guard let self, let viewModel else { return }
             self.backfillSessionId(sessionId, for: viewModel)
+        }
+        viewModel.onVoiceResponseComplete = { responseText in
+            guard !NSApp.isActive else { return }
+            let content = UNMutableNotificationContent()
+            content.title = "Response Ready"
+            content.body = String(responseText.prefix(200))
+            content.sound = .default
+            content.categoryIdentifier = "VOICE_RESPONSE_COMPLETE"
+
+            let request = UNNotificationRequest(
+                identifier: "voice-response-\(UUID().uuidString)",
+                content: content,
+                trigger: nil
+            )
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error {
+                    log.error("Failed to post voice response notification: \(error.localizedDescription)")
+                }
+            }
         }
         return viewModel
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -1,151 +1,356 @@
 import VellumAssistantShared
 import SwiftUI
+import AVFoundation
+import Speech
 
 @MainActor
 struct FnKeyStepView: View {
     @Bindable var state: OnboardingState
 
-    @State private var showButtons = false
-    @State private var highlightedKey: ActivationKey?
-    @State private var wrongKeyHint: String?
-    @State private var eventMonitor: Any?
+    @State private var showIcon = false
+    @State private var showTitle = false
+    @State private var showContent = false
+    @State private var pulseScale: CGFloat = 1.0
+    @State private var micGranted = false
+    @State private var speechGranted = false
+    @State private var permissionsRequested = false
+    @State private var permissionPollTimer: Timer?
 
-    private let keyOptions: [(key: ActivationKey, label: String)] = [
-        (.fn, "fn"),
-        (.ctrl, "ctrl"),
-    ]
+    private var allPermissionsGranted: Bool {
+        micGranted && speechGranted
+    }
 
     var body: some View {
-        VStack(spacing: VSpacing.xxl) {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // Icon
+            Group {
+                if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
+                   let nsImage = NSImage(contentsOf: url) {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .interpolation(.none)
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Image("VellyLogo")
+                        .resizable()
+                        .interpolation(.none)
+                        .aspectRatio(contentMode: .fit)
+                }
+            }
+            .frame(width: 128, height: 128)
+            .opacity(showIcon ? 1 : 0)
+            .scaleEffect(showIcon ? 1 : 0.8)
+            .padding(.bottom, VSpacing.xxl)
+
+            // Title
+            Text("Need voice mode?")
+                .font(.system(size: 32, weight: .regular, design: .serif))
+                .foregroundColor(VColor.textPrimary)
+                .opacity(showTitle ? 1 : 0)
+                .offset(y: showTitle ? 0 : 8)
+                .padding(.bottom, VSpacing.md)
+
+            // Subtitle
+            Text(permissionsRequested
+                 ? "Grant the permissions to continue."
+                 : "Hold fn + shift anywhere to talk to \(state.assistantName).")
+                .font(.system(size: 16))
+                .foregroundColor(VColor.textSecondary)
+                .opacity(showTitle ? 1 : 0)
+                .offset(y: showTitle ? 0 : 8)
+                .animation(.easeInOut(duration: 0.3), value: permissionsRequested)
+
+            Spacer()
+
+            // Content area
             VStack(spacing: VSpacing.md) {
-                Text("Let\u{2019}s find your voice.")
-                    .font(VFont.onboardingTitle)
-                    .foregroundColor(VColor.textPrimary)
-
-                Text("To call \(state.assistantName), you\u{2019}ll hold down a key. Try pressing it now \u{2014} which of these lights up?")
-                    .font(VFont.onboardingSubtitle)
-                    .foregroundColor(VColor.textSecondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 400)
-            }
-            .opacity(showButtons ? 1 : 0)
-
-            HStack(spacing: VSpacing.lg) {
-                ForEach(keyOptions, id: \.key) { option in
-                    keyButton(option.key, label: option.label)
+                if permissionsRequested {
+                    // Permission status rows
+                    VStack(spacing: 0) {
+                        permissionRow(
+                            icon: "mic.fill",
+                            label: "Microphone",
+                            granted: micGranted
+                        )
+                        Divider()
+                            .background(VColor.surfaceBorder)
+                        permissionRow(
+                            icon: "waveform",
+                            label: "Speech Recognition",
+                            granted: speechGranted
+                        )
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+                } else {
+                    // Key badge row
+                    HStack(spacing: VSpacing.sm) {
+                        keyBadge("fn")
+                        Text("+")
+                            .font(.system(size: 18, weight: .medium, design: .monospaced))
+                            .foregroundColor(VColor.textMuted)
+                        keyBadge("shift")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, VSpacing.lg)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                    .scaleEffect(pulseScale)
+                    .transition(.opacity.combined(with: .move(edge: .leading)))
                 }
-            }
-            .opacity(showButtons ? 1 : 0)
 
-            if let hint = wrongKeyHint {
-                Text(hint)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+                // Primary button
+                if allPermissionsGranted {
+                    Button(action: {
+                        state.chosenKey = .fnShift
+                        state.advance()
+                    }) {
+                        Text("Continue")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, VSpacing.lg)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .fill(adaptiveColor(
+                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                        dark: Violet._600
+                                    ))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
                     .transition(.opacity)
-            }
-
-            if highlightedKey != nil || state.chosenKey != .fn {
-                OnboardingButton(title: "Continue", style: .primary) {
-                    state.advance()
+                } else {
+                    Button(action: { requestPermissions() }) {
+                        Text(permissionsRequested ? "Open System Settings" : "Enable Voice Mode")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, VSpacing.lg)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .fill(adaptiveColor(
+                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                        dark: Violet._600
+                                    ))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
                 }
-                .transition(.opacity)
-            }
 
-            OnboardingButton(title: "Skip", style: .ghost) {
-                state.chosenKey = .none
-                state.advance()
+                // Skip + Back
+                HStack(spacing: VSpacing.lg) {
+                    Button(action: {
+                        stopPolling()
+                        state.chosenKey = .none
+                        state.advance()
+                    }) {
+                        Text("Skip")
+                            .font(.system(size: 13))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
+
+                    Button(action: {
+                        stopPolling()
+                        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                            state.currentStep = 2
+                        }
+                    }) {
+                        Text("Back")
+                            .font(.system(size: 13))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
+                }
+                .padding(.top, VSpacing.xs)
             }
-            .transition(.opacity)
+            .padding(.horizontal, VSpacing.xxl)
+            .padding(.bottom, VSpacing.xxl)
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 12)
+            .animation(.spring(duration: 0.4, bounce: 0.1), value: permissionsRequested)
+            .animation(.spring(duration: 0.4, bounce: 0.1), value: allPermissionsGranted)
         }
-        .animation(.easeOut(duration: 0.3), value: wrongKeyHint)
-        .animation(.easeOut(duration: 0.3), value: highlightedKey)
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                withAnimation(.easeOut(duration: 0.5)) {
-                    showButtons = true
-                }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            ZStack {
+                VColor.background
+
+                RadialGradient(
+                    colors: [
+                        Violet._600.opacity(0.15),
+                        Violet._700.opacity(0.05),
+                        Color.clear
+                    ],
+                    center: .bottom,
+                    startRadius: 20,
+                    endRadius: 350
+                )
+
+                RadialGradient(
+                    colors: [
+                        Violet._400.opacity(0.08),
+                        Color.clear
+                    ],
+                    center: UnitPoint(x: 0.7, y: 1.0),
+                    startRadius: 10,
+                    endRadius: 250
+                )
             }
-            startKeyMonitor()
+            .ignoresSafeArea()
+        )
+        .onAppear {
+            checkCurrentPermissions()
+            withAnimation(.easeOut(duration: 0.5).delay(0.2)) {
+                showIcon = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+                showTitle = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.8)) {
+                showContent = true
+            }
+            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true).delay(1.0)) {
+                pulseScale = 1.03
+            }
         }
         .onDisappear {
-            stopKeyMonitor()
+            stopPolling()
         }
     }
 
-    private func keyButton(_ key: ActivationKey, label: String) -> some View {
-        Button {
-            selectKey(key)
-        } label: {
+    // MARK: - Subviews
+
+    private func permissionRow(icon: String, label: String, granted: Bool) -> some View {
+        HStack {
+            Image(systemName: icon)
+                .font(.system(size: 14))
+                .foregroundColor(granted ? Emerald._500 : VColor.textMuted)
+                .frame(width: 24)
             Text(label)
-                .font(VFont.mono)
-                .foregroundColor(highlightedKey == key ? .white : VColor.textPrimary.opacity(0.85))
-                .frame(maxWidth: .infinity)
-                .frame(height: 44)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(highlightedKey == key ? VColor.accent : VColor.surface.opacity(0.5))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(highlightedKey == key ? Color.clear : VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
+                .font(.system(size: 15))
+                .foregroundColor(VColor.textPrimary)
+            Spacer()
+            Image(systemName: granted ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: 16))
+                .foregroundColor(granted ? Emerald._500 : VColor.textMuted)
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
     }
 
-    private func selectKey(_ key: ActivationKey) {
-        highlightedKey = key
-        state.chosenKey = key
-        wrongKeyHint = nil
+    private func keyBadge(_ label: String) -> some View {
+        Text(label)
+            .font(.system(size: 16, weight: .medium, design: .monospaced))
+            .foregroundColor(VColor.textPrimary)
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.vertical, VSpacing.sm)
     }
 
-    private func startKeyMonitor() {
-        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
-            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if flags.contains(.function) {
-                selectKey(.fn)
-            } else if flags.contains(.control) {
-                selectKey(.ctrl)
-            } else if flags.contains(.command) {
-                withAnimation {
-                    wrongKeyHint = "That\u{2019}s Cmd \u{2014} try fn or ctrl"
-                }
-                clearHintAfterDelay()
-            } else if flags.contains(.option) {
-                withAnimation {
-                    wrongKeyHint = "Close! That\u{2019}s Option \u{2014} try fn or ctrl"
-                }
-                clearHintAfterDelay()
+    // MARK: - Permissions
+
+    private func checkCurrentPermissions() {
+        micGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        speechGranted = SFSpeechRecognizer.authorizationStatus() == .authorized
+    }
+
+    private func requestPermissions() {
+        // If already requested and denied, open System Settings
+        if permissionsRequested {
+            if !micGranted {
+                openPrivacySettings(for: "Privacy_Microphone")
+            } else if !speechGranted {
+                openPrivacySettings(for: "Privacy_SpeechRecognition")
             }
-            return event
+            return
         }
-    }
 
-    private func stopKeyMonitor() {
-        if let monitor = eventMonitor {
-            NSEvent.removeMonitor(monitor)
-            eventMonitor = nil
+        withAnimation {
+            permissionsRequested = true
         }
-    }
 
-    private func clearHintAfterDelay() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            withAnimation {
-                wrongKeyHint = nil
+        // Request microphone first
+        let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        if micStatus == .notDetermined {
+            AVCaptureDevice.requestAccess(for: .audio) { granted in
+                Task { @MainActor in
+                    self.micGranted = granted
+                    // After mic, request speech
+                    self.requestSpeechPermission()
+                }
             }
+        } else {
+            micGranted = micStatus == .authorized
+            requestSpeechPermission()
+        }
+
+        // Start polling for permission changes (user may grant via System Settings)
+        startPolling()
+    }
+
+    private func requestSpeechPermission() {
+        let speechStatus = SFSpeechRecognizer.authorizationStatus()
+        if speechStatus == .notDetermined {
+            SFSpeechRecognizer.requestAuthorization { status in
+                Task { @MainActor in
+                    self.speechGranted = status == .authorized
+                }
+            }
+        } else {
+            speechGranted = speechStatus == .authorized
+        }
+    }
+
+    private func startPolling() {
+        permissionPollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            Task { @MainActor in
+                checkCurrentPermissions()
+            }
+        }
+    }
+
+    private func stopPolling() {
+        permissionPollTimer?.invalidate()
+        permissionPollTimer = nil
+    }
+
+    private func openPrivacySettings(for pane: String) {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") {
+            NSWorkspace.shared.open(url)
         }
     }
 }
 
 #Preview {
     ZStack {
-        VColor.background
+        VColor.background.ignoresSafeArea()
         FnKeyStepView(state: {
             let s = OnboardingState()
-            s.assistantName = "Alex"
-            s.currentStep = 2
+            s.assistantName = "Velly"
+            s.currentStep = 3
             return s
         }())
     }
-    .frame(width: 520, height: 400)
+    .frame(width: 460, height: 620)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -33,6 +33,16 @@ struct OnboardingFlowView: View {
                         )
                     )
                     .id(state.currentStep)
+            } else if state.currentStep == 3 {
+                // Step 3: Full-window voice activation screen
+                FnKeyStepView(state: state)
+                    .transition(
+                        .asymmetric(
+                            insertion: .opacity.combined(with: .offset(y: 12)),
+                            removal: .opacity.combined(with: .offset(y: -8))
+                        )
+                    )
+                    .id(state.currentStep)
             } else if state.currentStep <= 7 {
                 // Steps 1-7: Egg + content panel layout
                 VStack(spacing: 0) {
@@ -101,7 +111,7 @@ struct OnboardingFlowView: View {
         }
         .ignoresSafeArea()
         .onChange(of: state.currentStep) { _, newStep in
-            if newStep > 2 {
+            if newStep > 3 {
                 onComplete()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -8,12 +8,14 @@ enum OnboardingVariant: String {
 enum ActivationKey: String, CaseIterable {
     case fn
     case ctrl
+    case fnShift = "fn_shift"
     case none
 
     var displayName: String {
         switch self {
         case .fn: return "fn"
         case .ctrl: return "ctrl"
+        case .fnShift: return "fn + shift"
         case .none: return "Off"
         }
     }
@@ -106,7 +108,7 @@ final class OnboardingState {
         // Default onboarding now exits immediately after the first post-hatch
         // conversation entry point (step 2). Prevent stale persisted indices
         // from reopening legacy permission-request steps.
-        let maxStep = onboardingVariant == .firstMeeting ? 4 : 2
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : 3
         if currentStep > maxStep {
             currentStep = maxStep
         }

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
@@ -1,103 +1,36 @@
 import VellumAssistantShared
 import AppKit
-import Combine
 import SwiftUI
 
 final class VoiceTranscriptionViewModel: ObservableObject {
     @Published var transcriptionText: String = ""
-    @Published var contentHeight: CGFloat = 0
-    @Published var isOverflowing: Bool = false
-
-
-}
-
-private struct TextHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
 }
 
 struct VoiceTranscriptionView: View {
     @ObservedObject var viewModel: VoiceTranscriptionViewModel
 
-    private let lineHeight: CGFloat = 20
-    private let maxLines: Int = 4
-    private let fadeHeight: CGFloat = 20
-
-    private var maxTextHeight: CGFloat { CGFloat(maxLines) * lineHeight }
+    private let circleSize: CGFloat = 80
+    private let dinoPixelSize: CGFloat = 3
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(alignment: .top, spacing: 10) {
-                Image(systemName: "mic.fill")
-                    .foregroundColor(VColor.error)
-                    .font(.system(size: 18))
-                    .padding(.top, 2)
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .stroke(VColor.accent, lineWidth: 2.5)
+                    .frame(width: circleSize, height: circleSize)
 
-                if viewModel.transcriptionText.isEmpty {
-                    Text("Listening...")
-                        .foregroundColor(.secondary)
-                        .font(.system(size: 14))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    ScrollViewReader { proxy in
-                        ScrollView(.vertical, showsIndicators: false) {
-                            Text(viewModel.transcriptionText)
-                                .foregroundColor(.primary)
-                                .font(.system(size: 14))
-                                .fixedSize(horizontal: false, vertical: true)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(
-                                    GeometryReader { geometry in
-                                        Color.clear
-                                            .preference(key: TextHeightPreferenceKey.self, value: geometry.size.height)
-                                    }
-                                )
-                                .id("bottom")
-                        }
-                        .frame(height: min(viewModel.contentHeight, maxTextHeight))
-                        .mask(fadeMask)
-                        .onPreferenceChange(TextHeightPreferenceKey.self) { height in
-                            viewModel.contentHeight = height
-                            viewModel.isOverflowing = height > maxTextHeight
-                        }
-                        .onChange(of: viewModel.transcriptionText) {
-                            proxy.scrollTo("bottom", anchor: .bottom)
-                        }
-                    }
-                }
+                Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: dinoPixelSize))
+                    .interpolation(.none)
             }
 
+            Text("Listening")
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.textPrimary)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .frame(width: 320)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .frame(width: 140)
         .vPanelBackground()
-        .onChange(of: viewModel.transcriptionText) {
-            if viewModel.transcriptionText.isEmpty {
-                viewModel.contentHeight = 0
-                viewModel.isOverflowing = false
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var fadeMask: some View {
-        if viewModel.isOverflowing {
-            VStack(spacing: 0) {
-                LinearGradient(
-                    gradient: Gradient(colors: [.clear, .black]),
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-                .frame(height: fadeHeight)
-
-                Color.black
-            }
-        } else {
-            Color.black
-        }
     }
 }
 
@@ -105,19 +38,16 @@ struct VoiceTranscriptionView: View {
 final class VoiceTranscriptionWindow {
     private var panel: NSPanel?
     private let viewModel = VoiceTranscriptionViewModel()
-    private var heightCancellable: AnyCancellable?
 
-    private let panelWidth: CGFloat = 320
-    private let basePadding: CGFloat = 24 // vertical padding (12 top + 12 bottom)
-    private var bottomY: CGFloat = 0 // fixed bottom edge for upward growth
+    private let panelWidth: CGFloat = 140
+    private let panelHeight: CGFloat = 140
+    private let margin: CGFloat = 16
 
     func show() {
         let hostingController = NSHostingController(rootView: VoiceTranscriptionView(viewModel: viewModel))
 
-        let initialHeight: CGFloat = basePadding + 22 // mic icon / single text line
-
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: initialHeight),
+            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
             styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
@@ -127,29 +57,21 @@ final class VoiceTranscriptionWindow {
         panel.level = .floating
         panel.titleVisibility = .hidden
         panel.titlebarAppearsTransparent = true
-        panel.alphaValue = 0.9
+        panel.alphaValue = 0.95
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        panel.backgroundColor = .clear
 
-        // Position center-bottom of screen (above dock), anchored at bottom edge
+        // Position top-right corner of screen
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
-            let x = screenFrame.midX - panelWidth / 2
-            bottomY = screenFrame.minY + 20
-            let frame = NSRect(x: x, y: bottomY, width: panelWidth, height: initialHeight)
-            panel.setFrame(frame, display: false)
+            let x = screenFrame.maxX - panelWidth - margin
+            let y = screenFrame.maxY - panelHeight - margin
+            panel.setFrame(NSRect(x: x, y: y, width: panelWidth, height: panelHeight), display: false)
         }
 
         panel.orderFront(nil)
         self.panel = panel
-
-        // Subscribe to content height changes to resize the panel
-        heightCancellable = viewModel.$contentHeight
-            .combineLatest(viewModel.$transcriptionText)
-            .receive(on: RunLoop.main)
-            .sink { [weak self] contentHeight, text in
-                self?.resizePanel(textContentHeight: contentHeight, hasText: !text.isEmpty)
-            }
     }
 
     func updateText(_ text: String) {
@@ -157,28 +79,7 @@ final class VoiceTranscriptionWindow {
     }
 
     func close() {
-        heightCancellable?.cancel()
-        heightCancellable = nil
         panel?.close()
         panel = nil
-    }
-
-    private func resizePanel(textContentHeight: CGFloat, hasText: Bool) {
-        guard let panel = panel else { return }
-
-        let contentAreaHeight: CGFloat
-        if hasText {
-            let lineHeight: CGFloat = 20
-            let maxTextHeight = lineHeight * 4
-            contentAreaHeight = max(22, min(textContentHeight, maxTextHeight))
-        } else {
-            contentAreaHeight = 22 // mic icon height only
-        }
-
-        let totalHeight = basePadding + contentAreaHeight
-
-        // Grow upward from fixed bottom edge
-        let newFrame = NSRect(x: panel.frame.origin.x, y: bottomY, width: panelWidth, height: totalHeight)
-        panel.setFrame(newFrame, display: true, animate: true)
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -310,6 +310,14 @@ extension ChatViewModel {
             if !wasRefinement {
                 ingestAssistantAttachments(complete.attachments)
             }
+            if pendingVoiceMessage {
+                pendingVoiceMessage = false
+                if let existingId = currentAssistantMessageId,
+                   let index = messages.firstIndex(where: { $0.id == existingId }) {
+                    let responseText = messages[index].textSegments.joined()
+                    onVoiceResponseComplete?(responseText)
+                }
+            }
             var completedToolCalls: [ToolCallData]?
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -366,6 +374,7 @@ extension ChatViewModel {
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
+            pendingVoiceMessage = false
             isWorkspaceRefinementInFlight = false
             refinementMessagePreview = nil
             refinementStreamingText = nil

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -56,6 +56,10 @@ public final class ChatViewModel: ObservableObject {
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
+    /// Whether the current assistant response was triggered by a voice message.
+    public var pendingVoiceMessage: Bool = false
+    /// Called when a voice-triggered assistant response completes, with the response text.
+    public var onVoiceResponseComplete: ((String) -> Void)?
     var pendingUserAttachments: [IPCAttachment]?
     /// Stores the last user message that failed to send, enabling retry.
     private(set) var lastFailedMessageText: String?
@@ -384,6 +388,8 @@ public final class ChatViewModel: ObservableObject {
 
     public func stopGenerating() {
         guard isSending else { return }
+
+        pendingVoiceMessage = false
 
         // If we're still bootstrapping (no session yet), cancel locally:
         // discard the pending message so it won't be sent when session_info


### PR DESCRIPTION
## Summary
- Add fn+shift combo key for voice activation with simplified floating dino widget (top-right corner, no transcription text)
- Add voice mode onboarding step (step 3) with dynamic permission flow — shows mic/speech recognition status, polls for changes, transitions to Continue when granted
- Send macOS push notification when voice response completes while app is in background
- Send "Wake up, my friend" greeting before window appears after onboarding to eliminate empty state flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
