### PR TITLE
fix(ui): restrict composer auto-scroll to end-of-text edits and fix stale height check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -573,6 +573,28 @@ private struct ComposerTextView: NSViewRepresentable {
                 lastReportedHeight = clampedHeight
                 parent.onHeightChange(clampedHeight)
             }
+
+            // Auto-scroll the composer's NSScrollView to keep the cursor visible
+            // when content overflows the max height. Only scroll when the caret is
+            // at the end of the text so that in-place edits in the middle of a long
+            // draft don't jump the viewport to the bottom (addresses Codex P2 feedback).
+            // Checking inside syncHeight (rather than only on text change) also
+            // catches the first overflow after a paste or keystroke that pushes
+            // content past the threshold, since syncHeight fires whenever the
+            // layout updates (addresses Devin stale-height feedback).
+            if rawHeight > parent.maxHeight {
+                let insertionPoint = textView.selectedRange().location
+                let isAtEnd = insertionPoint >= (textView.string as NSString).length
+                if isAtEnd, let scrollView = textView.enclosingScrollView {
+                    let contentHeight = scrollView.documentView?.frame.height ?? 0
+                    let visibleHeight = scrollView.contentView.bounds.height
+                    if contentHeight > visibleHeight {
+                        let bottomPoint = NSPoint(x: 0, y: contentHeight - visibleHeight)
+                        scrollView.contentView.scroll(to: bottomPoint)
+                        scrollView.reflectScrolledClipView(scrollView.contentView)
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Restrict composer auto-scroll to only trigger when the cursor is at the end of the text, preventing viewport jumps when editing the middle of long drafts (Codex P2 feedback on #2149)
- Fix stale height check by placing auto-scroll logic inside `syncHeight()` which runs after layout, ensuring the first overflow is caught reliably (Devin feedback on #2149)

## Test plan
- [ ] Type a long message (>200pt / ~15+ lines) in the composer and verify it auto-scrolls to bottom as you type
- [ ] Click into the middle of a long message and edit — verify the viewport does NOT jump to the bottom
- [ ] Paste a large block of text into an empty composer — verify it auto-scrolls to the bottom on the first paste (not requiring a subsequent keystroke)
- [ ] Clear the composer and verify height resets normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
