### PR TITLE
fix: lower skill mutation ask-rule priority so user rules take precedence

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2141,6 +2141,49 @@ describe('Permission Checker', () => {
     });
   });
 
+  // ── user override of skill mutation default ask rules (priority fix) ──
+  // Regression tests: user-created allow rules (priority 100) must override
+  // the default ask rules for skill-source mutations (priority 50).
+
+  describe('user override of skill mutation default ask rules', () => {
+    function ensureSkillsDir(): void {
+      mkdirSync(join(checkerTestDir, 'skills'), { recursive: true });
+    }
+
+    test('user allowHighRisk rule at priority 100 overrides default ask for skill source writes', async () => {
+      ensureSkillsDir();
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'executor.ts');
+      // Simulate the rule the prompt UX creates: priority 100, allowHighRisk: true
+      addRule('file_write', `file_write:${checkerTestDir}/skills/**`, 'everywhere', 'allow', 100, { allowHighRisk: true });
+      const result = await check('file_write', { path: skillPath }, '/tmp');
+      // The user's allow rule (priority 100) must win over the default ask (priority 50),
+      // and allowHighRisk must auto-allow the High-risk skill mutation.
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('high-risk trust rule');
+      expect(result.matchedRule!.allowHighRisk).toBe(true);
+    });
+
+    test('user allow rule without allowHighRisk at priority 100 overrides default ask but high-risk still prompts', async () => {
+      ensureSkillsDir();
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'executor.ts');
+      // User allow rule without allowHighRisk — priority 100 still beats default ask at 50
+      addRule('file_write', `file_write:${checkerTestDir}/skills/**`, 'everywhere', 'allow', 100);
+      const result = await check('file_write', { path: skillPath }, '/tmp');
+      // The user rule wins over default ask, but skill mutations are High risk,
+      // so the allow rule without allowHighRisk falls through to high-risk prompt.
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('High risk');
+    });
+
+    test('without user rule, default ask still prompts for skill source mutations', async () => {
+      ensureSkillsDir();
+      const skillPath = join(checkerTestDir, 'skills', 'my-skill', 'executor.ts');
+      // No user rule — the default ask rule (priority 50) is the only match
+      const result = await check('file_write', { path: skillPath }, '/tmp');
+      expect(result.decision).toBe('prompt');
+    });
+  });
+
   // ── canonical file command candidates (PR 27) ─────────────────
 
   describe('canonical file command candidates (PR 27)', () => {

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -892,14 +892,14 @@ describe('Trust Store', () => {
       expect(managed).toBeDefined();
       expect(managed!.tool).toBe('file_write');
       expect(managed!.decision).toBe('ask');
-      expect(managed!.priority).toBe(1000);
+      expect(managed!.priority).toBe(50);
       expect(managed!.pattern).toContain('workspace/skills/**');
 
       const bundled = rules.find((r) => r.id === 'default:ask-file_write-bundled-skills');
       expect(bundled).toBeDefined();
       expect(bundled!.tool).toBe('file_write');
       expect(bundled!.decision).toBe('ask');
-      expect(bundled!.priority).toBe(1000);
+      expect(bundled!.priority).toBe(50);
     });
 
     test('default rules include ask rules for file_edit on skill source paths', () => {
@@ -908,14 +908,14 @@ describe('Trust Store', () => {
       expect(managed).toBeDefined();
       expect(managed!.tool).toBe('file_edit');
       expect(managed!.decision).toBe('ask');
-      expect(managed!.priority).toBe(1000);
+      expect(managed!.priority).toBe(50);
       expect(managed!.pattern).toContain('workspace/skills/**');
 
       const bundled = rules.find((r) => r.id === 'default:ask-file_edit-bundled-skills');
       expect(bundled).toBeDefined();
       expect(bundled!.tool).toBe('file_edit');
       expect(bundled!.decision).toBe('ask');
-      expect(bundled!.priority).toBe(1000);
+      expect(bundled!.priority).toBe(50);
     });
 
     test('default rules include ask rules for host_file_write on skill source paths', () => {
@@ -924,14 +924,14 @@ describe('Trust Store', () => {
       expect(managed).toBeDefined();
       expect(managed!.tool).toBe('host_file_write');
       expect(managed!.decision).toBe('ask');
-      expect(managed!.priority).toBe(1000);
+      expect(managed!.priority).toBe(50);
       expect(managed!.pattern).toContain('workspace/skills/**');
 
       const bundled = rules.find((r) => r.id === 'default:ask-host_file_write-bundled-skills');
       expect(bundled).toBeDefined();
       expect(bundled!.tool).toBe('host_file_write');
       expect(bundled!.decision).toBe('ask');
-      expect(bundled!.priority).toBe(1000);
+      expect(bundled!.priority).toBe(50);
     });
 
     test('default rules include ask rules for host_file_edit on skill source paths', () => {
@@ -940,14 +940,14 @@ describe('Trust Store', () => {
       expect(managed).toBeDefined();
       expect(managed!.tool).toBe('host_file_edit');
       expect(managed!.decision).toBe('ask');
-      expect(managed!.priority).toBe(1000);
+      expect(managed!.priority).toBe(50);
       expect(managed!.pattern).toContain('workspace/skills/**');
 
       const bundled = rules.find((r) => r.id === 'default:ask-host_file_edit-bundled-skills');
       expect(bundled).toBeDefined();
       expect(bundled!.tool).toBe('host_file_edit');
       expect(bundled!.decision).toBe('ask');
-      expect(bundled!.priority).toBe(1000);
+      expect(bundled!.priority).toBe(50);
     });
 
     test('no default ask rules exist for file_read on skill source paths', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -141,7 +141,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
       pattern: `${tool}:${dir}/**`,
       scope: 'everywhere',
       decision: 'ask' as const,
-      priority: 1000,
+      priority: 50,
     })),
     ...HOST_SKILL_MUTATION_TOOLS.map((tool) => ({
       id: `default:ask-${tool}-${label}-skills`,
@@ -149,7 +149,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
       pattern: `${tool}:${dir}/**`,
       scope: 'everywhere',
       decision: 'ask' as const,
-      priority: 1000,
+      priority: 50,
     })),
   ]);
 


### PR DESCRIPTION
## Summary
- Lowers the priority of default skill-source mutation ask rules from 1000 to 50
- This ensures user-defined allow rules (priority 100) take precedence over the built-in ask rules
- Previously, the high priority (1000) meant user allowlist entries for skill-source mutations were effectively ignored

## Test plan
- [x] Existing permission checker tests pass (398 tests, 0 failures)
- [x] Verified user rules at priority 100 now correctly override default ask rules at priority 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
