### PR TITLE
test: strengthen checker assertion for high-risk allow path

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -400,8 +400,9 @@ describe('Permission Checker', () => {
     test('allow rule for scaffold_managed_skill still prompts (High risk)', async () => {
       addRule('scaffold_managed_skill', 'scaffold_managed_skill:my-skill', 'everywhere', 'allow', 2000);
       const result = await check('scaffold_managed_skill', { skill_id: 'my-skill' }, '/tmp');
-      // High-risk tools always prompt even with allow rules (checker.ts line 302)
+      // High-risk tools always prompt even with allow rules
       expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
     });
 
     test('allow rule for scaffold_managed_skill does not match other skill ids', async () => {
@@ -413,8 +414,9 @@ describe('Permission Checker', () => {
     test('wildcard allow rule for delete_managed_skill still prompts (High risk)', async () => {
       addRule('delete_managed_skill', 'delete_managed_skill:*', 'everywhere', 'allow', 2000);
       const result = await check('delete_managed_skill', { skill_id: 'any-skill' }, '/tmp');
-      // High-risk tools always prompt even with allow rules (checker.ts line 302)
+      // High-risk tools always prompt even with allow rules
       expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
     });
 
     test('computer_use_click prompts by default via computer-use ask rule', async () => {
@@ -478,6 +480,7 @@ describe('Permission Checker', () => {
       addRule('bash', 'sudo *', 'everywhere');
       const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
       expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
     });
 
     // Deny rule tests
@@ -710,8 +713,11 @@ describe('Permission Checker', () => {
       registerTool(highRiskSkillTool);
       addRule('skill_high_risk_tool', 'skill_high_risk_tool:*', '/tmp', 'allow', 2000);
       const result = await check('skill_high_risk_tool', {}, '/tmp');
-      // High-risk tools always prompt even with allow rules
+      // High-risk tools always prompt even with allow rules — assert on the
+      // reason discriminator to verify it's the high-risk fallback path, not
+      // the generic skill-tool default-ask policy.
       expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
     });
   });
 


### PR DESCRIPTION
## Summary
- Strengthened four checker tests that verify high-risk tools always prompt even when an allow rule matches
- Added `expect(result.reason).toContain('High risk')` assertions to discriminate the high-risk fallback from the generic skill-tool default-ask policy or medium-risk fallback
- Addresses Codex review feedback on PR #3481: without the reason discriminator, these tests could pass even if allow-rule matching was broken

## Tests updated
- `allow rule for scaffold_managed_skill still prompts (High risk)`
- `wildcard allow rule for delete_managed_skill still prompts (High risk)`
- `skill tool with allow rule but High risk → still prompts`
- `high risk ignores allow rules`

## Test plan
- [x] All 127 checker tests pass
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
