### PR TITLE
fix: resolve symlinked ancestors in normalizeDirPath for non-existent extra roots

### DIFF
--- a/assistant/src/__tests__/path-classifier.test.ts
+++ b/assistant/src/__tests__/path-classifier.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, symlinkSync, realpathSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  normalizeDirPath,
+  normalizeFilePath,
+  isSkillSourcePath,
+} from '../skills/path-classifier.js';
+
+describe('normalizeDirPath symlink resolution for non-existent paths', () => {
+  let realDir: string;
+  let symlinkDir: string;
+
+  beforeAll(() => {
+    // Create a real temp directory and a symlink pointing to it.
+    // Resolve realDir through realpathSync because tmpdir() may itself
+    // traverse symlinks (e.g. /var → /private/var on macOS).
+    const raw = mkdtempSync(join(tmpdir(), 'path-classifier-real-'));
+    realDir = realpathSync(raw);
+    symlinkDir = realDir + '-link';
+    symlinkSync(realDir, symlinkDir);
+  });
+
+  afterAll(() => {
+    rmSync(symlinkDir);
+    rmSync(realDir, { recursive: true });
+  });
+
+  test('resolves symlink ancestor when target dir does not exist', () => {
+    const nonExistent = join(symlinkDir, 'nonexistent');
+    const normalized = normalizeDirPath(nonExistent);
+
+    // Should resolve through the symlink to the real path
+    expect(normalized.startsWith(realDir)).toBe(true);
+    expect(normalized).toContain('nonexistent');
+    expect(normalized.endsWith('/')).toBe(true);
+  });
+
+  test('normalizeDirPath and normalizeFilePath agree on symlinked prefix', () => {
+    const nonExistentDir = join(symlinkDir, 'nonexistent');
+    const nonExistentFile = join(symlinkDir, 'nonexistent', 'file.ts');
+
+    const dirNorm = normalizeDirPath(nonExistentDir);
+    const fileNorm = normalizeFilePath(nonExistentFile);
+
+    // Both should resolve through the symlink, so file path starts with dir path
+    expect(fileNorm.startsWith(dirNorm)).toBe(true);
+  });
+
+  test('isSkillSourcePath matches file under symlinked extra root', () => {
+    const extraRoot = join(symlinkDir, 'nonexistent');
+    const filePath = join(symlinkDir, 'nonexistent', 'my-skill', 'tool.ts');
+
+    expect(isSkillSourcePath(filePath, [extraRoot])).toBe(true);
+  });
+
+  test('normalizeDirPath resolves existing path through symlink', () => {
+    // The symlink dir itself exists, so this should resolve via realpathSync
+    const normalized = normalizeDirPath(symlinkDir);
+    expect(normalized.startsWith(realDir)).toBe(true);
+    expect(normalized.endsWith('/')).toBe(true);
+  });
+
+  test('normalizeDirPath handles deeply nested non-existent paths', () => {
+    const deep = join(symlinkDir, 'a', 'b', 'c', 'd');
+    const normalized = normalizeDirPath(deep);
+
+    expect(normalized.startsWith(realDir)).toBe(true);
+    expect(normalized).toContain(join('a', 'b', 'c', 'd'));
+    expect(normalized.endsWith('/')).toBe(true);
+  });
+});

--- a/assistant/src/skills/path-classifier.ts
+++ b/assistant/src/skills/path-classifier.ts
@@ -28,8 +28,31 @@ export function getBundledSkillsRoot(): string {
  * Otherwise resolve() is used for pure lexical normalization.
  */
 export function normalizeDirPath(dirPath: string): string {
-  const resolved = existsSync(dirPath) ? realpathSync(dirPath) : resolve(dirPath);
-  const normalized = normalize(resolved);
+  // If the path exists, resolve symlinks directly
+  if (existsSync(dirPath)) {
+    const resolved = realpathSync(dirPath);
+    const normalized = normalize(resolved);
+    return normalized.endsWith(sep) ? normalized : normalized + sep;
+  }
+
+  // Walk up to find the nearest existing ancestor and resolve through it
+  // (mirrors normalizeFilePath behavior for consistency)
+  const absPath = resolve(dirPath);
+  const segments: string[] = [];
+  let current = absPath;
+  while (current !== dirname(current)) {
+    if (existsSync(current)) {
+      const realBase = realpathSync(current);
+      const tail = segments.reduceRight((acc, seg) => acc + sep + seg, '');
+      const full = normalize(realBase + tail);
+      return full.endsWith(sep) ? full : full + sep;
+    }
+    segments.push(basename(current));
+    current = dirname(current);
+  }
+
+  // Nothing on the path exists — fall back to pure lexical resolution
+  const normalized = normalize(absPath);
   return normalized.endsWith(sep) ? normalized : normalized + sep;
 }
 


### PR DESCRIPTION
## Summary
- Fixes `normalizeDirPath()` to walk up ancestors and resolve symlinks even when the target directory doesn't exist yet
- On macOS `/tmp` → `/private/tmp`, so a non-existent extra root like `/tmp/custom-skill-root` was lexically normalized to `/tmp/custom-skill-root/` while `normalizeFilePath()` resolved files inside it to `/private/tmp/custom-skill-root/...` — the prefix check in `isSkillSourcePath()` failed
- Now both functions resolve through the same symlinked ancestors, so `isSkillSourcePath()` correctly identifies files under configured extra roots

## Test plan
- [x] 5 new path-classifier tests (symlink ancestor resolution, prefix agreement, isSkillSourcePath end-to-end)
- [x] checker.test.ts: 276 pass
- [x] trust-store.test.ts: 129 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
