### PR TITLE
fix: resolve file tool paths against workingDir in classifyRisk

### DIFF
--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -49,7 +49,7 @@ export async function approveHostAttachmentRead(
   const response = await prompter.prompt(
     toolName,
     input,
-    await classifyRisk(toolName, input),
+    await classifyRisk(toolName, input, workingDir),
     generateAllowlistOptions(toolName, input),
     generateScopeOptions(workingDir, toolName),
     undefined,

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -239,11 +239,11 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
   return [...new Set(candidates)];
 }
 
-export async function classifyRisk(toolName: string, input: Record<string, unknown>): Promise<RiskLevel> {
+export async function classifyRisk(toolName: string, input: Record<string, unknown>, workingDir?: string): Promise<RiskLevel> {
   if (toolName === 'file_read') return RiskLevel.Low;
   if (toolName === 'file_write' || toolName === 'file_edit') {
     const filePath = getStringField(input, 'path', 'file_path');
-    if (filePath && isSkillSourcePath(resolve(filePath))) {
+    if (filePath && isSkillSourcePath(resolve(workingDir ?? process.cwd(), filePath))) {
       return RiskLevel.High;
     }
     return RiskLevel.Medium;
@@ -342,7 +342,7 @@ export async function check(
   workingDir: string,
   policyContext?: PolicyContext,
 ): Promise<PermissionCheckResult> {
-  const risk = await classifyRisk(toolName, input);
+  const risk = await classifyRisk(toolName, input, workingDir);
 
   // Build command string candidates for rule matching
   const commandCandidates = buildCommandCandidates(toolName, input, workingDir);

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -95,7 +95,7 @@ export class ToolExecutor {
 
     try {
       // Check permissions
-      const risk = await classifyRisk(name, input);
+      const risk = await classifyRisk(name, input, context.workingDir);
       riskLevel = risk;
 
       // Build principal context from tool metadata so policy rules can


### PR DESCRIPTION
Fixes security bypass where classifyRisk resolved file_write/file_edit paths against process.cwd() instead of workingDir, allowing skill source mutations to bypass High-risk escalation when the process working directory differed from the tool's workingDir.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
