### PR TITLE
fix: add beforeSend PII redaction to Sentry

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -1,9 +1,57 @@
 import * as Sentry from "@sentry/node";
 import { APP_VERSION } from "./version.js";
 
+/** Patterns that match sensitive data in Sentry event values. */
+const PII_PATTERNS = [
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, // email
+  /\b(?:\d[ -]*?){13,19}\b/g, // credit card
+  /\b\d{3}-\d{2}-\d{4}\b/g, // SSN
+];
+
+function redactString(value: string): string {
+  let result = value;
+  for (const pattern of PII_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[REDACTED]");
+  }
+  return result;
+}
+
+function redactObject(obj: unknown): unknown {
+  if (typeof obj === "string") return redactString(obj);
+  if (Array.isArray(obj)) return obj.map(redactObject);
+  if (obj !== null && typeof obj === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(obj)) {
+      out[key] = redactObject(val);
+    }
+    return out;
+  }
+  return obj;
+}
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: `vellum-assistant@${APP_VERSION}`,
   environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
   sendDefaultPii: false,
+  beforeSend(event) {
+    if (event.exception?.values) {
+      event.exception.values = event.exception.values.map((ex) => ({
+        ...ex,
+        value: ex.value ? redactString(ex.value) : ex.value,
+      }));
+    }
+    if (event.breadcrumbs) {
+      event.breadcrumbs = event.breadcrumbs.map((bc) => ({
+        ...bc,
+        message: bc.message ? redactString(bc.message) : bc.message,
+        data: bc.data ? (redactObject(bc.data) as Record<string, unknown>) : bc.data,
+      }));
+    }
+    if (event.extra) {
+      event.extra = redactObject(event.extra) as Record<string, unknown>;
+    }
+    return event;
+  },
 });


### PR DESCRIPTION
## Summary
- Adds a `beforeSend` hook to Sentry that redacts PII before events leave the process
- Scrubs emails, credit card numbers, and SSNs from exception values, breadcrumb messages/data, and extra fields
- Replaces matched patterns with `[REDACTED]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
