### PR TITLE
fix: pass allowHighRisk when persisting trust rules (#3596)

### DIFF
--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -58,14 +58,25 @@ export async function approveHostAttachmentRead(
     'host',
   );
 
-  if (response.decision === 'always_allow' && response.selectedPattern && response.selectedScope) {
-    addRule(toolName, response.selectedPattern, response.selectedScope);
+  if (
+    (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
+    && response.selectedPattern
+    && response.selectedScope
+  ) {
+    addRule(
+      toolName,
+      response.selectedPattern,
+      response.selectedScope,
+      'allow',
+      100,
+      response.decision === 'always_allow_high_risk' ? { allowHighRisk: true } : undefined,
+    );
   }
   if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
     addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
   }
 
-  return response.decision === 'allow' || response.decision === 'always_allow';
+  return response.decision === 'allow' || response.decision === 'always_allow' || response.decision === 'always_allow_high_risk';
 }
 
 export function formatAttachmentWarnings(warnings: string[]): string | null {


### PR DESCRIPTION
Address Codex review feedback on #3596: pass allowHighRisk option to addRule in session-attachments.ts so persisted rules properly reflect high-risk allowlist decisions. Also handle always_allow_high_risk decision in the return value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
