### PR TITLE
fix: disable Sentry default PII collection

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -5,5 +5,5 @@ Sentry.init({
   dsn: "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992",
   release: `vellum-assistant@${APP_VERSION}`,
   environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
-  sendDefaultPii: true,
+  sendDefaultPii: false,
 });


### PR DESCRIPTION
## Summary
- Changes `sendDefaultPii` from `true` to `false` in Sentry init
- Prevents automatic collection of IP addresses, cookies, and user data on error reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
