### PR TITLE
feat: includes JSON array parsing utility

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -380,3 +380,97 @@ describe('tool manifest detection', () => {
     expect(skill!.toolManifest).toBeUndefined();
   });
 });
+
+describe('includes frontmatter parsing', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  function writeSkillWithIncludes(skillId: string, includes: string): void {
+    const skillDir = join(TEST_DIR, 'skills', skillId);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: "${skillId}"\ndescription: "test"\nincludes: ${includes}\n---\n\nBody.\n`,
+    );
+  }
+
+  test('parses valid includes array', () => {
+    writeSkillWithIncludes('parent', '["child-a", "child-b"]');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill).toBeDefined();
+    expect(skill!.includes).toEqual(['child-a', 'child-b']);
+  });
+
+  test('trims whitespace in includes entries', () => {
+    writeSkillWithIncludes('parent', '["  child-a  ", " child-b "]');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill!.includes).toEqual(['child-a', 'child-b']);
+  });
+
+  test('removes empty strings from includes', () => {
+    writeSkillWithIncludes('parent', '["child-a", "", "  ", "child-b"]');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill!.includes).toEqual(['child-a', 'child-b']);
+  });
+
+  test('deduplicates includes preserving first-seen order', () => {
+    writeSkillWithIncludes('parent', '["child-a", "child-b", "child-a"]');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill!.includes).toEqual(['child-a', 'child-b']);
+  });
+
+  test('returns undefined for invalid JSON', () => {
+    writeSkillWithIncludes('parent', 'not-json');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill!.includes).toBeUndefined();
+  });
+
+  test('returns undefined for non-array JSON', () => {
+    writeSkillWithIncludes('parent', '"just-a-string"');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill!.includes).toBeUndefined();
+  });
+
+  test('returns undefined for array with non-string elements', () => {
+    writeSkillWithIncludes('parent', '[123, true]');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill!.includes).toBeUndefined();
+  });
+
+  test('returns undefined for empty array', () => {
+    writeSkillWithIncludes('parent', '[]');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'parent');
+    expect(skill!.includes).toBeUndefined();
+  });
+
+  test('skill without includes has undefined includes', () => {
+    writeSkill('no-includes', 'No Includes', 'Test');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- no-includes\n');
+    const catalog = loadUserSkillCatalog();
+    const skill = catalog.find(s => s.id === 'no-includes');
+    expect(skill!.includes).toBeUndefined();
+  });
+});

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -230,6 +230,41 @@ interface ParsedFrontmatter {
   includes?: string[];
 }
 
+function parseIncludes(raw: string | undefined, skillFilePath: string): string[] | undefined {
+  if (!raw) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn({ err, skillFilePath }, 'Failed to parse includes JSON in frontmatter');
+    return undefined;
+  }
+
+  if (!Array.isArray(parsed)) {
+    log.warn({ skillFilePath }, 'includes must be a JSON array');
+    return undefined;
+  }
+
+  if (!parsed.every((item: unknown) => typeof item === 'string')) {
+    log.warn({ skillFilePath }, 'includes must be an array of strings');
+    return undefined;
+  }
+
+  // Normalize: trim, remove empty strings, deduplicate preserving first-seen order
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of parsed as string[]) {
+    const trimmed = item.trim();
+    if (trimmed.length === 0) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+
+  return result.length > 0 ? result : undefined;
+}
+
 function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontmatter | null {
   const match = content.match(FRONTMATTER_REGEX);
   if (!match) {
@@ -295,6 +330,8 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
     }
   }
 
+  const includes = parseIncludes(fields.includes, skillFilePath);
+
   return {
     name,
     description,
@@ -303,6 +340,7 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
     userInvocable,
     disableModelInvocation,
     metadata,
+    includes,
   };
 }
 
@@ -425,6 +463,7 @@ function readSkillFromDirectory(directoryPath: string, skillsDir: string, source
       source,
       metadata: parsed.metadata,
       toolManifest: detectToolManifest(directoryPath),
+      includes: parsed.includes,
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, 'Failed to read skill file');
@@ -465,6 +504,7 @@ function readBundledSkillFromDirectory(directoryPath: string): SkillDefinition |
       source: 'bundled',
       metadata: parsed.metadata,
       toolManifest: detectToolManifest(directoryPath),
+      includes: parsed.includes,
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, 'Failed to read bundled skill file');
@@ -518,6 +558,7 @@ function loadBundledSkills(): SkillSummary[] {
       source: 'bundled',
       metadata: skill.metadata,
       toolManifest: skill.toolManifest,
+      includes: skill.includes,
     });
   }
 
@@ -637,6 +678,7 @@ function skillSummaryFromDefinition(skill: SkillDefinition, source: SkillSource)
     source,
     metadata: skill.metadata,
     toolManifest: skill.toolManifest,
+    includes: skill.includes,
   };
 }
 
@@ -681,6 +723,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
             source: 'extra',
             metadata: parsed.metadata,
             toolManifest: detectToolManifest(directory),
+            includes: parsed.includes,
           });
         } catch (err) {
           log.warn({ err, directory }, 'Failed to read skill from extraDirs');
@@ -762,6 +805,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
           source: 'workspace',
           metadata: parsed.metadata,
           toolManifest: detectToolManifest(directory),
+          includes: parsed.includes,
         };
 
         if (seenIds.has(id)) {


### PR DESCRIPTION
Adds a parseIncludes() helper that parses, validates, and normalizes the includes frontmatter field. Fail-open at parse layer (returns undefined), fail-closed at skill_load validation layer in a later PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
