### PR TITLE
Fix: hide workspace activity feed when chat is docked to side

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -154,11 +154,15 @@ struct MainWindowView: View {
         coreLayoutView
             .onChange(of: windowState.isDynamicExpanded) { _, expanded in
                 threadManager.activeViewModel?.activeSurfaceId = expanded ? windowState.activeDynamicSurface?.surfaceId : nil
+                threadManager.activeViewModel?.isChatDockedToSide = expanded && windowState.isChatDockOpen
             }
             .onChange(of: windowState.activeDynamicSurface?.surfaceId) { _, surfaceId in
                 if windowState.isDynamicExpanded {
                     threadManager.activeViewModel?.activeSurfaceId = surfaceId
                 }
+            }
+            .onChange(of: windowState.isChatDockOpen) { _, docked in
+                threadManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && docked
             }
             .onChange(of: threadManager.activeViewModel?.messages.count) { _, _ in
                 // Close activity panel if the referenced message no longer exists
@@ -298,6 +302,7 @@ struct MainWindowView: View {
                 threadManager.clearActiveSurface(threadId: oldId)
             }
             threadManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
+            threadManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && windowState.isChatDockOpen
         }
         .onChange(of: windowState.activePanel) { _, newPanel in
             // Close the left sidebar when the activity panel opens to avoid crowding

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1369,7 +1369,9 @@ private struct DynamicWorkspaceWrapper: View {
 
                 Spacer()
 
-                WorkspaceActivityFeed(viewModel: viewModel)
+                if !isChatDockOpen {
+                    WorkspaceActivityFeed(viewModel: viewModel)
+                }
 
                 if !isChatDockOpen {
                     ComposerView(

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -149,6 +149,11 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    /// When true, the chat is docked to the side panel alongside the workspace.
+    /// Messages should flow through the normal chat conversation instead of the
+    /// workspace activity feed overlay.
+    public var isChatDockedToSide: Bool = false
+
     /// The page currently displayed in the workspace WebView (e.g. "settings.html").
     /// Set via the onPageChanged callback when the user navigates within a multi-page app.
     public var currentPage: String?
@@ -182,7 +187,7 @@ public final class ChatViewModel: ObservableObject {
         let attachments = pendingAttachments
         pendingAttachments = []
 
-        let isWorkspaceRefinement = activeSurfaceId != nil
+        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide
 
         let willBeQueued = isSending && sessionId != nil
         var queuedMessageId: UUID?


### PR DESCRIPTION
The purpose of this PR is to fix messages appearing as a floating overlay in the center of the workspace when the chat is docked to the side panel.

## Changes Made
- Conditionally hide `WorkspaceActivityFeed` when `isChatDockOpen` is true, so messages only appear in the sidebar conversation instead of as a center overlay

## Testing
- Manual testing: send a message with chat docked to side, messages now appear only in the sidebar

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
