### PR TITLE
refactor: remove what-only comments from OnboardingFooter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
@@ -1,10 +1,6 @@
 import VellumAssistantShared
 import SwiftUI
 
-/// Onboarding footer combining progress dots with copyright text.
-///
-/// Renders a row of filled dots indicating progress through onboarding
-/// steps, followed by a "2026 Vellum Inc." copyright label.
 struct OnboardingFooter: View {
     let currentStep: Int
     let totalSteps: Int
@@ -26,7 +22,6 @@ struct OnboardingFooter: View {
 
     var body: some View {
         VStack(spacing: VSpacing.sm) {
-            // Progress dots
             HStack(spacing: VSpacing.sm) {
                 ForEach(0..<totalDots, id: \.self) { index in
                     Circle()
@@ -36,7 +31,6 @@ struct OnboardingFooter: View {
                 }
             }
 
-            // Copyright text
             Text("\u{00A9} 2026 Vellum Inc.")
                 .font(VFont.monoSmall)
                 .foregroundStyle(VColor.textMuted.opacity(0.5))


### PR DESCRIPTION
## Summary
- Removes descriptive comments that only restate what the code does, per repo guidelines
- Removed: struct-level doc comment, `// Progress dots` section label, `// Copyright text` section label
- Retained: doc comment on `activeDotIndex` which explains the non-obvious step-to-dot mapping algorithm

Addresses review feedback on PR #3667.

## Test plan
- [x] Build succeeds (`./build.sh`)
- [x] No logic changes — only comment removal
- [ ] Visual verification: OnboardingFooter renders identically in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
