### PR TITLE
test: add path containment tests for skill script runner

### DIFF
--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -120,4 +120,18 @@ describe('runSkillToolScript — errors', () => {
     expect(result.content).toContain('Failed to load skill tool script');
     expect(result.content).toContain('nonexistent.ts');
   });
+
+  test('rejects executor paths that escape the skill directory via ../', async () => {
+    const result = await runSkillToolScript(tempDir, '../../etc/passwd', {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('escapes the skill directory');
+  });
+
+  test('rejects executor paths that escape via intermediate ../ segments', async () => {
+    const result = await runSkillToolScript(tempDir, 'sub/../../outside.ts', {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('escapes the skill directory');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds two tests verifying that `runSkillToolScript` rejects executor paths that escape the skill directory via `../` traversal
- Tests cover both direct traversal (`../../etc/passwd`) and intermediate segment traversal (`sub/../../outside.ts`)
- Exercises the defense-in-depth path containment guard added in PR #3454

Addresses Devin and Codex review feedback on PR #3454.

## Test plan

- [x] All 7 skill script runner tests pass (5 existing + 2 new)
- [x] TypeScript type-check passes (`tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
