### PR TITLE
fix: handle hash resolver failures in skill-script-runner (#3581)

### DIFF
--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -222,6 +222,21 @@ describe('runSkillToolScript — host hash guard', () => {
     expect(receivedDir!.endsWith('/')).toBe(true);
   });
 
+  test('returns structured error when hash resolver throws', async () => {
+    const resolver = (_dir: string): string => {
+      throw new Error('disk read failed');
+    };
+
+    const result = await runSkillToolScript(tempDir, 'success.ts', {}, makeContext(), {
+      expectedSkillVersionHash: 'v1:some-hash',
+      skillDirHashResolver: resolver,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Failed to compute skill version hash');
+    expect(result.content).toContain('disk read failed');
+  });
+
   test('RunSkillToolScriptOptions type accepts all fields', () => {
     const options: RunSkillToolScriptOptions = {
       target: 'host',

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -47,7 +47,16 @@ export async function runSkillToolScript(
   // Block execution if the skill has been modified since approval.
   if (options?.expectedSkillVersionHash) {
     const resolver = options.skillDirHashResolver ?? computeSkillVersionHash;
-    const currentHash = resolver(resolvedSkillDir);
+    let currentHash: string;
+    try {
+      currentHash = resolver(resolvedSkillDir);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: `Failed to compute skill version hash for "${resolvedSkillDir}": ${message}`,
+        isError: true,
+      };
+    }
     if (currentHash !== options.expectedSkillVersionHash) {
       return {
         content: `Skill version mismatch: expected ${options.expectedSkillVersionHash} but current is ${currentHash}. The skill has been modified since it was approved. Please reload the skill to re-approve.`,


### PR DESCRIPTION
Address Codex review feedback on #3581: wrap the hash resolver call in try/catch in runSkillToolScript so failures return a structured ToolExecutionResult instead of unhandled promise rejections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
