### PR TITLE
fix: decouple ingress blocking from secretDetection.action

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -98,7 +98,7 @@ describe('AssistantConfigSchema', () => {
       },
     });
     expect(result.rateLimit).toEqual({ maxRequestsPerMinute: 0, maxTokensPerSession: 0 });
-    expect(result.secretDetection).toEqual({ enabled: true, action: 'block', entropyThreshold: 4.0, allowOneTimeSend: false });
+    expect(result.secretDetection).toEqual({ enabled: true, action: 'block', entropyThreshold: 4.0, allowOneTimeSend: false, blockIngress: true });
     expect(result.auditLog).toEqual({ retentionDays: 0 });
   });
 

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -10,6 +10,7 @@ const mockConfig = {
     action: 'block' as 'redact' | 'warn' | 'block',
     entropyThreshold: 4.0,
     allowOneTimeSend: false,
+    blockIngress: true,
   },
   timeouts: { permissionTimeoutSec: 300 },
 };
@@ -162,11 +163,19 @@ describe('E2E: secret ingress blocking', () => {
     expect(check.blocked).toBe(false);
   });
 
-  test('bypasses when action is warn (not block)', () => {
-    mockConfig.secretDetection.action = 'warn';
+  test('bypasses when blockIngress is false', () => {
+    mockConfig.secretDetection.blockIngress = false;
     const awsKey = ['AKIA', 'IOSFODNN7', 'REALKEY'].join('');
     const check = checkIngressForSecrets(awsKey);
     expect(check.blocked).toBe(false);
+  });
+
+  test('still blocks when action is warn but blockIngress is true', () => {
+    mockConfig.secretDetection.action = 'warn';
+    mockConfig.secretDetection.blockIngress = true;
+    const awsKey = ['AKIA', 'IOSFODNN7', 'REALKEY'].join('');
+    const check = checkIngressForSecrets(awsKey);
+    expect(check.blocked).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -127,6 +127,7 @@ describe('Invariant 1: secrets never enter LLM context', () => {
         secretDetection: {
           enabled: true,
           action: 'block',
+          blockIngress: true,
         },
       }),
     }));
@@ -414,5 +415,11 @@ describe('One-time send override', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { DEFAULT_CONFIG } = require('../config/defaults.js');
     expect(DEFAULT_CONFIG.secretDetection.action).toBe('block');
+  });
+
+  test('default secretDetection.blockIngress is true', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { DEFAULT_CONFIG } = require('../config/defaults.js');
+    expect(DEFAULT_CONFIG.secretDetection.blockIngress).toBe(true);
   });
 });

--- a/assistant/src/__tests__/secret-ingress-handler.test.ts
+++ b/assistant/src/__tests__/secret-ingress-handler.test.ts
@@ -5,6 +5,7 @@ const mockConfig = {
     enabled: true,
     action: 'block' as 'redact' | 'warn' | 'block',
     entropyThreshold: 4.0,
+    blockIngress: true,
   },
 };
 
@@ -29,7 +30,7 @@ const GH_TOKEN = ['ghp_', 'ABCDEFghijklMN01234567', '89abcdefghijkl'].join('');
 
 describe('secret ingress handler', () => {
   beforeEach(() => {
-    mockConfig.secretDetection = { enabled: true, action: 'block', entropyThreshold: 4.0 };
+    mockConfig.secretDetection = { enabled: true, action: 'block', entropyThreshold: 4.0, blockIngress: true };
   });
 
   test('blocks message containing an AWS key', () => {
@@ -53,16 +54,21 @@ describe('secret ingress handler', () => {
     expect(result.blocked).toBe(false);
   });
 
-  test('does not block in warn mode (warn only applies to tool output)', () => {
-    mockConfig.secretDetection.action = 'warn';
+  test('does not block when blockIngress is false', () => {
+    mockConfig.secretDetection.blockIngress = false;
     const result = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
     expect(result.blocked).toBe(false);
   });
 
-  test('does not block in redact mode', () => {
+  test('blocks regardless of output action when blockIngress is true', () => {
+    mockConfig.secretDetection.action = 'warn';
+    mockConfig.secretDetection.blockIngress = true;
+    const resultWarn = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
+    expect(resultWarn.blocked).toBe(true);
+
     mockConfig.secretDetection.action = 'redact';
-    const result = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
-    expect(result.blocked).toBe(false);
+    const resultRedact = checkIngressForSecrets(`Here is my key: ${AWS_KEY}`);
+    expect(resultRedact.blocked).toBe(true);
   });
 
   test('user notice never contains the secret value', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -153,6 +153,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     action: 'block',
     entropyThreshold: 4.0,
     allowOneTimeSend: false,
+    blockIngress: true,
   },
   permissions: {
     mode: 'strict',

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -109,6 +109,9 @@ export const SecretDetectionConfigSchema = z.object({
   allowOneTimeSend: z
     .boolean({ error: 'secretDetection.allowOneTimeSend must be a boolean' })
     .default(false),
+  blockIngress: z
+    .boolean({ error: 'secretDetection.blockIngress must be a boolean' })
+    .default(true),
 });
 
 export const PermissionsConfigSchema = z.object({
@@ -911,6 +914,7 @@ export const AssistantConfigSchema = z.object({
     action: 'block',
     entropyThreshold: 4.0,
     allowOneTimeSend: false,
+    blockIngress: true,
   }),
   permissions: PermissionsConfigSchema.default({
     mode: 'strict',

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -19,9 +19,10 @@ export interface IngressCheckResult {
 /**
  * Scan inbound user text for secrets before it enters model context.
  *
- * When `secretDetection.action` is `block` (default), any message containing
- * a detected secret is rejected with a safe notice. The raw message content
- * is never logged or persisted.
+ * When `secretDetection.blockIngress` is `true` (default), any message
+ * containing a detected secret is rejected with a safe notice. This is
+ * independent of `secretDetection.action`, which only controls how
+ * secrets in tool *output* are handled.
  *
  * SECURITY: This function intentionally never logs the message content.
  */
@@ -31,8 +32,7 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
     return { blocked: false, detectedTypes: [] };
   }
 
-  // Only block in 'block' mode; 'warn' and 'redact' apply to tool output, not user input
-  if (config.secretDetection.action !== 'block') {
+  if (!config.secretDetection.blockIngress) {
     return { blocked: false, detectedTypes: [] };
   }
 


### PR DESCRIPTION
## Summary
- Add `secretDetection.blockIngress` boolean (default `true`) to independently control whether inbound user messages containing secrets are blocked
- `secretDetection.action` now only governs tool *output* behavior (redact/warn/block), fixing the bug where switching to `warn` or `redact` silently disabled ingress blocking
- Updated schema, defaults, secret-ingress handler, and all related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
