### PR TITLE
feat: add drag-to-reorder and pin functionality for sidebar items

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -95,6 +95,28 @@ final class AppListManager: ObservableObject {
         save()
     }
 
+    /// Move an app to a new position (for drag-and-drop reorder).
+    func moveApp(sourceId: String, beforeId: String) {
+        guard let sourceIdx = apps.firstIndex(where: { $0.id == sourceId }),
+              let targetIdx = apps.firstIndex(where: { $0.id == beforeId }) else { return }
+        let targetApp = apps[targetIdx]
+
+        if targetApp.isPinned {
+            if !apps[sourceIdx].isPinned {
+                apps[sourceIdx].isPinned = true
+            }
+            let targetOrder = targetApp.pinnedOrder ?? 0
+            apps[sourceIdx].pinnedOrder = targetOrder
+            for i in apps.indices where apps[i].isPinned && apps[i].id != sourceId {
+                if let order = apps[i].pinnedOrder, order >= targetOrder {
+                    apps[i].pinnedOrder = order + 1
+                }
+            }
+            recompactPinnedOrders()
+        }
+        save()
+    }
+
     // MARK: - Persistence
 
     private func save() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -363,13 +363,21 @@ struct MainWindowView: View {
                     windowState.activePanel = nil
                 }
             }) {
-                Text(thread.title)
-                    .font(.system(size: 13))
-                    .foregroundColor(VColor.textPrimary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
+                HStack(spacing: VSpacing.xs) {
+                    if thread.isPinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(VColor.textMuted)
+                            .rotationEffect(.degrees(-45))
+                    }
+                    Text(thread.title)
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
 
@@ -404,6 +412,20 @@ struct MainWindowView: View {
                 NSCursor.pop()
             }
         }
+        .contextMenu {
+            Button(thread.isPinned ? "Unpin" : "Pin to Top") {
+                if thread.isPinned {
+                    threadManager.unpinThread(id: thread.id)
+                } else {
+                    threadManager.pinThread(id: thread.id)
+                }
+            }
+            Divider()
+            Button("Archive", role: .destructive) {
+                threadPendingDeletion = thread.id
+            }
+        }
+        .draggable(thread.id.uuidString)
     }
 
     private var displayedThreads: [ThreadModel] {
@@ -444,6 +466,13 @@ struct MainWindowView: View {
 
                         ForEach(displayedThreads) { thread in
                             threadItem(thread)
+                                .dropDestination(for: String.self) { items, _ in
+                                    guard let droppedId = items.first,
+                                          let sourceUUID = UUID(uuidString: droppedId),
+                                          sourceUUID != thread.id else { return false }
+                                    threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
+                                    return true
+                                } isTargeted: { _ in }
                         }
 
                         if threadManager.visibleThreads.count > 5 {
@@ -468,6 +497,12 @@ struct MainWindowView: View {
 
                             ForEach(displayedApps) { app in
                                 sidebarAppItem(app)
+                                    .dropDestination(for: String.self) { items, _ in
+                                        guard let droppedId = items.first,
+                                              droppedId != app.id else { return false }
+                                        appListManager.moveApp(sourceId: droppedId, beforeId: app.id)
+                                        return true
+                                    } isTargeted: { _ in }
                             }
 
                             if appListManager.displayApps.count > 5 {
@@ -521,6 +556,13 @@ struct MainWindowView: View {
                 try? daemonClient.sendAppOpen(appId: app.id)
             }) {
                 HStack(spacing: VSpacing.sm) {
+                    if app.isPinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(VColor.textMuted)
+                            .rotationEffect(.degrees(-45))
+                            .frame(width: 14)
+                    }
                     if let icon = app.icon, !icon.isEmpty {
                         Text(icon)
                             .font(.system(size: 14))
@@ -566,6 +608,23 @@ struct MainWindowView: View {
                 NSCursor.pop()
             }
         }
+        .contextMenu {
+            Button(app.isPinned ? "Unpin" : "Pin to Top") {
+                if app.isPinned {
+                    appListManager.unpinApp(id: app.id)
+                } else {
+                    appListManager.pinApp(id: app.id)
+                }
+            }
+            Button("Open") {
+                try? daemonClient.sendAppOpen(appId: app.id)
+            }
+            Divider()
+            Button("Remove from Recents", role: .destructive) {
+                appListManager.removeApp(id: app.id)
+            }
+        }
+        .draggable(app.id)
     }
 
     // MARK: - Drawer Drag Helpers

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -280,6 +280,32 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads[index].lastInteractedAt = Date()
     }
 
+    /// Move a thread to a new position in the visible list (for drag-and-drop reorder).
+    /// If the source thread is pinned, reorder among pinned items.
+    /// If unpinned, pin it and insert at the target position.
+    func moveThread(sourceId: UUID, beforeId: UUID) {
+        guard let sourceIdx = threads.firstIndex(where: { $0.id == sourceId }),
+              let targetIdx = threads.firstIndex(where: { $0.id == beforeId }) else { return }
+        let targetThread = threads[targetIdx]
+
+        // If dropping onto a pinned item, pin the source too and reorder
+        if targetThread.isPinned {
+            if !threads[sourceIdx].isPinned {
+                threads[sourceIdx].isPinned = true
+            }
+            // Set pinnedOrder to place before the target
+            let targetOrder = targetThread.pinnedOrder ?? 0
+            threads[sourceIdx].pinnedOrder = targetOrder
+            // Bump all pinned items at or after targetOrder (except source)
+            for i in threads.indices where threads[i].isPinned && threads[i].id != sourceId {
+                if let order = threads[i].pinnedOrder, order >= targetOrder {
+                    threads[i].pinnedOrder = order + 1
+                }
+            }
+            recompactPinnedOrders()
+        }
+    }
+
     private func recompactPinnedOrders() {
         let pinned = threads.enumerated()
             .filter { $0.element.isPinned }


### PR DESCRIPTION
Part of #3700

- Add context menus with Pin/Unpin for threads and apps in sidebar
- Show pin icon indicator for pinned items
- Add draggable + drop destination for drag-to-reorder
- Add moveThread/moveApp methods for reorder persistence
- Thread context menu: Pin/Unpin, Archive
- App context menu: Pin/Unpin, Open, Remove from Recents

Closes #3703
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
