### PR TITLE
fix: collect vector cleanup IDs in consolidateAssistantMessages early-return path

### DIFF
--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -140,9 +140,21 @@ export function consolidateAssistantMessages(conversationId: string, userMessage
 
   // Only consolidate if there are multiple assistant messages
   if (messagesToConsolidate.length <= 1) {
-    // Still delete internal tool_result messages even if only one assistant message
+    // Still delete internal tool_result messages even if only one assistant message,
+    // and collect IDs for vector cleanup
+    const allSegmentIds: string[] = [];
+    const allOrphanedItemIds: string[] = [];
     for (const id of messagesToDelete) {
-      conversationStore.deleteMessageById(id);
+      const deleted = conversationStore.deleteMessageById(id);
+      allSegmentIds.push(...deleted.segmentIds);
+      allOrphanedItemIds.push(...deleted.orphanedItemIds);
+    }
+
+    // Clean up Qdrant vectors (fire-and-forget)
+    if (allSegmentIds.length > 0 || allOrphanedItemIds.length > 0) {
+      cleanupQdrantVectors(conversationId, allSegmentIds, allOrphanedItemIds).catch((err) => {
+        log.warn({ err, conversationId }, 'Qdrant cleanup after consolidation failed (non-fatal)');
+      });
     }
     return;
   }


### PR DESCRIPTION
Fixes the early-return path to collect segmentIds and orphanedItemIds from deleted messages, preventing stale Qdrant vectors when there are 0-1 assistant messages after a user message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
