### PR TITLE
fix: clear preactivatedSkillIds on persistence failure

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -140,6 +140,8 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
       attributes: { reason: 'persist_failure' },
     });
     next.onEvent({ type: 'error', message });
+    // runAgentLoop never ran, so its finally block won't clear this
+    session.preactivatedSkillIds = undefined;
     // Continue draining — don't strand remaining messages
     drainQueue(session);
     return;
@@ -222,6 +224,8 @@ export async function processMessage(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     onEvent({ type: 'error', message });
+    // runAgentLoop never ran, so its finally block won't clear this
+    session.preactivatedSkillIds = undefined;
     return '';
   }
 


### PR DESCRIPTION
## Summary
- Clears `session.preactivatedSkillIds` in both error paths where `persistUserMessage` fails
- In `drainQueue`: clear before the recursive `drainQueue(session)` call so the next queued message doesn't inherit stale skill IDs
- In `processMessage`: clear before early `return ''` so subsequent calls don't see leaked skill IDs

Addresses review feedback from PR #3471.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- Verify that after a `persistUserMessage` failure on a slash-command message, the next queued message does not have incorrect skill tools preactivated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
