### PR TITLE
feat: add always_allow_high_risk decision to permission prompt UX

### DIFF
--- a/assistant/src/__tests__/ipc-validate.test.ts
+++ b/assistant/src/__tests__/ipc-validate.test.ts
@@ -169,13 +169,30 @@ describe('IPC Validate', () => {
     });
 
     test('accepts all valid decision values', () => {
-      for (const decision of ['allow', 'always_allow', 'deny', 'always_deny']) {
+      for (const decision of ['allow', 'always_allow', 'always_allow_high_risk', 'deny', 'always_deny']) {
         const result = validateClientMessage({
           type: 'confirmation_response',
           requestId: 'req-1',
           decision,
         });
         expect(result.valid).toBe(true);
+      }
+    });
+
+    test('accepts always_allow_high_risk decision', () => {
+      const result = validateClientMessage({
+        type: 'confirmation_response',
+        requestId: 'req-1',
+        decision: 'always_allow_high_risk',
+        selectedPattern: 'Bash(*)',
+        selectedScope: 'global',
+      });
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        const msg = result.message as { decision: string; selectedPattern?: string; selectedScope?: string };
+        expect(msg.decision).toBe('always_allow_high_risk');
+        expect(msg.selectedPattern).toBe('Bash(*)');
+        expect(msg.selectedScope).toBe('global');
       }
     });
 

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -189,6 +189,7 @@ export async function startCli(): Promise<void> {
     process.stdout.write(`\u2502 [d] Deny once\n`);
     if (req.allowlistOptions.length > 0) {
       process.stdout.write(`\u2502 [A] Allowlist...\n`);
+      process.stdout.write(`\u2502 [H] Allowlist (high-risk)...\n`);
       process.stdout.write(`\u2502 [D] Denylist...\n`);
     }
     process.stdout.write(`\u2514 > `);
@@ -202,6 +203,13 @@ export async function startCli(): Promise<void> {
       if (trimmed === 'A' || choice === 'allowlist') {
         // pendingConfirmation stays true through sub-prompts
         renderPatternSelection(req, 'always_allow');
+        return;
+      }
+
+      // Uppercase 'H' → high-risk allowlist pattern selection
+      if (trimmed === 'H') {
+        // pendingConfirmation stays true through sub-prompts
+        renderPatternSelection(req, 'always_allow_high_risk');
         return;
       }
 
@@ -240,8 +248,8 @@ export async function startCli(): Promise<void> {
     });
   }
 
-  function renderPatternSelection(req: ConfirmationRequest, decision: 'always_allow' | 'always_deny'): void {
-    const label = decision === 'always_allow' ? 'Allowlist' : 'Denylist';
+  function renderPatternSelection(req: ConfirmationRequest, decision: 'always_allow' | 'always_allow_high_risk' | 'always_deny'): void {
+    const label = decision === 'always_deny' ? 'Denylist' : decision === 'always_allow_high_risk' ? 'Allowlist (high-risk)' : 'Allowlist';
     process.stdout.write('\n');
     process.stdout.write(`\u250C ${label}: choose command pattern\n`);
     for (let i = 0; i < req.allowlistOptions.length; i++) {
@@ -267,8 +275,8 @@ export async function startCli(): Promise<void> {
     });
   }
 
-  function renderScopeSelection(req: ConfirmationRequest, selectedPattern: string, decision: 'always_allow' | 'always_deny'): void {
-    const label = decision === 'always_allow' ? 'Allowlist' : 'Denylist';
+  function renderScopeSelection(req: ConfirmationRequest, selectedPattern: string, decision: 'always_allow' | 'always_allow_high_risk' | 'always_deny'): void {
+    const label = decision === 'always_deny' ? 'Denylist' : decision === 'always_allow_high_risk' ? 'Allowlist (high-risk)' : 'Allowlist';
     process.stdout.write('\n');
     process.stdout.write(`\u250C ${label}: choose scope\n`);
     for (let i = 0; i < req.scopeOptions.length; i++) {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -39,7 +39,7 @@ export interface UserMessageAttachment {
 export interface ConfirmationResponse {
   type: 'confirmation_response';
   requestId: string;
-  decision: 'allow' | 'always_allow' | 'deny' | 'always_deny';
+  decision: 'allow' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
   selectedPattern?: string;
   selectedScope?: string;
 }

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -116,7 +116,7 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     if (typeof obj.requestId !== 'string' || obj.requestId === '') {
       return 'confirmation_response requires a non-empty string "requestId"';
     }
-    const validDecisions = ['allow', 'always_allow', 'deny', 'always_deny'];
+    const validDecisions = ['allow', 'always_allow', 'always_allow_high_risk', 'deny', 'always_deny'];
     if (typeof obj.decision !== 'string' || !validDecisions.includes(obj.decision)) {
       return `confirmation_response "decision" must be one of: ${validDecisions.join(', ')}`;
     }

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -20,7 +20,7 @@ export interface TrustRule {
   allowHighRisk?: boolean;
 }
 
-export type UserDecision = 'allow' | 'always_allow' | 'deny' | 'always_deny';
+export type UserDecision = 'allow' | 'always_allow' | 'always_allow_high_risk' | 'deny' | 'always_deny';
 
 export interface PermissionCheckResult {
   decision: 'allow' | 'deny' | 'prompt';


### PR DESCRIPTION
PR 23 of security rollout: Extends the UserDecision type with always_allow_high_risk, wires it through IPC validation, prompter, and CLI selection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
