### PR TITLE
fix: compute version hash from disk before trusting tool input

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -74,18 +74,17 @@ function resolveSkillIdAndHash(selector: string, input: Record<string, unknown>)
   const resolved = resolveSkillSelector(selector);
   if (!resolved.skill) return null;
 
-  // Prefer an explicit version_hash from the input (set by the agent loop
-  // or prior enrichment) over computing it on the fly.
-  const explicitHash = getStringField(input, 'version_hash');
-  if (explicitHash) {
-    return { id: resolved.skill.id, versionHash: explicitHash };
-  }
-
-  // Fall back to computing the hash from the skill directory.
+  // Always compute the hash from disk so a modified skill cannot be approved
+  // using a stale hash supplied by the agent. Only fall back to the explicit
+  // version_hash from input when disk computation fails.
   try {
     const hash = computeSkillVersionHash(resolved.skill.directoryPath);
     return { id: resolved.skill.id, versionHash: hash };
   } catch {
+    const explicitHash = getStringField(input, 'version_hash');
+    if (explicitHash) {
+      return { id: resolved.skill.id, versionHash: explicitHash };
+    }
     return { id: resolved.skill.id };
   }
 }


### PR DESCRIPTION
Fixes security bypass where model-controlled version_hash input could forge a stale hash to match existing trust rules. Disk-computed hash is now authoritative; the explicit hash from tool input is only used as a fallback when disk computation fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
