### PR TITLE
feat: add host skill runner hash guard to block execution on version mismatch

### DIFF
--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -138,23 +138,23 @@ describe('runSkillToolScript — errors', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Runner options — expectedSkillVersionHash & skillDirHashResolver
+// Host skill runner hash guard
 // ---------------------------------------------------------------------------
 
-describe('runSkillToolScript — version hash options', () => {
-  test('accepts expectedSkillVersionHash option without affecting execution', async () => {
-    const result = await runSkillToolScript(tempDir, 'success.ts', { name: 'world' }, makeContext(), {
-      expectedSkillVersionHash: 'v1:abc123',
-    });
+describe('runSkillToolScript — host hash guard', () => {
+  test('allows execution when no expectedSkillVersionHash is provided', async () => {
+    const result = await runSkillToolScript(tempDir, 'success.ts', { name: 'world' }, makeContext());
 
     expect(result.isError).toBe(false);
     expect(result.content).toBe('hello from world');
   });
 
-  test('accepts skillDirHashResolver option without affecting execution', async () => {
-    const resolver = (_dir: string) => 'v1:custom-hash';
+  test('allows execution when hash matches', async () => {
+    const expectedHash = 'v1:matching-hash';
+    const resolver = (_dir: string) => expectedHash;
+
     const result = await runSkillToolScript(tempDir, 'success.ts', { name: 'world' }, makeContext(), {
-      expectedSkillVersionHash: 'v1:abc123',
+      expectedSkillVersionHash: expectedHash,
       skillDirHashResolver: resolver,
     });
 
@@ -162,7 +162,67 @@ describe('runSkillToolScript — version hash options', () => {
     expect(result.content).toBe('hello from world');
   });
 
-  test('RunSkillToolScriptOptions type accepts all new fields', () => {
+  test('blocks execution when hash mismatches', async () => {
+    const expectedHash = 'v1:approved-hash';
+    const currentHash = 'v1:modified-hash';
+    const resolver = (_dir: string) => currentHash;
+
+    const result = await runSkillToolScript(tempDir, 'success.ts', { name: 'world' }, makeContext(), {
+      expectedSkillVersionHash: expectedHash,
+      skillDirHashResolver: resolver,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Skill version mismatch');
+    expect(result.content).toContain(expectedHash);
+    expect(result.content).toContain(currentHash);
+    expect(result.content).toContain('Please reload the skill to re-approve');
+  });
+
+  test('mismatch error is non-throwing and user-readable', async () => {
+    const resolver = (_dir: string) => 'v1:different';
+
+    const result = await runSkillToolScript(tempDir, 'success.ts', {}, makeContext(), {
+      expectedSkillVersionHash: 'v1:original',
+      skillDirHashResolver: resolver,
+    });
+
+    // Should return a structured error result, not throw.
+    expect(result).toHaveProperty('content');
+    expect(result).toHaveProperty('isError', true);
+    expect(result.content).toContain('modified since it was approved');
+  });
+
+  test('uses computeSkillVersionHash by default when no resolver is provided', async () => {
+    // When expectedSkillVersionHash is set but no resolver is given, the runner
+    // falls back to the real computeSkillVersionHash. Since the temp dir content
+    // almost certainly won't match a fabricated hash, this should block.
+    const result = await runSkillToolScript(tempDir, 'success.ts', {}, makeContext(), {
+      expectedSkillVersionHash: 'v1:definitely-not-a-real-hash',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Skill version mismatch');
+  });
+
+  test('passes the resolved skill directory to the hash resolver', async () => {
+    let receivedDir: string | undefined;
+    const resolver = (dir: string) => {
+      receivedDir = dir;
+      return 'v1:match';
+    };
+
+    await runSkillToolScript(tempDir, 'success.ts', {}, makeContext(), {
+      expectedSkillVersionHash: 'v1:match',
+      skillDirHashResolver: resolver,
+    });
+
+    // The resolver should receive the resolved skill directory with trailing slash.
+    expect(receivedDir).toBeDefined();
+    expect(receivedDir!.endsWith('/')).toBe(true);
+  });
+
+  test('RunSkillToolScriptOptions type accepts all fields', () => {
     const options: RunSkillToolScriptOptions = {
       target: 'host',
       timeoutMs: 5000,

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -2,6 +2,7 @@ import type { ToolExecutionResult, ToolContext, ExecutionTarget } from '../types
 import type { SkillToolScript } from './script-contract.js';
 import { join, resolve } from 'node:path';
 import { runSkillToolScriptSandbox } from './sandbox-runner.js';
+import { computeSkillVersionHash } from '../../skills/version-hash.js';
 
 export interface RunSkillToolScriptOptions {
   /** Where to execute: 'host' runs in-process, 'sandbox' runs in an isolated subprocess. */
@@ -9,8 +10,8 @@ export interface RunSkillToolScriptOptions {
   /** Timeout in ms for sandbox execution. Ignored for host execution. */
   timeoutMs?: number;
   /** The skill version hash that was valid at approval time. When set, the runner
-   *  can verify the skill hasn't changed since the user approved it. Actual
-   *  verification is deferred to a follow-up PR. */
+   *  verifies the skill hasn't changed since the user approved it and blocks
+   *  execution on mismatch. */
   expectedSkillVersionHash?: string;
   /** Function to compute the current version hash for a skill directory. Defaults
    *  to `computeSkillVersionHash` from the version-hash module. Provided as an
@@ -39,6 +40,18 @@ export async function runSkillToolScript(
   const resolvedSkillDir = resolve(skillDir) + '/';
   if (!scriptPath.startsWith(resolvedSkillDir)) {
     return { content: `Skill tool script path "${executorPath}" escapes the skill directory`, isError: true };
+  }
+
+  // Block execution if the skill has been modified since approval.
+  if (options?.expectedSkillVersionHash) {
+    const resolver = options.skillDirHashResolver ?? computeSkillVersionHash;
+    const currentHash = resolver(resolvedSkillDir);
+    if (currentHash !== options.expectedSkillVersionHash) {
+      return {
+        content: `Skill version mismatch: expected ${options.expectedSkillVersionHash} but current is ${currentHash}. The skill has been modified since it was approved. Please reload the skill to re-approve.`,
+        isError: true,
+      };
+    }
   }
 
   let module: SkillToolScript;


### PR DESCRIPTION
PR 11 of skill tool security plan. Blocks host skill tool execution when the current skill hash differs from the expected hash, preventing silently-changed behavior.