### PR TITLE
fix: suppress thinking indicator for queued messages

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -312,7 +312,11 @@ public final class ChatViewModel: ObservableObject {
         }
 
         isSending = true
-        isThinking = true
+        // Only show "Thinking" for the primary send. Queued messages will
+        // set isThinking = true when they are dequeued for processing.
+        if queuedMessageId == nil {
+            isThinking = true
+        }
 
         // Make sure we're listening
         if messageLoopTask == nil {


### PR DESCRIPTION
## Summary
- When a user sends a follow-up message while a tool permission dialog is pending, the message correctly gets queued — but `isThinking` was set to `true` immediately, showing a spurious "Thinking" spinner
- Now only sets `isThinking = true` for primary (non-queued) sends; the `messageDequeued` handler already sets it at the right time when the daemon actually starts processing

## Test plan
- [ ] Send a message that triggers a tool permission dialog
- [ ] While the dialog is showing, send a follow-up message
- [ ] Verify the follow-up shows "Queued" status without a "Thinking" spinner
- [ ] Respond to the permission dialog and verify the queued message processes normally with the thinking indicator appearing at the correct time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
