### PR TITLE
fix: enforce directory boundary in interface file path check

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -403,7 +403,11 @@ export class RuntimeHttpServer {
       return Response.json({ error: 'Interface not found' }, { status: 404 });
     }
     const fullPath = resolve(this.interfacesDir, interfacePath);
-    if (!fullPath.startsWith(this.interfacesDir) || !existsSync(fullPath)) {
+    // Enforce directory boundary so prefix-sibling paths (e.g. "interfaces-other/") are rejected
+    if (
+      (fullPath !== this.interfacesDir && !fullPath.startsWith(this.interfacesDir + '/')) ||
+      !existsSync(fullPath)
+    ) {
       return Response.json({ error: 'Interface not found' }, { status: 404 });
     }
     const source = readFileSync(fullPath, 'utf-8');


### PR DESCRIPTION
## Summary
- The `startsWith(this.interfacesDir)` check in `handleGetInterface` did not enforce a directory boundary, allowing prefix-sibling paths (e.g. `interfaces-other/`) to bypass the guard.
- Fixed by checking `fullPath === base || fullPath.startsWith(base + '/')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
