### PR TITLE
fix: ride shotgun bug fixes

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -7,7 +7,6 @@ import {
   registerWatchCompletionNotifier,
   unregisterWatchCompletionNotifier,
   fireWatchStartNotifier,
-  fireWatchCompletionNotifier,
 } from '../tools/watch/watch-state.js';
 import type { WatchSession } from '../tools/watch/watch-state.js';
 import { lastSummaryBySession, generateSummary } from './watch-handler.js';
@@ -34,6 +33,7 @@ export async function handleRideShotgunStart(
     commentaryCount: 0,
     status: 'active',
     startedAt: Date.now(),
+    isRideShotgun: true,
   };
 
   watchSessions.set(watchId, session);
@@ -53,18 +53,9 @@ export async function handleRideShotgunStart(
     await generateSummary(session);
     session.status = 'completed';
     log.debug(
-      { watchId, sessionId, hasSummary: lastSummaryBySession.has(sessionId) },
-      'generateSummary returned — checking if completion notifier needs fallback fire',
+      { watchId, sessionId },
+      'generateSummary returned — completion notifier should have fired',
     );
-    // Fallback: if generateSummary failed or returned empty, fire notifier
-    // anyway so the client always receives a response
-    if (!lastSummaryBySession.has(sessionId)) {
-      log.warn(
-        { watchId, sessionId },
-        'No summary in map — firing completion notifier as fallback (will send empty summary)',
-      );
-      fireWatchCompletionNotifier(sessionId, session);
-    }
   }, durationSeconds * 1000);
 
   // Register completion notifier to send summary back to client

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -63,8 +63,8 @@ export async function handleWatchObservation(
       'Observation added to session',
     );
 
