### PR TITLE
feat: managed store emits and threads includes

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -171,6 +171,50 @@ describe('buildSkillMarkdown', () => {
     expect(skill!.name).toBe('path\\name');
   });
 
+  test('includes field emits JSON array in frontmatter', () => {
+    const result = buildSkillMarkdown({
+      name: 'Parent',
+      description: 'Has children',
+      bodyMarkdown: 'Body.',
+      includes: ['child-a', 'child-b'],
+    });
+    expect(result).toContain('includes: ["child-a","child-b"]');
+  });
+
+  test('omits includes when not provided', () => {
+    const result = buildSkillMarkdown({
+      name: 'Solo',
+      description: 'No children',
+      bodyMarkdown: 'Body.',
+    });
+    expect(result).not.toContain('includes');
+  });
+
+  test('omits includes when empty array', () => {
+    const result = buildSkillMarkdown({
+      name: 'Empty',
+      description: 'Empty array',
+      bodyMarkdown: 'Body.',
+      includes: [],
+    });
+    expect(result).not.toContain('includes:');
+  });
+
+  test('includes round-trips through write and catalog load', () => {
+    createManagedSkill({
+      id: 'roundtrip-includes',
+      name: 'Roundtrip',
+      description: 'Test roundtrip',
+      bodyMarkdown: 'Body.',
+      includes: ['child-x', 'child-y'],
+    });
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, 'skills')]);
+    const skill = catalog.find(s => s.id === 'roundtrip-includes');
+    expect(skill).toBeDefined();
+    expect(skill!.includes).toEqual(['child-x', 'child-y']);
+  });
+
   test('single-quoted frontmatter preserves backslashes literally', () => {
     // Single-quoted YAML values treat backslashes as literal characters.
     // Manually write a SKILL.md with single-quoted frontmatter to simulate

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -44,6 +44,7 @@ export interface BuildSkillMarkdownInput {
   emoji?: string;
   userInvocable?: boolean;
   disableModelInvocation?: boolean;
+  includes?: string[];
 }
 
 export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
@@ -59,6 +60,9 @@ export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
   }
   if (input.disableModelInvocation === true) {
     lines.push('disable-model-invocation: true');
+  }
+  if (input.includes && input.includes.length > 0) {
+    lines.push(`includes: ${JSON.stringify(input.includes)}`);
   }
   lines.push('---');
   lines.push('');
@@ -133,6 +137,7 @@ export interface CreateManagedSkillParams {
   disableModelInvocation?: boolean;
   overwrite?: boolean;
   addToIndex?: boolean;
+  includes?: string[];
 }
 
 export interface CreateManagedSkillResult {
@@ -174,6 +179,7 @@ export function createManagedSkill(params: CreateManagedSkillParams): CreateMana
     emoji: params.emoji,
     userInvocable: params.userInvocable,
     disableModelInvocation: params.disableModelInvocation,
+    includes: params.includes,
   });
 
   mkdirSync(skillDir, { recursive: true });


### PR DESCRIPTION
Extends BuildSkillMarkdownInput and CreateManagedSkillParams with optional includes field. Emits includes as JSON array in frontmatter. Round-trip tested.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
