### PR TITLE
M4: Add browser_view Swift types and DaemonClient handling

### DIFF
--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -10,6 +10,7 @@ public enum SurfaceType: String, Codable, Sendable {
     case confirmation
     case dynamicPage = "dynamic_page"
     case fileUpload = "file_upload"
+    case browserView = "browser_view"
 }
 
 public enum SurfaceActionStyle: String, Codable, Sendable {
@@ -269,6 +270,57 @@ public struct FileUploadSurfaceData: Sendable {
     }
 }
 
+public struct BrowserHighlight: Sendable, Identifiable {
+    public var id: String { label }
+    public let x: Double
+    public let y: Double
+    public let w: Double
+    public let h: Double
+    public let label: String
+
+    public init(x: Double, y: Double, w: Double, h: Double, label: String) {
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+        self.label = label
+    }
+}
+
+public struct BrowserPage: Sendable, Identifiable {
+    public let id: String
+    public let title: String
+    public let url: String
+    public let active: Bool
+
+    public init(id: String, title: String, url: String, active: Bool) {
+        self.id = id
+        self.title = title
+        self.url = url
+        self.active = active
+    }
+}
+
+public struct BrowserViewSurfaceData: Sendable {
+    public let sessionId: String
+    public let currentUrl: String
+    public let status: String // "navigating", "idle", "interacting"
+    public let frame: String? // base64 JPEG
+    public let actionText: String?
+    public let highlights: [BrowserHighlight]?
+    public let pages: [BrowserPage]?
+
+    public init(sessionId: String, currentUrl: String, status: String, frame: String? = nil, actionText: String? = nil, highlights: [BrowserHighlight]? = nil, pages: [BrowserPage]? = nil) {
+        self.sessionId = sessionId
+        self.currentUrl = currentUrl
+        self.status = status
+        self.frame = frame
+        self.actionText = actionText
+        self.highlights = highlights
+        self.pages = pages
+    }
+}
+
 public struct TableColumn: Identifiable, Sendable {
     public let id: String
     public let label: String
@@ -317,6 +369,7 @@ public enum SurfaceData: Sendable {
     case confirmation(ConfirmationSurfaceData)
     case dynamicPage(DynamicPageSurfaceData)
     case fileUpload(FileUploadSurfaceData)
+    case browserView(BrowserViewSurfaceData)
 }
 
 public struct SurfaceActionButton: Identifiable, Equatable, Sendable {
@@ -451,6 +504,8 @@ public extension Surface {
             return parseDynamicPageData(dict).map { .dynamicPage($0) }
         case .fileUpload:
             return parseFileUploadData(dict).map { .fileUpload($0) }
+        case .browserView:
+            return parseBrowserViewData(dict).map { .browserView($0) }
         }
     }
 
@@ -475,6 +530,8 @@ public extension Surface {
             return .dynamicPage(mergeDynamicPageData(existing: dp, update: update))
         case .fileUpload(let fu):
             return .fileUpload(mergeFileUploadData(existing: fu, update: update))
+        case .browserView(let bv):
+            return .browserView(mergeBrowserViewData(existing: bv, update: update))
         }
     }
 
