### PR TITLE
feat: flip default permissions mode to strict

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -466,9 +466,9 @@ describe('AssistantConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  test('defaults permissions.mode to legacy', () => {
+  test('defaults permissions.mode to strict', () => {
     const result = AssistantConfigSchema.parse({});
-    expect(result.permissions).toEqual({ mode: 'legacy' });
+    expect(result.permissions).toEqual({ mode: 'strict' });
   });
 
   test('accepts explicit permissions.mode strict', () => {
@@ -674,10 +674,10 @@ describe('loadConfig with schema validation', () => {
     expect(config.auditLog.retentionDays).toBe(0);
   });
 
-  test('defaults permissions.mode to legacy when not specified', () => {
+  test('defaults permissions.mode to strict when not specified', () => {
     writeConfig({});
     const config = loadConfig();
-    expect(config.permissions).toEqual({ mode: 'legacy' });
+    expect(config.permissions).toEqual({ mode: 'strict' });
   });
 
   test('loads explicit permissions.mode strict', () => {
@@ -689,7 +689,7 @@ describe('loadConfig with schema validation', () => {
   test('falls back for invalid permissions.mode', () => {
     writeConfig({ permissions: { mode: 'yolo' } });
     const config = loadConfig();
-    expect(config.permissions.mode).toBe('legacy');
+    expect(config.permissions.mode).toBe('strict');
   });
 
   test('does not mutate default apiKeys when fallback config is overridden by env keys', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -155,7 +155,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     allowOneTimeSend: false,
   },
   permissions: {
-    mode: 'legacy',
+    mode: 'strict',
   },
   auditLog: {
     retentionDays: 0,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -116,7 +116,7 @@ export const PermissionsConfigSchema = z.object({
     .enum(VALID_PERMISSIONS_MODES, {
       error: `permissions.mode must be one of: ${VALID_PERMISSIONS_MODES.join(', ')}`,
     })
-    .default('legacy'),
+    .default('strict'),
 });
 
 export const AuditLogConfigSchema = z.object({
@@ -913,7 +913,7 @@ export const AssistantConfigSchema = z.object({
     allowOneTimeSend: false,
   }),
   permissions: PermissionsConfigSchema.default({
-    mode: 'legacy',
+    mode: 'strict',
   }),
   auditLog: AuditLogConfigSchema.default({
     retentionDays: 0,


### PR DESCRIPTION
## Summary
- Changed default `permissions.mode` from `legacy` to `strict` in defaults.ts and schema.ts
- New installations now require explicit trust rules for all tool actions
- Existing users with explicit config are unaffected (migration-safe)
- Updated config-schema tests for new default

## Test plan
- [x] config-schema.test.ts: 62 pass, 0 fail
- [x] checker.test.ts: 235 pass, 0 fail
- [x] Existing explicit config values preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
