### PR TITLE
fix: check approval before rate-limit in check-pr-reviews (#3619)

### DIFF
--- a/.claude/check-pr-reviews
+++ b/.claude/check-pr-reviews
@@ -110,10 +110,10 @@ CODEX_RATE_LIMITED=$(jq '
 CODEX_REVIEW_COUNT=$(echo "$CODEX_REVIEWS" | jq 'length')
 CODEX_INLINE_COUNT=$(echo "$CODEX_INLINE" | jq 'length')
 
-if [ "$CODEX_RATE_LIMITED" = "true" ]; then
-  CODEX_STATUS="rate_limited"
-elif [ "$CODEX_PLUS_ONE" = "true" ]; then
+if [ "$CODEX_PLUS_ONE" = "true" ]; then
   CODEX_STATUS="approved"
+elif [ "$CODEX_RATE_LIMITED" = "true" ]; then
+  CODEX_STATUS="rate_limited"
 elif [ "$CODEX_REVIEW_COUNT" -gt 0 ] || [ "$CODEX_INLINE_COUNT" -gt 0 ]; then
   CODEX_STATUS="changes_requested"
 else


### PR DESCRIPTION
Address Codex review feedback on #3619: reorder condition checks so a +1 reaction (approval) takes priority over stale rate-limit comments in codex status detection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
