### PR TITLE
fix: resolve symlinks instead of skipping in skill version hash (#3653)

### DIFF
--- a/assistant/src/__tests__/skill-version-hash.test.ts
+++ b/assistant/src/__tests__/skill-version-hash.test.ts
@@ -112,27 +112,40 @@ describe('computeSkillVersionHash', () => {
     expect(hash).toMatch(/^v1:[0-9a-f]{64}$/);
   });
 
-  test('skips symlinked directories to avoid loops', () => {
+  test('skips symlinked directories that point back into skill dir', () => {
     const dir = makeTempSkill();
     writeFileSync(join(dir, 'SKILL.md'), '# Skill\n');
     const hash1 = computeSkillVersionHash(dir);
 
-    // Create a symlink that points back to the skill dir (would loop with statSync)
+    // Create a symlink that points back to the skill dir (would loop)
     symlinkSync(dir, join(dir, 'loop'));
     const hash2 = computeSkillVersionHash(dir);
 
     expect(hash1).toBe(hash2);
   });
 
-  test('skips symlinked files', () => {
+  test('resolves symlinked files and includes their content', () => {
     const dir = makeTempSkill();
     writeFileSync(join(dir, 'real.ts'), 'export {};');
     const hash1 = computeSkillVersionHash(dir);
 
-    // Add a symlink to an existing file — should be ignored
+    // Add a symlink to an existing file — should be included
     symlinkSync(join(dir, 'real.ts'), join(dir, 'linked.ts'));
     const hash2 = computeSkillVersionHash(dir);
 
-    expect(hash1).toBe(hash2);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test('hash changes when symlink target content changes', () => {
+    const dir = makeTempSkill();
+    const external = makeTempSkill();
+    writeFileSync(join(external, 'executor.ts'), 'export const run = () => "v1";');
+    symlinkSync(join(external, 'executor.ts'), join(dir, 'executor.ts'));
+    const hash1 = computeSkillVersionHash(dir);
+
+    writeFileSync(join(external, 'executor.ts'), 'export const run = () => "v2";');
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).not.toBe(hash2);
   });
 });

--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, lstatSync } from 'node:fs';
+import { readdirSync, readFileSync, lstatSync, realpathSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { createHash } from 'node:crypto';
 
@@ -36,7 +36,35 @@ function collectFiles(dir: string, base: string): string[] {
     } catch {
       continue;
     }
-    if (stat.isSymbolicLink()) continue;
+    if (stat.isSymbolicLink()) {
+      let resolved: string;
+      try {
+        resolved = realpathSync(full);
+      } catch {
+        continue;
+      }
+      let resolvedStat;
+      try {
+        resolvedStat = statSync(resolved);
+      } catch {
+        continue;
+      }
+      if (resolvedStat.isDirectory()) {
+        // Skip directory symlinks that resolve into the skill dir to avoid loops
+        let realBase: string;
+        try {
+          realBase = realpathSync(base);
+        } catch {
+          continue;
+        }
+        const relToBase = relative(realBase, resolved);
+        if (!relToBase.startsWith('..') && !relToBase.startsWith('/')) continue;
+        entries.push(...collectFiles(full, base));
+      } else if (resolvedStat.isFile()) {
+        entries.push(relative(base, full));
+      }
+      continue;
+    }
     if (stat.isDirectory()) {
       entries.push(...collectFiles(full, base));
     } else if (stat.isFile()) {


### PR DESCRIPTION
## Summary
- Resolve symlinked files and hash their content instead of skipping them entirely
- Skip directory symlinks that would cause loops (pointing back into skill dir)
- Addresses Codex review feedback on #3653 about version-pinning bypass

## Test plan
- [x] Existing symlink tests updated to reflect new behavior
- [x] Type-check passes
- [x] All version-hash tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
