### PR TITLE
M3: Wire browser tools to auto-start screencast and surface lifecycle

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -24,6 +24,7 @@ import {
 } from './session-surfaces.js';
 import type { SurfaceSessionContext } from './session-surfaces.js';
 import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
+import { registerSessionSender } from '../tools/browser/browser-screencast.js';
 
 // ── Context Interface ────────────────────────────────────────────────
 
@@ -75,6 +76,9 @@ export function createToolExecutor(
   handleToolLifecycleEvent: ToolLifecycleEventHandler,
   broadcastToAllClients?: (msg: ServerMessage) => void,
 ): (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<ToolExecutionResult> {
+  // Register the session's sendToClient for browser screencast surface messages
+  registerSessionSender(ctx.conversationId, (msg) => ctx.sendToClient(msg));
+
   return async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
     const result = await executor.execute(name, input, {
       workingDir: ctx.workingDir,

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,0 +1,138 @@
+import { v4 as uuid } from 'uuid';
+import { browserManager } from './browser-manager.js';
+import type { BrowserViewSurfaceData, BrowserFrame } from '../../daemon/ipc-contract.js';
+
+// Track active screencast sessions
+const activeScreencasts = new Map<string, { surfaceId: string }>();
+
+// Registry of sendToClient callbacks per session
+const sessionSenders = new Map<string, (msg: any) => void>();
+
+/**
+ * Register a sendToClient callback for a session.
+ * Called from session-tool-setup when the session is created.
+ */
+export function registerSessionSender(sessionId: string, sendToClient: (msg: any) => void): void {
+  sessionSenders.set(sessionId, sendToClient);
+}
+
+/**
+ * Unregister the sendToClient callback for a session.
+ */
+export function unregisterSessionSender(sessionId: string): void {
+  sessionSenders.delete(sessionId);
+}
+
+function getSender(sessionId: string): ((msg: any) => void) | undefined {
+  return sessionSenders.get(sessionId);
+}
+
+export async function ensureScreencast(
+  sessionId: string,
+  sendToClient: (msg: any) => void,
+): Promise<void> {
+  if (activeScreencasts.has(sessionId)) return;
+
+  const surfaceId = uuid();
+  activeScreencasts.set(sessionId, { surfaceId });
+
+  // Get current page info
+  const page = await browserManager.getOrCreateSessionPage(sessionId);
+  const currentUrl = page.url();
+  const title = await page.title();
+
+  // Send surface show
+  sendToClient({
+    type: 'ui_surface_show',
+    sessionId,
+    surfaceId,
+    surfaceType: 'browser_view',
+    title: 'Browser',
+    data: {
+      sessionId,
+      currentUrl: currentUrl || 'about:blank',
+      status: 'idle',
+      pages: [{ id: sessionId, title: title || 'New Tab', url: currentUrl || 'about:blank', active: true }],
+    } satisfies BrowserViewSurfaceData,
+    display: 'panel',
+  });
+
+  // Start CDP screencast
+  await browserManager.startScreencast(sessionId, (frame) => {
+    sendToClient({
+      type: 'browser_frame',
+      sessionId,
+      surfaceId,
+      frame: frame.data,
+      metadata: frame.metadata,
+    } satisfies BrowserFrame);
+  });
+}
+
+export function updateBrowserStatus(
+  sessionId: string,
+  sendToClient: (msg: any) => void,
+  status: 'navigating' | 'idle' | 'interacting',
+  actionText?: string,
+  currentUrl?: string,
+): void {
+  const state = activeScreencasts.get(sessionId);
+  if (!state) return;
+
+  const update: Record<string, unknown> = { status };
+  if (actionText !== undefined) update.actionText = actionText;
+  if (currentUrl !== undefined) update.currentUrl = currentUrl;
+
+  sendToClient({
+    type: 'ui_surface_update',
+    sessionId,
+    surfaceId: state.surfaceId,
+    data: update,
+  });
+}
+
+export async function updatePagesList(
+  sessionId: string,
+  sendToClient: (msg: any) => void,
+): Promise<void> {
+  const state = activeScreencasts.get(sessionId);
+  if (!state) return;
+
+  const page = await browserManager.getOrCreateSessionPage(sessionId);
+  const currentUrl = page.url();
+  const title = await page.title();
+
+  sendToClient({
+    type: 'ui_surface_update',
+    sessionId,
+    surfaceId: state.surfaceId,
+    data: {
+      currentUrl,
+      pages: [{ id: sessionId, title: title || 'Untitled', url: currentUrl, active: true }],
+    },
+  });
+}
+
+export async function stopBrowserScreencast(
+  sessionId: string,
+  sendToClient: (msg: any) => void,
+): Promise<void> {
+  const state = activeScreencasts.get(sessionId);
+  if (!state) return;
+
+  await browserManager.stopScreencast(sessionId);
+
+  sendToClient({
+    type: 'ui_surface_dismiss',
+    sessionId,
+    surfaceId: state.surfaceId,
+  });
+
+  activeScreencasts.delete(sessionId);
+}
+
+export function isScreencastActive(sessionId: string): boolean {
+  return activeScreencasts.has(sessionId);
+}
+
+export { getSender };

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -14,6 +14,13 @@ import { browserManager } from './browser-manager.js';
 import type { RouteHandler } from './browser-manager.js';
 import { detectAuthChallenge, formatAuthChallenge } from './auth-detector.js';
 import { credentialBroker } from '../credentials/broker.js';
+import {
+  ensureScreencast,
+  updateBrowserStatus,
+  updatePagesList,
+  stopBrowserScreencast,
+  getSender,
+} from './browser-screencast.js';
 
 const log = getLogger('headless-browser');
 
@@ -59,6 +66,13 @@ async function executeBrowserNavigate(
 
   let routeHandler: RouteHandler | null = null;
   let blockedUrl: string | null = null;
+
+  // Start screencast if a sender is registered for this session
+  const sender = getSender(context.sessionId);
+  if (sender) {
+    await ensureScreencast(context.sessionId, sender);
+    updateBrowserStatus(context.sessionId, sender, 'navigating', `Navigating to ${safeRequestedUrl}`);
+  }
 
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
@@ -166,6 +180,11 @@ async function executeBrowserNavigate(
       // Auth detection is best-effort; don't fail navigation
     }
 
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+      await updatePagesList(context.sessionId, sender);
+    }
+
     return { content: lines.join('\n'), isError: false };
   } catch (err) {
     // Best-effort cleanup of route handler on error
@@ -188,6 +207,9 @@ async function executeBrowserNavigate(
 
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, url: safeRequestedUrl }, 'Navigation failed');
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
     return { content: `Error: Navigation failed: ${msg}`, isError: true };
   }
 }
@@ -420,6 +442,11 @@ async function executeBrowserClose(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   try {
+    const sender = getSender(context.sessionId);
+    if (sender) {
+      await stopBrowserScreencast(context.sessionId, sender);
+    }
+
     if (input.close_all_pages === true) {
       await browserManager.closeAllPages();
       return { content: 'All browser pages and context closed.', isError: false };
@@ -498,13 +525,25 @@ async function executeBrowserClick(
   const { selector, error } = resolveSelector(context.sessionId, input);
   if (error) return { content: error, isError: true };
 
+  const sender = getSender(context.sessionId);
+  if (sender) {
+    await ensureScreencast(context.sessionId, sender);
+    updateBrowserStatus(context.sessionId, sender, 'interacting', 'Clicking element');
+  }
+
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
     await page.click(selector!);
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
     return { content: `Clicked element: ${selector}`, isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, selector }, 'Click failed');
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
     return { content: `Error: Click failed: ${msg}`, isError: true };
   }
 }
@@ -559,6 +598,12 @@ async function executeBrowserType(
   const clearFirst = input.clear_first !== false; // default true
   const pressEnter = input.press_enter === true;
 
+  const sender = getSender(context.sessionId);
+  if (sender) {
+    await ensureScreencast(context.sessionId, sender);
+    updateBrowserStatus(context.sessionId, sender, 'interacting', 'Typing text');
+  }
+
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
 
@@ -578,6 +623,10 @@ async function executeBrowserType(
       await page.press(selector!, 'Enter');
     }
 
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
+
     const lines = [`Typed into element: ${selector}`];
     if (clearFirst) lines.push('(cleared existing content first)');
     if (pressEnter) lines.push('(pressed Enter after typing)');
@@ -585,6 +634,9 @@ async function executeBrowserType(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, selector }, 'Type failed');
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
     return { content: `Error: Type failed: ${msg}`, isError: true };
   }
 }
