### PR TITLE
fix: parameterize GraphQL queries in gh-review to prevent injection

### DIFF
--- a/.claude/gh-review
+++ b/.claude/gh-review
@@ -32,9 +32,11 @@ cmd_resolve_threads() {
 
   echo "==> Fetching review threads for PR #$pr_number..."
   local threads_json
-  threads_json=$(gh api graphql -f query='query {
+  threads_json=$(gh api graphql \
+    -F prNumber="$pr_number" \
+    -f query='query($prNumber: Int!) {
     repository(owner: "vellum-ai", name: "vellum-assistant") {
-      pullRequest(number: '"$pr_number"') {
+      pullRequest(number: $prNumber) {
         reviewThreads(first: 100) {
           nodes {
             id
@@ -71,19 +73,24 @@ cmd_resolve_threads() {
     count=$((count + 1))
 
     echo "==> Replying to thread $thread_id..."
-    gh api graphql -f query='mutation {
-      addPullRequestReviewThreadReply(input: {
-        pullRequestReviewThreadId: "'"$thread_id"'"
-        body: "'"$message"'"
-      }) { comment { id } }
-    }' > /dev/null
+    gh api graphql \
+      -f query='mutation($threadId: ID!, $body: String!) {
+        addPullRequestReviewThreadReply(input: {
+          pullRequestReviewThreadId: $threadId
+          body: $body
+        }) { comment { id } }
+      }' \
+      -F threadId="$thread_id" \
+      -f body="$message" > /dev/null
 
     echo "==> Resolving thread $thread_id..."
-    gh api graphql -f query='mutation {
-      resolveReviewThread(input: {
-        threadId: "'"$thread_id"'"
-      }) { thread { isResolved } }
-    }' > /dev/null
+    gh api graphql \
+      -f query='mutation($threadId: ID!) {
+        resolveReviewThread(input: {
+          threadId: $threadId
+        }) { thread { isResolved } }
+      }' \
+      -F threadId="$thread_id" > /dev/null
 
   done <<< "$thread_ids"
 


### PR DESCRIPTION
Fixes GraphQL injection in .claude/gh-review by replacing direct string interpolation with parameterized queries using gh api graphql's -F/-f flags. All three GraphQL operations (fetch threads, reply, resolve) now use proper GraphQL variables instead of shell variable interpolation into query strings. This prevents messages containing double quotes, backslashes, or newlines from breaking the query.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
