### PR TITLE
fix: add reference counting to skill tool registration

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -15,6 +15,7 @@ import {
   registerSkillTools,
   unregisterSkillTools,
   getSkillToolNames,
+  getSkillRefCount,
 } from '../tools/registry.js';
 import { eagerModules, explicitTools, lazyTools } from '../tools/tool-manifest.js';
 
@@ -358,5 +359,44 @@ describe('dynamic skill tool registry', () => {
     expect(() => registerSkillTools(tools)).toThrow('collides with core tool');
     // The first tool should NOT have been registered either
     expect(getTool('sk_atomic_ok')).toBeUndefined();
+  });
+});
+
+describe('skill tool reference counting', () => {
+  test('ref count increments on each registerSkillTools call', () => {
+    registerSkillTools([makeSkillTool('rc_a', 'rc-skill')]);
+    expect(getSkillRefCount('rc-skill')).toBe(1);
+
+    // Second session registers the same skill (same ownerSkillId allows replacement)
+    registerSkillTools([makeSkillTool('rc_a', 'rc-skill')]);
+    expect(getSkillRefCount('rc-skill')).toBe(2);
+  });
+
+  test('unregister decrements ref count but keeps tools when count > 0', () => {
+    registerSkillTools([makeSkillTool('rc_keep', 'rc-multi')]);
+    registerSkillTools([makeSkillTool('rc_keep', 'rc-multi')]);
+    expect(getSkillRefCount('rc-multi')).toBe(2);
+
+    unregisterSkillTools('rc-multi');
+    expect(getSkillRefCount('rc-multi')).toBe(1);
+    // Tools still present
+    expect(getTool('rc_keep')).toBeDefined();
+  });
+
+  test('tools are removed only when last reference is unregistered', () => {
+    registerSkillTools([makeSkillTool('rc_last', 'rc-final')]);
+    registerSkillTools([makeSkillTool('rc_last', 'rc-final')]);
+
+    unregisterSkillTools('rc-final');
+    expect(getTool('rc_last')).toBeDefined();
+
+    unregisterSkillTools('rc-final');
+    expect(getTool('rc_last')).toBeUndefined();
+    expect(getSkillRefCount('rc-final')).toBe(0);
+  });
+
+  test('unregister with no prior registration is a no-op', () => {
+    unregisterSkillTools('nonexistent-skill');
+    expect(getSkillRefCount('nonexistent-skill')).toBe(0);
   });
 });

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -13,6 +13,7 @@ let mockCatalog: SkillSummary[] = [];
 let mockManifests: Record<string, SkillToolManifest | null> = {};
 let mockRegisteredTools: Map<string, Tool[]> = new Map();
 let mockUnregisteredSkillIds: string[] = [];
