### PR TITLE
PR 1: Baseline characterization — skill directory mutation is currently possible

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1022,4 +1022,57 @@ describe('Permission Checker', () => {
       expect(options[2].scope).toBe('/var/data');
     });
   });
+
+  // ── baseline: skill directory mutation is currently possible ──
+  // These tests lock the current behavior where file_write/file_edit
+  // targeting skill source directories are treated identically to any
+  // other workspace file — no special risk escalation or default ask
+  // rules exist for skill paths yet.
+
+  describe('baseline: skill directory mutation (PR 1)', () => {
+    test('file_write to skill directory is Medium risk (same as any file_write)', async () => {
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'executor.ts');
+      const risk = await classifyRisk('file_write', { path: skillPath });
+      expect(risk).toBe(RiskLevel.Medium);
+    });
+
+    test('file_edit of skill file is Medium risk (same as any file_edit)', async () => {
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'SKILL.md');
+      const risk = await classifyRisk('file_edit', { path: skillPath });
+      expect(risk).toBe(RiskLevel.Medium);
+    });
+
+    test('file_read of skill file is Low risk (same as any file_read)', async () => {
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'TOOLS.json');
+      const risk = await classifyRisk('file_read', { path: skillPath });
+      expect(risk).toBe(RiskLevel.Low);
+    });
+
+    test('file_write to skill directory has no special default ask rule', async () => {
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'executor.ts');
+      const result = await check('file_write', { path: skillPath }, '/tmp');
+      // Medium risk with no matching rule → prompt via risk-based fallback,
+      // NOT via a dedicated skill-path ask rule.
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('risk');
+      expect(result.matchedRule).toBeUndefined();
+    });
+
+    test('file_write to skill directory is allowed with a generic file_write allow rule', async () => {
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'executor.ts');
+      addRule('file_write', `file_write:${checkerTestDir}/skills/**`, '/tmp');
+      const result = await check('file_write', { path: skillPath }, '/tmp');
+      // A broad file_write allow rule currently permits skill-dir writes
+      // without any special approval — this is the gap we want to close.
+      expect(result.decision).toBe('allow');
+    });
+
+    test('host_file_write to skill directory prompts via generic host ask rule (not skill-specific)', async () => {
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'executor.ts');
+      const result = await check('host_file_write', { path: skillPath }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      // Should match the generic host_file_write ask rule, not a skill-specific one
+      expect(result.matchedRule?.id).toBe('default:ask-host_file_write-global');
+    });
+  });
 });

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -149,3 +149,36 @@ describe('hostPolicy', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Baseline: Skill directory paths have no special treatment (PR 1)
+// ---------------------------------------------------------------------------
+
+describe('baseline: skill directory paths (PR 1)', () => {
+  test('sandbox policy accepts skill directory paths within boundary', () => {
+    const boundary = makeTempDir();
+    mkdirSync(join(boundary, 'skills', 'my-skill'), { recursive: true });
+
+    const result = sandboxPolicy('skills/my-skill/executor.ts', boundary, { mustExist: false });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(boundary, 'skills', 'my-skill', 'executor.ts'));
+    }
+  });
+
+  test('sandbox policy treats skill TOOLS.json same as any other file', () => {
+    const boundary = makeTempDir();
+    mkdirSync(join(boundary, 'skills', 'my-skill'), { recursive: true });
+
+    const result = sandboxPolicy('skills/my-skill/TOOLS.json', boundary, { mustExist: false });
+    expect(result.ok).toBe(true);
+  });
+
+  test('host policy accepts absolute skill directory path', () => {
+    const result = hostPolicy('/Users/test/.vellum/workspace/skills/my-skill/executor.ts');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe('/Users/test/.vellum/workspace/skills/my-skill/executor.ts');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds baseline tests to `checker.test.ts` and `path-policy.test.ts` demonstrating that skill-directory file paths are currently treated as regular workspace paths
- Locks current risk classification and permission outcomes for skill paths so later hardening is measurable

## Test plan
- [x] `bun test src/__tests__/checker.test.ts src/__tests__/path-policy.test.ts` — 152 tests pass

Part of: Skill Tool Security rollout (PR 1/40)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
