### PR TITLE
fix: resolve CI test failures from strict permissions and new IPC types

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -556,6 +556,12 @@ exports[`IPC message snapshots ClientMessage types integration_disconnect serial
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types accept_starter_bundle serializes to expected JSON 1`] = `
+{
+  "type": "accept_starter_bundle",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,
@@ -1579,5 +1585,14 @@ exports[`IPC message snapshots ServerMessage types app_files_changed serializes 
 {
   "appId": "app-001",
   "type": "app_files_changed",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types accept_starter_bundle_response serializes to expected JSON 1`] = `
+{
+  "accepted": true,
+  "alreadyAccepted": false,
+  "rulesAdded": 5,
+  "type": "accept_starter_bundle_response",
 }
 `;

--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -1,4 +1,19 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
+
+// Mock config before importing modules that depend on it.
+// The permissions mode must be 'legacy' so computer-use tools
+// (which have no trust rules in test) don't trigger approval prompts.
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    permissions: { mode: 'legacy' },
+    apiKeys: {},
+    sandbox: { enabled: false },
+    timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
 import { ComputerUseSession } from '../daemon/computer-use-session.js';
 import type { Provider, ProviderResponse } from '../providers/types.js';
 import type { CuObservation, ServerMessage } from '../daemon/ipc-protocol.js';

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -39,6 +39,7 @@ mock.module('../config/loader.js', () => ({
     apiKeys: {},
     skills: { entries: {}, allowBundled: true },
     memory: { retrieval: { injectionStrategy: 'inline' } },
+    permissions: { mode: 'legacy' },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createSkillTool, createSkillToolsFromManifest } from '../tools/skills/skill-tool-factory.js';
 import { RiskLevel } from '../permissions/types.js';
+import { computeSkillVersionHash } from '../skills/version-hash.js';
 import type { SkillToolEntry } from '../config/skills.js';
 import type { ToolContext } from '../tools/types.js';
 
@@ -237,7 +238,8 @@ describe('createSkillToolsFromManifest', () => {
 
 describe('createSkillTool — version hash plumbing to runner', () => {
   test('execute() works correctly when versionHash is provided', async () => {
-    const hash = 'v1:abc123';
+    // Use the real hash of the temp directory so the runner's integrity check passes.
+    const hash = computeSkillVersionHash(tempDir);
     const tool = createSkillTool(
       makeEntry({ executor: 'echo.ts' }),
       'my-skill',


### PR DESCRIPTION
## Summary
- Add missing IPC snapshots for `accept_starter_bundle` and `accept_starter_bundle_response`
- Fix skill-tool-factory test to compute real version hash (was hardcoded, failed integrity check)
- Add config mocks with `permissions: { mode: 'legacy' }` and `timeouts` to computer-use and session-queue tests that were broken by the strict mode default flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
