### PR TITLE
feat: scaffold_managed_skill accepts includes

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -130,6 +130,50 @@ describe('scaffold_managed_skill tool', () => {
     }
   });
 
+  test('creates a skill with includes metadata', async () => {
+    const result = await tool.execute({
+      skill_id: 'parent-skill',
+      name: 'Parent',
+      description: 'Has children',
+      body_markdown: 'Parent body.',
+      includes: ['child-a', 'child-b'],
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const skillFile = join(TEST_DIR, 'skills', 'parent-skill', 'SKILL.md');
+    const content = readFileSync(skillFile, 'utf-8');
+    expect(content).toContain('includes: ["child-a","child-b"]');
+  });
+
+  test('normalizes includes — trims and deduplicates', async () => {
+    const result = await tool.execute({
+      skill_id: 'norm-skill',
+      name: 'Normalized',
+      description: 'Tests normalization',
+      body_markdown: 'Body.',
+      includes: ['  child-a  ', 'child-b', 'child-a', '', '  '],
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const skillFile = join(TEST_DIR, 'skills', 'norm-skill', 'SKILL.md');
+    const content = readFileSync(skillFile, 'utf-8');
+    expect(content).toContain('includes: ["child-a","child-b"]');
+  });
+
+  test('omits includes when not provided', async () => {
+    const result = await tool.execute({
+      skill_id: 'no-includes',
+      name: 'Solo',
+      description: 'No children',
+      body_markdown: 'Body.',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const skillFile = join(TEST_DIR, 'skills', 'no-includes', 'SKILL.md');
+    const content = readFileSync(skillFile, 'utf-8');
+    expect(content).not.toContain('includes');
+  });
+
   test('rejects invalid skill_id', async () => {
     const result = await tool.execute({
       skill_id: '../escape',

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -58,6 +58,11 @@ export class ScaffoldManagedSkillTool implements Tool {
             type: 'boolean',
             description: 'Whether to add the skill to SKILLS.md index (default: true).',
           },
+          includes: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional list of child skill IDs that this skill includes (metadata only, no auto-activation).',
+          },
         },
         required: ['skill_id', 'name', 'description', 'body_markdown'],
       },
@@ -85,6 +90,26 @@ export class ScaffoldManagedSkillTool implements Tool {
       return { content: 'Error: body_markdown is required and must be a non-empty string', isError: true };
     }
 
+    // Validate and normalize includes
+    let includes: string[] | undefined;
+    if (input.includes !== undefined) {
+      if (!Array.isArray(input.includes)) {
+        return { content: 'Error: includes must be an array of strings', isError: true };
+      }
+      const normalized: string[] = [];
+      const seen = new Set<string>();
+      for (const item of input.includes) {
+        if (typeof item !== 'string' || !item.trim()) continue;
+        const trimmed = item.trim();
+        if (seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        normalized.push(trimmed);
+      }
+      if (normalized.length > 0) {
+        includes = normalized;
+      }
+    }
+
     const result = createManagedSkill({
       id: skillId.trim(),
       name: sanitizeFrontmatterValue(name),
@@ -95,6 +120,7 @@ export class ScaffoldManagedSkillTool implements Tool {
       disableModelInvocation: typeof input.disable_model_invocation === 'boolean' ? input.disable_model_invocation : undefined,
       overwrite: input.overwrite === true,
       addToIndex: input.add_to_index !== false,
+      includes,
     });
 
     if (!result.created) {


### PR DESCRIPTION
Exposes includes in the scaffold_managed_skill tool input schema. Validates as array of strings, normalizes (trim + dedupe), and passes through to createManagedSkill.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
