### PR TITLE
fix: normalize version prefix in principal tag display (#3610)

### DIFF
--- a/assistant/src/__tests__/cli.test.ts
+++ b/assistant/src/__tests__/cli.test.ts
@@ -69,4 +69,13 @@ describe('formatPrincipalTag', () => {
     });
     expect(tag).toBe('[skill: skill@aabbccdd]');
   });
+
+  test('strips non-sha256 version prefix (e.g. v1:)', () => {
+    const tag = formatPrincipalTag({
+      principalKind: 'skill',
+      principalId: 'runtime-skill',
+      principalVersion: 'v1:abcdef1234567890',
+    });
+    expect(tag).toBe('[skill: runtime-skill@abcdef12]');
+  });
 });

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -49,9 +49,9 @@ export function sanitizeUrlForDisplay(rawUrl: unknown): string {
 export function formatPrincipalTag(req: Pick<ConfirmationRequest, 'principalKind' | 'principalId' | 'principalVersion' | 'executionTarget'>): string {
   if (!req.principalKind || req.principalKind === 'core') return '';
   const name = req.principalId ?? req.principalKind;
-  // Show a shortened version hash when available (first 8 hex chars after prefix)
+  // Show a shortened version hash when available (first 8 hex chars after any scheme prefix)
   const versionSuffix = req.principalVersion
-    ? `@${req.principalVersion.replace(/^sha256:/, '').slice(0, 8)}`
+    ? `@${req.principalVersion.replace(/^[^:]+:/, '').slice(0, 8)}`
     : '';
   const target = req.executionTarget ? ` \u2192 ${req.executionTarget}` : '';
   return `[${req.principalKind}: ${name}${versionSuffix}${target}]`;


### PR DESCRIPTION
Address Codex review feedback on #3610: strip any scheme prefix (sha256:, v1:, etc.) before taking the short hash for principal version display in approval prompts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
