### PR TITLE
fix: narrow legacy starter pattern check to match specific tool (#3696)

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -130,7 +130,7 @@ function migrateStarterRulePatterns(rules: TrustRule[]): boolean {
     // Only migrate patterns that match a known legacy format.
     // The "tool:**" prefix (e.g. "file_read:**") was the original pattern
     // before it was changed to standalone "**".
-    if (!isLegacyStarterPattern(rule.pattern)) continue;
+    if (!isLegacyStarterPattern(rule.pattern, rule.tool)) continue;
     log.info(
       { ruleId: rule.id, oldPattern: rule.pattern, newPattern: template.pattern },
       'Migrated starter rule pattern to current template',
@@ -142,9 +142,11 @@ function migrateStarterRulePatterns(rules: TrustRule[]): boolean {
 }
 
 /** Recognises legacy starter-rule patterns that should be auto-migrated. */
-function isLegacyStarterPattern(pattern: string): boolean {
+function isLegacyStarterPattern(pattern: string, tool: string): boolean {
   // Legacy format used "tool:**" prefixes, e.g. "file_read:**", "glob:**".
-  return /^[a-z_]+:\*\*$/.test(pattern);
+  // Only match the exact legacy pattern for this specific tool to avoid
+  // silently resetting user-customised patterns.
+  return pattern === `${tool}:**`;
 }
 
 function loadFromDisk(): TrustRule[] {


### PR DESCRIPTION
Address Codex review feedback on #3696: the isLegacyStarterPattern regex was too broad, matching any tool_name:** pattern. Now it checks against the specific rule's tool name, preventing unintended migration of user-customized patterns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
