### PR TITLE
feat: add .claude/gh-project script for project board operations

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -25,40 +25,19 @@ Everything after stripping flags is the **feature description**.
 
 ## Phase 1: Project Setup
 
-1. Source `.private/project-config.env` to load the project board IDs:
+1. If `.private/project-config.env` exists, source it. Otherwise, create the project board:
+
+```bash
+.claude/gh-project init
+```
+
+2. Source the config for later use:
 
 ```bash
 source .private/project-config.env
 ```
 
-This provides: `GH_PROJECT_NUMBER`, `GH_PROJECT_OWNER`, `GH_PROJECT_ID`, `GH_STATUS_FIELD_ID`, `GH_STATUS_TRIAGE_ID`, `GH_STATUS_READY_ID`, `GH_STATUS_IN_PROGRESS_ID`, `GH_STATUS_IN_REVIEW_ID`, `GH_STATUS_DONE_ID`.
-
-2. If `.private/project-config.env` doesn't exist, create the project and config:
-
-The project title follows the convention `<github-username>-vellum-assistant` where `<github-username>` is the current GitHub user's login (from `gh api user --jq '.login'`).
-
-```bash
-# Get the current GitHub username
-GH_USERNAME=$(gh api user --jq '.login')
-
-# Create the project under the vellum-ai org
-PROJECT_URL=$(gh project create --owner "vellum-ai" --title "${GH_USERNAME}-vellum-assistant" --format json | jq -r '.url')
-PROJECT_NUMBER=$(echo "$PROJECT_URL" | grep -oE '[0-9]+$')
-
-# Get the project node ID
-GH_PROJECT_ID=$(gh project view "$PROJECT_NUMBER" --owner "vellum-ai" --format json | jq -r '.id')
-
-# Add Status field (single select) with standard columns
-gh api graphql -f query='mutation {
-  addProjectV2SingleSelectField(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    name: "Status"
-    options: [{name:"Triage",color:GRAY},{name:"Ready",color:BLUE},{name:"In Progress",color:YELLOW},{name:"In Review",color:ORANGE},{name:"Done",color:GREEN}]
-  }) { projectV2SingleSelectField { id options { id name } } }
-}'
-```
-
-Then query the field and option IDs and write them to `.private/project-config.env` in the same format shown above. Include `GH_PROJECT_NUMBER` (the human-readable number from the project URL). Set `GH_PROJECT_OWNER=vellum-ai`.
+This provides: `GH_PROJECT_NUMBER`, `GH_PROJECT_OWNER`, `GH_PROJECT_ID`, and status option IDs.
 
 ## Phase 2: Plan & Spec
 
@@ -124,36 +103,11 @@ EOF
 4. Add all issues to the GH project board and set their statuses:
 
 ```bash
-# Add issue to project (repeat for each issue)
-ITEM_ID=$(gh api graphql -f query='mutation {
-  addProjectV2ItemById(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    contentId: "<issue-node-id>"
-  }) { item { id } }
-}' --jq '.data.addProjectV2ItemById.item.id')
+# Project-level (epic) issue → in-progress
+.claude/gh-project add-issue <epic-issue-number> --status in-progress
 
-# Get the issue node ID first:
-# gh api repos/vellum-ai/vellum-assistant/issues/<number> --jq '.node_id'
-
-# Set status — use GH_STATUS_IN_PROGRESS_ID for the project-level (epic) issue:
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_IN_PROGRESS_ID"'"}
-  }) { projectV2Item { id } }
-}'
-
-# Set status — use GH_STATUS_READY_ID for milestone issues:
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_READY_ID"'"}
-  }) { projectV2Item { id } }
-}'
+# Milestone issues → ready (repeat for each)
+.claude/gh-project add-issue <milestone-issue-number> --status ready
 ```
 
 5. **Present the plan to the user for approval.** Show:
