### PR TITLE
fix: resolve tsc errors for principal fields in ipc-snapshot test

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -4,6 +4,7 @@ import type {
   ClientMessage,
   ServerMessage,
 } from '../daemon/ipc-protocol.js';
+import type { ConfirmationRequest } from '../daemon/ipc-contract.js';
 
 /**
  * Snapshot tests for every IPC message type.
@@ -1139,7 +1140,7 @@ describe('IPC message snapshots', () => {
   // Baseline assertions for principal context in confirmation_request.
   describe('confirmation principal context baselines', () => {
     test('confirmation_request includes principal context fields', () => {
-      const req = serverMessages.confirmation_request;
+      const req = serverMessages.confirmation_request as ConfirmationRequest;
       expect(req.principalKind).toBe('skill');
       expect(req.principalId).toBe('my-skill');
       expect(req.principalVersion).toBe('sha256:abcdef1234567890');


### PR DESCRIPTION
## Summary
- Import `ConfirmationRequest` type from `ipc-contract.js` in the test file
- Cast `serverMessages.confirmation_request` to `ConfirmationRequest` so TypeScript can see the `principalKind`, `principalId`, and `principalVersion` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
