### PR TITLE
fix: require explicit VELLUM_DAEMON_NOAUTH flag to bypass token auth

### DIFF
--- a/assistant/src/__tests__/connection-policy.test.ts
+++ b/assistant/src/__tests__/connection-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { hasSocketOverride, shouldAutoStartDaemon } from '../daemon/connection-policy.js';
+import { hasSocketOverride, hasNoAuthOverride, shouldAutoStartDaemon } from '../daemon/connection-policy.js';
 
 describe('hasSocketOverride', () => {
   test('returns false when VELLUM_DAEMON_SOCKET is not set', () => {
@@ -16,6 +16,46 @@ describe('hasSocketOverride', () => {
 
   test('returns true when VELLUM_DAEMON_SOCKET is set', () => {
     expect(hasSocketOverride({ VELLUM_DAEMON_SOCKET: '/tmp/custom.sock' })).toBe(true);
+  });
+});
+
+describe('hasNoAuthOverride', () => {
+  test('returns false when VELLUM_DAEMON_NOAUTH is not set', () => {
+    expect(hasNoAuthOverride({})).toBe(false);
+  });
+
+  test('returns false when VELLUM_DAEMON_NOAUTH is empty', () => {
+    expect(hasNoAuthOverride({ VELLUM_DAEMON_NOAUTH: '' })).toBe(false);
+  });
+
+  test('returns false when VELLUM_DAEMON_NOAUTH is whitespace', () => {
+    expect(hasNoAuthOverride({ VELLUM_DAEMON_NOAUTH: '   ' })).toBe(false);
+  });
+
+  test('returns false when VELLUM_DAEMON_NOAUTH is 0', () => {
+    expect(hasNoAuthOverride({ VELLUM_DAEMON_NOAUTH: '0' })).toBe(false);
+  });
+
+  test('returns false when VELLUM_DAEMON_NOAUTH is false', () => {
+    expect(hasNoAuthOverride({ VELLUM_DAEMON_NOAUTH: 'false' })).toBe(false);
+  });
+
+  test('returns true when VELLUM_DAEMON_NOAUTH is 1', () => {
+    expect(hasNoAuthOverride({ VELLUM_DAEMON_NOAUTH: '1' })).toBe(true);
+  });
+
+  test('returns true when VELLUM_DAEMON_NOAUTH is true', () => {
+    expect(hasNoAuthOverride({ VELLUM_DAEMON_NOAUTH: 'true' })).toBe(true);
+  });
+
+  test('is independent of VELLUM_DAEMON_SOCKET', () => {
+    // Socket override alone does NOT enable no-auth
+    expect(hasNoAuthOverride({ VELLUM_DAEMON_SOCKET: '/tmp/custom.sock' })).toBe(false);
+    // No-auth requires its own explicit flag
+    expect(hasNoAuthOverride({
+      VELLUM_DAEMON_SOCKET: '/tmp/custom.sock',
+      VELLUM_DAEMON_NOAUTH: '1',
+    })).toBe(true);
   });
 });
 

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -3,7 +3,7 @@ import * as readline from 'node:readline';
 import { readFileSync, appendFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { getSocketPath, getHistoryPath, readSessionToken } from './util/platform.js';
-import { hasSocketOverride } from './daemon/connection-policy.js';
+import { hasNoAuthOverride } from './daemon/connection-policy.js';
 import {
   serialize,
   createMessageParser,
@@ -694,10 +694,11 @@ export async function startCli(): Promise<void> {
         // accept any other messages.
         const token = readSessionToken();
         if (!token) {
-          if (hasSocketOverride()) {
-            // SSH-forwarded socket: the token file lives on the remote
-            // host, not locally. Connect without auth and let the server
-            // decide whether to accept the unauthenticated connection.
+          if (hasNoAuthOverride()) {
+            // VELLUM_DAEMON_NOAUTH=1: the operator has explicitly opted
+            // into unauthenticated connections (e.g. SSH-forwarded socket
+            // where the token file lives on the remote host). Connect
+            // without auth and let the server decide.
             authenticated = true;
             startHeartbeat();
             resolve();

--- a/assistant/src/daemon/connection-policy.ts
+++ b/assistant/src/daemon/connection-policy.ts
@@ -1,14 +1,30 @@
 /**
- * Connection policy helpers for daemon autostart behavior.
+ * Connection policy helpers for daemon autostart and authentication behavior.
  *
  * When the user targets a remote/forwarded socket via VELLUM_DAEMON_SOCKET,
  * autostart should be disabled by default to avoid accidentally spawning
  * a local daemon. VELLUM_DAEMON_AUTOSTART=1 forces autostart regardless.
+ *
+ * Token authentication is always required, even with a socket override.
+ * To explicitly disable auth (e.g. SSH-forwarded sockets where the client
+ * can't read the remote token file), set VELLUM_DAEMON_NOAUTH=1 on both
+ * the daemon and the client. This is an intentional opt-in to an unsafe
+ * mode — never enable it on sockets accessible to untrusted users.
  */
 
 export function hasSocketOverride(env: Record<string, string | undefined> = process.env): boolean {
   const override = env.VELLUM_DAEMON_SOCKET?.trim();
   return !!override;
+}
+
+/**
+ * True when the user has explicitly opted into unauthenticated connections
+ * via VELLUM_DAEMON_NOAUTH=1. This is separate from the socket override
+ * so that using a custom socket path alone does NOT bypass token auth.
+ */
+export function hasNoAuthOverride(env: Record<string, string | undefined> = process.env): boolean {
+  const value = env.VELLUM_DAEMON_NOAUTH?.trim();
+  return value === '1' || value === 'true';
 }
 
 export function shouldAutoStartDaemon(env: Record<string, string | undefined> = process.env): boolean {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, chmodSync, writeFileSync, unlinkSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
 import { getSocketPath, getSessionTokenPath, getRootDir, getWorkspaceDir, getWorkspaceSkillsDir, getSandboxWorkingDir, removeSocketFile } from '../util/platform.js';
-import { hasSocketOverride } from './connection-policy.js';
+import { hasNoAuthOverride } from './connection-policy.js';
 import { getLogger } from '../util/logger.js';
 import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -486,15 +486,15 @@ export class DaemonServer {
     this.connectedSockets.add(socket);
     const parser = createMessageParser({ maxLineSize: MAX_LINE_SIZE });
 
-    // When the daemon is listening on a custom/forwarded socket
-    // (VELLUM_DAEMON_SOCKET), clients may not have access to the local
-    // session token file (e.g. SSH-forwarded connections). Auto-authenticate
-    // these connections so they aren't disconnected by the auth timeout.
-    // Clients that DO have a token will still send an auth message which
-    // is accepted normally via the auth gate below.
-    if (hasSocketOverride()) {
+    // When the operator explicitly opts into unauthenticated connections
+    // (VELLUM_DAEMON_NOAUTH=1), auto-authenticate so clients that can't
+    // read the local session token file (e.g. SSH-forwarded sockets)
+    // aren't disconnected by the auth timeout. This is intentionally
+    // gated on a separate flag — a custom socket path alone (via
+    // VELLUM_DAEMON_SOCKET) no longer bypasses token auth.
+    if (hasNoAuthOverride()) {
       this.authenticatedSockets.add(socket);
-      log.info('Auto-authenticated client on overridden socket path');
+      log.warn('Auto-authenticated client (VELLUM_DAEMON_NOAUTH is set — token auth bypassed)');
       this.send(socket, { type: 'auth_result', success: true });
       this.sendInitialSession(socket).catch((err) => {
         log.error({ err }, 'Failed to send initial session info after auto-auth');


### PR DESCRIPTION
## Summary
- Decouples socket path override (`VELLUM_DAEMON_SOCKET`) from authentication bypass — setting a custom socket path no longer auto-authenticates clients
- Introduces `VELLUM_DAEMON_NOAUTH=1` as an explicit opt-in flag for unauthenticated connections (e.g. SSH-forwarded sockets where the client can't read the remote token file)
- Adds `hasNoAuthOverride()` to `connection-policy.ts` and updates both server and CLI to gate auth bypass on the new flag
- Adds 7 new tests for `hasNoAuthOverride` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
