### PR TITLE
feat: detect skill version changes and refresh tool registrations on hash change

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -14,6 +14,8 @@ let mockManifests: Record<string, SkillToolManifest | null> = {};
 let mockRegisteredTools: Map<string, Tool[]> = new Map();
 let mockUnregisteredSkillIds: string[] = [];
 let mockSkillRefCount: Map<string, number> = new Map();
+/** Per-skill version hash overrides. When set, computeSkillVersionHash returns this value. */
+let mockVersionHashes: Record<string, string> = {};
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -142,6 +144,19 @@ mock.module('node:fs', () => ({
   },
 }));
 
+mock.module('../skills/version-hash.js', () => ({
+  computeSkillVersionHash: (skillDir: string) => {
+    // Extract skill ID from path: /skills/<id> → <id>
+    const parts = skillDir.split('/');
+    const skillId = parts[parts.length - 1];
+    if (skillId in mockVersionHashes) {
+      return mockVersionHashes[skillId];
+    }
+    // Default: stable hash based on skill ID so repeated calls return the same value
+    return `v1:default-hash-${skillId}`;
+  },
+}));
+
 mock.module('../util/logger.js', () => ({
   getLogger: () => ({
     info: () => {},
@@ -218,7 +233,7 @@ function skillLoadMessages(content: string): Message[] {
 afterAll(() => { mock.restore(); });
 
 describe('projectSkillTools', () => {
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   beforeEach(() => {
     mockCatalog = [];
@@ -227,7 +242,8 @@ describe('projectSkillTools', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('no active skills returns empty projection', () => {
@@ -436,6 +452,56 @@ describe('projectSkillTools', () => {
     expect(mockSkillRefCount.get('deploy')).toBe(1);
   });
 
+  test('skill version hash change triggers unregister and re-register', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:hash-aaa' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: skill registered with hash-aaa
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.has('deploy')).toBe(true);
+    expect(sessionState.get('deploy')).toBe('v1:hash-aaa');
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+
+    // Turn 2: hash changes — should unregister old and re-register new
+    mockVersionHashes = { deploy: 'v1:hash-bbb' };
+    mockUnregisteredSkillIds = [];
+    const result2 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result2.toolDefinitions).toHaveLength(1);
+    expect(result2.toolDefinitions[0].name).toBe('deploy_run');
+    expect(sessionState.get('deploy')).toBe('v1:hash-bbb');
+    // Unregister was called for the stale version
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+    // Ref count should remain 1 (unregister decremented, re-register incremented)
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+  });
+
+  test('skill version hash unchanged skips re-registration', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:stable-hash' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: skill registered
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+
+    // Turn 2: same hash — should NOT call registerSkillTools again
+    mockUnregisteredSkillIds = [];
+    const result2 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result2.toolDefinitions).toHaveLength(1);
+    expect(mockUnregisteredSkillIds).not.toContain('deploy');
+    // Ref count should still be 1 (no additional registration)
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+  });
+
   test('preactivated IDs merge with context-derived IDs (dedup)', () => {
     mockCatalog = [makeSkill('deploy')];
     mockManifests = { deploy: makeManifest(['deploy_run']) };
@@ -474,8 +540,8 @@ describe('projectSkillTools', () => {
       oncall: makeManifest(['oncall_page']),
     };
 
-    const sessionA = new Set<string>();
-    const sessionB = new Set<string>();
+    const sessionA = new Map<string, string>();
+    const sessionB = new Map<string, string>();
 
     // Session A activates deploy
     const historyA: Message[] = [...skillLoadMessages('<loaded_skill id="deploy" />')];
@@ -497,8 +563,8 @@ describe('projectSkillTools', () => {
     mockCatalog = [makeSkill('deploy')];
     mockManifests = { deploy: makeManifest(['deploy_run']) };
 
-    const sessionA = new Set<string>();
-    const sessionB = new Set<string>();
+    const sessionA = new Map<string, string>();
+    const sessionB = new Map<string, string>();
 
     const history: Message[] = [...skillLoadMessages('<loaded_skill id="deploy" />')];
 
@@ -525,8 +591,8 @@ describe('projectSkillTools', () => {
     mockCatalog = [makeSkill('deploy')];
     mockManifests = { deploy: makeManifest(['deploy_run']) };
 
-    const sessionA = new Set<string>();
-    const sessionB = new Set<string>();
+    const sessionA = new Map<string, string>();
+    const sessionB = new Map<string, string>();
 
     const history: Message[] = [...skillLoadMessages('<loaded_skill id="deploy" />')];
 
@@ -556,7 +622,7 @@ describe('resolveTools callback (session wiring)', () => {
     { name: 'bash', description: 'Run a shell command', input_schema: { type: 'object', properties: {} } },
   ];
 
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   function makeResolveTools(base: ToolDefinition[]) {
     return (history: Message[]): ToolDefinition[] => {
@@ -572,7 +638,8 @@ describe('resolveTools callback (session wiring)', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('returns only base tools when no skills are active', () => {
@@ -651,7 +718,7 @@ describe('resolveTools callback (session wiring)', () => {
 
 describe('allowed tool set merging', () => {
   const CORE_TOOL_NAMES = new Set(['bash', 'file_read', 'file_write', 'file_edit']);
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   beforeEach(() => {
     mockCatalog = [];
@@ -660,7 +727,8 @@ describe('allowed tool set merging', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   /**
@@ -769,7 +837,7 @@ describe('mid-run skill tool activation (end-to-end)', () => {
   ];
 
   const CORE_TOOL_NAMES = new Set(['bash', 'file_read', 'file_write', 'file_edit']);
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   function makeResolveTools(base: ToolDefinition[]) {
     return (history: Message[]) => {
@@ -788,7 +856,8 @@ describe('mid-run skill tool activation (end-to-end)', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('Turn 1 calls skill_load → Turn 2 sees added tool', () => {
@@ -964,7 +1033,7 @@ describe('context-derived deactivation regression', () => {
   ];
 
   const CORE_TOOL_NAMES = new Set(['bash', 'file_read', 'file_write', 'file_edit']);
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   function makeResolveTools(base: ToolDefinition[]) {
     return (history: Message[]) => {
@@ -983,7 +1052,8 @@ describe('context-derived deactivation regression', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('tool definitions shrink when skill load marker is removed from history', () => {
@@ -1158,7 +1228,7 @@ describe('context-derived deactivation regression', () => {
 // ---------------------------------------------------------------------------
 
 describe('slash preactivation through session processing', () => {
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   beforeEach(() => {
     mockCatalog = [];
@@ -1167,7 +1237,8 @@ describe('slash preactivation through session processing', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('slash-known skill has its tools available on first projection (turn-0)', () => {
@@ -1258,7 +1329,7 @@ const GMAIL_TOOL_NAMES = [
 ] as const;
 
 describe('bundled skill: gmail', () => {
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   beforeEach(() => {
     mockCatalog = [];
@@ -1267,7 +1338,8 @@ describe('bundled skill: gmail', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('gmail skill activation via loaded_skill marker projects all 12 tool definitions', () => {
@@ -1305,7 +1377,7 @@ describe('bundled skill: gmail', () => {
 });
 
 describe('bundled skill: claude-code', () => {
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   beforeEach(() => {
     mockCatalog = [];
@@ -1314,7 +1386,8 @@ describe('bundled skill: claude-code', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('claude-code skill activation produces claude_code tool definition', () => {
@@ -1348,7 +1421,7 @@ describe('bundled skill: claude-code', () => {
 });
 
 describe('bundled skill: weather', () => {
-  let sessionState: Set<string>;
+  let sessionState: Map<string, string>;
 
   beforeEach(() => {
     mockCatalog = [];
@@ -1357,7 +1430,8 @@ describe('bundled skill: weather', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
-    sessionState = new Set<string>();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
   });
 
   test('weather skill activation produces get_weather tool definition', () => {
@@ -1401,16 +1475,17 @@ describe('resetSkillToolProjection', () => {
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
+    mockVersionHashes = {};
   });
 
-  test('unregisters all tracked skills and clears the set', () => {
+  test('unregisters all tracked skills and clears the map', () => {
     mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
     mockManifests = {
       deploy: makeManifest(['deploy_run']),
       oncall: makeManifest(['oncall_page']),
     };
 
-    const trackedIds = new Set<string>();
+    const trackedIds = new Map<string, string>();
 
     // Activate both skills
     const history: Message[] = [
@@ -1434,9 +1509,9 @@ describe('resetSkillToolProjection', () => {
     expect(mockUnregisteredSkillIds).toHaveLength(0);
   });
 
-  test('no-op when called with empty set', () => {
+  test('no-op when called with empty map', () => {
     mockUnregisteredSkillIds = [];
-    resetSkillToolProjection(new Set());
+    resetSkillToolProjection(new Map());
     expect(mockUnregisteredSkillIds).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -13,6 +13,7 @@ import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import { deriveActiveSkillIds } from '../skills/active-skill-tools.js';
 import { parseToolManifestFile } from '../skills/tool-manifest.js';
+import { computeSkillVersionHash } from '../skills/version-hash.js';
 import { createSkillToolsFromManifest } from '../tools/skills/skill-tool-factory.js';
 import {
   registerSkillTools,
@@ -39,11 +40,13 @@ export interface ProjectSkillToolsOptions {
   /** Skill IDs that should be treated as active regardless of history markers. */
   preactivatedSkillIds?: string[];
   /**
-   * Session-scoped tracking set of previously active skill IDs. Each session
-   * should own its own set to prevent cross-session state bleed when the
-   * daemon serves multiple concurrent sessions.
+   * Session-scoped tracking map of previously active skill IDs to their
+   * version hashes. Each session should own its own map to prevent
+   * cross-session state bleed when the daemon serves multiple concurrent
+   * sessions. When a skill's hash changes between turns, its tools are
+   * unregistered and re-registered with the updated definitions.
    */
-  previouslyActiveSkillIds?: Set<string>;
+  previouslyActiveSkillIds?: Map<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,14 +90,14 @@ export function projectSkillTools(
 ): SkillToolProjection {
   const contextIds = deriveActiveSkillIds(history);
   const preactivated = options?.preactivatedSkillIds ?? [];
-  const prevActive = options?.previouslyActiveSkillIds ?? new Set<string>();
+  const prevActive = options?.previouslyActiveSkillIds ?? new Map<string, string>();
 
   // Union of context-derived and preactivated IDs
   const activeIds = new Set<string>([...contextIds, ...preactivated]);
 
   // Determine which skills were removed since last projection
   const removedIds = new Set<string>();
-  for (const id of prevActive) {
+  for (const id of prevActive.keys()) {
     if (!activeIds.has(id)) {
       removedIds.add(id);
     }
@@ -121,7 +124,7 @@ export function projectSkillTools(
 
   const allToolDefinitions: ToolDefinition[] = [];
   const allToolNames = new Set<string>();
-  const successfulIds = new Set<string>();
+  const successfulEntries = new Map<string, string>();
 
   for (const skillId of activeIds) {
     const skill = catalogById.get(skillId);
@@ -135,8 +138,16 @@ export function projectSkillTools(
       continue;
     }
 
-    // Create runtime Tool objects — only register if this skill is newly active
-    // to avoid inflating the registry refcount on every turn.
+    // Compute the current version hash for this skill directory
+    let currentHash: string;
+    try {
+      currentHash = computeSkillVersionHash(skill.directoryPath);
+    } catch (err) {
+      log.warn({ err, skillId }, 'Failed to compute skill version hash, treating as changed');
+      currentHash = `unknown-${Date.now()}`;
+    }
+
+    // Create runtime Tool objects
     const tools = createSkillToolsFromManifest(
       manifest.tools,
       skillId,
@@ -144,11 +155,19 @@ export function projectSkillTools(
     );
 
     if (tools.length > 0) {
-      if (!prevActive.has(skillId)) {
+      const prevHash = prevActive.get(skillId);
+      if (prevHash === undefined) {
+        // Newly active skill — register for the first time
+        registerSkillTools(tools);
+      } else if (prevHash !== currentHash) {
+        // Hash changed — unregister stale tools, then re-register with new definitions
+        log.info({ skillId, prevHash, currentHash }, 'Skill version changed, re-registering tools');
+        unregisterSkillTools(skillId);
         registerSkillTools(tools);
       }
+      // If hash is unchanged, skip registration to avoid inflating the refcount
 
-      successfulIds.add(skillId);
+      successfulEntries.set(skillId, currentHash);
       for (const tool of tools) {
         allToolDefinitions.push(tool.getDefinition());
         allToolNames.add(tool.name);
@@ -160,18 +179,18 @@ export function projectSkillTools(
   // turn (catalog miss, manifest failure, empty tools). Without this, the
   // skill would be re-registered when it recovers next turn, inflating the
   // refcount since the prior registration was never decremented.
-  for (const id of prevActive) {
-    if (activeIds.has(id) && !successfulIds.has(id)) {
+  for (const id of prevActive.keys()) {
+    if (activeIds.has(id) && !successfulEntries.has(id)) {
       log.info({ skillId: id }, 'Unregistering tools for transiently-failed skill');
       unregisterSkillTools(id);
     }
   }
 
-  // Update the session-scoped tracking set in-place — only include skills
+  // Update the session-scoped tracking map in-place — only include skills
   // that were successfully processed so failed skills can be retried next turn.
   prevActive.clear();
-  for (const id of successfulIds) {
-    prevActive.add(id);
+  for (const [id, hash] of successfulEntries) {
+    prevActive.set(id, hash);
   }
 
   return {
@@ -182,11 +201,11 @@ export function projectSkillTools(
 
 /**
  * Reset the projection state and unregister all skill tools tracked in the
- * given set. Used for session teardown and tests.
+ * given map. Used for session teardown and tests.
  */
-export function resetSkillToolProjection(trackedIds?: Set<string>): void {
+export function resetSkillToolProjection(trackedIds?: Map<string, string>): void {
   if (trackedIds) {
-    for (const id of trackedIds) {
+    for (const id of trackedIds.keys()) {
       unregisterSkillTools(id);
     }
     trackedIds.clear();

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -128,8 +128,8 @@ export class Session {
   preactivatedSkillIds?: string[];
   /** Core tool names (computed once in constructor), always allowed regardless of skill state. */
   private coreToolNames: Set<string>;
-  /** Per-session tracking of previously active skill IDs for projection diffing. */
-  private readonly skillProjectionState = new Set<string>();
+  /** Per-session tracking of previously active skill IDs and their version hashes for projection diffing. */
+  private readonly skillProjectionState = new Map<string, string>();
   /** @internal — exposed for session-usage.ts module functions. */
   usageStats: UsageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
   private readonly systemPrompt: string;


### PR DESCRIPTION
PR 7 of skill tool security plan. Replaces Set-based skill tracking with Map-based hash tracking to detect version changes and trigger re-registration.

## Changes

- **session-skill-tools.ts**: Replace `previouslyActiveSkillIds: Set<string>` with `Map<string, string>` (skillId -> versionHash). On each projection, compute the current version hash via `computeSkillVersionHash` and compare with the stored hash. When the hash changes, unregister stale tools and re-register with updated definitions. Unchanged hashes skip re-registration to avoid refcount inflation.

- **session.ts**: Update `skillProjectionState` from `Set<string>` to `Map<string, string>` to match the new interface.

- **session-skill-tools.test.ts**: Update all test session state from `Set` to `Map`, add mock for `computeSkillVersionHash`, and add two new tests:
  - `skill version hash change triggers unregister and re-register`
  - `skill version hash unchanged skips re-registration`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
