### PR TITLE
fix: ensure activity panel reliably closes when message is deleted

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -3,6 +3,7 @@ import VellumAssistantShared
 import Foundation
 import UserNotifications
 import os
+import Combine
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadManager")
 private let archivedSessionsKey = "archivedSessionIds"
@@ -29,6 +30,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             } else {
                 lastActiveThreadIdString = nil
             }
+            // Subscribe to the new active view model's changes
+            subscribeToActiveViewModel()
         }
     }
 
@@ -38,6 +41,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private let activityNotificationService: ActivityNotificationService?
     /// Flag to suppress lastActiveThreadIdString writes during initialization and session restoration.
     private var isRestoringThreads = false
+    /// Subscription to activeViewModel's objectWillChange publisher.
+    /// Forwards nested ObservableObject changes to ThreadManager's own objectWillChange.
+    private var activeViewModelCancellable: AnyCancellable?
 
     /// Threads that are not archived — used by the UI to populate the sidebar/tab bar.
     var visibleThreads: [ThreadModel] {
@@ -243,6 +249,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID) {
         chatViewModels[threadId] = vm
+        // Re-subscribe if this is the active view model
+        if threadId == activeThreadId {
+            subscribeToActiveViewModel()
+        }
     }
 
     func removeChatViewModel(for threadId: UUID) {
@@ -452,5 +462,23 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         // Clear the flag so future activeThreadId changes persist normally
         isRestoringThreads = false
+    }
+
+    /// Subscribe to the active ChatViewModel's objectWillChange publisher.
+    /// When a view reads properties from a nested ObservableObject, the parent
+    /// must subscribe to the child's objectWillChange and forward it so SwiftUI
+    /// can invalidate views that depend on nested properties.
+    private func subscribeToActiveViewModel() {
+        // Cancel previous subscription
+        activeViewModelCancellable?.cancel()
+        activeViewModelCancellable = nil
+
+        // Subscribe to the new active view model if one exists
+        guard let viewModel = activeViewModel else { return }
+
+        activeViewModelCancellable = viewModel.objectWillChange.sink { [weak self] _ in
+            // Forward nested ObservableObject changes to ThreadManager's objectWillChange
+            self?.objectWillChange.send()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where the `onChange(of: messages)` handler in `MainWindowView` doesn't reliably detect message deletions because `MainWindowView` doesn't directly subscribe to `ChatViewModel` updates - it only observes `ThreadManager`, and `activeViewModel` is a computed lookup.

## Context

The Codex Review feedback on PR #3338 identified that message mutations in regenerate/undo flows can change without the `onChange` closure running, leaving the Activity panel open with stale content.

## Root Cause

According to SwiftUI's observation rules and the project's CLAUDE.md architecture docs: **"When a view reads properties from a nested ObservableObject, the parent must subscribe to the child's objectWillChange and forward it."**

`MainWindowView` observes `ThreadManager` (`@ObservedObject`), but when it accesses `threadManager.activeViewModel?.messages`, it's reading from a nested `ObservableObject` (`ChatViewModel`). Without explicit forwarding, SwiftUI doesn't detect changes to `messages` and the `onChange(of:)` handler never runs.

## Solution

Implemented `subscribeToActiveViewModel()` in `ThreadManager` that:
1. Subscribes to the active `ChatViewModel`'s `objectWillChange` publisher
2. Forwards those changes to `ThreadManager`'s own `objectWillChange` publisher
3. Gets called whenever `activeThreadId` changes or a new view model is set

This ensures SwiftUI properly invalidates `MainWindowView` when `messages` changes in the active `ChatViewModel`, making the `onChange` handler reliable.

## Technical Details

**Changes to `ThreadManager.swift`:**
- Added `import Combine`
- Added `activeViewModelCancellable: AnyCancellable?` property to hold the subscription
- Implemented `subscribeToActiveViewModel()` method that forwards `objectWillChange` events
- Call `subscribeToActiveViewModel()` in `activeThreadId` didSet
- Re-subscribe in `setChatViewModel()` when the active view model is replaced

**Before:**
- Activity panel could stay open when message deleted within same thread ❌
- `onChange(of: threadManager.activeViewModel?.messages)` didn't reliably fire

**After:**
- Activity panel reliably closes when message is deleted ✅
- Nested ObservableObject changes properly propagate to parent
- Maintains reactivity for normal flows (tool results streaming in)

## Files Modified

- `clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift` — Added subscription mechanism

## Related

Addresses Codex Review feedback on #3338:
> "This `onChange` is attached in `MainWindowView`, but that view does not subscribe to `ChatViewModel` updates directly (it only observes `ThreadManager`, and `activeViewModel` is just a computed lookup), so message mutations inside the current thread do not reliably invalidate this view."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
