### PR TITLE
fix: enforce ingress checks on runtime HTTP paths

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -11,6 +11,8 @@ import { getConfig, invalidateConfigCache } from '../config/loader.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import { resetAllowlist } from '../security/secret-allowlist.js';
+import { checkIngressForSecrets } from '../security/secret-ingress.js';
+import { IngressBlockedError } from '../util/errors.js';
 import { clearEmbeddingBackendCache } from '../memory/embedding-backend.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
@@ -817,6 +819,12 @@ export class DaemonServer {
     attachmentIds?: string[],
     options?: SessionCreateOptions,
   ): Promise<{ messageId: string }> {
+    // Block inbound content that contains secrets — mirrors the IPC check in sessions.ts
+    const ingressCheck = checkIngressForSecrets(content);
+    if (ingressCheck.blocked) {
+      throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
+    }
+
     const session = await this.getOrCreateSession(conversationId, undefined, true, options);
 
     // Reject concurrent requests upfront. The HTTP path should never use
@@ -864,6 +872,12 @@ export class DaemonServer {
     attachmentIds?: string[],
     options?: SessionCreateOptions,
   ): Promise<{ messageId: string }> {
+    // Block inbound content that contains secrets — mirrors the IPC check in sessions.ts
+    const ingressCheck = checkIngressForSecrets(content);
+    if (ingressCheck.blocked) {
+      throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
+    }
+
     const session = await this.getOrCreateSession(conversationId, undefined, true, options);
 
     if (session.isProcessing()) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { ConfigError } from '../util/errors.js';
+import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 
@@ -274,6 +274,10 @@ export class RuntimeHttpServer {
 
       return Response.json({ error: 'Not found' }, { status: 404 });
     } catch (err) {
+      if (err instanceof IngressBlockedError) {
+        log.warn({ endpoint, assistantId, detectedTypes: err.detectedTypes }, 'Blocked HTTP request containing secrets');
+        return Response.json({ error: err.message, code: err.code }, { status: 422 });
+      }
       if (err instanceof ConfigError) {
         log.warn({ err, endpoint, assistantId }, 'Runtime HTTP config error');
         return Response.json({ error: err.message, code: err.code }, { status: 422 });

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -7,6 +7,7 @@ import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
 import { renderHistoryContent } from '../../daemon/handlers.js';
+import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import type {
   MessageProcessor,
@@ -218,6 +219,8 @@ export async function handleChannelInbound(
       channelDeliveryStore.markProcessed(result.eventId);
       processingSucceeded = true;
     } catch (err) {
+      // Secret ingress blocks are not retryable — let the top-level handler return 422
+      if (err instanceof IngressBlockedError) throw err;
       console.error(`[runtime-http] Processing failed`, err);
       log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       channelDeliveryStore.recordProcessingFailure(result.eventId, err);

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -15,6 +15,8 @@ import type { Run } from '../memory/runs-store.js';
 import type { Session } from '../daemon/session.js';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import type { UserDecision } from '../permissions/types.js';
+import { checkIngressForSecrets } from '../security/secret-ingress.js';
+import { IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('run-orchestrator');
@@ -67,6 +69,12 @@ export class RunOrchestrator {
     content: string,
     attachmentIds?: string[],
   ): Promise<Run> {
+    // Block inbound content that contains secrets — mirrors the IPC check in sessions.ts
+    const ingressCheck = checkIngressForSecrets(content);
+    if (ingressCheck.blocked) {
+      throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
+    }
+
     const session = await this.deps.getOrCreateSession(conversationId);
 
     if (session.isProcessing()) {

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -26,6 +26,9 @@ export enum ErrorCode {
   // Rate limit exceeded
   RATE_LIMIT_ERROR = 'RATE_LIMIT_ERROR',
 
+  // Secret detected in inbound content
+  INGRESS_BLOCKED = 'INGRESS_BLOCKED',
+
   // Internal/unexpected errors
   INTERNAL_ERROR = 'INTERNAL_ERROR',
 }
@@ -112,5 +115,15 @@ export class RateLimitError extends AssistantError {
   constructor(message: string) {
     super(message, ErrorCode.RATE_LIMIT_ERROR);
     this.name = 'RateLimitError';
+  }
+}
+
+export class IngressBlockedError extends AssistantError {
+  constructor(
+    message: string,
+    public readonly detectedTypes: string[],
+  ) {
+    super(message, ErrorCode.INGRESS_BLOCKED);
+    this.name = 'IngressBlockedError';
   }
 }


### PR DESCRIPTION
## Summary
- Added `IngressBlockedError` error type and `INGRESS_BLOCKED` error code
- Enforced `checkIngressForSecrets()` in the shared daemon processing methods (`persistAndProcessMessage`, `processMessage`) and `RunOrchestrator.startRun()` — covers conversation messages, channel inbound, and run creation HTTP paths
- HTTP server catches `IngressBlockedError` and returns 422 with a safe error message (never echoes content)
- Channel inbound handler re-throws `IngressBlockedError` to avoid recording it as a retryable processing failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)