### PR TITLE
fix: block open_link in sandbox mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -626,6 +626,14 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     log.warning("open_link: invalid URL")
                     return
                 }
+                // Sandbox: only allow the Vellum branding domain.
+                if sandboxMode {
+                    let host = url.host?.lowercased() ?? ""
+                    guard host == "vellum.ai" || host.hasSuffix(".vellum.ai") else {
+                        log.warning("open_link: blocked in sandbox mode (host=\(host, privacy: .public))")
+                        return
+                    }
+                }
                 let metadata = body["metadata"] as? [String: Any]
                 onLinkOpen?(urlString, metadata)
                 return


### PR DESCRIPTION
## Summary
- Sandbox mode blocked `open_external` but still forwarded `open_link` to the daemon, allowing sandboxed/shared apps to generate arbitrary outbound link prompts
- Added sandbox gating to the `open_link` handler with a domain allowlist (`vellum.ai` / `*.vellum.ai`) so the "Built on Vellum" branding badge continues to work
- Blocks all other domains in sandbox mode with a warning log, matching the existing `open_external` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
