### PR TITLE
fix: chain cd and .claude/ship with && to prevent wrong-directory execution

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -41,8 +41,7 @@ Review what changed, draft a commit message and PR title, then ship everything i
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree>
-.claude/ship \
+cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \
   --title "<PR title>" \
   --body "## Summary

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -95,8 +95,7 @@ Fix any failures before proceeding.
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree>
-.claude/ship \
+cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \
   --title "<title from plan>" \
   --body "## Summary

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -41,8 +41,7 @@ Review what changed, draft a commit message and PR title, then ship.
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree>
-.claude/ship \
+cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \
   --title "<PR title>" \
   --body "## Summary

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -72,8 +72,7 @@ Fix any failures before proceeding.
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree>
-.claude/ship \
+cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \
   --title "<title from plan>" \
   --body "## Summary


### PR DESCRIPTION
## Summary
- Chains `cd <worktree>` and `.claude/ship` with `&&` in do.md, safe-do.md, safe-execute-plan.md, and resume-plan.md
- Prevents .claude/ship from running in the wrong directory if the cd fails or cwd is not preserved between lines
- Addresses review feedback from PR #3621

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
