### PR TITLE
feat: add .claude/ship script for deterministic PR lifecycle

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -34,70 +34,25 @@ Working entirely inside the worktree directory, implement what was requested. Ex
 cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
 ```
 
-### 3. Stage and commit
+### 3. Ship
+
+Review what changed, draft a commit message and PR title, then ship everything in one step:
 
 ```bash
-cd <worktree>
-git add -A
-git diff --cached
-```
-
-Review the staged diff. Draft a clear commit message. Commit:
-
-```bash
-git commit -m "$(cat <<'EOF'
-<commit message>
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-```
-
-### 4. Push and create PR
-
-```bash
-git push -u origin HEAD
-```
-
-Infer a concise PR title from the changes.
-
-```bash
-gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
-## Summary
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<PR title>" \
+  --body "## Summary
 <1-3 bullet points>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --base main \
+  --merge \
+  --track-unreviewed \
+  --cleanup-worktree do/<slug> \
+  --pull-base
 ```
 
-### 5. Add to unreviewed list
+### 4. Report
 
-Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
-
-### 6. Merge
-
-```bash
-gh pr merge <N> --squash
-```
-
-### 7. Clean up worktree
-
-Change back to the main repo directory first (you may still be inside the worktree from earlier steps), then remove it:
-
-```bash
-cd <main-repo>
-.claude/worktree remove do/<slug> --delete-branch
-```
-
-### 8. Pull main
-
-```bash
-git checkout main && git pull origin main
-```
-
-### 9. Report
-
-Output the PR link and a summary of what was shipped. End your message with "Done."
-
-IMPORTANT: .private/UNREVIEWED_PRS.md is written to by other processes. Read before writing, verify after writing.
+Output the PR link (printed by `.claude/ship`) and a summary of what was shipped. End your message with "Done."

--- a/.claude/commands/execute-plan.md
+++ b/.claude/commands/execute-plan.md
@@ -37,14 +37,21 @@ Run the tests and type-checks specified in the PR section. Fix any failures befo
 
 #### 3c. Mainline
 
-Ship the changes using the same workflow as `/mainline`:
+Create a branch from the plan (or derive one from the PR title), then ship:
 
-1. Create a branch using the name from the plan (or derive one from the PR title).
-2. Stage and commit with a descriptive message.
-3. Push and create a PR with a title and summary matching the plan.
-4. Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
-5. Merge immediately: `gh pr merge <N> --squash`.
-6. Switch back to main and pull.
+```bash
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<title from plan>" \
+  --body "## Summary
+<1-3 bullet points>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --base main \
+  --merge \
+  --track-unreviewed \
+  --pull-base
+```
 
 #### 3d. Report progress
 

--- a/.claude/commands/mainline.md
+++ b/.claude/commands/mainline.md
@@ -24,65 +24,24 @@ git checkout -B <user>/<slug-from-title>
 git stash pop
 ```
 
-### 3. Stage and commit
+### 3. Ship
+
+Review the changes, draft a commit message and PR title (use `$ARGUMENTS` as the title if provided), then ship:
 
 ```bash
-git add -A
-git diff --cached
-```
-
-Review the staged diff. Draft a clear commit message summarizing the changes. Commit:
-
-```bash
-git commit -m "$(cat <<'EOF'
-<commit message>
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-```
-
-### 4. Push
-
-```bash
-git push -u origin HEAD
-```
-
-### 5. Create the PR
-
-```bash
-gh pr create --title "<title>" --body "$(cat <<'EOF'
-## Summary
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<PR title>" \
+  --body "## Summary
 <1-3 bullet points>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --base main \
+  --merge \
+  --track-unreviewed \
+  --pull-base
 ```
 
-### 6. Add to unreviewed list
+### 4. Report
 
-Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
-
-### 7. Merge
-
-```bash
-gh pr merge <N> --squash
-```
-
-### 8. Switch back to main and pull
-
-```bash
-git checkout main && git pull
-```
-
-### 9. Report
-
-Output the PR link and a summary of what was shipped. End your message with "Mainlined."
-
-## Repo-specific gotchas
-
-- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
-
-IMPORTANT: .private/UNREVIEWED_PRS.md is written to by other processes. Read before writing, verify after writing.
+Output the PR link (printed by `.claude/ship`) and a summary of what was shipped. End your message with "Mainlined."

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -90,37 +90,21 @@ cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEm
 
 Fix any failures before proceeding.
 
-#### 8d. Commit and push
+#### 8d. Ship (do NOT merge)
 
 ```bash
-cd <worktree>
-git add -A
-git commit -m "$(cat <<'EOF'
-<commit message>
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-git push -u origin HEAD
-```
-
-#### 8e. Create PR (do NOT merge)
-
-```bash
-gh pr create --base main --title "<title from plan>" --body "$(cat <<'EOF'
-## Summary
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<title from plan>" \
+  --body "## Summary
 <1-3 bullet points>
 
 Part of plan: <plan filename> (PR <X> of <total>)
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --base main \
+  --track-unreviewed
 ```
