### PR TITLE
fix: add registry reset for intra-file test isolation and mock cleanup

### DIFF
--- a/assistant/src/__tests__/account-registry.test.ts
+++ b/assistant/src/__tests__/account-registry.test.ts
@@ -47,6 +47,7 @@ const _ctx: ToolContext = {
 };
 
 afterAll(() => {
+  mock.restore();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -47,6 +47,8 @@ mock.module('../tools/registry.js', () => ({
 import { CredentialBroker } from '../tools/credentials/broker.js';
 import { upsertCredentialMetadata, _setMetadataPath } from '../tools/credentials/metadata-store.js';
 import { setSecureKey } from '../security/secure-keys.js';
+
+afterAll(() => { mock.restore(); });
 
 describe('CredentialBroker.browserFill', () => {
   let broker: CredentialBroker;

--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -51,6 +51,8 @@ import { setSecureKey } from '../security/secure-keys.js';
 // ---------------------------------------------------------------------------
 // Tests — serverUse (publish_page / unpublish_page regression)
 // ---------------------------------------------------------------------------
+
+afterAll(() => { mock.restore(); });
 
 describe('CredentialBroker.serverUse', () => {
   let broker: CredentialBroker;

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -38,6 +38,7 @@ _overrideDeps({
 // Restore process-level keychain deps so later test files are not affected
 afterAll(() => {
   _resetDeps();
+  mock.restore();
 });
 
 import { _resetBackend } from '../security/secure-keys.js';

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -150,6 +150,8 @@ async function executeVault(input: Record<string, unknown>): Promise<{ content: 
   }
 }
 
+afterAll(() => { mock.restore(); });
+
 describe('credential_store tool', () => {
   beforeEach(() => {
     _resetBackend();

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
 import { RiskLevel } from '../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../tools/types.js';
 import type { ToolDefinition } from '../providers/types.js';
@@ -16,8 +16,13 @@ import {
   unregisterSkillTools,
   getSkillToolNames,
   getSkillRefCount,
+  __resetRegistryForTesting,
 } from '../tools/registry.js';
 import { eagerModules, explicitTools, lazyTools } from '../tools/tool-manifest.js';
+
+// Clean up global registry after this file completes to prevent
+// contamination of subsequent test files in combined runs.
+afterAll(() => { __resetRegistryForTesting(); });
 
 function makeFakeTool(name: string): Tool {
   return {
@@ -231,6 +236,8 @@ describe('baseline characterization: hardcoded tool loading', () => {
 });
 
 describe('tool origin metadata', () => {
+  beforeEach(() => { __resetRegistryForTesting(); });
+
   test('registers a skill-origin tool and preserves metadata via getTool()', () => {
     const skillTool: Tool = {
       ...makeFakeTool('test-skill-origin-tool'),
@@ -257,6 +264,8 @@ describe('tool origin metadata', () => {
 });
 
 describe('dynamic skill tool registry', () => {
+  beforeEach(() => { __resetRegistryForTesting(); });
+
   test('registers skill tools and retrieves them', () => {
     const tools = [
       makeSkillTool('sk_tool_a', 'my-skill'),
@@ -363,6 +372,8 @@ describe('dynamic skill tool registry', () => {
 });
 
 describe('skill tool reference counting', () => {
+  beforeEach(() => { __resetRegistryForTesting(); });
+
   test('ref count increments on each registerSkillTools call', () => {
     registerSkillTools([makeSkillTool('rc_a', 'rc-skill')]);
     expect(getSkillRefCount('rc-skill')).toBe(1);

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import type { ToolExecutionResult, ToolLifecycleEvent, ToolLifecycleEventHandler } from '../tools/types.js';
 
 // ---------------------------------------------------------------------------
@@ -115,6 +115,8 @@ function makeMockPrompter() {
     dispose: () => {},
   } as unknown as PermissionPrompter;
 }
+
+afterAll(() => { mock.restore(); });
 
 describe('Secret scanner executor integration', () => {
   let executor: ToolExecutor;

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import * as realFs from 'node:fs';
 import type { Message, ToolDefinition } from '../providers/types.js';
 import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
@@ -214,6 +214,8 @@ function skillLoadMessages(content: string): Message[] {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+afterAll(() => { mock.restore(); });
 
 describe('projectSkillTools', () => {
   let sessionState: Set<string>;

--- a/assistant/src/__tests__/signup-e2e.test.ts
+++ b/assistant/src/__tests__/signup-e2e.test.ts
@@ -103,6 +103,7 @@ afterAll(async () => {
   _setStorePath(null);
   _resetBackend();
   _resetDeps();
+  mock.restore();
   try {
     rmSync(testDir, { recursive: true });
   } catch {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import type { ToolExecutionResult, ToolLifecycleEvent } from '../tools/types.js';
 
 const mockConfig = {
@@ -100,6 +100,8 @@ function makePrompter(promptImpl?: () => Promise<{ decision: 'allow' | 'always_a
     dispose: () => {},
   } as unknown as PermissionPrompter;
 }
+
+afterAll(() => { mock.restore(); });
 
 describe('ToolExecutor lifecycle events', () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import type { ToolExecutionResult } from '../tools/types.js';
 
 const mockConfig = {
@@ -90,6 +90,8 @@ function makePrompter(): PermissionPrompter {
     dispose: () => {},
   } as unknown as PermissionPrompter;
 }
+
+afterAll(() => { mock.restore(); });
 
 describe('ToolExecutor allowedToolNames gating', () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/weather-skill-regression.test.ts
+++ b/assistant/src/__tests__/weather-skill-regression.test.ts
@@ -1,14 +1,17 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { weatherCodeToDescription, weatherCodeToSFSymbol } from '../tools/weather/service.js';
-import { getTool } from '../tools/registry.js';
+import { getTool, __resetRegistryForTesting } from '../tools/registry.js';
 import type { ToolContext } from '../tools/types.js';
 
 // ---------------------------------------------------------------------------
 // Regression tests: ensure the skill-loaded path produces the same results
 // as the legacy hardcoded path after the weather tool migration.
 // ---------------------------------------------------------------------------
+
+// Clean up after this file to prevent contamination of later test files.
+afterAll(() => { __resetRegistryForTesting(); });
 
 const CONFIG_DIR = join(dirname(import.meta.dirname!), 'config', 'bundled-skills', 'weather');
 

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -217,3 +217,13 @@ export async function initializeTools(): Promise<void> {
 
   log.info({ count: tools.size }, 'Tools initialized');
 }
+
+/**
+ * Clear all registry state. Exposed exclusively for test isolation —
+ * prevents cross-file contamination when multiple test suites share
+ * a single Bun process.
+ */
+export function __resetRegistryForTesting(): void {
+  tools.clear();
+  skillRefCount.clear();
+}


### PR DESCRIPTION
## Summary
- Add `__resetRegistryForTesting()` to `registry.ts` for clearing global `tools` Map and `skillRefCount` Map between describe blocks
- Add `beforeEach` resets to three describe blocks in `registry.test.ts` that register test tools (tool origin metadata, dynamic skill tool registry, skill tool reference counting)
- Add `afterAll(() => { __resetRegistryForTesting(); })` cleanup to `registry.test.ts` and `weather-skill-regression.test.ts`
- Add `afterAll(() => { mock.restore(); })` to all 10 test files that use `mock.module('../tools/registry.js')` for good hygiene

Note: Cross-file `mock.module` contamination is inherent to Bun's compile-time mock hoisting — the existing `test.sh` runner already handles this correctly by running each file in a separate Bun process.

## Test plan
- [x] `bun test registry.test.ts` passes (31 tests, 0 failures)
- [x] `bun test weather-skill-regression.test.ts` passes (12 tests, 0 failures)
- [x] Full `bun run test` suite passes with same pre-existing failures as main (4 unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
