### PR TITLE
fix: require bearer token and bind HTTP server to loopback

### DIFF
--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -49,6 +49,9 @@ afterAll(() => {
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 
+const TEST_TOKEN = 'test-bearer-token-attach';
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+
 describe('Runtime attachment metadata', () => {
   let server: RuntimeHttpServer;
   let port: number;
@@ -63,7 +66,7 @@ describe('Runtime attachment metadata', () => {
 
     // Use a random port to avoid conflicts
     port = 17000 + Math.floor(Math.random() * 1000);
-    server = new RuntimeHttpServer({ port });
+    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN });
     await server.start();
   });
 
@@ -94,6 +97,7 @@ describe('Runtime attachment metadata', () => {
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/assistants/${assistantId}/messages?conversationKey=${conversationKey}`,
+      { headers: AUTH_HEADERS },
     );
     const body = await res.json() as { messages: Array<{ role: string; content: string; attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number; kind: string }> }> };
 
@@ -129,6 +133,7 @@ describe('Runtime attachment metadata', () => {
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/assistants/${assistantId}/messages?conversationKey=${conversationKey}`,
+      { headers: AUTH_HEADERS },
     );
     const body = await res.json() as { messages: Array<{ role: string; attachments: unknown[] }> };
 
@@ -144,6 +149,7 @@ describe('Runtime attachment metadata', () => {
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/assistants/${assistantId}/attachments/${stored.id}`,
+      { headers: AUTH_HEADERS },
     );
     const body = await res.json() as {
       id: string; filename: string; mimeType: string; sizeBytes: number; kind: string; data: string;
@@ -163,6 +169,7 @@ describe('Runtime attachment metadata', () => {
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/assistants/ast-other/attachments/${stored.id}`,
+      { headers: AUTH_HEADERS },
     );
     const body = await res.json() as { error: string };
 
@@ -173,6 +180,7 @@ describe('Runtime attachment metadata', () => {
   test('GET /attachments/:id returns 404 for nonexistent attachment', async () => {
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/assistants/ast-test-4/attachments/nonexistent-id`,
+      { headers: AUTH_HEADERS },
     );
     const body = await res.json() as { error: string };
 

--- a/assistant/src/__tests__/runtime-runs-http.test.ts
+++ b/assistant/src/__tests__/runtime-runs-http.test.ts
@@ -127,6 +127,8 @@ function makeHangingSession(): Session {
 // ---------------------------------------------------------------------------
 
 const ASSISTANT_ID = 'ast-run-http';
+const TEST_TOKEN = 'test-bearer-token-runs';
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
 
 describe('runtime runs — HTTP layer', () => {
   let server: RuntimeHttpServer;
@@ -151,7 +153,7 @@ describe('runtime runs — HTTP layer', () => {
       getOrCreateSession: async () => sessionFactory(),
       resolveAttachments: () => [],
     });
-    server = new RuntimeHttpServer({ port, runOrchestrator: orchestrator });
+    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN, runOrchestrator: orchestrator });
     await server.start();
     return { orchestrator };
   }
@@ -164,6 +166,46 @@ describe('runtime runs — HTTP layer', () => {
     return `http://127.0.0.1:${port}/v1/assistants/${ASSISTANT_ID}/runs${path}`;
   }
 
+  // ── Auth ────────────────────────────────────────────────────────────
+
+  test('returns 401 when bearer token is missing', async () => {
+    await startServer(() => makeCompletingSession());
+
+    const res = await fetch(runsUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationKey: 'conv-noauth', content: 'Hi' }),
+    });
+
+    expect(res.status).toBe(401);
+    await stopServer();
+  });
+
+  test('returns 401 when bearer token is wrong', async () => {
+    await startServer(() => makeCompletingSession());
+
+    const res = await fetch(runsUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer wrong-token' },
+      body: JSON.stringify({ conversationKey: 'conv-badauth', content: 'Hi' }),
+    });
+
+    expect(res.status).toBe(401);
+    await stopServer();
+  });
+
+  test('healthz is accessible without auth', async () => {
+    await startServer(() => makeCompletingSession());
+
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { status: string };
+    expect(body.status).toBe('healthy');
+
+    await stopServer();
+  });
+
   // ── POST /runs ──────────────────────────────────────────────────────
 
   test('POST /runs creates a run and returns 201', async () => {
@@ -171,7 +213,7 @@ describe('runtime runs — HTTP layer', () => {
 
     const res = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-1', content: 'Hello' }),
     });
     const body = await res.json() as { id: string; status: string; messageId: string; createdAt: string };
@@ -190,7 +232,7 @@ describe('runtime runs — HTTP layer', () => {
 
     const res = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ content: 'Hello' }),
     });
 
@@ -206,7 +248,7 @@ describe('runtime runs — HTTP layer', () => {
 
     const res = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-2', content: '' }),
     });
 
@@ -222,7 +264,7 @@ describe('runtime runs — HTTP layer', () => {
     // First run starts and hangs
     const res1 = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-busy', content: 'First' }),
     });
     expect(res1.status).toBe(201);
@@ -232,7 +274,7 @@ describe('runtime runs — HTTP layer', () => {
     // Second run should be rejected
     const res2 = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-busy', content: 'Second' }),
     });
     expect(res2.status).toBe(409);
@@ -247,12 +289,12 @@ describe('runtime runs — HTTP layer', () => {
 
     const createRes = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-get', content: 'Test' }),
     });
     const { id } = await createRes.json() as { id: string };
 
-    const getRes = await fetch(runsUrl(`/${id}`));
+    const getRes = await fetch(runsUrl(`/${id}`), { headers: AUTH_HEADERS });
     const body = await getRes.json() as { id: string; status: string; messageId: string };
 
     expect(getRes.status).toBe(200);
@@ -267,14 +309,14 @@ describe('runtime runs — HTTP layer', () => {
 
     const createRes = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-done', content: 'Build it' }),
     });
     const { id } = await createRes.json() as { id: string };
 
     await new Promise((r) => setTimeout(r, 100));
 
-    const getRes = await fetch(runsUrl(`/${id}`));
+    const getRes = await fetch(runsUrl(`/${id}`), { headers: AUTH_HEADERS });
     const body = await getRes.json() as { id: string; status: string };
 
     expect(getRes.status).toBe(200);
@@ -288,14 +330,14 @@ describe('runtime runs — HTTP layer', () => {
 
     const createRes = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-fail', content: 'Do it' }),
     });
     const { id } = await createRes.json() as { id: string };
 
     await new Promise((r) => setTimeout(r, 50));
 
-    const getRes = await fetch(runsUrl(`/${id}`));
+    const getRes = await fetch(runsUrl(`/${id}`), { headers: AUTH_HEADERS });
     const body = await getRes.json() as { id: string; status: string; error: string };
 
     expect(getRes.status).toBe(200);
@@ -308,7 +350,7 @@ describe('runtime runs — HTTP layer', () => {
   test('GET /runs/:id returns 404 for unknown run', async () => {
     await startServer(() => makeCompletingSession());
 
-    const res = await fetch(runsUrl('/nonexistent'));
+    const res = await fetch(runsUrl('/nonexistent'), { headers: AUTH_HEADERS });
     expect(res.status).toBe(404);
 
     await stopServer();
@@ -319,13 +361,13 @@ describe('runtime runs — HTTP layer', () => {
 
     const createRes = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-scope', content: 'Test' }),
     });
     const { id } = await createRes.json() as { id: string };
 
     // Try to access via a different assistant
-    const res = await fetch(`http://127.0.0.1:${port}/v1/assistants/other-assistant/runs/${id}`);
+    const res = await fetch(`http://127.0.0.1:${port}/v1/assistants/other-assistant/runs/${id}`, { headers: AUTH_HEADERS });
     expect(res.status).toBe(404);
 
     await stopServer();
@@ -338,7 +380,7 @@ describe('runtime runs — HTTP layer', () => {
 
     const createRes = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-decide', content: 'Approve' }),
     });
     const { id } = await createRes.json() as { id: string };
@@ -346,7 +388,7 @@ describe('runtime runs — HTTP layer', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     // Verify pending state via GET
-    const getRes = await fetch(runsUrl(`/${id}`));
+    const getRes = await fetch(runsUrl(`/${id}`), { headers: AUTH_HEADERS });
     const runBody = await getRes.json() as { status: string; pendingConfirmation: { toolName: string } };
     expect(runBody.status).toBe('needs_confirmation');
     expect(runBody.pendingConfirmation.toolName).toBe('swarm_delegate');
@@ -354,7 +396,7 @@ describe('runtime runs — HTTP layer', () => {
     // Submit decision
     const decisionRes = await fetch(runsUrl(`/${id}/decision`), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ decision: 'allow' }),
     });
     const decisionBody = await decisionRes.json() as { accepted: boolean };
@@ -370,14 +412,14 @@ describe('runtime runs — HTTP layer', () => {
 
     const createRes = await fetch(runsUrl(), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-bad-dec', content: 'Test' }),
     });
     const { id } = await createRes.json() as { id: string };
 
     const res = await fetch(runsUrl(`/${id}/decision`), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ decision: 'maybe' }),
     });
 
@@ -391,7 +433,7 @@ describe('runtime runs — HTTP layer', () => {
 
     const res = await fetch(runsUrl('/nonexistent/decision'), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ decision: 'allow' }),
     });
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
-import { cpSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, existsSync, openSync, closeSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { cpSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, existsSync, openSync, closeSync, chmodSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
 import * as Sentry from '@sentry/node';
@@ -7,6 +8,7 @@ import {
   getInterfacesDir,
   getSocketPath,
   getPidPath,
+  getHttpTokenPath,
   getRootDir,
   ensureDataDir,
   migrateToDataLayout,
@@ -307,8 +309,19 @@ export async function runDaemon(): Promise<void> {
   if (httpPortEnv) {
     const port = parseInt(httpPortEnv, 10);
     if (!isNaN(port) && port > 0) {
+      // Generate a bearer token and write it to disk so HTTP clients
+      // can authenticate. Written before the server starts listening.
+      const bearerToken = randomBytes(32).toString('hex');
+      const httpTokenPath = getHttpTokenPath();
+      writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
+      chmodSync(httpTokenPath, 0o600);
+
+      const hostname = process.env.RUNTIME_HTTP_HOST?.trim() || '127.0.0.1';
+
       runtimeHttp = new RuntimeHttpServer({
         port,
+        hostname,
+        bearerToken,
         processMessage: (assistantId, conversationId, content, attachmentIds, options) =>
           server.processMessage(assistantId, conversationId, content, attachmentIds, options),
         persistAndProcessMessage: (assistantId, conversationId, content, attachmentIds, options) =>
@@ -317,10 +330,10 @@ export async function runDaemon(): Promise<void> {
         interfacesDir: getInterfacesDir(),
       });
       try {
-        log.info({ port }, 'Daemon startup: starting runtime HTTP server');
+        log.info({ port, hostname }, 'Daemon startup: starting runtime HTTP server');
         await runtimeHttp.start();
         server.setHttpPort(port);
-        log.info({ port }, 'Daemon startup: runtime HTTP server listening');
+        log.info({ port, hostname }, 'Daemon startup: runtime HTTP server listening');
       } catch (err) {
         log.warn({ err, port }, 'Failed to start runtime HTTP server, continuing without it');
         runtimeHttp = null;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -7,6 +7,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { timingSafeEqual } from 'node:crypto';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
@@ -62,10 +63,13 @@ import type {
 const log = getLogger('runtime-http');
 
 const DEFAULT_PORT = 7821;
+const DEFAULT_HOSTNAME = '127.0.0.1';
 
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
+  private hostname: string;
+  private bearerToken: string | undefined;
   private processMessage?: MessageProcessor;
   private persistAndProcessMessage?: NonBlockingMessageProcessor;
   private runOrchestrator?: RunOrchestrator;
@@ -77,6 +81,8 @@ export class RuntimeHttpServer {
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
+    this.hostname = options.hostname ?? DEFAULT_HOSTNAME;
+    this.bearerToken = options.bearerToken;
     this.processMessage = options.processMessage;
     this.persistAndProcessMessage = options.persistAndProcessMessage;
     this.runOrchestrator = options.runOrchestrator;
@@ -86,6 +92,7 @@ export class RuntimeHttpServer {
   async start(): Promise<void> {
     this.server = Bun.serve({
       port: this.port,
+      hostname: this.hostname,
       fetch: (req) => this.handleRequest(req),
     });
 
@@ -98,7 +105,7 @@ export class RuntimeHttpServer {
       }, 30_000);
     }
 
-    log.info({ port: this.port }, 'Runtime HTTP server listening');
+    log.info({ port: this.port, hostname: this.hostname, auth: !!this.bearerToken }, 'Runtime HTTP server listening');
   }
 
   async stop(): Promise<void> {
@@ -113,9 +120,34 @@ export class RuntimeHttpServer {
     }
   }
 
+  /**
+   * Constant-time comparison of two bearer tokens to prevent timing attacks.
+   */
+  private verifyToken(provided: string): boolean {
+    const expected = this.bearerToken!;
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  }
+
   private async handleRequest(req: Request): Promise<Response> {
     const url = new URL(req.url);
     const path = url.pathname;
+
+    // Health checks are unauthenticated — they expose no sensitive data.
+    if (path === '/healthz' && req.method === 'GET') {
+      return this.handleHealth();
+    }
+
+    // Require bearer token when configured
+    if (this.bearerToken) {
+      const authHeader = req.headers.get('authorization');
+      const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+      if (!token || !this.verifyToken(token)) {
+        return Response.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+    }
 
     // Serve shareable app pages
     const pagesMatch = path.match(/^\/pages\/([^/]+)$/);
@@ -172,9 +204,6 @@ export class RuntimeHttpServer {
     // Match /v1/assistants/:assistantId/<endpoint>
     const match = path.match(/^\/v1\/assistants\/([^/]+)\/(.+)$/);
     if (!match) {
-      if (path === '/healthz' && req.method === 'GET') {
-        return this.handleHealth();
-      }
       return Response.json({ error: 'Not found' }, { status: 404 });
     }
 

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -34,6 +34,10 @@ export type NonBlockingMessageProcessor = (
 
 export interface RuntimeHttpServerOptions {
   port?: number;
+  /** Hostname / IP to bind to. Defaults to '127.0.0.1' (loopback-only). */
+  hostname?: string;
+  /** Bearer token required on every request (except health checks). */
+  bearerToken?: string;
   processMessage?: MessageProcessor;
   /** Non-blocking processor for POST /messages (persists + fires agent loop). */
   persistAndProcessMessage?: NonBlockingMessageProcessor;

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -102,6 +102,10 @@ export function getSessionTokenPath(): string {
   return join(getRootDir(), 'session-token');
 }
 
+export function getHttpTokenPath(): string {
+  return join(getRootDir(), 'http-token');
+}
+
 /**
  * Read the daemon session token from disk. Returns null if the file
  * doesn't exist or can't be read (daemon not running).
@@ -109,6 +113,18 @@ export function getSessionTokenPath(): string {
 export function readSessionToken(): string | null {
   try {
     return readFileSync(getSessionTokenPath(), 'utf-8').trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the runtime HTTP bearer token from disk. Returns null if the
+ * file doesn't exist or can't be read (HTTP server not running).
+ */
+export function readHttpToken(): string | null {
+  try {
+    return readFileSync(getHttpTokenPath(), 'utf-8').trim();
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Generate a per-launch bearer token (written to `~/.vellum/http-token`, mode 0600) and require `Authorization: Bearer <token>` on all endpoints except `/healthz`
- Bind `Bun.serve` to `127.0.0.1` by default (overridable via `RUNTIME_HTTP_HOST` env var) so the server is only reachable from the local machine
- Add timing-safe token comparison to prevent side-channel leaks

## Test plan
- [x] New tests: 401 returned for missing token, 401 for wrong token, healthz accessible without auth
- [x] All existing attachment-metadata tests pass with auth headers
- [x] Pre-existing run-orchestrator test failures confirmed on main (unrelated `secretDetection` mock gap)
- [x] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
