### PR TITLE
fix: disable ride shotgun trigger in pause/resume

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -44,11 +44,13 @@ public final class AmbientAgent: ObservableObject {
     }
 
     func pause() {
-        rideShotgunTrigger.stop()
+        // Ride Shotgun disabled — re-enable when the feature has a clearer value prop
+        // rideShotgunTrigger.stop()
     }
 
     func resume() {
-        rideShotgunTrigger.start()
+        // Ride Shotgun disabled — re-enable when the feature has a clearer value prop
+        // rideShotgunTrigger.start()
     }
 
     func teardown() {


### PR DESCRIPTION
## Summary
- Addresses review feedback from #3624: `AmbientAgent.resume()` and `pause()` still called `rideShotgunTrigger.start()`/`stop()`, causing a needless 60-second timer to run after every session even though Ride Shotgun is disabled
- Comments out those calls to match the pattern used in `AppDelegate.swift`

## Test plan
- [x] Build succeeds
- [ ] Verify no ride shotgun timer fires after a session completes (check logs for `RideShotgunTrigger`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
