### PR TITLE
fix: wire always_allow_high_risk through decision resolution (#3598)

### DIFF
--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -58,14 +58,15 @@ export async function approveHostAttachmentRead(
     'host',
   );
 
-  if (response.decision === 'always_allow' && response.selectedPattern && response.selectedScope) {
-    addRule(toolName, response.selectedPattern, response.selectedScope);
+  if ((response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') && response.selectedPattern && response.selectedScope) {
+    addRule(toolName, response.selectedPattern, response.selectedScope, 'allow', 100,
+      response.decision === 'always_allow_high_risk' ? { allowHighRisk: true } : undefined);
   }
   if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
     addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
   }
 
-  return response.decision === 'allow' || response.decision === 'always_allow';
+  return response.decision === 'allow' || response.decision === 'always_allow' || response.decision === 'always_allow_high_risk';
 }
 
 export function formatAttachmentWarnings(warnings: string[]): string | null {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -121,14 +121,15 @@ export function createToolExecutor(
           undefined, undefined,
           ctx.conversationId,
         );
-        if (response.decision === 'always_allow' && response.selectedPattern && response.selectedScope) {
-          addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope);
+        if ((response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') && response.selectedPattern && response.selectedScope) {
+          addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope, 'allow', 100,
+            response.decision === 'always_allow_high_risk' ? { allowHighRisk: true } : undefined);
         }
         if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
           addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope, 'deny');
         }
         return {
-          decision: (response.decision === 'allow' || response.decision === 'always_allow') ? 'allow' as const : 'deny' as const,
+          decision: (response.decision === 'allow' || response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') ? 'allow' as const : 'deny' as const,
         };
       },
     });


### PR DESCRIPTION
Address Codex and Devin review feedback on #3598: handle always_allow_high_risk in session-tool-setup.ts, session-attachments.ts, and executor.ts so the new permission option properly allows execution and persists high-risk trust rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
