### PR TITLE
fix: gate PiP dismissal to matching surface and serialize frame decode

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -299,7 +299,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         daemonClient.onSurfaceDismiss = { [weak self] msg in
             guard let self else { return }
-            self.browserPiPManager.dismissPanel()
+            self.browserPiPManager.dismissIfMatching(surfaceId: msg.surfaceId)
             self.surfaceManager.dismissSurface(msg)
         }
 

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -20,6 +20,7 @@ final class BrowserPiPManager: ObservableObject {
 
     private var moveObserver: Any?
     private var resizeObserver: Any?
+    private let decodeQueue = DispatchQueue(label: "browser-pip-frame-decode")
 
     // Saved position
     private static let positionXKey = "BrowserPiP.positionX"
@@ -84,6 +85,11 @@ final class BrowserPiPManager: ObservableObject {
         decodeFrame(message.frame)
     }
 
+    func dismissIfMatching(surfaceId: String) {
+        guard surfaceId == self.surfaceId else { return }
+        dismissPanel()
+    }
+
     func dismissPanel() {
         if let moveObs = moveObserver {
             NotificationCenter.default.removeObserver(moveObs)
@@ -104,7 +110,7 @@ final class BrowserPiPManager: ObservableObject {
     }
 
     private func decodeFrame(_ base64: String) {
-        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+        decodeQueue.async { [weak self] in
             guard let data = Data(base64Encoded: base64),
                   let image = NSImage(data: data) else { return }
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- Only dismiss browser PiP when the dismissed surfaceId matches the active one, preventing unrelated surface dismissals from closing the PiP panel
- Use a private serial dispatch queue for frame decoding to prevent out-of-order frame overwrites

## Test plan
- [ ] Verify that dismissing a non-browser surface does not close the browser PiP panel
- [ ] Verify that dismissing the browser surface still correctly closes the PiP panel
- [ ] Verify frames render in order under rapid frame updates

Addresses review feedback from PR #3755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