+let mockSkillRefCount: Map<string, number> = new Map();
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -84,15 +85,26 @@ mock.module('../tools/skills/skill-tool-factory.js', () => ({
 
 mock.module('../tools/registry.js', () => ({
   registerSkillTools: (tools: Tool[]) => {
+    const skillIds = new Set<string>();
     for (const tool of tools) {
       const skillId = tool.ownerSkillId!;
+      skillIds.add(skillId);
       const existing = mockRegisteredTools.get(skillId) ?? [];
       existing.push(tool);
       mockRegisteredTools.set(skillId, existing);
     }
+    for (const id of skillIds) {
+      mockSkillRefCount.set(id, (mockSkillRefCount.get(id) ?? 0) + 1);
+    }
   },
   unregisterSkillTools: (skillId: string) => {
     mockUnregisteredSkillIds.push(skillId);
+    const current = mockSkillRefCount.get(skillId) ?? 0;
+    if (current > 1) {
+      mockSkillRefCount.set(skillId, current - 1);
+      return;
+    }
+    mockSkillRefCount.delete(skillId);
     mockRegisteredTools.delete(skillId);
   },
   getSkillToolNames: () => {
@@ -187,6 +199,8 @@ describe('projectSkillTools', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -370,6 +384,56 @@ describe('projectSkillTools', () => {
     expect(sessionA.has('deploy')).toBe(true);
     expect(sessionB.has('oncall')).toBe(true);
   });
+
+  test('disposing session A while session B uses the same skill does NOT remove tools', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+
+    const sessionA = new Set<string>();
+    const sessionB = new Set<string>();
+
+    const history: Message[] = [toolResultMsg('<loaded_skill id="deploy" />')];
+
+    // Both sessions activate deploy
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionA });
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionB });
+
+    // Ref count should be 2
+    expect(mockSkillRefCount.get('deploy')).toBe(2);
+
+    // Session A tears down
+    resetSkillToolProjection(sessionA);
+
+    // Tools should still be registered (ref count decremented but > 0)
+    expect(mockRegisteredTools.has('deploy')).toBe(true);
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+
+    // Session B can still project the skill tools
+    const resultB = projectSkillTools(history, { previouslyActiveSkillIds: sessionB });
+    expect(resultB.allowedToolNames.has('deploy_run')).toBe(true);
+  });
+
+  test('tools ARE removed when the last session using them disposes', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+
+    const sessionA = new Set<string>();
+    const sessionB = new Set<string>();
+
+    const history: Message[] = [toolResultMsg('<loaded_skill id="deploy" />')];
+
+    // Both sessions activate deploy
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionA });
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionB });
+
+    // Both sessions tear down
+    resetSkillToolProjection(sessionA);
+    expect(mockRegisteredTools.has('deploy')).toBe(true);
+
+    resetSkillToolProjection(sessionB);
+    expect(mockRegisteredTools.has('deploy')).toBe(false);
+    expect(mockSkillRefCount.has('deploy')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -398,6 +462,8 @@ describe('resolveTools callback (session wiring)', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -484,6 +550,8 @@ describe('allowed tool set merging', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -610,6 +678,8 @@ describe('mid-run skill tool activation (end-to-end)', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -799,6 +869,8 @@ describe('context-derived deactivation regression', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -981,6 +1053,8 @@ describe('slash preactivation through session processing', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -1079,6 +1153,8 @@ describe('bundled skill: gmail', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -1124,6 +1200,8 @@ describe('bundled skill: claude-code', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -1165,6 +1243,8 @@ describe('bundled skill: weather', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockSkillRefCount = new Map();
     sessionState = new Set<string>();
   });
 
@@ -1208,6 +1288,7 @@ describe('resetSkillToolProjection', () => {
     mockManifests = {};
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
   });
 
   test('unregisters all tracked skills and clears the set', () => {

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -14,6 +14,10 @@ const log = getLogger('tool-registry');
 
 const tools = new Map<string, Tool>();
 
+// Tracks how many sessions are currently using each skill's tools.
+// Tools are only removed from the global registry when this drops to 0.
+const skillRefCount = new Map<string, number>();
+
 export interface LazyToolDescriptor {
   name: string;
   description: string;
@@ -120,16 +124,33 @@ export function registerSkillTools(newTools: Tool[]): void {
     }
   }
 
+  // Collect unique skill IDs from the batch to bump ref counts
+  const skillIds = new Set<string>();
   for (const tool of newTools) {
     tools.set(tool.name, tool);
+    if (tool.ownerSkillId) skillIds.add(tool.ownerSkillId);
     log.info({ name: tool.name, ownerSkillId: tool.ownerSkillId }, 'Skill tool registered');
+  }
+
+  for (const id of skillIds) {
+    skillRefCount.set(id, (skillRefCount.get(id) ?? 0) + 1);
   }
 }
 
 /**
- * Remove all tools owned by the given skill.
+ * Decrement the reference count for a skill and remove its tools only when
+ * no more sessions reference them.
  */
 export function unregisterSkillTools(skillId: string): void {
+  const current = skillRefCount.get(skillId) ?? 0;
+  if (current > 1) {
+    skillRefCount.set(skillId, current - 1);
+    log.info({ skillId, remaining: current - 1 }, 'Decremented skill ref count, tools kept');
+    return;
+  }
+
+  // Last reference — actually remove the tools
+  skillRefCount.delete(skillId);
   for (const [name, tool] of tools) {
     if (tool.origin === 'skill' && tool.ownerSkillId === skillId) {
       tools.delete(name);
@@ -145,6 +166,13 @@ export function getSkillToolNames(): string[] {
   return Array.from(tools.values())
     .filter((t) => t.origin === 'skill')
     .map((t) => t.name);
+}
+
+/**
+ * Return the current reference count for a skill's tools. Exposed for testing.
+ */
+export function getSkillRefCount(skillId: string): number {
+  return skillRefCount.get(skillId) ?? 0;
 }
 
 export function getAllToolDefinitions(): ToolDefinition[] {


### PR DESCRIPTION
## Summary

- Adds a `skillRefCount` map to the global tool registry that tracks how many sessions are concurrently using each skill's tools
- `registerSkillTools` increments the count; `unregisterSkillTools` decrements it and only removes tools when it reaches 0
- Prevents disposing one session from removing tools that another concurrent session is still using (fixes mid-run "Unknown tool" failures)

## Test plan

- [x] Added 4 new registry-level tests for reference counting (increment, decrement-but-keep, last-reference-removes, no-op-for-unknown)
- [x] Added 2 new session-skill-tools tests for concurrent session teardown (dispose A keeps tools for B, dispose both removes tools)
- [x] All 40 session-skill-tools tests pass
- [x] All 31 registry tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)

Addresses review feedback from PR #3534.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
