### PR TITLE
fix: improve host execution target scoping test (#3623)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3152,41 +3152,37 @@ describe('Permission Checker', () => {
       });
 
       test('execution target-scoped rule matches only the specified target', async () => {
+        await addVersionBoundRule({
+          id: 'inv4-target-scoped',
+          tool: 'host_bash',
+          pattern: 'run *',
+          scope: 'everywhere',
+          decision: 'allow',
+          priority: 2000,
+        });
+
+        // Write the executionTarget field directly (addVersionBoundRule doesn't support it)
         const trustPath = join(checkerTestDir, 'protected', 'trust.json');
-        const { writeFileSync, mkdirSync: mkdirSyncFs, existsSync } = await import('node:fs');
-        const { dirname: dirnameFn } = await import('node:path');
-
-        clearCache();
-        const trustDir = dirnameFn(trustPath);
-        if (!existsSync(trustDir)) mkdirSyncFs(trustDir, { recursive: true });
-
-        writeFileSync(trustPath, JSON.stringify({
-          version: 3,
-          rules: [{
-            id: 'inv4-target-scoped',
-            tool: 'bash',
-            pattern: 'run *',
-            scope: 'everywhere',
-            decision: 'allow',
-            priority: 2000,
-            createdAt: Date.now(),
-            executionTarget: '/usr/local/bin/node',
-          }],
-        }, null, 2));
+        const raw = JSON.parse((await import('node:fs')).readFileSync(trustPath, 'utf-8'));
+        const rule = raw.rules.find((r: any) => r.id === 'inv4-target-scoped');
+        rule.executionTarget = '/usr/local/bin/node';
+        (await import('node:fs')).writeFileSync(trustPath, JSON.stringify(raw, null, 2));
         clearCache();
 
-        // Matching target
-        const matchResult = findHighestPriorityRule('bash', ['run script.js'], '/tmp', {
+        // Matching target — check() should allow via the target-scoped rule
+        const matchResult = await check('host_bash', { command: 'run script.js' }, '/tmp', {
           executionTarget: '/usr/local/bin/node',
         });
-        expect(matchResult).not.toBeNull();
-        expect(matchResult!.id).toBe('inv4-target-scoped');
+        expect(matchResult.decision).toBe('allow');
+        expect(matchResult.matchedRule?.id).toBe('inv4-target-scoped');
 
-        // Different target
-        const noMatchResult = findHighestPriorityRule('bash', ['run script.js'], '/tmp', {
+        // Different target — the target-scoped rule should NOT match;
+        // falls back to the default host_bash ask rule (prompt)
+        const noMatchResult = await check('host_bash', { command: 'run script.js' }, '/tmp', {
           executionTarget: '/usr/local/bin/bun',
         });
-        expect(noMatchResult === null || noMatchResult.id !== 'inv4-target-scoped').toBe(true);
+        expect(noMatchResult.decision).toBe('prompt');
+        expect(noMatchResult.matchedRule?.id).not.toBe('inv4-target-scoped');
       });
     });
 


### PR DESCRIPTION
Address Codex review feedback on #3623: update the host execution approvals test to use host_bash and exercise through check() to validate the full host-scoping permission path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
