### PR TITLE
PR 4: Add deterministic skill version hash utility

### DIFF
--- a/assistant/src/__tests__/skill-version-hash.test.ts
+++ b/assistant/src/__tests__/skill-version-hash.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { computeSkillVersionHash } from '../skills/version-hash.js';
+
+const testDirs: string[] = [];
+
+function makeTempSkill(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-hash-test-'));
+  testDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('computeSkillVersionHash', () => {
+  test('returns a v1: prefixed sha256 hash', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'SKILL.md'), '# My Skill\n');
+    const hash = computeSkillVersionHash(dir);
+    expect(hash).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+
+  test('is deterministic for same content', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'SKILL.md'), '# My Skill\n');
+    writeFileSync(join(dir, 'executor.ts'), 'export const run = () => {};');
+    const hash1 = computeSkillVersionHash(dir);
+    const hash2 = computeSkillVersionHash(dir);
+    expect(hash1).toBe(hash2);
+  });
+
+  test('changes when file content changes', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'executor.ts'), 'export const run = () => "v1";');
+    const hash1 = computeSkillVersionHash(dir);
+
+    writeFileSync(join(dir, 'executor.ts'), 'export const run = () => "v2";');
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test('changes when a new file is added', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'SKILL.md'), '# Skill\n');
+    const hash1 = computeSkillVersionHash(dir);
+
+    writeFileSync(join(dir, 'extra.ts'), 'export {};');
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test('is insensitive to file traversal order', () => {
+    // Create two directories with the same files in different creation order
+    const dir1 = makeTempSkill();
+    writeFileSync(join(dir1, 'b.ts'), 'b');
+    writeFileSync(join(dir1, 'a.ts'), 'a');
+
+    const dir2 = makeTempSkill();
+    writeFileSync(join(dir2, 'a.ts'), 'a');
+    writeFileSync(join(dir2, 'b.ts'), 'b');
+
+    expect(computeSkillVersionHash(dir1)).toBe(computeSkillVersionHash(dir2));
+  });
+
+  test('excludes .vellum-skill-run directory', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'SKILL.md'), '# Skill\n');
+    const hash1 = computeSkillVersionHash(dir);
+
+    mkdirSync(join(dir, '.vellum-skill-run'), { recursive: true });
+    writeFileSync(join(dir, '.vellum-skill-run', 'state.json'), '{}');
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  test('excludes node_modules directory', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'SKILL.md'), '# Skill\n');
+    const hash1 = computeSkillVersionHash(dir);
+
+    mkdirSync(join(dir, 'node_modules', 'dep'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules', 'dep', 'index.js'), 'module.exports = {};');
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  test('includes subdirectory files', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'SKILL.md'), '# Skill\n');
+    const hash1 = computeSkillVersionHash(dir);
+
+    mkdirSync(join(dir, 'tools'), { recursive: true });
+    writeFileSync(join(dir, 'tools', 'helper.ts'), 'export {};');
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test('empty directory produces a consistent hash', () => {
+    const dir = makeTempSkill();
+    const hash = computeSkillVersionHash(dir);
+    expect(hash).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+});

--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -1,0 +1,76 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createHash } from 'node:crypto';
+
+/**
+ * Directories/files to exclude from skill hashing — these are transient
+ * runtime artifacts that do not affect the skill's behavior.
+ */
+const EXCLUDED_NAMES = new Set([
+  '.vellum-skill-run',
+  'node_modules',
+  '.git',
+  '__pycache__',
+  '.DS_Store',
+]);
+
+/**
+ * Collect all files under `dir` in sorted order, excluding transient entries.
+ */
+function collectFiles(dir: string, base: string): string[] {
+  const entries: string[] = [];
+
+  let items: string[];
+  try {
+    items = readdirSync(dir).sort();
+  } catch {
+    return entries;
+  }
+
+  for (const name of items) {
+    if (EXCLUDED_NAMES.has(name)) continue;
+    const full = join(dir, name);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      entries.push(...collectFiles(full, base));
+    } else if (stat.isFile()) {
+      entries.push(relative(base, full));
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Compute a deterministic version hash for a skill directory.
+ *
+ * The hash is computed from:
+ * - Sorted relative file paths (normalized to forward slashes)
+ * - File content lengths
+ * - File content bytes
+ *
+ * The result is a canonical string in the format `v1:<hex-sha256>`.
+ * File traversal order does not affect the result.
+ */
+export function computeSkillVersionHash(skillDir: string): string {
+  const files = collectFiles(skillDir, skillDir);
+  const hash = createHash('sha256');
+
+  for (const relPath of files) {
+    const normalized = relPath.replaceAll('\\', '/');
+    const content = readFileSync(join(skillDir, relPath));
+    hash.update(normalized);
+    hash.update('\0');
+    hash.update(String(content.length));
+    hash.update('\0');
+    hash.update(content);
+    hash.update('\n');
+  }
+
+  return `v1:${hash.digest('hex')}`;
+}


### PR DESCRIPTION
## Summary
- Add `computeSkillVersionHash()` in `assistant/src/skills/version-hash.ts` that produces a canonical `v1:<sha256>` digest from sorted file paths and content within a skill directory
- Excludes transient artifacts (node_modules, .vellum-skill-run, .git, __pycache__, .DS_Store) so the hash reflects only behavioral code
- 9 tests covering determinism, content sensitivity, exclusion rules, subdirectory inclusion, and traversal-order independence

## Test plan
- [x] All 9 tests pass (`bun test src/__tests__/skill-version-hash.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
