### PR TITLE
feat: trim onboarding to 3-step flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -13,9 +13,9 @@ struct OnboardingFlowView: View {
         ZStack {
             VColor.background.ignoresSafeArea()
 
-            if [0, 2, 3, 4].contains(state.currentStep) {
-                // Steps 0–4: Shared layout with persistent icon + background.
-                // Only the content below the icon transitions between steps.
+            if [0, 1, 2].contains(state.currentStep) {
+                // Steps 0–2: Trimmed onboarding flow (WakeUp → APIKey → ModelSelection).
+                // Previous flow used steps [0, 2, 3, 4] — kept below but unreachable.
                 VStack(spacing: 0) {
                     Spacer()
 
@@ -43,12 +43,14 @@ struct OnboardingFlowView: View {
                         switch state.currentStep {
                         case 0:
                             WakeUpStepView(state: state)
-                        case 2:
+                        case 1:
                             APIKeyStepView(state: state)
-                        case 3:
+                        case 2:
                             ModelSelectionStepView(state: state)
-                        case 4:
-                            FnKeyStepView(state: state)
+                        // Previous flow (preserved for revert):
+                        // case 2: APIKeyStepView(state: state)
+                        // case 3: ModelSelectionStepView(state: state)
+                        // case 4: FnKeyStepView(state: state)
                         default:
                             EmptyView()
                         }
@@ -156,7 +158,9 @@ struct OnboardingFlowView: View {
         }
         .ignoresSafeArea()
         .onChange(of: state.currentStep) { _, newStep in
-            if newStep > 4 {
+            // Trimmed flow ends after step 2 (ModelSelection).
+            // Previous threshold was > 4 (after FnKey step).
+            if newStep > 2 {
                 onComplete()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
@@ -7,7 +7,7 @@ struct OnboardingFooter: View {
 
     private let totalDots = 4
 
-    init(currentStep: Int, totalSteps: Int = 8) {
+    init(currentStep: Int, totalSteps: Int = 3) {
         self.currentStep = currentStep
         self.totalSteps = totalSteps
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -26,7 +26,7 @@ enum ActivationKey: String, CaseIterable {
 final class OnboardingState {
     /// Bump this version whenever the default-flow step order changes so that
     /// persisted step indices from a previous layout are not consumed as-is.
-    private static let currentFlowVersion = 5
+    private static let currentFlowVersion = 6
 
     var currentStep: Int = 0
     var assistantName: String = "Velly"
@@ -109,24 +109,18 @@ final class OnboardingState {
         // Default onboarding now exits immediately after the first post-hatch
         // conversation entry point (step 2). Prevent stale persisted indices
         // from reopening legacy permission-request steps.
-        let maxStep = onboardingVariant == .firstMeeting ? 4 : 4
+        // Trimmed flow: 3 steps (0, 1, 2). Previous default was 4.
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : 2
         if currentStep > maxStep {
             currentStep = maxStep
-        }
-        // Skip naming step (step 1) if restored to it
-        if onboardingVariant == .default && currentStep == 1 {
-            currentStep = 2
         }
     }
 
     func advance() {
         withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
             currentStep += 1
-            // Skip naming step (step 1) — name defaults to "Velly"
-            // Skip everything after API key (steps 3+) — go straight to chat
-            if currentStep == 1 {
-                currentStep = 2
-            }
+            // Previous flow skipped step 1 (naming) with: if currentStep == 1 { currentStep = 2 }
+            // Trimmed flow uses step 1 for APIKey, so no skip needed.
         }
         persist()
     }


### PR DESCRIPTION
Reduces the onboarding flow to 3 steps:
1. WakeUpStepView (step 0)
2. APIKeyStepView (step 1)
3. ModelSelectionStepView (step 2)

Previous steps (FnKey, permissions, interview) are preserved in code but unreachable — no views deleted. Flow version bumped to 6 so persisted state resets. Progress dots now default to 3 total steps.

Part of #3659.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
