### PR TITLE
fix: enforce request body size limits on runtime endpoints

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -63,6 +63,9 @@ const log = getLogger('runtime-http');
 
 const DEFAULT_PORT = 7821;
 
+/** Global hard cap on request body size (50 MB). Bun rejects larger payloads before they reach handlers. */
+const MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -86,6 +89,7 @@ export class RuntimeHttpServer {
   async start(): Promise<void> {
     this.server = Bun.serve({
       port: this.port,
+      maxRequestBodySize: MAX_REQUEST_BODY_BYTES,
       fetch: (req) => this.handleRequest(req),
     });
 

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -65,7 +65,18 @@ ${app.htmlDefinition}
   });
 }
 
+/** 50 MB — generous cap for zip app bundles. */
+const MAX_SHARE_BODY_BYTES = 50 * 1024 * 1024;
+
 export async function handleShareApp(req: Request): Promise<Response> {
+  const contentLength = Number(req.headers.get('content-length'));
+  if (contentLength > MAX_SHARE_BODY_BYTES) {
+    return Response.json(
+      { error: `Request body too large (limit: ${MAX_SHARE_BODY_BYTES} bytes)` },
+      { status: 413 },
+    );
+  }
+
   const rawBody = await req.arrayBuffer();
   const bundleData = Buffer.from(rawBody);
 

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -4,7 +4,18 @@
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import { validateAttachmentUpload } from '../../memory/attachments-store.js';
 
+/** 30 MB — base64-encoded 20 MB attachment ≈ 27 MB plus JSON wrapper overhead. */
+const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
+
 export async function handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
+  const contentLength = Number(req.headers.get('content-length'));
+  if (contentLength > MAX_UPLOAD_BODY_BYTES) {
+    return Response.json(
+      { error: `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)` },
+      { status: 413 },
+    );
+  }
+
   const body = await req.json() as {
     filename?: string;
     mimeType?: string;


### PR DESCRIPTION
## Summary
- Add per-route Content-Length header checks that return 413 before parsing: 30 MB for attachment uploads, 50 MB for app share bundles
- Set `maxRequestBodySize: 50 MB` on `Bun.serve()` as a global server-level backstop so Bun rejects oversized payloads before they reach any handler

## Test plan
- [ ] Send a POST to `/v1/assistants/:id/attachments` with Content-Length > 30 MB — expect 413
- [ ] Send a POST to `/v1/apps/share` with Content-Length > 50 MB — expect 413
- [ ] Send a request exceeding 50 MB to any endpoint without Content-Length — expect Bun-level rejection
- [ ] Normal attachment uploads and app shares still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
