### PR TITLE
feat: add LOOKS.md for dynamic avatar appearance and outfit customization

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -7,7 +7,7 @@ import { getConfig } from './loader.js';
 
 const log = getLogger('system-prompt');
 
-const PROMPT_FILES = ['SOUL.md', 'IDENTITY.md', 'USER.md'] as const;
+const PROMPT_FILES = ['SOUL.md', 'IDENTITY.md', 'USER.md', 'LOOKS.md'] as const;
 
 /**
  * Copy template prompt files into the data directory if they don't already exist.
@@ -86,15 +86,19 @@ export function buildSystemPrompt(): string {
   const userPath = getWorkspacePromptPath('USER.md');
   const bootstrapPath = getWorkspacePromptPath('BOOTSTRAP.md');
 
+  const looksPath = getWorkspacePromptPath('LOOKS.md');
+
   const soul = readPromptFile(soulPath);
   const identity = readPromptFile(identityPath);
   const user = readPromptFile(userPath);
+  const looks = readPromptFile(looksPath);
   const bootstrap = readPromptFile(bootstrapPath);
 
   const parts: string[] = [];
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
   if (user) parts.push(user);
+  if (looks) parts.push(looks);
   if (bootstrap) {
     parts.push(
       '# First-Run Ritual\n\n'
@@ -363,6 +367,7 @@ function buildConfigSection(): string {
     '- `IDENTITY.md` — Your name, nature, vibe, and emoji. Updated during the first-run ritual.',
     '- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.',
     '- `USER.md` — Profile of your user. Update as you learn about them over time.',
+    '- `LOOKS.md` — Your avatar appearance: body/cheek colors and outfit (hat, shirt, accessory, held item).',
     '- `BOOTSTRAP.md` — First-run ritual script (only present during onboarding; you delete it when done).',
     '- `skills/` — Directory of installed skills (loaded automatically at startup).',
     '',
@@ -385,6 +390,16 @@ function buildConfigSection(): string {
     '',
     '**IDENTITY.md** — update when:',
     '- They rename you or change your role',
+    '',
+    '**LOOKS.md** — update when:',
+    '- They ask you to change your appearance, colors, or outfit',
+    '- You want to refresh your look',
+    '- Available body/cheek colors: violet, emerald, rose, amber, indigo, slate, cyan, blue, green, red, orange, pink',
+    '- Available hats: none, top_hat, crown, cap, beanie, wizard_hat, cowboy_hat',
+    '- Available shirts: none, tshirt, suit, hoodie, tank_top, sweater',
+    '- Available accessories: none, sunglasses, monocle, bowtie, necklace, scarf, cape',
+    '- Available held items: none, sword, staff, shield, balloon',
+    '- Available outfit colors: red, blue, yellow, purple, orange, pink, cyan, brown, black, white, gold, silver',
     '',
     'When updating, read the file first, then make a targeted edit. Include all useful information, but don\'t bloat the files over time',
   ].join('\n');

--- a/assistant/src/config/templates/LOOKS.md
+++ b/assistant/src/config/templates/LOOKS.md
@@ -1,0 +1,25 @@
+_ Lines starting with _ are comments — they won't appear in the system prompt
+
+# LOOKS.md
+
+## Purpose of this file
+
+_ This file defines your avatar's appearance. Edit it to change how you look.
+_ Available body/cheek colors: violet, emerald, rose, amber, indigo, slate, cyan, blue, green, red, orange, pink
+_ Available hats: none, top_hat, crown, cap, beanie, wizard_hat, cowboy_hat
+_ Available shirts: none, tshirt, suit, hoodie, tank_top, sweater
+_ Available accessories: none, sunglasses, monocle, bowtie, necklace, scarf, cape
+_ Available held items: none, sword, staff, shield, balloon
+_ Available outfit colors: red, blue, yellow, purple, orange, pink, cyan, brown, black, white, gold, silver
+
+## Appearance
+
+- **Body:** violet
+- **Cheeks:** rose
+
+## Outfit
+
+- **Hat:** none
+- **Shirt:** none
+- **Accessory:** none
+- **Held Item:** none

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -228,6 +228,7 @@ export class DaemonServer {
       'SOUL.md': () => this.evictSessionsForReload(),
       'IDENTITY.md': () => this.evictSessionsForReload(),
       'USER.md': () => this.evictSessionsForReload(),
+      'LOOKS.md': () => this.evictSessionsForReload(),
     };
 
     // Watch protected/ for trust rules and secret allowlist

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -122,6 +122,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_ notification: Notification) {
         applyThemePreference()
         registerBundledFonts()
+        AvatarAppearanceManager.shared.start()
 
         #if DEBUG
         let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Loads avatar appearance from LOOKS.md, watches for changes, and provides
+/// the current DinoPalette for rendering. @Observable so SwiftUI views reactively update.
+@MainActor @Observable
+final class AvatarAppearanceManager {
+    private(set) var palette: DinoPalette = .violet
+    private(set) var outfit: DinoOutfit = .none
+    private(set) var config: LooksConfig = .default
+    private var fileMonitor: DispatchSourceFileSystemObject?
+
+    static let shared = AvatarAppearanceManager()
+
+    private var looksPath: String {
+        NSHomeDirectory() + "/.vellum/workspace/LOOKS.md"
+    }
+
+    func start() {
+        reload()
+        watchFile()
+    }
+
+    private func reload() {
+        guard let content = try? String(contentsOfFile: looksPath, encoding: .utf8) else {
+            return
+        }
+        config = LooksConfig.parse(from: content)
+        palette = config.toPalette()
+        outfit = config.toOutfit()
+    }
+
+    private func watchFile() {
+        fileMonitor?.cancel()
+        fileMonitor = nil
+
+        let path = looksPath
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename],
+            queue: .global(qos: .utility)
+        )
+
+        source.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.reload()
+                // Re-watch in case of delete+recreate
+                let flags = source.data
+                if flags.contains(.delete) || flags.contains(.rename) {
+                    self?.watchFile()
+                }
+            }
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        fileMonitor = source
+        source.resume()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Avatar/DinoPalette.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/DinoPalette.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// A resolved set of hex colors for the dino pixel art grid.
+struct DinoPalette: Equatable {
+    // Body (5 shades: outline → belly highlight)
+    let outline: UInt32   // darkest
+    let dark: UInt32
+    let mid: UInt32
+    let light: UInt32
+    let belly: UInt32     // lightest
+
+    // Eyes
+    let eyeWhite: UInt32 = 0xFFFFFF
+    let pupil: UInt32 = 0x1E293B
+
+    // Accents
+    let cheek: UInt32
+    let tongue: UInt32    // derived from cheek (one shade darker)
+
+    // Wings (3 shades)
+    let wingLight: UInt32
+    let wingMid: UInt32
+    let wingDark: UInt32
+
+    /// The default violet palette (matches current hardcoded values).
+    static let violet = DinoPalette(
+        outline: 0x5C2FB2, dark: 0x7240CC, mid: 0x8A5BE0,
+        light: 0x9878EA, belly: 0xB8A6F1,
+        cheek: 0xF99AAE, tongue: 0xF06A86,
+        wingLight: 0xFDD94E, wingMid: 0xFAC426, wingDark: 0xE8A020
+    )
+}
+
+// MARK: - Dino Outfit
+
+/// Outfit choices for the 3D voxel dino. Overrides seed-derived clothing when provided.
+struct DinoOutfit: Equatable {
+    var hat: String         // e.g. "crown", "none"
+    var hatColor: String?   // e.g. "gold" — uses item default if nil
+    var shirt: String       // e.g. "hoodie", "none"
+    var shirtColor: String?
+    var accessory: String   // e.g. "sunglasses", "none"
+    var accessoryColor: String?
+    var heldItem: String    // e.g. "sword", "none"
+
+    static let none = DinoOutfit(hat: "none", shirt: "none", accessory: "none", heldItem: "none")
+}
+
+// MARK: - Body Color Scales
+
+/// Maps color names to 5-shade body tuples (outline, dark, mid, light, belly).
+/// Hex values correspond to Tailwind-style _800, _700, _600, _500, _300 scales.
+enum BodyColorScale {
+    static let scales: [String: (outline: UInt32, dark: UInt32, mid: UInt32, light: UInt32, belly: UInt32)] = [
+        // From ColorTokens.swift
+        "violet":  (0x5C2FB2, 0x7240CC, 0x8A5BE0, 0x9878EA, 0xD4C8F7),
+        "emerald": (0x0C7356, 0x10906A, 0x18B07A, 0x38CF93, 0xA6F2D1),
+        "rose":    (0xA8183E, 0xD02050, 0xE84060, 0xF06A86, 0xFCBFC9),
+        "amber":   (0xA35E0C, 0xC97C10, 0xE8A020, 0xFAC426, 0xFEEC94),
+        "indigo":  (0x3525C4, 0x4636E8, 0x5B4EFF, 0x7B6BFF, 0xB8B4FF),
+        "slate":   (0x1E293B, 0x334155, 0x475569, 0x64748B, 0xCBD5E1),
+        // Additional colors (standard Tailwind hex values)
+        "cyan":    (0x0E7490, 0x0891B2, 0x06B6D4, 0x22D3EE, 0x67E8F9),
+        "blue":    (0x1E40AF, 0x1D4ED8, 0x2563EB, 0x3B82F6, 0x93C5FD),
+        "green":   (0x166534, 0x15803D, 0x16A34A, 0x22C55E, 0x86EFAC),
+        "red":     (0x991B1B, 0xB91C1C, 0xDC2626, 0xEF4444, 0xFCA5A5),
+        "orange":  (0x9A3412, 0xC2410C, 0xEA580C, 0xF97316, 0xFDBA74),
+        "pink":    (0x9D174D, 0xBE185D, 0xDB2777, 0xEC4899, 0xF9A8D4),
+    ]
+}
+
+// MARK: - Wing Color Scales
+
+/// Maps color names to 3-shade wing tuples (light, mid, dark).
+/// Hex values correspond to _400, _500, _600 scales.
+enum WingColorScale {
+    static let scales: [String: (light: UInt32, mid: UInt32, dark: UInt32)] = [
+        "violet":  (0xB8A6F1, 0x9878EA, 0x8A5BE0),
+        "emerald": (0x6EE7B5, 0x38CF93, 0x18B07A),
+        "rose":    (0xF99AAE, 0xF06A86, 0xE84060),
+        "amber":   (0xFDD94E, 0xFAC426, 0xE8A020),
+        "indigo":  (0x9488FF, 0x7B6BFF, 0x5B4EFF),
+        "slate":   (0x94A3B8, 0x64748B, 0x475569),
+        "cyan":    (0x22D3EE, 0x06B6D4, 0x0891B2),
+        "blue":    (0x60A5FA, 0x3B82F6, 0x2563EB),
+        "green":   (0x4ADE80, 0x22C55E, 0x16A34A),
+        "red":     (0xF87171, 0xEF4444, 0xDC2626),
+        "orange":  (0xFB923C, 0xF97316, 0xEA580C),
+        "pink":    (0xF472B6, 0xEC4899, 0xDB2777),
+    ]
+}
+
+// MARK: - Cheek Color Scales
+
+/// Maps color names to cheek + tongue pair (cheek = _400, tongue = _500).
+enum CheekColorScale {
+    static let scales: [String: (cheek: UInt32, tongue: UInt32)] = [
+        "violet":  (0xB8A6F1, 0x9878EA),
+        "emerald": (0x6EE7B5, 0x38CF93),
+        "rose":    (0xF99AAE, 0xF06A86),
+        "amber":   (0xFDD94E, 0xFAC426),
+        "indigo":  (0x9488FF, 0x7B6BFF),
+        "slate":   (0x94A3B8, 0x64748B),
+        "cyan":    (0x22D3EE, 0x06B6D4),
+        "blue":    (0x60A5FA, 0x3B82F6),
+        "green":   (0x4ADE80, 0x22C55E),
+        "red":     (0xF87171, 0xEF4444),
+        "orange":  (0xFB923C, 0xF97316),
+        "pink":    (0xF472B6, 0xEC4899),
+    ]
+}

--- a/clients/macos/vellum-assistant/Features/Avatar/LooksConfig.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/LooksConfig.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Parses LOOKS.md from the workspace and provides a color palette and outfit for the dino avatar.
+struct LooksConfig {
+    var bodyColor: String
+    var cheekColor: String
+
+    // Outfit
+    var hat: String
+    var hatColor: String?
+    var shirt: String
+    var shirtColor: String?
+    var accessory: String
+    var accessoryColor: String?
+    var heldItem: String
+
+    static let `default` = LooksConfig(
+        bodyColor: "violet", cheekColor: "rose",
+        hat: "none", shirt: "none", accessory: "none", heldItem: "none"
+    )
+
+    /// Parse LOOKS.md content into a LooksConfig.
+    /// Looks for lines like `- **Body:** violet`, `- **Hat:** crown (gold)`, etc.
+    static func parse(from content: String) -> LooksConfig {
+        var body = "violet"
+        var cheeks = "rose"
+        var hat = "none"
+        var hatColor: String?
+        var shirt = "none"
+        var shirtColor: String?
+        var accessory = "none"
+        var accessoryColor: String?
+        var heldItem = "none"
+
+        let range = NSRange(content.startIndex..., in: content)
+
+        func extractValue(_ label: String) -> String? {
+            let pattern = try? NSRegularExpression(
+                pattern: #"-\s*\*\*"# + NSRegularExpression.escapedPattern(for: label) + #":\*\*\s*(\w+)"#,
+                options: .caseInsensitive
+            )
+            if let match = pattern?.firstMatch(in: content, range: range),
+               let valueRange = Range(match.range(at: 1), in: content) {
+                return String(content[valueRange]).lowercased()
+            }
+            return nil
+        }
+
+        // For items that can have a color in parens: `- **Hat:** crown (gold)`
+        func extractValueAndColor(_ label: String) -> (value: String, color: String?)? {
+            let pattern = try? NSRegularExpression(
+                pattern: #"-\s*\*\*"# + NSRegularExpression.escapedPattern(for: label) + #":\*\*\s*(\w+)(?:\s*\((\w+)\))?"#,
+                options: .caseInsensitive
+            )
+            if let match = pattern?.firstMatch(in: content, range: range),
+               let valueRange = Range(match.range(at: 1), in: content) {
+                let value = String(content[valueRange]).lowercased()
+                var color: String?
+                if match.range(at: 2).location != NSNotFound,
+                   let colorRange = Range(match.range(at: 2), in: content) {
+                    color = String(content[colorRange]).lowercased()
+                }
+                return (value, color)
+            }
+            return nil
+        }
+
+        if let v = extractValue("Body") { body = v }
+        if let v = extractValue("Cheeks") { cheeks = v }
+
+        if let (v, c) = extractValueAndColor("Hat") { hat = v; hatColor = c }
+        if let (v, c) = extractValueAndColor("Shirt") { shirt = v; shirtColor = c }
+        if let (v, c) = extractValueAndColor("Accessory") { accessory = v; accessoryColor = c }
+
+        // "Held Item" has a space — match with regex
+        let heldItemPattern = try? NSRegularExpression(
+            pattern: #"-\s*\*\*Held\s+Item:\*\*\s*(\w+)"#,
+            options: .caseInsensitive
+        )
+        if let match = heldItemPattern?.firstMatch(in: content, range: range),
+           let valueRange = Range(match.range(at: 1), in: content) {
+            heldItem = String(content[valueRange]).lowercased()
+        }
+
+        return LooksConfig(
+            bodyColor: body, cheekColor: cheeks,
+            hat: hat, hatColor: hatColor,
+            shirt: shirt, shirtColor: shirtColor,
+            accessory: accessory, accessoryColor: accessoryColor,
+            heldItem: heldItem
+        )
+    }
+
+    /// Resolve to a DinoPalette using predefined color scales.
+    /// Wing colors are derived from the body color since the 3D voxel dino has no wings.
+    func toPalette() -> DinoPalette {
+        let bodyScale = BodyColorScale.scales[bodyColor] ?? BodyColorScale.scales["violet"]!
+        let cheekScale = CheekColorScale.scales[cheekColor] ?? CheekColorScale.scales["rose"]!
+        // Derive wing colors from body for the 2D pixel art (3D voxel has no wings)
+        let wingScale = WingColorScale.scales[bodyColor] ?? WingColorScale.scales["amber"]!
+
+        return DinoPalette(
+            outline: bodyScale.outline,
+            dark: bodyScale.dark,
+            mid: bodyScale.mid,
+            light: bodyScale.light,
+            belly: bodyScale.belly,
+            cheek: cheekScale.cheek,
+            tongue: cheekScale.tongue,
+            wingLight: wingScale.light,
+            wingMid: wingScale.mid,
+            wingDark: wingScale.dark
+        )
+    }
+
+    /// Convert outfit fields to a DinoOutfit for the voxel generator.
+    func toOutfit() -> DinoOutfit {
+        DinoOutfit(
+            hat: hat, hatColor: hatColor,
+            shirt: shirt, shirtColor: shirtColor,
+            accessory: accessory, accessoryColor: accessoryColor,
+            heldItem: heldItem
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -100,6 +100,7 @@ struct ChatView: View {
     @State private var emptyStatePlaceholder: String = placeholderTexts.randomElement()!
     @State private var emptyStateVisible = false
     @State private var identity: IdentityInfo? = IdentityInfo.load()
+    private let appearance = AvatarAppearanceManager.shared
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
@@ -198,7 +199,7 @@ struct ChatView: View {
             Spacer()
             Spacer()
 
-            DinoFaceView(seed: identity?.name ?? "default")
+            DinoFaceView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
                 .frame(width: 80, height: 80)
                 .allowsHitTesting(false)
                 .opacity(emptyStateVisible ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarSpriteBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarSpriteBuilder.swift
@@ -15,6 +15,12 @@ enum DinoVoxelGenerator {
             self.r = r; self.g = g; self.b = b
         }
 
+        init(hex: UInt32) {
+            self.r = UInt8((hex >> 16) & 0xFF)
+            self.g = UInt8((hex >> 8) & 0xFF)
+            self.b = UInt8(hex & 0xFF)
+        }
+
         var nsColor: NSColor {
             NSColor(
                 red: CGFloat(r) / 255.0,
@@ -31,13 +37,24 @@ enum DinoVoxelGenerator {
 
     // MARK: - Color Palette
 
-    private static let dinoGreen = RGB(76, 175, 80)
-    private static let dinoLight = RGB(129, 199, 132)
-    private static let dinoBelly = RGB(200, 230, 201)
-    private static let dinoDark  = RGB(56, 142, 60)
+    private static let defaultDinoGreen = RGB(76, 175, 80)
+    private static let defaultDinoLight = RGB(129, 199, 132)
+    private static let defaultDinoBelly = RGB(200, 230, 201)
+    private static let defaultDinoDark  = RGB(56, 142, 60)
     private static let eyeWhite  = RGB(255, 255, 255)
     private static let eyeBlack  = RGB(33, 33, 33)
-    private static let cheekPink = RGB(255, 160, 170)
+    private static let defaultCheekPink = RGB(255, 160, 170)
+
+    /// Derive 3D voxel colors from a DinoPalette.
+    private static func voxelColors(from palette: DinoPalette) -> (main: RGB, light: RGB, belly: RGB, dark: RGB, cheek: RGB) {
+        return (
+            main: RGB(hex: palette.mid),
+            light: RGB(hex: palette.light),
+            belly: RGB(hex: palette.belly),
+            dark: RGB(hex: palette.dark),
+            cheek: RGB(hex: palette.cheek)
+        )
+    }
 
     private static let palette: [String: RGB] = [
         "red": RGB(244, 67, 54),
@@ -211,8 +228,29 @@ enum DinoVoxelGenerator {
 
     // MARK: - Base Dino (chibi proportions)
 
-    private static func createBaseDino() -> [VoxelPos: RGB] {
+    private static func createBaseDino(palette: DinoPalette? = nil) -> [VoxelPos: RGB] {
         var voxels: [VoxelPos: RGB] = [:]
+
+        // Derive colors from palette or use defaults
+        let dinoMain: RGB
+        let dinoLt: RGB
+        let dinoBl: RGB
+        let dinoDk: RGB
+        let cheek: RGB
+        if let palette {
+            let c = voxelColors(from: palette)
+            dinoMain = c.main
+            dinoLt = c.light
+            dinoBl = c.belly
+            dinoDk = c.dark
+            cheek = c.cheek
+        } else {
+            dinoMain = defaultDinoGreen
+            dinoLt = defaultDinoLight
+            dinoBl = defaultDinoBelly
+            dinoDk = defaultDinoDark
+            cheek = defaultCheekPink
+        }
 
         func set(_ x: Int, _ y: Int, _ z: Int, _ color: RGB) {
             voxels[VoxelPos(x: x, y: y, z: z)] = color
@@ -226,7 +264,7 @@ enum DinoVoxelGenerator {
                 let edgeX = (x == 4 || x == 11)
                 let edgeZ = (z == 4 || z == 11)
                 if edgeX && edgeZ { continue }
-                set(x, 13, z, dinoGreen)
+                set(x, 13, z, dinoMain)
             }
         }
 
@@ -237,7 +275,7 @@ enum DinoVoxelGenerator {
                     let edgeX = (x == 3 || x == 12)
                     let edgeZ = (z == 3 || z == 12)
                     if edgeX && edgeZ { continue }
-                    set(x, y, z, dinoGreen)
+                    set(x, y, z, dinoMain)
                 }
             }
         }
@@ -248,28 +286,28 @@ enum DinoVoxelGenerator {
                 let edgeX = (x == 4 || x == 11)
                 let edgeZ = (z == 4 || z == 11)
                 if edgeX && edgeZ { continue }
-                set(x, 21, z, dinoGreen)
+                set(x, 21, z, dinoMain)
             }
         }
 
         // Top cap (y=22): small 6×6
-        for x in 5...10 { for z in 5...10 { set(x, 22, z, dinoGreen) } }
+        for x in 5...10 { for z in 5...10 { set(x, 22, z, dinoMain) } }
 
         // === SNOUT (protruding forward, lighter color) ===
         for x in 5...10 {
             for y in 14...17 {
                 for z in 12...14 {
-                    set(x, y, z, dinoLight)
+                    set(x, y, z, dinoLt)
                 }
             }
         }
 
         // Nostrils (dark dots on snout front)
-        set(6, 16, 14, dinoDark)
-        set(9, 16, 14, dinoDark)
+        set(6, 16, 14, dinoDk)
+        set(9, 16, 14, dinoDk)
 
         // Mouth line
-        for x in 6...9 { set(x, 14, 14, dinoDark) }
+        for x in 6...9 { set(x, 14, 14, dinoDk) }
 
         // === EYES (4×3 each, big & expressive) ===
 
@@ -290,19 +328,19 @@ enum DinoVoxelGenerator {
         set(10, 18, 12, eyeBlack)
 
         // Rosy cheeks (below and outside each eye)
-        set(4, 16, 12, cheekPink)
-        set(3, 16, 12, cheekPink)
-        set(11, 16, 12, cheekPink)
-        set(12, 16, 12, cheekPink)
+        set(4, 16, 12, cheek)
+        set(3, 16, 12, cheek)
+        set(11, 16, 12, cheek)
+        set(12, 16, 12, cheek)
 
         // === BODY (y=6-12) ===
         for x in 5...10 {
             for y in 6...12 {
                 for z in 5...10 {
                     if z >= 9 {
-                        set(x, y, z, dinoBelly)
+                        set(x, y, z, dinoBl)
                     } else {
-                        set(x, y, z, dinoGreen)
+                        set(x, y, z, dinoMain)
                     }
                 }
             }
@@ -311,25 +349,25 @@ enum DinoVoxelGenerator {
         // === ARMS (tiny T-rex style, y=9-11) ===
         for y in 9...11 {
             for z in 7...9 {
-                set(4, y, z, dinoGreen)
-                set(11, y, z, dinoGreen)
+                set(4, y, z, dinoMain)
+                set(11, y, z, dinoMain)
             }
         }
 
         // === LEGS (y=1-5, two stumpy legs) ===
         for y in 1...5 {
             for z in 6...9 {
-                set(5, y, z, dinoGreen)
-                set(6, y, z, dinoGreen)
-                set(9, y, z, dinoGreen)
-                set(10, y, z, dinoGreen)
+                set(5, y, z, dinoMain)
+                set(6, y, z, dinoMain)
+                set(9, y, z, dinoMain)
+                set(10, y, z, dinoMain)
             }
         }
 
         // === FEET (y=0, wider than legs for cute look) ===
         for z in 5...10 {
-            for x in 4...7 { set(x, 0, z, dinoGreen) }
-            for x in 8...11 { set(x, 0, z, dinoGreen) }
+            for x in 4...7 { set(x, 0, z, dinoMain) }
+            for x in 8...11 { set(x, 0, z, dinoMain) }
         }
 
         // === TAIL (extends behind, tapering) ===
@@ -339,18 +377,18 @@ enum DinoVoxelGenerator {
             let width = max(2, 4 - i)
             let startX = 8 - width / 2
             for dx in 0..<width {
-                set(startX + dx, 7, z, dinoGreen)
-                if i < 3 { set(startX + dx, 8, z, dinoGreen) }
+                set(startX + dx, 7, z, dinoMain)
+                if i < 3 { set(startX + dx, 8, z, dinoMain) }
             }
         }
-        set(7, 7, 0, dinoDark)
+        set(7, 7, 0, dinoDk)
 
         // === SPIKES (along back of head) ===
         for spikeY in [15, 18, 21] {
-            set(7, spikeY, 2, dinoLight)
-            set(8, spikeY, 2, dinoLight)
-            set(7, spikeY + 1, 2, dinoLight)
-            set(8, spikeY + 1, 2, dinoLight)
+            set(7, spikeY, 2, dinoLt)
+            set(8, spikeY, 2, dinoLt)
+            set(7, spikeY + 1, 2, dinoLt)
+            set(8, spikeY + 1, 2, dinoLt)
         }
 
         return voxels
@@ -365,7 +403,7 @@ enum DinoVoxelGenerator {
     ) {
         func applyItem(_ def: ClothingDef?, colorOverride: String) {
             guard let def else { return }
-            let color = palette[colorOverride] ?? palette[def.defaultColor] ?? dinoGreen
+            let color = palette[colorOverride] ?? palette[def.defaultColor] ?? defaultDinoGreen
             for pos in def.positions {
                 guard pos.x >= 0, pos.x < 16, pos.y >= 0, pos.y < 30, pos.z >= 0, pos.z < 16 else { continue }
                 voxels[pos] = color
@@ -397,19 +435,48 @@ enum DinoVoxelGenerator {
 
     // MARK: - Public API
 
-    static func generate(seed: String) -> [VoxelPos: RGB] {
+    static func generate(seed: String, palette: DinoPalette? = nil, outfit: DinoOutfit? = nil) -> [VoxelPos: RGB] {
         let hash = hashSeed(seed)
         var shift = 0
 
-        let hat = pick(hatNames, hash: hash, shift: &shift)
-        let shirt = pick(shirtNames, hash: hash, shift: &shift)
-        let accessory = pick(accessoryNames, hash: hash, shift: &shift)
-        let heldItem = pick(heldItemNames, hash: hash, shift: &shift)
-        let hatColor = pick(clothingColorNames, hash: hash, shift: &shift)
-        let shirtColor = pick(clothingColorNames, hash: hash, shift: &shift)
-        let accColor = pick(clothingColorNames, hash: hash, shift: &shift)
+        // Use outfit overrides when provided, otherwise derive from seed
+        let hat: String
+        let shirt: String
+        let accessory: String
+        let heldItem: String
+        let hatColor: String
+        let shirtColor: String
+        let accColor: String
 
-        var model = createBaseDino()
+        if let outfit {
+            hat = outfit.hat
+            shirt = outfit.shirt
+            accessory = outfit.accessory
+            heldItem = outfit.heldItem
+            // For colors, use outfit color or fall back to seed-derived
+            // (advance shift for each pick so seed hash stays deterministic)
+            let seedHat = pick(hatNames, hash: hash, shift: &shift)
+            let seedShirt = pick(shirtNames, hash: hash, shift: &shift)
+            let seedAccessory = pick(accessoryNames, hash: hash, shift: &shift)
+            let seedHeldItem = pick(heldItemNames, hash: hash, shift: &shift)
+            _ = (seedHat, seedShirt, seedAccessory, seedHeldItem) // suppress warnings
+            let seedHatColor = pick(clothingColorNames, hash: hash, shift: &shift)
+            let seedShirtColor = pick(clothingColorNames, hash: hash, shift: &shift)
+            let seedAccColor = pick(clothingColorNames, hash: hash, shift: &shift)
+            hatColor = outfit.hatColor ?? seedHatColor
+            shirtColor = outfit.shirtColor ?? seedShirtColor
+            accColor = outfit.accessoryColor ?? seedAccColor
+        } else {
+            hat = pick(hatNames, hash: hash, shift: &shift)
+            shirt = pick(shirtNames, hash: hash, shift: &shift)
+            accessory = pick(accessoryNames, hash: hash, shift: &shift)
+            heldItem = pick(heldItemNames, hash: hash, shift: &shift)
+            hatColor = pick(clothingColorNames, hash: hash, shift: &shift)
+            shirtColor = pick(clothingColorNames, hash: hash, shift: &shift)
+            accColor = pick(clothingColorNames, hash: hash, shift: &shift)
+        }
+
+        var model = createBaseDino(palette: palette)
         applyClothing(
             &model,
             hatName: hat, shirtName: shirt, accessoryName: accessory, heldItemName: heldItem,
@@ -419,8 +486,8 @@ enum DinoVoxelGenerator {
     }
 
     /// Builds a SceneKit scene from a voxel model for 3D rendering.
-    static func buildScene(seed: String) -> SCNScene {
-        let voxels = generate(seed: seed)
+    static func buildScene(seed: String, palette: DinoPalette? = nil, outfit: DinoOutfit? = nil) -> SCNScene {
+        let voxels = generate(seed: seed, palette: palette, outfit: outfit)
         let scene = SCNScene()
 
         let modelNode = SCNNode()
@@ -496,8 +563,8 @@ enum DinoVoxelGenerator {
     }
 
     /// Builds a SceneKit scene showing only the dino's face/head (y >= 12).
-    static func buildFaceScene(seed: String) -> SCNScene {
-        let allVoxels = generate(seed: seed)
+    static func buildFaceScene(seed: String, palette: DinoPalette? = nil, outfit: DinoOutfit? = nil) -> SCNScene {
+        let allVoxels = generate(seed: seed, palette: palette, outfit: outfit)
         let scene = SCNScene()
 
         // Filter to head region only (y >= 12 captures neck, head, hat, spikes)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarView.swift
@@ -5,9 +5,13 @@ import SceneKit
 /// Seeded from a string so the same name always produces the same dino.
 struct DinoSceneView: NSViewRepresentable {
     let seed: String
+    var palette: DinoPalette = .violet
+    var outfit: DinoOutfit = .none
 
     final class Coordinator {
         var currentSeed: String = ""
+        var currentPalette: DinoPalette = .violet
+        var currentOutfit: DinoOutfit = .none
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -17,24 +21,33 @@ struct DinoSceneView: NSViewRepresentable {
         scnView.backgroundColor = .clear
         scnView.allowsCameraControl = true
         scnView.antialiasingMode = .multisampling4X
-        scnView.scene = DinoVoxelGenerator.buildScene(seed: seed)
+        scnView.scene = DinoVoxelGenerator.buildScene(seed: seed, palette: palette, outfit: outfit)
         context.coordinator.currentSeed = seed
+        context.coordinator.currentPalette = palette
+        context.coordinator.currentOutfit = outfit
         return scnView
     }
 
     func updateNSView(_ nsView: SCNView, context: Context) {
-        guard context.coordinator.currentSeed != seed else { return }
-        context.coordinator.currentSeed = seed
-        nsView.scene = DinoVoxelGenerator.buildScene(seed: seed)
+        let coord = context.coordinator
+        guard coord.currentSeed != seed || coord.currentPalette != palette || coord.currentOutfit != outfit else { return }
+        coord.currentSeed = seed
+        coord.currentPalette = palette
+        coord.currentOutfit = outfit
+        nsView.scene = DinoVoxelGenerator.buildScene(seed: seed, palette: palette, outfit: outfit)
     }
 }
 
 /// 3D voxel dino face only — head cropped from the full model.
 struct DinoFaceView: NSViewRepresentable {
     let seed: String
+    var palette: DinoPalette = .violet
+    var outfit: DinoOutfit = .none
 
     final class Coordinator {
         var currentSeed: String = ""
+        var currentPalette: DinoPalette = .violet
+        var currentOutfit: DinoOutfit = .none
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -44,15 +57,20 @@ struct DinoFaceView: NSViewRepresentable {
         scnView.backgroundColor = .clear
         scnView.allowsCameraControl = true
         scnView.antialiasingMode = .multisampling4X
-        scnView.scene = DinoVoxelGenerator.buildFaceScene(seed: seed)
+        scnView.scene = DinoVoxelGenerator.buildFaceScene(seed: seed, palette: palette, outfit: outfit)
         context.coordinator.currentSeed = seed
+        context.coordinator.currentPalette = palette
+        context.coordinator.currentOutfit = outfit
         return scnView
     }
 
     func updateNSView(_ nsView: SCNView, context: Context) {
-        guard context.coordinator.currentSeed != seed else { return }
-        context.coordinator.currentSeed = seed
-        nsView.scene = DinoVoxelGenerator.buildFaceScene(seed: seed)
+        let coord = context.coordinator
+        guard coord.currentSeed != seed || coord.currentPalette != palette || coord.currentOutfit != outfit else { return }
+        coord.currentSeed = seed
+        coord.currentPalette = palette
+        coord.currentOutfit = outfit
+        nsView.scene = DinoVoxelGenerator.buildFaceScene(seed: seed, palette: palette, outfit: outfit)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -208,6 +208,7 @@ struct ConstellationView: View {
     let identity: IdentityInfo?
     let skills: [SkillInfo]
     let workspaceFiles: [WorkspaceFileNode]
+    private let appearance = AvatarAppearanceManager.shared
 
     @State private var phase: AnimationPhase = .hidden
     @State private var panOffset: CGSize = .zero
@@ -405,7 +406,7 @@ struct ConstellationView: View {
             }
 
             // Center dino face — non-interactive so drags pass to canvas pan
-            DinoFaceView(seed: identity?.name ?? "default")
+            DinoFaceView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
                 .frame(width: 80, height: 80)
                 .allowsHitTesting(false)
                 .position(center)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -4,6 +4,7 @@ import VellumAssistantShared
 struct IdentityPanel: View {
     let onClose: () -> Void
     let daemonClient: DaemonClient
+    private let appearance = AvatarAppearanceManager.shared
 
     @State private var identity: IdentityInfo?
     @State private var metadata: AssistantMetadata?
@@ -36,7 +37,7 @@ struct IdentityPanel: View {
 
             // Avatar + ID card side by side
             HStack(alignment: .center, spacing: VSpacing.lg) {
-                DinoSceneView(seed: identity?.name ?? "default")
+                DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
                     .frame(width: 180, height: 200)
 
                 if let identity {

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct CreatureView: View {
     let visible: Bool
     var animated: Bool = true
+    private let appearance = AvatarAppearanceManager.shared
 
     @State private var appeared = false
     @State private var bounceOffset: CGFloat = 0
@@ -51,7 +52,7 @@ struct CreatureView: View {
     }
 
     private var dinoImage: some View {
-        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: Meadow.artPixelSize))
+        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: Meadow.artPixelSize, palette: appearance.palette))
             .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EggHatchScene.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EggHatchScene.swift
@@ -46,7 +46,8 @@ final class EggHatchScene: SKScene {
         let ps = Meadow.artPixelSize
 
         // Build dino sprite (behind egg, starts invisible)
-        let (dinoTex, dinoSize) = PixelSpriteBuilder.buildTexture(from: PixelArtData.dino, pixelSize: ps)
+        let palette = AvatarAppearanceManager.shared.palette
+        let (dinoTex, dinoSize) = PixelSpriteBuilder.buildTexture(from: PixelArtData.dino(palette: palette), pixelSize: ps)
         dinoNode = SKSpriteNode(texture: dinoTex, size: dinoSize)
         dinoNode.position = CGPoint(x: 0, y: 10)
         dinoNode.zPosition = 8

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelArtData.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelArtData.swift
@@ -109,4 +109,41 @@ enum PixelArtData {
             [  n,   n,   n,   n,   n,   n,   O,   O,   O,   n,   n,   n,   n,   n,   n,   n,   n,   O,   O,   O,   n,   n,   n,   n,   n,   n], // 21 feet base
         ]
     }()
+
+    // MARK: - Dynamic Palette Dino Grid
+
+    /// Build a dino grid with custom palette colors.
+    static func dino(palette: DinoPalette) -> [[UInt32?]] {
+        let n: UInt32? = nil
+        let O = palette.outline, D = palette.dark, M = palette.mid
+        let L = palette.light, B = palette.belly
+        let W = palette.eyeWhite, P = palette.pupil
+        let K = palette.cheek, T = palette.tongue
+        let a = palette.wingLight, b = palette.wingMid, c = palette.wingDark
+        return [
+            //  0    1    2    3    4    5    6    7    8    9   10   11   12   13   14   15   16   17   18   19   20   21   22   23   24   25
+            [  n,   n,   n,   n,   n,   n,   n,   n,   n,   O,   O,   n,   n,   n,   n,   O,   O,   n,   n,   n,   n,   n,   n,   n,   n,   n], // 0  horns
+            [  n,   n,   n,   n,   n,   n,   n,   n,   O,   D,   M,   O,   n,   n,   O,   M,   D,   O,   n,   n,   n,   n,   n,   n,   n,   n], // 1  horn base
+            [  n,   n,   n,   n,   n,   n,   n,   O,   M,   L,   L,   L,   O,   O,   L,   L,   L,   M,   O,   n,   n,   n,   n,   n,   n,   n], // 2  head top
+            [  n,   n,   n,   n,   n,   n,   O,   D,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   D,   O,   n,   n,   n,   n,   n,   n], // 3  head
+            [  n,   n,   n,   n,   n,   O,   D,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   D,   O,   n,   n,   n,   n,   n], // 4  face
+            [  n,   n,   n,   n,   n,   O,   D,   L,   W,   P,   P,   P,   L,   L,   P,   P,   P,   W,   L,   D,   O,   n,   n,   n,   n,   n], // 5  eyes top
+            [  n,   n,   n,   n,   n,   O,   D,   L,   P,   P,   P,   P,   L,   L,   P,   P,   P,   P,   L,   D,   O,   n,   n,   n,   n,   n], // 6  eyes mid
+            [  n,   n,   n,   n,   n,   O,   D,   L,   P,   P,   P,   P,   L,   L,   P,   P,   P,   P,   L,   D,   O,   n,   n,   n,   n,   n], // 7  eyes bottom
+            [  n,   n,   n,   n,   n,   O,   D,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   D,   O,   n,   n,   n,   n,   n], // 8  below eyes
+            [  n,   n,   n,   n,   O,   D,   M,   L,   K,   K,   L,   O,   L,   L,   O,   L,   K,   K,   L,   M,   D,   O,   n,   n,   n,   n], // 9  cheeks + mouth
+            [  n,   n,   n,   n,   O,   D,   M,   L,   L,   L,   L,   L,   T,   T,   L,   L,   L,   L,   L,   M,   D,   O,   n,   n,   n,   n], // 10 tongue
+            [  n,   n,   n,   n,   O,   D,   M,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   M,   D,   O,   n,   n,   n,   n], // 11 upper body
+            [  n,   n,   n,   O,   D,   M,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   M,   D,   O,   n,   n,   n], // 12 body widens
+            [  n,   c,   b,   O,   D,   M,   L,   L,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   L,   L,   M,   D,   O,   b,   c,   n], // 13 wings + belly
+            [  c,   b,   a,   O,   D,   M,   L,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   L,   M,   D,   O,   a,   b,   c], // 14 wings peak
+            [  n,   c,   b,   O,   D,   M,   L,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   L,   M,   D,   O,   b,   c,   n], // 15 wings end
+            [  n,   n,   n,   O,   D,   M,   L,   L,   B,   B,   B,   B,   B,   B,   B,   B,   B,   B,   L,   L,   M,   D,   O,   n,   n,   n], // 16 body + belly
+            [  n,   n,   n,   n,   O,   D,   M,   L,   L,   L,   B,   B,   B,   B,   B,   B,   L,   L,   L,   M,   D,   O,   n,   n,   n,   n], // 17 lower body
+            [  n,   n,   n,   n,   n,   O,   D,   M,   L,   L,   L,   L,   L,   L,   L,   L,   L,   L,   M,   D,   O,   n,   n,   n,   n,   n], // 18 narrow
+            [  n,   n,   n,   n,   n,   n,   O,   D,   M,   M,   L,   L,   L,   L,   L,   L,   M,   M,   D,   O,   n,   n,   n,   n,   n,   n], // 19 bottom
+            [  n,   n,   n,   n,   n,   n,   O,   D,   D,   O,   O,   n,   n,   n,   n,   O,   O,   D,   D,   O,   n,   n,   n,   n,   n,   n], // 20 feet
+            [  n,   n,   n,   n,   n,   n,   O,   O,   O,   n,   n,   n,   n,   n,   n,   n,   n,   O,   O,   O,   n,   n,   n,   n,   n,   n], // 21 feet base
+        ]
+    }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
@@ -152,9 +152,19 @@ enum PixelSpriteBuilder {
 
     // MARK: - NSImage for SwiftUI
 
-    /// Builds an NSImage of the dino pixel art for use in SwiftUI views.
+    /// Builds an NSImage of the dino pixel art with a custom palette.
+    static func buildDinoNSImage(pixelSize: CGFloat, palette: DinoPalette) -> NSImage {
+        let grid = PixelArtData.dino(palette: palette)
+        return buildNSImage(from: grid, pixelSize: pixelSize)
+    }
+
+    /// Builds an NSImage of the dino pixel art using the default palette.
     static func buildDinoNSImage(pixelSize: CGFloat) -> NSImage {
-        let grid = PixelArtData.dino
+        return buildNSImage(from: PixelArtData.dino, pixelSize: pixelSize)
+    }
+
+    /// Renders any pixel grid into an NSImage.
+    static func buildNSImage(from grid: [[UInt32?]], pixelSize: CGFloat) -> NSImage {
         let rows = grid.count
         let cols = grid[0].count
         let width = Int(CGFloat(cols) * pixelSize)

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -5,6 +5,7 @@ struct TextResponseView: View {
     @ObservedObject var session: TextSession
     @Bindable var inputState: ConversationInputState
     var onClose: (() -> Void)?
+    private let appearance = AvatarAppearanceManager.shared
 
     /// Whether the session is actively processing (thinking or streaming).
     private var isActiveState: Bool {
@@ -222,7 +223,7 @@ struct TextResponseView: View {
     // MARK: - Assistant Avatar
 
     private var assistantAvatar: some View {
-        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: 2))
+        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: 2, palette: appearance.palette))
             .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)
@@ -254,6 +255,7 @@ struct TextResponseView: View {
 
 struct ConversationBubble: View {
     let message: ConversationMessage
+    private let appearance = AvatarAppearanceManager.shared
 
     private var isAssistant: Bool { message.role == .assistant }
 
@@ -308,7 +310,7 @@ struct ConversationBubble: View {
     }
 
     private var assistantAvatar: some View {
-        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: 2))
+        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: 2, palette: appearance.palette))
             .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)

--- a/clients/macos/vellum-assistant/Features/Surfaces/WorkspaceActivityFeed.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/WorkspaceActivityFeed.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 /// Displays the user's message, thinking dots, and streaming AI response.
 struct WorkspaceActivityFeed: View {
     @ObservedObject var viewModel: ChatViewModel
+    private let appearance = AvatarAppearanceManager.shared
 
     var body: some View {
         if viewModel.refinementMessagePreview != nil {
@@ -99,7 +100,7 @@ struct WorkspaceActivityFeed: View {
     }
 
     private var assistantAvatar: some View {
-        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: 2))
+        Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: 2, palette: appearance.palette))
             .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
@@ -8,6 +8,7 @@ final class VoiceTranscriptionViewModel: ObservableObject {
 
 struct VoiceTranscriptionView: View {
     @ObservedObject var viewModel: VoiceTranscriptionViewModel
+    private let appearance = AvatarAppearanceManager.shared
 
     private let circleSize: CGFloat = 80
     private let dinoPixelSize: CGFloat = 3
@@ -19,7 +20,7 @@ struct VoiceTranscriptionView: View {
                     .stroke(VColor.accent, lineWidth: 2.5)
                     .frame(width: circleSize, height: circleSize)
 
-                Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: dinoPixelSize))
+                Image(nsImage: PixelSpriteBuilder.buildDinoNSImage(pixelSize: dinoPixelSize, palette: appearance.palette))
                     .interpolation(.none)
             }
 


### PR DESCRIPTION
## Summary
- Add `LOOKS.md` workspace file that drives the avatar's body color, cheek color, hat, shirt, accessory, and held item — editable by the assistant via `file_edit`
- Wire LOOKS.md into the daemon system prompt pipeline (template, buildSystemPrompt, file watcher for session eviction)
- Parameterize both the 2D pixel art sprites and 3D voxel dino model with dynamic palettes and outfit overrides, with live file-watching via `AvatarAppearanceManager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
