### PR TITLE
fix: selector injection, coordinate normalization, and highlight ID uniqueness

### DIFF
--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -143,15 +143,23 @@ export async function getElementBounds(
 ): Promise<{ x: number; y: number; w: number; h: number } | null> {
   try {
     const page = await browserManager.getOrCreateSessionPage(sessionId);
-    const bounds = await page.evaluate(`
+    const result = await page.evaluate(`
       (() => {
-        const el = document.querySelector('${selector.replace(/'/g, "\\'")}');
+        const el = document.querySelector(${JSON.stringify(selector)});
         if (!el) return null;
         const rect = el.getBoundingClientRect();
-        return { x: rect.x, y: rect.y, w: rect.width, h: rect.height };
+        return { x: rect.x, y: rect.y, w: rect.width, h: rect.height, vw: window.innerWidth, vh: window.innerHeight };
       })()
-    `) as { x: number; y: number; w: number; h: number } | null;
-    return bounds;
+    `) as { x: number; y: number; w: number; h: number; vw: number; vh: number } | null;
+    if (!result) return null;
+    const scaleX = 800 / result.vw;
+    const scaleY = 600 / result.vh;
+    return {
+      x: result.x * scaleX,
+      y: result.y * scaleY,
+      w: result.w * scaleX,
+      h: result.h * scaleY,
+    };
   } catch {
     return null;
   }

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -271,7 +271,7 @@ public struct FileUploadSurfaceData: Sendable {
 }
 
 public struct BrowserHighlight: Sendable, Identifiable {
-    public var id: String { label }
+    public var id: String { "\(x),\(y),\(w),\(h):\(label)" }
     public let x: Double
     public let y: Double
     public let w: Double


### PR DESCRIPTION
Addresses review feedback from PR #3759:
- Use JSON.stringify for selector escaping instead of manual replace (prevents JS injection)
- Scale element bounds to screencast frame coordinates (800x600)
- Use position+label combo for BrowserHighlight Identifiable id (prevents duplicate IDs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
