### PR TITLE
M7: Add rich annotations — element highlights and action text overlays

### DIFF
--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -131,6 +131,41 @@ export async function stopBrowserScreencast(
   activeScreencasts.delete(sessionId);
 }
 
+export async function getElementBounds(
+  sessionId: string,
+  selector: string,
+): Promise<{ x: number; y: number; w: number; h: number } | null> {
+  try {
+    const page = await browserManager.getOrCreateSessionPage(sessionId);
+    const bounds = await page.evaluate(`
+      (() => {
+        const el = document.querySelector('${selector.replace(/'/g, "\\'")}');
+        if (!el) return null;
+        const rect = el.getBoundingClientRect();
+        return { x: rect.x, y: rect.y, w: rect.width, h: rect.height };
+      })()
+    `) as { x: number; y: number; w: number; h: number } | null;
+    return bounds;
+  } catch {
+    return null;
+  }
+}
+
+export function updateHighlights(
+  sessionId: string,
+  sendToClient: (msg: any) => void,
+  highlights: Array<{ x: number; y: number; w: number; h: number; label: string }>,
+): void {
+  const state = activeScreencasts.get(sessionId);
+  if (!state) return;
+  sendToClient({
+    type: 'ui_surface_update',
+    sessionId,
+    surfaceId: state.surfaceId,
+    data: { highlights },
+  });
+}
+
 export function isScreencastActive(sessionId: string): boolean {
   return activeScreencasts.has(sessionId);
 }

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -20,6 +20,8 @@ import {
   updatePagesList,
   stopBrowserScreencast,
   getSender,
+  getElementBounds,
+  updateHighlights,
 } from './browser-screencast.js';
 
 const log = getLogger('headless-browser');
@@ -529,12 +531,17 @@ async function executeBrowserClick(
   if (sender) {
     await ensureScreencast(context.sessionId, sender);
     updateBrowserStatus(context.sessionId, sender, 'interacting', 'Clicking element');
+    const bounds = await getElementBounds(context.sessionId, selector!);
+    if (bounds) {
+      updateHighlights(context.sessionId, sender, [{ ...bounds, label: 'Clicking element' }]);
+    }
   }
 
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
     await page.click(selector!);
     if (sender) {
+      updateHighlights(context.sessionId, sender, []);
       updateBrowserStatus(context.sessionId, sender, 'idle');
     }
     return { content: `Clicked element: ${selector}`, isError: false };
@@ -542,6 +549,7 @@ async function executeBrowserClick(
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, selector }, 'Click failed');
     if (sender) {
+      updateHighlights(context.sessionId, sender, []);
       updateBrowserStatus(context.sessionId, sender, 'idle');
     }
     return { content: `Error: Click failed: ${msg}`, isError: true };
