### PR TITLE
fix: add 30-day TTL and lazy GC to shared app links

### DIFF
--- a/assistant/src/memory/shared-app-links-store.ts
+++ b/assistant/src/memory/shared-app-links-store.ts
@@ -4,7 +4,7 @@
  * Each record holds a .vellumapp zip bundle keyed by a short, shareable token.
  */
 
-import { eq } from 'drizzle-orm';
+import { eq, lte } from 'drizzle-orm';
 import { randomUUID, randomBytes } from 'node:crypto';
 import { getDb } from './db.js';
 import { sharedAppLinks } from './schema.js';
@@ -21,14 +21,26 @@ export interface SharedAppLinkRecord {
   expiresAt: number | null;
 }
 
+const SHARE_LINK_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
 function generateShareToken(): string {
   return randomBytes(9).toString('base64url').slice(0, 12);
+}
+
+/** Delete all rows whose expiresAt has passed. */
+function sweepExpiredLinks(): void {
+  const db = getDb();
+  db.delete(sharedAppLinks)
+    .where(lte(sharedAppLinks.expiresAt, Date.now()))
+    .run();
 }
 
 export function createSharedAppLink(
   bundleData: Buffer,
   manifest: AppManifest,
 ): { id: string; shareToken: string } {
+  sweepExpiredLinks();
+
   const db = getDb();
   const id = randomUUID();
   const shareToken = generateShareToken();
@@ -43,7 +55,7 @@ export function createSharedAppLink(
       manifestJson: JSON.stringify(manifest),
       downloadCount: 0,
       createdAt: now,
-      expiresAt: null,
+      expiresAt: now + SHARE_LINK_TTL_MS,
     })
     .run();
 
@@ -59,6 +71,7 @@ export function getSharedAppLink(shareToken: string): SharedAppLinkRecord | null
     .get();
 
   if (!row) return null;
+  if (row.expiresAt != null && row.expiresAt < Date.now()) return null;
 
   return {
     id: row.id,


### PR DESCRIPTION
## Summary
- Shared app links now expire after 30 days instead of living forever
- Expired links return 404 on retrieval (checked before returning the row)
- Expired rows are lazily garbage-collected on each new share (no timers or cron needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
