### PR TITLE
feat: add default allow rules for workspace prompt files

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -573,12 +573,11 @@ describe('Trust Store', () => {
   // ── default rules ─────────────────────────────────────────────
 
   describe('default rules', () => {
-    test('backfills default ask rules for protected directory on first load', () => {
+    test('backfills default rules on first load', () => {
       const rules = getAllRules();
       const defaults = rules.filter((r) => r.id.startsWith('default:'));
       expect(defaults).toHaveLength(NUM_DEFAULTS);
       for (const rule of defaults) {
-        expect(rule.decision).toBe('ask');
         expect(rule.priority).toBe(DEFAULT_PRIORITY_BY_ID.get(rule.id)!);
         expect(rule.scope).toBe('everywhere');
       }
@@ -590,13 +589,15 @@ describe('Trust Store', () => {
       }
     });
 
-    test('default rules cover file, host file, and host shell tools', () => {
+    test('default rules cover file, host file, host shell, and workspace prompt tools', () => {
       const rules = getAllRules();
-      const defaultTools = rules
-        .filter((r) => r.id.startsWith('default:'))
-        .map((r) => r.tool)
-        .sort();
+      const defaultTools = [...new Set(
+        rules
+          .filter((r) => r.id.startsWith('default:'))
+          .map((r) => r.tool),
+      )].sort();
       expect(defaultTools).toEqual([
+        'bash',
         'computer_use_click',
         'computer_use_double_click',
         'computer_use_drag',

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -6,8 +6,6 @@ import { getTool } from '../tools/registry.js';
 import { dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/network/url-safety.js';
-import { isOnboardingComplete } from '../config/system-prompt.js';
-import { getWorkspacePromptPath } from '../util/platform.js';
 
 // Low-risk shell programs that are read-only / informational
 const LOW_RISK_PROGRAMS = new Set([
@@ -272,36 +270,11 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   return RiskLevel.Medium;
 }
 
-/** Workspace prompt files the agent needs to edit during the BOOTSTRAP.md ritual. */
-const ONBOARDING_PROMPT_FILES = ['IDENTITY.md', 'USER.md', 'SOUL.md', 'BOOTSTRAP.md'];
-
-/**
- * Returns true when the tool call targets a workspace prompt file and
- * onboarding is still in progress.  Used to auto-allow the edits /
- * deletions that the BOOTSTRAP.md ritual requires.
- */
-function isOnboardingAutoAllowed(toolName: string, input: Record<string, unknown>, workingDir: string): boolean {
-  if (toolName === 'file_edit' || toolName === 'file_write') {
-    const filePath = getStringField(input, 'path', 'file_path');
-    if (!filePath) return false;
-    const resolved = resolve(workingDir, filePath);
-    return ONBOARDING_PROMPT_FILES.some((f) => resolved === getWorkspacePromptPath(f));
-  }
-
-  return false;
-}
-
 export async function check(
   toolName: string,
   input: Record<string, unknown>,
   workingDir: string,
 ): Promise<PermissionCheckResult> {
-  // During onboarding, auto-allow workspace prompt file operations so the
-  // agent can complete the identity ritual without prompting the user.
-  if (!isOnboardingComplete() && isOnboardingAutoAllowed(toolName, input, workingDir)) {
-    return { decision: 'allow', reason: 'Auto-allowed during onboarding' };
-  }
-
   const risk = await classifyRisk(toolName, input);
 
   // Build command string candidates for rule matching

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -95,5 +95,39 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 1000,
   }));
 
-  return [...protectedFileRules, ...hostFileRules, hostShellRule, ...computerUseRules, ...managedSkillRules];
+  // Workspace prompt files — the agent should always be able to read, edit,
+  // and write these without prompting.  Also allow `rm BOOTSTRAP.md` so the
+  // agent can delete it at the end of the onboarding ritual.
+  const workspaceDir = join(getRootDir(), 'workspace').replaceAll('\\', '/');
+  const WORKSPACE_PROMPT_FILES = ['IDENTITY.md', 'USER.md', 'SOUL.md', 'BOOTSTRAP.md'] as const;
+  const WORKSPACE_FILE_TOOLS = ['file_read', 'file_write', 'file_edit'] as const;
+  const workspacePromptRules = WORKSPACE_FILE_TOOLS.flatMap((tool) =>
+    WORKSPACE_PROMPT_FILES.map((file) => ({
+      id: `default:allow-${tool}-${file.toLowerCase().replace('.md', '')}`,
+      tool,
+      pattern: `${tool}:${workspaceDir}/${file}`,
+      scope: 'everywhere',
+      decision: 'allow' as const,
+      priority: 100,
+    })),
+  );
+
+  const bootstrapDeleteRule: DefaultRuleTemplate = {
+    id: 'default:allow-bash-rm-bootstrap',
+    tool: 'bash',
+    pattern: 'rm BOOTSTRAP.md',
+    scope: 'everywhere',
+    decision: 'allow',
+    priority: 100,
+  };
+
+  return [
+    ...protectedFileRules,
+    ...hostFileRules,
+    hostShellRule,
+    ...computerUseRules,
+    ...managedSkillRules,
+    ...workspacePromptRules,
+    bootstrapDeleteRule,
+  ];
 }


### PR DESCRIPTION
## Summary
- Replaced the onboarding-only `isOnboardingAutoAllowed` mechanism in `checker.ts` with permanent default trust rules in `defaults.ts`
- The agent can now always edit/write IDENTITY.md, USER.md, SOUL.md, and BOOTSTRAP.md without prompting (not just during onboarding)
- Added a default allow rule for `rm BOOTSTRAP.md` so the onboarding ritual can delete it without a permission prompt

## Test plan
- [x] All 202 tests pass across `checker.test.ts` and `trust-store.test.ts`
- [ ] Verify new default rules appear in Trust Rules settings panel
- [ ] Verify BOOTSTRAP.md deletion no longer prompts during onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
