### PR TITLE
M2: Add OnboardingFooter to all onboarding step views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -119,7 +119,7 @@ struct APIKeyStepView: View {
             .padding(.top, VSpacing.xs)
         }
         .padding(.horizontal, VSpacing.xxl)
-        .padding(.bottom, VSpacing.xxl)
+        .padding(.bottom, VSpacing.lg)
         .opacity(showContent ? 1 : 0)
         .offset(y: showContent ? 0 : 12)
         .onAppear {
@@ -137,6 +137,9 @@ struct APIKeyStepView: View {
                 keyFieldFocused = true
             }
         }
+
+        OnboardingFooter(currentStep: 2)
+            .padding(.bottom, VSpacing.lg)
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -162,7 +162,7 @@ struct FnKeyStepView: View {
             .padding(.top, VSpacing.xs)
         }
         .padding(.horizontal, VSpacing.xxl)
-        .padding(.bottom, VSpacing.xxl)
+        .padding(.bottom, VSpacing.lg)
         .opacity(showContent ? 1 : 0)
         .offset(y: showContent ? 0 : 12)
         .animation(.spring(duration: 0.4, bounce: 0.1), value: permissionsRequested)
@@ -182,6 +182,9 @@ struct FnKeyStepView: View {
         .onDisappear {
             stopPolling()
         }
+
+        OnboardingFooter(currentStep: 3)
+            .padding(.bottom, VSpacing.lg)
     }
 
     // MARK: - Subviews

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -83,6 +83,9 @@ struct InterviewStepView: View {
                 .transition(.opacity)
                 .padding(.vertical, VSpacing.md)
             }
+
+            OnboardingFooter(currentStep: 8)
+                .padding(.bottom, VSpacing.lg)
         }
         .onAppear {
             viewModel.startInterview()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -131,8 +131,7 @@ struct OnboardingFlowView: View {
                         )
                         .id(state.currentStep)
 
-                        OnboardingProgressDots(currentStep: state.currentStep)
-                            .padding(.top, VSpacing.xs)
+                        OnboardingFooter(currentStep: state.currentStep)
                     }
                     .padding(.horizontal, VSpacing.xxl)
                     .padding(.top, VSpacing.xl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -66,7 +66,7 @@ struct WakeUpStepView: View {
             }
         }
         .padding(.horizontal, VSpacing.xxl)
-        .padding(.bottom, VSpacing.xxl)
+        .padding(.bottom, VSpacing.lg)
         .opacity(showButtons ? 1 : 0)
         .offset(y: showButtons ? 0 : 12)
         .disabled(isAdvancing)
@@ -81,6 +81,9 @@ struct WakeUpStepView: View {
                 showButtons = true
             }
         }
+
+        OnboardingFooter(currentStep: 0)
+            .padding(.bottom, VSpacing.lg)
     }
 
     private func advanceStep() {


### PR DESCRIPTION
## Summary
- Replace bare `OnboardingProgressDots` with `OnboardingFooter` (progress dots + copyright) in the panel-layout section (steps 1, 4-7) of `OnboardingFlowView`
- Add `OnboardingFooter` to `WakeUpStepView` (step 0), `APIKeyStepView` (step 2), `FnKeyStepView` (step 3), and `InterviewStepView` (step 8)
- Reduce bottom padding on step content VStacks from `VSpacing.xxl` to `VSpacing.lg` to make room for the footer

## Test plan
- [ ] Verify footer appears at the bottom of every onboarding step (0 through 8)
- [ ] Confirm progress dots advance correctly as steps change
- [ ] Check that copyright text "2026 Vellum Inc." is visible in all steps
- [ ] Verify existing button layouts and animations are not broken
- [ ] Confirm FirstMeeting variant views are NOT affected

Part of #3659, closes #3661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
