### PR TITLE
fix: avoid following symlinks in skill version hash (#3570)

### DIFF
--- a/assistant/src/__tests__/skill-version-hash.test.ts
+++ b/assistant/src/__tests__/skill-version-hash.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
@@ -110,5 +110,29 @@ describe('computeSkillVersionHash', () => {
     const dir = makeTempSkill();
     const hash = computeSkillVersionHash(dir);
     expect(hash).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+
+  test('skips symlinked directories to avoid loops', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'SKILL.md'), '# Skill\n');
+    const hash1 = computeSkillVersionHash(dir);
+
+    // Create a symlink that points back to the skill dir (would loop with statSync)
+    symlinkSync(dir, join(dir, 'loop'));
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  test('skips symlinked files', () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, 'real.ts'), 'export {};');
+    const hash1 = computeSkillVersionHash(dir);
+
+    // Add a symlink to an existing file — should be ignored
+    symlinkSync(join(dir, 'real.ts'), join(dir, 'linked.ts'));
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).toBe(hash2);
   });
 });

--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, lstatSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { createHash } from 'node:crypto';
 
@@ -32,10 +32,11 @@ function collectFiles(dir: string, base: string): string[] {
     const full = join(dir, name);
     let stat;
     try {
-      stat = statSync(full);
+      stat = lstatSync(full);
     } catch {
       continue;
     }
+    if (stat.isSymbolicLink()) continue;
     if (stat.isDirectory()) {
       entries.push(...collectFiles(full, base));
     } else if (stat.isFile()) {


### PR DESCRIPTION
Address Codex review feedback on #3570: replace statSync with lstatSync in version-hash.ts to prevent recursive traversal of symlinked directories during hash computation. Symlinks (both files and directories) are now skipped entirely. Added two tests verifying symlink loop and symlink file handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
