### PR TITLE
fix: scope bootstrap delete rule to workspace directory

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -579,7 +579,11 @@ describe('Trust Store', () => {
       expect(defaults).toHaveLength(NUM_DEFAULTS);
       for (const rule of defaults) {
         expect(rule.priority).toBe(DEFAULT_PRIORITY_BY_ID.get(rule.id)!);
-        expect(rule.scope).toBe('everywhere');
+        if (rule.id === 'default:allow-bash-rm-bootstrap') {
+          expect(rule.scope).toBe(join(testDir, 'workspace'));
+        } else {
+          expect(rule.scope).toBe('everywhere');
+        }
       }
 
       const protectedDefaults = defaults.filter((rule) => rule.id.endsWith('-protected'));
@@ -740,6 +744,18 @@ describe('Trust Store', () => {
       expect(match!.id).toBe('default:ask-request_computer_control-global');
       expect(match!.decision).toBe('ask');
       expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-request_computer_control-global')!);
+    });
+
+    test('bootstrap delete rule matches only when workingDir is the workspace dir', () => {
+      const workspaceDir = join(testDir, 'workspace');
+      // Should match when workingDir is the workspace directory
+      const match = findHighestPriorityRule('bash', ['rm BOOTSTRAP.md'], workspaceDir);
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:allow-bash-rm-bootstrap');
+      expect(match!.decision).toBe('allow');
+      // Should NOT match when workingDir is somewhere else
+      const noMatch = findHighestPriorityRule('bash', ['rm BOOTSTRAP.md'], '/tmp/other-project');
+      expect(noMatch).toBeNull();
     });
 
     test('default ask does not affect files outside protected directory', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -116,7 +116,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     id: 'default:allow-bash-rm-bootstrap',
     tool: 'bash',
     pattern: 'rm BOOTSTRAP.md',
-    scope: 'everywhere',
+    scope: workspaceDir,
     decision: 'allow',
     priority: 100,
   };


### PR DESCRIPTION
## Summary
- Changed `bootstrapDeleteRule` scope from `'everywhere'` to `workspaceDir` in `defaults.ts` so that the auto-allow rule for `rm BOOTSTRAP.md` only applies when the agent is working from within the workspace directory, not from any arbitrary directory.
- Updated the existing default rules backfill test to account for the bootstrap rule having a workspace-scoped scope instead of `'everywhere'`.
- Added a new test verifying the bootstrap delete rule matches only when `workingDir` is the workspace directory and returns `null` when the working directory is elsewhere.

Addresses review feedback from #3554.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/trust-store.test.ts` passes — including the new scope-restriction test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
