### PR TITLE
fix: guard error state variables in retry catch for queued messages

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -319,17 +319,17 @@ public final class ChatViewModel: ObservableObject {
             ))
         } catch {
             log.error("Failed to send user_message: \(error.localizedDescription)")
-            // Only reset sending state when this is the primary send (not a
-            // queued retry). A queued retry failing must not clobber the
-            // isSending/isThinking flags of the original turn still in flight.
+            // Only update UI error state for the primary send (not a queued
+            // retry). A queued retry failing must not clobber the active turn's
+            // isSending/isThinking flags or show an error banner over it.
             if queuedMessageId == nil {
                 isSending = false
                 isThinking = false
+                lastFailedMessageText = text
+                lastFailedMessageAttachments = attachments
+                lastFailedSendError = "Failed to send message."
+                errorText = lastFailedSendError
             }
-            lastFailedMessageText = text
-            lastFailedMessageAttachments = attachments
-            lastFailedSendError = "Failed to send message."
-            errorText = lastFailedSendError
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
                 pendingMessageIds.removeAll { $0 == queuedMessageId }


### PR DESCRIPTION
## Summary
- Moves `errorText`, `lastFailedMessageText`, `lastFailedMessageAttachments`, and `lastFailedSendError` assignments inside the existing `if queuedMessageId == nil` guard in `sendUserMessage`'s catch block.
- Previously these were set unconditionally, causing the UI to show an error banner with a Retry button while the original turn was still actively streaming a response.
- Addresses review feedback from Codex and Devin on #3518.

## Test plan
- [ ] Verify that when a queued retry fails, no error banner appears while the original turn is still streaming.
- [ ] Verify that when a primary send fails (no queued message), the error banner and Retry button still appear correctly.
- [ ] Verify that clicking Retry after a primary send failure re-sends the message successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
