### PR TITLE
feat: add expected version hash option to skill script runner contract

### DIFF
--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';
+import type { RunSkillToolScriptOptions } from '../tools/skills/skill-script-runner.js';
 import type { ToolContext } from '../tools/types.js';
 
 // ---------------------------------------------------------------------------
@@ -133,5 +134,44 @@ describe('runSkillToolScript — errors', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('escapes the skill directory');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runner options — expectedSkillVersionHash & skillDirHashResolver
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript — version hash options', () => {
+  test('accepts expectedSkillVersionHash option without affecting execution', async () => {
+    const result = await runSkillToolScript(tempDir, 'success.ts', { name: 'world' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:abc123',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('hello from world');
+  });
+
+  test('accepts skillDirHashResolver option without affecting execution', async () => {
+    const resolver = (_dir: string) => 'v1:custom-hash';
+    const result = await runSkillToolScript(tempDir, 'success.ts', { name: 'world' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:abc123',
+      skillDirHashResolver: resolver,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('hello from world');
+  });
+
+  test('RunSkillToolScriptOptions type accepts all new fields', () => {
+    const options: RunSkillToolScriptOptions = {
+      target: 'host',
+      timeoutMs: 5000,
+      expectedSkillVersionHash: 'v1:deadbeef',
+      skillDirHashResolver: (dir: string) => `v1:hash-of-${dir}`,
+    };
+
+    expect(options.expectedSkillVersionHash).toBe('v1:deadbeef');
+    expect(options.skillDirHashResolver).toBeInstanceOf(Function);
+    expect(options.skillDirHashResolver!('/some/dir')).toBe('v1:hash-of-/some/dir');
   });
 });

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -230,3 +230,45 @@ describe('createSkillToolsFromManifest', () => {
     expect(tools[0].ownerSkillVersionHash).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// createSkillTool — expectedSkillVersionHash plumbing
+// ---------------------------------------------------------------------------
+
+describe('createSkillTool — version hash plumbing to runner', () => {
+  test('execute() works correctly when versionHash is provided', async () => {
+    const hash = 'v1:abc123';
+    const tool = createSkillTool(
+      makeEntry({ executor: 'echo.ts' }),
+      'my-skill',
+      tempDir,
+      hash,
+    );
+    const ctx = makeContext({ workingDir: '/my/project' });
+    const input = { query: 'test' };
+
+    const result = await tool.execute(input, ctx);
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.input).toEqual({ query: 'test' });
+    expect(parsed.workingDir).toBe('/my/project');
+    // Confirm the tool still has the hash stored
+    expect(tool.ownerSkillVersionHash).toBe(hash);
+  });
+
+  test('execute() works correctly when no versionHash is provided', async () => {
+    const tool = createSkillTool(
+      makeEntry({ executor: 'echo.ts' }),
+      'my-skill',
+      tempDir,
+    );
+    const ctx = makeContext();
+    const input = { query: 'no-hash' };
+
+    const result = await tool.execute(input, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(tool.ownerSkillVersionHash).toBeUndefined();
+  });
+});

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -8,6 +8,14 @@ export interface RunSkillToolScriptOptions {
   target?: ExecutionTarget;
   /** Timeout in ms for sandbox execution. Ignored for host execution. */
   timeoutMs?: number;
+  /** The skill version hash that was valid at approval time. When set, the runner
+   *  can verify the skill hasn't changed since the user approved it. Actual
+   *  verification is deferred to a follow-up PR. */
+  expectedSkillVersionHash?: string;
+  /** Function to compute the current version hash for a skill directory. Defaults
+   *  to `computeSkillVersionHash` from the version-hash module. Provided as an
+   *  option to support testing and custom resolution strategies. */
+  skillDirHashResolver?: (skillDir: string) => string;
 }
 
 /**

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -42,6 +42,7 @@ export function createSkillTool(
     async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
       return runSkillToolScript(skillDir, entry.executor, input, context, {
         target: entry.execution_target,
+        expectedSkillVersionHash: versionHash,
       });
     },
   };


### PR DESCRIPTION
PR 10 of skill tool security plan. Extends skill runner options with expectedSkillVersionHash and skillDirHashResolver for future version verification.

## Changes

- **skill-script-runner.ts**: Added `expectedSkillVersionHash` and `skillDirHashResolver` fields to `RunSkillToolScriptOptions`. These are plumbed through but verification is deferred to the next PR.
- **skill-tool-factory.ts**: When calling `runSkillToolScript`, passes the tool's `ownerSkillVersionHash` (from the skill registration) as `expectedSkillVersionHash`.
- **Tests**: Added tests verifying the new options are accepted by the runner and that the factory plumbs the version hash through correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
