### PR TITLE
fix: use state.currentStep in OnboardingFooter calls

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -138,7 +138,7 @@ struct APIKeyStepView: View {
             }
         }
 
-        OnboardingFooter(currentStep: 2)
+        OnboardingFooter(currentStep: state.currentStep)
             .padding(.bottom, VSpacing.lg)
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -183,7 +183,7 @@ struct FnKeyStepView: View {
             stopPolling()
         }
 
-        OnboardingFooter(currentStep: 3)
+        OnboardingFooter(currentStep: state.currentStep)
             .padding(.bottom, VSpacing.lg)
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -84,7 +84,7 @@ struct InterviewStepView: View {
                 .padding(.vertical, VSpacing.md)
             }
 
-            OnboardingFooter(currentStep: 8)
+            OnboardingFooter(currentStep: state.currentStep)
                 .padding(.bottom, VSpacing.lg)
         }
         .onAppear {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -82,7 +82,7 @@ struct WakeUpStepView: View {
             }
         }
 
-        OnboardingFooter(currentStep: 0)
+        OnboardingFooter(currentStep: state.currentStep)
             .padding(.bottom, VSpacing.lg)
     }
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded step indices with `state.currentStep` in all `OnboardingFooter` calls
- Fixes FnKeyStepView showing wrong progress (hardcoded `3`, actually rendered at step `4`)
- Prevents future bugs if onboarding steps are reordered

## Changes
- `WakeUpStepView.swift`: `OnboardingFooter(currentStep: 0)` -> `OnboardingFooter(currentStep: state.currentStep)`
- `APIKeyStepView.swift`: `OnboardingFooter(currentStep: 2)` -> `OnboardingFooter(currentStep: state.currentStep)`
- `FnKeyStepView.swift`: `OnboardingFooter(currentStep: 3)` -> `OnboardingFooter(currentStep: state.currentStep)`
- `InterviewStepView.swift`: `OnboardingFooter(currentStep: 8)` -> `OnboardingFooter(currentStep: state.currentStep)`

Addresses review feedback on PR #3682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
