### PR TITLE
fix: route prompt responses by requestId, not socket binding

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -125,13 +125,14 @@ export async function handleUserMessage(
 
 export function handleConfirmationResponse(
   msg: ConfirmationResponse,
-  socket: net.Socket,
+  _socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const sessionId = ctx.socketToSession.get(socket);
-  if (sessionId) {
-    const session = ctx.sessions.get(sessionId);
-    if (session) {
+  // Route by requestId to the session that originated the prompt, not by
+  // the current socket-session binding which may have changed since the
+  // request was issued (e.g. after a session switch).
+  for (const [sessionId, session] of ctx.sessions) {
+    if (session.hasPendingConfirmation(msg.requestId)) {
       ctx.touchSession(sessionId);
       session.handleConfirmationResponse(
         msg.requestId,
@@ -139,13 +140,15 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
+      return;
     }
   }
+  log.warn({ requestId: msg.requestId }, 'No session found with pending confirmation for requestId');
 }
 
 export function handleSecretResponse(
   msg: SecretResponse,
-  socket: net.Socket,
+  _socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   // Check standalone (non-session) prompts first, since they use a dedicated
@@ -158,15 +161,17 @@ export function handleSecretResponse(
     return;
   }
 
-  // Otherwise route to the session's secret prompter
-  const sessionId = ctx.socketToSession.get(socket);
-  if (sessionId) {
-    const session = ctx.sessions.get(sessionId);
-    if (session) {
+  // Route by requestId to the session that originated the prompt, not by
+  // the current socket-session binding which may have changed since the
+  // request was issued (e.g. after a session switch).
+  for (const [sessionId, session] of ctx.sessions) {
+    if (session.hasPendingSecret(msg.requestId)) {
       ctx.touchSession(sessionId);
       session.handleSecretResponse(msg.requestId, msg.value, msg.delivery);
+      return;
     }
   }
+  log.warn({ requestId: msg.requestId }, 'No session found with pending secret prompt for requestId');
 }
 
 export function handleSessionList(socket: net.Socket, ctx: HandlerContext): void {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -499,6 +499,14 @@ export class Session {
     return this.processing && this.hasQueuedMessages();
   }
 
+  hasPendingConfirmation(requestId: string): boolean {
+    return this.prompter.hasPendingRequest(requestId);
+  }
+
+  hasPendingSecret(requestId: string): boolean {
+    return this.secretPrompter.hasPendingRequest(requestId);
+  }
+
   handleConfirmationResponse(
     requestId: string,
     decision: UserDecision,

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -70,6 +70,10 @@ export class PermissionPrompter {
     });
   }
 
+  hasPendingRequest(requestId: string): boolean {
+    return this.pending.has(requestId);
+  }
+
   resolveConfirmation(
     requestId: string,
     decision: UserDecision,

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -82,6 +82,10 @@ export class SecretPrompter {
     });
   }
 
+  hasPendingRequest(requestId: string): boolean {
+    return this.pending.has(requestId);
+  }
+
   /**
    * Resolve a pending secret prompt with the user-supplied value.
    *


### PR DESCRIPTION
## Summary
- Added `hasPendingRequest()` to `PermissionPrompter` and `SecretPrompter` so callers can check whether a given requestId is pending
- Added `hasPendingConfirmation()` / `hasPendingSecret()` delegation methods to `Session`
- Changed `handleConfirmationResponse` and `handleSecretResponse` handlers to find the correct session by scanning for the pending requestId instead of relying on the mutable `socketToSession` binding — prevents misrouting when a session switch occurs while a prompt is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
