### PR TITLE
fix: redact secrets from shell command logs and drop upstream response bodies

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -7,6 +7,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
+import { redactSecrets } from '../../security/secret-scanner.js';
 import { formatShellOutput } from '../shared/shell-output.js';
 
 const log = getLogger('host-shell-tool');
@@ -100,7 +101,7 @@ class HostShellTool implements Tool {
     const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
     const timeoutMs = timeoutSec * 1000;
 
-    log.info({ command, cwd: workingDir, timeoutSec, sessionId: context.sessionId }, 'Executing host shell command');
+    log.info({ command: redactSecrets(command), cwd: workingDir, timeoutSec, sessionId: context.sessionId }, 'Executing host shell command');
 
     return new Promise<ToolExecutionResult>((resolve) => {
       const stdoutChunks: Buffer[] = [];

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -152,7 +152,6 @@ class WebSearchTool implements Tool {
     try {
       log.debug({ query, count, offset }, 'Executing web search');
 
-      let lastBody = '';
       for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
         const response = await fetch(url, {
           headers: {
@@ -168,7 +167,9 @@ class WebSearchTool implements Tool {
           return { content: formatResults(results, query), isError: false };
         }
 
-        lastBody = await response.text();
+        // Consume body to release the connection, but don't log it —
+        // upstream error bodies may echo sensitive data from the request.
+        await response.text();
 
         if (response.status === 401 || response.status === 403) {
           return { content: 'Error: Invalid or expired Brave Search API key', isError: true };
@@ -183,7 +184,7 @@ class WebSearchTool implements Tool {
           continue;
         }
 
-        log.warn({ status: response.status, body: lastBody }, 'Brave Search API error');
+        log.warn({ status: response.status }, 'Brave Search API error');
         if (response.status === 429) {
           return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
         }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -5,6 +5,7 @@ import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
+import { redactSecrets } from '../../security/secret-scanner.js';
 import { wrapCommand } from './sandbox.js';
 import { formatShellOutput } from '../shared/shell-output.js';
 import { buildSanitizedEnv } from './safe-env.js';
@@ -56,7 +57,7 @@ class ShellTool implements Tool {
     const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
     const timeoutMs = timeoutSec * 1000;
 
-    log.info({ command, cwd: context.workingDir, timeoutSec }, 'Executing shell command');
+    log.info({ command: redactSecrets(command), cwd: context.workingDir, timeoutSec }, 'Executing shell command');
 
     return new Promise<ToolExecutionResult>((resolve) => {
       const stdoutChunks: Buffer[] = [];


### PR DESCRIPTION
## Summary
- Redact known secret patterns (API keys, tokens, passwords, etc.) from shell command strings before logging in `shell.ts` and `host-shell.ts`, using the existing `redactSecrets` scanner
- Stop logging full upstream response bodies in `web-search.ts` to prevent sensitive data echoed by external APIs from landing in log files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
