### PR TITLE
fix: align standalone secret prompt with session prompt policy context

### DIFF
--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -74,7 +74,9 @@ export async function handlePublishPage(
         label: 'Vercel API Token',
         description: 'Required to publish site apps to the web. Create a token at vercel.com/account/tokens.',
         placeholder: 'Enter your Vercel API token',
+        purpose: 'Publish site apps to the web',
         allowedTools,
+        allowedDomains: ['api.vercel.com'],
       });
 
       if (!secretResult.value) {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -7,6 +7,7 @@ import { execSync } from 'node:child_process';
 import { estimateBase64Bytes } from '../assistant-attachments.js';
 import type { CuSessionCreate, ServerMessage, SessionTransportMetadata } from '../ipc-protocol.js';
 import type { SecretPromptResult } from '../../permissions/secret-prompter.js';
+import { getConfig } from '../../config/loader.js';
 
 const log = getLogger('handlers');
 
@@ -447,14 +448,24 @@ export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistor
 export function requestSecretStandalone(
   socket: net.Socket,
   ctx: HandlerContext,
-  params: { service: string; field: string; label: string; description?: string; placeholder?: string; allowedTools?: string[] },
+  params: {
+    service: string;
+    field: string;
+    label: string;
+    description?: string;
+    placeholder?: string;
+    purpose?: string;
+    allowedTools?: string[];
+    allowedDomains?: string[];
+  },
 ): Promise<SecretPromptResult> {
   const requestId = uuid();
+  const config = getConfig();
   return new Promise((resolve) => {
     const timer = setTimeout(() => {
       pendingStandaloneSecrets.delete(requestId);
       resolve({ value: null, delivery: 'store' });
-    }, 120_000);
+    }, config.timeouts.permissionTimeoutSec * 1000);
     pendingStandaloneSecrets.set(requestId, { resolve, timer });
     ctx.send(socket, {
       type: 'secret_request',
@@ -464,8 +475,10 @@ export function requestSecretStandalone(
       label: params.label,
       description: params.description,
       placeholder: params.placeholder,
-      purpose: 'Publish site apps to the web',
+      purpose: params.purpose,
       allowedTools: params.allowedTools,
+      allowedDomains: params.allowedDomains,
+      allowOneTimeSend: config.secretDetection.allowOneTimeSend,
     });
   });
 }


### PR DESCRIPTION
## Summary
- Added `purpose`, `allowedDomains`, and `allowOneTimeSend` fields to `requestSecretStandalone`, matching the full policy context sent by `SecretPrompter.prompt` in the session path.
- Replaced the hardcoded 120s timeout with the configurable `permissionTimeoutSec` from config (consistent with session path).
- Updated the `publish_page` caller to pass `purpose` and `allowedDomains: ['api.vercel.com']` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
