### PR TITLE
fix: split onboarding API key and model selection into separate steps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -11,15 +11,7 @@ struct APIKeyStepView: View {
     @State private var showIcon = false
     @State private var showTitle = false
     @State private var showContent = false
-    @State private var showModelSelector = false
-    @State private var selectedModel = "claude-sonnet-4-5-20250929"
     @FocusState private var keyFieldFocused: Bool
-
-    private static let models: [(id: String, name: String, detail: String)] = [
-        ("claude-opus-4-6", "Opus 4.6", "Most capable"),
-        ("claude-sonnet-4-5-20250929", "Sonnet 4.5", "Balanced"),
-        ("claude-haiku-4-5-20251001", "Haiku 4.5", "Fastest"),
-    ]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -46,85 +38,64 @@ struct APIKeyStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
             // Title
-            Text(showModelSelector ? "Choose your model" : "Add your API key")
+            Text("Add your API key")
                 .font(.system(size: 32, weight: .regular, design: .serif))
                 .foregroundColor(VColor.textPrimary)
                 .opacity(showTitle ? 1 : 0)
                 .offset(y: showTitle ? 0 : 8)
                 .padding(.bottom, VSpacing.md)
-                .animation(.easeInOut(duration: 0.3), value: showModelSelector)
 
             // Subtitle
-            Text(showModelSelector
-                 ? "Pick the model that powers your assistant."
-                 : "Enter your Anthropic API key to get started.")
+            Text("Enter your Anthropic API key to get started.")
                 .font(.system(size: 16))
                 .foregroundColor(VColor.textSecondary)
                 .opacity(showTitle ? 1 : 0)
                 .offset(y: showTitle ? 0 : 8)
-                .animation(.easeInOut(duration: 0.3), value: showModelSelector)
 
             Spacer()
 
             // Content
             VStack(spacing: VSpacing.md) {
-                if showModelSelector {
-                    // Model selection cards
-                    VStack(spacing: VSpacing.sm) {
-                        ForEach(Self.models, id: \.id) { model in
-                            modelCard(id: model.id, name: model.name, detail: model.detail)
-                        }
-                    }
-                    .transition(.opacity.combined(with: .move(edge: .trailing)))
-                } else {
-                    Group {
-                        if hasExistingKey && !isEditing {
-                            Text(maskedKey)
-                                .font(.system(size: 16, weight: .medium, design: .monospaced))
-                                .foregroundColor(VColor.textPrimary)
-                                .frame(maxWidth: .infinity)
-                                .padding(.horizontal, 20)
-                                .padding(.vertical, VSpacing.lg)
-                                .background(
-                                    RoundedRectangle(cornerRadius: VRadius.lg)
-                                        .stroke(VColor.surfaceBorder, lineWidth: 1)
-                                )
-                                .onTapGesture {
-                                    isEditing = true
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                        keyFieldFocused = true
-                                    }
+                Group {
+                    if hasExistingKey && !isEditing {
+                        Text(maskedKey)
+                            .font(.system(size: 16, weight: .medium, design: .monospaced))
+                            .foregroundColor(VColor.textPrimary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, VSpacing.lg)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+                            )
+                            .onTapGesture {
+                                isEditing = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                    keyFieldFocused = true
                                 }
-                        } else {
-                            SecureField("sk-ant-\u{2026}", text: $apiKey)
-                                .textFieldStyle(.plain)
-                                .font(.system(size: 16, weight: .medium, design: .monospaced))
-                                .foregroundColor(VColor.textPrimary)
-                                .multilineTextAlignment(.center)
-                                .padding(.horizontal, 20)
-                                .padding(.vertical, VSpacing.lg)
-                                .background(
-                                    RoundedRectangle(cornerRadius: VRadius.lg)
-                                        .stroke(VColor.surfaceBorder, lineWidth: 1)
-                                )
-                                .focused($keyFieldFocused)
-                                .onSubmit {
-                                    saveKeyAndShowModels()
-                                }
-                        }
+                            }
+                    } else {
+                        SecureField("sk-ant-\u{2026}", text: $apiKey)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 16, weight: .medium, design: .monospaced))
+                            .foregroundColor(VColor.textPrimary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, VSpacing.lg)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+                            )
+                            .focused($keyFieldFocused)
+                            .onSubmit {
+                                saveKeyAndContinue()
+                            }
                     }
