### PR TITLE
feat: add .claude/check-pr-reviews script for review status detection

### DIFF
--- a/.claude/check-pr-reviews
+++ b/.claude/check-pr-reviews
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .claude/check-pr-reviews — Fetch and classify reviewer status for a PR
+# Outputs structured JSON with reviewer verdicts and raw review data.
+
+usage() {
+  cat <<'EOF'
+Usage: .claude/check-pr-reviews <pr-number>
+
+Fetches review data for a PR and classifies each reviewer's status.
+
+Output is JSON with this structure:
+{
+  "pr_number": 123,
+  "created_at": "2024-01-15T10:00:00Z",
+  "age_seconds": 3600,
+  "codex": {
+    "status": "approved|changes_requested|rate_limited|pending",
+    "reviews": [...],
+    "inline_comments": [...],
+    "has_plus_one_reaction": true|false
+  },
+  "devin": {
+    "status": "approved|changes_requested|pending",
+    "reviews": [...],
+    "inline_comments": [...]
+  }
+}
+
+Reviewer classification:
+  codex (chatgpt-codex-connector[bot]):
+    approved          — +1 reaction on PR description
+    changes_requested — review or inline comment with suggestions
+    rate_limited      — most recent comment mentions rate limit
+    pending           — none of the above
+
+  devin (devin-ai-integration[bot]):
+    approved          — review containing "No Issues Found"
+    changes_requested — review or inline comment (not "No Issues Found")
+    pending           — no review from this user
+
+Examples:
+  .claude/check-pr-reviews 123
+  .claude/check-pr-reviews 123 | jq '.codex.status'
+EOF
+}
+
+if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+PR_NUMBER="$1"
+NOW=$(date -u +%s)
+
+# Fetch all data in parallel using temp files
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+# 1. PR reviews + comments + creation time
+gh pr view "$PR_NUMBER" --json comments,reviews,createdAt > "$TMPDIR_WORK/pr.json" &
+PID1=$!
+
+# 2. PR description reactions (uses issues API)
+gh api "repos/vellum-ai/vellum-assistant/issues/$PR_NUMBER/reactions" \
+  --jq '[.[] | {user: .user.login, content: .content}]' > "$TMPDIR_WORK/reactions.json" &
+PID2=$!
+
+# 3. Inline review comments
+gh api "repos/vellum-ai/vellum-assistant/pulls/$PR_NUMBER/comments" \
+  --jq '[.[] | {user: .user.login, body: .body, path: .path, line: .line}]' > "$TMPDIR_WORK/inline.json" &
+PID3=$!
+
+wait $PID1 $PID2 $PID3
+
+# Parse creation time and compute age
+CREATED_AT=$(jq -r '.createdAt' "$TMPDIR_WORK/pr.json")
+# macOS date: convert ISO 8601 to epoch
+if date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s >/dev/null 2>&1; then
+  CREATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s)
+else
+  CREATED_EPOCH=$(date -d "$CREATED_AT" +%s 2>/dev/null || echo "$NOW")
+fi
+AGE_SECONDS=$((NOW - CREATED_EPOCH))
+
+# --- Classify Codex ---
+
+# Check for +1 reaction
+CODEX_PLUS_ONE=$(jq '[.[] | select(.user == "chatgpt-codex-connector[bot]" and .content == "+1")] | length > 0' "$TMPDIR_WORK/reactions.json")
+
+# Get codex reviews
+CODEX_REVIEWS=$(jq '[.reviews[] | select(.author.login == "chatgpt-codex-connector[bot]") | {body: .body, state: .state}]' "$TMPDIR_WORK/pr.json")
+
+# Get codex inline comments
+CODEX_INLINE=$(jq '[.[] | select(.user == "chatgpt-codex-connector[bot]")]' "$TMPDIR_WORK/inline.json")
+
+# Check for rate limiting in most recent comment
+CODEX_RATE_LIMITED=$(jq '
+  [.comments[] | select(.author.login == "chatgpt-codex-connector[bot]")]
+  | sort_by(.createdAt)
+  | last
+  | if . == null then false
+    elif (.body | test("rate.?limit|too many requests"; "i")) then true
+    else false
+    end
+' "$TMPDIR_WORK/pr.json")
+
+# Classify codex status
+CODEX_REVIEW_COUNT=$(echo "$CODEX_REVIEWS" | jq 'length')
+CODEX_INLINE_COUNT=$(echo "$CODEX_INLINE" | jq 'length')
+
+if [ "$CODEX_RATE_LIMITED" = "true" ]; then
+  CODEX_STATUS="rate_limited"
+elif [ "$CODEX_PLUS_ONE" = "true" ]; then
+  CODEX_STATUS="approved"
+elif [ "$CODEX_REVIEW_COUNT" -gt 0 ] || [ "$CODEX_INLINE_COUNT" -gt 0 ]; then
+  CODEX_STATUS="changes_requested"
+else
+  CODEX_STATUS="pending"
+fi
+
+# --- Classify Devin ---
+
+# Get devin reviews
+DEVIN_REVIEWS=$(jq '[.reviews[] | select(.author.login == "devin-ai-integration[bot]") | {body: .body, state: .state}]' "$TMPDIR_WORK/pr.json")
+
+# Get devin inline comments
+DEVIN_INLINE=$(jq '[.[] | select(.user == "devin-ai-integration[bot]")]' "$TMPDIR_WORK/inline.json")
+
+DEVIN_REVIEW_COUNT=$(echo "$DEVIN_REVIEWS" | jq 'length')
+DEVIN_INLINE_COUNT=$(echo "$DEVIN_INLINE" | jq 'length')
+
+# Check if any devin review says "No Issues Found"
+DEVIN_APPROVED=$(echo "$DEVIN_REVIEWS" | jq '[.[] | select(.body | test("No Issues Found"))] | length > 0')
+
+if [ "$DEVIN_APPROVED" = "true" ]; then
+  DEVIN_STATUS="approved"
+elif [ "$DEVIN_REVIEW_COUNT" -gt 0 ] || [ "$DEVIN_INLINE_COUNT" -gt 0 ]; then
+  DEVIN_STATUS="changes_requested"
+else
+  DEVIN_STATUS="pending"
+fi
+
+# --- Output JSON ---
+
+jq -n \
+  --argjson pr_number "$PR_NUMBER" \
+  --arg created_at "$CREATED_AT" \
+  --argjson age_seconds "$AGE_SECONDS" \
+  --arg codex_status "$CODEX_STATUS" \
+  --argjson codex_reviews "$CODEX_REVIEWS" \
+  --argjson codex_inline "$CODEX_INLINE" \
+  --argjson codex_plus_one "$CODEX_PLUS_ONE" \
+  --arg devin_status "$DEVIN_STATUS" \
+  --argjson devin_reviews "$DEVIN_REVIEWS" \
+  --argjson devin_inline "$DEVIN_INLINE" \
+  '{
+    pr_number: $pr_number,
+    created_at: $created_at,
+    age_seconds: $age_seconds,
+    codex: {
+      status: $codex_status,
+      reviews: $codex_reviews,
+      inline_comments: $codex_inline,
+      has_plus_one_reaction: $codex_plus_one
+    },
+    devin: {
+      status: $devin_status,
+      reviews: $devin_reviews,
+      inline_comments: $devin_inline
+    }
+  }'

