### PR TITLE
fix: toggle title bar double-click zoom back to previous window size

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -14,6 +14,8 @@ import SwiftUI
 /// back to the previous size.
 class TitleBarZoomableWindow: NSWindow {
     private var preZoomFrame: NSRect?
+    /// Guards against invalidating `preZoomFrame` during our own restore animation.
+    private var isRestoringFrame = false
 
     override func mouseUp(with event: NSEvent) {
         super.mouseUp(with: event)
@@ -34,13 +36,34 @@ class TitleBarZoomableWindow: NSWindow {
             if let savedFrame = preZoomFrame {
                 // Restore to pre-zoom frame
                 preZoomFrame = nil
+                isRestoringFrame = true
                 setFrame(savedFrame, display: true, animate: true)
+                isRestoringFrame = false
             } else {
                 // Save current frame and zoom
                 preZoomFrame = frame
                 zoom(nil)
             }
         }
+    }
+
+    override func setFrame(_ frameRect: NSRect, display displayFlag: Bool, animate animateFlag: Bool) {
+        super.setFrame(frameRect, display: displayFlag, animate: animateFlag)
+        invalidatePreZoomFrameIfNeeded()
+    }
+
+    override func setFrame(_ frameRect: NSRect, display flag: Bool) {
+        super.setFrame(frameRect, display: flag)
+        invalidatePreZoomFrameIfNeeded()
+    }
+
+    /// Invalidate the saved pre-zoom frame when the window is resized through
+    /// paths other than our own restore (e.g. user drag-resize, green button,
+    /// programmatic resize). This prevents restoring an outdated frame on the
+    /// next title-bar double-click.
+    private func invalidatePreZoomFrameIfNeeded() {
+        guard !isRestoringFrame else { return }
+        preZoomFrame = nil
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -14,8 +14,6 @@ import SwiftUI
 /// back to the previous size.
 class TitleBarZoomableWindow: NSWindow {
     private var preZoomFrame: NSRect?
-    /// Guards against invalidating `preZoomFrame` during our own restore animation.
-    private var isRestoringFrame = false
 
     override func mouseUp(with event: NSEvent) {
         super.mouseUp(with: event)
@@ -36,34 +34,13 @@ class TitleBarZoomableWindow: NSWindow {
             if let savedFrame = preZoomFrame {
                 // Restore to pre-zoom frame
                 preZoomFrame = nil
-                isRestoringFrame = true
                 setFrame(savedFrame, display: true, animate: true)
-                isRestoringFrame = false
             } else {
                 // Save current frame and zoom
                 preZoomFrame = frame
                 zoom(nil)
             }
         }
-    }
-
-    override func setFrame(_ frameRect: NSRect, display displayFlag: Bool, animate animateFlag: Bool) {
-        super.setFrame(frameRect, display: displayFlag, animate: animateFlag)
-        invalidatePreZoomFrameIfNeeded()
-    }
-
-    override func setFrame(_ frameRect: NSRect, display flag: Bool) {
-        super.setFrame(frameRect, display: flag)
-        invalidatePreZoomFrameIfNeeded()
-    }
-
-    /// Invalidate the saved pre-zoom frame when the window is resized through
-    /// paths other than our own restore (e.g. user drag-resize, green button,
-    /// programmatic resize). This prevents restoring an outdated frame on the
-    /// next title-bar double-click.
-    private func invalidatePreZoomFrameIfNeeded() {
-        guard !isRestoringFrame else { return }
-        preZoomFrame = nil
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -8,7 +8,13 @@ import SwiftUI
 /// title bar becomes invisible and stops handling double-clicks. This
 /// subclass detects double-clicks in the title bar zone and performs the
 /// action configured in System Settings (zoom or minimize).
+///
+/// We manually track the pre-zoom frame because `NSWindow.isZoomed` can be
+/// unreliable with `fullSizeContentView`, causing `zoom(nil)` not to toggle
+/// back to the previous size.
 class TitleBarZoomableWindow: NSWindow {
+    private var preZoomFrame: NSRect?
+
     override func mouseUp(with event: NSEvent) {
         super.mouseUp(with: event)
         guard event.clickCount == 2 else { return }
@@ -25,7 +31,15 @@ class TitleBarZoomableWindow: NSWindow {
         case "None":
             break
         default: // "Maximize"
-            zoom(nil)
+            if let savedFrame = preZoomFrame {
+                // Restore to pre-zoom frame
+                preZoomFrame = nil
+                setFrame(savedFrame, display: true, animate: true)
+            } else {
+                // Save current frame and zoom
+                preZoomFrame = frame
+                zoom(nil)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Double-clicking the title bar now properly toggles between maximized and the previous window size
- `NSWindow.isZoomed` is unreliable with `fullSizeContentView`, so `zoom(nil)` wasn't toggling back — we now manually track the pre-zoom frame and restore it on the second double-click

## Test plan
- [ ] Double-click title bar → window should maximize
- [ ] Double-click title bar again → window should restore to previous size
- [ ] Resize window manually, then double-click → should maximize from the new size
- [ ] Double-click again → should restore to that manually resized size

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
