### PR TITLE
docs: update architecture and skills docs for security model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1509,6 +1509,178 @@ graph TB
 
 ---
 
+## Permission and Trust Security Model
+
+The permission system controls which tool actions the agent can execute without explicit user approval. It supports two operating modes, principal-aware trust rules, and risk-based escalation to provide defense-in-depth against unintended or malicious tool execution.
+
+### Permission Evaluation Flow
+
+```mermaid
+graph TB
+    TOOL_CALL["Tool invocation<br/>(toolName, input, policyContext)"] --> CLASSIFY["classifyRisk()<br/>→ Low / Medium / High"]
+    CLASSIFY --> CANDIDATES["buildCommandCandidates()<br/>tool:target strings +<br/>canonical path variants"]
+    CANDIDATES --> FIND_RULE["findHighestPriorityRule()<br/>iterate sorted rules:<br/>tool, scope, pattern (minimatch),<br/>principal, executionTarget"]
+
+    FIND_RULE -->|"Deny rule"| DENY["decision: deny<br/>Blocked by rule"]
+    FIND_RULE -->|"Ask rule"| PROMPT_ASK["decision: prompt<br/>Always ask user"]
+    FIND_RULE -->|"Allow rule"| RISK_CHECK{"Risk level?"}
+    FIND_RULE -->|"No match"| NO_MATCH{"Fallback logic"}
+
+    RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
+    RISK_CHECK -->|"High"| HIGH_CHECK{"allowHighRisk<br/>on rule?"}
+    HIGH_CHECK -->|"true"| AUTO_ALLOW
+    HIGH_CHECK -->|"false / absent"| PROMPT_HIGH["decision: prompt<br/>High risk override"]
+
+    NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
+    NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
+    NO_MATCH -->|"legacy mode"| RISK_FALLBACK{"Risk level?"}
+    RISK_FALLBACK -->|"Low"| AUTO_LOW["decision: allow<br/>Low risk auto-allow"]
+    RISK_FALLBACK -->|"Medium"| PROMPT_MED["decision: prompt"]
+    RISK_FALLBACK -->|"High"| PROMPT_HIGH2["decision: prompt"]
+```
+
+### Strict Mode vs Legacy Mode
+
+The `permissions.mode` config option (`legacy` or `strict`) controls the default behavior when no trust rule matches a tool invocation.
+
+| Behavior | Legacy mode (default) | Strict mode |
+|---|---|---|
+| Low-risk tools with no matching rule | Auto-allowed | Prompted |
+| Medium-risk tools with no matching rule | Prompted | Prompted |
+| High-risk tools with no matching rule | Prompted | Prompted |
+| `skill_load` with no matching rule | Auto-allowed (low risk) | Prompted (explicit rule required) |
+| Skill-origin tools with no matching rule | Prompted | Prompted |
+| Allow rules for non-high-risk tools | Auto-allowed | Auto-allowed |
+| Allow rules with `allowHighRisk: true` | Auto-allowed (even high risk) | Auto-allowed (even high risk) |
+| Deny rules | Blocked | Blocked |
+
+Strict mode is designed for security-conscious deployments where every tool action must have an explicit matching rule in the trust store. It eliminates implicit auto-allow for any risk level, ensuring the user has consciously approved each class of tool usage.
+
+### Trust Rules (v3 Schema)
+
+Rules are stored in `~/.vellum/protected/trust.json` with version `3`. Each rule can include the following fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | `string` | Unique identifier (UUID for user rules, `default:*` for system defaults) |
+| `tool` | `string` | Tool name to match (e.g., `bash`, `file_write`, `skill_load`) |
+| `pattern` | `string` | Minimatch glob pattern for the command/target string |
+| `scope` | `string` | Path prefix or `everywhere` — restricts where the rule applies |
+| `decision` | `allow \| deny \| ask` | What to do when the rule matches |
+| `priority` | `number` | Higher priority wins; deny wins ties at equal priority |
+| `principalKind` | `string?` | `core` or `skill` — filters by tool origin |
+| `principalId` | `string?` | Skill ID — only matches invocations from this skill |
+| `principalVersion` | `string?` | Version hash — only matches this exact skill version |
+| `executionTarget` | `string?` | `sandbox` or `host` — restricts by execution context |
+| `allowHighRisk` | `boolean?` | When true, auto-allows even high-risk invocations |
+
+Missing optional fields act as wildcards. A rule with no `principalKind`, `principalId`, or `principalVersion` matches any principal. A rule with no `executionTarget` matches any target.
+
+### Principal and Version Matching
+
+When a tool invocation carries a `PolicyContext` with a `ToolPrincipal`, the trust store filters rules by principal constraints:
+
+```mermaid
+graph TB
+    RULE["Trust rule with<br/>principalKind, principalId,<br/>principalVersion"] --> KIND_CHECK{"principalKind<br/>on rule?"}
+    KIND_CHECK -->|"absent"| ID_CHECK
+    KIND_CHECK -->|"present"| KIND_MATCH{"ctx.principal.kind<br/>matches?"}
+    KIND_MATCH -->|"no"| SKIP["Rule does not match"]
+    KIND_MATCH -->|"yes"| ID_CHECK{"principalId<br/>on rule?"}
+
+    ID_CHECK -->|"absent"| VER_CHECK
+    ID_CHECK -->|"present"| ID_MATCH{"ctx.principal.id<br/>matches?"}
+    ID_MATCH -->|"no"| SKIP
+    ID_MATCH -->|"yes"| VER_CHECK{"principalVersion<br/>on rule?"}
+
+    VER_CHECK -->|"absent"| MATCH["Rule matches<br/>(any version)"]
+    VER_CHECK -->|"present"| VER_MATCH{"ctx.principal.version<br/>matches?"}
+    VER_MATCH -->|"no"| SKIP
+    VER_MATCH -->|"yes"| MATCH
+```
+
+Version-bound rules are central to the security model for skills: when a user approves a specific skill version, the trust rule records the version hash. If the skill's source files change (producing a different hash from `computeSkillVersionHash()`), the old rule no longer matches and the user is re-prompted.
+
+### Risk Classification and Escalation
+
+The `classifyRisk()` function determines the risk level for each tool invocation:
+
+| Tool | Risk level | Notes |
+|---|---|---|
+| `file_read`, `web_search`, `skill_load` | Low | Read-only or informational |
+| `file_write`, `file_edit` | Medium (default) | Filesystem mutations |
+| `file_write`, `file_edit` targeting skill source paths | **High** | `isSkillSourcePath()` detects managed/bundled/workspace/extra skill roots |
+| `host_file_write`, `host_file_edit` targeting skill source paths | **High** | Same path classification, host variant |
+| `bash`, `host_bash` | Varies | Parsed via tree-sitter: low-risk programs = Low, high-risk programs = High, unknown = Medium |
+| `scaffold_managed_skill`, `delete_managed_skill` | High | Skill lifecycle mutations always high-risk |
+| `evaluate_typescript_code` | High | Arbitrary code execution |
+| Skill-origin tools with no matching rule | Prompted regardless of risk | Even Low-risk skill tools default to `ask` |
+
+The escalation of skill source file mutations to High risk is a privilege-escalation defense: modifying skill source code could grant the agent new capabilities, so such operations always require explicit approval.
+
+### Skill Load Approval
+
+The `skill_load` tool generates version-aware command candidates for rule matching:
+
+1. `skill_load:<skill-id>@<version-hash>` — matches version-pinned rules
+2. `skill_load:<skill-id>` — matches any-version rules
+3. `skill_load:<raw-selector>` — matches the raw user-provided selector
+
+In strict mode, `skill_load` without a matching rule is always prompted. In legacy mode, it is auto-allowed as a Low-risk tool. The allowlist options presented to the user include both version-specific and any-version patterns.
+
+### Starter Approval Bundle
+
+The starter bundle is an opt-in set of low-risk allow rules that reduces prompt noise, particularly in strict mode. It covers read-only tools that never mutate the filesystem or execute arbitrary code:
+
+| Rule | Tool | Pattern |
+|---|---|---|
+| `file_read` | `file_read` | `file_read:**` |
+| `glob` | `glob` | `glob:**` |
+| `grep` | `grep` | `grep:**` |
+| `list_directory` | `list_directory` | `list_directory:**` |
+| `web_search` | `web_search` | `web_search:**` |
+| `web_fetch` | `web_fetch` | `web_fetch:**` |
+
+Acceptance is idempotent and persisted as `starterBundleAccepted: true` in `trust.json`. Rules are seeded at priority 90 (below user rules at 100, above system defaults at 50).
+
+### Prompt UX
+
+When a permission prompt is sent to the client (via `confirmation_request` IPC message), it includes:
+
+| Field | Content |
+|---|---|
+| `toolName` | The tool being invoked |
+| `input` | Redacted tool input (sensitive fields removed) |
+| `riskLevel` | `low`, `medium`, or `high` |
+| `executionTarget` | `sandbox` or `host` — where the action will execute |
+| `principalKind` | `core` or `skill` — who owns the tool |
+| `principalId` | Skill ID (if skill-origin) |
+| `principalVersion` | Version hash (if available) |
+| `allowlistOptions` | Suggested patterns for "always allow" rules |
+| `scopeOptions` | Suggested scopes for rule persistence |
+
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `always_allow_high_risk` (create allow rule with `allowHighRisk: true`), `deny` (one-time), or `always_deny` (create deny rule).
+
+### Canonical Paths
+
+File tool candidates include canonical (symlink-resolved) absolute paths via `normalizeFilePath()` to prevent policy bypass through symlinked or relative path variations. The path classifier (`isSkillSourcePath()`) also resolves symlinks before checking against skill root directories.
+
+### Key Source Files
+
+| File | Role |
+|---|---|
+| `assistant/src/permissions/types.ts` | `TrustRule`, `PolicyContext`, `ToolPrincipal`, `RiskLevel`, `UserDecision` types |
+| `assistant/src/permissions/checker.ts` | `classifyRisk()`, `check()`, `buildCommandCandidates()`, allowlist/scope generation |
+| `assistant/src/permissions/trust-store.ts` | Rule persistence, `findHighestPriorityRule()`, principal/version matching, starter bundle |
+| `assistant/src/permissions/prompter.ts` | IPC prompt flow: `confirmation_request` → `confirmation_response` |
+| `assistant/src/permissions/defaults.ts` | Default rule templates (system ask rules for host tools, CU, etc.) |
+| `assistant/src/skills/version-hash.ts` | `computeSkillVersionHash()` — deterministic SHA-256 of skill source files |
+| `assistant/src/skills/path-classifier.ts` | `isSkillSourcePath()`, `normalizeFilePath()`, skill root detection |
+| `assistant/src/config/schema.ts` | `PermissionsConfigSchema` — `permissions.mode` (`legacy` / `strict`) |
+| `assistant/src/tools/executor.ts` | `ToolExecutor` — orchestrates risk classification, permission check, and execution |
+
+---
+
 ## Swarm Orchestration — Parallel Task Execution
 
 When the model invokes `swarm_delegate`, the daemon decomposes a complex task into parallel specialist subtasks and executes them concurrently.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,41 @@ All three tools require explicit user approval before execution (Risk Level = Hi
 - After a skill is written or deleted, the file watcher triggers session eviction. The next turn runs in a fresh session.
 - Managed skills appear in the macOS Settings UI with Inspect and Delete controls.
 
+## Permission Modes and Trust Rules
+
+The assistant uses a permission system to control which tool actions the agent can execute without explicit user approval. Permission behavior is configured via `permissions.mode`:
+
+```bash
+# Default — low-risk tools auto-allowed, medium/high prompted
+vellum config set permissions.mode '"legacy"'
+
+# Strict — ALL tools require an explicit trust rule, no implicit auto-allow
+vellum config set permissions.mode '"strict"'
+```
+
+### Trust rules
+
+User approval decisions are persisted as trust rules in `~/.vellum/protected/trust.json`. Rules support:
+
+- **Pattern matching**: Minimatch glob patterns for tool commands and file paths.
+- **Principal binding**: Rules can target specific skills (`principalId`) and even specific versions (`principalVersion`) via content hashing.
+- **Execution target binding**: Rules can be scoped to `sandbox` or `host` execution contexts.
+- **High-risk override**: Rules with `allowHighRisk: true` auto-allow even high-risk tool invocations.
+
+### Version-bound skill approvals
+
+When you approve a skill-originated action, the trust rule can record the skill's version hash. If the skill's source files change, the hash changes and the old rule no longer matches — you are re-prompted. This prevents modified skills from silently inheriting previous approvals.
+
+### Starter approval bundle
+
+In strict mode, a **starter bundle** can be accepted to seed common safe rules (file reads, glob, grep, web search, etc.), reducing initial prompt noise without compromising security for mutation or execution tools.
+
+### Skill source mutation protection
+
+Writing to files inside skill directories (managed, bundled, workspace, or extra) is classified as **high risk** regardless of the tool used. This prevents the agent from modifying skill code — which could alter its own capabilities — without explicit user consent.
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full permission evaluation flow diagrams and [`assistant/docs/skills.md`](assistant/docs/skills.md) for detailed skills security documentation.
+
 ## Assistant Attachments
 
 The assistant can attach files and images to its replies. Attachments flow through three delivery channels:

--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -1,0 +1,158 @@
+# Skills — Security Model
+
+This document describes the security model for the Vellum Assistant skill system, including how skills are authorized, how trust rules interact with skill versions, and how the system protects against privilege escalation through skill source mutations.
+
+## Overview
+
+Skills extend the assistant's capabilities by providing instructions (via `SKILL.md`) and optional custom tools (via `TOOLS.json`). Skills can be **bundled** (shipped with the application), **managed** (user-installed via `scaffold_managed_skill`), **workspace** (project-local), or **extra** (additional directories configured by the user).
+
+Because skills can introduce arbitrary tool behavior, they are subject to stricter permission defaults than core tools. The permission system uses **principal-aware trust rules** and **version-bound approvals** to ensure that skill-originated actions are explicitly authorized by the user.
+
+## Permission Defaults for Skill Tools
+
+Skill-origin tools follow a stricter default permission policy than core tools:
+
+| Scenario | Core tool behavior | Skill tool behavior |
+|---|---|---|
+| Low risk, no matching rule | Auto-allowed (legacy mode) | **Prompted** |
+| Medium risk, no matching rule | Prompted | Prompted |
+| High risk, no matching rule | Prompted | Prompted |
+| Allow rule matches, non-high risk | Auto-allowed | Auto-allowed |
+| Allow rule matches, high risk, `allowHighRisk: true` | Auto-allowed | Auto-allowed |
+| Allow rule matches, high risk, `allowHighRisk` absent | Prompted | Prompted |
+
+Even if a skill's `TOOLS.json` declares `"risk": "low"` for one of its tools, the permission checker will prompt the user unless an explicit trust rule in `~/.vellum/protected/trust.json` allows it. This prevents third-party skill tools from silently auto-executing.
+
+## Skill Load Approval
+
+The `skill_load` tool activates a skill within the current session. In **strict mode** (`permissions.mode = 'strict'`), loading a skill requires an explicit matching trust rule. In **legacy mode**, `skill_load` is classified as low risk and auto-allowed.
+
+When `skill_load` is invoked, the permission checker generates multiple command candidates for rule matching:
+
+1. **Version-specific**: `skill_load:<skill-id>@<version-hash>` — matches rules that pin approval to an exact version of the skill's source code.
+2. **Any-version**: `skill_load:<skill-id>` — matches rules that allow loading the skill regardless of its current version.
+3. **Raw selector**: `skill_load:<raw-input>` — matches the literal user-provided selector as a fallback.
+
+The allowlist options presented during a permission prompt include both version-specific and any-version patterns, letting the user choose their desired granularity.
+
+## Version-Bound Approvals
+
+Trust rules can include a `principalVersion` field that binds the rule to a specific content hash of the skill's source files. This is the primary mechanism for ensuring that approving a skill does not grant blanket permission to future (potentially modified) versions of that skill.
+
+### How version hashing works
+
+The `computeSkillVersionHash(directoryPath)` function computes a deterministic SHA-256 hash of a skill directory:
+
+1. All files under the skill directory are collected recursively, excluding transient entries (`node_modules`, `.git`, `__pycache__`, `.DS_Store`, `.vellum-skill-run`).
+2. Files are sorted by relative path to ensure deterministic ordering regardless of filesystem traversal order.
+3. For each file: the normalized relative path, a null byte, the file content length, a null byte, the full file content, and a newline are fed into the hash.
+4. The result is a canonical string: `v1:<hex-sha256>`.
+
+### Version invalidation
+
+When a skill's source files change (any file added, removed, or modified), the hash changes. Trust rules with the old `principalVersion` no longer match, and the user is re-prompted. This protects against:
+
+- **Supply-chain attacks**: A malicious update to a managed or workspace skill cannot silently inherit previous approvals.
+- **Accidental drift**: Editing a skill's tool scripts invalidates stale approvals, ensuring the user reviews the new behavior.
+
+### Choosing between version-specific and any-version rules
+
+| Approval type | Rule pattern | Behavior |
+|---|---|---|
+| Version-specific | `skill_load:my-skill@v1:abc123...` | Only this exact version is auto-allowed. Any code change triggers re-prompt. |
+| Any-version | `skill_load:my-skill` | All versions of this skill are auto-allowed. No re-prompt on code changes. |
+
+Version-specific rules are more secure but require re-approval after every skill update. Any-version rules are more convenient but grant persistent access regardless of code changes.
+
+## Skill Source Mutation Protection
+
+Writing to skill source files is treated as a **high-risk** operation by the risk classifier. The `isSkillSourcePath()` function detects whether a file path falls under any known skill directory:
+
+- **Managed skills**: `~/.vellum/workspace/skills/`
+- **Bundled skills**: The application's built-in `bundled-skills/` directory
+- **Workspace skills**: Project-local skill directories
+- **Extra skills**: Additional roots configured by the user
+
+When `file_write`, `file_edit`, `host_file_write`, or `host_file_edit` targets a path inside any of these directories, the risk level is escalated from its normal level (typically Medium) to **High**. High-risk operations always require user approval unless a matching trust rule with `allowHighRisk: true` exists.
+
+This escalation prevents the agent from modifying skill code without explicit user consent. Since modifying a skill's source could grant the agent new capabilities or alter existing tool behavior, such mutations are treated as a privilege-escalation vector.
+
+### Path normalization and symlink safety
+
+The path classifier resolves symlinks before checking paths against skill root directories. This prevents bypass through:
+
+- Symlinked parent directories that map into skill roots
+- Relative paths with redundant segments (e.g., `./foo/../skills/my-skill/tool.ts`)
+- Unnormalized paths that lexically differ from the canonical form
+
+The `normalizeFilePath()` function walks up the directory tree to find the nearest existing ancestor, resolves it via `realpathSync`, and re-appends the remaining segments.
+
+## Strict Mode
+
+When `permissions.mode` is set to `strict` in the assistant configuration, **all** tool actions require a matching trust rule. There is no implicit auto-allow for any risk level. This means:
+
+- Low-risk tools that would normally auto-execute in legacy mode (e.g., `file_read`, `web_search`) will prompt unless a trust rule allows them.
+- `skill_load` requires an explicit rule match, even though it is classified as low risk.
+- The **starter bundle** can be accepted to seed common safe rules and reduce prompt noise.
+
+### Starter approval bundle
+
+The starter bundle is an opt-in set of allow rules for read-only tools that most users would approve individually. Accepting the bundle seeds these rules at once:
+
+| Tool | Pattern |
+|---|---|
+| `file_read` | `file_read:**` |
+| `glob` | `glob:**` |
+| `grep` | `grep:**` |
+| `list_directory` | `list_directory:**` |
+| `web_search` | `web_search:**` |
+| `web_fetch` | `web_fetch:**` |
+
+Acceptance is idempotent and recorded in `trust.json`. The bundle does not include any tools that mutate the filesystem or execute arbitrary code.
+
+## Execution Targets
+
+Tools can execute in two contexts:
+
+| Target | Description |
+|---|---|
+| `sandbox` | Isolated execution within `~/.vellum/workspace` (Docker container or OS-level sandbox) |
+| `host` | Direct execution on the host machine |
+
+Trust rules can include an `executionTarget` field to bind the rule to a specific context. A rule without `executionTarget` matches both sandbox and host invocations.
+
+Permission prompts include the `executionTarget` field so the user can see where the action will execute before approving it.
+
+## Troubleshooting
+
+### "Why am I being re-prompted after editing a skill?"
+
+When you modify any file in a skill's directory, the version hash changes. If your trust rules use version-specific patterns (e.g., `skill_load:my-skill@v1:abc123...`), the old rule no longer matches the new hash. The system re-prompts to ensure you approve the updated skill.
+
+**Fix**: Either re-approve the skill (which creates a new version-specific rule), or create an any-version rule (`skill_load:my-skill`) if you trust all future versions.
+
+### "Why does file_write to my skill directory require high-risk approval?"
+
+Writing to skill source paths is classified as high risk because it could alter the agent's capabilities. This is a deliberate security measure.
+
+**Fix**: If you trust the operation, approve it. To permanently allow it, select "Always allow" and choose the `allowHighRisk` option if offered.
+
+### "Why is strict mode prompting for everything?"
+
+Strict mode requires an explicit trust rule for every tool action. There is no implicit auto-allow.
+
+**Fix**: Accept the starter approval bundle to seed common safe rules. Then approve additional tools as needed — each approval creates a persistent trust rule.
+
+### "Why does skill_load prompt in strict mode but not in legacy mode?"
+
+In legacy mode, `skill_load` is classified as low risk and auto-allowed. In strict mode, low-risk auto-allow is disabled, so an explicit rule is needed.
+
+**Fix**: Create a rule for the specific skill (version-specific or any-version) or accept the starter bundle if it covers your needs.
+
+### "How do I see what trust rules are currently active?"
+
+Trust rules are stored in `~/.vellum/protected/trust.json`. You can inspect this file directly. Rules with `default:` prefixed IDs are system defaults; rules with UUID IDs are user-created.
+
+### "A skill tool keeps prompting even though I approved it."
+
+Check whether the rule in `trust.json` has a `principalVersion` field. If so, the rule is version-specific and will stop matching if the skill's code has changed since approval. Also check whether the rule has the correct `executionTarget` — a rule scoped to `sandbox` will not match a tool running on `host`.


### PR DESCRIPTION
## Summary
- Added comprehensive "Permission and Trust Security Model" section to ARCHITECTURE.md with Mermaid flowcharts
- Created new assistant/docs/skills.md with security model overview, version-bound approvals, and troubleshooting
- Added "Permission Modes and Trust Rules" section to README.md

## Test plan
- [x] Documentation review for consistency with implemented flow
- [x] Mermaid diagrams render correctly
- [x] Cross-references between docs are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
