### PR TITLE
fix: increase dot grid visibility in constellation dark background

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -104,7 +104,7 @@ private struct DotGridBackground: View {
                         width: dotRadius * 2,
                         height: dotRadius * 2
                     )
-                    context.fill(Circle().path(in: rect), with: .color(Slate._600.opacity(0.25)))
+                    context.fill(Circle().path(in: rect), with: .color(Slate._500.opacity(0.4)))
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Changed constellation dot grid from `Slate._600.opacity(0.25)` to `Slate._500.opacity(0.4)` so dots are visible against the dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
