### PR TITLE
fix: update allowedToolNames when skill tools are dynamically registered

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -257,13 +257,20 @@ export class Session {
 
     const config = getConfig();
     // Build a resolveTools callback that merges base tool definitions with
-    // dynamically projected skill tools on each agent turn.
+    // dynamically projected skill tools on each agent turn. Also updates
+    // allowedToolNames so newly-activated skill tools aren't blocked by
+    // the executor's stale gate.
     const resolveTools = toolDefs.length > 0
       ? (history: Message[]) => {
           const projection = projectSkillTools(history, {
             preactivatedSkillIds: this.preactivatedSkillIds,
             previouslyActiveSkillIds: this.skillProjectionState,
           });
+          const turnAllowed = new Set(this.coreToolNames);
+          for (const name of projection.allowedToolNames) {
+            turnAllowed.add(name);
+          }
+          this.allowedToolNames = turnAllowed;
           return [...toolDefs, ...projection.toolDefinitions];
         }
       : undefined;
@@ -743,18 +750,6 @@ export class Session {
         activeSurface,
         workspaceTopLevelContext: this.workspaceTopLevelContext,
       });
-
-      // Project skill tools for this turn and build the allowed tool set.
-      // Core tools are always included so they're never gated.
-      const skillProjection = projectSkillTools(runMessages, {
-        preactivatedSkillIds: this.preactivatedSkillIds,
-        previouslyActiveSkillIds: this.skillProjectionState,
-      });
-      const turnAllowed = new Set(this.coreToolNames);
-      for (const name of skillProjection.allowedToolNames) {
-        turnAllowed.add(name);
-      }
-      this.allowedToolNames = turnAllowed;
 
       // Pre-run repair: fix any message ordering issues before sending to provider.
       // Keep a reference to the original (un-repaired) messages so we can


### PR DESCRIPTION
## Summary

- Moves the `allowedToolNames` update logic into the `resolveTools` callback so it runs on every agent loop turn, keeping the executor's tool gate in sync with dynamically projected skill tools
- Removes the duplicate pre-loop `projectSkillTools` call and `allowedToolNames` assignment that was computed once before the agent loop started
- Fixes the bug where newly-activated skill tools were offered to the LLM (via `resolveTools`) but blocked when called (via stale `allowedToolNames` in the executor)

Addresses review feedback on #3467.

## Test plan

- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All 38 session-skill-tools tests pass
- [x] Verified `resolveTools` callback now updates `this.allowedToolNames` on each turn
- [x] Verified the pre-loop `projectSkillTools` call is removed (no duplicate projection)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
