### PR TITLE
feat: include principal metadata in IPC confirmation payloads and run records

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -672,6 +672,9 @@ exports[`IPC message snapshots ServerMessage types confirmation_request serializ
   "input": {
     "command": "rm -rf /tmp/test",
   },
+  "principalId": "my-skill",
+  "principalKind": "skill",
+  "principalVersion": "sha256:abcdef1234567890",
   "requestId": "req-002",
   "riskLevel": "high",
   "sandboxed": false,

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -441,6 +441,9 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     },
     sandboxed: false,
     sessionId: 'sess-001',
+    principalKind: 'skill',
+    principalId: 'my-skill',
+    principalVersion: 'sha256:abcdef1234567890',
   },
   message_complete: {
     type: 'message_complete',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -774,6 +774,12 @@ export interface ConfirmationRequest {
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
   sandboxed?: boolean;
   sessionId?: string;
+  /** Principal kind that initiated this tool use (e.g. 'core' or 'skill'). */
+  principalKind?: string;
+  /** Skill ID when principalKind is 'skill'. */
+  principalId?: string;
+  /** Content-hash of the skill source for version tracking. */
+  principalVersion?: string;
 }
 
 export interface SecretRequest {

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -24,6 +24,12 @@ export interface PendingConfirmation {
   executionTarget?: 'sandbox' | 'host';
   allowlistOptions?: Array<{ label: string; pattern: string }>;
   scopeOptions?: Array<{ label: string; scope: string }>;
+  /** Principal kind that initiated this tool use (e.g. 'core' or 'skill'). */
+  principalKind?: string;
+  /** Skill ID when principalKind is 'skill'. */
+  principalId?: string;
+  /** Content-hash of the skill source for version tracking. */
+  principalVersion?: string;
 }
 
 export interface Run {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -37,6 +37,7 @@ export class PermissionPrompter {
     sandboxed?: boolean,
     sessionId?: string,
     executionTarget?: ExecutionTarget,
+    principal?: { kind?: string; id?: string; version?: string },
   ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
     const requestId = uuid();
 
@@ -62,6 +63,9 @@ export class PermissionPrompter {
         sandboxed,
         sessionId,
         executionTarget,
+        principalKind: principal?.kind,
+        principalId: principal?.id,
+        principalVersion: principal?.version,
       });
     });
   }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -100,6 +100,9 @@ export class RunOrchestrator {
           executionTarget: msg.executionTarget,
           allowlistOptions: msg.allowlistOptions,
           scopeOptions: msg.scopeOptions,
+          principalKind: msg.principalKind,
+          principalId: msg.principalId,
+          principalVersion: msg.principalVersion,
         });
         this.pending.set(run.id, {
           prompterRequestId: msg.requestId,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -160,6 +160,12 @@ public struct IPCConfirmationRequest: Codable, Sendable {
     public let diff: IPCConfirmationRequestDiff?
     public let sandboxed: Bool?
     public let sessionId: String?
+    /// Principal kind that initiated this tool use (e.g. 'core' or 'skill').
+    public let principalKind: String?
+    /// Skill ID when principalKind is 'skill'.
+    public let principalId: String?
+    /// Content-hash of the skill source for version tracking.
+    public let principalVersion: String?
 }
 
 public struct IPCConfirmationRequestAllowlistOption: Codable, Sendable {


### PR DESCRIPTION
PR 9 of skill tool security plan.

## Summary
- Adds optional `principalKind`, `principalId`, and `principalVersion` fields to the `ConfirmationRequest` IPC payload so CLI/frontend can display which principal initiated a tool use
- Threads the same fields through the `PermissionPrompter.prompt()` method signature
- Includes the fields in `PendingConfirmation` in the runs store so API callers can see principal provenance
- Passes the fields from the run orchestrator's confirmation interception into the runs store
- Updates IPC snapshot tests and regenerates Swift models
- **No decision logic changes** — metadata-only, preparing for future policy enforcement

## Test plan
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — 163 tests pass, snapshots regenerated with new fields
- [x] `bun test src/__tests__/runtime-runs.test.ts` — 6 tests pass
- [x] Pre-commit hooks pass (generated Swift models up to date)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
