### PR TITLE
fix: use visited-set for symlink cycle detection in version hash (#3697)

### DIFF
--- a/assistant/src/__tests__/skill-version-hash.test.ts
+++ b/assistant/src/__tests__/skill-version-hash.test.ts
@@ -136,6 +136,21 @@ describe('computeSkillVersionHash', () => {
     expect(hash1).not.toBe(hash2);
   });
 
+  test('skips symlinked directories that point to parent (avoids infinite recursion)', () => {
+    // Create a controlled parent so the symlink doesn't traverse the OS temp dir
+    const parent = makeTempSkill();
+    const skillDir = join(parent, 'skill');
+    mkdirSync(skillDir);
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Skill\n');
+
+    // Symlink "up -> .." resolves to `parent`, which contains `skill` as a
+    // normal child — without cycle detection this causes infinite recursion.
+    symlinkSync(parent, join(skillDir, 'up'));
+    const hash = computeSkillVersionHash(skillDir);
+
+    expect(hash).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+
   test('hash changes when symlink target content changes', () => {
     const dir = makeTempSkill();
     const external = makeTempSkill();

--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -16,9 +16,19 @@ const EXCLUDED_NAMES = new Set([
 
 /**
  * Collect all files under `dir` in sorted order, excluding transient entries.
+ * Uses a `visited` set of real directory paths to prevent all symlink cycle types.
  */
-function collectFiles(dir: string, base: string): string[] {
+function collectFiles(dir: string, base: string, visited: Set<string> = new Set()): string[] {
   const entries: string[] = [];
+
+  let realDir: string;
+  try {
+    realDir = realpathSync(dir);
+  } catch {
+    return entries;
+  }
+  if (visited.has(realDir)) return entries;
+  visited.add(realDir);
 
   let items: string[];
   try {
@@ -50,23 +60,14 @@ function collectFiles(dir: string, base: string): string[] {
         continue;
       }
       if (resolvedStat.isDirectory()) {
-        // Skip directory symlinks that resolve into the skill dir to avoid loops
-        let realBase: string;
-        try {
-          realBase = realpathSync(base);
-        } catch {
-          continue;
-        }
-        const relToBase = relative(realBase, resolved);
-        if (!relToBase.startsWith('..') && !relToBase.startsWith('/')) continue;
-        entries.push(...collectFiles(full, base));
+        entries.push(...collectFiles(full, base, visited));
       } else if (resolvedStat.isFile()) {
         entries.push(relative(base, full));
       }
       continue;
     }
     if (stat.isDirectory()) {
-      entries.push(...collectFiles(full, base));
+      entries.push(...collectFiles(full, base, visited));
     } else if (stat.isFile()) {
       entries.push(relative(base, full));
     }


### PR DESCRIPTION
Address Codex and Devin review feedback on #3697: the relative()-based loop detection only caught symlinks pointing back into the skill dir, but missed parent-dir and mutual-cycle symlinks causing infinite recursion. Replaced with a visited-set approach that tracks all real directory paths and prevents all cycle types.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
