### PR TITLE
fix: only register newly-active skills to prevent refcount inflation

### DIFF
--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -134,7 +134,8 @@ export function projectSkillTools(
       continue;
     }
 
-    // Create runtime Tool objects and register them
+    // Create runtime Tool objects — only register if this skill is newly active
+    // to avoid inflating the registry refcount on every turn.
     const tools = createSkillToolsFromManifest(
       manifest.tools,
       skillId,
@@ -142,7 +143,9 @@ export function projectSkillTools(
     );
 
     if (tools.length > 0) {
-      registerSkillTools(tools);
+      if (!prevActive.has(skillId)) {
+        registerSkillTools(tools);
+      }
 
       for (const tool of tools) {
         allToolDefinitions.push(tool.getDefinition());


### PR DESCRIPTION
## Summary
- [P1] Fix skill tool refcount inflation: `registerSkillTools()` was called for ALL active skills on every turn, not just newly-active ones
- Only skills not already in `prevActive` are now registered, keeping the refcount accurate (+1 activation, -1 deactivation)
- Without this fix, tools could remain globally registered after deactivation because the refcount never reached zero

## Test plan
- [x] 38/40 session-skill-tools tests pass (2 pre-existing failures from separate `toolResultMsg` bug)
- [x] Existing re-projection test validates that already-active skills don't duplicate definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
