### PR TITLE
fix: starter bundle glob patterns and re-acceptance after clear

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -396,6 +396,8 @@ export function getAllRules(): TrustRule[] {
 }
 
 export function clearAllRules(): void {
+  // Reset the starter bundle flag so the bundle can be re-accepted after clear.
+  cachedStarterBundleAccepted = false;
   // Re-backfill default rules so protected directory stays guarded.
   const rules: TrustRule[] = [];
   backfillDefaults(rules);
@@ -433,12 +435,16 @@ export interface StarterBundleRule {
  */
 export function getStarterBundleRules(): StarterBundleRule[] {
   return [
-    { id: 'starter:allow-file_read', tool: 'file_read', pattern: 'file_read:**', scope: 'everywhere', decision: 'allow', priority: 90 },
-    { id: 'starter:allow-glob', tool: 'glob', pattern: 'glob:**', scope: 'everywhere', decision: 'allow', priority: 90 },
-    { id: 'starter:allow-grep', tool: 'grep', pattern: 'grep:**', scope: 'everywhere', decision: 'allow', priority: 90 },
-    { id: 'starter:allow-list_directory', tool: 'list_directory', pattern: 'list_directory:**', scope: 'everywhere', decision: 'allow', priority: 90 },
-    { id: 'starter:allow-web_search', tool: 'web_search', pattern: 'web_search:**', scope: 'everywhere', decision: 'allow', priority: 90 },
-    { id: 'starter:allow-web_fetch', tool: 'web_fetch', pattern: 'web_fetch:**', scope: 'everywhere', decision: 'allow', priority: 90 },
+    // Use standalone "**" globstar — minimatch only treats ** as globstar when
+    // it is its own path segment, so a "tool:**" prefix would collapse to
+    // single-star behavior and fail to match candidates containing "/".
+    // The tool field is already filtered by findHighestPriorityRule.
+    { id: 'starter:allow-file_read', tool: 'file_read', pattern: '**', scope: 'everywhere', decision: 'allow', priority: 90 },
+    { id: 'starter:allow-glob', tool: 'glob', pattern: '**', scope: 'everywhere', decision: 'allow', priority: 90 },
+    { id: 'starter:allow-grep', tool: 'grep', pattern: '**', scope: 'everywhere', decision: 'allow', priority: 90 },
+    { id: 'starter:allow-list_directory', tool: 'list_directory', pattern: '**', scope: 'everywhere', decision: 'allow', priority: 90 },
+    { id: 'starter:allow-web_search', tool: 'web_search', pattern: '**', scope: 'everywhere', decision: 'allow', priority: 90 },
+    { id: 'starter:allow-web_fetch', tool: 'web_fetch', pattern: '**', scope: 'everywhere', decision: 'allow', priority: 90 },
   ];
 }
 


### PR DESCRIPTION
Fixes two bugs in the starter approval bundle:

1. **Glob patterns now match slash-containing candidates** — Starter rules used `tool:**` patterns (e.g. `file_read:**`), but minimatch only treats `**` as globstar when it is its own path segment. Since `buildCommandCandidates` produces values like `file_read:/Users/...` containing slashes, the prefixed pattern collapsed to single-star behavior and failed to match. Fixed by using standalone `**` as the pattern, consistent with how `defaults.ts` handles `host_bash` and computer use tools.

2. **`clearAllRules()` now resets `starterBundleAccepted` flag** — Previously, clearing all rules removed the starter rules from the store but left `cachedStarterBundleAccepted = true`, which was then persisted back to disk by `saveToDisk()`. This made re-acceptance impossible without manually editing trust.json.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
