### PR TITLE
test: baseline skill_load has no child metadata

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -160,4 +160,23 @@ describe('skill_load tool', () => {
     expect(result.content).toContain('No skill matched');
     expect(result.content).not.toContain('<loaded_skill');
   });
+
+  test('successful skill_load output has no child metadata section', async () => {
+    writeSkill('standalone', 'Standalone Skill', 'A skill with no children', 'Do the thing');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- standalone\n');
+
+    const result = await executeSkillLoad({ skill: 'standalone' });
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain('Included Skills');
+  });
+
+  test('successful skill_load emits exactly one loaded_skill marker', async () => {
+    writeSkill('single-marker', 'Single Marker Skill', 'Should have one marker', 'Step 1');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- single-marker\n');
+
+    const result = await executeSkillLoad({ skill: 'single-marker' });
+    expect(result.isError).toBe(false);
+    const markers = result.content.match(/<loaded_skill/g) || [];
+    expect(markers.length).toBe(1);
+  });
 });


### PR DESCRIPTION
Baseline characterization tests locking current skill_load output shape before introducing includes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
