### PR TITLE
fix: prevent CDP session leaks and stale screencast state in BrowserManager

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -157,8 +157,10 @@ class BrowserManager {
       return existing;
     }
 
-    // Clear stale snapshot mappings when replacing a closed page
+    // Clear stale snapshot mappings and CDP state when replacing a closed page
     this.snapshotMaps.delete(sessionId);
+    this.cdpSessions.delete(sessionId);
+    this.screencastCallbacks.delete(sessionId);
 
     const page = await context.newPage();
     this.pages.set(sessionId, page);
@@ -226,13 +228,16 @@ class BrowserManager {
     const rawPage = this.rawPages.get(sessionId);
     if (!rawPage) throw new Error('No page for session');
 
+    // Stop any existing screencast before creating a new CDP session
+    await this.stopScreencast(sessionId);
+
     const cdp = await rawPage.context().newCDPSession(rawPage);
     this.cdpSessions.set(sessionId, cdp);
     this.screencastCallbacks.set(sessionId, onFrame);
 
     cdp.on('Page.screencastFrame', (params: any) => {
       onFrame({ data: params.data, metadata: params.metadata });
-      cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId });
+      cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId }).catch(() => {});
     });
 
     await cdp.send('Page.startScreencast', {


### PR DESCRIPTION
Addresses review feedback from PR #3751:
- Stop existing screencast before creating new CDP session (prevents resource leaks on double-start)
- Catch screencast ACK send failures during teardown (prevents unhandled rejections)
- Clean up cdpSessions and screencastCallbacks when replacing a closed page
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
