### PR TITLE
refactor: remove descriptive comments from Gmail integration test

### DIFF
--- a/assistant/src/__tests__/gmail-integration.test.ts
+++ b/assistant/src/__tests__/gmail-integration.test.ts
@@ -42,12 +42,10 @@ describe('Gmail integration contract', () => {
       (t: { name: string }) => t.name,
     );
 
-    // Every tool in the integration must exist in the manifest
     for (const name of gmailIntegration.allowedTools) {
       expect(manifestToolNames).toContain(name);
     }
 
-    // Every tool in the manifest must exist in the integration
     for (const name of manifestToolNames) {
       expect(gmailIntegration.allowedTools).toContain(name);
     }


### PR DESCRIPTION
## Summary

- Removed two comments in `gmail-integration.test.ts` that restated obvious loop behavior instead of explaining rationale
- Addresses Codex review feedback on PR #3495: comments should explain **why**, not **what**

## Test plan

- [x] All 11 Gmail integration tests pass
- [x] Type-check passes (`tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
