### PR TITLE
fix: remove broken doc links left by stale docs cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -931,7 +931,7 @@ graph TB
 
 ## IPC Contract — Source of Truth and Code Generation
 
-The TypeScript file `assistant/src/daemon/ipc-contract.ts` is the **single source of truth** for all IPC message types. Swift client models are auto-generated from it. See [assistant/docs/ipc-contract.md](./assistant/docs/ipc-contract.md) for the full developer guide.
+The TypeScript file `assistant/src/daemon/ipc-contract.ts` is the **single source of truth** for all IPC message types. Swift client models are auto-generated from it.
 
 ```mermaid
 graph LR

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The assistant can store and use credentials (API keys, tokens, passwords) withou
 - **One-time send**: When `secretDetection.allowOneTimeSend` is enabled (default: `false`), a "Send Once" button lets users provide a value for immediate use without persisting it.
 - **No plaintext read API**: There is no tool-layer function that returns a stored secret as plaintext. Secrets are only consumed by the broker for scoped tool execution.
 
-See [`docs/security/credential-storage.md`](docs/security/credential-storage.md) for the full security model and [`ARCHITECTURE.md`](ARCHITECTURE.md) for data flow diagrams.
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full security model and data flow diagrams.
 
 ## Dynamic Skill Authoring
 


### PR DESCRIPTION
Fixes broken links in README.md and ARCHITECTURE.md after PR #3580 deleted the referenced files.

- README.md: Removed link to deleted `docs/security/credential-storage.md`, kept reference to ARCHITECTURE.md for security model details.
- ARCHITECTURE.md: Removed sentence linking to deleted `assistant/docs/ipc-contract.md` — the surrounding section already describes the contract file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
