### PR TITLE
fix: scope registry reset snapshot to core tools only (#3630)

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -190,6 +190,10 @@ export function getAllToolDefinitions(): ToolDefinition[] {
 }
 
 export async function initializeTools(): Promise<void> {
+  // Remember which tools already exist before we register core tools,
+  // so the snapshot below captures only the core set.
+  const preExisting = new Set(tools.keys());
+
   const { eagerModules, explicitTools, lazyTools } = await import('./tool-manifest.js');
 
   // Import tool modules to trigger registration side effects.
@@ -221,13 +225,17 @@ export async function initializeTools(): Promise<void> {
     registerLazyTool(descriptor);
   }
 
-  // Snapshot the core tool set on first initialization so
-  // __resetRegistryForTesting() can restore it. ESM import caching
-  // means eager side-effect modules won't re-register on subsequent
-  // initializeTools() calls, so we need this snapshot to avoid
-  // silently losing tools.
+  // Snapshot only the tools registered during this call so
+  // __resetRegistryForTesting() can restore them. We filter out
+  // any tools that existed before initializeTools() ran (e.g. test
+  // helpers), preventing test contamination on reset.
   if (!coreToolsSnapshot) {
-    coreToolsSnapshot = new Map(tools);
+    coreToolsSnapshot = new Map<string, Tool>();
+    for (const [name, tool] of tools) {
+      if (!preExisting.has(name)) {
+        coreToolsSnapshot.set(name, tool);
+      }
+    }
   }
 
   log.info({ count: tools.size }, 'Tools initialized');


### PR DESCRIPTION
Address Codex review feedback on #3630: ensure __resetRegistryForTesting snapshot only captures tools registered during initializeTools(), excluding any pre-registered test helpers.

Before this fix, `coreToolsSnapshot = new Map(tools)` copied every entry in the registry at snapshot time, including any tools registered before `initializeTools()` (e.g., test helpers). This could cause test contamination when `__resetRegistryForTesting()` restored non-core tools.

Now we record `preExisting` tool names before registration begins and filter them out when building the snapshot.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
