### PR TITLE
fix: guard error state in connectivity check for queued retries

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -286,10 +286,15 @@ public final class ChatViewModel: ObservableObject {
         // daemon has disconnected between turns.
         guard daemonClient.isConnected else {
             log.error("Cannot send user_message: daemon not connected")
-            lastFailedMessageText = text
-            lastFailedMessageAttachments = attachments
-            lastFailedSendError = "Cannot connect to daemon. Please ensure it's running."
-            errorText = lastFailedSendError
+            // Only update UI error state for the primary send (not a queued
+            // retry). A queued retry failing must not clobber the active turn's
+            // isSending/isThinking flags or show an error banner over it.
+            if queuedMessageId == nil {
+                lastFailedMessageText = text
+                lastFailedMessageAttachments = attachments
+                lastFailedSendError = "Cannot connect to daemon. Please ensure it's running."
+                errorText = lastFailedSendError
+            }
             // Remove the queued message ID to prevent stale FIFO entries
             if let queuedMessageId {
                 pendingMessageIds.removeAll { $0 == queuedMessageId }


### PR DESCRIPTION
Extends the queuedMessageId guard from PR #3526's catch block fix to the connectivity guard. Devin's review correctly identified that the `guard daemonClient.isConnected` path still sets error state unconditionally for queued retries, which can show an error banner over an active streaming response.

The error state assignments (`lastFailedMessageText`, `lastFailedMessageAttachments`, `lastFailedSendError`, `errorText`) are now wrapped in `if queuedMessageId == nil`, matching the pattern already applied in the catch block.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
