### PR TITLE
fix: keep onboarding icon persistent across step transitions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -8,190 +8,132 @@ struct APIKeyStepView: View {
     @State private var apiKey: String = ""
     @State private var hasExistingKey = false
     @State private var isEditing = false
-    @State private var showIcon = false
     @State private var showTitle = false
     @State private var showContent = false
     @FocusState private var keyFieldFocused: Bool
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        // Title
+        Text("Add your API key")
+            .font(.system(size: 32, weight: .regular, design: .serif))
+            .foregroundColor(VColor.textPrimary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.md)
 
-            // Icon
+        // Subtitle
+        Text("Enter your Anthropic API key to get started.")
+            .font(.system(size: 16))
+            .foregroundColor(VColor.textSecondary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+
+        Spacer()
+
+        // Content
+        VStack(spacing: VSpacing.md) {
             Group {
-                if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
-                   let nsImage = NSImage(contentsOf: url) {
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
-                } else {
-                    Image("VellyLogo")
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
-                }
-            }
-            .frame(width: 128, height: 128)
-            .opacity(showIcon ? 1 : 0)
-            .scaleEffect(showIcon ? 1 : 0.8)
-            .padding(.bottom, VSpacing.xxl)
-
-            // Title
-            Text("Add your API key")
-                .font(.system(size: 32, weight: .regular, design: .serif))
-                .foregroundColor(VColor.textPrimary)
-                .opacity(showTitle ? 1 : 0)
-                .offset(y: showTitle ? 0 : 8)
-                .padding(.bottom, VSpacing.md)
-
-            // Subtitle
-            Text("Enter your Anthropic API key to get started.")
-                .font(.system(size: 16))
-                .foregroundColor(VColor.textSecondary)
-                .opacity(showTitle ? 1 : 0)
-                .offset(y: showTitle ? 0 : 8)
-
-            Spacer()
-
-            // Content
-            VStack(spacing: VSpacing.md) {
-                Group {
-                    if hasExistingKey && !isEditing {
-                        Text(maskedKey)
-                            .font(.system(size: 16, weight: .medium, design: .monospaced))
-                            .foregroundColor(VColor.textPrimary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-                            )
-                            .onTapGesture {
-                                isEditing = true
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                    keyFieldFocused = true
-                                }
-                            }
-                    } else {
-                        SecureField("sk-ant-\u{2026}", text: $apiKey)
-                            .textFieldStyle(.plain)
-                            .font(.system(size: 16, weight: .medium, design: .monospaced))
-                            .foregroundColor(VColor.textPrimary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-                            )
-                            .focused($keyFieldFocused)
-                            .onSubmit {
-                                saveKeyAndContinue()
-                            }
-                    }
-                }
-
-                // Primary button
-                Button(action: { saveKeyAndContinue() }) {
-                    Text("Save API key")
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(adaptiveColor(light: .white, dark: .white))
+                if hasExistingKey && !isEditing {
+                    Text(maskedKey)
+                        .font(.system(size: 16, weight: .medium, design: .monospaced))
+                        .foregroundColor(VColor.textPrimary)
                         .frame(maxWidth: .infinity)
+                        .padding(.horizontal, 20)
                         .padding(.vertical, VSpacing.lg)
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.lg)
-                                .fill(primaryButtonDisabled
-                                    ? adaptiveColor(
-                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 0.3)),
-                                        dark: Violet._600.opacity(0.3)
-                                    )
-                                    : adaptiveColor(
-                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
-                                        dark: Violet._600
-                                    )
-                                )
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
                         )
+                        .onTapGesture {
+                            isEditing = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                keyFieldFocused = true
+                            }
+                        }
+                } else {
+                    SecureField("sk-ant-\u{2026}", text: $apiKey)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 16, weight: .medium, design: .monospaced))
+                        .foregroundColor(VColor.textPrimary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, VSpacing.lg)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                        .focused($keyFieldFocused)
+                        .onSubmit {
+                            saveKeyAndContinue()
+                        }
                 }
