### PR TITLE
fix: thread principal info into permission prompts (#3577)

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -120,6 +120,8 @@ export function createToolExecutor(
           scopeOptions,
           undefined, undefined,
           ctx.conversationId,
+          req.executionTarget,
+          req.principal,
         );
         if (response.decision === 'always_allow' && response.selectedPattern && response.selectedScope) {
           addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope);

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -139,6 +139,7 @@ export const claudeCodeTool: Tool = {
           toolName,
           input: toolInput,
           riskLevel: APPROVAL_REQUIRED_TOOLS.has(toolName) ? 'Medium' : 'Low',
+          principal: context.principal,
         });
         if (result.decision === 'allow') {
           return { behavior: 'allow' as const };

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -306,6 +306,13 @@ export class ToolExecutor {
       let execResult: ToolExecutionResult;
       const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
       const toolTimeoutMs = safeTimeoutMs(rawTimeoutSec);
+
+      // Enrich context with principal so tools (e.g. claude_code) can
+      // forward it through sub-tool confirmation requests.
+      const execContext = policyContext?.principal
+        ? { ...context, principal: policyContext.principal }
+        : context;
+
       if (tool.executionMode === 'proxy') {
         if (!context.proxyToolResolver) {
           const msg = `No proxy resolver configured for proxy tool "${name}". This tool requires an external resolver (e.g. a connected macOS client for computer-use tools).`;
@@ -334,7 +341,7 @@ export class ToolExecutor {
         );
       } else {
         execResult = await executeWithTimeout(
-          tool.execute(input, context),
+          tool.execute(input, execContext),
           toolTimeoutMs,
           name,
         );

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -102,12 +102,16 @@ export interface ToolContext {
   proxyToolResolver?: ProxyToolResolver;
   /** When set, only tools in this set may execute. Tools outside the set are blocked with an error. */
   allowedToolNames?: Set<string>;
+  /** Principal that owns this tool invocation (set by executor from tool metadata). */
+  principal?: { kind?: string; id?: string; version?: string };
   /** Request user confirmation for a sub-tool operation (used by claude_code tool). */
   requestConfirmation?: (req: {
     toolName: string;
     input: Record<string, unknown>;
     riskLevel: string;
     executionTarget?: ExecutionTarget;
+    /** Principal that owns the parent tool invocation. */
+    principal?: { kind?: string; id?: string; version?: string };
   }) => Promise<{ decision: 'allow' | 'deny' }>;
   /** Prompt the user for a secret value via native SecureField UI. */
   requestSecret?: (params: {


### PR DESCRIPTION
Address Codex review feedback on #3577: pass ToolPrincipal through ToolContext, ToolExecutor.execute, and session-tool-setup requestConfirmation to PermissionPrompter.prompt so confirmation_request events include principal metadata.

Changes:
- Add principal field to ToolContext so tools can access their own principal
- Executor enriches context with principal from policy context before tool.execute()
- claude_code tool forwards context.principal through requestConfirmation
- Add principal to requestConfirmation request type
- session-tool-setup forwards req.principal and req.executionTarget to prompter.prompt()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