@@ -883,6 +940,99 @@ public extension Surface {
             acceptedTypes: acceptedTypes,
             maxFiles: maxFiles,
             maxSizeBytes: maxSizeBytes
+        )
+    }
+
+    // MARK: - Browser View Helpers
+
+    private static func parseBrowserViewData(_ dict: [String: Any?]) -> BrowserViewSurfaceData? {
+        guard let sessionId = dict["sessionId"] as? String,
+              let currentUrl = dict["currentUrl"] as? String,
+              let status = dict["status"] as? String else {
+            return nil
+        }
+
+        let frame = dict["frame"] as? String
+        let actionText = dict["actionText"] as? String
+
+        var highlights: [BrowserHighlight]?
+        if let highlightsArray = dict["highlights"] as? [[String: Any?]] {
+            highlights = highlightsArray.compactMap { item in
+                guard let x = item["x"] as? Double,
+                      let y = item["y"] as? Double,
+                      let w = item["w"] as? Double,
+                      let h = item["h"] as? Double,
+                      let label = item["label"] as? String else { return nil }
+                return BrowserHighlight(x: x, y: y, w: w, h: h, label: label)
+            }
+        }
+
+        var pages: [BrowserPage]?
+        if let pagesArray = dict["pages"] as? [[String: Any?]] {
+            pages = pagesArray.compactMap { pageDict in
+                guard let id = pageDict["id"] as? String,
+                      let title = pageDict["title"] as? String,
+                      let url = pageDict["url"] as? String else { return nil }
+                return BrowserPage(id: id, title: title, url: url, active: pageDict["active"] as? Bool ?? false)
+            }
+        }
+
+        return BrowserViewSurfaceData(
+            sessionId: sessionId,
+            currentUrl: currentUrl,
+            status: status,
+            frame: frame,
+            actionText: actionText,
+            highlights: highlights,
+            pages: pages
+        )
+    }
+
+    private static func mergeBrowserViewData(existing: BrowserViewSurfaceData, update: [String: Any?]) -> BrowserViewSurfaceData {
+        let sessionId = (update["sessionId"] as? String) ?? existing.sessionId
+        let currentUrl = (update["currentUrl"] as? String) ?? existing.currentUrl
+        let status = (update["status"] as? String) ?? existing.status
+        let frame: String? = update.keys.contains("frame") ? (update["frame"] as? String) : existing.frame
+        let actionText: String? = update.keys.contains("actionText") ? (update["actionText"] as? String) : existing.actionText
+
+        var highlights = existing.highlights
+        if update.keys.contains("highlights") {
+            if let highlightsArray = update["highlights"] as? [[String: Any?]] {
+                highlights = highlightsArray.compactMap { item in
+                    guard let x = item["x"] as? Double,
+                          let y = item["y"] as? Double,
+                          let w = item["w"] as? Double,
+                          let h = item["h"] as? Double,
+                          let label = item["label"] as? String else { return nil }
+                    return BrowserHighlight(x: x, y: y, w: w, h: h, label: label)
+                }
+            } else {
+                highlights = nil
+            }
+        }
+
+        var pages = existing.pages
+        if update.keys.contains("pages") {
+            if let pagesArray = update["pages"] as? [[String: Any?]] {
+                pages = pagesArray.compactMap { pageDict in
+                    guard let id = pageDict["id"] as? String,
+                          let title = pageDict["title"] as? String,
+                          let url = pageDict["url"] as? String else { return nil }
+                    return BrowserPage(id: id, title: title, url: url, active: pageDict["active"] as? Bool ?? false)
+                }
+            } else {
+                pages = nil
+            }
+        }
+
+        return BrowserViewSurfaceData(
+            sessionId: sessionId,
+            currentUrl: currentUrl,
+            status: status,
+            frame: frame,
+            actionText: actionText,
+            highlights: highlights,
+            pages: pages
         )
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -217,6 +217,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `integration_connect_result` message.
     public var onIntegrationConnectResult: ((IPCIntegrationConnectResult) -> Void)?
 
+    /// Called when the daemon sends a `browser_frame` message with a new screenshot frame.
+    public var onBrowserFrame: ((BrowserFrameMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -1170,6 +1173,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onIntegrationListResponse?(msg)
         case .integrationConnectResult(let msg):
             onIntegrationConnectResult?(msg)
+        case .browserFrame(let msg):
+            onBrowserFrame?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -41,6 +41,9 @@ import Foundation
 // │                                 │ LayoutConfig.swift (M1 / #2973)         │
 // │ SlotContentWire                 │ Temporary; canonical home is             │
 // │                                 │ LayoutConfig.swift (M1 / #2973)         │
+// │ BrowserFrameMessage             │ New message type for browser_view       │
+// │                                 │ surface frame updates; not yet in       │
+// │                                 │ generated contract                      │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.
@@ -1502,6 +1505,20 @@ public typealias VercelApiConfigResponseMessage = IPCVercelApiConfigResponse
 /// Backed by generated `IPCAuthResult`.
 public typealias AuthResultMessage = IPCAuthResult
 
+/// Browser frame update from the daemon, delivering a new screenshot frame for an active browser session.
+/// Wire type: `"browser_frame"`
+public struct BrowserFrameMessage: Decodable, Sendable {
+    public let sessionId: String
+    public let surfaceId: String
+    public let frame: String // base64 JPEG
+
+    public init(sessionId: String, surfaceId: String, frame: String) {
+        self.sessionId = sessionId
+        self.surfaceId = surfaceId
+        self.frame = frame
+    }
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 public enum ServerMessage: Decodable, Sendable {
@@ -1576,6 +1593,7 @@ public enum ServerMessage: Decodable, Sendable {
     case integrationConnectResult(IPCIntegrationConnectResult)
     case appFilesChanged(AppFilesChangedMessage)
     case getSigningIdentity(IPCGetSigningIdentityRequest)
+    case browserFrame(BrowserFrameMessage)
     case pong
     case unknown(String)
 
@@ -1801,6 +1819,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "app_files_changed":
             let message = try AppFilesChangedMessage(from: decoder)
             self = .appFilesChanged(message)
+        case "browser_frame":
+            let message = try BrowserFrameMessage(from: decoder)
+            self = .browserFrame(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Adds `browserView` case to `SurfaceType` enum
- Adds `BrowserViewSurfaceData`, `BrowserHighlight`, `BrowserPage` structs with full parse and merge support
- Adds `browserView` case to `SurfaceData` enum with parsing in `parseSurfaceData` and partial merge in `mergeSurfaceData`
- Adds `BrowserFrameMessage` struct and `browserFrame` case to `ServerMessage` enum with decoder
- Adds `onBrowserFrame` callback to `DaemonClient` and handles it in `handleServerMessage`
- Part of #3734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
