### PR TITLE
feat: add includes field to Skill type definitions

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -55,6 +55,8 @@ export interface SkillSummary {
   metadata?: VellumMetadata;
   /** Parsed tool manifest metadata, if the skill has a valid TOOLS.json. */
   toolManifest?: SkillToolManifestMeta;
+  /** IDs of child skills that this skill includes (composed into its prompt). */
+  includes?: string[];
 }
 
 export interface SkillDefinition extends SkillSummary {
@@ -225,6 +227,7 @@ interface ParsedFrontmatter {
   userInvocable: boolean;
   disableModelInvocation: boolean;
   metadata?: VellumMetadata;
+  includes?: string[];
 }
 
 function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontmatter | null {


### PR DESCRIPTION
Adds optional `includes?: string[]` to `SkillSummary` and `ParsedFrontmatter` interfaces. `SkillDefinition` inherits the field from `SkillSummary`. Type-only change, no runtime behavior.

Part of child-skill relationships rollout (PR 2).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
