### PR TITLE
fix: thread configured extra skill dirs into path classification and default rules

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -32,8 +32,9 @@ mock.module('../util/logger.js', () => ({
 
 // Mutable config object so tests can switch permissions.mode between
 // 'legacy' and 'strict' without re-registering the mock.
-const testConfig = {
+const testConfig: Record<string, any> = {
   permissions: { mode: 'legacy' as 'legacy' | 'strict' },
+  skills: { load: { extraDirs: [] as string[] } },
 };
 
 mock.module('../config/loader.js', () => ({
@@ -50,6 +51,7 @@ mock.module('../config/loader.js', () => ({
 import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { RiskLevel, type PolicyContext } from '../permissions/types.js';
 import { addRule, clearCache, findHighestPriorityRule } from '../permissions/trust-store.js';
+import { getDefaultRuleTemplates } from '../permissions/defaults.js';
 import { registerTool } from '../tools/registry.js';
 import type { Tool } from '../tools/types.js';
 
@@ -95,7 +97,8 @@ describe('Permission Checker', () => {
     // Reset trust-store state between tests
     clearCache();
     // Reset permissions mode to legacy so existing tests are not affected
-    testConfig.permissions.mode = 'legacy';
+    testConfig.permissions = { mode: 'legacy' };
+    testConfig.skills = { load: { extraDirs: [] } };
     try { rmSync(join(checkerTestDir, 'protected', 'trust.json')); } catch { /* may not exist */ }
     try { rmSync(join(checkerTestDir, 'skills'), { recursive: true, force: true }); } catch { /* may not exist */ }
   });
@@ -3303,6 +3306,94 @@ describe('Permission Checker', () => {
         expect(result.decision).toBe('allow');
         expect(result.matchedRule!.pattern).toBe('skill_load:*');
       });
+    });
+  });
+
+  // ── extra skill dirs coverage ─────────────────────────────────────
+  // Files in user-configured extra skill directories must be treated as
+  // skill source paths (High risk escalation) and receive default ask
+  // rules, just like managed and bundled dirs.
+
+  describe('extra skill dirs coverage', () => {
+    const extraSkillDir = join(checkerTestDir, 'extra-skills');
+
+    function ensureExtraDir(): void {
+      mkdirSync(extraSkillDir, { recursive: true });
+    }
+
+    // Temporarily wire up the extra dir in the mock config, then restore.
+    function withExtraDirs(fn: () => void | Promise<void>): () => Promise<void> {
+      return async () => {
+        ensureExtraDir();
+        testConfig.skills = { load: { extraDirs: [extraSkillDir] } };
+        try {
+          await fn();
+        } finally {
+          testConfig.skills = { load: { extraDirs: [] } };
+        }
+      };
+    }
+
+    test(
+      'file_write to extra skill dir is High risk',
+      withExtraDirs(async () => {
+        const risk = await classifyRisk('file_write', { path: join(extraSkillDir, 'my-skill', 'foo.ts') }, '/tmp');
+        expect(risk).toBe(RiskLevel.High);
+      }),
+    );
+
+    test(
+      'file_edit of file in extra skill dir is High risk',
+      withExtraDirs(async () => {
+        const risk = await classifyRisk('file_edit', { path: join(extraSkillDir, 'my-skill', 'SKILL.md') }, '/tmp');
+        expect(risk).toBe(RiskLevel.High);
+      }),
+    );
+
+    test(
+      'host_file_write to extra skill dir is High risk',
+      withExtraDirs(async () => {
+        const risk = await classifyRisk('host_file_write', { path: join(extraSkillDir, 'my-skill', 'executor.ts') });
+        expect(risk).toBe(RiskLevel.High);
+      }),
+    );
+
+    test(
+      'host_file_edit of file in extra skill dir is High risk',
+      withExtraDirs(async () => {
+        const risk = await classifyRisk('host_file_edit', { path: join(extraSkillDir, 'my-skill', 'SKILL.md') });
+        expect(risk).toBe(RiskLevel.High);
+      }),
+    );
+
+    test(
+      'file_write to non-extra dir remains Medium when extra dirs are configured',
+      withExtraDirs(async () => {
+        const risk = await classifyRisk('file_write', { path: '/tmp/unrelated.txt' }, '/tmp');
+        expect(risk).toBe(RiskLevel.Medium);
+      }),
+    );
+
+    test(
+      'getDefaultRuleTemplates includes rules for extra skill dirs',
+      withExtraDirs(() => {
+        const templates = getDefaultRuleTemplates();
+        const extraRules = templates.filter((t) => t.id.includes('extra-0'));
+        // Should have rules for file_write, file_edit, host_file_write, host_file_edit
+        expect(extraRules.length).toBe(4);
+        for (const rule of extraRules) {
+          expect(rule.decision).toBe('ask');
+          expect(rule.pattern).toContain(extraSkillDir);
+        }
+      }),
+    );
+
+    test('getDefaultRuleTemplates has no extra rules when extraDirs is empty', () => {
+      // Default testConfig has no skills property → getConfig returns default
+      // with extraDirs: []
+      const templates = getDefaultRuleTemplates();
+      const extraRules = templates.filter((t) => t.id.includes('extra-'));
+      expect(extraRules.length).toBe(0);
     });
   });
 });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -235,7 +235,7 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'file_read') return RiskLevel.Low;
   if (toolName === 'file_write' || toolName === 'file_edit') {
     const filePath = getStringField(input, 'path', 'file_path');
-    if (filePath && isSkillSourcePath(resolve(workingDir ?? process.cwd(), filePath))) {
+    if (filePath && isSkillSourcePath(resolve(workingDir ?? process.cwd(), filePath), getConfig().skills.load.extraDirs)) {
       return RiskLevel.High;
     }
     return RiskLevel.Medium;
@@ -256,7 +256,7 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   // but writing to skill source code is a privilege-escalation vector.
   if (toolName === 'host_file_write' || toolName === 'host_file_edit') {
     const filePath = getStringField(input, 'path', 'file_path');
-    if (filePath && isSkillSourcePath(resolve(filePath))) {
+    if (filePath && isSkillSourcePath(resolve(filePath), getConfig().skills.load.extraDirs)) {
       return RiskLevel.High;
     }
     // Fall through to the tool registry default (Medium) below.

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { getRootDir } from '../util/platform.js';
 import { getBundledSkillsDir } from '../config/skills.js';
+import { getConfig } from '../config/loader.js';
 
 export interface DefaultRuleTemplate {
   id: string;
@@ -129,10 +130,17 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   const bundledSkillsDir = getBundledSkillsDir().replaceAll('\\', '/');
   const SKILL_MUTATION_TOOLS = ['file_write', 'file_edit'] as const;
   const HOST_SKILL_MUTATION_TOOLS = ['host_file_write', 'host_file_edit'] as const;
-  const skillDirs = [
+  const skillDirs: { dir: string; label: string }[] = [
     { dir: managedSkillsDir, label: 'managed' },
     { dir: bundledSkillsDir, label: 'bundled' },
   ];
+
+  // Append any user-configured extra skill directories so they get the
+  // same default ask rules as managed and bundled dirs.
+  const extraDirs = getConfig().skills.load.extraDirs;
+  for (let i = 0; i < extraDirs.length; i++) {
+    skillDirs.push({ dir: extraDirs[i].replaceAll('\\', '/'), label: `extra-${i}` });
+  }
 
   const skillSourceMutationRules = skillDirs.flatMap(({ dir, label }) => [
     ...SKILL_MUTATION_TOOLS.map((tool) => ({


### PR DESCRIPTION
## Summary
- Passes `getConfig().skills.load.extraDirs` to `isSkillSourcePath()` calls in `checker.ts` so files in extra skill directories are correctly escalated to High risk
- Generates default ask rules in `defaults.ts` for each configured extra skill directory (in addition to managed and bundled dirs)
- Adds 7 regression tests covering extra dir classification and default rule generation

## Test plan
- [x] checker.test.ts: 276 tests pass (0 failures)
- [x] trust-store.test.ts: 129 tests pass (0 failures)
- [x] Verified file_write/file_edit/host_file_write/host_file_edit to extra skill dirs return RiskLevel.High
- [x] Verified getDefaultRuleTemplates() includes rules for extra dirs when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
