### PR TITLE
perf: lazily compute skill versionHash during catalog load

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -115,7 +115,11 @@ export interface SkillToolManifestMeta {
   toolCount: number;
   /** Tool names declared in the manifest (empty if invalid). */
   toolNames: string[];
-  /** Deterministic content hash of the skill directory (`v1:<hex-sha256>`). */
+  /**
+   * Deterministic content hash of the skill directory (`v1:<hex-sha256>`).
+   * Lazily computed on first access to avoid hashing every skill directory
+   * during catalog load.
+   */
   versionHash?: string;
 }
 
@@ -317,6 +321,34 @@ function isOutsideSkillsRoot(skillsDir: string, candidatePath: string): boolean 
 // ─── Tool manifest detection ─────────────────────────────────────────────────
 
 /**
+ * Create a SkillToolManifestMeta with a lazily-computed versionHash.
+ * The hash is only computed when first accessed, avoiding the cost of
+ * recursively hashing the skill directory during catalog load.
+ */
+function createManifestMeta(
+  base: Omit<SkillToolManifestMeta, 'versionHash'>,
+  directoryPath: string,
+): SkillToolManifestMeta {
+  let cached: string | undefined;
+  let computed = false;
+  return Object.defineProperty({ ...base }, 'versionHash', {
+    get() {
+      if (!computed) {
+        computed = true;
+        try {
+          cached = computeSkillVersionHash(directoryPath);
+        } catch (err) {
+          log.warn({ err, directoryPath }, 'Failed to compute skill version hash');
+        }
+      }
+      return cached;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+/**
  * Detect and parse a TOOLS.json manifest in a skill directory.
  * Returns the manifest metadata if the file exists, or undefined if it doesn't.
  * On parse failure, returns a degraded metadata object (present but invalid).
@@ -327,31 +359,22 @@ function detectToolManifest(directoryPath: string): SkillToolManifestMeta | unde
     return undefined;
   }
 
-  let versionHash: string | undefined;
-  try {
-    versionHash = computeSkillVersionHash(directoryPath);
-  } catch (err) {
-    log.warn({ err, directoryPath }, 'Failed to compute skill version hash');
-  }
-
   try {
     const manifest = parseToolManifestFile(manifestPath);
-    return {
+    return createManifestMeta({
       present: true,
       valid: true,
       toolCount: manifest.tools.length,
       toolNames: manifest.tools.map((t) => t.name),
-      versionHash,
-    };
+    }, directoryPath);
   } catch (err) {
     log.warn({ err, manifestPath }, 'Failed to parse TOOLS.json manifest');
-    return {
+    return createManifestMeta({
       present: true,
       valid: false,
       toolCount: 0,
       toolNames: [],
-      versionHash,
-    };
+    }, directoryPath);
   }
 }
 


### PR DESCRIPTION
Addresses Codex feedback on PR #3571: computeSkillVersionHash() was being called eagerly during detectToolManifest(), meaning every loadSkillCatalog() call recursively hashed every skill directory with a TOOLS.json. This is wasteful because the hash is only needed when the skill is actually loaded or its permissions are checked, not during catalog enumeration.

This PR replaces the eager computation with a lazy getter via Object.defineProperty. The versionHash is only computed on first access, memoized for subsequent reads. This keeps the same interface and behavior while avoiding unnecessary I/O during catalog load.

No production code currently reads toolManifest.versionHash from the catalog — load.ts and checker.ts both compute the hash independently. The lazy getter ensures the property remains available if needed in the future without the catalog-time cost.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
