### PR TITLE
feat: add .claude/gh-review script for review thread resolution

### DIFF
--- a/.claude/commands/safe-check-review.md
+++ b/.claude/commands/safe-check-review.md
@@ -99,10 +99,9 @@ EOF
    )"
    git push origin HEAD
    ```
-6. For each unresolved thread from step 2, reply and resolve:
+6. Resolve all bot review threads from step 2:
    ```
-   gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<thread-id>", body:"Addressed in latest push."}) { comment { id } } }'
-   gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread-id>"}) { thread { isResolved } } }'
+   .claude/gh-review resolve-threads <pr-number> "Addressed in latest push."
    ```
 7. After pushing, request re-review by posting two separate comments on the PR:
    ```bash

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -80,12 +80,7 @@ For "Address the feedback on <PR URL>" tasks:
 - Follow the same PR creation and merge workflow above.
 - After creating the followup PR, leave a paper trail on the original PR:
   1. Comment on the original PR: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
-  2. Reply to each review thread and resolve it. Fetch threads:
-     `gh api graphql -f query='query { repository(owner:"vellum-ai", name:"vellum-assistant") { pullRequest(number:<original-PR-number>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { body author { login } } } } } } } }'`
-  3. For each unresolved thread from `chatgpt-codex-connector[bot]` or `devin-ai-integration[bot]`, reply and resolve:
-     `gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<thread-id>", body:"Addressed in <new-PR-URL>"}) { comment { id } } }'`
-     `gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread-id>"}) { thread { isResolved } } }'`
-  4. Leave human review threads untouched.
+  2. Resolve all bot review threads: `.claude/gh-review resolve-threads <original-PR-number> "Addressed in <new-PR-URL>"`
 ```
 
 ## Phase 4: When an agent finishes

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -32,14 +32,7 @@ If you can implement it in a single PR:
 - CRITICAL: Merge it immediately with `gh pr merge <N> --squash` and switch back to the main branch
 - If this task was addressing feedback on a previous PR (either "Address the feedback on <PR URL>" or a sub-task with "(feedback from <PR URL>)"), leave a paper trail on the original PR:
   1. **Comment on the original PR** linking to the new PR: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
-  2. **Reply to each review thread** on the original PR with a link to the followup PR, then resolve the thread. For each review thread:
-     - Fetch all review threads: `gh api graphql -f query='query { repository(owner:"vellum-ai", name:"vellum-assistant") { pullRequest(number:<original-PR-number>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { body author { login } } } } } } } }'`
-     - For each unresolved thread from a reviewer bot, reply and resolve it:
-       ```
-       gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<thread-id>", body:"Addressed in <new-PR-URL>"}) { comment { id } } }'
-       gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread-id>"}) { thread { isResolved } } }'
-       ```
-     - Only reply to and resolve threads from `chatgpt-codex-connector[bot]` and `devin-ai-integration[bot]`. Leave human review threads untouched.
+  2. **Resolve all bot review threads**: `.claude/gh-review resolve-threads <original-PR-number> "Addressed in <new-PR-URL>"`
 
 After you've handled the item:
 

--- a/.claude/gh-review
+++ b/.claude/gh-review
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .claude/gh-review — Review thread operations
+# Reply to and resolve bot review threads on PRs.
+
+usage() {
+  cat <<'EOF'
+Usage: .claude/gh-review <command> [args]
+
+Commands:
+  resolve-threads <pr-number> <message>   Reply to and resolve all bot review threads
+
+Only resolves threads from chatgpt-codex-connector[bot] and
+devin-ai-integration[bot]. Human review threads are left untouched.
+
+Examples:
+  .claude/gh-review resolve-threads 123 "Addressed in #456"
+  .claude/gh-review resolve-threads 123 "Addressed in latest push."
+EOF
+}
+
+cmd_resolve_threads() {
+  if [ $# -lt 2 ]; then
+    echo "Error: PR number and message are required" >&2
+    echo "Usage: .claude/gh-review resolve-threads <pr-number> <message>" >&2
+    exit 1
+  fi
+
+  local pr_number="$1"
+  local message="$2"
+
+  echo "==> Fetching review threads for PR #$pr_number..."
+  local threads_json
+  threads_json=$(gh api graphql -f query='query {
+    repository(owner: "vellum-ai", name: "vellum-assistant") {
+      pullRequest(number: '"$pr_number"') {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes {
+                body
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }')
+
+  # Extract unresolved bot threads
+  local thread_ids
+  thread_ids=$(echo "$threads_json" | jq -r '
+    .data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.isResolved == false)
+    | select(.comments.nodes[0].author.login == "chatgpt-codex-connector[bot]" or .comments.nodes[0].author.login == "devin-ai-integration[bot]")
+    | .id
+  ')
+
+  if [ -z "$thread_ids" ]; then
+    echo "No unresolved bot threads found."
+    return 0
+  fi
+
+  local count=0
+  while IFS= read -r thread_id; do
+    [ -z "$thread_id" ] && continue
+    count=$((count + 1))
+
+    echo "==> Replying to thread $thread_id..."
+    gh api graphql -f query='mutation {
+      addPullRequestReviewThreadReply(input: {
+        pullRequestReviewThreadId: "'"$thread_id"'"
+        body: "'"$message"'"
+      }) { comment { id } }
+    }' > /dev/null
+
+    echo "==> Resolving thread $thread_id..."
+    gh api graphql -f query='mutation {
+      resolveReviewThread(input: {
+        threadId: "'"$thread_id"'"
+      }) { thread { isResolved } }
+    }' > /dev/null
+
+  done <<< "$thread_ids"
+
+  echo "Done. Resolved $count bot thread(s)."
+}
+
+# --- Dispatch ---
+
+if [ $# -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  resolve-threads) shift; cmd_resolve_threads "$@" ;;
+  -h|--help) usage ;;
+  *) echo "Error: unknown command '$1'" >&2; usage >&2; exit 1 ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ dist
 !.claude/worktree
 !.claude/ship
 !.claude/gh-project
+!.claude/gh-review
 .private/
 temp.sh
 context.md


### PR DESCRIPTION
## Summary
- Adds `.claude/gh-review` with `resolve-threads` subcommand that fetches all review threads on a PR, replies to unresolved bot threads (codex + devin), and resolves them
- Updates `swarm.md`, `work.md`, and `safe-check-review.md` to replace inline GraphQL mutation sequences with a single script call
- Eliminates error-prone manual thread ID extraction and GraphQL quoting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
