### PR TITLE
fix: normalize file tool candidates to forward slashes for Windows compatibility

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -772,6 +772,49 @@ describe('Permission Checker', () => {
     });
   });
 
+  // ── default workspace prompt file allow rules ──────────────────
+
+  describe('default workspace prompt file allow rules', () => {
+    test('file_edit of workspace IDENTITY.md is auto-allowed', async () => {
+      const identityPath = join(checkerTestDir, 'workspace', 'IDENTITY.md');
+      const result = await check('file_edit', { path: identityPath }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:allow-file_edit-identity');
+    });
+
+    test('file_read of workspace USER.md is auto-allowed', async () => {
+      const userPath = join(checkerTestDir, 'workspace', 'USER.md');
+      const result = await check('file_read', { path: userPath }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:allow-file_read-user');
+    });
+
+    test('file_write of workspace SOUL.md is auto-allowed', async () => {
+      const soulPath = join(checkerTestDir, 'workspace', 'SOUL.md');
+      const result = await check('file_write', { path: soulPath }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:allow-file_write-soul');
+    });
+
+    test('file_write of workspace BOOTSTRAP.md is auto-allowed', async () => {
+      const bootstrapPath = join(checkerTestDir, 'workspace', 'BOOTSTRAP.md');
+      const result = await check('file_write', { path: bootstrapPath }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:allow-file_write-bootstrap');
+    });
+
+    test('file_write of non-workspace file is not auto-allowed', async () => {
+      const otherPath = join(checkerTestDir, 'workspace', 'OTHER.md');
+      const result = await check('file_write', { path: otherPath }, '/tmp');
+      // Medium risk with no matching allow rule → prompt
+      expect(result.decision).toBe('prompt');
+    });
+  });
+
   // ── generateAllowlistOptions ───────────────────────────────────
 
   describe('generateAllowlistOptions', () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -179,7 +179,7 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
     return candidates;
   }
 
-  const resolved = fileTarget ? resolve(workingDir, fileTarget) : fileTarget;
+  const resolved = fileTarget ? resolve(workingDir, fileTarget).replaceAll('\\', '/') : fileTarget;
   const candidates = [`${toolName}:${resolved}`];
   // Also include the raw path if it differs, so user-created rules with
   // raw paths still match.


### PR DESCRIPTION
## Summary
- In `buildCommandCandidates` in `checker.ts`, the `resolve()` call for file tool candidates (file_read, file_write, file_edit) produces backslash paths on Windows. Since minimatch treats backslashes as escapes, the workspace prompt allow rules from `defaults.ts` (which use forward slashes) would never match on Windows.
- Added `.replaceAll('\\', '/')` to normalize the resolved path to forward slashes, matching the normalization already used in `defaults.ts` for protected directory and workspace prompt patterns.
- Added tests verifying the default workspace prompt file allow rules (IDENTITY.md, USER.md, SOUL.md, BOOTSTRAP.md) work end-to-end via the `check()` function.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All existing checker tests pass (`bun test src/__tests__/checker.test.ts`)
- [x] New workspace prompt file allow rule tests pass (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
