### PR TITLE
feat: add permissions.mode config with legacy and strict options

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -465,6 +465,36 @@ describe('AssistantConfigSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test('defaults permissions.mode to legacy', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.permissions).toEqual({ mode: 'legacy' });
+  });
+
+  test('accepts explicit permissions.mode strict', () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { mode: 'strict' },
+    });
+    expect(result.permissions.mode).toBe('strict');
+  });
+
+  test('accepts explicit permissions.mode legacy', () => {
+    const result = AssistantConfigSchema.parse({
+      permissions: { mode: 'legacy' },
+    });
+    expect(result.permissions.mode).toBe('legacy');
+  });
+
+  test('rejects invalid permissions.mode', () => {
+    const result = AssistantConfigSchema.safeParse({
+      permissions: { mode: 'permissive' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('permissions.mode'))).toBe(true);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -642,6 +672,24 @@ describe('loadConfig with schema validation', () => {
     writeConfig({ auditLog: { retentionDays: -7 } });
     const config = loadConfig();
     expect(config.auditLog.retentionDays).toBe(0);
+  });
+
+  test('defaults permissions.mode to legacy when not specified', () => {
+    writeConfig({});
+    const config = loadConfig();
+    expect(config.permissions).toEqual({ mode: 'legacy' });
+  });
+
+  test('loads explicit permissions.mode strict', () => {
+    writeConfig({ permissions: { mode: 'strict' } });
+    const config = loadConfig();
+    expect(config.permissions.mode).toBe('strict');
+  });
+
+  test('falls back for invalid permissions.mode', () => {
+    writeConfig({ permissions: { mode: 'yolo' } });
+    const config = loadConfig();
+    expect(config.permissions.mode).toBe('legacy');
   });
 
   test('does not mutate default apiKeys when fallback config is overridden by env keys', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -154,6 +154,9 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     entropyThreshold: 4.0,
     allowOneTimeSend: false,
   },
+  permissions: {
+    mode: 'legacy',
+  },
   auditLog: {
     retentionDays: 0,
   },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -6,6 +6,7 @@ const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
 const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
+const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -108,6 +109,14 @@ export const SecretDetectionConfigSchema = z.object({
   allowOneTimeSend: z
     .boolean({ error: 'secretDetection.allowOneTimeSend must be a boolean' })
     .default(false),
+});
+
+export const PermissionsConfigSchema = z.object({
+  mode: z
+    .enum(VALID_PERMISSIONS_MODES, {
+      error: `permissions.mode must be one of: ${VALID_PERMISSIONS_MODES.join(', ')}`,
+    })
+    .default('legacy'),
 });
 
 export const AuditLogConfigSchema = z.object({
@@ -903,6 +912,9 @@ export const AssistantConfigSchema = z.object({
     entropyThreshold: 4.0,
     allowOneTimeSend: false,
   }),
+  permissions: PermissionsConfigSchema.default({
+    mode: 'legacy',
+  }),
   auditLog: AuditLogConfigSchema.default({
     retentionDays: 0,
   }),
@@ -959,6 +971,7 @@ export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;
 export type DockerConfig = z.infer<typeof DockerConfigSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
 export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
+export type PermissionsConfig = z.infer<typeof PermissionsConfigSchema>;
 export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;
 export type LogFileConfig = z.infer<typeof LogFileConfigSchema>;
 export type ThinkingConfig = z.infer<typeof ThinkingConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -5,6 +5,7 @@ export type {
   DockerConfig,
   RateLimitConfig,
   SecretDetectionConfig,
+  PermissionsConfig,
   AuditLogConfig,
   LogFileConfig,
   ThinkingConfig,


### PR DESCRIPTION
PR 20 of skill tool security plan. Introduces `permissions.mode` enum (`legacy` | `strict`) defaulting to `legacy` for backward compatibility.

## Changes

- **`schema.ts`**: Added `PermissionsConfigSchema` with a `mode` enum field (`legacy` | `strict`), integrated into `AssistantConfigSchema` with `legacy` as default
- **`defaults.ts`**: Added `permissions: { mode: 'legacy' }` to `DEFAULT_CONFIG`
- **`types.ts`**: Exported `PermissionsConfig` type
- **`config-schema.test.ts`**: Added 7 tests covering default value, explicit `strict`/`legacy` acceptance, invalid value rejection, and loader integration tests

## Test plan

- [x] Schema defaults `permissions.mode` to `'legacy'`
- [x] Schema accepts explicit `'strict'` and `'legacy'` values
- [x] Schema rejects invalid values like `'permissive'` with descriptive error
- [x] Loader defaults `permissions.mode` to `'legacy'` when config file has no permissions section
- [x] Loader accepts explicit `permissions.mode: 'strict'` from config file
- [x] Loader falls back to `'legacy'` for invalid `permissions.mode` values
- [x] All 62 tests pass