### PR TITLE
fix: prevent tool chip from overlapping long message text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -881,6 +881,9 @@ private struct ChatBubble: View {
                         .foregroundColor(VColor.textMuted)
                 }
             }
+            // Prevent LazyVStack from compressing the bubble height, which causes the
+            // trailing tool-chip to overlap long text content.
+            .fixedSize(horizontal: false, vertical: true)
 
             if !isUser { Spacer(minLength: 0) }
         }


### PR DESCRIPTION
## Summary
- Add `.fixedSize(horizontal: false, vertical: true)` to the ChatBubble body VStack to prevent the LazyVStack from compressing long messages
- This ensures the trailing "Used N tools" chip is positioned below the text rather than overlapping it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
