### PR TITLE
fix: always pin skill allowlist to exact version

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2425,26 +2425,16 @@ describe('Permission Checker', () => {
 
     // ── generateAllowlistOptions for skill_load ──
 
-    test('allowlist options include version-specific and any-version choices when hash is available', () => {
+    test('allowlist options only include version-specific option when hash is available', () => {
       ensureSkillsDir();
       writeSkill('test-opts-skill', 'Test Options Skill');
 
       const options = generateAllowlistOptions('skill_load', { skill: 'test-opts-skill' });
 
-      // Should have: version-specific, any-version, wildcard
-      expect(options.length).toBeGreaterThanOrEqual(3);
-
-      // First option should be the version-specific pattern
+      // Should have only the version-specific option
+      expect(options).toHaveLength(1);
       expect(options[0].pattern).toMatch(/^skill_load:test-opts-skill@v1:/);
       expect(options[0].description).toBe('This exact version');
-
-      // Second option should be any-version
-      expect(options[1].pattern).toBe('skill_load:test-opts-skill');
-      expect(options[1].description).toBe('Any version of this skill');
-
-      // Last option should be wildcard
-      expect(options[options.length - 1].pattern).toBe('skill_load:*');
-      expect(options[options.length - 1].description).toBe('All skill loads');
     });
 
     test('allowlist options ignore input version_hash and use disk-computed hash (regression)', () => {
@@ -2458,13 +2448,11 @@ describe('Permission Checker', () => {
         version_hash: 'v1:customhash123',
       });
 
-      expect(options.length).toBeGreaterThanOrEqual(3);
-      // First option should be the disk-computed hash, NOT the input hash
+      expect(options).toHaveLength(1);
+      // Should be the disk-computed hash, NOT the input hash
       expect(options[0].pattern).toMatch(/^skill_load:test-opts-explicit@v1:/);
       expect(options[0].pattern).not.toBe('skill_load:test-opts-explicit@v1:customhash123');
       expect(options[0].description).toBe('This exact version');
-      expect(options[1].pattern).toBe('skill_load:test-opts-explicit');
-      expect(options[1].description).toBe('Any version of this skill');
     });
 
     test('allowlist options for unresolvable skill fall back to raw selector', () => {
@@ -2472,11 +2460,10 @@ describe('Permission Checker', () => {
 
       const options = generateAllowlistOptions('skill_load', { skill: 'no-such-skill' });
 
-      // Should have: raw selector, wildcard
-      expect(options).toHaveLength(2);
+      // Should have only the raw selector
+      expect(options).toHaveLength(1);
       expect(options[0].pattern).toBe('skill_load:no-such-skill');
       expect(options[0].description).toBe('This skill');
-      expect(options[1].pattern).toBe('skill_load:*');
     });
 
     test('allowlist options for empty skill selector only has wildcard', () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -533,48 +533,38 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
 
   if (toolName === 'skill_load') {
     const rawSelector = getStringField(input, 'skill').trim();
-    const options: AllowlistOption[] = [];
 
     if (rawSelector) {
       const resolved = resolveSkillIdAndHash(rawSelector);
-      if (resolved) {
-        // Version-specific option: pin approval to an exact version
-        if (resolved.versionHash) {
-          options.push({
+      if (resolved && resolved.versionHash) {
+        // Always pin approval to the exact version
+        return [
+          {
             label: `${resolved.id}@${resolved.versionHash}`,
             description: 'This exact version',
             pattern: `skill_load:${resolved.id}@${resolved.versionHash}`,
-          });
-        }
-        // Any-version option: allow loading this skill regardless of version
-        options.push({
-          label: resolved.id,
-          description: 'Any version of this skill',
-          pattern: `skill_load:${resolved.id}`,
-        });
-      } else {
-        // Couldn't resolve — use the raw selector
-        options.push({
-          label: rawSelector,
-          description: 'This skill',
-          pattern: `skill_load:${rawSelector}`,
-        });
+          },
+        ];
       }
+      // No version hash — use the resolved id or raw selector
+      const id = resolved ? resolved.id : rawSelector;
+      return [
+        {
+          label: id,
+          description: 'This skill',
+          pattern: `skill_load:${id}`,
+        },
+      ];
     }
 
-    options.push({
-      label: 'skill_load:*',
-      description: 'All skill loads',
-      pattern: 'skill_load:*',
-    });
-
-    // Deduplicate
-    const seen = new Set<string>();
-    return options.filter((o) => {
-      if (seen.has(o.pattern)) return false;
-      seen.add(o.pattern);
-      return true;
-    });
+    // No selector at all — fallback to wildcard
+    return [
+      {
+        label: 'skill_load:*',
+        description: 'All skill loads',
+        pattern: 'skill_load:*',
+      },
+    ];
   }
 
   return [{ label: '*', description: 'Everything', pattern: '*' }];


### PR DESCRIPTION
## Summary
- Skill permission prompts now only offer a single allowlist option ("This exact version") instead of a 3-option dropdown
- This causes the macOS UI to render a simple "Always Allow" button instead of a popover menu, since option count drops from 3 to 1
- Updated tests to match the new single-option behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