-                .buttonStyle(.plain)
-                .disabled(primaryButtonDisabled)
+            }
+
+            // Primary button
+            Button(action: { saveKeyAndContinue() }) {
+                Text("Save API key")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(adaptiveColor(light: .white, dark: .white))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, VSpacing.lg)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(primaryButtonDisabled
+                                ? adaptiveColor(
+                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 0.3)),
+                                    dark: Violet._600.opacity(0.3)
+                                )
+                                : adaptiveColor(
+                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                    dark: Violet._600
+                                )
+                            )
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(primaryButtonDisabled)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+
+            HStack(spacing: VSpacing.lg) {
+                Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
+                    Text("Get an API key")
+                        .font(.system(size: 13))
+                        .foregroundColor(adaptiveColor(light: VColor.accent, dark: .white))
+                }
                 .onHover { hovering in
                     if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                 }
 
-                HStack(spacing: VSpacing.lg) {
-                    Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
-                        Text("Get an API key")
-                            .font(.system(size: 13))
-                            .foregroundColor(adaptiveColor(light: VColor.accent, dark: .white))
-                    }
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
-
-                    Button(action: { goBack() }) {
-                        Text("Back")
-                            .font(.system(size: 13))
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
+                Button(action: { goBack() }) {
+                    Text("Back")
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textMuted)
                 }
-                .padding(.top, VSpacing.xs)
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
             }
-            .padding(.horizontal, VSpacing.xxl)
-            .padding(.bottom, VSpacing.xxl)
-            .opacity(showContent ? 1 : 0)
-            .offset(y: showContent ? 0 : 12)
+            .padding(.top, VSpacing.xs)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            ZStack {
-                VColor.background
-
-                // Purple glow at bottom
-                RadialGradient(
-                    colors: [
-                        Violet._600.opacity(0.15),
-                        Violet._700.opacity(0.05),
-                        Color.clear
-                    ],
-                    center: .bottom,
-                    startRadius: 20,
-                    endRadius: 350
-                )
-
-                // Subtle secondary glow offset to bottom-right
-                RadialGradient(
-                    colors: [
-                        Violet._400.opacity(0.08),
-                        Color.clear
-                    ],
-                    center: UnitPoint(x: 0.7, y: 1.0),
-                    startRadius: 10,
-                    endRadius: 250
-                )
-            }
-            .ignoresSafeArea()
-        )
+        .padding(.horizontal, VSpacing.xxl)
+        .padding(.bottom, VSpacing.xxl)
+        .opacity(showContent ? 1 : 0)
+        .offset(y: showContent ? 0 : 12)
         .onAppear {
             if let existingKey = APIKeyManager.getKey() {
                 apiKey = existingKey
                 hasExistingKey = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.2)) {
-                showIcon = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.8)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.3) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
                 keyFieldFocused = true
             }
         }