@@ -602,6 +610,10 @@ async function executeBrowserType(
   if (sender) {
     await ensureScreencast(context.sessionId, sender);
     updateBrowserStatus(context.sessionId, sender, 'interacting', 'Typing text');
+    const bounds = await getElementBounds(context.sessionId, selector!);
+    if (bounds) {
+      updateHighlights(context.sessionId, sender, [{ ...bounds, label: 'Typing' }]);
+    }
   }
 
   try {
@@ -624,6 +636,7 @@ async function executeBrowserType(
     }
 
     if (sender) {
+      updateHighlights(context.sessionId, sender, []);
       updateBrowserStatus(context.sessionId, sender, 'idle');
     }
 
@@ -635,6 +648,7 @@ async function executeBrowserType(
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, selector }, 'Type failed');
     if (sender) {
+      updateHighlights(context.sessionId, sender, []);
       updateBrowserStatus(context.sessionId, sender, 'idle');
     }
     return { content: `Error: Type failed: ${msg}`, isError: true };
@@ -714,8 +728,15 @@ async function executeBrowserPressKey(
     if (elementId || rawSelector) {
       const { selector, error } = resolveSelector(context.sessionId, input);
       if (error) return { content: error, isError: true };
+      if (sender) {
+        const bounds = await getElementBounds(context.sessionId, selector!);
+        if (bounds) {
+          updateHighlights(context.sessionId, sender, [{ ...bounds, label: `Pressing ${key}` }]);
+        }
+      }
       await page.press(selector!, key);
       if (sender) {
+        updateHighlights(context.sessionId, sender, []);
         updateBrowserStatus(context.sessionId, sender, 'idle');
       }
       return { content: `Pressed "${key}" on element: ${selector}`, isError: false };
@@ -731,6 +752,7 @@ async function executeBrowserPressKey(
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, key }, 'Press key failed');
     if (sender) {
+      updateHighlights(context.sessionId, sender, []);
       updateBrowserStatus(context.sessionId, sender, 'idle');
     }
     return { content: `Error: Press key failed: ${msg}`, isError: true };

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -13,8 +13,11 @@ final class BrowserPiPManager: ObservableObject {
     @Published var actionText: String?
     @Published var currentFrame: NSImage?
     @Published var pages: [BrowserPage] = []
+    @Published var highlights: [BrowserHighlight] = []
+    var frameSize: CGSize = CGSize(width: 800, height: 600)
 
     private var panel: NSPanel?
+    private var actionTextClearTask: Task<Void, Never>?
     private var surfaceId: String?
     private var sessionId: String?
 
@@ -65,9 +68,24 @@ final class BrowserPiPManager: ObservableObject {
         }
         if dict.keys.contains("actionText") {
             actionText = dict["actionText"] as? String
+            scheduleActionTextClear()
         }
         if let frameStr = dict["frame"] as? String {
             decodeFrame(frameStr)
+        }
+        if dict.keys.contains("highlights") {
+            if let highlightsArray = dict["highlights"] as? [[String: Any?]] {
+                highlights = highlightsArray.compactMap { item in
+                    guard let x = item["x"] as? Double,
+                          let y = item["y"] as? Double,
+                          let w = item["w"] as? Double,
+                          let h = item["h"] as? Double,
+                          let label = item["label"] as? String else { return nil }
+                    return BrowserHighlight(x: x, y: y, w: w, h: h, label: label)
+                }
+            } else {
+                highlights = []
+            }
         }
         if let pagesArray = dict["pages"] as? [[String: Any?]] {
             pages = pagesArray.compactMap { pageDict in
@@ -109,7 +127,20 @@ final class BrowserPiPManager: ObservableObject {
                   let image = NSImage(data: data) else { return }
             DispatchQueue.main.async {
                 self?.currentFrame = image
+                if image.size.width > 0 && image.size.height > 0 {
+                    self?.frameSize = image.size
+                }
             }
+        }
+    }
+
+    private func scheduleActionTextClear() {
+        actionTextClearTask?.cancel()
+        guard actionText != nil else { return }
+        actionTextClearTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            self.actionText = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPView.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 struct BrowserPiPView: View {
     @ObservedObject var manager: BrowserPiPManager
@@ -36,6 +37,20 @@ struct BrowserPiPView: View {
                         .foregroundColor(.secondary)
                 }
 
+                // Highlight overlays
+                if !manager.highlights.isEmpty, let _ = manager.currentFrame {
+                    GeometryReader { geometry in
+                        ForEach(manager.highlights) { highlight in
+                            let scaled = scaleHighlight(highlight, viewSize: geometry.size, frameSize: manager.frameSize)
+                            RoundedRectangle(cornerRadius: 2)
+                                .stroke(Color.blue, lineWidth: 2)
+                                .background(RoundedRectangle(cornerRadius: 2).fill(Color.blue.opacity(0.1)))
+                                .frame(width: scaled.width, height: scaled.height)
+                                .position(x: scaled.midX, y: scaled.midY)
+                        }
+                    }
+                }
+
                 // Action text overlay
                 if let action = manager.actionText {
                     VStack {
@@ -52,9 +67,26 @@ struct BrowserPiPView: View {
                         }
                         .padding(8)
                     }
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.2), value: manager.actionText)
                 }
             }
+            .animation(.easeInOut(duration: 0.2), value: manager.actionText)
         }
+    }
+
+    private func scaleHighlight(_ highlight: BrowserHighlight, viewSize: CGSize, frameSize: CGSize) -> CGRect {
+        let scaleX = viewSize.width / frameSize.width
+        let scaleY = viewSize.height / frameSize.height
+        let scale = min(scaleX, scaleY)
+        let offsetX = (viewSize.width - frameSize.width * scale) / 2
+        let offsetY = (viewSize.height - frameSize.height * scale) / 2
+        return CGRect(
+            x: offsetX + highlight.x * scale,
+            y: offsetY + highlight.y * scale,
+            width: highlight.w * scale,
+            height: highlight.h * scale
+        )
     }
 
     private var statusColor: Color {


### PR DESCRIPTION
## Summary
- Backend: `getElementBounds` computes element bounding boxes via `page.evaluate`
- Backend: `updateHighlights` sends highlight data as surface updates
- Backend: browser tools send highlights before click/type/press, clear after
- Frontend: `BrowserPiPView` renders scaled highlight overlays on top of frame
- Frontend: Coordinate scaling accounts for aspect-fit rendering
- Frontend: Action text auto-clears after 3 seconds with fade transition
- Part of #3734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
