### PR TITLE
fix: subscribe only to message count changes in ThreadManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -41,8 +41,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private let activityNotificationService: ActivityNotificationService?
     /// Flag to suppress lastActiveThreadIdString writes during initialization and session restoration.
     private var isRestoringThreads = false
-    /// Subscription to activeViewModel's objectWillChange publisher.
-    /// Forwards nested ObservableObject changes to ThreadManager's own objectWillChange.
+    /// Subscription to activeViewModel's messages count changes.
+    /// Forwards only message count changes to ThreadManager's objectWillChange.
     private var activeViewModelCancellable: AnyCancellable?
 
     /// Threads that are not archived — used by the UI to populate the sidebar/tab bar.
@@ -464,10 +464,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         isRestoringThreads = false
     }
 
-    /// Subscribe to the active ChatViewModel's objectWillChange publisher.
-    /// When a view reads properties from a nested ObservableObject, the parent
-    /// must subscribe to the child's objectWillChange and forward it so SwiftUI
-    /// can invalidate views that depend on nested properties.
+    /// Subscribe to the active ChatViewModel's messages publisher.
+    /// Only forwards changes when the message count changes, preserving the
+    /// wrapper-view isolation pattern that prevents high-frequency ChatViewModel
+    /// updates (like keystroke events, streaming deltas) from invalidating MainWindowView.
     private func subscribeToActiveViewModel() {
         // Cancel previous subscription
         activeViewModelCancellable?.cancel()
@@ -476,9 +476,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Subscribe to the new active view model if one exists
         guard let viewModel = activeViewModel else { return }
 
-        activeViewModelCancellable = viewModel.objectWillChange.sink { [weak self] _ in
-            // Forward nested ObservableObject changes to ThreadManager's objectWillChange
-            self?.objectWillChange.send()
-        }
+        // Only observe message count changes, not all ChatViewModel property changes
+        activeViewModelCancellable = viewModel.$messages
+            .map { $0.count }
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the performance regression in PR #3545 by replacing the blanket `objectWillChange` forwarding with a targeted subscription to message count changes.

## Problem

PR #3545 introduced a performance regression by forwarding **every** `objectWillChange` event from `ChatViewModel` to `ThreadManager`. This defeated the wrapper-view isolation pattern that was specifically designed to prevent high-frequency ChatViewModel updates (keystroke events, streaming deltas) from invalidating the entire `MainWindowView`.

As identified by both reviewers (Devin and Codex), during an active streaming response, `ChatViewModel` can fire `objectWillChange` dozens of times per second for:
- `inputText` changes (every keystroke)
- `refinementStreamingText` (every streaming delta)
- `messages` array mutations (every streaming token)
- `isThinking` toggles
- etc.

The previous sink at `ThreadManager.swift:479-481` forced `MainWindowView` to re-evaluate its entire `body` on each of these events, causing excessive re-renders.

## Solution

Instead of forwarding all `objectWillChange` events, the code now subscribes only to `viewModel.$messages` with `.map { $0.count }.removeDuplicates()`. This ensures `ThreadManager` only notifies SwiftUI when the message count actually changes, which is sufficient for the activity panel closure fix (since the `onChange` handler at `MainWindowView.swift:162` observes `messages.count`).

## Changes

**Modified `ThreadManager.swift`:**
- Updated `subscribeToActiveViewModel()` to observe only message count changes
- Changed from `viewModel.objectWillChange.sink` to `viewModel.$messages.map { $0.count }.removeDuplicates().sink`
- Updated documentation to explain the performance isolation pattern

## Before/After

**Before (PR #3545):**
- Activity panel reliably closes when message is deleted ✅
- BUT: Every ChatViewModel property change invalidates MainWindowView ❌
- Performance regression during streaming/typing ❌

**After (this PR):**
- Activity panel reliably closes when message is deleted ✅
- Only message count changes invalidate MainWindowView ✅
- Preserves wrapper-view isolation pattern ✅
- No performance regression ✅

## Related

- Addresses feedback from #3545 by @devin-ai-integration and @chatgpt-codex-connector
- Maintains the fix for the original issue (activity panel closure on message deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
