### PR TITLE
fix: prevent extra-dir rule from masking managed-skill rule in tests (#3685)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2162,21 +2162,29 @@ describe('Permission Checker', () => {
   // because getDefaultRuleTemplates builds the managed-skill ask rule from
   // getRootDir(), so using a different prefix would avoid contention with
   // the default rule and silently pass even if the priority regressed.
-  // The workspace/skills dir is registered as an extraDir so that
-  // isSkillSourcePath correctly classifies the paths as High risk.
+  //
+  // extraDirs is set to the parent "workspace" directory (not "workspace/skills")
+  // so that isSkillSourcePath classifies the paths as High risk without creating
+  // a duplicate extra-0 ask rule for the exact same path as the managed rule.
+  // The third test explicitly asserts the matched rule ID is the managed-skill
+  // rule to guard against regressions in default rule generation.
 
   describe('user override of skill mutation default ask rules', () => {
     // Must match the path getDefaultRuleTemplates computes for managedSkillsDir
     const wsSkillsDir = join(checkerTestDir, 'workspace', 'skills');
+    // Use parent directory for extraDirs — broad enough for isSkillSourcePath
+    // to recognize skill paths, but distinct from the managed-skill rule path.
+    const wsDir = join(checkerTestDir, 'workspace');
 
     function ensureSkillsDir(): void {
       mkdirSync(wsSkillsDir, { recursive: true });
     }
 
     beforeEach(() => {
-      // Register workspace/skills as an extra skill dir so isSkillSourcePath
-      // detects it (the mock for getWorkspaceSkillsDir points elsewhere).
-      testConfig.skills.load.extraDirs = [wsSkillsDir];
+      // Register the workspace parent dir so isSkillSourcePath detects skill
+      // paths under workspace/skills/ without duplicating the managed-skill
+      // default ask rule (the mock for getWorkspaceSkillsDir points elsewhere).
+      testConfig.skills.load.extraDirs = [wsDir];
     });
 
     test('user allowHighRisk rule at priority 100 overrides default ask for skill source writes', async () => {
@@ -2207,8 +2215,10 @@ describe('Permission Checker', () => {
       const skillPath = join(wsSkillsDir, 'my-skill', 'executor.ts');
       const result = await check('file_write', { path: skillPath }, '/tmp');
       expect(result.decision).toBe('prompt');
-      // Verify the default ask rule is what matched, not just a generic high-risk fallback
+      // Verify the managed-skill default ask rule is what matched (not the
+      // extra-dir fallback or a generic high-risk prompt).
       expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:ask-file_write-managed-skills');
       expect(result.matchedRule!.decision).toBe('ask');
       expect(result.reason).toContain('ask rule');
     });


### PR DESCRIPTION
## Summary
- Change `extraDirs` in skill mutation regression tests from the exact `workspace/skills` path to the parent `workspace` directory, eliminating a duplicate ask rule that could mask managed-skill rule regressions
- Add explicit `matchedRule.id` assertion in the "without user rule" test to verify the managed-skill default rule (not the extra-dir fallback) is what matches
- Addresses Codex review feedback on #3685

## Test plan
- [x] All 276 checker tests pass
- [x] Type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
