### PR TITLE
fix: require skill versionHash in tool factory (#3575)

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -89,7 +89,7 @@ mock.module('../tools/skills/skill-tool-factory.js', () => ({
     entries: SkillToolManifest['tools'],
     skillId: string,
     _skillDir: string,
-    versionHash?: string,
+    versionHash: string,
   ): Tool[] => {
     return entries.map((entry) => ({
       name: entry.name,

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -69,7 +69,7 @@ afterAll(async () => {
 
 describe('createSkillTool', () => {
   test('produces a tool with correct name, description, and category', () => {
-    const tool = createSkillTool(makeEntry(), 'my-skill', '/skills/my-skill');
+    const tool = createSkillTool(makeEntry(), 'my-skill', '/skills/my-skill', 'v1:test');
 
     expect(tool.name).toBe('test_tool');
     expect(tool.description).toBe('A test tool');
@@ -77,23 +77,17 @@ describe('createSkillTool', () => {
   });
 
   test('sets origin to skill and ownerSkillId', () => {
-    const tool = createSkillTool(makeEntry(), 'weather-skill', '/skills/weather');
+    const tool = createSkillTool(makeEntry(), 'weather-skill', '/skills/weather', 'v1:test');
 
     expect(tool.origin).toBe('skill');
     expect(tool.ownerSkillId).toBe('weather-skill');
   });
 
-  test('sets ownerSkillVersionHash when versionHash is provided', () => {
+  test('sets ownerSkillVersionHash from versionHash', () => {
     const hash = 'v1:abc123def456';
     const tool = createSkillTool(makeEntry(), 'my-skill', '/skills/my-skill', hash);
 
     expect(tool.ownerSkillVersionHash).toBe(hash);
-  });
-
-  test('ownerSkillVersionHash is undefined when no versionHash is provided', () => {
-    const tool = createSkillTool(makeEntry(), 'my-skill', '/skills/my-skill');
-
-    expect(tool.ownerSkillVersionHash).toBeUndefined();
   });
 
   test.each([
@@ -101,7 +95,7 @@ describe('createSkillTool', () => {
     ['medium', RiskLevel.Medium],
     ['high', RiskLevel.High],
   ] as const)('maps risk "%s" to RiskLevel.%s', (risk, expected) => {
-    const tool = createSkillTool(makeEntry({ risk }), 'sk', '/skills/sk');
+    const tool = createSkillTool(makeEntry({ risk }), 'sk', '/skills/sk', 'v1:test');
 
     expect(tool.defaultRiskLevel).toBe(expected);
   });
@@ -120,6 +114,7 @@ describe('createSkillTool', () => {
       makeEntry({ name: 'web_scrape', description: 'Scrape a URL', input_schema: schema }),
       'scraper',
       '/skills/scraper',
+      'v1:test',
     );
 
     const def = tool.getDefinition();
@@ -134,10 +129,12 @@ describe('createSkillTool', () => {
   // ---------------------------------------------------------------------------
 
   test('execute() routes through runSkillToolScript to the executor', async () => {
+    const hash = computeSkillVersionHash(tempDir);
     const tool = createSkillTool(
       makeEntry({ executor: 'echo.ts' }),
       'my-skill',
       tempDir,
+      hash,
     );
     const ctx = makeContext({ workingDir: '/my/project' });
     const input = { query: 'hello' };
@@ -155,6 +152,7 @@ describe('createSkillTool', () => {
       makeEntry({ executor: 'nonexistent.ts' }),
       'my-skill',
       tempDir,
+      'v1:test',
     );
 
     const result = await tool.execute({}, makeContext());
@@ -176,7 +174,7 @@ describe('createSkillToolsFromManifest', () => {
       makeEntry({ name: 'tool_c', description: 'Tool C', risk: 'medium' }),
     ];
 
-    const tools = createSkillToolsFromManifest(entries, 'multi-skill', '/skills/multi');
+    const tools = createSkillToolsFromManifest(entries, 'multi-skill', '/skills/multi', 'v1:test');
 
     expect(tools).toHaveLength(3);
     expect(tools.map(t => t.name)).toEqual(['tool_a', 'tool_b', 'tool_c']);
@@ -193,7 +191,7 @@ describe('createSkillToolsFromManifest', () => {
       makeEntry({ name: 'beta' }),
     ];
 
-    const tools = createSkillToolsFromManifest(entries, 'shared-skill', '/skills/shared');
+    const tools = createSkillToolsFromManifest(entries, 'shared-skill', '/skills/shared', 'v1:test');
 
     for (const tool of tools) {
       expect(tool.origin).toBe('skill');
@@ -202,7 +200,7 @@ describe('createSkillToolsFromManifest', () => {
   });
 
   test('returns an empty array when given no entries', () => {
-    const tools = createSkillToolsFromManifest([], 'empty-skill', '/skills/empty');
+    const tools = createSkillToolsFromManifest([], 'empty-skill', '/skills/empty', 'v1:test');
 
     expect(tools).toEqual([]);
   });
@@ -221,15 +219,6 @@ describe('createSkillToolsFromManifest', () => {
     }
   });
 
-  test('ownerSkillVersionHash is undefined when no versionHash passed to manifest function', () => {
-    const entries: SkillToolEntry[] = [
-      makeEntry({ name: 'gamma' }),
-    ];
-
-    const tools = createSkillToolsFromManifest(entries, 'no-hash-skill', '/skills/no-hash');
-
-    expect(tools[0].ownerSkillVersionHash).toBeUndefined();
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -259,18 +248,4 @@ describe('createSkillTool — version hash plumbing to runner', () => {
     expect(tool.ownerSkillVersionHash).toBe(hash);
   });
 
-  test('execute() works correctly when no versionHash is provided', async () => {
-    const tool = createSkillTool(
-      makeEntry({ executor: 'echo.ts' }),
-      'my-skill',
-      tempDir,
-    );
-    const ctx = makeContext();
-    const input = { query: 'no-hash' };
-
-    const result = await tool.execute(input, ctx);
-
-    expect(result.isError).toBe(false);
-    expect(tool.ownerSkillVersionHash).toBeUndefined();
-  });
 });

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -19,7 +19,7 @@ export function createSkillTool(
   entry: SkillToolEntry,
   skillId: string,
   skillDir: string,
-  versionHash?: string,
+  versionHash: string,
 ): Tool {
   return {
     name: entry.name,
@@ -55,7 +55,7 @@ export function createSkillToolsFromManifest(
   entries: SkillToolEntry[],
   skillId: string,
   skillDir: string,
-  versionHash?: string,
+  versionHash: string,
 ): Tool[] {
   return entries.map(entry => createSkillTool(entry, skillId, skillDir, versionHash));
 }


### PR DESCRIPTION
Address Codex review feedback on #3575: make versionHash required in createSkillToolsFromManifest and wire it through from all callers so ownerSkillVersionHash is always populated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
