### PR TITLE
fix: reset composer height when input is cleared

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -128,6 +128,8 @@ struct ChatView: View {
         messages.isEmpty && !isThinking
     }
 
+    private let composerMinHeight: CGFloat = 34
+
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
@@ -182,6 +184,12 @@ struct ChatView: View {
         }
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
+        }
+        .onChange(of: inputText) {
+            // Reset composer height when input is cleared
+            if inputText.isEmpty {
+                editorContentHeight = composerMinHeight
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `composerMinHeight` constant (34pt) to track the minimum composer height
- Adds `onChange(of: inputText)` handler that resets `editorContentHeight` when input becomes empty
- Ensures composer returns to compact size after sending long messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
