### PR TITLE
feat: default ask rules for skill source mutations (#PR28)

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -797,6 +797,97 @@ describe('Trust Store', () => {
       const defaults = rules.filter((r) => r.id.startsWith('default:'));
       expect(defaults).toHaveLength(NUM_DEFAULTS);
     });
+
+    // ── skill source mutation rules ────────────────────────────────
+
+    test('default rules include ask rules for file_write on skill source paths', () => {
+      const rules = getAllRules();
+      const managed = rules.find((r) => r.id === 'default:ask-file_write-managed-skills');
+      expect(managed).toBeDefined();
+      expect(managed!.tool).toBe('file_write');
+      expect(managed!.decision).toBe('ask');
+      expect(managed!.priority).toBe(1000);
+      expect(managed!.pattern).toContain('workspace/skills/**');
+
+      const bundled = rules.find((r) => r.id === 'default:ask-file_write-bundled-skills');
+      expect(bundled).toBeDefined();
+      expect(bundled!.tool).toBe('file_write');
+      expect(bundled!.decision).toBe('ask');
+      expect(bundled!.priority).toBe(1000);
+    });
+
+    test('default rules include ask rules for file_edit on skill source paths', () => {
+      const rules = getAllRules();
+      const managed = rules.find((r) => r.id === 'default:ask-file_edit-managed-skills');
+      expect(managed).toBeDefined();
+      expect(managed!.tool).toBe('file_edit');
+      expect(managed!.decision).toBe('ask');
+      expect(managed!.priority).toBe(1000);
+      expect(managed!.pattern).toContain('workspace/skills/**');
+
+      const bundled = rules.find((r) => r.id === 'default:ask-file_edit-bundled-skills');
+      expect(bundled).toBeDefined();
+      expect(bundled!.tool).toBe('file_edit');
+      expect(bundled!.decision).toBe('ask');
+      expect(bundled!.priority).toBe(1000);
+    });
+
+    test('default rules include ask rules for host_file_write on skill source paths', () => {
+      const rules = getAllRules();
+      const managed = rules.find((r) => r.id === 'default:ask-host_file_write-managed-skills');
+      expect(managed).toBeDefined();
+      expect(managed!.tool).toBe('host_file_write');
+      expect(managed!.decision).toBe('ask');
+      expect(managed!.priority).toBe(1000);
+      expect(managed!.pattern).toContain('workspace/skills/**');
+
+      const bundled = rules.find((r) => r.id === 'default:ask-host_file_write-bundled-skills');
+      expect(bundled).toBeDefined();
+      expect(bundled!.tool).toBe('host_file_write');
+      expect(bundled!.decision).toBe('ask');
+      expect(bundled!.priority).toBe(1000);
+    });
+
+    test('default rules include ask rules for host_file_edit on skill source paths', () => {
+      const rules = getAllRules();
+      const managed = rules.find((r) => r.id === 'default:ask-host_file_edit-managed-skills');
+      expect(managed).toBeDefined();
+      expect(managed!.tool).toBe('host_file_edit');
+      expect(managed!.decision).toBe('ask');
+      expect(managed!.priority).toBe(1000);
+      expect(managed!.pattern).toContain('workspace/skills/**');
+
+      const bundled = rules.find((r) => r.id === 'default:ask-host_file_edit-bundled-skills');
+      expect(bundled).toBeDefined();
+      expect(bundled!.tool).toBe('host_file_edit');
+      expect(bundled!.decision).toBe('ask');
+      expect(bundled!.priority).toBe(1000);
+    });
+
+    test('no default ask rules exist for file_read on skill source paths', () => {
+      const rules = getAllRules();
+      // There should be no default rules with IDs matching file_read for skill sources
+      const readManagedSkill = rules.find((r) => r.id === 'default:ask-file_read-managed-skills');
+      const readBundledSkill = rules.find((r) => r.id === 'default:ask-file_read-bundled-skills');
+      expect(readManagedSkill).toBeUndefined();
+      expect(readBundledSkill).toBeUndefined();
+    });
+
+    test('findHighestPriorityRule matches default ask for file_write on managed skill path', () => {
+      const skillFile = join(testDir, 'workspace', 'skills', 'my-skill', 'SKILL.md');
+      const match = findHighestPriorityRule('file_write', [`file_write:${skillFile}`], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-file_write-managed-skills');
+      expect(match!.decision).toBe('ask');
+    });
+
+    test('findHighestPriorityRule matches default ask for file_edit on managed skill path', () => {
+      const skillFile = join(testDir, 'workspace', 'skills', 'my-skill', 'tools.ts');
+      const match = findHighestPriorityRule('file_edit', [`file_edit:${skillFile}`], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-file_edit-managed-skills');
+      expect(match!.decision).toBe('ask');
+    });
   });
 
   // ── trust rule schema v3 (PR 14) ──────────────────────────────

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 import { getRootDir } from '../util/platform.js';
+import { getBundledSkillsDir } from '../config/skills.js';
 
 export interface DefaultRuleTemplate {
   id: string;
@@ -121,6 +122,37 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
+  // Skill source directories — writing or editing skill source files should
+  // require explicit user approval so a compromised agent loop cannot silently
+  // modify skill code to escalate privileges.
+  const managedSkillsDir = join(getRootDir(), 'workspace', 'skills').replaceAll('\\', '/');
+  const bundledSkillsDir = getBundledSkillsDir().replaceAll('\\', '/');
+  const SKILL_MUTATION_TOOLS = ['file_write', 'file_edit'] as const;
+  const HOST_SKILL_MUTATION_TOOLS = ['host_file_write', 'host_file_edit'] as const;
+  const skillDirs = [
+    { dir: managedSkillsDir, label: 'managed' },
+    { dir: bundledSkillsDir, label: 'bundled' },
+  ];
+
+  const skillSourceMutationRules = skillDirs.flatMap(({ dir, label }) => [
+    ...SKILL_MUTATION_TOOLS.map((tool) => ({
+      id: `default:ask-${tool}-${label}-skills`,
+      tool,
+      pattern: `${tool}:${dir}/**`,
+      scope: 'everywhere',
+      decision: 'ask' as const,
+      priority: 1000,
+    })),
+    ...HOST_SKILL_MUTATION_TOOLS.map((tool) => ({
+      id: `default:ask-${tool}-${label}-skills`,
+      tool,
+      pattern: `${tool}:${dir}/**`,
+      scope: 'everywhere',
+      decision: 'ask' as const,
+      priority: 1000,
+    })),
+  ]);
+
   return [
     ...protectedFileRules,
     ...hostFileRules,
@@ -129,5 +161,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     ...managedSkillRules,
     ...workspacePromptRules,
     bootstrapDeleteRule,
+    ...skillSourceMutationRules,
   ];
 }


### PR DESCRIPTION
## Summary
- Adds default `ask` trust rules for `file_write`, `file_edit`, `host_file_write`, and `host_file_edit` operations targeting managed (`~/.vellum/workspace/skills`) and bundled skill source directories
- Prevents a compromised agent loop from silently modifying skill code to escalate privileges
- Read operations (`file_read`, `host_file_read`) are intentionally left unchanged -- no new default rules for reads

## Test plan
- [x] Verified default rules include ask rules for `file_write` on skill source paths
- [x] Verified default rules include ask rules for `file_edit` on skill source paths
- [x] Verified default rules include ask rules for `host_file_write` on skill source paths
- [x] Verified default rules include ask rules for `host_file_edit` on skill source paths
- [x] Verified no default ask rules exist for `file_read` on skill paths (reads stay unchanged)
- [x] Verified `findHighestPriorityRule` matches the new rules for managed skill paths
- [x] All 124 existing trust-store tests pass (0 failures)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
