### PR TITLE
fix: make sidebar archive button more prominent

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -394,8 +394,8 @@ struct MainWindowView: View {
                 threadPendingDeletion = thread.id
             } label: {
                 Image(systemName: "archivebox")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(VColor.textMuted)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(VColor.textSecondary)
                     .frame(width: 24, height: 24)
                     .contentShape(Rectangle())
             }


### PR DESCRIPTION
## Summary
- Increase archive icon size from 11pt to 13pt
- Use `textSecondary` (Slate._400) instead of `textMuted` (Slate._500) for better contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
