### PR TITLE
fix: model provider switching bugs

### DIFF
--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -89,8 +89,8 @@ function resolveProviderModelCommand(content: string): SlashResolution | null {
   const config = getConfig();
   const name = getAssistantName();
 
-  // Check if API key exists for this provider
-  if (!config.apiKeys[provider]) {
+  // Check if API key exists for this provider (Ollama doesn't require an API key)
+  if (provider !== 'ollama' && !config.apiKeys[provider]) {
     return {
       kind: 'unknown',
       message: `Cannot switch to ${displayName}. No API key configured for ${provider}.\n\nSet it with: \`config set apiKeys.${provider} <your-key>\``,
@@ -155,7 +155,7 @@ function resolveModelCommand(content: string): SlashResolution | null {
 
     // Group by provider
     for (const [cmd, { provider, model, displayName }] of Object.entries(PROVIDER_MODEL_SHORTCUTS)) {
-      const hasKey = !!config.apiKeys[provider];
+      const hasKey = provider === 'ollama' || !!config.apiKeys[provider];
       const isCurrent = config.provider === provider && config.model === model;
       const status = hasKey ? '✓' : '✗';
       const current = isCurrent ? ' **[current]**' : '';
@@ -193,6 +193,15 @@ function resolveModelCommand(content: string): SlashResolution | null {
     return {
       kind: 'unknown',
       message: alreadyMsg,
+    };
+  }
+
+  // Validate that Anthropic provider is available
+  if (!currentConfig.apiKeys.anthropic) {
+    const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
+    return {
+      kind: 'unknown',
+      message: `Cannot switch to ${displayName}. No API key configured for Anthropic.\n\nSet it with: \`config set apiKeys.anthropic <your-key>\``,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes two bugs in model provider switching logic identified in PR #3546 review:

1. **Allow /ollama shortcut without API key** - Ollama doesn't require an API key and works with local instances. Updated `resolveProviderModelCommand` and `/model list` to treat Ollama as configured even without an API key.

2. **Validate Anthropic availability before switching** - The `/model` command was unconditionally setting provider to 'anthropic', breaking users who only configured other providers. Now validates that Anthropic API key exists before switching.

## Changes

- `assistant/src/daemon/session-slash.ts`:
  - Line 93: Added exception for Ollama in API key check: `if (provider !== 'ollama' && !config.apiKeys[provider])`
  - Line 158: Adjusted hasKey check for `/model list`: `const hasKey = provider === 'ollama' || !!config.apiKeys[provider]`
  - Lines 199-206: Added validation to ensure Anthropic API key exists before switching with `/model` command

## Test plan

- [ ] `/ollama` command works without API key configured
- [ ] `/model list` shows Ollama as configured (✓) even without API key
- [ ] `/model haiku` fails gracefully when no Anthropic API key is configured
- [ ] Other provider shortcuts still require API keys (e.g., `/gpt4`, `/gemini`)

Addresses feedback from PR #3546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
