### PR TITLE
fix: only track successfully-registered skills in prevActive

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -352,6 +352,56 @@ describe('projectSkillTools', () => {
     expect(result.allowedToolNames.size).toBe(0);
   });
 
+  test('skill with catalog miss on turn 1 is registered when catalog is populated on turn 2', () => {
+    // Turn 1: skill is active but NOT in the catalog — should not be tracked
+    mockCatalog = []; // empty catalog
+    mockManifests = {};
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    const result1 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result1.toolDefinitions).toEqual([]);
+    expect(sessionState.has('deploy')).toBe(false);
+
+    // Turn 2: catalog now has the skill — should register successfully
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+
+    const result2 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result2.toolDefinitions).toHaveLength(1);
+    expect(result2.toolDefinitions[0].name).toBe('deploy_run');
+    expect(result2.allowedToolNames.has('deploy_run')).toBe(true);
+    expect(sessionState.has('deploy')).toBe(true);
+
+    // Verify registerSkillTools was called (tool is in the registry)
+    expect(mockRegisteredTools.has('deploy')).toBe(true);
+  });
+
+  test('skill with manifest failure on turn 1 is registered when manifest is available on turn 2', () => {
+    mockCatalog = [makeSkill('deploy')];
+    // No manifest — will fail to load
+    mockManifests = {};
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    const result1 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result1.toolDefinitions).toEqual([]);
+    expect(sessionState.has('deploy')).toBe(false);
+
+    // Turn 2: manifest now available
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+
+    const result2 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result2.toolDefinitions).toHaveLength(1);
+    expect(result2.toolDefinitions[0].name).toBe('deploy_run');
+    expect(sessionState.has('deploy')).toBe(true);
+    expect(mockRegisteredTools.has('deploy')).toBe(true);
+  });
+
   test('preactivated IDs merge with context-derived IDs (dedup)', () => {
     mockCatalog = [makeSkill('deploy')];
     mockManifests = { deploy: makeManifest(['deploy_run']) };

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -121,6 +121,7 @@ export function projectSkillTools(
 
   const allToolDefinitions: ToolDefinition[] = [];
   const allToolNames = new Set<string>();
+  const successfulIds = new Set<string>();
 
   for (const skillId of activeIds) {
     const skill = catalogById.get(skillId);
@@ -147,6 +148,7 @@ export function projectSkillTools(
         registerSkillTools(tools);
       }
 
+      successfulIds.add(skillId);
       for (const tool of tools) {
         allToolDefinitions.push(tool.getDefinition());
         allToolNames.add(tool.name);
@@ -154,9 +156,10 @@ export function projectSkillTools(
     }
   }
 
-  // Update the session-scoped tracking set in-place
+  // Update the session-scoped tracking set in-place — only include skills
+  // that were successfully processed so failed skills can be retried next turn.
   prevActive.clear();
-  for (const id of activeIds) {
+  for (const id of successfulIds) {
     prevActive.add(id);
   }
 


### PR DESCRIPTION
Fixes prevActive tracking to only include skill IDs that were successfully registered, so transiently-failed skills (catalog miss, manifest failure, empty tools) can be retried on subsequent turns when the issue resolves.

**Problem:** `prevActive` was updated with ALL `activeIds` at the end of `projectSkillTools`, including skill IDs that were skipped due to catalog miss, manifest load failure, or empty tools. On subsequent turns, `!prevActive.has(skillId)` returned `false` for these skills, so `registerSkillTools` was never called — even if the underlying issue resolved.

**Fix:** Build a `successfulIds` set that only includes skills where `registerSkillTools` was actually called (or the skill was already registered from a previous turn). Use this set instead of `activeIds` when updating `prevActive`.

**Tests added:**
- Skill with catalog miss on turn 1 is registered when catalog is populated on turn 2
- Skill with manifest failure on turn 1 is registered when manifest is available on turn 2

Addresses feedback on #3541.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
