### PR TITLE
Disable Ride Shotgun feature

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -188,11 +188,7 @@ extension AppDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
-        let rideShotgunItem = NSMenuItem(title: "Ride Shotgun", action: #selector(showRideShotgunInvitation), keyEquivalent: "")
-        rideShotgunItem.target = self
-        rideShotgunItem.image = NSImage(systemSymbolName: "binoculars", accessibilityDescription: nil)
-        rideShotgunItem.isEnabled = ambientAgent.currentSession == nil
-        menu.addItem(rideShotgunItem)
+        // Ride Shotgun menu item disabled — re-enable when the feature has a clearer value prop
 
         let updateItem = NSMenuItem(title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
         updateItem.target = self

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -556,7 +556,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     func setupAmbientAgent() {
         ambientAgent.appDelegate = self
         ambientAgent.daemonClient = daemonClient
-        ambientAgent.setupRideShotgun()
+        // Ride Shotgun disabled — re-enable when the feature has a clearer value prop
+        // ambientAgent.setupRideShotgun()
     }
 
     func updateMenuBarIcon() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -206,23 +206,6 @@ struct SettingsPanel: View {
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
 
-                // RIDE SHOTGUN section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("RIDE SHOTGUN")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    Text("Ride Shotgun lets the assistant watch how you work for a few minutes, then offers to help based on what it observed.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-
-                    Text("Use the menu bar icon or wait for the assistant to offer.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
                 // DISPLAY section
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     Text("DISPLAY")
@@ -408,7 +391,7 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textPrimary)
 
                     VStack(alignment: .leading, spacing: 0) {
-                        privacyBullet(icon: "eye.slash", text: "AI only runs when you trigger it or enable Ride Shotgun sessions")
+                        privacyBullet(icon: "eye.slash", text: "AI only runs when you explicitly trigger it")
                         Divider().background(VColor.surfaceBorder)
                         privacyBullet(icon: "lock.shield", text: "API key stored in macOS Keychain")
                         Divider().background(VColor.surfaceBorder)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -170,16 +170,6 @@ public struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("Ride Shotgun") {
-                Text("Ride Shotgun lets the assistant watch how you work for a few minutes, then offers to help based on what it observed.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Text("Use the menu bar icon or wait for the assistant to offer.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
             Section("Permissions") {
                 HStack {
                     Image(systemName: accessibilityGranted ? "checkmark.circle.fill" : "xmark.circle.fill")
@@ -274,7 +264,7 @@ public struct SettingsView: View {
             }
 
             Section("Privacy & Security") {
-                PrivacyBullet(icon: "eye.slash", text: "AI only runs when you trigger it or enable Ride Shotgun sessions")
+                PrivacyBullet(icon: "eye.slash", text: "AI only runs when you explicitly trigger it")
                 PrivacyBullet(icon: "lock.shield", text: "API key stored in macOS Keychain")
                 PrivacyBullet(icon: "xmark.shield", text: "Your data is not used to train AI models")
                 PrivacyBullet(icon: "internaldrive", text: "Session logs and knowledge stored locally on your Mac")
@@ -408,7 +398,7 @@ private struct PrivacyDetailView: View {
                     privacySection(
                         title: "How Velly Works",
                         items: [
-                            "Velly only activates AI when you explicitly trigger a task, use voice input, or accept a Ride Shotgun invitation. It does not run in the background unless you opt in.",
+                            "Velly only activates AI when you explicitly trigger a task or use voice input. It does not run in the background unless you opt in.",
                             "You are always in control. You can disable the ambient agent, revoke permissions, or clear stored data at any time from Settings.",
                         ]
                     )
@@ -417,7 +407,6 @@ private struct PrivacyDetailView: View {
                         title: "What Data Leaves Your Mac",
                         items: [
                             "When you run a task: screenshots (compressed, max 1280x720) and UI element data (window titles, button labels, text field values) are sent to the Anthropic API over HTTPS.",
-                            "When Ride Shotgun is active: screenshots and UI element data from the current session are sent to Anthropic for analysis.",
                             "Voice input: speech is transcribed on-device using Apple Speech Recognition. Only the final text is sent to Anthropic as part of the task.",
                         ]
                     )


### PR DESCRIPTION
The purpose of this PR is to disable the Ride Shotgun feature until it has a clearer value prop and user stories.

## Changes Made
- Comment out `setupRideShotgun()` call in AppDelegate (stops trigger/timer from running)
- Remove "Ride Shotgun" menu bar item
- Remove Ride Shotgun sections from both SettingsView and SettingsPanel
- Update privacy text to remove Ride Shotgun references

## Notes
- All implementation files (RideShotgunSession, RideShotgunTrigger, progress/summary windows) are preserved for future re-enablement
- Re-enable by uncommenting `ambientAgent.setupRideShotgun()` and restoring UI elements

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
