### PR TITLE
fix: filter auth_result in sendOneMessage after authentication

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -104,6 +104,12 @@ function sendOneMessage(
         if (m.type === 'daemon_status') {
           continue;
         }
+        // On auto-auth sockets the server may send a second auth_result
+        // in response to the client's auth message after we're already
+        // authenticated — ignore it so it doesn't resolve as the response.
+        if (m.type === 'auth_result') {
+          continue;
+        }
         if (m.type === 'session_info' && msg.type !== 'session_create') {
           continue;
         }


### PR DESCRIPTION
## Summary

When `hasSocketOverride()` is enabled, the server auto-authenticates the socket and sends an `auth_result`. If the client also sends an `auth` message (because it has a local token), the server responds with a **second** `auth_result`. After the first `auth_result` sets `authenticated = true`, the second one falls through to the response handler in `sendOneMessage` and gets resolved as the command response — breaking all CLI subcommands (`sessions list`, `session_create`, etc.) in forwarded-socket environments.

**Fix:** Filter `auth_result` messages in the authenticated path of `sendOneMessage`, matching the existing pattern for `daemon_status` and `session_info`.

Addresses feedback from Codex and Devin on #3440.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
