### PR TITLE
fix: prioritize manifest executionTarget over prefix heuristics (#3574)

### DIFF
--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -87,6 +87,24 @@ mock.module('../tools/registry.js', () => ({
         },
       };
     }
+    // Skill tool whose name starts with host_ but manifest says sandbox —
+    // verifies manifest takes priority over prefix heuristics.
+    if (name === 'host_skill_sandboxed') {
+      return {
+        name,
+        description: 'skill tool with host_ prefix but sandbox target',
+        category: 'skill',
+        defaultRiskLevel: 'low',
+        origin: 'skill' as const,
+        ownerSkillId: 'test-skill',
+        executionTarget: 'sandbox' as const,
+        getDefinition: () => ({}),
+        execute: async () => {
+          if (toolThrow) throw toolThrow;
+          return fakeToolResult;
+        },
+      };
+    }
     return {
       name,
       description: 'test tool',
@@ -331,6 +349,21 @@ describe('ToolExecutor lifecycle events', () => {
     const executed = events[1];
     if (executed.type !== 'executed') throw new Error('Expected executed event');
     expect(executed.executionTarget).toBe('host');
+  });
+
+  test('manifest executionTarget takes priority over host_ prefix heuristic', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute('host_skill_sandboxed', { query: 'test' }, makeContext(events));
+
+    expect(events.map((event) => event.type)).toEqual(['start', 'executed']);
+    const startEvent = events[0];
+    if (startEvent.type !== 'start') throw new Error('Expected start event');
+    expect(startEvent.executionTarget).toBe('sandbox');
+    const executed = events[1];
+    if (executed.type !== 'executed') throw new Error('Expected executed event');
+    expect(executed.executionTarget).toBe('sandbox');
   });
 
   test('skill tool with sandbox execution_target resolves to sandbox executionTarget', async () => {

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -565,20 +565,20 @@ function buildPolicyContext(tool: Tool): PolicyContext | undefined {
 }
 
 function resolveExecutionTarget(toolName: string): ExecutionTarget {
-  if (toolName.startsWith('host_') || toolName.startsWith('computer_use_') || toolName === 'request_computer_control') {
-    return 'host';
-  }
   const tool = getTool(toolName);
+  // Manifest-declared execution target is authoritative — check it first so
+  // skill tools with host_/computer_use_ prefixes aren't mis-classified.
+  if (tool?.executionTarget) {
+    return tool.executionTarget;
+  }
   // Check the tool's executionMode metadata — proxy tools run on the connected
   // client (host), not inside the sandbox.
   if (tool?.executionMode === 'proxy') {
     return 'host';
   }
-  // Skill tools carry an explicit execution target from their manifest entry.
-  // Trust the manifest value so lifecycle events accurately reflect where the
-  // tool script actually runs.
-  if (tool?.executionTarget) {
-    return tool.executionTarget;
+  // Prefix heuristics for core tools that don't declare an explicit target.
+  if (toolName.startsWith('host_') || toolName.startsWith('computer_use_') || toolName === 'request_computer_control') {
+    return 'host';
   }
   return 'sandbox';
 }


### PR DESCRIPTION
Address Codex review feedback on #3574: check tool.executionTarget before prefix-based heuristics in resolveExecutionTarget so manifest-declared targets remain authoritative. Adds regression test for a skill tool with host_ prefix but sandbox executionTarget.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
