### PR TITLE
feat: surface skill version hash in catalog metadata

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -273,6 +273,7 @@ describe('tool manifest detection', () => {
       valid: true,
       toolCount: 2,
       toolNames: ['run-lint', 'run-test'],
+      versionHash: expect.stringMatching(/^v1:[0-9a-f]{64}$/),
     });
   });
 
@@ -291,6 +292,7 @@ describe('tool manifest detection', () => {
       valid: false,
       toolCount: 0,
       toolNames: [],
+      versionHash: expect.stringMatching(/^v1:[0-9a-f]{64}$/),
     });
   });
 
@@ -310,6 +312,7 @@ describe('tool manifest detection', () => {
       valid: false,
       toolCount: 0,
       toolNames: [],
+      versionHash: expect.stringMatching(/^v1:[0-9a-f]{64}$/),
     });
   });
 
@@ -318,6 +321,61 @@ describe('tool manifest detection', () => {
 
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === 'no-tools');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toBeUndefined();
+  });
+
+  test('versionHash is a v1: prefixed string when TOOLS.json is valid', () => {
+    writeSkill('hash-valid', 'Hash Valid Skill', 'Skill with valid tools for hash check');
+    const toolsJson = {
+      version: 1,
+      tools: [
+        {
+          name: 'hash-tool',
+          description: 'A tool for hash testing',
+          category: 'test',
+          risk: 'low',
+          input_schema: { type: 'object', properties: {} },
+          executor: 'run.sh',
+          execution_target: 'host',
+        },
+      ],
+    };
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'hash-valid', 'TOOLS.json'),
+      JSON.stringify(toolsJson),
+    );
+
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'hash-valid');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toBeDefined();
+    expect(typeof skill!.toolManifest!.versionHash).toBe('string');
+    expect(skill!.toolManifest!.versionHash).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+
+  test('versionHash is computed even when TOOLS.json is invalid', () => {
+    writeSkill('hash-invalid', 'Hash Invalid Skill', 'Skill with invalid tools for hash check');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'hash-invalid', 'TOOLS.json'),
+      '{ broken json',
+    );
+
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'hash-invalid');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toBeDefined();
+    expect(skill!.toolManifest!.valid).toBe(false);
+    // Hash is based on the directory content, not manifest validity
+    expect(typeof skill!.toolManifest!.versionHash).toBe('string');
+    expect(skill!.toolManifest!.versionHash).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+
+  test('toolManifest is undefined when TOOLS.json is absent (no hash computed)', () => {
+    writeSkill('hash-absent', 'Hash Absent Skill', 'Skill without tools for hash check');
+
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'hash-absent');
     expect(skill).toBeDefined();
     expect(skill!.toolManifest).toBeUndefined();
   });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -6,6 +6,7 @@ import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { stripCommentLines } from './system-prompt.js';
 import { parseToolManifestFile } from '../skills/tool-manifest.js';
+import { computeSkillVersionHash } from '../skills/version-hash.js';
 
 const log = getLogger('skills');
 
@@ -114,6 +115,8 @@ export interface SkillToolManifestMeta {
   toolCount: number;
   /** Tool names declared in the manifest (empty if invalid). */
   toolNames: string[];
+  /** Deterministic content hash of the skill directory (`v1:<hex-sha256>`). */
+  versionHash?: string;
 }
 
 // ─── Requirements check ──────────────────────────────────────────────────────
@@ -324,6 +327,13 @@ function detectToolManifest(directoryPath: string): SkillToolManifestMeta | unde
     return undefined;
   }
 
+  let versionHash: string | undefined;
+  try {
+    versionHash = computeSkillVersionHash(directoryPath);
+  } catch (err) {
+    log.warn({ err, directoryPath }, 'Failed to compute skill version hash');
+  }
+
   try {
     const manifest = parseToolManifestFile(manifestPath);
     return {
@@ -331,6 +341,7 @@ function detectToolManifest(directoryPath: string): SkillToolManifestMeta | unde
       valid: true,
       toolCount: manifest.tools.length,
       toolNames: manifest.tools.map((t) => t.name),
+      versionHash,
     };
   } catch (err) {
     log.warn({ err, manifestPath }, 'Failed to parse TOOLS.json manifest');
@@ -339,6 +350,7 @@ function detectToolManifest(directoryPath: string): SkillToolManifestMeta | unde
       valid: false,
       toolCount: 0,
       toolNames: [],
+      versionHash,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Extends `SkillToolManifestMeta` with an optional `versionHash?: string` field containing a deterministic `v1:<hex-sha256>` hash of the skill directory contents.
- Updates `detectToolManifest()` to compute the hash via `computeSkillVersionHash()` (from PR 4) and attach it to the returned metadata — for both valid and invalid manifests.
- Adds 3 new tests verifying: hash present on valid manifests, hash present on invalid manifests, and no hash when TOOLS.json is absent (toolManifest remains undefined).

## Test plan
- [x] All 19 existing + new skills tests pass (`bun test src/__tests__/skills.test.ts`)
- [x] Hash format matches `v1:<64-hex-chars>` regex
- [x] Hash is computed even when TOOLS.json is invalid (hash is directory-based, not manifest-validity-based)
- [x] Existing behavior preserved: no toolManifest when TOOLS.json is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)