### PR TITLE
docs: fix default permissions mode references to match strict default

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1533,7 +1533,7 @@ graph TB
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
-    NO_MATCH -->|"legacy mode"| RISK_FALLBACK{"Risk level?"}
+    NO_MATCH -->|"legacy mode (non-default)"| RISK_FALLBACK{"Risk level?"}
     RISK_FALLBACK -->|"Low"| AUTO_LOW["decision: allow<br/>Low risk auto-allow"]
     RISK_FALLBACK -->|"Medium"| PROMPT_MED["decision: prompt"]
     RISK_FALLBACK -->|"High"| PROMPT_HIGH2["decision: prompt"]
@@ -1543,7 +1543,7 @@ graph TB
 
 The `permissions.mode` config option (`legacy` or `strict`) controls the default behavior when no trust rule matches a tool invocation.
 
-| Behavior | Legacy mode (default) | Strict mode |
+| Behavior | Legacy mode | Strict mode (default) |
 |---|---|---|
 | Low-risk tools with no matching rule | Auto-allowed | Prompted |
 | Medium-risk tools with no matching rule | Prompted | Prompted |

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ All three tools require explicit user approval before execution (Risk Level = Hi
 The assistant uses a permission system to control which tool actions the agent can execute without explicit user approval. Permission behavior is configured via `permissions.mode`:
 
 ```bash
-# Default — low-risk tools auto-allowed, medium/high prompted
-vellum config set permissions.mode '"legacy"'
-
-# Strict — ALL tools require an explicit trust rule, no implicit auto-allow
+# Default — ALL tools require an explicit trust rule, no implicit auto-allow
 vellum config set permissions.mode '"strict"'
+
+# Legacy — low-risk tools auto-allowed, medium/high prompted
+vellum config set permissions.mode '"legacy"'
 ```
 
 ### Trust rules


### PR DESCRIPTION
## Summary
- **P3 fix**: README.md and ARCHITECTURE.md still described the default as legacy after PR #3618 flipped it to strict
- Updated both files to correctly indicate strict mode is the default

## Test plan
- [x] README.md shows strict as default
- [x] ARCHITECTURE.md table header shows "Strict mode (default)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
