### PR TITLE
docs: require agents to track merged PRs in UNREVIEWED_PRS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,5 +35,9 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/scrub` | Kill the running Vellum app (non-fatal if not running), wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
 
 
+## Track merged PRs
+
+Whenever you merge a PR, you MUST append its URL to `.private/UNREVIEWED_PRS.md` so that `/check-reviews` can pick it up for review triage.
+
 ## Implementing new functionality
 Before implementing new functionality do a quick check to see if the new feature has already been implemented


### PR DESCRIPTION
## Summary
- Adds a "Track merged PRs" section to AGENTS.md instructing agents to append every merged PR URL to `.private/UNREVIEWED_PRS.md` for review triage by `/check-reviews`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
