### PR TITLE
feat: display principal and execution target in approval prompts

### DIFF
--- a/assistant/src/__tests__/cli.test.ts
+++ b/assistant/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { sanitizeUrlForDisplay } from '../cli.js';
+import { sanitizeUrlForDisplay, formatPrincipalTag } from '../cli.js';
 
 describe('sanitizeUrlForDisplay', () => {
   test('removes userinfo from absolute URLs', () => {
@@ -22,5 +22,51 @@ describe('sanitizeUrlForDisplay', () => {
     const rawValue = `not-a-url //${userinfo}@example.com`;
 
     expect(sanitizeUrlForDisplay(rawValue)).toBe('not-a-url //[REDACTED]@example.com');
+  });
+});
+
+describe('formatPrincipalTag', () => {
+  test('returns empty string for core principals', () => {
+    expect(formatPrincipalTag({ principalKind: 'core' })).toBe('');
+  });
+
+  test('returns empty string when principalKind is absent', () => {
+    expect(formatPrincipalTag({})).toBe('');
+  });
+
+  test('formats skill with name, version, and target', () => {
+    const tag = formatPrincipalTag({
+      principalKind: 'skill',
+      principalId: 'weather-skill',
+      principalVersion: 'sha256:abcdef1234567890fedcba',
+      executionTarget: 'host',
+    });
+    expect(tag).toBe('[skill: weather-skill@abcdef12 \u2192 host]');
+  });
+
+  test('formats skill without version hash', () => {
+    const tag = formatPrincipalTag({
+      principalKind: 'skill',
+      principalId: 'my-skill',
+    });
+    expect(tag).toBe('[skill: my-skill]');
+  });
+
+  test('formats skill with sandbox target', () => {
+    const tag = formatPrincipalTag({
+      principalKind: 'skill',
+      principalId: 'deploy-skill',
+      principalVersion: 'sha256:1111222233334444',
+      executionTarget: 'sandbox',
+    });
+    expect(tag).toBe('[skill: deploy-skill@11112222 \u2192 sandbox]');
+  });
+
+  test('falls back to principalKind when principalId is absent', () => {
+    const tag = formatPrincipalTag({
+      principalKind: 'skill',
+      principalVersion: 'sha256:aabbccdd',
+    });
+    expect(tag).toBe('[skill: skill@aabbccdd]');
   });
 });

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1127,6 +1127,43 @@ describe('IPC message snapshots', () => {
     });
   });
 
