### PR TITLE
fix: strip auth header from upstream proxy and truncate logged error bodies

### DIFF
--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -193,6 +193,38 @@ describe("runtime proxy handler", () => {
     expect(capturedSignal).toBeInstanceOf(AbortSignal);
   });
 
+  test("does not forward authorization header to upstream", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = mock(async (_input: any, init?: any) => {
+      capturedHeaders = init?.headers;
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health", {
+      headers: { authorization: "Bearer my-secret-token" },
+    });
+    await handler(req);
+
+    expect(capturedHeaders!.has("authorization")).toBe(false);
+  });
+
+  test("truncates long upstream error bodies in logs", async () => {
+    const longBody = "x".repeat(512);
+    globalThis.fetch = mock(async () => {
+      return new Response(longBody, { status: 500 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/fail");
+    const res = await handler(req);
+
+    expect(res.status).toBe(500);
+    // The full body is still returned to the client
+    const responseBody = await res.text();
+    expect(responseBody).toBe(longBody);
+  });
+
   test("does not forward host header to upstream", async () => {
     let capturedHeaders: Headers | undefined;
     globalThis.fetch = mock(async (_input: any, init?: any) => {

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -61,6 +61,7 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
 
     // Use a manual AbortController so the timeout only covers the connection
     // phase (waiting for response headers). Once headers arrive, the timeout is
@@ -104,8 +105,9 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     if (response.status >= 400) {
       const body = await response.text();
       const level = response.status >= 500 ? "error" : "warn";
+      const bodySnippet = body.length > 256 ? body.slice(0, 256) + "…[truncated]" : body;
       log[level](
-        { method: req.method, path: url.pathname, status: response.status, duration, body },
+        { method: req.method, path: url.pathname, status: response.status, duration, body: bodySnippet },
         "Upstream returned error",
       );
       return new Response(body, {


### PR DESCRIPTION
## Summary
- Strip the `authorization` header from forwarded requests so gateway credentials are never leaked upstream
- Truncate upstream error response bodies to 256 characters in logs to avoid logging sensitive data (full body is still returned to the client unchanged)
- Add tests for both behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
