### PR TITLE
feat: persistent high-risk allow rules (#PR22)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1512,6 +1512,86 @@ describe('Permission Checker', () => {
     });
   });
 
+  // ── persistent high-risk allow rules (PR 22) ──────────────────
+
+  describe('persistent high-risk allow rules (PR 22)', () => {
+    test('high-risk tool with allowHighRisk: true allow rule returns allow', async () => {
+      addRule('bash', 'kill *', 'everywhere', 'allow', 2000, { allowHighRisk: true });
+      const result = await check('bash', { command: 'kill -9 1234' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('high-risk trust rule');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.allowHighRisk).toBe(true);
+    });
+
+    test('high-risk tool with allow rule WITHOUT allowHighRisk still prompts', async () => {
+      addRule('bash', 'kill *', 'everywhere', 'allow', 2000);
+      const result = await check('bash', { command: 'kill -9 1234' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
+    });
+
+    test('high-risk tool with allowHighRisk: false still prompts', async () => {
+      addRule('bash', 'kill *', 'everywhere', 'allow', 2000, { allowHighRisk: false });
+      const result = await check('bash', { command: 'kill -9 1234' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
+    });
+
+    test('high-risk tool with no matching rule returns prompt', async () => {
+      const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
+    });
+
+    test('low-risk tool is NOT affected by allowHighRisk (still auto-allows without it)', async () => {
+      const result = await check('bash', { command: 'ls' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('Low risk');
+    });
+
+    test('medium-risk tool with allow rule is NOT affected by allowHighRisk', async () => {
+      addRule('bash', 'rm *', '/tmp', 'allow', 100);
+      const result = await check('bash', { command: 'rm file.txt' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('Matched trust rule');
+      // No mention of high-risk in the reason
+      expect(result.reason).not.toContain('high-risk');
+    });
+
+    test('high-risk scaffold_managed_skill with allowHighRisk: true returns allow', async () => {
+      addRule('scaffold_managed_skill', 'scaffold_managed_skill:my-skill', 'everywhere', 'allow', 2000, { allowHighRisk: true });
+      const result = await check('scaffold_managed_skill', { skill_id: 'my-skill' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('high-risk trust rule');
+    });
+
+    test('high-risk delete_managed_skill with allowHighRisk: true returns allow', async () => {
+      addRule('delete_managed_skill', 'delete_managed_skill:*', 'everywhere', 'allow', 2000, { allowHighRisk: true });
+      const result = await check('delete_managed_skill', { skill_id: 'any-skill' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('high-risk trust rule');
+    });
+
+    test('deny rule still takes precedence over allowHighRisk allow rule', async () => {
+      addRule('bash', 'kill *', 'everywhere', 'allow', 100, { allowHighRisk: true });
+      addRule('bash', 'kill *', 'everywhere', 'deny', 200);
+      const result = await check('bash', { command: 'kill -9 1234' }, '/tmp');
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toContain('deny rule');
+    });
+
+    test('allowHighRisk persists through addRule', () => {
+      const rule = addRule('bash', 'kill *', 'everywhere', 'allow', 100, { allowHighRisk: true });
+      expect(rule.allowHighRisk).toBe(true);
+    });
+
+    test('addRule without allowHighRisk option does not set the field', () => {
+      const rule = addRule('bash', 'git *', '/tmp');
+      expect(rule.allowHighRisk).toBeUndefined();
+    });
+  });
+
   // ── canonical file command candidates (PR 27) ─────────────────
 
   describe('canonical file command candidates (PR 27)', () => {

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -119,6 +119,27 @@ describe('Trust Store', () => {
       expect(userRules[2].priority).toBe(0);
     });
 
+    test('accepts allowHighRisk option and persists it', () => {
+      const rule = addRule('bash', 'sudo *', 'everywhere', 'allow', 100, { allowHighRisk: true });
+      expect(rule.allowHighRisk).toBe(true);
+      // Verify it persists to disk
+      clearCache();
+      const rules = getAllRules();
+      const found = rules.find((r) => r.id === rule.id);
+      expect(found).toBeDefined();
+      expect(found!.allowHighRisk).toBe(true);
+    });
+
+    test('addRule without allowHighRisk option does not set the field', () => {
+      const rule = addRule('bash', 'git *', '/tmp');
+      expect(rule.allowHighRisk).toBeUndefined();
+      // Verify on disk
+      const raw = JSON.parse(readFileSync(trustPath, 'utf-8'));
+      const diskRule = raw.rules.find((r: { id: string }) => r.id === rule.id);
+      expect(diskRule).toBeDefined();
+      expect(diskRule).not.toHaveProperty('allowHighRisk');
+    });
+
     test('at same priority deny rules sort before allow rules', () => {
       addRule('bash', 'allow *', '/tmp', 'allow', 100);
       addRule('bash', 'deny *', '/tmp', 'deny', 100);

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -318,7 +318,11 @@ export async function check(
     if (risk !== RiskLevel.High) {
       return { decision: 'allow', reason: `Matched trust rule: ${matchedRule.pattern}`, matchedRule };
     }
-    // High risk with allow rule → fall through to prompt
+    // High risk with allow rule that explicitly permits high-risk → auto-allow
+    if (matchedRule.allowHighRisk === true) {
+      return { decision: 'allow', reason: `Matched high-risk trust rule: ${matchedRule.pattern}`, matchedRule };
+    }
+    // High risk with allow rule (without allowHighRisk) → fall through to prompt
   }
 
   // No matching rule (or High risk with allow rule) → risk-based fallback

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -202,6 +202,7 @@ export function addRule(
   scope: string,
   decision: 'allow' | 'deny' | 'ask' = 'allow',
   priority: number = 100,
+  options?: { allowHighRisk?: boolean },
 ): TrustRule {
   // Re-read from disk to avoid lost updates if another call modified rules
   // between our last read and now (e.g. two rapid trust rule additions).
@@ -216,6 +217,9 @@ export function addRule(
     priority,
     createdAt: Date.now(),
   };
+  if (options?.allowHighRisk != null) {
+    rule.allowHighRisk = options.allowHighRisk;
+  }
   rules.push(rule);
   rules.sort(ruleOrder);
   cachedRules = rules;


### PR DESCRIPTION
## Summary
- Allow trust rules with `allowHighRisk: true` to auto-approve high-risk tools instead of always prompting
- Extend `addRule()` in trust-store to accept an `options` parameter with `allowHighRisk` for programmatic rule creation
- Preserve existing behavior: rules without `allowHighRisk` (or with `allowHighRisk: false`) still always prompt for high-risk tools

## Test plan
- [x] High-risk tool with `allowHighRisk: true` allow rule returns `allow`
- [x] High-risk tool with allow rule WITHOUT `allowHighRisk` still returns `prompt`
- [x] High-risk tool with `allowHighRisk: false` still returns `prompt`
- [x] High-risk tool with no matching rule returns `prompt`
- [x] Low/medium-risk tools are NOT affected by `allowHighRisk`
- [x] High-risk managed skill tools (`scaffold_managed_skill`, `delete_managed_skill`) work with `allowHighRisk: true`
- [x] Deny rules still take precedence over `allowHighRisk` allow rules
- [x] `addRule()` persists `allowHighRisk` to disk and omits it when not set
- [x] All existing tests continue to pass (298 total)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
