### PR TITLE
fix: guard isSending reset in retry catch to preserve active turn state

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -319,8 +319,13 @@ public final class ChatViewModel: ObservableObject {
             ))
         } catch {
             log.error("Failed to send user_message: \(error.localizedDescription)")
-            isSending = false
-            isThinking = false
+            // Only reset sending state when this is the primary send (not a
+            // queued retry). A queued retry failing must not clobber the
+            // isSending/isThinking flags of the original turn still in flight.
+            if queuedMessageId == nil {
+                isSending = false
+                isThinking = false
+            }
             lastFailedMessageText = text
             lastFailedMessageAttachments = attachments
             lastFailedSendError = "Failed to send message."


### PR DESCRIPTION
When `retryLastMessage()` triggers `sendUserMessage` with a `queuedMessageId` and the send throws, the catch block unconditionally resets `isSending`/`isThinking`. This clobbers the state of the original turn still in flight.

**Fix:** Only reset `isSending` and `isThinking` when `queuedMessageId` is nil (primary send, not a queued retry). When a queued retry fails, the original turn is still active and should keep its sending state.

Addresses Devin review feedback on PR #3444.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
