### PR TITLE
fix: env-gate Sentry DSN

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/node";
 import { APP_VERSION } from "./version.js";
 
 Sentry.init({
-  dsn: "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992",
+  dsn: process.env.SENTRY_DSN,
   release: `vellum-assistant@${APP_VERSION}`,
   environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
   sendDefaultPii: true,


### PR DESCRIPTION
## Summary
- Removes the hardcoded Sentry DSN from `instrument.ts`
- Reads the DSN from the `SENTRY_DSN` environment variable instead
- When the env var is unset, Sentry silently disables itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
