### PR TITLE
fix: remove head dependency in ship script (#3612)

### DIFF
--- a/.claude/ship
+++ b/.claude/ship
@@ -89,7 +89,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 fi
 
 # Find the main repo root (first worktree is always the main one)
-MAIN_REPO=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+# Use read instead of head to avoid dependency on external utilities
+MAIN_REPO=$(git worktree list --porcelain | { read -r line; echo "${line#worktree }"; })
 
 echo "==> Staging changes..."
 git add -A


### PR DESCRIPTION
## Summary
- Replace `head -1 | sed` pipeline with shell-only `read + parameter expansion` to find main worktree root
- The `do.md` path issue was already fixed in #3621

Addresses Codex review feedback on #3612.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
