### PR TITLE
fix: clear isRestoringThreads flag in all handleSessionListResponse code paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -77,8 +77,14 @@ final class ThreadSessionRestorer {
 
     func handleSessionListResponse(_ response: SessionListResponseMessage) {
         guard let delegate else { return }
-        guard delegate.restoreRecentThreads else { return }
-        guard !response.sessions.isEmpty else { return }
+        guard delegate.restoreRecentThreads else {
+            delegate.restoreLastActiveThread()
+            return
+        }
+        guard !response.sessions.isEmpty else {
+            delegate.restoreLastActiveThread()
+            return
+        }
 
         let recentSessions = Array(response.sessions.prefix(5))
 


### PR DESCRIPTION
Ensures the flag is cleared even when handleSessionListResponse returns early due to disabled restoration, empty sessions, or daemon connection failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
