### PR TITLE
fix: change progress dots from 4 to 3 to match trimmed flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
@@ -5,7 +5,7 @@ struct OnboardingFooter: View {
     let currentStep: Int
     let totalSteps: Int
 
-    private let totalDots = 4
+    private let totalDots = 3
 
     init(currentStep: Int, totalSteps: Int = 3) {
         self.currentStep = currentStep
@@ -43,9 +43,8 @@ struct OnboardingFooter: View {
         VColor.background
         VStack(spacing: 24) {
             OnboardingFooter(currentStep: 0)
+            OnboardingFooter(currentStep: 1)
             OnboardingFooter(currentStep: 2)
-            OnboardingFooter(currentStep: 4)
-            OnboardingFooter(currentStep: 7)
         }
     }
     .frame(width: 240, height: 260)


### PR DESCRIPTION
With 4 dots and 3 steps, the rounding formula caused step 1 (APIKey) to show 3 filled dots instead of 2. Changed totalDots from 4 to 3 for a clean 1:1 mapping. Part of #3659.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
