### PR TITLE
fix: restore double-click-to-zoom on transparent title bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -3,6 +3,33 @@ import Combine
 import VellumAssistantShared
 import SwiftUI
 
+/// NSWindow subclass that restores double-click-to-zoom on the title bar.
+/// With `fullSizeContentView` + `titlebarAppearsTransparent`, the system
+/// title bar becomes invisible and stops handling double-clicks. This
+/// subclass detects double-clicks in the title bar zone and performs the
+/// action configured in System Settings (zoom or minimize).
+class TitleBarZoomableWindow: NSWindow {
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
+        guard event.clickCount == 2 else { return }
+
+        // Check if the click landed in the title bar zone (above contentLayoutRect)
+        let clickY = event.locationInWindow.y
+        guard clickY >= contentLayoutRect.maxY else { return }
+
+        // Respect "Double-click a window's title bar to" system preference
+        let action = UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick") ?? "Maximize"
+        switch action {
+        case "Minimize":
+            miniaturize(nil)
+        case "None":
+            break
+        default: // "Maximize"
+            zoom(nil)
+        }
+    }
+}
+
 @MainActor
 final class MainWindow {
     private let services: AppServices
@@ -101,7 +128,7 @@ final class MainWindow {
             height: windowHeight
         )
 
-        let window = NSWindow(
+        let window = TitleBarZoomableWindow(
             contentRect: windowRect,
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,


### PR DESCRIPTION
## Summary
- With `fullSizeContentView` + `titlebarAppearsTransparent`, the system title bar is invisible and stops handling double-clicks
- Adds a `TitleBarZoomableWindow` NSWindow subclass that detects double-clicks in the title bar zone (above `contentLayoutRect`)
- Respects the macOS System Settings preference for "Double-click a window's title bar to" (zoom, minimize, or do nothing)

## Test plan
- [ ] Double-click the title bar area (top strip near traffic lights) — window should zoom to fill screen
- [ ] Double-click again to restore original size
- [ ] Verify behavior matches System Settings > Desktop & Dock > "Double-click a window's title bar to" preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
