### PR TITLE
feat: execution target accuracy for skill tools

### DIFF
--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -54,6 +54,39 @@ mock.module('../memory/tool-usage-store.js', () => ({
 mock.module('../tools/registry.js', () => ({
   getTool: (name: string) => {
     if (name === 'unknown_tool') return undefined;
+    // Skill tools carry origin and executionTarget from their manifest
+    if (name === 'skill_host_tool') {
+      return {
+        name,
+        description: 'skill host tool',
+        category: 'skill',
+        defaultRiskLevel: 'low',
+        origin: 'skill' as const,
+        ownerSkillId: 'test-skill',
+        executionTarget: 'host' as const,
+        getDefinition: () => ({}),
+        execute: async () => {
+          if (toolThrow) throw toolThrow;
+          return fakeToolResult;
+        },
+      };
+    }
+    if (name === 'skill_sandbox_tool') {
+      return {
+        name,
+        description: 'skill sandbox tool',
+        category: 'skill',
+        defaultRiskLevel: 'low',
+        origin: 'skill' as const,
+        ownerSkillId: 'test-skill',
+        executionTarget: 'sandbox' as const,
+        getDefinition: () => ({}),
+        execute: async () => {
+          if (toolThrow) throw toolThrow;
+          return fakeToolResult;
+        },
+      };
+    }
     return {
       name,
       description: 'test tool',
@@ -283,6 +316,36 @@ describe('ToolExecutor lifecycle events', () => {
     expect(startEvent.executionTarget).toBe('host');
     const executedEvent = events.find((e) => e.type === 'executed' || e.type === 'error');
     expect(executedEvent?.executionTarget).toBe('host');
+  });
+
+  test('skill tool with host execution_target resolves to host executionTarget', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute('skill_host_tool', { query: 'test' }, makeContext(events));
+
+    expect(events.map((event) => event.type)).toEqual(['start', 'executed']);
+    const startEvent = events[0];
+    if (startEvent.type !== 'start') throw new Error('Expected start event');
+    expect(startEvent.executionTarget).toBe('host');
+    const executed = events[1];
+    if (executed.type !== 'executed') throw new Error('Expected executed event');
+    expect(executed.executionTarget).toBe('host');
+  });
+
+  test('skill tool with sandbox execution_target resolves to sandbox executionTarget', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute('skill_sandbox_tool', { query: 'test' }, makeContext(events));
+
+    expect(events.map((event) => event.type)).toEqual(['start', 'executed']);
+    const startEvent = events[0];
+    if (startEvent.type !== 'start') throw new Error('Expected start event');
+    expect(startEvent.executionTarget).toBe('sandbox');
+    const executed = events[1];
+    if (executed.type !== 'executed') throw new Error('Expected executed event');
+    expect(executed.executionTarget).toBe('sandbox');
   });
 
   test('does not block tool execution on unresolved lifecycle callbacks', async () => {

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -505,11 +505,17 @@ function resolveExecutionTarget(toolName: string): ExecutionTarget {
   if (toolName.startsWith('host_') || toolName.startsWith('computer_use_') || toolName === 'request_computer_control') {
     return 'host';
   }
+  const tool = getTool(toolName);
   // Check the tool's executionMode metadata — proxy tools run on the connected
   // client (host), not inside the sandbox.
-  const tool = getTool(toolName);
   if (tool?.executionMode === 'proxy') {
     return 'host';
+  }
+  // Skill tools carry an explicit execution target from their manifest entry.
+  // Trust the manifest value so lifecycle events accurately reflect where the
+  // tool script actually runs.
+  if (tool?.executionTarget) {
+    return tool.executionTarget;
   }
   return 'sandbox';
 }

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -1,4 +1,4 @@
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ExecutionTarget, Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { SkillToolEntry } from '../../config/skills.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { RiskLevel } from '../../permissions/types.js';
@@ -27,6 +27,7 @@ export function createSkillTool(
     defaultRiskLevel: riskMap[entry.risk],
     origin: 'skill',
     ownerSkillId: skillId,
+    executionTarget: entry.execution_target as ExecutionTarget,
 
     getDefinition(): ToolDefinition {
       return {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -152,6 +152,9 @@ export interface Tool {
   ownerSkillId?: string;
   /** Content-hash of the owning skill's source at registration time. */
   ownerSkillVersionHash?: string;
+  /** Declared execution target from the skill manifest. Used by resolveExecutionTarget
+   * to accurately label lifecycle events for skill-provided tools. */
+  executionTarget?: ExecutionTarget;
   getDefinition(): ToolDefinition;
   execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult>;
 }


### PR DESCRIPTION
## Summary
- Added `executionTarget?: ExecutionTarget` field to the `Tool` interface so skill tools can carry their manifest-declared execution target
- Updated `createSkillTool` to populate `executionTarget` from the manifest's `execution_target` field
- Updated `resolveExecutionTarget` in `executor.ts` to check `tool.executionTarget` when present, so lifecycle events for skill tools report the correct target ('host' or 'sandbox') instead of always defaulting to 'sandbox'
- Added tests for both host and sandbox skill tool lifecycle event targets

## Test plan
- [x] Existing lifecycle event tests pass (12/12)
- [x] Skill tool factory tests pass (11/11)
- [x] New test: skill tool with `execution_target: 'host'` emits `executionTarget: 'host'` in lifecycle events
- [x] New test: skill tool with `execution_target: 'sandbox'` emits `executionTarget: 'sandbox'` in lifecycle events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
