### PR TITLE
fix: unregister transiently-failed skills to prevent refcount leak

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -402,6 +402,38 @@ describe('projectSkillTools', () => {
     expect(mockRegisteredTools.has('deploy')).toBe(true);
   });
 
+  test('previously-registered skill that transiently fails is unregistered to prevent refcount leak', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: skill registered successfully
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.has('deploy')).toBe(true);
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+
+    // Turn 2: manifest transiently fails — skill should be unregistered
+    mockManifests = {};
+    mockUnregisteredSkillIds = [];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.has('deploy')).toBe(false);
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+    // Ref count should be 0 (properly decremented)
+    expect(mockSkillRefCount.has('deploy')).toBe(false);
+
+    // Turn 3: manifest recovers — skill re-registered with correct ref count
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockUnregisteredSkillIds = [];
+    const result3 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result3.toolDefinitions).toHaveLength(1);
+    expect(sessionState.has('deploy')).toBe(true);
+    // Ref count should be exactly 1, not 2
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+  });
+
   test('preactivated IDs merge with context-derived IDs (dedup)', () => {
     mockCatalog = [makeSkill('deploy')];
     mockManifests = { deploy: makeManifest(['deploy_run']) };

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -156,6 +156,17 @@ export function projectSkillTools(
     }
   }
 
+  // Unregister skills that were previously active but failed processing this
+  // turn (catalog miss, manifest failure, empty tools). Without this, the
+  // skill would be re-registered when it recovers next turn, inflating the
+  // refcount since the prior registration was never decremented.
+  for (const id of prevActive) {
+    if (activeIds.has(id) && !successfulIds.has(id)) {
+      log.info({ skillId: id }, 'Unregistering tools for transiently-failed skill');
+      unregisterSkillTools(id);
+    }
+  }
+
   // Update the session-scoped tracking set in-place — only include skills
   // that were successfully processed so failed skills can be retried next turn.
   prevActive.clear();


### PR DESCRIPTION
## Summary
When a previously-registered skill transiently fails on a subsequent turn (catalog miss, manifest failure, empty tools), it was dropped from `prevActive` without being unregistered. This meant on recovery, `registerSkillTools` was called again, inflating the refcount. Since `resetSkillToolProjection` only decrements once per skill on teardown, the tools would never be cleaned up.

Fix: after the main loop, detect skills that were in `prevActive` but not in `successfulIds` (still active per history but failed processing), and call `unregisterSkillTools` to properly decrement the refcount before dropping them from tracking.

Addresses review feedback on PR #3553.

## Test plan
- [x] Added test: previously-registered skill that transiently fails is unregistered, then re-registered with correct refcount on recovery
- [x] All 43 session-skill-tools tests pass
- [x] Type-check clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