@@ -182,51 +136,10 @@ Read and follow the instructions in `.claude/commands/swarm.md` with these modif
 
 - Pass the `--workers` count (or default: 12) as the first argument.
 - **After each milestone task completes and its PR merges**, update the corresponding GitHub issue. Skip this for non-milestone tasks (e.g., "Address the feedback on ..." items from Phase 5 — those are PR-based and have no associated milestone issue):
-  1. Set the project board status to "Done":
+  1. Set the project board status to "Done" and close the issue:
 
 ```bash
-# Get the item ID for this issue on the project board (paginated to handle >100 items)
-ITEM_ID=""
-CURSOR=""
-while [ -z "$ITEM_ID" ]; do
-  if [ -z "$CURSOR" ]; then
-    AFTER_ARG=""
-  else
-    AFTER_ARG=", after: \"$CURSOR\""
-  fi
-  RESULT=$(gh api graphql -f query='{
-    node(id: "'"$GH_PROJECT_ID"'") {
-      ... on ProjectV2 {
-        items(first: 100'"$AFTER_ARG"') {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            id
-            content { ... on Issue { number } }
-          }
-        }
-      }
-    }
-  }')
-  ITEM_ID=$(echo "$RESULT" | jq -r '.data.node.items.nodes[] | select(.content.number == <issue-number>) | .id')
-  HAS_NEXT=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.hasNextPage')
-  CURSOR=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.endCursor')
-  if [ "$HAS_NEXT" != "true" ]; then break; fi
-done
-
-# Update status to Done
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_DONE_ID"'"}
-  }) { projectV2Item { id } }
-}'
-```
-
-  2. Close the GitHub issue:
-
-```bash
+.claude/gh-project set-status <issue-number> done
 gh issue close <issue-number>
 ```
 
@@ -247,11 +160,10 @@ gh issue close <issue-number>
 
 ## Phase 6: Report
 
-1. Update the project-level issue status to "Done" on the GH project board (same GraphQL pattern as Phase 4).
-
-2. Close the project-level issue:
+1. Update the project-level issue status to "Done" and close it:
 
 ```bash
+.claude/gh-project set-status <project-issue-number> done
 gh issue close <project-issue-number>
 ```
 

--- a/.claude/commands/safe-blitz-done.md
+++ b/.claude/commands/safe-blitz-done.md
@@ -101,57 +101,10 @@ Wait for the merge to complete. Confirm with:
 gh pr view <pr-number> --json state,mergedAt
 ```
 
-## Step 4: Update project board status to Done
-
-Source project config:
+## Step 4: Update project board and close issue
 
 ```bash
