### PR TITLE
fix: only show archive button on row hover

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -401,8 +401,8 @@ struct MainWindowView: View {
             }
             .buttonStyle(.plain)
             .frame(width: 24)
-            .opacity(isSelected || isHoveredThread == thread.id ? 1 : 0)
-            .allowsHitTesting(isSelected || isHoveredThread == thread.id)
+            .opacity(isHoveredThread == thread.id ? 1 : 0)
+            .allowsHitTesting(isHoveredThread == thread.id)
             .accessibilityLabel("Archive \(thread.title)")
         }
         .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Remove `isSelected` condition from archive button visibility in the thread drawer sidebar
- Archive button now only appears when hovering over a conversation row, not when the row is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
