### PR TITLE
fix: improve test quality for skill runners (#3586)

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -16,6 +16,8 @@ let mockUnregisteredSkillIds: string[] = [];
 let mockSkillRefCount: Map<string, number> = new Map();
 /** Per-skill version hash overrides. When set, computeSkillVersionHash returns this value. */
 let mockVersionHashes: Record<string, string> = {};
+/** Skill IDs for which computeSkillVersionHash should throw (simulates unreadable directories). */
+let mockVersionHashErrors: Set<string> = new Set();
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -159,13 +161,14 @@ mock.module('node:fs', () => ({
 
 mock.module('../skills/version-hash.js', () => ({
   computeSkillVersionHash: (skillDir: string) => {
-    // Extract skill ID from path: /skills/<id> → <id>
     const parts = skillDir.split('/');
     const skillId = parts[parts.length - 1];
+    if (mockVersionHashErrors.has(skillId)) {
+      throw new Error(`EACCES: permission denied, scandir '${skillDir}'`);
+    }
     if (skillId in mockVersionHashes) {
       return mockVersionHashes[skillId];
     }
-    // Default: stable hash based on skill ID so repeated calls return the same value
     return `v1:default-hash-${skillId}`;
   },
 }));
@@ -256,6 +259,7 @@ describe('projectSkillTools', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -652,6 +656,7 @@ describe('resolveTools callback (session wiring)', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -741,6 +746,7 @@ describe('allowed tool set merging', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -861,6 +867,7 @@ describe('skill activation requires loaded_skill marker (security invariant)', (
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -929,6 +936,7 @@ describe('mid-run skill tool activation (end-to-end)', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1125,6 +1133,7 @@ describe('context-derived deactivation regression', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1310,6 +1319,7 @@ describe('slash preactivation through session processing', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1411,6 +1421,7 @@ describe('bundled skill: gmail', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1459,6 +1470,7 @@ describe('bundled skill: claude-code', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1503,6 +1515,7 @@ describe('bundled skill: weather', () => {
     mockSkillRefCount = new Map();
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1550,6 +1563,7 @@ describe('tamper detection', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1688,22 +1702,21 @@ describe('tamper detection', () => {
       ...skillLoadMessages('<loaded_skill id="deploy" />'),
     ];
 
-    // Turn 1: normal registration
     projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
     expect(sessionState.get('deploy')).toBe('v1:initial-hash');
 
-    // Turn 2: remove hash override so computeSkillVersionHash returns the
-    // default fallback which differs from the stored hash
-    delete mockVersionHashes['deploy'];
+    // Make computeSkillVersionHash throw to exercise the catch branch
+    // in session-skill-tools.ts that falls back to `unknown-${Date.now()}`
+    mockVersionHashErrors.add('deploy');
     mockUnregisteredSkillIds = [];
 
     const result = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
     expect(result.toolDefinitions).toHaveLength(1);
 
-    // Hash changed (from stored 'v1:initial-hash' to default 'v1:default-hash-deploy')
-    // so re-registration should have occurred
+    // The exception triggers re-registration since the fallback hash
+    // (`unknown-<timestamp>`) will never match the stored hash
     expect(mockUnregisteredSkillIds).toContain('deploy');
-    expect(sessionState.get('deploy')).toBe('v1:default-hash-deploy');
+    expect(sessionState.get('deploy')).toMatch(/^unknown-\d+$/);
   });
 });
 
@@ -1719,6 +1732,7 @@ describe('resetSkillToolProjection', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
   });
 
   test('unregisters all tracked skills and clears the map', () => {
@@ -1773,6 +1787,7 @@ describe('versioned markers through session projection', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1845,6 +1860,7 @@ describe('hash change re-prompt regressions (PR 35)', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -1998,6 +2014,7 @@ describe('version hash plumbing to projected tools', () => {
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
     sessionState = new Map<string, string>();
   });
 

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -257,15 +257,9 @@ describe('runSkillToolScript — host hash guard', () => {
 
 describe('runSkillToolScript — tamper regression lifecycle', () => {
   test('execution succeeds with matching hash, fails after tamper, succeeds after re-approval', async () => {
-    // Simulates the full lifecycle:
-    // 1. Tool approved with hash A — execution succeeds
-    // 2. File tampered (hash changes to B) — execution blocked
-    // 3. Skill reloaded (re-approved with hash B) — execution succeeds again
-
     let currentDiskHash = 'v1:approved-hash-aaa';
     const resolver = (_dir: string) => currentDiskHash;
 
-    // Phase 1: hash matches approved hash — execution succeeds
     const result1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'phase1' }, makeContext(), {
       expectedSkillVersionHash: 'v1:approved-hash-aaa',
       skillDirHashResolver: resolver,
@@ -273,11 +267,10 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     expect(result1.isError).toBe(false);
     expect(result1.content).toBe('hello from phase1');
 
-    // Phase 2: file tampered on disk — hash drifts
     currentDiskHash = 'v1:tampered-hash-bbb';
 
     const result2 = await runSkillToolScript(tempDir, 'success.ts', { name: 'phase2' }, makeContext(), {
-      expectedSkillVersionHash: 'v1:approved-hash-aaa', // still using old approval
+      expectedSkillVersionHash: 'v1:approved-hash-aaa',
       skillDirHashResolver: resolver,
     });
     expect(result2.isError).toBe(true);
@@ -285,9 +278,8 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     expect(result2.content).toContain('v1:approved-hash-aaa');
     expect(result2.content).toContain('v1:tampered-hash-bbb');
 
-    // Phase 3: skill reloaded — now approved with the new hash
     const result3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'phase3' }, makeContext(), {
-      expectedSkillVersionHash: 'v1:tampered-hash-bbb', // updated approval
+      expectedSkillVersionHash: 'v1:tampered-hash-bbb',
       skillDirHashResolver: resolver,
     });
     expect(result3.isError).toBe(false);
@@ -297,18 +289,14 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
   test('multiple sequential tampers each block until re-approved', async () => {
     let currentDiskHash = 'v1:version-1';
     const resolver = (_dir: string) => currentDiskHash;
-
-    // Approved at version-1
     let approvedHash = 'v1:version-1';
 
-    // Execute successfully with version-1
     const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v1' }, makeContext(), {
       expectedSkillVersionHash: approvedHash,
       skillDirHashResolver: resolver,
     });
     expect(r1.isError).toBe(false);
 
-    // First tamper to version-2
     currentDiskHash = 'v1:version-2';
     const r2 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v2' }, makeContext(), {
       expectedSkillVersionHash: approvedHash,
@@ -317,7 +305,6 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     expect(r2.isError).toBe(true);
     expect(r2.content).toContain('Skill version mismatch');
 
-    // Re-approve at version-2
     approvedHash = 'v1:version-2';
     const r2ok = await runSkillToolScript(tempDir, 'success.ts', { name: 'v2' }, makeContext(), {
       expectedSkillVersionHash: approvedHash,
@@ -325,7 +312,6 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     });
     expect(r2ok.isError).toBe(false);
 
-    // Second tamper to version-3
     currentDiskHash = 'v1:version-3';
     const r3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'v3' }, makeContext(), {
       expectedSkillVersionHash: approvedHash,
@@ -334,7 +320,6 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     expect(r3.isError).toBe(true);
     expect(r3.content).toContain('Skill version mismatch');
 
-    // Re-approve at version-3
     approvedHash = 'v1:version-3';
     const r3ok = await runSkillToolScript(tempDir, 'success.ts', { name: 'v3' }, makeContext(), {
       expectedSkillVersionHash: approvedHash,
@@ -348,7 +333,6 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     let currentDiskHash = 'v1:skill-hash-ok';
     const resolver = (_dir: string) => currentDiskHash;
 
-    // Both scripts work when hash matches
     const r1 = await runSkillToolScript(tempDir, 'success.ts', { name: 'a' }, makeContext(), {
       expectedSkillVersionHash: 'v1:skill-hash-ok',
       skillDirHashResolver: resolver,
@@ -361,10 +345,8 @@ describe('runSkillToolScript — tamper regression lifecycle', () => {
     });
     expect(r2.isError).toBe(false);
 
-    // Tamper the skill directory
     currentDiskHash = 'v1:skill-hash-tampered';
 
-    // Both scripts are blocked
     const r3 = await runSkillToolScript(tempDir, 'success.ts', { name: 'b' }, makeContext(), {
       expectedSkillVersionHash: 'v1:skill-hash-ok',
       skillDirHashResolver: resolver,


### PR DESCRIPTION
Address Codex review feedback on #3586: remove descriptive comments that restate code, and make the hash failure test actually exercise the exception path by having the mock throw.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
