### PR TITLE
feat: include graph cycle detection

### DIFF
--- a/assistant/src/__tests__/skill-include-graph.test.ts
+++ b/assistant/src/__tests__/skill-include-graph.test.ts
@@ -211,3 +211,70 @@ describe('validateIncludes — missing detection', () => {
     }
   });
 });
+
+describe('validateIncludes — cycle detection', () => {
+  test('detects direct self-cycle (a -> a)', () => {
+    const catalog = [makeSkill('a', ['a'])];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('a', index);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('cycle');
+      if (result.error === 'cycle') {
+        expect(result.cyclePath).toEqual(['a', 'a']);
+      }
+    }
+  });
+
+  test('detects simple two-node cycle (a -> b -> a)', () => {
+    const catalog = [
+      makeSkill('a', ['b']),
+      makeSkill('b', ['a']),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('a', index);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error === 'cycle') {
+      expect(result.cyclePath).toEqual(['a', 'b', 'a']);
+    }
+  });
+
+  test('detects indirect cycle (a -> b -> c -> a)', () => {
+    const catalog = [
+      makeSkill('a', ['b']),
+      makeSkill('b', ['c']),
+      makeSkill('c', ['a']),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('a', index);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error === 'cycle') {
+      expect(result.cyclePath).toEqual(['a', 'b', 'c', 'a']);
+    }
+  });
+
+  test('no false positive on diamond dependency', () => {
+    const catalog = [
+      makeSkill('root', ['a', 'b']),
+      makeSkill('a', ['shared']),
+      makeSkill('b', ['shared']),
+      makeSkill('shared'),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('root', index);
+    expect(result.ok).toBe(true);
+  });
+
+  test('missing check still works alongside cycle detection', () => {
+    const catalog = [
+      makeSkill('root', ['exists', 'missing']),
+      makeSkill('exists'),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = validateIncludes('root', index);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('missing');
+    }
+  });
+});

--- a/assistant/src/skills/include-graph.ts
+++ b/assistant/src/skills/include-graph.ts
@@ -53,46 +53,67 @@ export interface IncludeValidationError {
   path: string[];  // full path from root to the parent that referenced the missing child
 }
 
-export type IncludeValidationResult = IncludeValidationSuccess | IncludeValidationError;
+export interface IncludeValidationCycleError {
+  ok: false;
+  error: 'cycle';
+  cyclePath: string[];  // the IDs forming the cycle, e.g. ['a', 'b', 'c', 'a']
+}
+
+export type IncludeValidationResult = IncludeValidationSuccess | IncludeValidationError | IncludeValidationCycleError;
 
 /**
  * Validate the include graph starting from the given root skill ID.
- * Returns an error result on the first missing child encountered (DFS order),
- * including the full path from root to the parent that referenced it.
+ * Uses three-state DFS (unseen/visiting/done) to detect both missing children
+ * and cycles. Returns the first error encountered in DFS order.
  */
 export function validateIncludes(
   rootId: string,
   catalogIndex: Map<string, SkillSummary>,
 ): IncludeValidationResult {
   const visited: string[] = [];
-  const seen = new Set<string>();
+  type State = 'unseen' | 'visiting' | 'done';
+  const state = new Map<string, State>();
+  const ancestry: string[] = [];  // current DFS path for cycle reporting
 
-  function dfs(id: string, path: string[]): IncludeValidationError | null {
-    if (seen.has(id)) return null;
-    seen.add(id);
+  function dfs(id: string): IncludeValidationError | IncludeValidationCycleError | null {
+    const currentState = state.get(id) ?? 'unseen';
+
+    if (currentState === 'done') return null;
+
+    if (currentState === 'visiting') {
+      // Found a cycle — build the cycle path from the point where id first appears
+      const cycleStart = ancestry.indexOf(id);
+      const cyclePath = [...ancestry.slice(cycleStart), id];
+      return { ok: false, error: 'cycle', cyclePath };
+    }
+
+    state.set(id, 'visiting');
+    ancestry.push(id);
     visited.push(id);
 
     const skill = catalogIndex.get(id);
-    if (!skill?.includes) return null;
-
-    const currentPath = [...path, id];
-    for (const childId of skill.includes) {
-      if (!catalogIndex.has(childId)) {
-        return {
-          ok: false,
-          error: 'missing',
-          missingChildId: childId,
-          parentId: id,
-          path: currentPath,
-        };
+    if (skill?.includes) {
+      for (const childId of skill.includes) {
+        if (!catalogIndex.has(childId)) {
+          return {
+            ok: false,
+            error: 'missing',
+            missingChildId: childId,
+            parentId: id,
+            path: [...ancestry],
+          };
+        }
+        const childError = dfs(childId);
+        if (childError) return childError;
       }
-      const childError = dfs(childId, currentPath);
-      if (childError) return childError;
     }
+
+    ancestry.pop();
+    state.set(id, 'done');
     return null;
   }
 
-  const error = dfs(rootId, []);
+  const error = dfs(rootId);
   if (error) return error;
   return { ok: true, visited };
 }


### PR DESCRIPTION
Adds three-state DFS (unseen/visiting/done) to validateIncludes for cycle detection. Reports the full cycle path. Works alongside existing missing-child detection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
