### PR TITLE
fix: enforce hard max-size and base64 validation on attachment uploads

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -45,6 +45,9 @@ import {
   getAttachmentsForMessageUnscoped,
   deleteOrphanAttachments,
   validateAttachmentUpload,
+  isValidBase64,
+  AttachmentUploadError,
+  MAX_UPLOAD_BYTES,
 } from '../memory/attachments-store.js';
 import { createConversation, addMessage } from '../memory/conversation-store.js';
 
@@ -122,9 +125,69 @@ describe('uploadAttachment', () => {
   });
 
   test('does not deduplicate different content', () => {
-    const first = uploadAttachment('ast-1', 'a.txt', 'text/plain', 'CONTENT_A');
-    const second = uploadAttachment('ast-1', 'b.txt', 'text/plain', 'CONTENT_B');
+    const first = uploadAttachment('ast-1', 'a.txt', 'text/plain', 'CONTENTA');
+    const second = uploadAttachment('ast-1', 'b.txt', 'text/plain', 'CONTENTB');
     expect(second.id).not.toBe(first.id);
+  });
+
+  test('rejects payloads exceeding MAX_UPLOAD_BYTES', () => {
+    // Build a base64 string that decodes to just over the limit.
+    // 4 base64 chars → 3 bytes, so we need ceil((MAX_UPLOAD_BYTES+1)/3)*4 chars.
+    const oversizedLength = Math.ceil((MAX_UPLOAD_BYTES + 1) / 3) * 4;
+    const oversizedData = 'A'.repeat(oversizedLength);
+
+    expect(() =>
+      uploadAttachment('ast-1', 'huge.bin', 'application/octet-stream', oversizedData),
+    ).toThrow(AttachmentUploadError);
+  });
+
+  test('rejects invalid base64 data', () => {
+    expect(() =>
+      uploadAttachment('ast-1', 'bad.txt', 'text/plain', '!!!not-base64!!!'),
+    ).toThrow(AttachmentUploadError);
+  });
+
+  test('accepts base64 with non-standard padding/length', () => {
+    // Lenient on length — only character set is validated
+    expect(() =>
+      uploadAttachment('ast-1', 'ok.txt', 'text/plain', 'AAA'),
+    ).not.toThrow();
+  });
+
+  test('accepts payload exactly at MAX_UPLOAD_BYTES', () => {
+    // MAX_UPLOAD_BYTES (20 MB) is divisible by 3, so (MAX/3)*4 base64 chars
+    // decodes to exactly MAX bytes with no padding.
+    const exactLength = (MAX_UPLOAD_BYTES / 3) * 4;
+    const exactData = 'A'.repeat(exactLength);
+
+    expect(() =>
+      uploadAttachment('ast-1', 'exact.bin', 'application/octet-stream', exactData),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidBase64
+// ---------------------------------------------------------------------------
+
+describe('isValidBase64', () => {
+  test('accepts valid base64 strings', () => {
+    expect(isValidBase64('aGVsbG8=')).toBe(true);     // "hello"
+    expect(isValidBase64('dGVzdA==')).toBe(true);      // "test"
+    expect(isValidBase64('AAAA')).toBe(true);          // no padding
+    expect(isValidBase64('')).toBe(true);              // empty
+  });
+
+  test('accepts strings with non-standard length (lenient)', () => {
+    expect(isValidBase64('AAA')).toBe(true);           // 3 chars, OK
+    expect(isValidBase64('AAAAA')).toBe(true);         // 5 chars, OK
+  });
+
+  test('rejects strings with invalid characters', () => {
+    expect(isValidBase64('!!!!')).toBe(false);
+    expect(isValidBase64('abc@')).toBe(false);
+    expect(isValidBase64('hello world')).toBe(false);  // space
+    expect(isValidBase64('data_here')).toBe(false);    // underscore
   });
 });
 
@@ -165,8 +228,8 @@ describe('deleteAttachment', () => {
     const msg2 = addMessage(conv.id, 'user', 'Duplicate upload');
 
     // Dedup: both uploads return the same attachment row
-    const first = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHARED_CONTENT');
-    const second = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHARED_CONTENT');
+    const first = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHAREDCONTENT1');
+    const second = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHAREDCONTENT1');
     expect(second.id).toBe(first.id);
 
     linkAttachmentToMessage(msg1.id, first.id, 0);

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -25,6 +25,39 @@ function classifyKind(mimeType: string): string {
   return 'document';
 }
 
+export class AttachmentUploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AttachmentUploadError';
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ---------------------------------------------------------------------------
+// Size and encoding limits
+// ---------------------------------------------------------------------------
+
+/** Hard ceiling on a single uploaded attachment (20 MB, matching assistant limits). */
+export const MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Validate that a string contains only characters from the standard base64
+ * alphabet (plus padding `=`). Rejects payloads with clearly non-base64
+ * content while staying lenient on padding/length so callers don't need to
+ * pre-pad truncated previews or test fixtures.
+ */
+const INVALID_BASE64_RE = /[^A-Za-z0-9+/=]/;
+
+export function isValidBase64(data: string): boolean {
+  if (data.length === 0) return true;
+  return !INVALID_BASE64_RE.test(data);
+}
+
 // ---------------------------------------------------------------------------
 // Inbound attachment MIME validation
 // ---------------------------------------------------------------------------
@@ -123,6 +156,19 @@ export function uploadAttachment(
   mimeType: string,
   dataBase64: string,
 ): StoredAttachment {
+  if (!isValidBase64(dataBase64)) {
+    throw new AttachmentUploadError('Invalid base64 encoding');
+  }
+
+  const padding = dataBase64.endsWith('==') ? 2 : (dataBase64.endsWith('=') ? 1 : 0);
+  const sizeBytes = Math.max(0, Math.floor((dataBase64.length * 3) / 4) - padding);
+
+  if (sizeBytes > MAX_UPLOAD_BYTES) {
+    throw new AttachmentUploadError(
+      `Attachment too large: ${formatBytes(sizeBytes)} exceeds ${formatBytes(MAX_UPLOAD_BYTES)} limit`,
+    );
+  }
+
   const db = getDb();
   const contentHash = computeContentHash(dataBase64);
 
@@ -152,8 +198,6 @@ export function uploadAttachment(
   }
 
   const now = Date.now();
-  const padding = dataBase64.endsWith('==') ? 2 : (dataBase64.endsWith('=') ? 1 : 0);
-  const sizeBytes = Math.max(0, Math.floor((dataBase64.length * 3) / 4) - padding);
   const kind = classifyKind(mimeType);
 
   const record = {

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for attachment upload, download, and deletion.
  */
 import * as attachmentsStore from '../../memory/attachments-store.js';
-import { validateAttachmentUpload } from '../../memory/attachments-store.js';
+import { validateAttachmentUpload, AttachmentUploadError } from '../../memory/attachments-store.js';
 
 export async function handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
   const body = await req.json() as {
@@ -42,12 +42,21 @@ export async function handleUploadAttachment(assistantId: string, req: Request):
     );
   }
 
-  const attachment = attachmentsStore.uploadAttachment(
-    assistantId,
-    filename,
-    mimeType,
-    data,
-  );
+  let attachment: attachmentsStore.StoredAttachment;
+  try {
+    attachment = attachmentsStore.uploadAttachment(
+      assistantId,
+      filename,
+      mimeType,
+      data,
+    );
+  } catch (err) {
+    if (err instanceof AttachmentUploadError) {
+      const status = err.message.startsWith('Attachment too large') ? 413 : 400;
+      return Response.json({ error: err.message }, { status });
+    }
+    throw err;
+  }
 
   return Response.json({
     id: attachment.id,


### PR DESCRIPTION
## Summary
- Add `MAX_UPLOAD_BYTES` (20 MB) ceiling and `isValidBase64()` character-set check in `uploadAttachment()` — throws `AttachmentUploadError` on violation
- Update the HTTP route handler to catch the error and return 413 (too large) or 400 (bad encoding)
- Add tests for oversized payloads, invalid base64, and boundary-size acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