@@ -228,11 +170,20 @@ struct APIKeyStepView: View {
 #Preview {
     ZStack {
         VColor.background.ignoresSafeArea()
-        APIKeyStepView(state: {
-            let s = OnboardingState()
-            s.currentStep = 2
-            return s
-        }())
+        VStack(spacing: 0) {
+            Spacer()
+            Image("VellyLogo")
+                .resizable()
+                .interpolation(.none)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 128, height: 128)
+                .padding(.bottom, VSpacing.xxl)
+            APIKeyStepView(state: {
+                let s = OnboardingState()
+                s.currentStep = 2
+                return s
+            }())
+        }
     }
     .frame(width: 460, height: 620)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -7,7 +7,6 @@ import Speech
 struct FnKeyStepView: View {
     @Bindable var state: OnboardingState
 
-    @State private var showIcon = false
     @State private var showTitle = false
     @State private var showContent = false
     @State private var pulseScale: CGFloat = 1.0
@@ -21,217 +20,162 @@ struct FnKeyStepView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        // Title
+        Text("Need voice mode?")
+            .font(.system(size: 32, weight: .regular, design: .serif))
+            .foregroundColor(VColor.textPrimary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.md)
 
-            // Icon
-            Group {
-                if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
-                   let nsImage = NSImage(contentsOf: url) {
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
-                } else {
-                    Image("VellyLogo")
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
+        // Subtitle
+        Text(permissionsRequested
+             ? "Grant the permissions to continue."
+             : "Hold fn + shift anywhere to talk to \(state.assistantName).")
+            .font(.system(size: 16))
+            .foregroundColor(VColor.textSecondary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .animation(.easeInOut(duration: 0.3), value: permissionsRequested)
+
+        Spacer()
+
+        // Content area
+        VStack(spacing: VSpacing.md) {
+            if permissionsRequested {
+                // Permission status rows
+                VStack(spacing: 0) {
+                    permissionRow(
+                        icon: "mic.fill",
+                        label: "Microphone",
+                        granted: micGranted
+                    )
+                    Divider()
+                        .background(VColor.surfaceBorder)
+                    permissionRow(
+                        icon: "waveform",
+                        label: "Speech Recognition",
+                        granted: speechGranted
+                    )
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .transition(.opacity.combined(with: .move(edge: .trailing)))
+            } else {
+                // Key badge row
+                HStack(spacing: VSpacing.sm) {
+                    keyBadge("fn")
+                    Text("+")
+                        .font(.system(size: 18, weight: .medium, design: .monospaced))
+                        .foregroundColor(VColor.textMuted)
+                    keyBadge("shift")
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, VSpacing.lg)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
+                .scaleEffect(pulseScale)
+                .transition(.opacity.combined(with: .move(edge: .leading)))
+            }
+
+            // Primary button
+            if allPermissionsGranted {
+                Button(action: {
+                    state.chosenKey = .fnShift
+                    state.advance()
+                }) {
+                    Text("Continue")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, VSpacing.lg)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .fill(adaptiveColor(
+                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                    dark: Violet._600
+                                ))
+                        )
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+                .transition(.opacity)
+            } else {
+                Button(action: { requestPermissions() }) {
+                    Text(permissionsRequested ? "Open System Settings" : "Enable Voice Mode")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, VSpacing.lg)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .fill(adaptiveColor(
+                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                    dark: Violet._600
+                                ))
+                        )
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                 }
             }
-            .frame(width: 128, height: 128)
-            .opacity(showIcon ? 1 : 0)
-            .scaleEffect(showIcon ? 1 : 0.8)
-            .padding(.bottom, VSpacing.xxl)
 
-            // Title
-            Text("Need voice mode?")
-                .font(.system(size: 32, weight: .regular, design: .serif))
-                .foregroundColor(VColor.textPrimary)
-                .opacity(showTitle ? 1 : 0)
-                .offset(y: showTitle ? 0 : 8)
-                .padding(.bottom, VSpacing.md)
-
-            // Subtitle
-            Text(permissionsRequested
-                 ? "Grant the permissions to continue."
-                 : "Hold fn + shift anywhere to talk to \(state.assistantName).")
-                .font(.system(size: 16))
-                .foregroundColor(VColor.textSecondary)
-                .opacity(showTitle ? 1 : 0)
-                .offset(y: showTitle ? 0 : 8)
-                .animation(.easeInOut(duration: 0.3), value: permissionsRequested)
-
-            Spacer()
-
-            // Content area
-            VStack(spacing: VSpacing.md) {
-                if permissionsRequested {
-                    // Permission status rows
-                    VStack(spacing: 0) {
-                        permissionRow(
-                            icon: "mic.fill",
-                            label: "Microphone",
-                            granted: micGranted
-                        )
-                        Divider()
-                            .background(VColor.surfaceBorder)
-                        permissionRow(
-                            icon: "waveform",
-                            label: "Speech Recognition",
-                            granted: speechGranted
-                        )
-                    }
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .transition(.opacity.combined(with: .move(edge: .trailing)))
-                } else {
-                    // Key badge row
-                    HStack(spacing: VSpacing.sm) {
-                        keyBadge("fn")
-                        Text("+")
-                            .font(.system(size: 18, weight: .medium, design: .monospaced))
-                            .foregroundColor(VColor.textMuted)
-                        keyBadge("shift")
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, VSpacing.lg)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-                    .scaleEffect(pulseScale)
-                    .transition(.opacity.combined(with: .move(edge: .leading)))
+            // Skip + Back
+            HStack(spacing: VSpacing.lg) {
+                Button(action: {
+                    stopPolling()
+                    state.chosenKey = .none
+                    state.advance()
+                }) {
+                    Text("Skip")
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                 }
 
-                // Primary button
-                if allPermissionsGranted {
-                    Button(action: {
-                        state.chosenKey = .fnShift
-                        state.advance()
-                    }) {
-                        Text("Continue")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .fill(adaptiveColor(
-                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
-                                        dark: Violet._600
-                                    ))
-                            )
+                Button(action: {
+                    stopPolling()
+                    withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                        state.currentStep = 3
                     }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
-                    .transition(.opacity)
-                } else {
-                    Button(action: { requestPermissions() }) {
-                        Text(permissionsRequested ? "Open System Settings" : "Enable Voice Mode")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .fill(adaptiveColor(
-                                        light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
-                                        dark: Violet._600
-                                    ))
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
+                }) {
+                    Text("Back")
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textMuted)
                 }
-
-                // Skip + Back
-                HStack(spacing: VSpacing.lg) {
-                    Button(action: {
-                        stopPolling()
-                        state.chosenKey = .none
-                        state.advance()
-                    }) {
-                        Text("Skip")
-                            .font(.system(size: 13))
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
-
-                    Button(action: {
-                        stopPolling()
-                        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
-                            state.currentStep = 3
-                        }
-                    }) {
-                        Text("Back")
-                            .font(.system(size: 13))
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                 }
-                .padding(.top, VSpacing.xs)
             }
-            .padding(.horizontal, VSpacing.xxl)
-            .padding(.bottom, VSpacing.xxl)
-            .opacity(showContent ? 1 : 0)
-            .offset(y: showContent ? 0 : 12)
-            .animation(.spring(duration: 0.4, bounce: 0.1), value: permissionsRequested)
-            .animation(.spring(duration: 0.4, bounce: 0.1), value: allPermissionsGranted)
+            .padding(.top, VSpacing.xs)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            ZStack {
-                VColor.background
-
-                RadialGradient(
-                    colors: [
-                        Violet._600.opacity(0.15),
-                        Violet._700.opacity(0.05),
-                        Color.clear
-                    ],
-                    center: .bottom,
-                    startRadius: 20,
-                    endRadius: 350
-                )
-
-                RadialGradient(
-                    colors: [
-                        Violet._400.opacity(0.08),
-                        Color.clear
-                    ],
-                    center: UnitPoint(x: 0.7, y: 1.0),
-                    startRadius: 10,
-                    endRadius: 250
-                )
-            }
-            .ignoresSafeArea()
-        )
+        .padding(.horizontal, VSpacing.xxl)
+        .padding(.bottom, VSpacing.xxl)
+        .opacity(showContent ? 1 : 0)
+        .offset(y: showContent ? 0 : 12)
+        .animation(.spring(duration: 0.4, bounce: 0.1), value: permissionsRequested)
+        .animation(.spring(duration: 0.4, bounce: 0.1), value: allPermissionsGranted)
         .onAppear {
             checkCurrentPermissions()
-            withAnimation(.easeOut(duration: 0.5).delay(0.2)) {
-                showIcon = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.8)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
-            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true).delay(1.0)) {
+            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true).delay(0.5)) {
                 pulseScale = 1.03
             }
         }
@@ -345,12 +289,21 @@ struct FnKeyStepView: View {
 #Preview {
     ZStack {
         VColor.background.ignoresSafeArea()
-        FnKeyStepView(state: {
-            let s = OnboardingState()
-            s.assistantName = "Velly"
-            s.currentStep = 3
-            return s
-        }())
+        VStack(spacing: 0) {
+            Spacer()
+            Image("VellyLogo")
+                .resizable()
+                .interpolation(.none)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 128, height: 128)
+                .padding(.bottom, VSpacing.xxl)
+            FnKeyStepView(state: {
+                let s = OnboardingState()
+                s.assistantName = "Velly"
+                s.currentStep = 4
+                return s
+            }())
+        }
     }
     .frame(width: 460, height: 620)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 struct ModelSelectionStepView: View {
     @Bindable var state: OnboardingState
 
-    @State private var showIcon = false
     @State private var showTitle = false
     @State private var showContent = false
     @State private var selectedModel = "claude-sonnet-4-5-20250929"
@@ -17,131 +16,75 @@ struct ModelSelectionStepView: View {
     ]
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        // Title
+        Text("Choose your model")
+            .font(.system(size: 32, weight: .regular, design: .serif))
+            .foregroundColor(VColor.textPrimary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.md)
 
-            // Icon
-            Group {
-                if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
-                   let nsImage = NSImage(contentsOf: url) {
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
-                } else {
-                    Image("VellyLogo")
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
+        // Subtitle
+        Text("Pick the model that powers your assistant.")
+            .font(.system(size: 16))
+            .foregroundColor(VColor.textSecondary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+
+        Spacer()
+
+        // Content
+        VStack(spacing: VSpacing.md) {
+            // Model selection cards
+            VStack(spacing: VSpacing.sm) {
+                ForEach(Self.models, id: \.id) { model in
+                    modelCard(id: model.id, name: model.name, detail: model.detail)
                 }
             }
-            .frame(width: 128, height: 128)
-            .opacity(showIcon ? 1 : 0)
-            .scaleEffect(showIcon ? 1 : 0.8)
-            .padding(.bottom, VSpacing.xxl)
 
-            // Title
-            Text("Choose your model")
-                .font(.system(size: 32, weight: .regular, design: .serif))
-                .foregroundColor(VColor.textPrimary)
-                .opacity(showTitle ? 1 : 0)
-                .offset(y: showTitle ? 0 : 8)
-                .padding(.bottom, VSpacing.md)
-
-            // Subtitle
-            Text("Pick the model that powers your assistant.")
-                .font(.system(size: 16))
-                .foregroundColor(VColor.textSecondary)
-                .opacity(showTitle ? 1 : 0)
-                .offset(y: showTitle ? 0 : 8)
-
-            Spacer()
-
-            // Content
-            VStack(spacing: VSpacing.md) {
-                // Model selection cards
-                VStack(spacing: VSpacing.sm) {
-                    ForEach(Self.models, id: \.id) { model in
-                        modelCard(id: model.id, name: model.name, detail: model.detail)
-                    }
-                }
-
-                // Primary button
-                Button(action: { saveModelAndContinue() }) {
-                    Text("Select model")
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(adaptiveColor(light: .white, dark: .white))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, VSpacing.lg)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .fill(adaptiveColor(
-                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
-                                    dark: Violet._600
-                                ))
-                        )
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
-
-                Button(action: { goBack() }) {
-                    Text("Back")
-                        .font(.system(size: 13))
-                        .foregroundColor(VColor.textMuted)
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
-                .padding(.top, VSpacing.xs)
+            // Primary button
+            Button(action: { saveModelAndContinue() }) {
+                Text("Select model")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(adaptiveColor(light: .white, dark: .white))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, VSpacing.lg)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(adaptiveColor(
+                                light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                dark: Violet._600
+                            ))
+                    )
             }
-            .padding(.horizontal, VSpacing.xxl)
-            .padding(.bottom, VSpacing.xxl)
-            .opacity(showContent ? 1 : 0)
-            .offset(y: showContent ? 0 : 12)
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+
+            Button(action: { goBack() }) {
+                Text("Back")
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            .padding(.top, VSpacing.xs)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            ZStack {
-                VColor.background
-
-                RadialGradient(
-                    colors: [
-                        Violet._600.opacity(0.15),
-                        Violet._700.opacity(0.05),
-                        Color.clear
-                    ],
-                    center: .bottom,
-                    startRadius: 20,
-                    endRadius: 350
-                )
-
-                RadialGradient(
-                    colors: [
-                        Violet._400.opacity(0.08),
-                        Color.clear
-                    ],
-                    center: UnitPoint(x: 0.7, y: 1.0),
-                    startRadius: 10,
-                    endRadius: 250
-                )
-            }
-            .ignoresSafeArea()
-        )
+        .padding(.horizontal, VSpacing.xxl)
+        .padding(.bottom, VSpacing.xxl)
+        .opacity(showContent ? 1 : 0)
+        .offset(y: showContent ? 0 : 12)
         .onAppear {
-            // Load previously selected model if any
             if let existing = loadModelFromConfig() {
                 selectedModel = existing
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.2)) {
-                showIcon = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.8)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
         }
@@ -242,11 +185,20 @@ struct ModelSelectionStepView: View {
 #Preview {
     ZStack {
         VColor.background.ignoresSafeArea()
-        ModelSelectionStepView(state: {
-            let s = OnboardingState()
-            s.currentStep = 3
-            return s
-        }())
+        VStack(spacing: 0) {
+            Spacer()
+            Image("VellyLogo")
+                .resizable()
+                .interpolation(.none)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 128, height: 128)
+                .padding(.bottom, VSpacing.xxl)
+            ModelSelectionStepView(state: {
+                let s = OnboardingState()
+                s.currentStep = 3
+                return s
+            }())
+        }
     }
     .frame(width: 460, height: 620)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -13,9 +13,46 @@ struct OnboardingFlowView: View {
         ZStack {
             VColor.background.ignoresSafeArea()
 
-            if state.currentStep == 0 {
-                // Step 0: Full-window welcome screen
-                WakeUpStepView(state: state)
+            if [0, 2, 3, 4].contains(state.currentStep) {
+                // Steps 0–4: Shared layout with persistent icon + background.
+                // Only the content below the icon transitions between steps.
+                VStack(spacing: 0) {
+                    Spacer()
+
+                    // Persistent icon — stays in place across step transitions
+                    Group {
+                        if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
+                           let nsImage = NSImage(contentsOf: url) {
+                            Image(nsImage: nsImage)
+                                .resizable()
+                                .interpolation(.none)
+                                .aspectRatio(contentMode: .fit)
+                        } else {
+                            Image("VellyLogo")
+                                .resizable()
+                                .interpolation(.none)
+                                .aspectRatio(contentMode: .fit)
+                        }
+                    }
+                    .frame(width: 128, height: 128)
+                    .padding(.bottom, VSpacing.xxl)
+
+                    // Step content — Group flattens into parent VStack so
+                    // the inner Spacer flexes with the top Spacer above.
+                    Group {
+                        switch state.currentStep {
+                        case 0:
+                            WakeUpStepView(state: state)
+                        case 2:
+                            APIKeyStepView(state: state)
+                        case 3:
+                            ModelSelectionStepView(state: state)
+                        case 4:
+                            FnKeyStepView(state: state)
+                        default:
+                            EmptyView()
+                        }
+                    }
                     .transition(
                         .asymmetric(
                             insertion: .opacity.combined(with: .offset(y: 12)),
@@ -23,36 +60,35 @@ struct OnboardingFlowView: View {
                         )
                     )
                     .id(state.currentStep)
-            } else if state.currentStep == 2 {
-                // Step 2: Full-window API key screen
-                APIKeyStepView(state: state)
-                    .transition(
-                        .asymmetric(
-                            insertion: .opacity.combined(with: .offset(y: 12)),
-                            removal: .opacity.combined(with: .offset(y: -8))
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(
+                    ZStack {
+                        VColor.background
+
+                        RadialGradient(
+                            colors: [
+                                Violet._600.opacity(0.15),
+                                Violet._700.opacity(0.05),
+                                Color.clear
+                            ],
+                            center: .bottom,
+                            startRadius: 20,
+                            endRadius: 350
                         )
-                    )
-                    .id(state.currentStep)
-            } else if state.currentStep == 3 {
-                // Step 3: Full-window model selection screen
-                ModelSelectionStepView(state: state)
-                    .transition(
-                        .asymmetric(
-                            insertion: .opacity.combined(with: .offset(y: 12)),
-                            removal: .opacity.combined(with: .offset(y: -8))
+
+                        RadialGradient(
+                            colors: [
+                                Violet._400.opacity(0.08),
+                                Color.clear
+                            ],
+                            center: UnitPoint(x: 0.7, y: 1.0),
+                            startRadius: 10,
+                            endRadius: 250
                         )
-                    )
-                    .id(state.currentStep)
-            } else if state.currentStep == 4 {
-                // Step 4: Full-window voice activation screen
-                FnKeyStepView(state: state)
-                    .transition(
-                        .asymmetric(
-                            insertion: .opacity.combined(with: .offset(y: 12)),
-                            removal: .opacity.combined(with: .offset(y: -8))
-                        )
-                    )
-                    .id(state.currentStep)
+                    }
+                    .ignoresSafeArea()
+                )
             } else if state.currentStep <= 7 {
                 // Steps 1-7: Egg + content panel layout
                 VStack(spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -5,137 +5,79 @@ import SwiftUI
 struct WakeUpStepView: View {
     @Bindable var state: OnboardingState
 
-    @State private var showIcon = false
     @State private var showTitle = false
     @State private var showSubtext = false
     @State private var showButtons = false
     @State private var isAdvancing = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        // Title
+        Text("Create your Velly")
+            .font(.system(size: 32, weight: .regular, design: .serif))
+            .foregroundColor(VColor.textPrimary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.md)
 
-            // Icon
-            Group {
-                if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
-                   let nsImage = NSImage(contentsOf: url) {
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
-                } else {
-                    Image("VellyLogo")
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
-                }
+        // Subtitle
+        Text("The safest way to create your personal assistant.")
+            .font(.system(size: 16))
+            .foregroundColor(VColor.textSecondary)
+            .opacity(showSubtext ? 1 : 0)
+            .offset(y: showSubtext ? 0 : 8)
+
+        Spacer()
+
+        // Buttons
+        VStack(spacing: VSpacing.md) {
+            Button(action: { advanceStep() }) {
+                Text("Start with an API key")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, VSpacing.lg)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(adaptiveColor(
+                                light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                dark: Violet._600
+                            ))
+                    )
             }
-            .frame(width: 128, height: 128)
-            .opacity(showIcon ? 1 : 0)
-            .scaleEffect(showIcon ? 1 : 0.8)
-            .padding(.bottom, VSpacing.xxl)
-
-            // Title
-            Text("Create your Velly")
-                .font(.system(size: 32, weight: .regular, design: .serif))
-                .foregroundColor(VColor.textPrimary)
-                .opacity(showTitle ? 1 : 0)
-                .offset(y: showTitle ? 0 : 8)
-                .padding(.bottom, VSpacing.md)
-
-            // Subtitle
-            Text("The safest way to create your personal assistant.")
-                .font(.system(size: 16))
-                .foregroundColor(VColor.textSecondary)
-                .opacity(showSubtext ? 1 : 0)
-                .offset(y: showSubtext ? 0 : 8)
-
-            Spacer()
-
-            // Buttons
-            VStack(spacing: VSpacing.md) {
-                Button(action: { advanceStep() }) {
-                    Text("Start with an API key")
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, VSpacing.lg)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .fill(adaptiveColor(
-                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
-                                    dark: Violet._600
-                                ))
-                        )
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
-
-                Button(action: {}) {
-                    Text("Continue with Google")
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(VColor.textPrimary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, VSpacing.lg)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .fill(adaptiveColor(light: .white, dark: VColor.surface))
-                        )
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
             }
-            .padding(.horizontal, VSpacing.xxl)
-            .padding(.bottom, VSpacing.xxl)
-            .opacity(showButtons ? 1 : 0)
-            .offset(y: showButtons ? 0 : 12)
-            .disabled(isAdvancing)
+
+            Button(action: {}) {
+                Text("Continue with Google")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(VColor.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, VSpacing.lg)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(adaptiveColor(light: .white, dark: VColor.surface))
+                    )
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            ZStack {
-                VColor.background
-
-                // Purple glow at bottom
-                RadialGradient(
-                    colors: [
-                        Violet._600.opacity(0.15),
-                        Violet._700.opacity(0.05),
-                        Color.clear
-                    ],
-                    center: .bottom,
-                    startRadius: 20,
-                    endRadius: 350
-                )
-
-                // Subtle secondary glow offset to bottom-right
-                RadialGradient(
-                    colors: [
-                        Violet._400.opacity(0.08),
-                        Color.clear
-                    ],
-                    center: UnitPoint(x: 0.7, y: 1.0),
-                    startRadius: 10,
-                    endRadius: 250
-                )
-            }
-            .ignoresSafeArea()
-        )
+        .padding(.horizontal, VSpacing.xxl)
+        .padding(.bottom, VSpacing.xxl)
+        .opacity(showButtons ? 1 : 0)
+        .offset(y: showButtons ? 0 : 12)
+        .disabled(isAdvancing)
         .onAppear {
-            withAnimation(.easeOut(duration: 0.5).delay(0.2)) {
-                showIcon = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.8)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showSubtext = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(1.1)) {
+            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
                 showButtons = true
             }
         }
@@ -154,7 +96,16 @@ struct WakeUpStepView: View {
 #Preview {
     ZStack {
         VColor.background.ignoresSafeArea()
-        WakeUpStepView(state: OnboardingState())
+        VStack(spacing: 0) {
+            Spacer()
+            Image("VellyLogo")
+                .resizable()
+                .interpolation(.none)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 128, height: 128)
+                .padding(.bottom, VSpacing.xxl)
+            WakeUpStepView(state: OnboardingState())
+        }
     }
     .frame(width: 460, height: 520)
 }


### PR DESCRIPTION
## Summary
- Lifted the shared icon and gradient background into `OnboardingFlowView` as persistent elements
- Refactored all 4 step views (WakeUp, APIKey, ModelSelection, FnKey) to be content-only — they no longer render their own icon or background
- Only the step content (title + subtitle + form) transitions via `.id(state.currentStep)`; the icon stays in place
- Shortened animation delays since there's no icon fade-in to wait for

## Test plan
- [ ] Reset onboarding and walk through all steps — icon should stay perfectly still across transitions
- [ ] Verify back navigation works smoothly (icon doesn't flicker)
- [ ] Check that title/subtitle/content still animate in with staggered delays on each step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
