### PR TITLE
fix: invalidate cached trust rules on extraDirs config change (#3647)

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -333,6 +333,9 @@ export class DaemonServer {
     if (fingerprint === this.lastConfigFingerprint) {
       return false;
     }
+    // Default trust rules depend on config (e.g. skills.load.extraDirs),
+    // so clear the trust cache so rules are regenerated from fresh config.
+    clearTrustCache();
     clearEmbeddingBackendCache();
     const isFirstInit = this.lastConfigFingerprint === '';
     initializeProviders(config);


### PR DESCRIPTION
Address Codex review feedback on #3647: ensure trust rules cache is invalidated when skills.load.extraDirs config changes so default rules reflect the updated directories.

When the daemon detects a config change in refreshConfigFromSources(), the trust store cache is now also cleared. This ensures that default rules generated from getDefaultRuleTemplates() — which depend on extraDirs — are regenerated with the fresh config values rather than serving stale cached rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
