### PR TITLE
feat: include graph missing skill detection

### DIFF
--- a/assistant/src/__tests__/skill-include-graph.test.ts
+++ b/assistant/src/__tests__/skill-include-graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import type { SkillSummary } from '../config/skills.js';
-import { indexCatalogById, getImmediateChildren, traverseIncludes } from '../skills/include-graph.js';
+import { indexCatalogById, getImmediateChildren, traverseIncludes, validateIncludes } from '../skills/include-graph.js';
 
 function makeSkill(id: string, includes?: string[]): SkillSummary {
   return {
@@ -134,5 +134,80 @@ describe('traverseIncludes', () => {
     const index = indexCatalogById([]);
     const result = traverseIncludes('unknown', index);
     expect(result.visited).toEqual(['unknown']);
+  });
+});
+
+describe('validateIncludes — missing detection', () => {
+  test('valid graph with no missing children returns success', () => {
+    const catalog = [
+      makeSkill('root', ['child']),
+      makeSkill('child'),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('root', index);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.visited).toEqual(['root', 'child']);
+    }
+  });
+
+  test('detects immediate missing child', () => {
+    const catalog = [
+      makeSkill('root', ['missing-child']),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('root', index);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('missing');
+      expect(result.missingChildId).toBe('missing-child');
+      expect(result.parentId).toBe('root');
+      expect(result.path).toEqual(['root']);
+    }
+  });
+
+  test('detects deeply nested missing child', () => {
+    const catalog = [
+      makeSkill('root', ['mid']),
+      makeSkill('mid', ['missing-leaf']),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('root', index);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('missing');
+      expect(result.missingChildId).toBe('missing-leaf');
+      expect(result.parentId).toBe('mid');
+      expect(result.path).toEqual(['root', 'mid']);
+    }
+  });
+
+  test('first missing child is reported when multiple are missing', () => {
+    const catalog = [
+      makeSkill('root', ['missing-a', 'missing-b']),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('root', index);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.missingChildId).toBe('missing-a');
+    }
+  });
+
+  test('succeeds when skill has no includes', () => {
+    const catalog = [makeSkill('root')];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('root', index);
+    expect(result.ok).toBe(true);
+  });
+
+  test('root skill itself missing still returns success (just the root ID visited)', () => {
+    const index = indexCatalogById([]);
+    const result = validateIncludes('unknown-root', index);
+    // Root doesn't need to be in catalog — it has no includes, so nothing to validate
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.visited).toEqual(['unknown-root']);
+    }
   });
 });

--- a/assistant/src/skills/include-graph.ts
+++ b/assistant/src/skills/include-graph.ts
@@ -40,6 +40,63 @@ export function getImmediateChildren(
  * Returns all visited skill IDs in DFS pre-order.
  * Happy-path only — skips missing children silently.
  */
+export interface IncludeValidationSuccess {
+  ok: true;
+  visited: string[];
+}
+
+export interface IncludeValidationError {
+  ok: false;
+  error: 'missing';
+  missingChildId: string;
+  parentId: string;
+  path: string[];  // full path from root to the parent that referenced the missing child
+}
+
+export type IncludeValidationResult = IncludeValidationSuccess | IncludeValidationError;
+
+/**
+ * Validate the include graph starting from the given root skill ID.
+ * Returns an error result on the first missing child encountered (DFS order),
+ * including the full path from root to the parent that referenced it.
+ */
+export function validateIncludes(
+  rootId: string,
+  catalogIndex: Map<string, SkillSummary>,
+): IncludeValidationResult {
+  const visited: string[] = [];
+  const seen = new Set<string>();
+
+  function dfs(id: string, path: string[]): IncludeValidationError | null {
+    if (seen.has(id)) return null;
+    seen.add(id);
+    visited.push(id);
+
+    const skill = catalogIndex.get(id);
+    if (!skill?.includes) return null;
+
+    const currentPath = [...path, id];
+    for (const childId of skill.includes) {
+      if (!catalogIndex.has(childId)) {
+        return {
+          ok: false,
+          error: 'missing',
+          missingChildId: childId,
+          parentId: id,
+          path: currentPath,
+        };
+      }
+      const childError = dfs(childId, currentPath);
+      if (childError) return childError;
+    }
+    return null;
+  }
+
+  const error = dfs(rootId, []);
+  if (error) return error;
+  return { ok: true, visited };
+}
+
 export function traverseIncludes(
   rootId: string,
   catalogIndex: Map<string, SkillSummary>,


### PR DESCRIPTION
Extends the include graph module with validateIncludes() that detects missing children and reports the parent ID, missing child ID, and full path for debugging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
