### PR TITLE
fix: emit terminal lifecycle event for allowlist-blocked tools

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -49,10 +49,24 @@ export class ToolExecutor {
 
     // Gate tools not active for the current turn
     if (context.allowedToolNames && !context.allowedToolNames.has(name)) {
-      return {
-        content: `Tool "${name}" is not currently active. Load the skill that provides this tool first.`,
-        isError: true,
-      };
+      const msg = `Tool "${name}" is not currently active. Load the skill that provides this tool first.`;
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent(context, {
+        type: 'error',
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: 'error',
+        durationMs,
+        errorMessage: msg,
+        isExpected: true,
+      });
+      return { content: msg, isError: true };
     }
 
     const tool = getTool(name);


### PR DESCRIPTION
## Summary

- Emit an `error` lifecycle event when a tool is blocked by the `allowedToolNames` gate, consistent with the unknown-tool pattern
- Fixes orphaned `start` events in audit logs that made allowlist-blocked invocations invisible to the audit listener and duration/open-invocation tracking

Addresses feedback from PR #3463.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
