### PR TITLE
feat: include version hash in skill_load marker (#PR31)

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -91,7 +91,9 @@ describe('skill_load tool', () => {
     expect(result.content).toContain('ID: release-checklist');
     expect(result.content).toContain('1. Run tests');
     expect(result.content).not.toContain('name: "Release Checklist"');
-    expect(result.content).toContain('<loaded_skill id="release-checklist" />');
+    // Marker must include a version attribute with the v1:<hex> format
+    const markerMatch = result.content.match(/<loaded_skill id="release-checklist" version="(v1:[a-f0-9]{64})" \/>/);
+    expect(markerMatch).not.toBeNull();
   });
 
   test('loads a skill by exact name (case-insensitive)', async () => {
@@ -102,7 +104,8 @@ describe('skill_load tool', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Skill: Oncall Runbook');
     expect(result.content).toContain('Page primary responder');
-    expect(result.content).toContain('<loaded_skill id="oncall" />');
+    const markerMatch = result.content.match(/<loaded_skill id="oncall" version="(v1:[a-f0-9]{64})" \/>/);
+    expect(markerMatch).not.toBeNull();
   });
 
   test('loads a skill by unique id prefix', async () => {
@@ -113,7 +116,8 @@ describe('skill_load tool', () => {
     const result = await executeSkillLoad({ skill: 'incident' });
     expect(result.isError).toBe(false);
     expect(result.content).toContain('ID: incident-response');
-    expect(result.content).toContain('<loaded_skill id="incident-response" />');
+    const markerMatch = result.content.match(/<loaded_skill id="incident-response" version="(v1:[a-f0-9]{64})" \/>/);
+    expect(markerMatch).not.toBeNull();
   });
 
   test('returns an error when name resolution is ambiguous', async () => {
@@ -125,6 +129,26 @@ describe('skill_load tool', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Ambiguous skill name');
     expect(result.content).not.toContain('<loaded_skill');
+  });
+
+  test('version hash changes when skill content changes', async () => {
+    writeSkill('versioned', 'Versioned Skill', 'Test versioning', 'Original body');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- versioned\n');
+
+    const result1 = await executeSkillLoad({ skill: 'versioned' });
+    const match1 = result1.content.match(/<loaded_skill id="versioned" version="(v1:[a-f0-9]{64})" \/>/);
+    expect(match1).not.toBeNull();
+    const hash1 = match1![1];
+
+    // Modify the skill body
+    writeSkill('versioned', 'Versioned Skill', 'Test versioning', 'Updated body');
+
+    const result2 = await executeSkillLoad({ skill: 'versioned' });
+    const match2 = result2.content.match(/<loaded_skill id="versioned" version="(v1:[a-f0-9]{64})" \/>/);
+    expect(match2).not.toBeNull();
+    const hash2 = match2![1];
+
+    expect(hash1).not.toBe(hash2);
   });
 
   test('returns an error when skill is missing', async () => {

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -3,6 +3,10 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { loadSkillBySelector } from '../../config/skills.js';
+import { computeSkillVersionHash } from '../../skills/version-hash.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('skill-load');
 
 export class SkillLoadTool implements Tool {
   name = 'skill_load';
@@ -40,6 +44,15 @@ export class SkillLoadTool implements Tool {
 
     const skill = loaded.skill;
     const body = skill.body.length > 0 ? skill.body : '(No body content)';
+
+    let versionHash: string | undefined;
+    try {
+      versionHash = computeSkillVersionHash(skill.directoryPath);
+    } catch (err) {
+      log.warn({ err, skillId: skill.id }, 'Failed to compute skill version hash for marker');
+    }
+
+    const versionAttr = versionHash ? ` version="${versionHash}"` : '';
     return {
       content: [
         `Skill: ${skill.name}`,
@@ -49,7 +62,7 @@ export class SkillLoadTool implements Tool {
         '',
         body,
         '',
-        `<loaded_skill id="${skill.id}" />`,
+        `<loaded_skill id="${skill.id}"${versionAttr} />`,
       ].join('\n'),
       isError: false,
     };


### PR DESCRIPTION
Adds version hash attribute to loaded_skill markers in history for downstream version-aware parsing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
