### PR TITLE
fix: constrain principalKind type and improve checker tests (#3568)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1207,19 +1207,28 @@ describe('Permission Checker', () => {
   // ── principal types (PR 3) ──────────────────────────────────
 
   describe('principal types (PR 3)', () => {
-    test('ToolPrincipal type exists and is importable', async () => {
-      // ToolPrincipalKind is a type alias, not a runtime value,
-      // so we just verify the module imports without error.
-      const types = await import('../permissions/types.js');
-      expect(types).toBeDefined();
+    test('ToolPrincipal accepts valid principal objects', () => {
+      // Type assertions verified at compile time — if ToolPrincipal or
+      // PolicyContext change shape, these assignments will fail tsc.
+      const corePrincipal: import('../permissions/types.js').ToolPrincipal = { kind: 'core' };
+      const skillPrincipal: import('../permissions/types.js').ToolPrincipal = {
+        kind: 'skill',
+        id: 'my-skill',
+        version: 'abc123',
+      };
+      expect(corePrincipal.kind).toBe('core');
+      expect(skillPrincipal.kind).toBe('skill');
+      expect(skillPrincipal.id).toBe('my-skill');
+      expect(skillPrincipal.version).toBe('abc123');
     });
 
-    test('PolicyContext type is available', async () => {
-      // Verify type-level import works — RiskLevel is the only
-      // runtime enum in the module, so its presence confirms
-      // the module loaded (and its new types compiled) correctly.
-      const types = await import('../permissions/types.js');
-      expect(types.RiskLevel).toBeDefined();
+    test('PolicyContext carries principal and executionTarget', () => {
+      const ctx: import('../permissions/types.js').PolicyContext = {
+        principal: { kind: 'skill', id: 'test-skill' },
+        executionTarget: 'sandbox',
+      };
+      expect(ctx.principal?.kind).toBe('skill');
+      expect(ctx.executionTarget).toBe('sandbox');
     });
   });
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,4 +1,4 @@
-import type { RiskLevel, AllowlistOption, ScopeOption } from '../permissions/types.js';
+import type { RiskLevel, AllowlistOption, ScopeOption, ToolPrincipalKind } from '../permissions/types.js';
 import type { ToolDefinition, ContentBlock } from '../providers/types.js';
 import type { SecretPromptResult } from '../permissions/secret-prompter.js';
 
@@ -13,7 +13,7 @@ interface ToolLifecycleEventBase {
   requestId?: string;
   executionTarget?: ExecutionTarget;
   /** Security principal kind (e.g. 'core' or 'skill'). */
-  principalKind?: string;
+  principalKind?: ToolPrincipalKind;
   /** Security principal ID (skill ID when principalKind is 'skill'). */
   principalId?: string;
   /** Content-hash of the principal's source at invocation time. */


### PR DESCRIPTION
Address Codex review feedback on #3568: use ToolPrincipalKind union instead of string for principalKind field, and replace runtime-only import checks with meaningful type assertions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
