### PR TITLE
docs: replace stale Gmail tool references with bundled-skill paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1871,8 +1871,8 @@ sequenceDiagram
 | `assistant/src/integrations/gmail/client.ts` | Thin Gmail REST API wrapper (listMessages, getMessage, modify, send, etc.) |
 | `assistant/src/integrations/gmail/types.ts` | Gmail API response types |
 | `assistant/src/integrations/gmail/newsletter-analyzer.ts` | `groupBySender()` helper for email declutter flow |
-| `assistant/src/tools/gmail/definitions.ts` | Gmail tool definitions with risk levels and confidence scoring |
-| `assistant/src/tools/gmail/executors.ts` | Tool executors using `withValidToken` pattern |
+| `assistant/src/config/bundled-skills/gmail/TOOLS.json` | Gmail tool manifest (12 tools) loaded by skill-tool framework |
+| `assistant/src/config/bundled-skills/gmail/tools/` | Gmail skill scripts delegating to integration layer |
 
 ---
 


### PR DESCRIPTION
## Summary
- [P2] Update ARCHITECTURE.md to remove references to deleted `definitions.ts` and `executors.ts`
- Replace with references to `TOOLS.json` manifest and `tools/` skill scripts
- Re-validated: 99 tests across 5 skill-related files, 0 failures; tsc clean

## Test plan
- [x] 99 tests pass across session-skill-tools, registry, weather-regression, gmail-integration, claude-code-regression
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
