### PR TITLE
docs: add high-risk exception to permission flow diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1477,13 +1477,15 @@ graph TB
 
 ### Permission Flow for Skill Tools
 
-Skill-origin tools follow a stricter default permission model than core tools. Even if a skill tool declares `risk: "low"` in its manifest, the permission checker defaults to prompting the user unless a trust rule explicitly allows it.
+Skill-origin tools follow a stricter default permission model than core tools. Even if a skill tool declares `risk: "low"` in its manifest, the permission checker defaults to prompting the user unless a trust rule explicitly allows it. Additionally, high-risk tool invocations always prompt the user even when a matching allow rule exists.
 
 ```mermaid
 graph TB
     TOOL_CALL["Skill tool invocation"] --> PERM["PermissionChecker"]
     PERM --> TRUST{"Matching trust rule<br/>in trust.json?"}
-    TRUST -->|"Allow rule matches"| ALLOW["Auto-allow"]
+    TRUST -->|"Allow rule matches"| HRISK{"Risk level?"}
+    HRISK -->|"Low / Medium"| ALLOW["Auto-allow"]
+    HRISK -->|"High"| HPROMPT["Prompt user<br/>(high-risk always prompts)"]
     TRUST -->|"No rule matches"| ORIGIN{"tool.origin?"}
     ORIGIN -->|"core"| RISK["Normal risk-level logic<br/>Low=auto, Medium=check, High=prompt"]
     ORIGIN -->|"skill"| PROMPT["Always prompt user<br/>(default ask for skill tools)"]


### PR DESCRIPTION
## Summary
- Fixes the permission flow Mermaid diagram in ARCHITECTURE.md to show that high-risk tool invocations always prompt the user, even when a matching allow trust rule exists
- Adds a risk-level decision node between "Allow rule matches" and "Auto-allow" to reflect the actual `checker.ts` logic (`risk !== RiskLevel.High`)
- Updates the explanatory text to mention the high-risk exception

Addresses review feedback from Codex on PR #3499.

## Test plan
- [ ] Verify the Mermaid diagram renders correctly on GitHub
- [ ] Confirm the diagram matches the logic in `assistant/src/permissions/checker.ts` lines 324-328
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
