### PR TITLE
fix: enforce directory-boundary match in trust scope checks

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -362,6 +362,30 @@ describe('Trust Store', () => {
         const match = findMatchingRule('bash', 'ls', '/');
         expect(match).not.toBeNull();
       });
+
+      test('does not match sibling path with shared prefix', () => {
+        addRule('bash', 'npm *', '/home/user/project');
+        const match = findMatchingRule('bash', 'npm install', '/home/user/project-evil');
+        expect(match).toBeNull();
+      });
+
+      test('matches exact scope with trailing slash on working dir', () => {
+        addRule('bash', 'npm *', '/home/user/project');
+        const match = findMatchingRule('bash', 'npm install', '/home/user/project/');
+        expect(match).not.toBeNull();
+      });
+
+      test('matches when rule scope has trailing slash', () => {
+        addRule('bash', 'npm *', '/home/user/project/');
+        const match = findMatchingRule('bash', 'npm install', '/home/user/project');
+        expect(match).not.toBeNull();
+      });
+
+      test('does not match sibling with glob-suffixed scope', () => {
+        addRule('bash', 'npm *', '/home/user/project*');
+        const match = findMatchingRule('bash', 'npm install', '/home/user/project-evil');
+        expect(match).toBeNull();
+      });
     });
 
     // Pattern matching with minimatch

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -342,7 +342,11 @@ export function removeRule(id: string): boolean {
 
 function matchesScope(ruleScope: string, workingDir: string): boolean {
   if (ruleScope === 'everywhere') return true;
-  return workingDir.startsWith(ruleScope.replace(/\*$/, ''));
+  // Strip optional trailing wildcard, then enforce a directory-boundary match
+  // so that a rule for "/path/project" does NOT match "/path/project-evil".
+  const prefix = ruleScope.replace(/\*$/, '').replace(/\/+$/, '');
+  const dir = workingDir.replace(/\/+$/, '');
+  return dir === prefix || dir.startsWith(prefix + '/');
 }
 
 function findRuleByDecision(tool: string, command: string, scope: string, decision: 'allow' | 'deny' | 'ask'): TrustRule | null {


### PR DESCRIPTION
## Summary
- `matchesScope()` previously used a bare `startsWith` prefix check, which meant a trust rule scoped to `/path/project` would also match `/path/project-evil` (sibling path with a shared prefix).
- Now normalizes trailing slashes and requires the working directory to either equal the scope exactly or continue with a `/` separator.
- Adds tests for sibling-path rejection, trailing-slash tolerance, and glob-suffixed scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