--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -6,33 +6,15 @@ Look at every item in .private/UNREVIEWED_PRS.md. Each line is a PR URL like `ht
 
 Check each PR to see if **both** chatgpt-codex-connector and devin-ai-integration have reviewed it and whether they have feedback.
 
-## How to fetch PR data
+## How to fetch PR data and determine review status
 
-Before fetching any PR data, run `date -u +%s` to get the current UTC epoch time. You will need this to accurately compute PR ages for the output table — do not guess the current time.
+For each PR, run:
 
-For each PR, run these commands in parallel:
+```bash
+.claude/check-pr-reviews <number>
+```
 
-1. **Reviews, comments, and creation time:** `gh pr view <number> --json comments,reviews,createdAt`
-2. **PR description reactions:** `gh api repos/vellum-ai/vellum-assistant/issues/<number>/reactions --jq '[.[] | {user: .user.login, content: .content}]'`
-
-Note: PR description reactions use the **issues** API endpoint (not pulls). The `reactionGroups` field from `gh pr view` doesn't include user info.
-
-Also fetch inline review comments if needed: `gh api repos/vellum-ai/vellum-assistant/pulls/<number>/comments --jq '[.[] | {user: .user.login, body: .body}]'`
-
-## How to determine review status
-
-### chatgpt-codex-connector (appears as `chatgpt-codex-connector[bot]`)
-
-- **Approved:** Left a `+1` reaction on the PR description (check the issues reactions endpoint)
-- **Requested changes:** Left a PR review or inline review comment with suggestions/issues (look for reviews or comments by `chatgpt-codex-connector[bot]`)
-- **Rate-limited:** The most recent comment from Codex mentions a rate limit was reached (e.g. "rate limit", "rate_limit", "too many requests"). This is NOT a review — treat it as **Pending**.
-- **Pending:** Neither of the above
-
-### devin-ai-integration (appears as `devin-ai-integration[bot]`)
-
-- **Approved:** Left a PR review containing "No Issues Found" (typically "✅ Devin Review: No Issues Found")
-- **Requested changes:** Left a PR review or inline comment with issues/findings (any review that does NOT say "No Issues Found")
-- **Pending:** No review from this user
+This outputs JSON with `codex.status` and `devin.status` fields (each one of: `approved`, `changes_requested`, `rate_limited`, `pending`), plus the raw review data (`reviews`, `inline_comments`) for contextual assessment. It also includes `age_seconds` for computing the age column.
 
 ## Contextual review assessment
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist
 !.claude/ship
 !.claude/gh-project
 !.claude/gh-review
+!.claude/check-pr-reviews
 .private/
 temp.sh
 context.md


### PR DESCRIPTION
## Summary
- Adds `.claude/check-pr-reviews` that fetches PR reviews, reactions, and inline comments in parallel and classifies each reviewer's status as structured JSON
- Updates `check-reviews.md` to replace 3-4 manual API calls + classification logic with a single script call
- LLM still handles contextual assessment (regression risk, nonsensical feedback) using the structured data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
