### PR TITLE
fix: add OnboardingFooter to ModelSelectionStepView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -72,9 +72,11 @@ struct ModelSelectionStepView: View {
                 if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
             }
             .padding(.top, VSpacing.xs)
+
+            OnboardingFooter(currentStep: state.currentStep)
         }
         .padding(.horizontal, VSpacing.xxl)
-        .padding(.bottom, VSpacing.xxl)
+        .padding(.bottom, VSpacing.lg)
         .opacity(showContent ? 1 : 0)
         .offset(y: showContent ? 0 : 12)
         .onAppear {


### PR DESCRIPTION
The model selection step (step 3) was missing the progress dots and "2026 Vellum Inc." copyright footer. All other onboarding steps already had the footer added in PR #3682, but ModelSelectionStepView was missed.

Uses `state.currentStep` (not hardcoded) consistent with the fix in PR #3690.

Part of #3659.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
