### PR TITLE
test: add hash change re-prompt regression tests

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2512,4 +2512,269 @@ describe('Permission Checker', () => {
       expect(result.reason).toContain('Strict mode');
     });
   });
+
+  // ── Hash change re-prompt regression tests (PR 35) ──────────────────
+  // Verify that version-bound approval rules stop matching after a skill's
+  // source changes, forcing re-approval for the updated version.
+
+  describe('hash change re-prompt regressions (PR 35)', () => {
+    function ensureSkillsDir(): void {
+      mkdirSync(join(checkerTestDir, 'skills'), { recursive: true });
+    }
+
+    // Reuse the addVersionBoundRule helper from PR 30 tests (same pattern).
+    async function addVersionBoundRule(opts: {
+      id: string;
+      tool: string;
+      pattern: string;
+      scope: string;
+      decision: 'allow' | 'deny' | 'ask';
+      priority: number;
+      principalKind?: string;
+      principalId?: string;
+      principalVersion?: string;
+      allowHighRisk?: boolean;
+    }): Promise<void> {
+      const trustPath = join(checkerTestDir, 'protected', 'trust.json');
+      const { readFileSync, writeFileSync, mkdirSync: mkdirSyncFs, existsSync } = await import('node:fs');
+      const { dirname: dirnameFn } = await import('node:path');
+
+      clearCache();
+      const trustDir = dirnameFn(trustPath);
+      if (!existsSync(trustDir)) mkdirSyncFs(trustDir, { recursive: true });
+
+      let currentRules: any[] = [];
+      try {
+        const raw = readFileSync(trustPath, 'utf-8');
+        currentRules = JSON.parse(raw).rules ?? [];
+      } catch { /* first run */ }
+
+      currentRules = currentRules.filter((r: any) => r.id !== opts.id);
+      currentRules.push({
+        ...opts,
+        createdAt: Date.now(),
+      });
+
+      writeFileSync(trustPath, JSON.stringify({ version: 3, rules: currentRules }, null, 2));
+      clearCache();
+    }
+
+    // ── skill_load: version-specific rule allows v1 but prompts for v2 ──
+
+    test('skill_load: version-specific rule allows v1 but prompts for v2 (strict mode)', async () => {
+      ensureSkillsDir();
+      writeSkill('pr35-hash-skill', 'PR35 Hash Change Skill');
+      testConfig.permissions.mode = 'strict';
+
+      const { computeSkillVersionHash: computeHash } = await import('../skills/version-hash.js');
+      const skillDir = join(checkerTestDir, 'skills', 'pr35-hash-skill');
+      const hashV1 = computeHash(skillDir);
+
+      // Add a version-specific rule matching the current hash
+      addRule('skill_load', `skill_load:pr35-hash-skill@${hashV1}`, 'everywhere', 'allow', 2000);
+
+      // v1: should auto-allow
+      const resultV1 = await check('skill_load', { skill: 'pr35-hash-skill' }, '/tmp');
+      expect(resultV1.decision).toBe('allow');
+      expect(resultV1.matchedRule).toBeDefined();
+      expect(resultV1.matchedRule!.pattern).toBe(`skill_load:pr35-hash-skill@${hashV1}`);
+
+      // Simulate skill edit: rewrite the skill file to change the hash
+      writeSkill('pr35-hash-skill', 'PR35 Hash Change Skill', 'Updated description v2');
+      const hashV2 = computeHash(skillDir);
+      expect(hashV2).not.toBe(hashV1);
+
+      // v2: the version-specific candidate changes, so the old rule no
+      // longer matches. The bare id candidate doesn't match the versioned
+      // rule either. Strict mode kicks in.
+      const resultV2 = await check('skill_load', { skill: 'pr35-hash-skill' }, '/tmp');
+      expect(resultV2.decision).toBe('prompt');
+      expect(resultV2.reason).toContain('Strict mode');
+    });
+
+    // ── skill tool use: principal version binding stops matching after edit ──
+
+    test('skill tool use: version-bound allow rule matches v1 but prompts after version change', async () => {
+      await addVersionBoundRule({
+        id: 'pr35-tool-version-match',
+        tool: 'skill_test_tool',
+        pattern: 'skill_test_tool:*',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 2000,
+        principalKind: 'skill',
+        principalId: 'pr35-edit-skill',
+        principalVersion: 'v1:hash-before-edit',
+      });
+
+      // v1: context version matches the rule — auto-allow
+      const ctxV1: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-edit-skill', version: 'v1:hash-before-edit' },
+      };
+      const resultV1 = await check('skill_test_tool', {}, '/tmp', ctxV1);
+      expect(resultV1.decision).toBe('allow');
+      expect(resultV1.matchedRule?.id).toBe('pr35-tool-version-match');
+
+      // v2: skill has been edited — version hash drifts. The same rule
+      // should no longer match, and the default-ask policy for skill tools
+      // should trigger a prompt.
+      const ctxV2: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-edit-skill', version: 'v2:hash-after-edit' },
+      };
+      const resultV2 = await check('skill_test_tool', {}, '/tmp', ctxV2);
+      expect(resultV2.decision).toBe('prompt');
+      expect(resultV2.matchedRule?.id).not.toBe('pr35-tool-version-match');
+    });
+
+    test('skill tool use: re-approval with new version hash restores auto-allow', async () => {
+      // Phase 1: approved at v1
+      await addVersionBoundRule({
+        id: 'pr35-reapproval',
+        tool: 'skill_test_tool',
+        pattern: 'skill_test_tool:*',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 2000,
+        principalKind: 'skill',
+        principalId: 'pr35-reapproval-skill',
+        principalVersion: 'v1:original',
+      });
+
+      const ctxV1: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-reapproval-skill', version: 'v1:original' },
+      };
+      const r1 = await check('skill_test_tool', {}, '/tmp', ctxV1);
+      expect(r1.decision).toBe('allow');
+
+      // Phase 2: skill edited — version changes, old rule stops matching
+      const ctxV2: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-reapproval-skill', version: 'v2:updated' },
+      };
+      const r2 = await check('skill_test_tool', {}, '/tmp', ctxV2);
+      expect(r2.decision).toBe('prompt');
+
+      // Phase 3: user re-approves with new version hash
+      await addVersionBoundRule({
+        id: 'pr35-reapproval-v2',
+        tool: 'skill_test_tool',
+        pattern: 'skill_test_tool:*',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 2000,
+        principalKind: 'skill',
+        principalId: 'pr35-reapproval-skill',
+        principalVersion: 'v2:updated',
+      });
+
+      const r3 = await check('skill_test_tool', {}, '/tmp', ctxV2);
+      expect(r3.decision).toBe('allow');
+      expect(r3.matchedRule?.id).toBe('pr35-reapproval-v2');
+    });
+
+    // ── high-risk: version-bound allowHighRisk rule stops matching after edit ──
+
+    test('high-risk bash: version-bound allowHighRisk rule stops matching after skill edit', async () => {
+      await addVersionBoundRule({
+        id: 'pr35-hr-version-drift',
+        tool: 'bash',
+        pattern: 'sudo *',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 2000,
+        principalKind: 'skill',
+        principalId: 'pr35-admin-skill',
+        principalVersion: 'v1:trusted-hash',
+        allowHighRisk: true,
+      });
+
+      // v1: version matches — high-risk auto-allow
+      const ctxV1: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-admin-skill', version: 'v1:trusted-hash' },
+      };
+      const r1 = await check('bash', { command: 'sudo apt update' }, '/tmp', ctxV1);
+      expect(r1.decision).toBe('allow');
+      expect(r1.reason).toContain('high-risk trust rule');
+      expect(r1.matchedRule?.id).toBe('pr35-hr-version-drift');
+
+      // v2: skill edited — version drifts, rule stops matching, prompts
+      const ctxV2: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-admin-skill', version: 'v2:modified-hash' },
+      };
+      const r2 = await check('bash', { command: 'sudo apt update' }, '/tmp', ctxV2);
+      expect(r2.decision).toBe('prompt');
+      expect(r2.matchedRule?.id).not.toBe('pr35-hr-version-drift');
+    });
+
+    // ── skill_load: explicit version_hash in input changes candidate ──
+
+    test('skill_load: explicit version_hash in input generates correct candidate for v2', async () => {
+      ensureSkillsDir();
+      writeSkill('pr35-explicit-hash', 'PR35 Explicit Hash');
+      testConfig.permissions.mode = 'strict';
+
+      const hashV1 = 'v1:explicit-hash-v1';
+      const hashV2 = 'v1:explicit-hash-v2';
+
+      // Add a rule for v1
+      addRule('skill_load', `skill_load:pr35-explicit-hash@${hashV1}`, 'everywhere', 'allow', 2000);
+
+      // v1: explicit hash matches rule
+      const resultV1 = await check(
+        'skill_load',
+        { skill: 'pr35-explicit-hash', version_hash: hashV1 },
+        '/tmp',
+      );
+      expect(resultV1.decision).toBe('allow');
+      expect(resultV1.matchedRule!.pattern).toBe(`skill_load:pr35-explicit-hash@${hashV1}`);
+
+      // v2: explicit hash differs — rule no longer matches
+      const resultV2 = await check(
+        'skill_load',
+        { skill: 'pr35-explicit-hash', version_hash: hashV2 },
+        '/tmp',
+      );
+      expect(resultV2.decision).toBe('prompt');
+      expect(resultV2.reason).toContain('Strict mode');
+    });
+
+    // ── wildcard principal version still matches after edit ──
+
+    test('wildcard (no principalVersion) rule continues to match after version change', async () => {
+      await addVersionBoundRule({
+        id: 'pr35-wildcard-survives-edit',
+        tool: 'skill_test_tool',
+        pattern: 'skill_test_tool:*',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 2000,
+        principalKind: 'skill',
+        principalId: 'pr35-wc-skill',
+        // principalVersion intentionally omitted — wildcard
+      });
+
+      // v1: matches
+      const ctxV1: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-wc-skill', version: 'v1:hash-aaa' },
+      };
+      const r1 = await check('skill_test_tool', {}, '/tmp', ctxV1);
+      expect(r1.decision).toBe('allow');
+      expect(r1.matchedRule?.id).toBe('pr35-wildcard-survives-edit');
+
+      // v2: still matches (wildcard)
+      const ctxV2: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-wc-skill', version: 'v2:hash-bbb' },
+      };
+      const r2 = await check('skill_test_tool', {}, '/tmp', ctxV2);
+      expect(r2.decision).toBe('allow');
+      expect(r2.matchedRule?.id).toBe('pr35-wildcard-survives-edit');
+
+      // no version at all: still matches
+      const ctxNone: PolicyContext = {
+        principal: { kind: 'skill', id: 'pr35-wc-skill' },
+      };
+      const r3 = await check('skill_test_tool', {}, '/tmp', ctxNone);
+      expect(r3.decision).toBe('allow');
+      expect(r3.matchedRule?.id).toBe('pr35-wildcard-survives-edit');
+    });
+  });
 });

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -1825,3 +1825,156 @@ describe('versioned markers through session projection', () => {
     expect(mockUnregisteredSkillIds).toContain('deploy');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hash change re-prompt regression tests (PR 35)
+// Verify that version hash changes trigger re-registration and that the
+// session state accurately tracks the new hash, which downstream components
+// use to decide whether cached approvals still apply.
+// ---------------------------------------------------------------------------
+
+describe('hash change re-prompt regressions (PR 35)', () => {
+  let sessionState: Map<string, string>;
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockVersionHashes = {};
+    sessionState = new Map<string, string>();
+  });
+
+  test('approve v1, edit skill (hash changes), v2 triggers re-registration with new hash', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:approved-hash' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: skill approved and registered with v1 hash
+    const result1 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(result1.toolDefinitions).toHaveLength(1);
+    expect(sessionState.get('deploy')).toBe('v1:approved-hash');
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+
+    // Simulate skill edit — hash changes on disk
+    mockVersionHashes = { deploy: 'v2:edited-hash' };
+    mockUnregisteredSkillIds = [];
+
+    // Turn 2: projection detects hash drift, unregisters old, re-registers new
+    const result2 = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(result2.toolDefinitions).toHaveLength(1);
+    expect(result2.toolDefinitions[0].name).toBe('deploy_run');
+
+    // Old version was unregistered
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+
+    // Session state updated to the new hash
+    expect(sessionState.get('deploy')).toBe('v2:edited-hash');
+
+    // Ref count balanced (unregister decremented, re-register incremented)
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+  });
+
+  test('two consecutive edits each trigger re-registration with correct hash', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:first-version' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: initial registration
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.get('deploy')).toBe('v1:first-version');
+
+    // Edit 1: hash changes to v2
+    mockVersionHashes = { deploy: 'v2:second-version' };
+    mockUnregisteredSkillIds = [];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.get('deploy')).toBe('v2:second-version');
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+
+    // Edit 2: hash changes to v3
+    mockVersionHashes = { deploy: 'v3:third-version' };
+    mockUnregisteredSkillIds = [];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.get('deploy')).toBe('v3:third-version');
+    expect(mockUnregisteredSkillIds).toContain('deploy');
+
+    // Ref count stays at 1 through all edits
+    expect(mockSkillRefCount.get('deploy')).toBe(1);
+  });
+
+  test('hash change in one skill does not affect co-active skill with stable hash', () => {
+    mockCatalog = [makeSkill('deploy'), makeSkill('oncall')];
+    mockManifests = {
+      deploy: makeManifest(['deploy_run']),
+      oncall: makeManifest(['oncall_page']),
+    };
+    mockVersionHashes = {
+      deploy: 'v1:deploy-stable',
+      oncall: 'v1:oncall-original',
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+      ...skillLoadMessages('<loaded_skill id="oncall" />'),
+    ];
+
+    // Turn 1: both skills registered
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    expect(sessionState.get('deploy')).toBe('v1:deploy-stable');
+    expect(sessionState.get('oncall')).toBe('v1:oncall-original');
+
+    // Edit only oncall
+    mockVersionHashes = {
+      deploy: 'v1:deploy-stable', // unchanged
+      oncall: 'v2:oncall-edited',
+    };
+    mockUnregisteredSkillIds = [];
+
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    // Only oncall was re-registered
+    expect(mockUnregisteredSkillIds).toContain('oncall');
+    expect(mockUnregisteredSkillIds).not.toContain('deploy');
+
+    // Hashes updated correctly
+    expect(sessionState.get('deploy')).toBe('v1:deploy-stable');
+    expect(sessionState.get('oncall')).toBe('v2:oncall-edited');
+  });
+
+  test('registered tools carry updated ownerSkillId after hash change re-registration', () => {
+    mockCatalog = [makeSkill('deploy')];
+    mockManifests = { deploy: makeManifest(['deploy_run']) };
+    mockVersionHashes = { deploy: 'v1:pre-edit' };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    const toolsV1 = mockRegisteredTools.get('deploy');
+    expect(toolsV1).toBeDefined();
+    expect(toolsV1!.length).toBe(1);
+    expect(toolsV1![0].ownerSkillId).toBe('deploy');
+
+    // Edit
+    mockVersionHashes = { deploy: 'v2:post-edit' };
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    // After re-registration, tools should still be associated with the skill
+    const toolsV2 = mockRegisteredTools.get('deploy');
+    expect(toolsV2).toBeDefined();
+    expect(toolsV2!.length).toBeGreaterThanOrEqual(1);
+    expect(toolsV2![0].ownerSkillId).toBe('deploy');
+  });
+});

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -378,3 +378,115 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     expect(result.content).toContain('modified since it was approved');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hash change re-prompt regression tests (PR 35)
+// Lock behavior: version-bound approval hashes no longer match after skill
+// source changes, forcing re-approval before host execution resumes.
+// ---------------------------------------------------------------------------
+
+describe('runSkillToolScript — hash change re-prompt regressions (PR 35)', () => {
+  test('approve v1, edit skill, v2 blocks until re-approved with new hash', async () => {
+    let currentDiskHash = 'v1:approved-v1';
+    const resolver = (_dir: string) => currentDiskHash;
+
+    // Phase 1: approved at v1 — execution succeeds
+    const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v1-ok' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:approved-v1',
+      skillDirHashResolver: resolver,
+    });
+    expect(r1.isError).toBe(false);
+    expect(r1.content).toBe('hello from v1-ok');
+
+    // Phase 2: skill source edited — hash changes on disk
+    currentDiskHash = 'v2:edited-on-disk';
+
+    // Old approval hash no longer matches — blocked
+    const r2 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v2-blocked' }, makeContext(), {
+      expectedSkillVersionHash: 'v1:approved-v1',
+      skillDirHashResolver: resolver,
+    });
+    expect(r2.isError).toBe(true);
+    expect(r2.content).toContain('Skill version mismatch');
+    expect(r2.content).toContain('v1:approved-v1');
+    expect(r2.content).toContain('v2:edited-on-disk');
+
+    // Phase 3: re-approved with new hash — execution succeeds again
+    const r3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v2-ok' }, makeContext(), {
+      expectedSkillVersionHash: 'v2:edited-on-disk',
+      skillDirHashResolver: resolver,
+    });
+    expect(r3.isError).toBe(false);
+    expect(r3.content).toBe('hello from v2-ok');
+  });
+
+  test('version-bound rule for one executor blocks all executors in the same skill after edit', async () => {
+    let currentDiskHash = 'v1:skill-hash-before';
+    const resolver = (_dir: string) => currentDiskHash;
+    const approvedHash = 'v1:skill-hash-before';
+
+    // Both executors work with matching hash
+    const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'a' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r1.isError).toBe(false);
+
+    const r2 = await runSkillToolScript(tempDir, 'echo.ts', { key: 'val' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r2.isError).toBe(false);
+
+    // Skill edited — hash changes
+    currentDiskHash = 'v1:skill-hash-after';
+
+    // Both executors are now blocked with the old approval hash
+    const r3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'blocked' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r3.isError).toBe(true);
+    expect(r3.content).toContain('Skill version mismatch');
+
+    const r4 = await runSkillToolScript(tempDir, 'echo.ts', { key: 'blocked' }, makeContext(), {
+      expectedSkillVersionHash: approvedHash,
+      skillDirHashResolver: resolver,
+    });
+    expect(r4.isError).toBe(true);
+    expect(r4.content).toContain('Skill version mismatch');
+  });
+
+  test('no expectedSkillVersionHash skips guard entirely — edits have no effect', async () => {
+    let currentDiskHash = 'v1:whatever';
+    const resolver = (_dir: string) => currentDiskHash;
+
+    // Without expectedSkillVersionHash, the guard is not active
+    const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'unguarded' }, makeContext());
+    expect(r1.isError).toBe(false);
+    expect(r1.content).toBe('hello from unguarded');
+
+    // Change hash on disk — still no guard
+    currentDiskHash = 'v2:changed';
+    const r2 = await runSkillToolScript(tempDir, 'success.ts', { name: 'still-ok' }, makeContext());
+    expect(r2.isError).toBe(false);
+    expect(r2.content).toBe('hello from still-ok');
+  });
+
+  test('hash mismatch error includes both expected and actual hashes for debugging', async () => {
+    const expectedHash = 'v1:expected-aaa';
+    const actualHash = 'v1:actual-bbb';
+    const resolver = (_dir: string) => actualHash;
+
+    const result = await runSkillToolScript(tempDir, 'success.ts', {}, makeContext(), {
+      expectedSkillVersionHash: expectedHash,
+      skillDirHashResolver: resolver,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(expectedHash);
+    expect(result.content).toContain(actualHash);
+    expect(result.content).toContain('modified since it was approved');
+    expect(result.content).toContain('Please reload the skill to re-approve');
+  });
+});


### PR DESCRIPTION
## Summary
- Verifies version-bound approval rules stop matching after skill source changes
- 7 checker tests, 4 session-skill-tools tests, 4 skill-script-runner-host tests
- Covers version drift, re-approval flow, wildcard persistence, and multi-executor blocking

## Test plan
- [x] checker.test.ts: 235 pass, 0 fail
- [x] session-skill-tools.test.ts: 59 pass, 0 fail
- [x] skill-script-runner-host.test.ts: 22 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
