### PR TITLE
fix: correct bot username matching in check-pr-reviews script

### DIFF
--- a/.claude/check-pr-reviews
+++ b/.claude/check-pr-reviews
@@ -90,14 +90,14 @@ AGE_SECONDS=$((NOW - CREATED_EPOCH))
 CODEX_PLUS_ONE=$(jq '[.[] | select(.user == "chatgpt-codex-connector[bot]" and .content == "+1")] | length > 0' "$TMPDIR_WORK/reactions.json")
 
 # Get codex reviews
-CODEX_REVIEWS=$(jq '[.reviews[] | select(.author.login == "chatgpt-codex-connector[bot]") | {body: .body, state: .state}]' "$TMPDIR_WORK/pr.json")
+CODEX_REVIEWS=$(jq '[.reviews[] | select(.author.login == "chatgpt-codex-connector") | {body: .body, state: .state}]' "$TMPDIR_WORK/pr.json")
 
 # Get codex inline comments
 CODEX_INLINE=$(jq '[.[] | select(.user == "chatgpt-codex-connector[bot]")]' "$TMPDIR_WORK/inline.json")
 
 # Check for rate limiting in most recent comment
 CODEX_RATE_LIMITED=$(jq '
-  [.comments[] | select(.author.login == "chatgpt-codex-connector[bot]")]
+  [.comments[] | select(.author.login == "chatgpt-codex-connector")]
   | sort_by(.createdAt)
   | last
   | if . == null then false
@@ -123,7 +123,7 @@ fi
 # --- Classify Devin ---
 
 # Get devin reviews
-DEVIN_REVIEWS=$(jq '[.reviews[] | select(.author.login == "devin-ai-integration[bot]") | {body: .body, state: .state}]' "$TMPDIR_WORK/pr.json")
+DEVIN_REVIEWS=$(jq '[.reviews[] | select(.author.login == "devin-ai-integration") | {body: .body, state: .state}]' "$TMPDIR_WORK/pr.json")
 
 # Get devin inline comments
 DEVIN_INLINE=$(jq '[.[] | select(.user == "devin-ai-integration[bot]")]' "$TMPDIR_WORK/inline.json")


### PR DESCRIPTION
## Summary
- `gh pr view --json` returns `author.login` without the `[bot]` suffix, but the `jq` filters in `check-pr-reviews` expected it — so reviews from `pr.json` never matched
- Removed `[bot]` from the three selectors that filter against `pr.json` data (lines 93, 100, 126)
- Left `[bot]` intact for selectors against `gh api` data (`reactions.json`, `inline.json`) which do include the suffix
- This was causing all 57 tracked PRs to show Devin as "Pending" despite Devin having reviewed them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
