### PR TITLE
feat: include version hash in skill_load permission candidates

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2264,4 +2264,147 @@ describe('Permission Checker', () => {
       expect(result.matchedRule).toBeDefined();
     });
   });
+
+  // ── hash-aware skill_load permission candidates (PR 33) ──────
+  // When a version hash is available (either computed from disk or provided
+  // in the input), skill_load command candidates and allowlist options
+  // include both a version-specific pattern (skillId@hash) and an
+  // any-version pattern (bare skillId).
+
+  describe('hash-aware skill_load permission candidates (PR 33)', () => {
+    function ensureSkillsDir(): void {
+      mkdirSync(join(checkerTestDir, 'skills'), { recursive: true });
+    }
+
+    test('buildCommandCandidates includes hash-qualified candidate when skill exists on disk', async () => {
+      ensureSkillsDir();
+      writeSkill('test-hash-skill', 'Test Hash Skill');
+
+      // skill_load is Low risk, so with no trust rule in legacy mode it
+      // auto-allows. We set strict mode and add specific rules to verify
+      // the correct candidates are generated.
+      testConfig.permissions.mode = 'strict';
+
+      // Compute the expected hash from the skill directory
+      const { computeSkillVersionHash: computeHash } = await import('../skills/version-hash.js');
+      const skillDir = join(checkerTestDir, 'skills', 'test-hash-skill');
+      const expectedHash = computeHash(skillDir);
+
+      // Add a rule matching the hash-qualified candidate
+      addRule('skill_load', `skill_load:test-hash-skill@${expectedHash}`, 'everywhere', 'allow', 2000);
+
+      const result = await check('skill_load', { skill: 'test-hash-skill' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe(`skill_load:test-hash-skill@${expectedHash}`);
+    });
+
+    test('bare skillId candidate still matches any-version rules', async () => {
+      ensureSkillsDir();
+      writeSkill('test-anyver-skill', 'Test Any Version Skill');
+
+      testConfig.permissions.mode = 'strict';
+
+      // Add a rule matching the bare skill id (no hash)
+      addRule('skill_load', 'skill_load:test-anyver-skill', 'everywhere', 'allow', 2000);
+
+      const result = await check('skill_load', { skill: 'test-anyver-skill' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe('skill_load:test-anyver-skill');
+    });
+
+    test('when version hash is absent (no skill on disk), only bare skillId candidate is generated', async () => {
+      ensureSkillsDir();
+      // Do NOT write a skill — selector resolution will fail, so no hash
+      // candidate is generated. Only the raw selector candidate remains.
+      testConfig.permissions.mode = 'strict';
+
+      addRule('skill_load', 'skill_load:nonexistent-skill', 'everywhere', 'allow', 2000);
+
+      const result = await check('skill_load', { skill: 'nonexistent-skill' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe('skill_load:nonexistent-skill');
+    });
+
+    test('explicit version_hash in input is used for candidate generation', async () => {
+      ensureSkillsDir();
+      writeSkill('test-explicit-hash', 'Test Explicit Hash');
+
+      testConfig.permissions.mode = 'strict';
+      const explicitHash = 'v1:explicit0000';
+
+      // Add a rule matching the explicit hash
+      addRule('skill_load', `skill_load:test-explicit-hash@${explicitHash}`, 'everywhere', 'allow', 2000);
+
+      const result = await check(
+        'skill_load',
+        { skill: 'test-explicit-hash', version_hash: explicitHash },
+        '/tmp',
+      );
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe(`skill_load:test-explicit-hash@${explicitHash}`);
+    });
+
+    // ── generateAllowlistOptions for skill_load ──
+
+    test('allowlist options include version-specific and any-version choices when hash is available', () => {
+      ensureSkillsDir();
+      writeSkill('test-opts-skill', 'Test Options Skill');
+
+      const options = generateAllowlistOptions('skill_load', { skill: 'test-opts-skill' });
+
+      // Should have: version-specific, any-version, wildcard
+      expect(options.length).toBeGreaterThanOrEqual(3);
+
+      // First option should be the version-specific pattern
+      expect(options[0].pattern).toMatch(/^skill_load:test-opts-skill@v1:/);
+      expect(options[0].description).toBe('This exact version');
+
+      // Second option should be any-version
+      expect(options[1].pattern).toBe('skill_load:test-opts-skill');
+      expect(options[1].description).toBe('Any version of this skill');
+
+      // Last option should be wildcard
+      expect(options[options.length - 1].pattern).toBe('skill_load:*');
+      expect(options[options.length - 1].description).toBe('All skill loads');
+    });
+
+    test('allowlist options include explicit version_hash from input', () => {
+      ensureSkillsDir();
+      writeSkill('test-opts-explicit', 'Test Opts Explicit');
+
+      const options = generateAllowlistOptions('skill_load', {
+        skill: 'test-opts-explicit',
+        version_hash: 'v1:customhash123',
+      });
+
+      expect(options.length).toBeGreaterThanOrEqual(3);
+      expect(options[0].pattern).toBe('skill_load:test-opts-explicit@v1:customhash123');
+      expect(options[0].description).toBe('This exact version');
+      expect(options[1].pattern).toBe('skill_load:test-opts-explicit');
+      expect(options[1].description).toBe('Any version of this skill');
+    });
+
+    test('allowlist options for unresolvable skill fall back to raw selector', () => {
+      ensureSkillsDir();
+
+      const options = generateAllowlistOptions('skill_load', { skill: 'no-such-skill' });
+
+      // Should have: raw selector, wildcard
+      expect(options).toHaveLength(2);
+      expect(options[0].pattern).toBe('skill_load:no-such-skill');
+      expect(options[0].description).toBe('This skill');
+      expect(options[1].pattern).toBe('skill_load:*');
+    });
+
+    test('allowlist options for empty skill selector only has wildcard', () => {
+      const options = generateAllowlistOptions('skill_load', { skill: '' });
+
+      expect(options).toHaveLength(1);
+      expect(options[0].pattern).toBe('skill_load:*');
+    });
+  });
 });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -2,6 +2,7 @@ import { RiskLevel, type PermissionCheckResult, type AllowlistOption, type Scope
 import { findHighestPriorityRule } from './trust-store.js';
 import { parse } from '../tools/terminal/parser.js';
 import { resolveSkillSelector } from '../config/skills.js';
+import { computeSkillVersionHash } from '../skills/version-hash.js';
 import { getTool } from '../tools/registry.js';
 import { getConfig } from '../config/loader.js';
 import { dirname, resolve } from 'node:path';
@@ -62,6 +63,31 @@ function getStringField(input: Record<string, unknown>, ...keys: string[]): stri
     if (typeof value === 'string') return value;
   }
   return '';
+}
+
+/**
+ * Resolve a skill selector to its id and version hash. The version hash
+ * lets trust rules differentiate between skill versions so an approval
+ * for one version doesn't silently apply after the skill is updated.
+ */
+function resolveSkillIdAndHash(selector: string, input: Record<string, unknown>): { id: string; versionHash?: string } | null {
+  const resolved = resolveSkillSelector(selector);
+  if (!resolved.skill) return null;
+
+  // Prefer an explicit version_hash from the input (set by the agent loop
+  // or prior enrichment) over computing it on the fly.
+  const explicitHash = getStringField(input, 'version_hash');
+  if (explicitHash) {
+    return { id: resolved.skill.id, versionHash: explicitHash };
+  }
+
+  // Fall back to computing the hash from the skill directory.
+  try {
+    const hash = computeSkillVersionHash(resolved.skill.directoryPath);
+    return { id: resolved.skill.id, versionHash: hash };
+  } catch {
+    return { id: resolved.skill.id };
+  }
 }
 
 function canonicalizeWebFetchUrl(parsed: URL): URL {
@@ -136,9 +162,14 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
     if (!rawSelector) {
       targets.push('');
     } else {
-      const resolved = resolveSkillSelector(rawSelector);
-      if (resolved.skill) {
-        targets.push(resolved.skill.id);
+      const resolved = resolveSkillIdAndHash(rawSelector, input);
+      if (resolved) {
+        // Version-specific candidate lets rules pin to an exact skill version
+        if (resolved.versionHash) {
+          targets.push(`${resolved.id}@${resolved.versionHash}`);
+        }
+        // Bare skill id candidate for backward compat / any-version rules
+        targets.push(resolved.id);
       }
       targets.push(rawSelector);
     }
@@ -503,6 +534,52 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
       pattern: `${toolName}:*`,
     });
     return options;
+  }
+
+  if (toolName === 'skill_load') {
+    const rawSelector = getStringField(input, 'skill').trim();
+    const options: AllowlistOption[] = [];
+
+    if (rawSelector) {
+      const resolved = resolveSkillIdAndHash(rawSelector, input);
+      if (resolved) {
+        // Version-specific option: pin approval to an exact version
+        if (resolved.versionHash) {
+          options.push({
+            label: `${resolved.id}@${resolved.versionHash}`,
+            description: 'This exact version',
+            pattern: `skill_load:${resolved.id}@${resolved.versionHash}`,
+          });
+        }
+        // Any-version option: allow loading this skill regardless of version
+        options.push({
+          label: resolved.id,
+          description: 'Any version of this skill',
+          pattern: `skill_load:${resolved.id}`,
+        });
+      } else {
+        // Couldn't resolve — use the raw selector
+        options.push({
+          label: rawSelector,
+          description: 'This skill',
+          pattern: `skill_load:${rawSelector}`,
+        });
+      }
+    }
+
+    options.push({
+      label: 'skill_load:*',
+      description: 'All skill loads',
+      pattern: 'skill_load:*',
+    });
+
+    // Deduplicate
+    const seen = new Set<string>();
+    return options.filter((o) => {
+      if (seen.has(o.pattern)) return false;
+      seen.add(o.pattern);
+      return true;
+    });
   }
 
   return [{ label: '*', description: 'Everything', pattern: '*' }];

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -25,6 +25,10 @@ export class SkillLoadTool implements Tool {
             type: 'string',
             description: 'The skill id or skill name to load.',
           },
+          version_hash: {
+            type: 'string',
+            description: 'Optional pre-computed version hash for the skill. Used by the permission system to generate version-specific trust rules.',
+          },
         },
         required: ['skill'],
       },


### PR DESCRIPTION
PR 33 of security rollout: skill_load approvals are now hash-aware, with allowlist options for exact version vs any version.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
