### PR TITLE
feat: add sandbox skill runner hash guard (#PR12)

### DIFF
--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, mock, spyOn } from 'bun:test';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -51,6 +51,7 @@ mock.module('../tools/terminal/sandbox.js', () => ({
 }));
 
 import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';
+import type { RunSkillToolScriptOptions } from '../tools/skills/skill-script-runner.js';
 import type { ToolContext } from '../tools/types.js';
 
 // ---------------------------------------------------------------------------
@@ -216,5 +217,133 @@ describe('runSkillToolScript routing', () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toBe('sandbox hello from explicit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox skill runner hash guard
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript sandbox — hash guard', () => {
+  test('allows execution when no expectedSkillVersionHash is provided', async () => {
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', { name: 'world' }, makeContext(), { target: 'sandbox' },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('sandbox hello from world');
+  }, 15_000);
+
+  test('allows execution when hash matches', async () => {
+    const expectedHash = 'v1:matching-hash';
+    const resolver = (_dir: string) => expectedHash;
+
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', { name: 'world' }, makeContext(), {
+        target: 'sandbox',
+        expectedSkillVersionHash: expectedHash,
+        skillDirHashResolver: resolver,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('sandbox hello from world');
+  }, 15_000);
+
+  test('blocks execution when hash mismatches', async () => {
+    const expectedHash = 'v1:approved-hash';
+    const currentHash = 'v1:modified-hash';
+    const resolver = (_dir: string) => currentHash;
+
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', { name: 'world' }, makeContext(), {
+        target: 'sandbox',
+        expectedSkillVersionHash: expectedHash,
+        skillDirHashResolver: resolver,
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Skill version mismatch');
+    expect(result.content).toContain(expectedHash);
+    expect(result.content).toContain(currentHash);
+    expect(result.content).toContain('Please reload the skill to re-approve');
+  });
+
+  test('mismatch error is non-throwing and user-readable', async () => {
+    const resolver = (_dir: string) => 'v1:different';
+
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', {}, makeContext(), {
+        target: 'sandbox',
+        expectedSkillVersionHash: 'v1:original',
+        skillDirHashResolver: resolver,
+      },
+    );
+
+    // Should return a structured error result, not throw.
+    expect(result).toHaveProperty('content');
+    expect(result).toHaveProperty('isError', true);
+    expect(result.content).toContain('modified since it was approved');
+  });
+
+  test('uses computeSkillVersionHash by default when no resolver is provided', async () => {
+    // When expectedSkillVersionHash is set but no resolver is given, the runner
+    // falls back to the real computeSkillVersionHash. Since the temp dir content
+    // almost certainly won't match a fabricated hash, this should block.
+    const result = await runSkillToolScript(
+      tempDir, 'success.ts', {}, makeContext(), {
+        target: 'sandbox',
+        expectedSkillVersionHash: 'v1:definitely-not-a-real-hash',
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Skill version mismatch');
+  });
+
+  test('passes the resolved skill directory to the hash resolver', async () => {
+    let receivedDir: string | undefined;
+    const resolver = (dir: string) => {
+      receivedDir = dir;
+      return 'v1:match';
+    };
+
+    await runSkillToolScript(
+      tempDir, 'success.ts', {}, makeContext(), {
+        target: 'sandbox',
+        expectedSkillVersionHash: 'v1:match',
+        skillDirHashResolver: resolver,
+      },
+    );
+
+    // The resolver should receive the resolved skill directory with trailing slash.
+    expect(receivedDir).toBeDefined();
+    expect(receivedDir!.endsWith('/')).toBe(true);
+  });
+
+  test('hash mismatch prevents subprocess spawn', async () => {
+    // Verify that on mismatch, no subprocess is spawned — the function returns
+    // immediately with the error result. We can confirm this by checking that
+    // the result does not contain any sandbox-specific markers (like timeout
+    // status) and returns near-instantly.
+    const start = Date.now();
+    const resolver = (_dir: string) => 'v1:current';
+
+    const result = await runSkillToolScript(
+      tempDir, 'hang.ts', {}, makeContext(), {
+        target: 'sandbox',
+        expectedSkillVersionHash: 'v1:expected',
+        skillDirHashResolver: resolver,
+      },
+    );
+
+    const elapsed = Date.now() - start;
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Skill version mismatch');
+    // Should return almost instantly — well under even a 1-second threshold,
+    // confirming no subprocess was spawned (hang.ts sleeps for 120s).
+    expect(elapsed).toBeLessThan(1_000);
   });
 });

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -6,6 +6,7 @@ import type { ToolExecutionResult, ToolContext } from '../types.js';
 import { getConfig } from '../../config/loader.js';
 import { wrapCommand } from '../terminal/sandbox.js';
 import { buildSanitizedEnv } from '../terminal/safe-env.js';
+import { computeSkillVersionHash } from '../../skills/version-hash.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_OUTPUT_CHARS = 50_000;
@@ -62,12 +63,28 @@ export async function runSkillToolScriptSandbox(
   executorPath: string,
   input: Record<string, unknown>,
   context: ToolContext,
-  options?: { timeoutMs?: number },
+  options?: {
+    timeoutMs?: number;
+    expectedSkillVersionHash?: string;
+    skillDirHashResolver?: (skillDir: string) => string;
+  },
 ): Promise<ToolExecutionResult> {
   const scriptPath = resolve(join(skillDir, executorPath));
   const resolvedSkillDir = resolve(skillDir) + '/';
   if (!scriptPath.startsWith(resolvedSkillDir)) {
     return { content: `Skill tool script path "${executorPath}" escapes the skill directory`, isError: true };
+  }
+
+  // Block execution if the skill has been modified since approval.
+  if (options?.expectedSkillVersionHash) {
+    const resolver = options.skillDirHashResolver ?? computeSkillVersionHash;
+    const currentHash = resolver(resolvedSkillDir);
+    if (currentHash !== options.expectedSkillVersionHash) {
+      return {
+        content: `Skill version mismatch: expected ${options.expectedSkillVersionHash} but current is ${currentHash}. The skill has been modified since it was approved. Please reload the skill to re-approve.`,
+        isError: true,
+      };
+    }
   }
 
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -33,6 +33,8 @@ export async function runSkillToolScript(
   if (options?.target === 'sandbox') {
     return runSkillToolScriptSandbox(skillDir, executorPath, input, context, {
       timeoutMs: options.timeoutMs,
+      expectedSkillVersionHash: options.expectedSkillVersionHash,
+      skillDirHashResolver: options.skillDirHashResolver,
     });
   }
 


### PR DESCRIPTION
Applies version hash guard to sandbox skill execution path. Blocks subprocess spawn if skill has been modified since approval.

## Changes

- **`sandbox-runner.ts`**: Added `expectedSkillVersionHash` and `skillDirHashResolver` options. Before spawning the subprocess, verifies the current skill directory hash matches the expected hash. Returns a deterministic mismatch error without spawning if they differ.
- **`skill-script-runner.ts`**: Passes `expectedSkillVersionHash` and `skillDirHashResolver` through to the sandbox runner when `target` is `sandbox`.
- **`skill-script-runner-sandbox.test.ts`**: Added 7 tests covering hash match (execution proceeds), hash mismatch (execution blocked), no hash provided (execution proceeds), default resolver fallback, resolver receiving correct directory, and confirming mismatch prevents subprocess spawn.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
