### PR TITLE
fix: subscribe only to message count changes in ThreadManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -41,8 +41,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private let activityNotificationService: ActivityNotificationService?
     /// Flag to suppress lastActiveThreadIdString writes during initialization and session restoration.
     private var isRestoringThreads = false
-    /// Subscription to activeViewModel's objectWillChange publisher.
-    /// Forwards nested ObservableObject changes to ThreadManager's own objectWillChange.
+    /// Subscription to activeViewModel's messages count changes.
+    /// Forwards only message count changes to ThreadManager's objectWillChange.
     private var activeViewModelCancellable: AnyCancellable?
 
     /// Threads that are not archived — used by the UI to populate the sidebar/tab bar.
@@ -464,10 +464,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         isRestoringThreads = false
     }
 
-    /// Subscribe to the active ChatViewModel's objectWillChange publisher.
-    /// When a view reads properties from a nested ObservableObject, the parent
-    /// must subscribe to the child's objectWillChange and forward it so SwiftUI
-    /// can invalidate views that depend on nested properties.
+    /// Subscribe to the active ChatViewModel's messages publisher.
+    /// Only forwards changes when the message count changes, preserving the
+    /// wrapper-view isolation pattern that prevents high-frequency ChatViewModel
+    /// updates (like keystroke events, streaming deltas) from invalidating MainWindowView.
     private func subscribeToActiveViewModel() {
         // Cancel previous subscription
         activeViewModelCancellable?.cancel()
@@ -476,9 +476,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Subscribe to the new active view model if one exists
         guard let viewModel = activeViewModel else { return }
 
-        activeViewModelCancellable = viewModel.objectWillChange.sink { [weak self] _ in
-            // Forward nested ObservableObject changes to ThreadManager's objectWillChange
-            self?.objectWillChange.send()
-        }
+        // Only observe message count changes, not all ChatViewModel property changes
+        activeViewModelCancellable = viewModel.$messages
+            .map { $0.count }
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
     }
 }


### PR DESCRIPTION
## Summary
- Address performance regression in PR #3545 by subscribing only to message count changes instead of all ChatViewModel objectWillChange events
- Preserves the wrapper-view isolation pattern that prevents high-frequency updates from invalidating MainWindowView

## Context
PR #3545 added a fix to ensure the activity panel closes when a message is deleted. However, the implementation forwarded every `objectWillChange` event from `ChatViewModel` to `ThreadManager`, which defeats the wrapper-view isolation pattern and causes excessive MainWindowView re-renders during streaming, typing, and other high-frequency updates.

## Changes
**Modified:** `clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift`
- Replaced `viewModel.objectWillChange.sink` with `viewModel.$messages.map { $0.count }.removeDuplicates().sink`
- Only triggers when message count actually changes, which is sufficient for the activity panel closure fix
- Updated comments to reflect the more targeted subscription

## Test plan
- [ ] Verify activity panel still closes when a message is deleted
- [ ] Confirm no excessive re-renders during streaming responses (check with Instruments or debug prints)
- [ ] Test keyboard input doesn't cause MainWindowView invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
