### PR TITLE
fix: screencast error recovery, status resets, and session cleanup

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -91,6 +91,7 @@ import {
   createToolExecutor,
   type ToolSetupContext,
 } from './session-tool-setup.js';
+import { unregisterSessionSender } from '../tools/browser/browser-screencast.js';
 import { projectSkillTools, resetSkillToolProjection } from './session-skill-tools.js';
 
 const log = getLogger('session');
@@ -449,6 +450,7 @@ export class Session {
       sessionId: this.conversationId,
     });
     this.abort();
+    unregisterSessionSender(this.conversationId);
     resetSkillToolProjection(this.skillProjectionState);
     this.eventBus.dispose();
   }

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -36,37 +36,43 @@ export async function ensureScreencast(
   const surfaceId = uuid();
   activeScreencasts.set(sessionId, { surfaceId });
 
-  // Get current page info
-  const page = await browserManager.getOrCreateSessionPage(sessionId);
-  const currentUrl = page.url();
-  const title = await page.title();
+  try {
+    // Get current page info
+    const page = await browserManager.getOrCreateSessionPage(sessionId);
+    const currentUrl = page.url();
+    const title = await page.title();
 
-  // Send surface show
-  sendToClient({
-    type: 'ui_surface_show',
-    sessionId,
-    surfaceId,
-    surfaceType: 'browser_view',
-    title: 'Browser',
-    data: {
-      sessionId,
-      currentUrl: currentUrl || 'about:blank',
-      status: 'idle',
-      pages: [{ id: sessionId, title: title || 'New Tab', url: currentUrl || 'about:blank', active: true }],
-    } satisfies BrowserViewSurfaceData,
-    display: 'panel',
-  });
-
-  // Start CDP screencast
-  await browserManager.startScreencast(sessionId, (frame) => {
+    // Send surface show
     sendToClient({
-      type: 'browser_frame',
+      type: 'ui_surface_show',
       sessionId,
       surfaceId,
-      frame: frame.data,
-      metadata: frame.metadata,
-    } satisfies BrowserFrame);
-  });
+      surfaceType: 'browser_view',
+      title: 'Browser',
+      data: {
+        sessionId,
+        currentUrl: currentUrl || 'about:blank',
+        status: 'idle',
+        pages: [{ id: sessionId, title: title || 'New Tab', url: currentUrl || 'about:blank', active: true }],
+      } satisfies BrowserViewSurfaceData,
+      display: 'panel',
+    });
+
+    // Start CDP screencast
+    await browserManager.startScreencast(sessionId, (frame) => {
+      sendToClient({
+        type: 'browser_frame',
+        sessionId,
+        surfaceId,
+        frame: frame.data,
+        metadata: frame.metadata,
+      } satisfies BrowserFrame);
+    });
+  } catch (err) {
+    // Roll back so future calls can retry
+    activeScreencasts.delete(sessionId);
+    throw err;
+  }
 }
 
 export function updateBrowserStatus(
@@ -164,6 +170,24 @@ export function updateHighlights(
     surfaceId: state.surfaceId,
     data: { highlights },
   });
+}
+
+export async function stopAllScreencasts(): Promise<void> {
+  const entries = Array.from(activeScreencasts.entries());
+  for (const [sessionId, state] of entries) {
+    try {
+      await browserManager.stopScreencast(sessionId);
+    } catch { /* best-effort */ }
+    const sender = sessionSenders.get(sessionId);
+    if (sender) {
+      sender({
+        type: 'ui_surface_dismiss',
+        sessionId,
+        surfaceId: state.surfaceId,
+      });
+    }
+  }
+  activeScreencasts.clear();
 }
 
 export function isScreencastActive(sessionId: string): boolean {

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -19,6 +19,7 @@ import {
   updateBrowserStatus,
   updatePagesList,
   stopBrowserScreencast,
+  stopAllScreencasts,
   getSender,
   getElementBounds,
   updateHighlights,
@@ -137,6 +138,9 @@ async function executeBrowserNavigate(
     }
 
     if (blockedUrl) {
+      if (sender) {
+        updateBrowserStatus(context.sessionId, sender, 'idle');
+      }
       return {
         content: `Error: Navigation blocked. A request targeted a local/private network address (${blockedUrl}). Set allow_private_network=true if you explicitly need it.`,
         isError: true,
@@ -201,6 +205,9 @@ async function executeBrowserNavigate(
     // page.goto() throws. Return the clear security message instead of the
     // raw Playwright error (which could leak credentials from the URL).
     if (blockedUrl) {
+      if (sender) {
+        updateBrowserStatus(context.sessionId, sender, 'idle');
+      }
       return {
         content: `Error: Navigation blocked. A request targeted a local/private network address (${blockedUrl}). Set allow_private_network=true if you explicitly need it.`,
         isError: true,
@@ -450,6 +457,7 @@ async function executeBrowserClose(
     }
 
     if (input.close_all_pages === true) {
+      await stopAllScreencasts();
       await browserManager.closeAllPages();
       return { content: 'All browser pages and context closed.', isError: false };
     }
@@ -727,7 +735,12 @@ async function executeBrowserPressKey(
 
     if (elementId || rawSelector) {
       const { selector, error } = resolveSelector(context.sessionId, input);
-      if (error) return { content: error, isError: true };
+      if (error) {
+        if (sender) {
+          updateBrowserStatus(context.sessionId, sender, 'idle');
+        }
+        return { content: error, isError: true };
+      }
       if (sender) {
         const bounds = await getElementBounds(context.sessionId, selector!);
         if (bounds) {


### PR DESCRIPTION
Addresses review feedback from PR #3756:
- Roll back activeScreencasts on ensureScreencast failure (prevents permanent streaming loss)
- Clear all screencast state on close_all_pages (prevents stale entries)
- Reset status to idle on early returns in browser_press_key and browser_navigate
- Call unregisterSessionSender on session teardown (prevents memory leak)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