-    // 4. Every 3 observations: call Haiku for live commentary
-    if (session.observations.length % 3 === 0) {
+    // 4. Every 3 observations: call Haiku for live commentary (chat-initiated watch only)
+    if (!session.isRideShotgun && session.observations.length % 3 === 0) {
       log.debug(
         { watchId: msg.watchId, observationCount: session.observations.length },
         'Triggering commentary generation (every 3rd observation)',
@@ -85,7 +85,6 @@ export async function handleWatchObservation(
 
 async function generateCommentary(session: WatchSession): Promise<void> {
   try {
-    log.debug({ watchId: session.watchId, sessionId: session.sessionId }, 'generateCommentary starting — calling Haiku');
     const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
       log.warn({ watchId: session.watchId }, 'No Anthropic API key available for commentary generation');
@@ -93,7 +92,6 @@ async function generateCommentary(session: WatchSession): Promise<void> {
     }
     const client = new Anthropic({ apiKey });
     const lastThree = session.observations.slice(-3);
-
     const previousCommentary = lastCommentaryBySession.get(session.sessionId);
 
     const userContent = [
@@ -122,11 +120,6 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       '- If they seem to be context-switching a lot, gently note it.',
       '- Do NOT repeat your previous commentary. Say something new or say nothing.',
       '- If nothing interesting or meaningfully different has happened since the last observations, respond with exactly "SKIP" (no quotes, no extra text).',
-      '',
-      'Example style:',
-      '"I see you\'ve been bouncing between Slack and your doc — looks like you\'re getting pulled into side conversations."',
-      '"You\'ve been heads-down in VS Code for a while now, nice focused stretch."',
-      '"Looks like you just switched to the browser to look something up mid-task."',
     ].join('\n');
 
     const response = await client.messages.create({
@@ -136,34 +129,28 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       messages: [{ role: 'user', content: userContent }],
     });
 
-    log.debug({ watchId: session.watchId }, 'Haiku API call completed successfully');
-
     const textBlock = response.content.find((b) => b.type === 'text');
     const commentaryText =
       textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
-
-    log.debug(
-      { watchId: session.watchId, commentaryLength: commentaryText.length, isSkip: commentaryText === 'SKIP' },
-      'Commentary result from Haiku',
-    );
 
     if (commentaryText && commentaryText !== 'SKIP') {
       lastCommentaryBySession.set(session.sessionId, commentaryText);
       fireWatchCommentaryNotifier(session.sessionId, session);
       session.commentaryCount++;
-      log.debug(
-        { watchId: session.watchId, commentaryCount: session.commentaryCount },
-        'Commentary notifier fired',
-      );
-    } else {
-      log.debug({ watchId: session.watchId }, 'Commentary skipped (empty or SKIP)');
     }
   } catch (err) {
-    log.error({ err, watchId: session.watchId }, 'Error generating watch commentary — API call failed');
+    log.error({ err, watchId: session.watchId }, 'Error generating watch commentary');
   }
 }
 
 export async function generateSummary(session: WatchSession): Promise<void> {
+  // Guard against concurrent calls (timeout + last observation race)
+  if (session.summaryInFlight) {
+    log.debug({ watchId: session.watchId }, 'generateSummary already in flight — skipping duplicate call');
+    return;
+  }
+  session.summaryInFlight = true;
+
   try {
     log.debug(
       { watchId: session.watchId, sessionId: session.sessionId, observationCount: session.observations.length, commentaryCount: session.commentaryCount },
@@ -172,6 +159,8 @@ export async function generateSummary(session: WatchSession): Promise<void> {
     const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
       log.warn({ watchId: session.watchId }, 'No Anthropic API key available for summary generation');
+      lastSummaryBySession.set(session.sessionId, '[error] No Anthropic API key configured. Check your settings.');
+      fireWatchCompletionNotifier(session.sessionId, session);
       return;
     }
     const client = new Anthropic({ apiKey });
@@ -272,9 +261,14 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       log.debug({ watchId: session.watchId, sessionId: session.sessionId }, 'Firing completion notifier with summary');
       fireWatchCompletionNotifier(session.sessionId, session);
     } else {
-      log.warn({ watchId: session.watchId }, 'Summary was empty — completion notifier NOT fired');
+      log.warn({ watchId: session.watchId }, 'Summary was empty from API response');
+      lastSummaryBySession.set(session.sessionId, '[error] The API returned an empty summary. This may indicate a service issue.');
+      fireWatchCompletionNotifier(session.sessionId, session);
     }
   } catch (err) {
     log.error({ err, watchId: session.watchId }, 'Error generating watch summary — Sonnet API call failed');
+    const message = err instanceof Error ? err.message : String(err);
+    lastSummaryBySession.set(session.sessionId, `[error] Summary generation failed: ${message}`);
+    fireWatchCompletionNotifier(session.sessionId, session);
   }
 }

--- a/assistant/src/tools/watch/watch-state.ts
+++ b/assistant/src/tools/watch/watch-state.ts
@@ -22,6 +22,10 @@ export interface WatchSession {
   status: 'active' | 'completing' | 'completed' | 'cancelled';
   startedAt: number;
   timeoutHandle?: ReturnType<typeof setTimeout>;
+  /** Guards against concurrent generateSummary calls */
+  summaryInFlight?: boolean;
+  /** Whether this session was started via ride shotgun (no live commentary) */
+  isRideShotgun?: boolean;
 }
 
 /** Module-level map of watch sessions keyed by watchId. */

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -68,8 +68,8 @@ public final class AmbientAgent: ObservableObject {
         // Check notification authorization; fall back to starting session directly
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         guard settings.authorizationStatus == .authorized else {
-            log.warning("Notifications not authorized; falling back to direct ride shotgun session")
-            startRideShotgun(durationSeconds: 60)
+            log.warning("Notifications not authorized; falling back to direct ride shotgun session (default 3 min)")
+            startRideShotgun(durationSeconds: 180)
             return
         }
 
@@ -142,9 +142,14 @@ public final class AmbientAgent: ObservableObject {
             let hasSession = currentSession != nil
             let summary = currentSession?.summary ?? ""
             log.debug("Session complete: hasSession=\(hasSession) summaryLength=\(summary.count)")
-            showSummary(summary.isEmpty
-                ? "I watched your screen but wasn't able to generate a report. This can happen if the analysis timed out or there was an API error."
-                : summary)
+            if summary.isEmpty {
+                showSummary("I watched your screen but wasn't able to generate a report. No response was received from the daemon.")
+            } else if summary.hasPrefix("[error]") {
+                let errorDetail = String(summary.dropFirst("[error] ".count))
+                showSummary("Something went wrong during analysis:\n\n\(errorDetail)")
+            } else {
+                showSummary(summary)
+            }
             rideShotgunTrigger.recordCompleted()
             sessionCancellable?.cancel()
             sessionCancellable = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -329,80 +329,9 @@ struct ConstellationView: View {
                 endRadius: min(size.width, size.height) * 0.5
             )
 
-            // Center → hub branches
-            ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-                let hubKey = "hub-\(group.category.rawValue)"
-                let hubPos = effectivePos(hubBasePositions[groupIdx], key: hubKey)
-                BranchShape(from: center, to: hubPos)
-                    .stroke(group.category.color.opacity(0.25), lineWidth: 1.5)
-                    .opacity(phase.hubBranchesVisible ? 1 : 0)
-                    .animation(
-                        .easeIn(duration: 0.3).delay(0.20 + Double(groupIdx) * 0.04),
-                        value: phase
-                    )
-            }
-
-            // Hub → leaf branches
-            ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-                let hubKey = "hub-\(group.category.rawValue)"
-                let hubPos = effectivePos(hubBasePositions[groupIdx], key: hubKey)
-                let leafBasePositions = computeLeafPositions(
-                    hub: hubBasePositions[groupIdx], center: center, radius: leafRadius,
-                    count: group.items.count
-                )
-
-                ForEach(Array(group.items.enumerated()), id: \.element.id) { leafIdx, item in
-                    let leafPos = effectivePos(leafBasePositions[leafIdx], key: item.id)
-                    BranchShape(from: hubPos, to: leafPos)
-                        .stroke(group.category.color.opacity(0.18), lineWidth: 1)
-                        .opacity(phase.leafBranchesVisible ? 1 : 0)
-                        .animation(
-                            .easeIn(duration: 0.25).delay(0.35 + Double(groupIdx) * 0.04 + Double(leafIdx) * 0.03),
-                            value: phase
-                        )
-                }
-            }
-
-            // Hub labels (draggable)
-            ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-                let hubKey = "hub-\(group.category.rawValue)"
-                DraggableNode(nodeKey: hubKey, offsets: $nodeOffsets) {
-                    CategoryHubLabel(category: group.category, itemCount: group.items.count)
-                }
-                .position(hubBasePositions[groupIdx])
-                .scaleEffect(phase.hubsVisible ? 1 : 0.3)
-                .opacity(phase.hubsVisible ? 1 : 0)
-                .animation(
-                    .spring(response: 0.45, dampingFraction: 0.7)
-                        .delay(0.12 + Double(groupIdx) * 0.05),
-                    value: phase
-                )
-            }
-
-            // Leaf pills (draggable)
-            ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-                let leafBasePositions = computeLeafPositions(
-                    hub: hubBasePositions[groupIdx], center: center, radius: leafRadius,
-                    count: group.items.count
-                )
-
-                ForEach(Array(group.items.enumerated()), id: \.element.id) { leafIdx, item in
-                    DraggableNode(nodeKey: item.id, offsets: $nodeOffsets) {
-                        ConstellationPill(
-                            label: item.label, icon: item.icon,
-                            emoji: item.emoji, color: item.color
-                        )
-                    }
-                    .position(leafBasePositions[leafIdx])
-                    .scaleEffect(phase.leavesVisible ? 1 : 0.4)
-                    .opacity(phase.leavesVisible ? 1 : 0)
-                    .animation(
-                        .spring(response: 0.5, dampingFraction: 0.7)
-                            .delay(0.25 + Double(groupIdx) * 0.06 + Double(leafIdx) * 0.04),
-                        value: phase
-                    )
-                }
-            }
+            canvasBranches(center: center, hubBasePositions: hubBasePositions, leafRadius: leafRadius, layoutGroups: layoutGroups)
+            canvasHubs(hubBasePositions: hubBasePositions, layoutGroups: layoutGroups)
+            canvasLeaves(center: center, hubBasePositions: hubBasePositions, leafRadius: leafRadius, layoutGroups: layoutGroups)
 
             // Center dino face — non-interactive so drags pass to canvas pan
             DinoFaceView(seed: identity?.name ?? "default")
@@ -415,6 +344,96 @@ struct ConstellationView: View {
                     .spring(response: 0.5, dampingFraction: 0.7).delay(0.05),
                     value: phase
                 )
+        }
+    }
+
+    @ViewBuilder
+    private func canvasBranches(center: CGPoint, hubBasePositions: [CGPoint], leafRadius: CGFloat, layoutGroups: [CategoryGroup]) -> some View {
+        // Center → hub branches
+        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
+            let hubKey = "hub-\(group.category.rawValue)"
+            let hubPos = effectivePos(hubBasePositions[groupIdx], key: hubKey)
+            BranchShape(from: center, to: hubPos)
+                .stroke(group.category.color.opacity(0.25), lineWidth: 1.5)
+                .opacity(phase.hubBranchesVisible ? 1 : 0)
+                .animation(
+                    .easeIn(duration: 0.3).delay(0.20 + Double(groupIdx) * 0.04),
+                    value: phase
+                )
+        }
+
+        // Hub → leaf branches
+        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
+            let hubKey = "hub-\(group.category.rawValue)"
+            let hubPos = effectivePos(hubBasePositions[groupIdx], key: hubKey)
+            let leafBasePositions = computeLeafPositions(
+                hub: hubBasePositions[groupIdx], center: center, radius: leafRadius,
+                count: group.items.count
+            )
+
+            ForEach(Array(group.items.enumerated()), id: \.element.id) { leafIdx, item in
+                let leafPos = effectivePos(leafBasePositions[leafIdx], key: item.id)
+                BranchShape(from: hubPos, to: leafPos)
+                    .stroke(group.category.color.opacity(0.18), lineWidth: 1)
+                    .opacity(phase.leafBranchesVisible ? 1 : 0)
+                    .animation(
+                        .easeIn(duration: 0.25).delay(0.35 + Double(groupIdx) * 0.04 + Double(leafIdx) * 0.03),
+                        value: phase
+                    )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func canvasHubs(hubBasePositions: [CGPoint], layoutGroups: [CategoryGroup]) -> some View {
+        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
+            let hubKey = "hub-\(group.category.rawValue)"
+            DraggableNode(nodeKey: hubKey, offsets: $nodeOffsets) {
+                CategoryHubLabel(category: group.category, itemCount: group.items.count)
+            }
+            .position(hubBasePositions[groupIdx])
+            .scaleEffect(phase.hubsVisible ? 1 : 0.3)
+            .opacity(phase.hubsVisible ? 1 : 0)
+            .animation(
+                .spring(response: 0.45, dampingFraction: 0.7)
+                    .delay(0.12 + Double(groupIdx) * 0.05),
+                value: phase
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func canvasLeaves(center: CGPoint, hubBasePositions: [CGPoint], leafRadius: CGFloat, layoutGroups: [CategoryGroup]) -> some View {
+        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
+            canvasLeafGroup(
+                groupIdx: groupIdx, group: group, center: center,
+                hubPosition: hubBasePositions[groupIdx], leafRadius: leafRadius
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func canvasLeafGroup(groupIdx: Int, group: CategoryGroup, center: CGPoint, hubPosition: CGPoint, leafRadius: CGFloat) -> some View {
+        let leafBasePositions = computeLeafPositions(
+            hub: hubPosition, center: center, radius: leafRadius,
+            count: group.items.count
+        )
+
+        ForEach(Array(group.items.enumerated()), id: \.element.id) { leafIdx, item in
+            DraggableNode(nodeKey: item.id, offsets: $nodeOffsets) {
+                ConstellationPill(
+                    label: item.label, icon: item.icon,
+                    emoji: item.emoji, color: item.color
+                )
+            }
+            .position(leafBasePositions[leafIdx])
+            .scaleEffect(phase.leavesVisible ? 1 : 0.4)
+            .opacity(phase.leavesVisible ? 1 : 0)
+            .animation(
+                .spring(response: 0.5, dampingFraction: 0.7)
+                    .delay(0.25 + Double(groupIdx) * 0.06 + Double(leafIdx) * 0.04),
+                value: phase
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- **Race condition**: Added `summaryInFlight` guard on `WatchSession` to prevent `generateSummary` from being called twice (timeout handler + late observation handler)
- **Silent failures**: Missing API key, empty API response, and API errors now propagate specific `[error]` messages to the client instead of showing a generic fallback or silently dropping the session
- **Wasted API calls**: Commentary generation (Haiku every 3 observations) was running during ride shotgun sessions but never displayed — now skipped via `isRideShotgun` flag; chat-initiated watch still gets commentary
- **Fallback duration**: Notification-denied fallback changed from hardcoded 60s to 180s (matches middle notification option)

## Test plan
- [ ] Start a ride shotgun session and verify summary arrives with no duplicate API calls in daemon logs
- [ ] Remove API key and start a session — verify client shows "No Anthropic API key configured" error
- [ ] Confirm chat-initiated watch (`start_screen_watch` tool) still generates live commentary
- [ ] Deny notification permissions and verify ride shotgun falls back to 3-minute session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