@@ -646,6 +698,12 @@ async function executeBrowserPressKey(
     return { content: 'Error: key is required.', isError: true };
   }
 
+  const sender = getSender(context.sessionId);
+  if (sender) {
+    await ensureScreencast(context.sessionId, sender);
+    updateBrowserStatus(context.sessionId, sender, 'interacting', `Pressing ${key}`);
+  }
+
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
 
@@ -657,15 +715,24 @@ async function executeBrowserPressKey(
       const { selector, error } = resolveSelector(context.sessionId, input);
       if (error) return { content: error, isError: true };
       await page.press(selector!, key);
+      if (sender) {
+        updateBrowserStatus(context.sessionId, sender, 'idle');
+      }
       return { content: `Pressed "${key}" on element: ${selector}`, isError: false };
     }
 
     // No target → press key on the page (focused element)
     await page.keyboard.press(key);
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
     return { content: `Pressed "${key}"`, isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, key }, 'Press key failed');
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
     return { content: `Error: Press key failed: ${msg}`, isError: true };
   }
 }


### PR DESCRIPTION
## Summary
- Creates `browser-screencast.ts` module for screencast-to-surface bridge
- Auto-starts screencast on first browser tool use (navigate, click, type, press key)
- Updates status/actionText for each browser action (navigating, interacting, idle)
- Updates pages list after navigation completes
- Dismisses surface on browser_close
- Registers sendToClient per session via session-tool-setup

## Files changed
- `assistant/src/tools/browser/browser-screencast.ts` — new module managing screencast lifecycle
- `assistant/src/tools/browser/headless-browser.ts` — integrated screencast calls into browser tools
- `assistant/src/daemon/session-tool-setup.ts` — registers session sender for screencast

Part of #3734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
