### PR TITLE
fix: remove unreachable dead code guard for skill_load in strict mode

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -393,14 +393,6 @@ export async function check(
     return { decision: 'prompt', reason: `Strict mode: no matching rule, requires approval` };
   }
 
-  // In strict mode skill_load must always have an explicit rule — never
-  // fall through to the low-risk auto-allow below. The check above
-  // already handles !matchedRule, so this guard covers defensive edge
-  // cases (e.g., a matched rule that was consumed but didn't return).
-  if (permissionsMode === 'strict' && toolName === 'skill_load' && !matchedRule) {
-    return { decision: 'prompt', reason: 'Strict mode: skill_load requires explicit approval' };
-  }
-
   if (risk === RiskLevel.High) {
     return { decision: 'prompt', reason: `High risk: always requires approval` };
   }


### PR DESCRIPTION
Removes dead code block in checker.ts that was unreachable due to a broader strict mode check already returning earlier. The guard provided zero defensive value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
