### PR TITLE
fix: prefer Xcode.app over CommandLineTools in build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -18,7 +18,12 @@ set -euo pipefail
 #   SIGN_IDENTITY     Override code signing identity
 
 if [ -z "${DEVELOPER_DIR:-}" ]; then
-    DEVELOPER_DIR=$(xcode-select -p 2>/dev/null || echo "/Applications/Xcode.app/Contents/Developer")
+    # Prefer full Xcode over CommandLineTools — CLT lacks PreviewsMacros plugin
+    if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+        DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+    else
+        DEVELOPER_DIR=$(xcode-select -p 2>/dev/null || echo "/Applications/Xcode.app/Contents/Developer")
+    fi
 fi
 export DEVELOPER_DIR
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -18,12 +18,15 @@ set -euo pipefail
 #   SIGN_IDENTITY     Override code signing identity
 
 if [ -z "${DEVELOPER_DIR:-}" ]; then
-    # Prefer full Xcode over CommandLineTools — CLT lacks PreviewsMacros plugin
-    if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+    # Use xcode-select, but fall back to Xcode.app if it points to
+    # CommandLineTools (which lacks PreviewsMacros needed for #Preview).
+    _dev_dir=$(xcode-select -p 2>/dev/null || echo "")
+    if [ -z "$_dev_dir" ] || [[ "$_dev_dir" == */CommandLineTools* ]]; then
         DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
     else
-        DEVELOPER_DIR=$(xcode-select -p 2>/dev/null || echo "/Applications/Xcode.app/Contents/Developer")
+        DEVELOPER_DIR="$_dev_dir"
     fi
+    unset _dev_dir
 fi
 export DEVELOPER_DIR
 


### PR DESCRIPTION
## Summary
- `build.sh` now checks for `/Applications/Xcode.app/Contents/Developer` before falling back to `xcode-select -p`
- Fixes build failures when `xcode-select` points to CommandLineTools, which lacks the `PreviewsMacros` plugin needed for `#Preview` macros

## Test plan
- [ ] Run `./build.sh run` with `xcode-select -p` pointing to CommandLineTools — should build successfully
- [ ] Run `./build.sh run` with `DEVELOPER_DIR` explicitly set — should still respect the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
