### PR TITLE
M1: Add browser_view surface type and browser_frame IPC message

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1020,6 +1020,13 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'app_files_changed',
     appId: 'app-001',
   },
+  browser_frame: {
+    type: 'browser_frame',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
+    frame: 'base64-jpeg-data',
+    metadata: { offsetTop: 0, pageScaleFactor: 1, scrollOffsetX: 0, scrollOffsetY: 0, timestamp: 1700000000 },
+  },
   accept_starter_bundle_response: {
     type: 'accept_starter_bundle_response',
     accepted: true,

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -447,7 +447,7 @@ export interface IpcBlobProbe {
 
 // === Surface types ===
 
-export type SurfaceType = 'card' | 'form' | 'list' | 'table' | 'confirmation' | 'dynamic_page' | 'file_upload';
+export type SurfaceType = 'card' | 'form' | 'list' | 'table' | 'confirmation' | 'dynamic_page' | 'file_upload' | 'browser_view';
 
 export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page', 'file_upload'];
 
@@ -560,7 +560,17 @@ export interface TableSurfaceData {
   caption?: string;
 }
 
-export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | TableSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData | FileUploadSurfaceData;
+export interface BrowserViewSurfaceData {
+  sessionId: string;
+  currentUrl: string;
+  status: 'navigating' | 'idle' | 'interacting';
+  frame?: string; // base64 JPEG
+  actionText?: string; // "Clicking 'Submit' button"
+  highlights?: Array<{ x: number; y: number; w: number; h: number; label: string }>;
+  pages?: Array<{ id: string; title: string; url: string; active: boolean }>;
+}
+
+export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | TableSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData | FileUploadSurfaceData | BrowserViewSurfaceData;
 
 export interface UiSurfaceAction {
   type: 'ui_surface_action';
@@ -647,6 +657,14 @@ export interface UnpublishPageResponse {
 export interface AppFilesChanged {
   type: 'app_files_changed';
   appId: string;
+}
+
+export interface BrowserFrame {
+  type: 'browser_frame';
+  sessionId: string;
+  surfaceId: string;
+  frame: string; // base64 JPEG
+  metadata?: { offsetTop: number; pageScaleFactor: number; scrollOffsetX: number; scrollOffsetY: number; timestamp: number };
 }
 
 export type ClientMessage =
@@ -1473,6 +1491,11 @@ export interface UiSurfaceShowFileUpload extends UiSurfaceShowBase {
   data: FileUploadSurfaceData;
 }
 
+export interface UiSurfaceShowBrowserView extends UiSurfaceShowBase {
+  surfaceType: 'browser_view';
+  data: BrowserViewSurfaceData;
+}
+
 export type UiSurfaceShow =
   | UiSurfaceShowCard
   | UiSurfaceShowForm
@@ -1480,7 +1503,8 @@ export type UiSurfaceShow =
   | UiSurfaceShowTable
   | UiSurfaceShowConfirmation
   | UiSurfaceShowDynamicPage
-  | UiSurfaceShowFileUpload;
+  | UiSurfaceShowFileUpload
+  | UiSurfaceShowBrowserView;
 
 export interface UiSurfaceUpdate {
   type: 'ui_surface_update';
@@ -1592,7 +1616,8 @@ export type ServerMessage =
   | AppUpdatePreviewResponse
   | PublishPageResponse
   | UnpublishPageResponse
-  | AppFilesChanged;
+  | AppFilesChanged
+  | BrowserFrame;
 
 // === Contract schema ===
 


### PR DESCRIPTION
## Summary
- Adds browser_view to SurfaceType union for PiP browser view
- Adds BrowserViewSurfaceData interface with URL, status, frame, highlights, pages
- Adds UiSurfaceShowBrowserView to the UiSurfaceShow discriminated union
- Adds BrowserFrame server message type for high-frequency frame streaming
- Part of #3734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
