### PR TITLE
fix: limit starter rule migration to legacy tool:** patterns (#3678)

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -113,25 +113,38 @@ function backfillDefaults(rules: TrustRule[]): boolean {
 }
 
 /**
- * Update persisted starter-bundle rules whose pattern no longer matches the
- * canonical template (e.g. the old "tool:**" prefix was changed to standalone
- * "**").  Returns true when at least one rule was updated.
+ * Update persisted starter-bundle rules whose pattern matches a known legacy
+ * format (e.g. the old "tool:**" prefix was changed to standalone "**").
+ * Returns true when at least one rule was updated.
+ *
+ * Only rules with a recognised legacy pattern are migrated. If a user has
+ * intentionally customised a starter rule's pattern (e.g. narrowed it), it is
+ * left untouched.
  */
 function migrateStarterRulePatterns(rules: TrustRule[]): boolean {
   const templatesByID = new Map(getStarterBundleRules().map((t) => [t.id, t]));
   let changed = false;
   for (const rule of rules) {
     const template = templatesByID.get(rule.id);
-    if (template && rule.pattern !== template.pattern) {
-      log.info(
-        { ruleId: rule.id, oldPattern: rule.pattern, newPattern: template.pattern },
-        'Migrated starter rule pattern to current template',
-      );
-      rule.pattern = template.pattern;
-      changed = true;
-    }
+    if (!template || rule.pattern === template.pattern) continue;
+    // Only migrate patterns that match a known legacy format.
+    // The "tool:**" prefix (e.g. "file_read:**") was the original pattern
+    // before it was changed to standalone "**".
+    if (!isLegacyStarterPattern(rule.pattern)) continue;
+    log.info(
+      { ruleId: rule.id, oldPattern: rule.pattern, newPattern: template.pattern },
+      'Migrated starter rule pattern to current template',
+    );
+    rule.pattern = template.pattern;
+    changed = true;
   }
   return changed;
+}
+
+/** Recognises legacy starter-rule patterns that should be auto-migrated. */
+function isLegacyStarterPattern(pattern: string): boolean {
+  // Legacy format used "tool:**" prefixes, e.g. "file_read:**", "glob:**".
+  return /^[a-z_]+:\*\*$/.test(pattern);
 }
 
 function loadFromDisk(): TrustRule[] {


### PR DESCRIPTION
## Summary
- Only migrate starter rules whose pattern matches the known legacy format (tool:** prefix)
- Preserves user-customized starter rule patterns instead of silently resetting them
- Addresses Codex review feedback on #3678

## Test plan
- [x] Type-check passes
- [x] Existing tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
