### PR TITLE
feat: add skill version hash to runtime tool objects

### DIFF
--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -82,6 +82,19 @@ describe('createSkillTool', () => {
     expect(tool.ownerSkillId).toBe('weather-skill');
   });
 
+  test('sets ownerSkillVersionHash when versionHash is provided', () => {
+    const hash = 'v1:abc123def456';
+    const tool = createSkillTool(makeEntry(), 'my-skill', '/skills/my-skill', hash);
+
+    expect(tool.ownerSkillVersionHash).toBe(hash);
+  });
+
+  test('ownerSkillVersionHash is undefined when no versionHash is provided', () => {
+    const tool = createSkillTool(makeEntry(), 'my-skill', '/skills/my-skill');
+
+    expect(tool.ownerSkillVersionHash).toBeUndefined();
+  });
+
   test.each([
     ['low', RiskLevel.Low],
     ['medium', RiskLevel.Medium],
@@ -191,5 +204,29 @@ describe('createSkillToolsFromManifest', () => {
     const tools = createSkillToolsFromManifest([], 'empty-skill', '/skills/empty');
 
     expect(tools).toEqual([]);
+  });
+
+  test('passes versionHash through to all created tools', () => {
+    const hash = 'v1:deadbeef';
+    const entries: SkillToolEntry[] = [
+      makeEntry({ name: 'alpha' }),
+      makeEntry({ name: 'beta' }),
+    ];
+
+    const tools = createSkillToolsFromManifest(entries, 'versioned-skill', '/skills/versioned', hash);
+
+    for (const tool of tools) {
+      expect(tool.ownerSkillVersionHash).toBe(hash);
+    }
+  });
+
+  test('ownerSkillVersionHash is undefined when no versionHash passed to manifest function', () => {
+    const entries: SkillToolEntry[] = [
+      makeEntry({ name: 'gamma' }),
+    ];
+
+    const tools = createSkillToolsFromManifest(entries, 'no-hash-skill', '/skills/no-hash');
+
+    expect(tools[0].ownerSkillVersionHash).toBeUndefined();
   });
 });

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -19,6 +19,7 @@ export function createSkillTool(
   entry: SkillToolEntry,
   skillId: string,
   skillDir: string,
+  versionHash?: string,
 ): Tool {
   return {
     name: entry.name,
@@ -28,6 +29,7 @@ export function createSkillTool(
     origin: 'skill',
     ownerSkillId: skillId,
     executionTarget: entry.execution_target as ExecutionTarget,
+    ownerSkillVersionHash: versionHash,
 
     getDefinition(): ToolDefinition {
       return {
@@ -52,6 +54,7 @@ export function createSkillToolsFromManifest(
   entries: SkillToolEntry[],
   skillId: string,
   skillDir: string,
+  versionHash?: string,
 ): Tool[] {
-  return entries.map(entry => createSkillTool(entry, skillId, skillDir));
+  return entries.map(entry => createSkillTool(entry, skillId, skillDir, versionHash));
 }


### PR DESCRIPTION
## Summary
- Add optional `versionHash` parameter to `createSkillTool` and `createSkillToolsFromManifest` in `skill-tool-factory.ts`
- When provided, the hash is set on the returned Tool object's `ownerSkillVersionHash` field (added to the Tool interface in PR 3)
- Add tests verifying the hash is correctly passed through by both functions, and that it remains undefined when omitted

## Test plan
- [x] Existing tests continue to pass (no breaking changes -- parameter is optional)
- [x] New tests verify `ownerSkillVersionHash` is set when hash is provided
- [x] New tests verify `ownerSkillVersionHash` is undefined when no hash is provided
- [x] New tests verify `createSkillToolsFromManifest` passes hash through to all created tools
- [x] All 15 tests pass via `bun test`

Part of the skill-tool security plan (PR 6 of 7).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
