### PR TITLE
fix: resolve 33 eslint errors across test files and session-skill-tools

### DIFF
--- a/assistant/src/__tests__/active-skill-tools.test.ts
+++ b/assistant/src/__tests__/active-skill-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { deriveActiveSkillIds, deriveActiveSkills } from '../skills/active-skill-tools.js';
-import type { ActiveSkillEntry } from '../skills/active-skill-tools.js';
+
 import type { Message } from '../providers/types.js';
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeAll, beforeEach, mock } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, realpathSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
@@ -1227,7 +1228,7 @@ describe('Permission Checker', () => {
     test('check() passes policyContext through to findHighestPriorityRule', async () => {
       // Create a rule with principal constraints so we can verify the
       // context is actually forwarded to the matching logic.
-      const rules = (await import('../permissions/trust-store.js')).getAllRules();
+      const _rules = (await import('../permissions/trust-store.js')).getAllRules();
       const trustPath = join(checkerTestDir, 'protected', 'trust.json');
       const { readFileSync, writeFileSync, mkdirSync, existsSync } = await import('node:fs');
       const { dirname } = await import('node:path');
@@ -2156,8 +2157,8 @@ describe('Permission Checker', () => {
     // fully resolved paths when writing rules that should match the
     // canonical (realpath-resolved) candidate.
     let realDirResolved: string;
-    let symDirResolved: string;
-    let symlinkTestDirResolved: string;
+    let _symDirResolved: string;
+    let _symlinkTestDirResolved: string;
 
     beforeAll(() => {
       mkdirSync(realDir, { recursive: true });
@@ -2165,8 +2166,8 @@ describe('Permission Checker', () => {
       symlinkSync(realDir, symDir);
 
       realDirResolved = realpathSync(realDir);
-      symDirResolved = realpathSync(symDir); // resolves to realDirResolved
-      symlinkTestDirResolved = realpathSync(symlinkTestDir);
+      _symDirResolved = realpathSync(symDir); // resolves to realDirResolved
+      _symlinkTestDirResolved = realpathSync(symlinkTestDir);
     });
 
     test('relative path with .. segments matches rule for canonical absolute path', async () => {

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -459,7 +459,7 @@ describe('runSkillToolScript — hash change re-prompt regressions (PR 35)', () 
 
   test('no expectedSkillVersionHash skips guard entirely — edits have no effect', async () => {
     let currentDiskHash = 'v1:whatever';
-    const resolver = (_dir: string) => currentDiskHash;
+    const _resolver = (_dir: string) => currentDiskHash;
 
     // Without expectedSkillVersionHash, the guard is not active
     const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'unguarded' }, makeContext());

--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, afterAll, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -51,7 +51,7 @@ mock.module('../tools/terminal/sandbox.js', () => ({
 }));
 
 import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';
-import type { RunSkillToolScriptOptions } from '../tools/skills/skill-script-runner.js';
+
 import type { ToolContext } from '../tools/types.js';
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/starter-bundle.test.ts
+++ b/assistant/src/__tests__/starter-bundle.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 
 // Stub the root dir before importing trust-store so it uses our temp directory
@@ -26,7 +26,6 @@ import {
   getStarterBundleRules,
   getAllRules,
   clearCache,
-  clearAllRules,
 } from '../permissions/trust-store.js';
 
 describe('Starter approval bundle', () => {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test';
 import type { ToolExecutionResult, Tool } from '../tools/types.js';
 import { RiskLevel } from '../permissions/types.js';
@@ -362,7 +363,7 @@ describe('ToolExecutor contextual rule creation', () => {
 
     expect(result.isError).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
-    const [tool, pattern, scope, decision, priority, options] = spy.mock.calls[0];
+    const [tool, pattern, scope, decision, _priority, options] = spy.mock.calls[0];
     expect(tool).toBe('skill_tool');
     expect(pattern).toBe('skill_tool:*');
     expect(scope).toBe('/tmp/project');
@@ -400,7 +401,7 @@ describe('ToolExecutor contextual rule creation', () => {
 
     expect(result.isError).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
-    const [tool, pattern, scope, decision, priority, options] = spy.mock.calls[0];
+    const [tool, pattern, scope, decision, _priority, options] = spy.mock.calls[0];
     expect(tool).toBe('risky_tool');
     expect(pattern).toBe('risky_tool:*');
     expect(scope).toBe('everywhere');
@@ -426,7 +427,7 @@ describe('ToolExecutor contextual rule creation', () => {
 
     expect(result.isError).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
-    const [tool, pattern, scope, decision, priority, options] = spy.mock.calls[0];
+    const [tool, pattern, scope, decision, _priority, options] = spy.mock.calls[0];
     expect(tool).toBe('bash');
     expect(pattern).toBe('git *');
     expect(scope).toBe('/tmp/project');
@@ -559,7 +560,7 @@ describe('ToolExecutor strict mode + high-risk integration (PR 25)', () => {
 
     expect(result.isError).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
-    const [tool, pattern, scope, decision, priority, options] = spy.mock.calls[0];
+    const [tool, pattern, scope, decision, _priority, options] = spy.mock.calls[0];
     expect(tool).toBe('deploy_tool');
     expect(pattern).toBe('deploy_tool:*');
     expect(scope).toBe('everywhere');

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1099,7 +1099,9 @@ describe('Trust Store', () => {
       expect(rule!.tool).toBe('bash');
       expect(rule!.pattern).toBe('git *');
       // Extra fields pass through because the migration does not strip them
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- asserting extra fields pass through migration
       expect((rule as any).customField).toBe('should-survive');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- asserting extra fields pass through migration
       expect((rule as any).nested).toEqual({ deep: true });
     });
 

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -12,7 +12,7 @@ import type { Message, ToolDefinition } from '../providers/types.js';
 import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import { deriveActiveSkills } from '../skills/active-skill-tools.js';
-import type { ActiveSkillEntry } from '../skills/active-skill-tools.js';
+
 import { parseToolManifestFile } from '../skills/tool-manifest.js';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
 import { createSkillToolsFromManifest } from '../tools/skills/skill-tool-factory.js';


### PR DESCRIPTION
## Summary
- Remove unused imports (`ActiveSkillEntry`, `writeFileSync`, `clearAllRules`, `spyOn`, `RunSkillToolScriptOptions`)
- Prefix unused variables with `_` (`rules`, `symDirResolved`, `symlinkTestDirResolved`, `resolver`, `priority`)
- Add file-level `eslint-disable @typescript-eslint/no-explicit-any` for `checker.test.ts` and `tool-executor.test.ts` (test files with legitimate `any` usage in mocks/assertions)
- Add inline eslint-disable for 2 `any` casts in `trust-store.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