-source .private/project-config.env
-```
-
-Find the project item for the epic issue and set status to Done:
-
-```bash
-ITEM_ID=""
-CURSOR=""
-while [ -z "$ITEM_ID" ]; do
-  if [ -z "$CURSOR" ]; then
-    AFTER_ARG=""
-  else
-    AFTER_ARG=", after: \"$CURSOR\""
-  fi
-  RESULT=$(gh api graphql -f query='{
-    node(id: "'"$GH_PROJECT_ID"'") {
-      ... on ProjectV2 {
-        items(first: 100'"$AFTER_ARG"') {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            id
-            content { ... on Issue { number } }
-          }
-        }
-      }
-    }
-  }')
-  ITEM_ID=$(echo "$RESULT" | jq -r '.data.node.items.nodes[] | select(.content.number == <issue-number>) | .id')
-  HAS_NEXT=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.hasNextPage')
-  CURSOR=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.endCursor')
-  if [ "$HAS_NEXT" != "true" ]; then break; fi
-done
-
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_DONE_ID"'"}
-  }) { projectV2Item { id } }
-}'
-```
-
-## Step 5: Close the project issue
-
-```bash
+.claude/gh-project set-status <project-issue-number> done
 gh issue close <project-issue-number>
 ```
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -28,40 +28,19 @@ Everything after stripping flags is the **feature description**.
 
 ## Phase 1: Project Setup
 
-1. Source `.private/project-config.env` to load the project board IDs:
+1. If `.private/project-config.env` exists, source it. Otherwise, create the project board:
+
+```bash
+.claude/gh-project init
+```
+
+2. Source the config for later use:
 
 ```bash
 source .private/project-config.env
 ```
 
-This provides: `GH_PROJECT_NUMBER`, `GH_PROJECT_OWNER`, `GH_PROJECT_ID`, `GH_STATUS_FIELD_ID`, `GH_STATUS_TRIAGE_ID`, `GH_STATUS_READY_ID`, `GH_STATUS_IN_PROGRESS_ID`, `GH_STATUS_IN_REVIEW_ID`, `GH_STATUS_DONE_ID`.
-
-2. If `.private/project-config.env` doesn't exist, create the project and config:
-
-The project title follows the convention `<github-username>-vellum-assistant` where `<github-username>` is the current GitHub user's login (from `gh api user --jq '.login'`).
-
-```bash
-# Get the current GitHub username
-GH_USERNAME=$(gh api user --jq '.login')
-
-# Create the project under the vellum-ai org
-PROJECT_URL=$(gh project create --owner "vellum-ai" --title "${GH_USERNAME}-vellum-assistant" --format json | jq -r '.url')
-PROJECT_NUMBER=$(echo "$PROJECT_URL" | grep -oE '[0-9]+$')
-
-# Get the project node ID
-GH_PROJECT_ID=$(gh project view "$PROJECT_NUMBER" --owner "vellum-ai" --format json | jq -r '.id')
-
-# Add Status field (single select) with standard columns
-gh api graphql -f query='mutation {
-  addProjectV2SingleSelectField(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    name: "Status"
-    options: [{name:"Triage",color:GRAY},{name:"Ready",color:BLUE},{name:"In Progress",color:YELLOW},{name:"In Review",color:ORANGE},{name:"Done",color:GREEN}]
-  }) { projectV2SingleSelectField { id options { id name } } }
-}'
-```
-
-Then query the field and option IDs and write them to `.private/project-config.env` in the same format shown above. Include `GH_PROJECT_NUMBER` (the human-readable number from the project URL). Set `GH_PROJECT_OWNER=vellum-ai`.
+This provides: `GH_PROJECT_NUMBER`, `GH_PROJECT_OWNER`, `GH_PROJECT_ID`, and status option IDs.
 
 ## Phase 1.5: Create the Feature Branch
 
@@ -150,36 +129,11 @@ EOF
 4. Add all issues to the GH project board and set their statuses:
 
 ```bash
-# Add issue to project (repeat for each issue)
-ITEM_ID=$(gh api graphql -f query='mutation {
-  addProjectV2ItemById(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    contentId: "<issue-node-id>"
-  }) { item { id } }
-}' --jq '.data.addProjectV2ItemById.item.id')
+# Project-level (epic) issue → in-progress
+.claude/gh-project add-issue <epic-issue-number> --status in-progress
 
-# Get the issue node ID first:
-# gh api repos/vellum-ai/vellum-assistant/issues/<number> --jq '.node_id'
-
-# Set status — use GH_STATUS_IN_PROGRESS_ID for the project-level (epic) issue:
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_IN_PROGRESS_ID"'"}
-  }) { projectV2Item { id } }
-}'
-
-# Set status — use GH_STATUS_READY_ID for milestone issues:
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_READY_ID"'"}
-  }) { projectV2Item { id } }
-}'
+# Milestone issues → ready (repeat for each)
+.claude/gh-project add-issue <milestone-issue-number> --status ready
 ```
 
 5. **Present the plan to the user for approval.** Show:
@@ -275,49 +229,9 @@ git fetch origin <feature-branch-name>
 ```
 
 9. **After each milestone task completes and its PR merges**, update the corresponding GitHub issue. Skip this for non-milestone tasks (e.g., "Address the feedback on ..." items):
