### PR TITLE
fix: add missing browserView case to SurfaceContainerView switch statements

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -93,8 +93,8 @@ struct SurfaceContainerView: View {
                         viewModel.onAction("cancel", ["files": [Any]()])
                     }
                 )
-            case .table:
-                // Table surfaces are rendered inline in chat, not in floating panels.
+            case .table, .browserView:
+                // Table and browser surfaces are rendered inline in chat, not in floating panels.
                 EmptyView()
             }
 
@@ -112,7 +112,7 @@ struct SurfaceContainerView: View {
         switch surface.data {
         case .form, .confirmation, .dynamicPage, .fileUpload:
             return true
-        case .card, .list, .table:
+        case .card, .list, .table, .browserView:
             return false
         }
     }


### PR DESCRIPTION
## Summary
- Add `.browserView` to both switch statements in `SurfaceContainerView.swift` that were missing the case added in #3752
- Browser view surfaces render as `EmptyView()` (like table surfaces — rendered inline in chat, not in floating panels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
