### PR TITLE
fix: add explicit cd to worktree root before .claude/ship calls

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -36,9 +36,12 @@ cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEm
 
 ### 3. Ship
 
-Review what changed, draft a commit message and PR title, then ship everything in one step:
+Review what changed, draft a commit message and PR title, then ship everything in one step.
+
+**Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
+cd <worktree>
 .claude/ship \
   --commit-msg "<commit message>" \
   --title "<PR title>" \

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -92,7 +92,10 @@ Fix any failures before proceeding.
 
 #### 8d. Ship (do NOT merge)
 
+**Run from the worktree root** (not `assistant/` or the main repo):
+
 ```bash
+cd <worktree>
 .claude/ship \
   --commit-msg "<commit message>" \
   --title "<title from plan>" \

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -196,8 +196,8 @@ ALL work happens here. Do NOT touch the main repo.
 ## Workflow
 1. Make the changes in your worktree.
 2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
-3. Ship it (stages, commits, pushes, creates PR, and merges in one step):
-   .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base <feature-branch-name> --merge --assignee @me
+3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
+   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base <feature-branch-name> --merge --assignee @me
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -36,9 +36,12 @@ cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEm
 
 ### 3. Ship (do NOT merge)
 
-Review what changed, draft a commit message and PR title, then ship:
+Review what changed, draft a commit message and PR title, then ship.
+
+**Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
+cd <worktree>
 .claude/ship \
   --commit-msg "<commit message>" \
   --title "<PR title>" \

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -69,7 +69,10 @@ Fix any failures before proceeding.
 
 #### 4d. Ship (do NOT merge)
 
+**Run from the worktree root** (not `assistant/` or the main repo):
+
 ```bash
+cd <worktree>
 .claude/ship \
   --commit-msg "<commit message>" \
   --title "<title from plan>" \

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -66,8 +66,8 @@ ALL work happens here. Do NOT touch the main repo.
 ## Workflow
 1. Make the changes in your worktree.
 2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
-3. Ship it (stages, commits, pushes, creates PR, and merges in one step):
-   .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base main --merge --assignee @me
+3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
+   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base main --merge --assignee @me
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why


### PR DESCRIPTION
## Summary
- Added explicit `cd <worktree>` before every `.claude/ship` call in worktree-based commands
- Fixes agents running `.claude/ship` from the main repo (or `assistant/` subdir) instead of the worktree root, which caused 'nothing to commit' errors
- Updated 6 files: do.md, safe-do.md, safe-execute-plan.md, resume-plan.md, swarm.md, safe-blitz.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