-   1. Set the project board status to "Done":
 
 ```bash
-ITEM_ID=""
-CURSOR=""
-while [ -z "$ITEM_ID" ]; do
-  if [ -z "$CURSOR" ]; then
-    AFTER_ARG=""
-  else
-    AFTER_ARG=", after: \"$CURSOR\""
-  fi
-  RESULT=$(gh api graphql -f query='{
-    node(id: "'"$GH_PROJECT_ID"'") {
-      ... on ProjectV2 {
-        items(first: 100'"$AFTER_ARG"') {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            id
-            content { ... on Issue { number } }
-          }
-        }
-      }
-    }
-  }')
-  ITEM_ID=$(echo "$RESULT" | jq -r '.data.node.items.nodes[] | select(.content.number == <issue-number>) | .id')
-  HAS_NEXT=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.hasNextPage')
-  CURSOR=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.endCursor')
-  if [ "$HAS_NEXT" != "true" ]; then break; fi
-done
-
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_DONE_ID"'"}
-  }) { projectV2Item { id } }
-}'
-```
-
-   2. Close the GitHub issue:
-
-```bash
+.claude/gh-project set-status <issue-number> done
 gh issue close <issue-number>
 ```
 
@@ -341,18 +255,10 @@ gh issue close <issue-number>
 
 This is the key difference from `/blitz`. Instead of closing the epic, we create the final PR.
 
-1. Update the project-level issue status to "In Review" on the GH project board:
+1. Update the project-level issue status to "In Review":
 
 ```bash
-# Same paginated lookup pattern, then:
-gh api graphql -f query='mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: "'"$GH_PROJECT_ID"'"
-    itemId: "'"$ITEM_ID"'"
-    fieldId: "'"$GH_STATUS_FIELD_ID"'"
-    value: {singleSelectOptionId: "'"$GH_STATUS_IN_REVIEW_ID"'"}
-  }) { projectV2Item { id } }
-}'
+.claude/gh-project set-status <project-issue-number> in-review
 ```
 
 2. Create the final PR from the feature branch into main. **Do NOT merge it.**

