### PR TITLE
test: add delegation spy to Claude Code regression test

### DIFF
--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from 'bun:test';
+import { describe, test, expect, mock, spyOn } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -102,18 +102,26 @@ describe('Claude Code skill migration regression', () => {
 
   test('wrapper run() delegates to claudeCodeTool.execute()', async () => {
     // Verifies the wrapper is not a stale stub but actually calls through
-    // to the canonical execute method.
+    // to the canonical execute method with the exact input and context.
+    const spy = spyOn(claudeCodeTool, 'execute');
+
     const wrapperPath = path.join(SKILL_DIR, 'tools/claude-code.ts');
     const mod = await import(wrapperPath);
 
+    const input = { prompt: 'hello' };
     const ctx = {
       sessionId: 'test',
       workingDir: '/tmp',
       onOutput: () => {},
     };
 
-    // Calling with a valid profile should succeed (SDK mock returns success)
-    const result = await mod.run({ prompt: 'hello' }, ctx);
+    const result = await mod.run(input, ctx);
     expect(result.isError).toBeFalsy();
+
+    // The wrapper must delegate to the canonical execute method
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(input, ctx);
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Spies on `claudeCodeTool.execute` in the wrapper delegation test and asserts it is called exactly once with the provided `input` and `context`
- A wrapper that bypasses `execute()` (e.g. returning a hard-coded success) will now fail the test
- Addresses Codex review feedback on PR #3493

## Test plan
- [x] All 5 tests pass (11 expect() calls, up from 9)
- [x] Type-check passes (`tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
