### PR TITLE
fix: use real hash in missing-executor test (#3664)

### DIFF
--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -148,11 +148,12 @@ describe('createSkillTool', () => {
   });
 
   test('execute() returns error when executor script is missing', async () => {
+    const hash = computeSkillVersionHash(tempDir);
     const tool = createSkillTool(
       makeEntry({ executor: 'nonexistent.ts' }),
       'my-skill',
       tempDir,
-      'v1:test',
+      hash,
     );
 
     const result = await tool.execute({}, makeContext());


### PR DESCRIPTION
## Summary
- Replace hardcoded 'v1:test' with computeSkillVersionHash(tempDir) in the missing-executor test
- Ensures the test exercises the missing-script import path rather than tripping the hash-mismatch guard
- Addresses Codex review feedback on #3664

## Test plan
- [x] skill-tool-factory tests pass
- [x] Type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
