### PR TITLE
fix: pass execution_target from manifest to skill script runner

### DIFF
--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -37,7 +37,9 @@ export function createSkillTool(
     },
 
     async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-      return runSkillToolScript(skillDir, entry.executor, input, context);
+      return runSkillToolScript(skillDir, entry.executor, input, context, {
+        target: entry.execution_target,
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary

`createSkillTool()` in `skill-tool-factory.ts` was calling `runSkillToolScript()` without forwarding `entry.execution_target` from the TOOLS.json manifest. This meant skills declaring `execution_target: "sandbox"` were silently running on the host instead of in an isolated subprocess.

**Fix**: Pass `{ target: entry.execution_target }` as the options argument to `runSkillToolScript()`.

Addresses review feedback on PR #3498 and PR #3456.

## Changes

- `assistant/src/tools/skills/skill-tool-factory.ts` — forward `execution_target` to the script runner options

## Test plan

- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Create a skill with `execution_target: "sandbox"` in TOOLS.json and confirm the tool runs via the sandbox runner
- [ ] Create a skill with `execution_target: "host"` and confirm it still runs in-process as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
