### PR TITLE
M5: Implement BrowserPiPPanel — floating NSPanel with frame rendering

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -94,6 +94,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var daemonClient: DaemonClient { services.daemonClient }
     var ambientAgent: AmbientAgent { services.ambientAgent }
     var surfaceManager: SurfaceManager { services.surfaceManager }
+    var browserPiPManager: BrowserPiPManager { services.browserPiPManager }
     private var secretPromptManager: SecretPromptManager { services.secretPromptManager }
     var zoomManager: ZoomManager { services.zoomManager }
 
@@ -282,15 +283,29 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupSurfaceManager() {
-        // Wire daemon surface messages to SurfaceManager
+        // Wire daemon surface messages to SurfaceManager (or BrowserPiPManager for browser_view)
         daemonClient.onSurfaceShow = { [weak self] msg in
-            self?.surfaceManager.showSurface(msg)
+            guard let self else { return }
+            if msg.surfaceType == SurfaceType.browserView.rawValue {
+                self.browserPiPManager.showPanel(for: msg)
+            } else {
+                self.surfaceManager.showSurface(msg)
+            }
         }
         daemonClient.onSurfaceUpdate = { [weak self] msg in
-            self?.surfaceManager.updateSurface(msg)
+            guard let self else { return }
+            self.browserPiPManager.updateSurface(msg)
+            self.surfaceManager.updateSurface(msg)
         }
         daemonClient.onSurfaceDismiss = { [weak self] msg in
-            self?.surfaceManager.dismissSurface(msg)
+            guard let self else { return }
+            self.browserPiPManager.dismissPanel()
+            self.surfaceManager.dismissSurface(msg)
+        }
+
+        // Wire browser frame updates to BrowserPiPManager
+        daemonClient.onBrowserFrame = { [weak self] msg in
+            self?.browserPiPManager.updateFrame(msg)
         }
 
         // Reload webviews for surfaces whose app files changed (cross-session broadcast)

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -7,6 +7,7 @@ public final class AppServices {
     public let daemonClient = DaemonClient()
     public let ambientAgent = AmbientAgent()
     let surfaceManager = SurfaceManager()
+    let browserPiPManager = BrowserPiPManager()
     let secretPromptManager = SecretPromptManager()
     let zoomManager = ZoomManager()
 

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+import AppKit
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "BrowserPiPManager")
+
+@MainActor
+final class BrowserPiPManager: ObservableObject {
+    @Published var isVisible: Bool = false
+    @Published var currentUrl: String = ""
+    @Published var status: String = "idle"
+    @Published var actionText: String?
+    @Published var currentFrame: NSImage?
+    @Published var pages: [BrowserPage] = []
+
+    private var panel: NSPanel?
+    private var surfaceId: String?
+    private var sessionId: String?
+
+    private var moveObserver: Any?
+    private var resizeObserver: Any?
+
+    // Saved position
+    private static let positionXKey = "BrowserPiP.positionX"
+    private static let positionYKey = "BrowserPiP.positionY"
+    private static let sizeWKey = "BrowserPiP.sizeW"
+    private static let sizeHKey = "BrowserPiP.sizeH"
+
+    func showPanel(for message: UiSurfaceShowMessage) {
+        guard let surface = Surface.from(message),
+              case .browserView(let data) = surface.data else { return }
+
+        surfaceId = message.surfaceId
+        sessionId = message.sessionId
+        currentUrl = data.currentUrl
+        status = data.status
+        actionText = data.actionText
+        pages = data.pages ?? []
+
+        if let frameStr = data.frame {
+            decodeFrame(frameStr)
+        }
+
+        if panel == nil {
+            createPanel()
+        }
+
+        panel?.orderFront(nil)
+        isVisible = true
+
+        log.info("Showing browser PiP panel: surfaceId=\(message.surfaceId, privacy: .public)")
+    }
+
+    func updateSurface(_ message: UiSurfaceUpdateMessage) {
+        guard message.surfaceId == surfaceId else { return }
+
+        let dict = message.data.value as? [String: Any?] ?? [:]
+
+        if let url = dict["currentUrl"] as? String {
+            currentUrl = url
+        }
+        if let s = dict["status"] as? String {
+            status = s
+        }
+        if dict.keys.contains("actionText") {
+            actionText = dict["actionText"] as? String
+        }
+        if let frameStr = dict["frame"] as? String {
+            decodeFrame(frameStr)
+        }
+        if let pagesArray = dict["pages"] as? [[String: Any?]] {
+            pages = pagesArray.compactMap { pageDict in
+                guard let id = pageDict["id"] as? String,
+                      let title = pageDict["title"] as? String,
+                      let url = pageDict["url"] as? String else { return nil }
+                return BrowserPage(id: id, title: title, url: url, active: pageDict["active"] as? Bool ?? false)
+            }
+        }
+    }
+
+    func updateFrame(_ message: BrowserFrameMessage) {
+        guard message.surfaceId == surfaceId else { return }
+        decodeFrame(message.frame)
+    }
+
+    func dismissPanel() {
+        if let moveObs = moveObserver {
+            NotificationCenter.default.removeObserver(moveObs)
+            moveObserver = nil
+        }
+        if let resizeObs = resizeObserver {
+            NotificationCenter.default.removeObserver(resizeObs)
+            resizeObserver = nil
+        }
+        panel?.close()
+        panel = nil
+        isVisible = false
+        surfaceId = nil
+        sessionId = nil
+        currentFrame = nil
+
+        log.info("Dismissed browser PiP panel")
+    }
+
+    private func decodeFrame(_ base64: String) {
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            guard let data = Data(base64Encoded: base64),
+                  let image = NSImage(data: data) else { return }
+            DispatchQueue.main.async {
+                self?.currentFrame = image
+            }
+        }
+    }
+
+    private func createPanel() {
+        let view = BrowserPiPView(manager: self)
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: savedFrame(),
+            styleMask: [.titled, .closable, .resizable, .nonactivatingPanel, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.title = "Browser"
+        panel.isReleasedWhenClosed = false
+        panel.minSize = NSSize(width: 200, height: 150)
+        panel.aspectRatio = NSSize(width: 4, height: 3)
+
+        // Position bottom-right by default
+        if !hasSavedPosition() {
+            positionBottomRight(panel)
+        }
+
+        // Save position on move
+        moveObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            self?.savePosition()
+        }
+        resizeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            self?.savePosition()
+        }
+
+        self.panel = panel
+    }
+
+    private func positionBottomRight(_ panel: NSPanel) {
+        guard let screen = NSScreen.main else { return }
+        let padding: CGFloat = 20
+        let frame = panel.frame
+        let x = screen.visibleFrame.maxX - frame.width - padding
+        let y = screen.visibleFrame.minY + padding
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func savedFrame() -> NSRect {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: Self.sizeWKey) != nil {
+            return NSRect(
+                x: defaults.double(forKey: Self.positionXKey),
+                y: defaults.double(forKey: Self.positionYKey),
+                width: max(defaults.double(forKey: Self.sizeWKey), 200),
+                height: max(defaults.double(forKey: Self.sizeHKey), 150)
+            )
+        }
+        return NSRect(x: 0, y: 0, width: 400, height: 300)
+    }
+
+    private func hasSavedPosition() -> Bool {
+        UserDefaults.standard.object(forKey: Self.positionXKey) != nil
+    }
+
+    private func savePosition() {
+        guard let frame = panel?.frame else { return }
+        let defaults = UserDefaults.standard
+        defaults.set(frame.origin.x, forKey: Self.positionXKey)
+        defaults.set(frame.origin.y, forKey: Self.positionYKey)
+        defaults.set(frame.size.width, forKey: Self.sizeWKey)
+        defaults.set(frame.size.height, forKey: Self.sizeHKey)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPView.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct BrowserPiPView: View {
+    @ObservedObject var manager: BrowserPiPManager
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // URL bar + status
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 8, height: 8)
+                Text(manager.currentUrl)
+                    .font(.system(size: 11, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(Color(NSColor.windowBackgroundColor))
+
+            Divider()
+
+            // Frame
+            ZStack {
+                if let frame = manager.currentFrame {
+                    Image(nsImage: frame)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Color(NSColor.controlBackgroundColor)
+                    Text("Waiting for browser...")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                }
+
+                // Action text overlay
+                if let action = manager.actionText {
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Text(action)
+                                .font(.system(size: 11))
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(Color.black.opacity(0.75))
+                                .cornerRadius(4)
+                            Spacer()
+                        }
+                        .padding(8)
+                    }
+                }
+            }
+        }
+    }
+
+    private var statusColor: Color {
+        switch manager.status {
+        case "navigating": return .yellow
+        case "interacting": return .blue
+        default: return .green
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Creates `BrowserPiPManager` (`@MainActor ObservableObject`) for panel lifecycle management
- Creates `BrowserPiPView` SwiftUI view with URL bar, status indicator dot, frame rendering, and action text overlay
- Floating `NSPanel` anchored bottom-right, always-on-top, resizable with 4:3 aspect ratio lock
- Saves/restores panel position via UserDefaults
- Decodes base64 JPEG frames on background queue to avoid blocking main thread
- Routes `browser_view` surfaces from `SurfaceManager` to `BrowserPiPManager`
- Wires `onBrowserFrame` daemon callback to `BrowserPiPManager.updateFrame`
- Part of #3734

## Test plan
- [ ] Verify browser_view surface show message creates floating PiP panel
- [ ] Verify panel appears bottom-right with 20px padding
- [ ] Verify panel is resizable and maintains 4:3 aspect ratio
- [ ] Verify URL bar shows current URL with status indicator
- [ ] Verify base64 frames render in the panel
- [ ] Verify action text overlay appears when actionText is set
- [ ] Verify panel position persists across dismiss/show cycles
- [ ] Verify dismiss cleans up panel and resets state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