--- a/.claude/gh-project
+++ b/.claude/gh-project
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .claude/gh-project — GitHub Projects V2 operations
+# Wraps common project board GraphQL queries into simple CLI commands.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_FILE="$REPO_ROOT/.private/project-config.env"
+
+usage() {
+  cat <<'EOF'
+Usage: .claude/gh-project <command> [args]
+
+Commands:
+  init                               Create project board and write config
+  add-issue <number> [--status S]    Add issue to project, optionally set status
+  set-status <number> <status>       Update an issue's status on the project board
+
+Statuses: triage, ready, in-progress, in-review, done
+
+The config file at .private/project-config.env is auto-sourced for all
+commands except init (which creates it).
+
+Examples:
+  .claude/gh-project init
+  .claude/gh-project add-issue 42 --status ready
+  .claude/gh-project set-status 42 done
+EOF
+}
+
+# Map human-friendly status name to the env var name suffix
+status_var_for() {
+  local status="$1"
+  case "$status" in
+    triage)      echo "GH_STATUS_TRIAGE_ID" ;;
+    ready)       echo "GH_STATUS_READY_ID" ;;
+    in-progress) echo "GH_STATUS_IN_PROGRESS_ID" ;;
+    in-review)   echo "GH_STATUS_IN_REVIEW_ID" ;;
+    done)        echo "GH_STATUS_DONE_ID" ;;
+    *) echo "Error: unknown status '$status'. Use: triage, ready, in-progress, in-review, done" >&2; exit 1 ;;
+  esac
+}
+
+load_config() {
+  if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: $CONFIG_FILE not found. Run '.claude/gh-project init' first." >&2
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+}
+
+# Find the project item ID for a given issue number (paginated)
+find_item_id() {
+  local issue_number="$1"
+  local item_id=""
+  local cursor=""
+
+  while [ -z "$item_id" ]; do
+    local after_arg=""
+    if [ -n "$cursor" ]; then
+      after_arg=", after: \"$cursor\""
+    fi
+
+    local result
+    result=$(gh api graphql -f query='{
+      node(id: "'"$GH_PROJECT_ID"'") {
+        ... on ProjectV2 {
+          items(first: 100'"$after_arg"') {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              content { ... on Issue { number } }
+            }
+          }
+        }
+      }
+    }')
+
+    item_id=$(echo "$result" | jq -r '.data.node.items.nodes[] | select(.content.number == '"$issue_number"') | .id')
+    local has_next
+    has_next=$(echo "$result" | jq -r '.data.node.items.pageInfo.hasNextPage')
+    cursor=$(echo "$result" | jq -r '.data.node.items.pageInfo.endCursor')
+
+    if [ "$has_next" != "true" ]; then break; fi
+  done
+
+  if [ -z "$item_id" ]; then
+    echo "Error: issue #$issue_number not found on the project board" >&2
+    exit 1
+  fi
+
+  echo "$item_id"
+}
+
+# Update a project item's status field
+update_status() {
+  local item_id="$1"
+  local status_option_id="$2"
+
+  gh api graphql -f query='mutation {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: "'"$GH_PROJECT_ID"'"
+      itemId: "'"$item_id"'"
+      fieldId: "'"$GH_STATUS_FIELD_ID"'"
+      value: {singleSelectOptionId: "'"$status_option_id"'"}
+    }) { projectV2Item { id } }
+  }' > /dev/null
+}
+
+# --- Commands ---
+
+cmd_init() {
+  mkdir -p "$(dirname "$CONFIG_FILE")"
+
+  echo "==> Getting GitHub username..."
+  local gh_username
+  gh_username=$(gh api user --jq '.login')
+
+  local project_title="${gh_username}-vellum-assistant"
+  echo "==> Creating project: $project_title"
+
+  local project_url
+  project_url=$(gh project create --owner "vellum-ai" --title "$project_title" --format json | jq -r '.url')
+  local project_number
+  project_number=$(echo "$project_url" | grep -oE '[0-9]+$')
+
+  echo "==> Getting project node ID..."
+  local project_id
+  project_id=$(gh project view "$project_number" --owner "vellum-ai" --format json | jq -r '.id')
+
+  echo "==> Adding Status field..."
+  local field_result
+  field_result=$(gh api graphql -f query='mutation {
+    addProjectV2SingleSelectField(input: {
+      projectId: "'"$project_id"'"
+      name: "Status"
+      options: [{name:"Triage",color:GRAY},{name:"Ready",color:BLUE},{name:"In Progress",color:YELLOW},{name:"In Review",color:ORANGE},{name:"Done",color:GREEN}]
+    }) { projectV2SingleSelectField { id options { id name } } }
+  }')
+
+  local field_id
+  field_id=$(echo "$field_result" | jq -r '.data.addProjectV2SingleSelectField.projectV2SingleSelectField.id')
+
+  local triage_id ready_id in_progress_id in_review_id done_id
+  triage_id=$(echo "$field_result" | jq -r '.data.addProjectV2SingleSelectField.projectV2SingleSelectField.options[] | select(.name == "Triage") | .id')
+  ready_id=$(echo "$field_result" | jq -r '.data.addProjectV2SingleSelectField.projectV2SingleSelectField.options[] | select(.name == "Ready") | .id')
+  in_progress_id=$(echo "$field_result" | jq -r '.data.addProjectV2SingleSelectField.projectV2SingleSelectField.options[] | select(.name == "In Progress") | .id')
+  in_review_id=$(echo "$field_result" | jq -r '.data.addProjectV2SingleSelectField.projectV2SingleSelectField.options[] | select(.name == "In Review") | .id')
+  done_id=$(echo "$field_result" | jq -r '.data.addProjectV2SingleSelectField.projectV2SingleSelectField.options[] | select(.name == "Done") | .id')
+
+  echo "==> Writing config to $CONFIG_FILE"
+  cat > "$CONFIG_FILE" <<ENVEOF
+GH_PROJECT_NUMBER=$project_number
+GH_PROJECT_OWNER=vellum-ai
+GH_PROJECT_ID=$project_id
+GH_STATUS_FIELD_ID=$field_id
+GH_STATUS_TRIAGE_ID=$triage_id
+GH_STATUS_READY_ID=$ready_id
+GH_STATUS_IN_PROGRESS_ID=$in_progress_id
+GH_STATUS_IN_REVIEW_ID=$in_review_id
+GH_STATUS_DONE_ID=$done_id
+ENVEOF
+
+  echo "Done. Project #$project_number created: $project_url"
+}
+
+cmd_add_issue() {
+  local issue_number=""
+  local status=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --status) status="$2"; shift 2 ;;
+      *) issue_number="$1"; shift ;;
+    esac
+  done
+
+  if [ -z "$issue_number" ]; then
+    echo "Error: issue number is required" >&2
+    echo "Usage: .claude/gh-project add-issue <number> [--status STATUS]" >&2
+    exit 1
+  fi
+
+  load_config
+
+  echo "==> Getting node ID for issue #$issue_number..."
+  local node_id
+  node_id=$(gh api "repos/vellum-ai/vellum-assistant/issues/$issue_number" --jq '.node_id')
+
+  echo "==> Adding issue #$issue_number to project..."
+  local item_id
+  item_id=$(gh api graphql -f query='mutation {
+    addProjectV2ItemById(input: {
+      projectId: "'"$GH_PROJECT_ID"'"
+      contentId: "'"$node_id"'"
+    }) { item { id } }
+  }' --jq '.data.addProjectV2ItemById.item.id')
+
+  echo "Added issue #$issue_number (item: $item_id)"
+
+  if [ -n "$status" ]; then
+    local var_name
+    var_name=$(status_var_for "$status")
+    local option_id="${!var_name}"
+    echo "==> Setting status to $status..."
+    update_status "$item_id" "$option_id"
+    echo "Status set to $status."
+  fi
+}
+
+cmd_set_status() {
+  if [ $# -lt 2 ]; then
+    echo "Error: issue number and status are required" >&2
+    echo "Usage: .claude/gh-project set-status <number> <status>" >&2
+    exit 1
+  fi
+
+  local issue_number="$1"
+  local status="$2"
+
+  load_config
+
+  local var_name
+  var_name=$(status_var_for "$status")
+  local option_id="${!var_name}"
+
+  echo "==> Finding issue #$issue_number on project board..."
+  local item_id
+  item_id=$(find_item_id "$issue_number")
+
+  echo "==> Setting status to $status..."
+  update_status "$item_id" "$option_id"
+
+  echo "Done. Issue #$issue_number status set to $status."
+}
+
+# --- Dispatch ---
+
+if [ $# -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  init) shift; cmd_init "$@" ;;
+  add-issue) shift; cmd_add_issue "$@" ;;
+  set-status) shift; cmd_set_status "$@" ;;
+  -h|--help) usage ;;
+  *) echo "Error: unknown command '$1'" >&2; usage >&2; exit 1 ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist
 !.claude/README.md
 !.claude/worktree
 !.claude/ship
+!.claude/gh-project
 .private/
 temp.sh
 context.md


### PR DESCRIPTION
## Summary
- Adds `.claude/gh-project` with three subcommands: `init` (create project board + write config), `add-issue` (add issue + set status), `set-status` (paginated lookup + status update)
- Updates `blitz.md`, `safe-blitz.md`, and `safe-blitz-done.md` to replace ~150 lines of inline GraphQL with one-liner script calls
- Eliminates the riskiest shell quoting in the codebase (nested GraphQL inside bash variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