-
-#### 8f. Add to unreviewed list
-
-Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
 
 ### 9. Save state
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -242,12 +242,10 @@ ALL work happens here. Do NOT touch the main repo.
 ## Workflow
 1. Make the changes in your worktree.
 2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
-3. Commit with a descriptive message.
-4. Push and create a PR targeting the FEATURE BRANCH (not main):
-   gh pr create --base <feature-branch-name> --title "<concise title>" --body "<what changed and why>" --assignee @me
-5. Merge immediately into the feature branch: gh pr merge <number> --squash
-6. Send a message to "lead" with:
-   - The PR link
+3. Ship it (stages, commits, pushes, creates PR, and merges in one step):
+   .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base <feature-branch-name> --merge --assignee @me
+4. Send a message to "lead" with:
+   - The PR link (printed by .claude/ship)
    - A summary of what you changed and why
    - Which files were modified
    - Any issues or concerns

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -34,48 +34,23 @@ Working entirely inside the worktree directory, implement what was requested. Ex
 cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
 ```
 
-### 3. Stage and commit
+### 3. Ship (do NOT merge)
+
+Review what changed, draft a commit message and PR title, then ship:
 
 ```bash
-cd <worktree>
-git add -A
-git diff --cached
-```
-
-Review the staged diff. Draft a clear commit message. Commit:
-
-```bash
-git commit -m "$(cat <<'EOF'
-<commit message>
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-```
-
-### 4. Push and create PR (do NOT merge)
-
-```bash
-git push -u origin HEAD
-```
-
-Infer a concise PR title from the changes.
-
-```bash
-gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
-## Summary
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<PR title>" \
+  --body "## Summary
 <1-3 bullet points>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --base main \
+  --track-unreviewed
 ```
 
-### 5. Add to unreviewed list
-
-Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
-
-### 6. Notify the user and stop
+### 4. Notify the user and stop
 
 Tell the user:
 

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -67,37 +67,21 @@ cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEm
 
 Fix any failures before proceeding.
 
-#### 4d. Commit and push
+#### 4d. Ship (do NOT merge)
 
 ```bash
