### PR TITLE
feat: add skill path classifier utility (#PR26)

### DIFF
--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -1,8 +1,49 @@
-import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import { sandboxPolicy, hostPolicy } from '../tools/shared/filesystem/path-policy.js';
+
+// ── Mock setup for skill path classifier ────────────────────────────────────
+// The classifier imports getWorkspaceSkillsDir and getBundledSkillsDir, which
+// need stable test directories to avoid depending on the real home directory.
+// We create and realpath the root eagerly so that macOS's /tmp -> /private/tmp
+// symlink doesn't cause prefix mismatches between normalized roots and paths.
+
+const CLASSIFIER_TEST_ROOT = realpathSync(mkdtempSync(join(tmpdir(), 'path-classifier-')));
+const MOCK_MANAGED_DIR = join(CLASSIFIER_TEST_ROOT, 'workspace', 'skills');
+const MOCK_BUNDLED_DIR = join(CLASSIFIER_TEST_ROOT, 'bundled-skills');
+
+mock.module('../util/platform.js', () => ({
+  getWorkspaceSkillsDir: () => MOCK_MANAGED_DIR,
+  getRootDir: () => CLASSIFIER_TEST_ROOT,
+  getWorkspaceDir: () => join(CLASSIFIER_TEST_ROOT, 'workspace'),
+  getDataDir: () => join(CLASSIFIER_TEST_ROOT, 'data'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getPlatformName: () => process.platform,
+  ensureDataDir: () => {},
+}));
+
+mock.module('../config/skills.js', () => ({
+  getBundledSkillsDir: () => MOCK_BUNDLED_DIR,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+const {
+  isSkillSourcePath,
+  normalizeDirPath,
+  normalizeFilePath,
+  getSkillRoots,
+  getManagedSkillsRoot,
+  getBundledSkillsRoot,
+} = await import('../skills/path-classifier.js');
 
 const testDirs: string[] = [];
 
@@ -180,5 +221,174 @@ describe('baseline: skill directory paths (PR 1)', () => {
     if (result.ok) {
       expect(result.resolved).toBe('/Users/test/.vellum/workspace/skills/my-skill/executor.ts');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skill path classifier (PR 26)
+// ---------------------------------------------------------------------------
+
+describe('normalizeDirPath', () => {
+  test('appends trailing separator to plain path', () => {
+    const result = normalizeDirPath('/foo/bar');
+    expect(result.endsWith(sep)).toBe(true);
+  });
+
+  test('does not double-add trailing separator', () => {
+    const result = normalizeDirPath('/foo/bar/');
+    expect(result).toBe(`/foo/bar${sep}`);
+    // Should not end with double separators
+    expect(result.endsWith(`${sep}${sep}`)).toBe(false);
+  });
+
+  test('resolves dot segments', () => {
+    const result = normalizeDirPath('/foo/bar/../baz');
+    expect(result).toBe(`/foo/baz${sep}`);
+  });
+
+  test('resolves symlinks when directory exists on disk', () => {
+    const real = makeTempDir();
+    const linkParent = makeTempDir();
+    const link = join(linkParent, 'link-to-real');
+    symlinkSync(real, link);
+
+    const result = normalizeDirPath(link);
+    expect(result).toBe(real + sep);
+  });
+});
+
+describe('normalizeFilePath', () => {
+  test('resolves dot segments for non-existent path', () => {
+    const result = normalizeFilePath('/foo/bar/../baz/file.ts');
+    expect(result).toBe('/foo/baz/file.ts');
+  });
+
+  test('resolves symlinks for existing files', () => {
+    const dir = makeTempDir();
+    const realFile = join(dir, 'real.txt');
+    writeFileSync(realFile, 'content');
+    const linkFile = join(dir, 'link.txt');
+    symlinkSync(realFile, linkFile);
+
+    const result = normalizeFilePath(linkFile);
+    expect(result).toBe(realFile);
+  });
+});
+
+describe('getManagedSkillsRoot / getBundledSkillsRoot', () => {
+  test('returns managed skills dir with trailing separator', () => {
+    const root = getManagedSkillsRoot();
+    expect(root.endsWith(sep)).toBe(true);
+    expect(root).toContain('workspace');
+    expect(root).toContain('skills');
+  });
+
+  test('returns bundled skills dir with trailing separator', () => {
+    const root = getBundledSkillsRoot();
+    expect(root.endsWith(sep)).toBe(true);
+    expect(root).toContain('bundled-skills');
+  });
+});
+
+describe('getSkillRoots', () => {
+  test('includes managed and bundled roots by default', () => {
+    const roots = getSkillRoots();
+    expect(roots.length).toBeGreaterThanOrEqual(2);
+    expect(roots.some((r) => r.includes('skills'))).toBe(true);
+    expect(roots.some((r) => r.includes('bundled-skills'))).toBe(true);
+  });
+
+  test('includes extra roots when provided', () => {
+    const extra = '/custom/skill-dir';
+    const roots = getSkillRoots([extra]);
+    expect(roots.length).toBeGreaterThanOrEqual(3);
+    expect(roots.some((r) => r.includes('custom'))).toBe(true);
+  });
+
+  test('all roots end with separator', () => {
+    const roots = getSkillRoots(['/extra/root']);
+    for (const root of roots) {
+      expect(root.endsWith(sep)).toBe(true);
+    }
+  });
+});
+
+describe('isSkillSourcePath', () => {
+  test('returns true for path inside managed skills dir', () => {
+    mkdirSync(MOCK_MANAGED_DIR, { recursive: true });
+    const filePath = join(MOCK_MANAGED_DIR, 'my-skill', 'executor.ts');
+    expect(isSkillSourcePath(filePath)).toBe(true);
+  });
+
+  test('returns true for path inside bundled skills dir', () => {
+    mkdirSync(MOCK_BUNDLED_DIR, { recursive: true });
+    const filePath = join(MOCK_BUNDLED_DIR, 'web-search', 'SKILL.md');
+    expect(isSkillSourcePath(filePath)).toBe(true);
+  });
+
+  test('returns true for deeply nested path inside managed skills dir', () => {
+    mkdirSync(MOCK_MANAGED_DIR, { recursive: true });
+    const filePath = join(MOCK_MANAGED_DIR, 'my-skill', 'src', 'lib', 'helper.ts');
+    expect(isSkillSourcePath(filePath)).toBe(true);
+  });
+
+  test('returns false for path outside all skill dirs', () => {
+    expect(isSkillSourcePath('/usr/local/bin/something')).toBe(false);
+  });
+
+  test('returns false for path that shares prefix but is not under skill dir', () => {
+    // e.g. if managed dir is /tmp/.../workspace/skills, a path
+    // like /tmp/.../workspace/skillsX/foo should not match
+    mkdirSync(MOCK_MANAGED_DIR, { recursive: true });
+    const sibling = MOCK_MANAGED_DIR + 'X';
+    expect(isSkillSourcePath(join(sibling, 'foo.ts'))).toBe(false);
+  });
+
+  test('returns true for path inside extra roots', () => {
+    const extraRoot = makeTempDir();
+    const filePath = join(extraRoot, 'project-skill', 'SKILL.md');
+    expect(isSkillSourcePath(filePath, [extraRoot])).toBe(true);
+  });
+
+  test('returns false for extra root itself (must be inside)', () => {
+    const extraRoot = makeTempDir();
+    // The root directory itself should not match — only children
+    // normalizeDirPath adds trailing separator, so the root dir path
+    // without the separator won't start with root + sep
+    expect(isSkillSourcePath(extraRoot, [extraRoot])).toBe(false);
+  });
+
+  test('resolves symlinks when checking paths', () => {
+    mkdirSync(MOCK_MANAGED_DIR, { recursive: true });
+    const realDir = makeTempDir();
+    const linkPath = join(MOCK_MANAGED_DIR, 'linked-skill');
+    // Don't create the symlink if the test directory cleanup removed it
+    try {
+      symlinkSync(realDir, linkPath);
+    } catch {
+      // Link may already exist from a prior run; ignore
+    }
+    testDirs.push(linkPath);
+
+    // A file inside the symlinked skill should NOT match because realpath
+    // resolves it to realDir which is outside the managed skills dir
+    const filePath = join(linkPath, 'executor.ts');
+    // The symlink target (realDir) is outside MOCK_MANAGED_DIR, so this
+    // should be false (symlink-safe detection)
+    expect(isSkillSourcePath(filePath)).toBe(false);
+  });
+
+  test('handles normalized vs non-normalized paths', () => {
+    mkdirSync(MOCK_MANAGED_DIR, { recursive: true });
+    // Path with redundant dot segments that should normalize to managed dir
+    const messyPath = join(MOCK_MANAGED_DIR, 'my-skill', '..', 'my-skill', 'file.ts');
+    expect(isSkillSourcePath(messyPath)).toBe(true);
+  });
+
+  test('handles trailing slashes in paths', () => {
+    mkdirSync(MOCK_MANAGED_DIR, { recursive: true });
+    // A path with trailing slash (unusual for a file, but should not crash)
+    const filePath = join(MOCK_MANAGED_DIR, 'my-skill') + '/';
+    expect(isSkillSourcePath(filePath)).toBe(true);
   });
 });

--- a/assistant/src/skills/path-classifier.ts
+++ b/assistant/src/skills/path-classifier.ts
@@ -1,0 +1,105 @@
+import { realpathSync, existsSync } from 'node:fs';
+import { basename, dirname, resolve, normalize, sep } from 'node:path';
+import { getWorkspaceSkillsDir } from '../util/platform.js';
+import { getBundledSkillsDir } from '../config/skills.js';
+
+/**
+ * Returns the managed skills root directory. Managed skills are user-installed
+ * skills that live under ~/.vellum/workspace/skills.
+ */
+export function getManagedSkillsRoot(): string {
+  return normalizeDirPath(getWorkspaceSkillsDir());
+}
+
+/**
+ * Returns the bundled skills root directory. Bundled skills ship with the
+ * application binary and are read-only.
+ */
+export function getBundledSkillsRoot(): string {
+  return normalizeDirPath(getBundledSkillsDir());
+}
+
+/**
+ * Normalizes a directory path to a canonical form suitable for prefix
+ * comparison. Resolves relative segments and ensures a trailing separator
+ * so that "/foo/bar" won't false-match "/foo/barbaz".
+ *
+ * When the path exists on disk, realpath is used to resolve symlinks.
+ * Otherwise resolve() is used for pure lexical normalization.
+ */
+export function normalizeDirPath(dirPath: string): string {
+  const resolved = existsSync(dirPath) ? realpathSync(dirPath) : resolve(dirPath);
+  const normalized = normalize(resolved);
+  return normalized.endsWith(sep) ? normalized : normalized + sep;
+}
+
+/**
+ * Normalizes an absolute file path for comparison. Resolves symlinks
+ * through the nearest existing ancestor so that a symlinked parent
+ * directory is detected even when the leaf file doesn't exist yet.
+ */
+export function normalizeFilePath(filePath: string): string {
+  if (existsSync(filePath)) {
+    return realpathSync(filePath);
+  }
+
+  // Walk up until we find an ancestor that exists on disk, resolve it,
+  // then re-append the tail segments. This catches symlinked parent dirs.
+  const resolved = resolve(filePath);
+  const segments: string[] = [];
+  let current = resolved;
+  while (current !== dirname(current)) {
+    if (existsSync(current)) {
+      const realBase = realpathSync(current);
+      return segments.reduceRight((acc, seg) => acc + sep + seg, realBase);
+    }
+    segments.push(basename(current));
+    current = dirname(current);
+  }
+
+  // Nothing on the path exists — fall back to pure lexical resolution
+  return resolved;
+}
+
+/**
+ * Returns all known skill root directories as normalized paths with trailing
+ * separators. Additional roots (e.g. workspace-local skill directories) can
+ * be passed via the `extraRoots` parameter.
+ */
+export function getSkillRoots(extraRoots?: string[]): string[] {
+  const roots = [
+    getManagedSkillsRoot(),
+    getBundledSkillsRoot(),
+  ];
+  if (extraRoots) {
+    for (const root of extraRoots) {
+      roots.push(normalizeDirPath(root));
+    }
+  }
+  return roots;
+}
+
+/**
+ * Checks whether an absolute path falls under any known skill directory.
+ *
+ * Returns true if the path is inside the managed skills dir, the bundled
+ * skills dir, or any of the provided extra roots. The check is
+ * symlink-safe: both the candidate path and the skill roots are resolved
+ * through realpath when the paths exist on disk.
+ *
+ * @param absPath  - The absolute path to classify.
+ * @param extraRoots - Optional additional skill root directories to check.
+ * @returns true if the path is inside any skill directory.
+ */
+export function isSkillSourcePath(absPath: string, extraRoots?: string[]): boolean {
+  const normalizedPath = normalizeFilePath(absPath);
+  const roots = getSkillRoots(extraRoots);
+
+  for (const root of roots) {
+    if (normalizedPath.startsWith(root)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Centralizes skill path detection with isSkillSourcePath() and related helpers for consistent policy matching.

## Summary
- Adds path-classifier.ts with isSkillSourcePath(), normalizeDirPath(), normalizeFilePath(), getSkillRoots()
- Symlink-safe: walks up ancestor directories to resolve symlinked parents
- Trailing-separator guard prevents false prefix matches (e.g. skillsX vs skills/)
- Tests cover managed/bundled/extra roots, outside paths, symlink escape, dot segments, trailing slashes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
