### PR TITLE
fix: prevent starter trust rules from auto-allowing private-network fetches

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -146,12 +146,12 @@ describe('Permission Checker', () => {
         expect(risk).toBe(RiskLevel.Low);
       });
 
-      test('web_fetch with allow_private_network is medium risk', async () => {
+      test('web_fetch with allow_private_network is high risk', async () => {
         const risk = await classifyRisk('web_fetch', {
           url: 'http://localhost:3000',
           allow_private_network: true,
         });
-        expect(risk).toBe(RiskLevel.Medium);
+        expect(risk).toBe(RiskLevel.High);
       });
     });
 
@@ -551,8 +551,18 @@ describe('Permission Checker', () => {
       expect(result.decision).toBe('allow');
     });
 
-    test('web_fetch allow rule can approve medium-risk private-network fetches', async () => {
+    test('web_fetch allow rule does not auto-approve high-risk private-network fetches', async () => {
       addRule('web_fetch', 'web_fetch:http://localhost:3000/*', '/tmp');
+      const result = await check(
+        'web_fetch',
+        { url: 'http://localhost:3000/health', allow_private_network: true },
+        '/tmp',
+      );
+      expect(result.decision).toBe('prompt');
+    });
+
+    test('web_fetch allowHighRisk rule can approve private-network fetches', async () => {
+      addRule('web_fetch', 'web_fetch:http://localhost:3000/*', '/tmp', 'allow', 100, { allowHighRisk: true });
       const result = await check(
         'web_fetch',
         { url: 'http://localhost:3000/health', allow_private_network: true },
@@ -567,7 +577,7 @@ describe('Permission Checker', () => {
 
       const allowed = await check(
         'web_fetch',
-        { url: 'https://example.com/search?q=test', allow_private_network: true },
+        { url: 'https://example.com/search?q=test' },
         '/tmp',
       );
       expect(allowed.decision).toBe('allow');

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -242,10 +242,12 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   }
   if (toolName === 'web_search') return RiskLevel.Low;
   if (toolName === 'web_fetch') {
-    return input.allow_private_network === true ? RiskLevel.Medium : RiskLevel.Low;
+    // Private-network fetches are High risk so that blanket allow rules
+    // (including the starter bundle) cannot silently bypass the prompt.
+    return input.allow_private_network === true ? RiskLevel.High : RiskLevel.Low;
   }
   if (toolName === 'browser_navigate') {
-    return input.allow_private_network === true ? RiskLevel.Medium : RiskLevel.Low;
+    return input.allow_private_network === true ? RiskLevel.High : RiskLevel.Low;
   }
   // All other browser tools are low risk — the browser is sandboxed and user-visible.
   if (toolName.startsWith('browser_')) return RiskLevel.Low;


### PR DESCRIPTION
## Summary
- Escalate `allow_private_network=true` on `web_fetch` and `browser_navigate` from Medium to High risk
- This prevents the starter bundle's blanket `web_fetch` allow rule from silently bypassing the private-network prompt
- The existing `allowHighRisk` mechanism ensures users can still create explicit trust rules for private-network access when needed
- Updated tests to match the new High-risk classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
