### PR TITLE
fix: handle hash resolver failures in sandbox-runner (#3588)

### DIFF
--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -77,11 +77,19 @@ export async function runSkillToolScriptSandbox(
 
   // Block execution if the skill has been modified since approval.
   if (options?.expectedSkillVersionHash) {
-    const resolver = options.skillDirHashResolver ?? computeSkillVersionHash;
-    const currentHash = resolver(resolvedSkillDir);
-    if (currentHash !== options.expectedSkillVersionHash) {
+    try {
+      const resolver = options.skillDirHashResolver ?? computeSkillVersionHash;
+      const currentHash = resolver(resolvedSkillDir);
+      if (currentHash !== options.expectedSkillVersionHash) {
+        return {
+          content: `Skill version mismatch: expected ${options.expectedSkillVersionHash} but current is ${currentHash}. The skill has been modified since it was approved. Please reload the skill to re-approve.`,
+          isError: true,
+        };
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       return {
-        content: `Skill version mismatch: expected ${options.expectedSkillVersionHash} but current is ${currentHash}. The skill has been modified since it was approved. Please reload the skill to re-approve.`,
+        content: `Failed to verify skill version hash for "${executorPath}": ${message}`,
         isError: true,
       };
     }


### PR DESCRIPTION
Address Codex review feedback on #3588: wrap the hash resolver call in try/catch in sandbox-runner so failures return a structured ToolExecutionResult instead of unhandled promise rejections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
