### PR TITLE
fix: replace undefined toolResultMsg with skillLoadMessages in tests

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -416,7 +416,7 @@ describe('projectSkillTools', () => {
     const sessionA = new Set<string>();
     const sessionB = new Set<string>();
 
-    const history: Message[] = [toolResultMsg('<loaded_skill id="deploy" />')];
+    const history: Message[] = [...skillLoadMessages('<loaded_skill id="deploy" />')];
 
     // Both sessions activate deploy
     projectSkillTools(history, { previouslyActiveSkillIds: sessionA });
@@ -444,7 +444,7 @@ describe('projectSkillTools', () => {
     const sessionA = new Set<string>();
     const sessionB = new Set<string>();
 
-    const history: Message[] = [toolResultMsg('<loaded_skill id="deploy" />')];
+    const history: Message[] = [...skillLoadMessages('<loaded_skill id="deploy" />')];
 
     // Both sessions activate deploy
     projectSkillTools(history, { previouslyActiveSkillIds: sessionA });


### PR DESCRIPTION
## Summary
- [P1] Fix 2 failing tests in `session-skill-tools.test.ts` that referenced undefined `toolResultMsg()`
- Replace with `...skillLoadMessages()` which properly constructs the tool_use/tool_result message pair

## Test plan
- [x] All 40 session-skill-tools tests now pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
