### PR TITLE
feat: include graph builder module

### DIFF
--- a/assistant/src/__tests__/skill-include-graph.test.ts
+++ b/assistant/src/__tests__/skill-include-graph.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect } from 'bun:test';
+import type { SkillSummary } from '../config/skills.js';
+import { indexCatalogById, getImmediateChildren, traverseIncludes } from '../skills/include-graph.js';
+
+function makeSkill(id: string, includes?: string[]): SkillSummary {
+  return {
+    id,
+    name: id,
+    description: `Skill ${id}`,
+    directoryPath: `/skills/${id}`,
+    skillFilePath: `/skills/${id}/SKILL.md`,
+    userInvocable: true,
+    disableModelInvocation: false,
+    source: 'managed',
+    includes,
+  };
+}
+
+describe('indexCatalogById', () => {
+  test('creates a map keyed by skill ID', () => {
+    const catalog = [makeSkill('a'), makeSkill('b'), makeSkill('c')];
+    const index = indexCatalogById(catalog);
+    expect(index.size).toBe(3);
+    expect(index.get('a')?.id).toBe('a');
+    expect(index.get('b')?.id).toBe('b');
+    expect(index.get('c')?.id).toBe('c');
+  });
+
+  test('empty catalog produces empty map', () => {
+    const index = indexCatalogById([]);
+    expect(index.size).toBe(0);
+  });
+
+  test('last skill wins on duplicate IDs', () => {
+    const catalog = [makeSkill('a'), { ...makeSkill('a'), name: 'A-override' }];
+    const index = indexCatalogById(catalog);
+    expect(index.get('a')?.name).toBe('A-override');
+  });
+});
+
+describe('getImmediateChildren', () => {
+  test('returns immediate children that exist in catalog', () => {
+    const catalog = [
+      makeSkill('parent', ['child-a', 'child-b']),
+      makeSkill('child-a'),
+      makeSkill('child-b'),
+    ];
+    const index = indexCatalogById(catalog);
+    const children = getImmediateChildren('parent', index);
+    expect(children.map(c => c.id)).toEqual(['child-a', 'child-b']);
+  });
+
+  test('skips children not in catalog', () => {
+    const catalog = [
+      makeSkill('parent', ['child-a', 'missing']),
+      makeSkill('child-a'),
+    ];
+    const index = indexCatalogById(catalog);
+    const children = getImmediateChildren('parent', index);
+    expect(children.map(c => c.id)).toEqual(['child-a']);
+  });
+
+  test('returns empty array when parent has no includes', () => {
+    const catalog = [makeSkill('parent')];
+    const index = indexCatalogById(catalog);
+    expect(getImmediateChildren('parent', index)).toEqual([]);
+  });
+
+  test('returns empty array when parent has empty includes', () => {
+    const catalog = [makeSkill('parent', [])];
+    const index = indexCatalogById(catalog);
+    expect(getImmediateChildren('parent', index)).toEqual([]);
+  });
+
+  test('returns empty array for unknown parent ID', () => {
+    const index = indexCatalogById([]);
+    expect(getImmediateChildren('unknown', index)).toEqual([]);
+  });
+});
+
+describe('traverseIncludes', () => {
+  test('single skill with no includes returns just itself', () => {
+    const catalog = [makeSkill('root')];
+    const index = indexCatalogById(catalog);
+    const result = traverseIncludes('root', index);
+    expect(result.visited).toEqual(['root']);
+  });
+
+  test('parent with immediate children visits all in DFS order', () => {
+    const catalog = [
+      makeSkill('root', ['child-a', 'child-b']),
+      makeSkill('child-a'),
+      makeSkill('child-b'),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = traverseIncludes('root', index);
+    expect(result.visited).toEqual(['root', 'child-a', 'child-b']);
+  });
+
+  test('deep nesting traverses recursively', () => {
+    const catalog = [
+      makeSkill('root', ['mid']),
+      makeSkill('mid', ['leaf']),
+      makeSkill('leaf'),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = traverseIncludes('root', index);
+    expect(result.visited).toEqual(['root', 'mid', 'leaf']);
+  });
+
+  test('diamond dependency visits each node only once', () => {
+    const catalog = [
+      makeSkill('root', ['a', 'b']),
+      makeSkill('a', ['shared']),
+      makeSkill('b', ['shared']),
+      makeSkill('shared'),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = traverseIncludes('root', index);
+    expect(result.visited).toEqual(['root', 'a', 'shared', 'b']);
+  });
+
+  test('missing children are silently skipped in happy path', () => {
+    const catalog = [
+      makeSkill('root', ['exists', 'missing']),
+      makeSkill('exists'),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = traverseIncludes('root', index);
+    expect(result.visited).toEqual(['root', 'exists']);
+  });
+
+  test('unknown root returns just the root ID', () => {
+    const index = indexCatalogById([]);
+    const result = traverseIncludes('unknown', index);
+    expect(result.visited).toEqual(['unknown']);
+  });
+});

--- a/assistant/src/skills/include-graph.ts
+++ b/assistant/src/skills/include-graph.ts
@@ -1,0 +1,68 @@
+import type { SkillSummary } from '../config/skills.js';
+
+export interface IncludeGraphResult {
+  /** Ordered list of all skill IDs visited during traversal (including the root). */
+  visited: string[];
+}
+
+/**
+ * Build an index of skills by their exact ID for O(1) lookup.
+ */
+export function indexCatalogById(catalog: SkillSummary[]): Map<string, SkillSummary> {
+  const index = new Map<string, SkillSummary>();
+  for (const skill of catalog) {
+    index.set(skill.id, skill);
+  }
+  return index;
+}
+
+/**
+ * Get the immediate child skill summaries for a given parent.
+ * Returns only children that exist in the catalog.
+ */
+export function getImmediateChildren(
+  parentId: string,
+  catalogIndex: Map<string, SkillSummary>,
+): SkillSummary[] {
+  const parent = catalogIndex.get(parentId);
+  if (!parent?.includes || parent.includes.length === 0) return [];
+
+  const children: SkillSummary[] = [];
+  for (const childId of parent.includes) {
+    const child = catalogIndex.get(childId);
+    if (child) children.push(child);
+  }
+  return children;
+}
+
+/**
+ * Recursively traverse the include graph starting from the given root skill ID.
+ * Returns all visited skill IDs in DFS pre-order.
+ * Happy-path only — skips missing children silently.
+ */
+export function traverseIncludes(
+  rootId: string,
+  catalogIndex: Map<string, SkillSummary>,
+): IncludeGraphResult {
+  const visited: string[] = [];
+  const seen = new Set<string>();
+
+  function dfs(id: string): void {
+    if (seen.has(id)) return;
+    seen.add(id);
+    visited.push(id);
+
+    const skill = catalogIndex.get(id);
+    if (!skill?.includes) return;
+
+    for (const childId of skill.includes) {
+      if (seen.has(childId)) continue;
+      // Only traverse children that exist in the catalog
+      if (!catalogIndex.has(childId)) continue;
+      dfs(childId);
+    }
+  }
+
+  dfs(rootId);
+  return { visited };
+}


### PR DESCRIPTION
Standalone recursive include resolver utility with catalog indexing, immediate children lookup, and DFS traversal. Happy-path only — error handling added in subsequent PRs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
