### PR TITLE
fix: close any active panel when selecting a recent thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -373,8 +373,11 @@ struct MainWindowView: View {
         HStack(spacing: 0) {
             Button(action: {
                 threadManager.selectThread(id: thread.id)
-                if windowState.activePanel == .directory || windowState.activePanel == .identity {
+                switch windowState.activePanel {
+                case .settings, .agent, .directory, .debug, .doctor, .identity:
                     windowState.activePanel = nil
+                default:
+                    break
                 }
             }) {
                 Text(thread.title)


### PR DESCRIPTION
## Summary
- Clicking a recent thread in the sidebar now dismisses any open side panel (Settings, Skills, Debug, Doctor), not just Directory and Identity
- The previous conditional check was incomplete, so panels like Debug/Doctor stayed open when switching threads

## Test plan
- [ ] Open Settings/Skills/Debug/Doctor panel, then click a recent thread — panel should close
- [ ] Verify Directory and Identity panels still close as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
