### PR TITLE
M6: Add tab bar for multiple pages in PiP panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -14,6 +14,10 @@ final class BrowserPiPManager: ObservableObject {
     @Published var currentFrame: NSImage?
     @Published var pages: [BrowserPage] = []
 
+    var activePage: BrowserPage? {
+        pages.first(where: { $0.active })
+    }
+
     private var panel: NSPanel?
     private var surfaceId: String?
     private var sessionId: String?

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPView.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPView.swift
@@ -10,7 +10,7 @@ struct BrowserPiPView: View {
                 Circle()
                     .fill(statusColor)
                     .frame(width: 8, height: 8)
-                Text(manager.currentUrl)
+                Text(manager.activePage?.url ?? manager.currentUrl)
                     .font(.system(size: 11, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -22,6 +22,21 @@ struct BrowserPiPView: View {
             .background(Color(NSColor.windowBackgroundColor))
 
             Divider()
+
+            // Tab bar (only shown when multiple pages)
+            if manager.pages.count > 1 {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 2) {
+                        ForEach(manager.pages) { page in
+                            BrowserTabView(page: page)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                }
+                .background(Color(NSColor.controlBackgroundColor))
+                Divider()
+            }
 
             // Frame
             ZStack {
@@ -63,5 +78,31 @@ struct BrowserPiPView: View {
         case "interacting": return .blue
         default: return .green
         }
+    }
+}
+
+struct BrowserTabView: View {
+    let page: BrowserPage
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(page.active ? Color.accentColor : Color.gray)
+                .frame(width: 8, height: 8)
+            Text(page.title.isEmpty ? domainFrom(page.url) : page.title)
+                .font(.system(size: 10))
+                .lineLimit(1)
+                .frame(maxWidth: 120)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(page.active ? Color(NSColor.selectedContentBackgroundColor).opacity(0.3) : Color.clear)
+        .cornerRadius(4)
+    }
+
+    private func domainFrom(_ url: String) -> String {
+        guard let components = URLComponents(string: url),
+              let host = components.host else { return url }
+        return host
     }
 }


### PR DESCRIPTION
## Summary
- Adds scrollable tab bar showing page titles when multiple pages are open
- Tab bar only visible when pages.count > 1
- Active tab highlighted with accent color
- URL bar shows active page's URL
- Extracts domain from URL as fallback when title is empty
- Part of #3734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