+  // Baseline assertions for principal context in confirmation_request.
+  describe('confirmation principal context baselines', () => {
+    test('confirmation_request includes principal context fields', () => {
+      const req = serverMessages.confirmation_request;
+      expect(req.principalKind).toBe('skill');
+      expect(req.principalId).toBe('my-skill');
+      expect(req.principalVersion).toBe('sha256:abcdef1234567890');
+    });
+
+    test('confirmation_request principal fields are optional (backward-compatible)', () => {
+      // Core tools omit principal fields — verify the contract allows it
+      const minimal: typeof serverMessages.confirmation_request = {
+        type: 'confirmation_request',
+        requestId: 'req-minimal',
+        toolName: 'bash',
+        input: { command: 'ls' },
+        riskLevel: 'low',
+        allowlistOptions: [],
+        scopeOptions: [],
+      };
+      const serialized = serialize(minimal);
+      const parsed = JSON.parse(serialized.trimEnd());
+      expect(parsed.principalKind).toBeUndefined();
+      expect(parsed.principalId).toBeUndefined();
+      expect(parsed.principalVersion).toBeUndefined();
+    });
+
+    test('confirmation_request round-trips with all principal fields', () => {
+      const req = serverMessages.confirmation_request;
+      const serialized = serialize(req);
+      const parsed = JSON.parse(serialized.trimEnd());
+      expect(parsed.principalKind).toBe('skill');
+      expect(parsed.principalId).toBe('my-skill');
+      expect(parsed.principalVersion).toBe('sha256:abcdef1234567890');
+    });
+  });
+
   // Baseline assertions for error-related message contracts.
   // These document the current shape before error handling modernization.
   describe('error message baselines', () => {

--- a/assistant/src/__tests__/runtime-runs.test.ts
+++ b/assistant/src/__tests__/runtime-runs.test.ts
@@ -92,7 +92,7 @@ function makeFailingSession(errorMsg: string): Session {
 }
 
 /** Session whose agent loop emits a confirmation_request. */
-function makeConfirmationSession(toolName: string): Session {
+function makeConfirmationSession(toolName: string, principal?: { kind?: string; id?: string; version?: string }): Session {
   let clientHandler: (msg: ServerMessage) => void = () => {};
   return {
     isProcessing: () => false,
@@ -110,6 +110,9 @@ function makeConfirmationSession(toolName: string): Session {
         riskLevel: 'medium',
         allowlistOptions: [],
         scopeOptions: [],
+        principalKind: principal?.kind,
+        principalId: principal?.id,
+        principalVersion: principal?.version,
       });
       // Hang to simulate waiting for decision
       await new Promise<void>(() => {});
@@ -236,6 +239,27 @@ describe('runtime runs — swarm lifecycle', () => {
       resolveAttachments: () => [],
     });
     expect(orchestrator.getRun('nonexistent-id')).toBeNull();
+  });
+
+  test('principal context flows through to pending confirmation', async () => {
+    const conversation = createConversation('principal context test');
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => makeConfirmationSession('bash', {
+        kind: 'skill',
+        id: 'weather-skill',
+        version: 'sha256:abcdef1234567890',
+      }),
+      resolveAttachments: () => [],
+    });
+
+    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Run with principal');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stored = orchestrator.getRun(run.id);
+    expect(stored?.status).toBe('needs_confirmation');
+    expect(stored?.pendingConfirmation?.principalKind).toBe('skill');
+    expect(stored?.pendingConfirmation?.principalId).toBe('weather-skill');
+    expect(stored?.pendingConfirmation?.principalVersion).toBe('sha256:abcdef1234567890');
   });
 
   test('submitDecision returns run_not_found for unknown run', () => {

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -41,6 +41,22 @@ export function sanitizeUrlForDisplay(rawUrl: unknown): string {
   }
 }
 
+/**
+ * Format a human-readable principal tag for display in permission prompts.
+ * Core principals are omitted (empty string) since they're the default.
+ * Skill principals show the skill name, shortened version hash, and target.
+ */
+export function formatPrincipalTag(req: Pick<ConfirmationRequest, 'principalKind' | 'principalId' | 'principalVersion' | 'executionTarget'>): string {
+  if (!req.principalKind || req.principalKind === 'core') return '';
+  const name = req.principalId ?? req.principalKind;
+  // Show a shortened version hash when available (first 8 hex chars after prefix)
+  const versionSuffix = req.principalVersion
+    ? `@${req.principalVersion.replace(/^sha256:/, '').slice(0, 8)}`
+    : '';
+  const target = req.executionTarget ? ` \u2192 ${req.executionTarget}` : '';
+  return `[${req.principalKind}: ${name}${versionSuffix}${target}]`;
+}
+
 export async function startCli(): Promise<void> {
   const socketPath = getSocketPath();
   let socket: net.Socket;
@@ -167,10 +183,13 @@ export async function startCli(): Promise<void> {
 
   function renderConfirmationPrompt(req: ConfirmationRequest): void {
     const preview = formatCommandPreview(req);
+    const principalTag = formatPrincipalTag(req);
     process.stdout.write('\n');
     process.stdout.write(`\u250C ${req.toolName}: ${preview}\n`);
     process.stdout.write(`\u2502 Risk: ${req.riskLevel}${req.sandboxed ? '  [sandboxed]' : ''}\n`);
-    if (req.executionTarget) {
+    if (principalTag) {
+      process.stdout.write(`\u2502 Principal: ${principalTag}\n`);
+    } else if (req.executionTarget) {
       process.stdout.write(`\u2502 Target: ${req.executionTarget}\n`);
     }
     if (req.diff) {


### PR DESCRIPTION
## Summary
- Added `formatPrincipalTag()` to cli.ts showing skill name, version hash, and target in prompts
- Renders as `[skill: weather-skill@abcdef12 -> host]` for skill-originated tool calls
- Core principals show no annotation (default behavior)
- Protocol already had the fields — this PR adds the display layer

## Test plan
- [x] cli.test.ts: 9 pass (6 new formatPrincipalTag tests)
- [x] ipc-snapshot.test.ts: 165 pass (3 new principal context baselines)
- [x] runtime-runs.test.ts: 8 pass (1 new principal flow-through test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