-cd <worktree>
-git add -A
-git commit -m "$(cat <<'EOF'
-<commit message>
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-git push -u origin HEAD
-```
-
-#### 4e. Create PR (do NOT merge)
-
-```bash
-gh pr create --base main --title "<title from plan>" --body "$(cat <<'EOF'
-## Summary
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<title from plan>" \
+  --body "## Summary
 <1-3 bullet points>
 
 Part of plan: <plan filename> (PR <X> of <total>)
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --base main \
+  --track-unreviewed
 ```
-
-#### 4f. Add to unreviewed list
-
-Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
 
 ### 5. Save state
 

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -66,12 +66,10 @@ ALL work happens here. Do NOT touch the main repo.
 ## Workflow
 1. Make the changes in your worktree.
 2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
-3. Commit with a descriptive message.
-4. Push and create a PR:
-   gh pr create --base main --title "<concise title>" --body "<what changed and why>" --assignee @me
-5. Merge immediately: gh pr merge <number> --squash
-6. Send a message to "lead" with:
-   - The PR link
+3. Ship it (stages, commits, pushes, creates PR, and merges in one step):
+   .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base main --merge --assignee @me
+4. Send a message to "lead" with:
+   - The PR link (printed by .claude/ship)
    - A summary of what you changed and why
    - Which files were modified
    - Any issues or concerns

--- a/.claude/ship
+++ b/.claude/ship
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .claude/ship — PR lifecycle pipeline
+# Stages, commits, pushes, creates a PR, optionally merges, tracks, and cleans up.
+
+usage() {
+  cat <<'EOF'
+Usage: .claude/ship [options]
+
+Stages all changes, commits, pushes, creates a PR, and optionally merges it.
+Co-Authored-By trailer is appended to the commit message automatically.
+
+Required:
+  --commit-msg MSG         Commit message
+  --title TITLE            PR title
+
+Optional:
+  --body BODY              PR body (default: none)
+  --base BRANCH            Base branch for PR (default: main)
+  --merge                  Squash-merge the PR after creation
+  --assignee USER          PR assignee (e.g., @me)
+  --track-unreviewed       Append PR URL to .private/UNREVIEWED_PRS.md
+  --cleanup-worktree NAME  Remove named worktree after merge (requires --merge)
+  --pull-base              Checkout and pull base branch after merge (requires --merge)
+  -h, --help               Show this help
+
+Examples:
+  # Full lifecycle (do.md style)
+  .claude/ship --commit-msg "feat: add validation" --title "Add validation" \
+    --body "## Summary" --merge --track-unreviewed \
+    --cleanup-worktree do/add-validation --pull-base
+
+  # Create PR without merging (safe-do.md style)
+  .claude/ship --commit-msg "feat: add validation" --title "Add validation" \
+    --body "## Summary" --track-unreviewed
+
+  # Swarm agent style
+  .claude/ship --commit-msg "fix: bug" --title "Fix bug" \
+    --body "Fixed the bug" --merge --assignee @me
+EOF
+}
+
+# Defaults
+BASE="main"
+MERGE=false
+TRACK_UNREVIEWED=false
+CLEANUP_WORKTREE=""
+ASSIGNEE=""
+COMMIT_MSG=""
+TITLE=""
+BODY=""
+PULL_BASE=false
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --commit-msg) COMMIT_MSG="$2"; shift 2 ;;
+    --title) TITLE="$2"; shift 2 ;;
+    --body) BODY="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    --merge) MERGE=true; shift ;;
+    --assignee) ASSIGNEE="$2"; shift 2 ;;
+    --track-unreviewed) TRACK_UNREVIEWED=true; shift ;;
+    --cleanup-worktree) CLEANUP_WORKTREE="$2"; shift 2 ;;
+    --pull-base) PULL_BASE=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# Validate required args
+[[ -z "$COMMIT_MSG" ]] && { echo "Error: --commit-msg is required" >&2; exit 1; }
+[[ -z "$TITLE" ]] && { echo "Error: --title is required" >&2; exit 1; }
+
+# Validate flag combinations
+if [[ -n "$CLEANUP_WORKTREE" ]] && ! $MERGE; then
+  echo "Error: --cleanup-worktree requires --merge" >&2; exit 1
+fi
+if $PULL_BASE && ! $MERGE; then
+  echo "Error: --pull-base requires --merge" >&2; exit 1
+fi
+
+# Append Co-Authored-By if not already present
+if [[ "$COMMIT_MSG" != *"Co-Authored-By:"* ]]; then
+  COMMIT_MSG="$COMMIT_MSG
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+fi
+
+# Find the main repo root (first worktree is always the main one)
+MAIN_REPO=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+
+echo "==> Staging changes..."
+git add -A
+
+echo "==> Committing..."
+git commit -m "$COMMIT_MSG"
+
+echo "==> Pushing..."
+git push -u origin HEAD
+
+echo "==> Creating PR..."
+PR_ARGS=(--base "$BASE" --title "$TITLE")
+[[ -n "$BODY" ]] && PR_ARGS+=(--body "$BODY")
+[[ -n "$ASSIGNEE" ]] && PR_ARGS+=(--assignee "$ASSIGNEE")
+
+PR_URL=$(gh pr create "${PR_ARGS[@]}")
+PR_NUMBER=$(basename "$PR_URL")
+
+echo "Created PR #$PR_NUMBER: $PR_URL"
+
+# Track in unreviewed list
+if $TRACK_UNREVIEWED; then
+  UNREVIEWED="$MAIN_REPO/.private/UNREVIEWED_PRS.md"
+  mkdir -p "$(dirname "$UNREVIEWED")"
+  echo "$PR_URL" >> "$UNREVIEWED"
+  echo "==> Added to unreviewed list"
+fi
+
+# Merge
+if $MERGE; then
+  echo "==> Merging PR #$PR_NUMBER (squash)..."
+  gh pr merge "$PR_NUMBER" --squash
+  echo "Merged."
+fi
+
+# Clean up worktree (must cd out first since we may be inside it)
+if [[ -n "$CLEANUP_WORKTREE" ]]; then
+  echo "==> Cleaning up worktree: $CLEANUP_WORKTREE"
+  cd "$MAIN_REPO"
+  "$MAIN_REPO/.claude/worktree" remove "$CLEANUP_WORKTREE" --delete-branch
+fi
+
+# Pull base branch
+if $PULL_BASE; then
+  echo "==> Pulling $BASE..."
+  cd "$MAIN_REPO"
+  git checkout "$BASE"
+  git pull origin "$BASE"
+fi
+
+echo ""
+echo "Done. PR #$PR_NUMBER: $PR_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dist
 !.claude/commands/
 !.claude/README.md
 !.claude/worktree
+!.claude/ship
 .private/
 temp.sh
 context.md


### PR DESCRIPTION
## Summary
- Adds `.claude/ship` — a bash script that handles the entire PR lifecycle (stage, commit, push, create PR, optionally merge, track in UNREVIEWED_PRS.md, cleanup worktree, pull base) in a single deterministic invocation
- Updates 8 slash commands (`do`, `safe-do`, `mainline`, `swarm`, `safe-blitz`, `execute-plan`, `safe-execute-plan`, `resume-plan`) to use `.claude/ship` instead of 5-8 sequential manual steps
- Net reduction of ~140 lines of duplicated PR lifecycle boilerplate across commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
