### PR TITLE
fix: pass principal context to permission prompter

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -516,6 +516,85 @@ describe('ToolExecutor contextual rule creation', () => {
   });
 });
 
+describe('ToolExecutor prompter principal arg (PR fix3)', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+    lastCheckArgs = undefined;
+    getToolOverride = undefined;
+    checkResultOverride = { decision: 'prompt', reason: 'test prompt' };
+    if (addRuleSpy) { addRuleSpy.mockRestore(); addRuleSpy = undefined; }
+  });
+
+  test('passes principal context (kind, id, version) to prompter for skill-origin tools', async () => {
+    getToolOverride = (name: string) => {
+      if (name === 'unknown_tool') return undefined;
+      return {
+        name,
+        description: 'skill tool',
+        category: 'skill',
+        defaultRiskLevel: RiskLevel.Low,
+        origin: 'skill' as const,
+        ownerSkillId: 'prompt-skill-42',
+        ownerSkillVersionHash: 'sha256-prompt-v1',
+        executionTarget: 'sandbox' as const,
+        getDefinition: () => ({ name, description: 'skill tool', input_schema: { type: 'object' as const, properties: {} } }),
+        execute: async () => fakeToolResult,
+      };
+    };
+
+    let capturedPrincipal: unknown;
+    const prompter = {
+      prompt: async (
+        _toolName: string, _input: Record<string, unknown>, _riskLevel: string,
+        _allowlistOptions: any[], _scopeOptions: any[], _diff: any, _sandboxed: any,
+        _sessionId: any, _executionTarget: any, principal: any,
+      ) => {
+        capturedPrincipal = principal;
+        return { decision: 'allow' as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('skill_tool', { action: 'run' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(capturedPrincipal).toEqual({
+      kind: 'skill',
+      id: 'prompt-skill-42',
+      version: 'sha256-prompt-v1',
+    });
+  });
+
+  test('passes undefined principal to prompter for core tools', async () => {
+    // Default getTool returns core tools with no origin field
+    getToolOverride = undefined;
+
+    let capturedPrincipal: unknown = 'NOT_CALLED';
+    const prompter = {
+      prompt: async (
+        _toolName: string, _input: Record<string, unknown>, _riskLevel: string,
+        _allowlistOptions: any[], _scopeOptions: any[], _diff: any, _sandboxed: any,
+        _sessionId: any, _executionTarget: any, principal: any,
+      ) => {
+        capturedPrincipal = principal;
+        return { decision: 'allow' as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('file_read', { path: 'test.txt' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(capturedPrincipal).toBeUndefined();
+  });
+});
+
 describe('ToolExecutor strict mode + high-risk integration (PR 25)', () => {
   beforeEach(() => {
     fakeToolResult = { content: 'ok', isError: false };

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -175,6 +175,11 @@ export class ToolExecutor {
           sandboxed,
           context.conversationId,
           executionTarget,
+          policyContext?.principal ? {
+            kind: policyContext.principal.kind,
+            id: policyContext.principal.id,
+            version: policyContext.principal.version,
+          } : undefined,
         );
 
         decision = response.decision;


### PR DESCRIPTION
## Summary
- **P1 fix**: policyContext was built from tool metadata but never forwarded to `prompter.prompt()`
- Approval prompts now show skill identity, version hash, and execution target
- 2 regression tests verifying principal arg for skill vs core tools

## Test plan
- [x] 27 tests pass in tool-executor.test.ts
- [x] Skill tools pass principal {kind, id, version} to prompter
- [x] Core tools pass undefined principal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
