### PR TITLE
fix: gh-project validation and blitz init guard (#3613)

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -25,10 +25,12 @@ Everything after stripping flags is the **feature description**.
 
 ## Phase 1: Project Setup
 
-1. If `.private/project-config.env` exists, source it. Otherwise, create the project board:
+1. If `.private/project-config.env` does not exist, create the project board:
 
 ```bash
-.claude/gh-project init
+if [ ! -f .private/project-config.env ]; then
+  .claude/gh-project init
+fi
 ```
 
 2. Source the config for later use:

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -28,10 +28,12 @@ Everything after stripping flags is the **feature description**.
 
 ## Phase 1: Project Setup
 
-1. If `.private/project-config.env` exists, source it. Otherwise, create the project board:
+1. If `.private/project-config.env` does not exist, create the project board:
 
 ```bash
-.claude/gh-project init
+if [ ! -f .private/project-config.env ]; then
+  .claude/gh-project init
+fi
 ```
 
 2. Source the config for later use:

--- a/.claude/gh-project
+++ b/.claude/gh-project
@@ -184,6 +184,14 @@ cmd_add_issue() {
 
   load_config
 
+  # Validate status before mutating project state
+  local var_name=""
+  local option_id=""
+  if [ -n "$status" ]; then
+    var_name=$(status_var_for "$status")
+    option_id="${!var_name}"
+  fi
+
   echo "==> Getting node ID for issue #$issue_number..."
   local node_id
   node_id=$(gh api "repos/vellum-ai/vellum-assistant/issues/$issue_number" --jq '.node_id')
@@ -200,9 +208,6 @@ cmd_add_issue() {
   echo "Added issue #$issue_number (item: $item_id)"
 
   if [ -n "$status" ]; then
-    local var_name
-    var_name=$(status_var_for "$status")
-    local option_id="${!var_name}"
     echo "==> Setting status to $status..."
     update_status "$item_id" "$option_id"
     echo "Status set to $status."


### PR DESCRIPTION
Address Codex review feedback on #3613: validate --status before adding issue to project, and gate project init behind .private/project-config.env existence check in blitz.md and safe-blitz.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
