### PR TITLE
fix: use -f for string threadId in gh-review GraphQL queries

### DIFF
--- a/.claude/gh-review
+++ b/.claude/gh-review
@@ -80,7 +80,7 @@ cmd_resolve_threads() {
           body: $body
         }) { comment { id } }
       }' \
-      -F threadId="$thread_id" \
+      -f threadId="$thread_id" \
       -f body="$message" > /dev/null
 
     echo "==> Resolving thread $thread_id..."
@@ -90,7 +90,7 @@ cmd_resolve_threads() {
           threadId: $threadId
         }) { thread { isResolved } }
       }' \
-      -F threadId="$thread_id" > /dev/null
+      -f threadId="$thread_id" > /dev/null
 
   done <<< "$thread_ids"
 


### PR DESCRIPTION
Changes -F to -f for threadId parameters in gh-review GraphQL mutations. ID! is a string type and -F applies unwanted type coercion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
