### PR TITLE
fix: show all threads in sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -435,7 +435,7 @@ struct MainWindowView: View {
 
             ScrollView {
                 VStack(spacing: VSpacing.xs) {
-                    ForEach(threadManager.visibleThreads.filter { $0.sessionId != nil || threadManager.threadHasMessages($0.id) }) { thread in
+                    ForEach(threadManager.visibleThreads) { thread in
                         threadItem(thread)
                     }
                 }


### PR DESCRIPTION
## Summary
- Removes overly restrictive filter that only showed threads with a sessionId or messages
- Ensures all visible (non-archived) threads appear in the sidebar
- Fixes issue where existing conversations weren't visible to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