-                    .transition(.opacity.combined(with: .move(edge: .leading)))
                 }
 
                 // Primary button
-                Button(action: {
-                    if showModelSelector {
-                        saveModelAndContinue()
-                    } else {
-                        saveKeyAndShowModels()
-                    }
-                }) {
-                    Text(showModelSelector ? "Select model" : "Save API key")
+                Button(action: { saveKeyAndContinue() }) {
+                    Text("Save API key")
                         .font(.system(size: 15, weight: .medium))
                         .foregroundColor(adaptiveColor(light: .white, dark: .white))
                         .frame(maxWidth: .infinity)
@@ -150,15 +121,13 @@ struct APIKeyStepView: View {
                 }
 
                 HStack(spacing: VSpacing.lg) {
-                    if !showModelSelector {
-                        Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
-                            Text("Get an API key")
-                                .font(.system(size: 13))
-                                .foregroundColor(adaptiveColor(light: VColor.accent, dark: .white))
-                        }
-                        .onHover { hovering in
-                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
+                    Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
+                        Text("Get an API key")
+                            .font(.system(size: 13))
+                            .foregroundColor(adaptiveColor(light: VColor.accent, dark: .white))
+                    }
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                     }
 
                     Button(action: { goBack() }) {
@@ -228,56 +197,10 @@ struct APIKeyStepView: View {
         }
     }
 
-    // MARK: - Model Card
-
-    private func modelCard(id: String, name: String, detail: String) -> some View {
-        let isSelected = selectedModel == id
-        return Button(action: { selectedModel = id }) {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(name)
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(VColor.textPrimary)
-                    Text(detail)
-                        .font(.system(size: 12))
-                        .foregroundColor(VColor.textSecondary)
-                }
-                Spacer()
-                Circle()
-                    .fill(isSelected ? Violet._600 : Color.clear)
-                    .overlay(
-                        Circle().stroke(isSelected ? Violet._600 : VColor.surfaceBorder, lineWidth: 1.5)
-                    )
-                    .overlay(
-                        isSelected
-                            ? Circle().fill(Color.white).frame(width: 6, height: 6)
-                            : nil
-                    )
-                    .frame(width: 18, height: 18)
-            }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.md)
-            .contentShape(Rectangle())
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? Violet._600.opacity(0.1) : Color.clear)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(isSelected ? Violet._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
-                    )
-            )
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-    }
-
     // MARK: - Helpers
 
     private var primaryButtonDisabled: Bool {
-        if showModelSelector { return false }
-        return apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var maskedKey: String {
@@ -289,51 +212,16 @@ struct APIKeyStepView: View {
     }
 
     private func goBack() {
-        if showModelSelector {
-            withAnimation(.spring(duration: 0.4, bounce: 0.1)) {
-                showModelSelector = false
-            }
-        } else {
-            withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
-                state.currentStep = 0
-            }
+        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+            state.currentStep = 0
         }
     }
 
-    private func saveKeyAndShowModels() {
+    private func saveKeyAndContinue() {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         APIKeyManager.setKey(trimmed)
-        withAnimation(.spring(duration: 0.4, bounce: 0.1)) {
-            showModelSelector = true
-        }
-    }
-
-    private func saveModelAndContinue() {
-        saveModelToConfig(selectedModel)
         state.advance()
-    }
-
-    private func saveModelToConfig(_ model: String) {
-        let configURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".vellum/workspace/config.json")
-
-        let dirURL = configURL.deletingLastPathComponent()
-        try? FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
-
-        do {
-            let data = try Data(contentsOf: configURL)
-            if var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                json["model"] = model
-                let updated = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-                try updated.write(to: configURL)
-            }
-        } catch {
-            let json: [String: Any] = ["model": model]
-            if let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) {
-                try? data.write(to: configURL)
-            }
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -171,7 +171,7 @@ struct FnKeyStepView: View {
                     Button(action: {
                         stopPolling()
                         withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
-                            state.currentStep = 2
+                            state.currentStep = 3
                         }
                     }) {
                         Text("Back")

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -1,0 +1,252 @@
+import VellumAssistantShared
+import SwiftUI
+
+@MainActor
+struct ModelSelectionStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showIcon = false
+    @State private var showTitle = false
+    @State private var showContent = false
+    @State private var selectedModel = "claude-sonnet-4-5-20250929"
+
+    private static let models: [(id: String, name: String, detail: String)] = [
+        ("claude-opus-4-6", "Opus 4.6", "Most capable"),
+        ("claude-sonnet-4-5-20250929", "Sonnet 4.5", "Balanced"),
+        ("claude-haiku-4-5-20251001", "Haiku 4.5", "Fastest"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // Icon
+            Group {
+                if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
+                   let nsImage = NSImage(contentsOf: url) {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .interpolation(.none)
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Image("VellyLogo")
+                        .resizable()
+                        .interpolation(.none)
+                        .aspectRatio(contentMode: .fit)
+                }
+            }
+            .frame(width: 128, height: 128)
+            .opacity(showIcon ? 1 : 0)
+            .scaleEffect(showIcon ? 1 : 0.8)
+            .padding(.bottom, VSpacing.xxl)
+
+            // Title
+            Text("Choose your model")
+                .font(.system(size: 32, weight: .regular, design: .serif))
+                .foregroundColor(VColor.textPrimary)
+                .opacity(showTitle ? 1 : 0)
+                .offset(y: showTitle ? 0 : 8)
+                .padding(.bottom, VSpacing.md)
+
+            // Subtitle
+            Text("Pick the model that powers your assistant.")
+                .font(.system(size: 16))
+                .foregroundColor(VColor.textSecondary)
+                .opacity(showTitle ? 1 : 0)
+                .offset(y: showTitle ? 0 : 8)
+
+            Spacer()
+
+            // Content
+            VStack(spacing: VSpacing.md) {
+                // Model selection cards
+                VStack(spacing: VSpacing.sm) {
+                    ForEach(Self.models, id: \.id) { model in
+                        modelCard(id: model.id, name: model.name, detail: model.detail)
+                    }
+                }
+
+                // Primary button
+                Button(action: { saveModelAndContinue() }) {
+                    Text("Select model")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(adaptiveColor(light: .white, dark: .white))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, VSpacing.lg)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .fill(adaptiveColor(
+                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                    dark: Violet._600
+                                ))
+                        )
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+
+                Button(action: { goBack() }) {
+                    Text("Back")
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+                .padding(.top, VSpacing.xs)
+            }
+            .padding(.horizontal, VSpacing.xxl)
+            .padding(.bottom, VSpacing.xxl)
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 12)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            ZStack {
+                VColor.background
+
+                RadialGradient(
+                    colors: [
+                        Violet._600.opacity(0.15),
+                        Violet._700.opacity(0.05),
+                        Color.clear
+                    ],
+                    center: .bottom,
+                    startRadius: 20,
+                    endRadius: 350
+                )
+
+                RadialGradient(
+                    colors: [
+                        Violet._400.opacity(0.08),
+                        Color.clear
+                    ],
+                    center: UnitPoint(x: 0.7, y: 1.0),
+                    startRadius: 10,
+                    endRadius: 250
+                )
+            }
+            .ignoresSafeArea()
+        )
+        .onAppear {
+            // Load previously selected model if any
+            if let existing = loadModelFromConfig() {
+                selectedModel = existing
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.2)) {
+                showIcon = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+                showTitle = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.8)) {
+                showContent = true
+            }
+        }
+    }
+
+    // MARK: - Model Card
+
+    private func modelCard(id: String, name: String, detail: String) -> some View {
+        let isSelected = selectedModel == id
+        return Button(action: { selectedModel = id }) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(name)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(VColor.textPrimary)
+                    Text(detail)
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.textSecondary)
+                }
+                Spacer()
+                Circle()
+                    .fill(isSelected ? Violet._600 : Color.clear)
+                    .overlay(
+                        Circle().stroke(isSelected ? Violet._600 : VColor.surfaceBorder, lineWidth: 1.5)
+                    )
+                    .overlay(
+                        isSelected
+                            ? Circle().fill(Color.white).frame(width: 6, height: 6)
+                            : nil
+                    )
+                    .frame(width: 18, height: 18)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isSelected ? Violet._600.opacity(0.1) : Color.clear)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(isSelected ? Violet._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func goBack() {
+        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+            state.currentStep = 2
+        }
+    }
+
+    private func saveModelAndContinue() {
+        saveModelToConfig(selectedModel)
+        state.advance()
+    }
+
+    private func saveModelToConfig(_ model: String) {
+        let configURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum/workspace/config.json")
+
+        let dirURL = configURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
+        do {
+            let data = try Data(contentsOf: configURL)
+            if var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                json["model"] = model
+                let updated = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
+                try updated.write(to: configURL)
+            }
+        } catch {
+            let json: [String: Any] = ["model": model]
+            if let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) {
+                try? data.write(to: configURL)
+            }
+        }
+    }
+
+    private func loadModelFromConfig() -> String? {
+        let configURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum/workspace/config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let model = json["model"] as? String else {
+            return nil
+        }
+        return model
+    }
+}
+
+#Preview {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ModelSelectionStepView(state: {
+            let s = OnboardingState()
+            s.currentStep = 3
+            return s
+        }())
+    }
+    .frame(width: 460, height: 620)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -34,7 +34,17 @@ struct OnboardingFlowView: View {
                     )
                     .id(state.currentStep)
             } else if state.currentStep == 3 {
-                // Step 3: Full-window voice activation screen
+                // Step 3: Full-window model selection screen
+                ModelSelectionStepView(state: state)
+                    .transition(
+                        .asymmetric(
+                            insertion: .opacity.combined(with: .offset(y: 12)),
+                            removal: .opacity.combined(with: .offset(y: -8))
+                        )
+                    )
+                    .id(state.currentStep)
+            } else if state.currentStep == 4 {
+                // Step 4: Full-window voice activation screen
                 FnKeyStepView(state: state)
                     .transition(
                         .asymmetric(
@@ -111,7 +121,7 @@ struct OnboardingFlowView: View {
         }
         .ignoresSafeArea()
         .onChange(of: state.currentStep) { _, newStep in
-            if newStep > 3 {
+            if newStep > 4 {
                 onComplete()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -26,7 +26,7 @@ enum ActivationKey: String, CaseIterable {
 final class OnboardingState {
     /// Bump this version whenever the default-flow step order changes so that
     /// persisted step indices from a previous layout are not consumed as-is.
-    private static let currentFlowVersion = 4
+    private static let currentFlowVersion = 5
 
     var currentStep: Int = 0
     var assistantName: String = "Velly"
@@ -62,11 +62,12 @@ final class OnboardingState {
         case 0: return hasHatched ? 0.15 : 0.0
         case 1: return 0.20
         case 2: return 0.30
-        case 3: return 0.40
-        case 4: return speechGranted ? 0.55 : 0.45
-        case 5: return accessibilityGranted ? 0.75 : 0.60
-        case 6: return screenGranted ? 0.95 : 0.80
-        case 7: return 1.0
+        case 3: return 0.45
+        case 4: return 0.60
+        case 5: return speechGranted ? 0.70 : 0.65
+        case 6: return accessibilityGranted ? 0.80 : 0.70
+        case 7: return screenGranted ? 0.95 : 0.85
+        case 8: return 1.0
         default: return 1.0
         }
     }
@@ -108,7 +109,7 @@ final class OnboardingState {
         // Default onboarding now exits immediately after the first post-hatch
         // conversation entry point (step 2). Prevent stale persisted indices
         // from reopening legacy permission-request steps.
-        let maxStep = onboardingVariant == .firstMeeting ? 4 : 3
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : 4
         if currentStep > maxStep {
             currentStep = maxStep
         }


### PR DESCRIPTION
## Summary
- Extracted model selection from `APIKeyStepView` into a new standalone `ModelSelectionStepView` (step 3)
- `APIKeyStepView` now only handles API key entry and advances to model selection on save
- Voice activation (`FnKeyStepView`) moved from step 3 to step 4
- Back navigation now works correctly: voice → model selection → API key → welcome

## Test plan
- [ ] Reset onboarding (`defaults delete com.vellum.vellum-assistant` onboarding keys) and walk through the full flow
- [ ] Verify each step transitions smoothly without page refresh/jump
- [ ] Verify back button on model selection goes to API key
- [ ] Verify back button on voice setup goes to model selection
- [ ] Verify selecting a model and continuing reaches voice setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
