### PR TITLE
test: add strict mode and high-risk allow integration tests

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1645,6 +1645,212 @@ describe('Permission Checker', () => {
     });
   });
 
+  // ── strict mode + high-risk integration tests (PR 25) ─────────
+
+  describe('strict mode + high-risk integration (PR 25)', () => {
+    test('strict mode: low-risk with no rule prompts (baseline)', async () => {
+      testConfig.permissions.mode = 'strict';
+      const result = await check('file_read', { path: '/tmp/test.txt' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('Strict mode');
+    });
+
+    test('strict mode: high-risk with allowHighRisk rule auto-allows', async () => {
+      testConfig.permissions.mode = 'strict';
+      addRule('bash', 'kill *', 'everywhere', 'allow', 2000, { allowHighRisk: true });
+      const result = await check('bash', { command: 'kill -9 1234' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('high-risk trust rule');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.allowHighRisk).toBe(true);
+    });
+
+    test('strict mode: high-risk with allow rule (no allowHighRisk) still prompts', async () => {
+      testConfig.permissions.mode = 'strict';
+      addRule('bash', 'kill *', 'everywhere', 'allow', 2000);
+      const result = await check('bash', { command: 'kill -9 1234' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
+    });
+
+    test('strict mode: medium-risk with matching allow rule auto-allows', async () => {
+      testConfig.permissions.mode = 'strict';
+      addRule('bash', 'rm *', '/tmp', 'allow');
+      const result = await check('bash', { command: 'rm file.txt' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('Matched trust rule');
+    });
+
+    test('strict mode: principal-scoped rule auto-allows when principal matches', async () => {
+      testConfig.permissions.mode = 'strict';
+      const trustPath = join(checkerTestDir, 'protected', 'trust.json');
+      const { writeFileSync, mkdirSync, existsSync } = await import('node:fs');
+      const { dirname } = await import('node:path');
+
+      clearCache();
+      const trustDir = dirname(trustPath);
+      if (!existsSync(trustDir)) mkdirSync(trustDir, { recursive: true });
+
+      writeFileSync(trustPath, JSON.stringify({
+        version: 3,
+        rules: [{
+          id: 'test-strict-principal',
+          tool: 'bash',
+          pattern: 'echo *',
+          scope: 'everywhere',
+          decision: 'allow',
+          priority: 2000,
+          createdAt: Date.now(),
+          principalKind: 'skill',
+          principalId: 'trusted-skill',
+        }],
+      }, null, 2));
+      clearCache();
+
+      const ctx: PolicyContext = {
+        principal: { kind: 'skill', id: 'trusted-skill' },
+      };
+      const result = await check('bash', { command: 'echo hello' }, '/tmp', ctx);
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule?.id).toBe('test-strict-principal');
+    });
+
+    test('strict mode: principal-scoped rule does NOT match wrong principal', async () => {
+      testConfig.permissions.mode = 'strict';
+      const trustPath = join(checkerTestDir, 'protected', 'trust.json');
+      const { writeFileSync, mkdirSync, existsSync } = await import('node:fs');
+      const { dirname } = await import('node:path');
+
+      clearCache();
+      const trustDir = dirname(trustPath);
+      if (!existsSync(trustDir)) mkdirSync(trustDir, { recursive: true });
+
+      writeFileSync(trustPath, JSON.stringify({
+        version: 3,
+        rules: [{
+          id: 'test-strict-principal-mismatch',
+          tool: 'bash',
+          pattern: 'echo *',
+          scope: 'everywhere',
+          decision: 'allow',
+          priority: 2000,
+          createdAt: Date.now(),
+          principalKind: 'skill',
+          principalId: 'trusted-skill',
+        }],
+      }, null, 2));
+      clearCache();
+
+      // Wrong principal — rule should not match. In strict mode, bash 'echo' is
+      // low risk but has no matching rule → prompt with "Strict mode" reason.
+      const ctx: PolicyContext = {
+        principal: { kind: 'skill', id: 'attacker-skill' },
+      };
+      const result = await check('bash', { command: 'echo hello' }, '/tmp', ctx);
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('Strict mode');
+    });
+
+    test('strict mode: high-risk allowHighRisk rule with version-bound principal auto-allows', async () => {
+      testConfig.permissions.mode = 'strict';
+      const trustPath = join(checkerTestDir, 'protected', 'trust.json');
+      const { writeFileSync, mkdirSync, existsSync } = await import('node:fs');
+      const { dirname } = await import('node:path');
+
+      clearCache();
+      const trustDir = dirname(trustPath);
+      if (!existsSync(trustDir)) mkdirSync(trustDir, { recursive: true });
+
+      writeFileSync(trustPath, JSON.stringify({
+        version: 3,
+        rules: [{
+          id: 'test-strict-hr-principal',
+          tool: 'bash',
+          pattern: 'sudo *',
+          scope: 'everywhere',
+          decision: 'allow',
+          priority: 2000,
+          createdAt: Date.now(),
+          allowHighRisk: true,
+          principalKind: 'skill',
+          principalId: 'admin-skill',
+          principalVersion: 'v1:hash123',
+        }],
+      }, null, 2));
+      clearCache();
+
+      const ctx: PolicyContext = {
+        principal: { kind: 'skill', id: 'admin-skill', version: 'v1:hash123' },
+      };
+      const result = await check('bash', { command: 'sudo apt update' }, '/tmp', ctx);
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('high-risk trust rule');
+      expect(result.matchedRule?.id).toBe('test-strict-hr-principal');
+    });
+
+    test('strict mode: high-risk allowHighRisk rule with wrong version still prompts', async () => {
+      testConfig.permissions.mode = 'strict';
+      const trustPath = join(checkerTestDir, 'protected', 'trust.json');
+      const { writeFileSync, mkdirSync, existsSync } = await import('node:fs');
+      const { dirname } = await import('node:path');
+
+      clearCache();
+      const trustDir = dirname(trustPath);
+      if (!existsSync(trustDir)) mkdirSync(trustDir, { recursive: true });
+
+      writeFileSync(trustPath, JSON.stringify({
+        version: 3,
+        rules: [{
+          id: 'test-strict-hr-version-mismatch',
+          tool: 'bash',
+          pattern: 'sudo *',
+          scope: 'everywhere',
+          decision: 'allow',
+          priority: 2000,
+          createdAt: Date.now(),
+          allowHighRisk: true,
+          principalKind: 'skill',
+          principalId: 'admin-skill',
+          principalVersion: 'v1:hash123',
+        }],
+      }, null, 2));
+      clearCache();
+
+      // Same principal but different version — rule should not match.
+      const ctx: PolicyContext = {
+        principal: { kind: 'skill', id: 'admin-skill', version: 'v2:different' },
+      };
+      const result = await check('bash', { command: 'sudo apt update' }, '/tmp', ctx);
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('requires approval');
+    });
+
+    test('strict mode: deny rule overrides allowHighRisk rule even in strict mode', async () => {
+      testConfig.permissions.mode = 'strict';
+      addRule('bash', 'kill *', 'everywhere', 'allow', 100, { allowHighRisk: true });
+      addRule('bash', 'kill *', 'everywhere', 'deny', 200);
+      const result = await check('bash', { command: 'kill -9 1234' }, '/tmp');
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toContain('deny rule');
+    });
+
+    test('strict mode: scaffold_managed_skill with allowHighRisk auto-allows', async () => {
+      testConfig.permissions.mode = 'strict';
+      addRule('scaffold_managed_skill', 'scaffold_managed_skill:my-skill', 'everywhere', 'allow', 2000, { allowHighRisk: true });
+      const result = await check('scaffold_managed_skill', { skill_id: 'my-skill' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('high-risk trust rule');
+    });
+
+    test('strict mode: scaffold_managed_skill without allowHighRisk still prompts', async () => {
+      testConfig.permissions.mode = 'strict';
+      addRule('scaffold_managed_skill', 'scaffold_managed_skill:my-skill', 'everywhere', 'allow', 2000);
+      const result = await check('scaffold_managed_skill', { skill_id: 'my-skill' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
+    });
+  });
+
   // ── canonical file command candidates (PR 27) ─────────────────
 
   describe('canonical file command candidates (PR 27)', () => {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -513,3 +513,170 @@ describe('ToolExecutor contextual rule creation', () => {
     expect(options.principalVersion).toBe('host-hash-v1');
   });
 });
+
+describe('ToolExecutor strict mode + high-risk integration (PR 25)', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+    lastCheckArgs = undefined;
+    getToolOverride = undefined;
+    checkResultOverride = undefined;
+    if (addRuleSpy) { addRuleSpy.mockRestore(); addRuleSpy = undefined; }
+  });
+
+  function setupAddRuleSpy() {
+    addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      },
+    );
+    return addRuleSpy;
+  }
+
+  test('always_allow_high_risk creates rule with allowHighRisk: true for high-risk skill tool', async () => {
+    checkResultOverride = { decision: 'prompt', reason: 'High risk: always requires approval' };
+    const spy = setupAddRuleSpy();
+
+    getToolOverride = (name: string) => {
+      if (name === 'unknown_tool') return undefined;
+      return {
+        name,
+        description: 'high-risk skill tool',
+        category: 'skill',
+        defaultRiskLevel: 'high' as const,
+        origin: 'skill' as const,
+        ownerSkillId: 'deploy-skill',
+        ownerSkillVersionHash: 'sha256-deploy-v1',
+        executionTarget: 'host' as const,
+        getDefinition: () => ({ name, description: 'high-risk skill tool', input_schema: { type: 'object' as const, properties: {} } }),
+        execute: async () => fakeToolResult,
+      };
+    };
+
+    const prompter = makePrompterWithDecision('always_allow_high_risk', 'deploy_tool:*', 'everywhere');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('deploy_tool', { target: 'prod' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [tool, pattern, scope, decision, priority, options] = spy.mock.calls[0];
+    expect(tool).toBe('deploy_tool');
+    expect(pattern).toBe('deploy_tool:*');
+    expect(scope).toBe('everywhere');
+    expect(decision).toBe('allow');
+    // The key integration assertion: allowHighRisk + principal context together
+    expect(options.allowHighRisk).toBe(true);
+    expect(options.principalKind).toBe('skill');
+    expect(options.principalId).toBe('deploy-skill');
+    expect(options.principalVersion).toBe('sha256-deploy-v1');
+    expect(options.executionTarget).toBe('host');
+  });
+
+  test('always_allow creates rule without allowHighRisk even for high-risk skill tool', async () => {
+    checkResultOverride = { decision: 'prompt', reason: 'test prompt' };
+    const spy = setupAddRuleSpy();
+
+    getToolOverride = (name: string) => {
+      if (name === 'unknown_tool') return undefined;
+      return {
+        name,
+        description: 'high-risk skill tool',
+        category: 'skill',
+        defaultRiskLevel: 'high' as const,
+        origin: 'skill' as const,
+        ownerSkillId: 'risky-skill',
+        ownerSkillVersionHash: 'sha256-risky',
+        executionTarget: 'sandbox' as const,
+        getDefinition: () => ({ name, description: 'high-risk skill tool', input_schema: { type: 'object' as const, properties: {} } }),
+        execute: async () => fakeToolResult,
+      };
+    };
+
+    // User chooses always_allow (NOT always_allow_high_risk) — the rule
+    // should NOT have allowHighRisk set, meaning future high-risk checks
+    // will still prompt.
+    const prompter = makePrompterWithDecision('always_allow', 'risky_op:*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('risky_op', {}, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [,,,, , options] = spy.mock.calls[0];
+    expect(options).toBeDefined();
+    // Principal context should be present
+    expect(options.principalKind).toBe('skill');
+    expect(options.principalId).toBe('risky-skill');
+    // But allowHighRisk should NOT be set
+    expect(options.allowHighRisk).toBeUndefined();
+  });
+
+  test('executor forwards policyContext to check() for version-bound skill tool', async () => {
+    getToolOverride = (name: string) => {
+      if (name === 'unknown_tool') return undefined;
+      return {
+        name,
+        description: 'versioned skill tool',
+        category: 'skill',
+        defaultRiskLevel: 'low' as const,
+        origin: 'skill' as const,
+        ownerSkillId: 'versioned-skill',
+        ownerSkillVersionHash: 'v3:content-hash-xyz',
+        executionTarget: 'sandbox' as const,
+        getDefinition: () => ({ name, description: 'versioned skill tool', input_schema: { type: 'object' as const, properties: {} } }),
+        execute: async () => fakeToolResult,
+      };
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    await executor.execute('versioned_tool', { action: 'test' }, makeContext());
+
+    expect(lastCheckArgs).toBeDefined();
+    expect(lastCheckArgs!.policyContext).toEqual({
+      principal: {
+        kind: 'skill',
+        id: 'versioned-skill',
+        version: 'v3:content-hash-xyz',
+      },
+      executionTarget: 'sandbox',
+    });
+  });
+
+  test('executor creates principal-scoped rule on always_allow_high_risk with full context', async () => {
+    checkResultOverride = { decision: 'prompt', reason: 'High risk: always requires approval' };
+    const spy = setupAddRuleSpy();
+
+    getToolOverride = (name: string) => {
+      if (name === 'unknown_tool') return undefined;
+      return {
+        name,
+        description: 'admin skill tool',
+        category: 'skill',
+        defaultRiskLevel: 'high' as const,
+        origin: 'skill' as const,
+        ownerSkillId: 'admin-skill',
+        ownerSkillVersionHash: 'sha256-admin-v2',
+        executionTarget: 'host' as const,
+        getDefinition: () => ({ name, description: 'admin skill tool', input_schema: { type: 'object' as const, properties: {} } }),
+        execute: async () => fakeToolResult,
+      };
+    };
+
+    const prompter = makePrompterWithDecision('always_allow_high_risk', 'admin_action:*', 'everywhere');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('admin_action', { op: 'restart' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [tool, pattern, scope, decision, , options] = spy.mock.calls[0];
+
+    // Verify complete integration of all fields
+    expect(tool).toBe('admin_action');
+    expect(pattern).toBe('admin_action:*');
+    expect(scope).toBe('everywhere');
+    expect(decision).toBe('allow');
+    expect(options.allowHighRisk).toBe(true);
+    expect(options.principalKind).toBe('skill');
+    expect(options.principalId).toBe('admin-skill');
+    expect(options.principalVersion).toBe('sha256-admin-v2');
+    expect(options.executionTarget).toBe('host');
+  });
+});


### PR DESCRIPTION
PR 25 of security rollout: Adds integration tests locking strict-mode prompt behavior, high-risk allow auto-approve, and principal-scoped rule matching.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
