### PR TITLE
test: add end-to-end tamper regression tests (#PR13)

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -1465,6 +1465,177 @@ describe('bundled skill: weather', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tamper detection regression tests
+// ---------------------------------------------------------------------------
+
+describe('tamper detection', () => {
+  let sessionState: Map<string, string>;
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
+  });
+
+  test('file mutation after projection invalidates the stored hash, causing re-registration on next turn', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:original-file-hash' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: project with original hash
+    const result1 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result1.toolDefinitions).toHaveLength(1);
+    expect(result1.toolDefinitions[0].name).toBe('deploy_run');
+    expect(sessionState.get('deploy')).toBe('v1:original-file-hash');
+
+    // Simulate file mutation on disk — the hash changes
+    mockVersionHashes = { deploy: 'v1:tampered-file-hash' };
+
+    // Turn 2: re-project detects hash drift and re-registers
+    mockUnregisteredSkillIds = [];
+    const result2 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    // Tools are still available (re-registered with new hash)
+    expect(result2.toolDefinitions).toHaveLength(1);
+    expect(result2.toolDefinitions[0].name).toBe('deploy_run');
+
+    // Old tools were unregistered before new ones registered
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+
+    // Session state now tracks the new hash
+    expect(sessionState.get('deploy')).toBe('v1:tampered-file-hash');
+
+    // Refcount stays at 1 (unregister decremented, re-register incremented)
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+  });
+
+  test('unmodified skill file does NOT trigger re-registration across multiple turns', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:stable-content-hash' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: initial projection
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+
+    // Turns 2-4: hash stays the same, no re-registration should occur
+    for (let turn = 2; turn <= 4; turn++) {
+      mockUnregisteredSkillIds = [];
+      const result = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+      expect(result.toolDefinitions).toHaveLength(1);
+      expect(mockUnregisteredSkillIds).not.toContain('deploy');
+      expect(mockSkillRefCount.get('deploy')).toBe(1);
+    }
+  });
+
+  test('re-projection after tamper produces tools with the updated hash', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run', 'deploy_status']) };
+    mockVersionHashes = { deploy: 'v1:hash-before-edit' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: initial projection
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.get('deploy')).toBe('v1:hash-before-edit');
+
+    // Simulate tamper: file changes on disk
+    mockVersionHashes = { deploy: 'v1:hash-after-edit' };
+
+    // Turn 2: re-projection picks up the new hash
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(result.toolDefinitions).toHaveLength(2);
+    expect(result.allowedToolNames).toEqual(new Set(['deploy_run', 'deploy_status']));
+    expect(sessionState.get('deploy')).toBe('v1:hash-after-edit');
+  });
+
+  test('multiple skills with only one tampered triggers selective re-registration', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+    mockVersionHashes = {
+      deploy: 'v1:deploy-hash-v1',
+      oncall: 'v1:oncall-hash-v1',
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+      ...skillLoadMessages('<loaded_skill id="oncall" />'),
+    ];
+
+    // Turn 1: both skills registered
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.get('deploy')).toBe('v1:deploy-hash-v1');
+    expect(sessionState.get('oncall')).toBe('v1:oncall-hash-v1');
+
+    // Tamper only deploy
+    mockVersionHashes = {
+      deploy: 'v1:deploy-hash-v2-tampered',
+      oncall: 'v1:oncall-hash-v1', // unchanged
+    };
+    mockUnregisteredSkillIds = [];
+
+    // Turn 2: only deploy should be re-registered
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(result.toolDefinitions).toHaveLength(2);
+    expect(result.allowedToolNames).toEqual(new Set(['deploy_run', 'oncall_page']));
+
+    // Only deploy was unregistered (for re-registration), oncall was untouched
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+    expect(mockUnregisteredSkillIds).not.toContain('oncall');
+
+    // Hashes updated accordingly
+    expect(sessionState.get('deploy')).toBe('v1:deploy-hash-v2-tampered');
+    expect(sessionState.get('oncall')).toBe('v1:oncall-hash-v1');
+  });
+
+  test('hash failure (e.g., unreadable directory) causes fallback re-registration', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:initial-hash' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: normal registration
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.get('deploy')).toBe('v1:initial-hash');
+
+    // Turn 2: remove hash override so computeSkillVersionHash returns the
+    // default fallback which differs from the stored hash
+    delete mockVersionHashes['deploy'];
+    mockUnregisteredSkillIds = [];
+
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result.toolDefinitions).toHaveLength(1);
+
+    // Hash changed (from stored 'v1:initial-hash' to default 'v1:default-hash-deploy')
+    // so re-registration should have occurred
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+    expect(sessionState.get('deploy')).toBe('v1:default-hash-deploy');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // resetSkillToolProjection tests
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -235,3 +235,146 @@ describe('runSkillToolScript — host hash guard', () => {
     expect(options.skillDirHashResolver!('/some/dir')).toBe('v1:hash-of-/some/dir');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tamper regression: end-to-end hash guard lifecycle
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript — tamper regression lifecycle', () => {
+  test('execution succeeds with matching hash, fails after tamper, succeeds after re-approval', async () => {
+    // Simulates the full lifecycle:
+    // 1. Tool approved with hash A — execution succeeds
+    // 2. File tampered (hash changes to B) — execution blocked
+    // 3. Skill reloaded (re-approved with hash B) — execution succeeds again
+
+    let currentDiskHash = 'v1:approved-hash-aaa';
+    const resolver = (_dir: string) => currentDiskHash;
+
+    // Phase 1: hash matches approved hash — execution succeeds
+    const result1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'phase1' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:approved-hash-aaa',
+      skillDirHashResolver: resolver,
+    });
+    expect(result1.isError).toBe(false);
+    expect(result1.content).toBe('hello from phase1');
+
+    // Phase 2: file tampered on disk — hash drifts
+    currentDiskHash = 'v1:tampered-hash-bbb';
+
+    const result2 = await runSkillToolScript(tempDir, 'success.ts', { name: 'phase2' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:approved-hash-aaa', // still using old approval
+      skillDirHashResolver: resolver,
+    });
+    expect(result2.isError).toBe(true);
+    expect(result2.content).toContain('Skill version mismatch');
+    expect(result2.content).toContain('v1:approved-hash-aaa');
+    expect(result2.content).toContain('v1:tampered-hash-bbb');
+
+    // Phase 3: skill reloaded — now approved with the new hash
+    const result3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'phase3' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:tampered-hash-bbb', // updated approval
+      skillDirHashResolver: resolver,
+    });
+    expect(result3.isError).toBe(false);
+    expect(result3.content).toBe('hello from phase3');
+  });
+
+  test('multiple sequential tampers each block until re-approved', async () => {
+    let currentDiskHash = 'v1:version-1';
+    const resolver = (_dir: string) => currentDiskHash;
+
+    // Approved at version-1
+    let approvedHash = 'v1:version-1';
+
+    // Execute successfully with version-1
+    const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v1' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r1.isError).toBe(false);
+
+    // First tamper to version-2
+    currentDiskHash = 'v1:version-2';
+    const r2 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v2' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r2.isError).toBe(true);
+    expect(r2.content).toContain('Skill version mismatch');
+
+    // Re-approve at version-2
+    approvedHash = 'v1:version-2';
+    const r2ok = await runSkillToolScript(tempDir, 'success.ts', { name: 'v2' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r2ok.isError).toBe(false);
+
+    // Second tamper to version-3
+    currentDiskHash = 'v1:version-3';
+    const r3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v3' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r3.isError).toBe(true);
+    expect(r3.content).toContain('Skill version mismatch');
+
+    // Re-approve at version-3
+    approvedHash = 'v1:version-3';
+    const r3ok = await runSkillToolScript(tempDir, 'success.ts', { name: 'v3' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r3ok.isError).toBe(false);
+    expect(r3ok.content).toBe('hello from v3');
+  });
+
+  test('tamper blocks execution even for different executor scripts in the same skill', async () => {
+    let currentDiskHash = 'v1:skill-hash-ok';
+    const resolver = (_dir: string) => currentDiskHash;
+
+    // Both scripts work when hash matches
+    const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'a' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:skill-hash-ok',
+      skillDirHashResolver: resolver,
+    });
+    expect(r1.isError).toBe(false);
+
+    const r2 = await runSkillToolScript(tempDir, 'echo.ts', { key: 'val' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:skill-hash-ok',
+      skillDirHashResolver: resolver,
+    });
+    expect(r2.isError).toBe(false);
+
+    // Tamper the skill directory
+    currentDiskHash = 'v1:skill-hash-tampered';
+
+    // Both scripts are blocked
+    const r3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'b' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:skill-hash-ok',
+      skillDirHashResolver: resolver,
+    });
+    expect(r3.isError).toBe(true);
+    expect(r3.content).toContain('Skill version mismatch');
+
+    const r4 = await runSkillToolScript(tempDir, 'echo.ts', { key: 'val2' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:skill-hash-ok',
+      skillDirHashResolver: resolver,
+    });
+    expect(r4.isError).toBe(true);
+    expect(r4.content).toContain('Skill version mismatch');
+  });
+
+  test('error message instructs user to reload the skill', async () => {
+    const resolver = (_dir: string) => 'v1:changed';
+
+    const result = await runSkillToolScript(tempDir, 'success.ts', {}, makeContext(), {
+      expectedSkillVersionHash: 'v1:original',
+      skillDirHashResolver: resolver,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Please reload the skill to re-approve');
+    expect(result.content).toContain('modified since it was approved');
+  });
+});


### PR DESCRIPTION
Adds regression tests ensuring skill file mutations invalidate prior hash approvals and require re-projection.

## Changes

### `session-skill-tools.test.ts` — tamper detection describe block (5 tests)
- File mutation after projection invalidates stored hash, triggering re-registration
- Unmodified files do NOT trigger re-registration across multiple turns
- Re-projection after tamper produces tools with the updated hash
- Multiple skills with only one tampered triggers selective re-registration
- Hash failure (e.g., unreadable directory) causes fallback re-registration

### `skill-script-runner-host.test.ts` — tamper regression lifecycle (4 tests)
- Full lifecycle: approve → tamper → block → re-approve → succeed
- Multiple sequential tampers each block until individually re-approved
- Tamper blocks all executor scripts within the same skill directory
- Error message instructs user to reload the skill
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
