### PR TITLE
feat: skill_load shows immediate child metadata

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -170,13 +170,13 @@ describe('skill_load tool', () => {
     expect(result.content).not.toContain('<loaded_skill');
   });
 
-  test('successful skill_load output has no child metadata section', async () => {
+  test('successful skill_load output shows "none" for skills without includes', async () => {
     writeSkill('standalone', 'Standalone Skill', 'A skill with no children', 'Do the thing');
     writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- standalone\n');
 
     const result = await executeSkillLoad({ skill: 'standalone' });
     expect(result.isError).toBe(false);
-    expect(result.content).not.toContain('Included Skills');
+    expect(result.content).toContain('Included Skills (immediate): none');
   });
 
   test('successful skill_load emits exactly one loaded_skill marker', async () => {
@@ -265,5 +265,31 @@ describe('skill_load tool', () => {
     const result = await executeSkillLoad({ skill: 'no-includes' });
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Skill: No Includes');
+  });
+
+  test('skill_load output includes immediate child metadata', async () => {
+    writeSkill('child-skill', 'Child Skill', 'A child skill', 'Child body');
+    const parentDir = join(TEST_DIR, 'skills', 'parent-with-children');
+    mkdirSync(parentDir, { recursive: true });
+    writeFileSync(
+      join(parentDir, 'SKILL.md'),
+      '---\nname: "Parent"\ndescription: "Has children"\nincludes: ["child-skill"]\n---\n\nParent body.\n',
+    );
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- parent-with-children\n- child-skill\n');
+
+    const result = await executeSkillLoad({ skill: 'parent-with-children' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Included Skills (immediate):');
+    expect(result.content).toContain('child-skill: Child Skill');
+    expect(result.content).toContain('<loaded_skill');
+  });
+
+  test('skill_load output shows "none" when no includes', async () => {
+    writeSkill('solo-skill', 'Solo', 'No children', 'Body');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- solo-skill\n');
+
+    const result = await executeSkillLoad({ skill: 'solo-skill' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Included Skills (immediate): none');
   });
 });

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { loadSkillBySelector, loadSkillCatalog } from '../../config/skills.js';
+import type { SkillSummary } from '../../config/skills.js';
 import { indexCatalogById, validateIncludes } from '../../skills/include-graph.js';
 import { computeSkillVersionHash } from '../../skills/version-hash.js';
 import { getLogger } from '../../util/logger.js';
@@ -45,10 +46,13 @@ export class SkillLoadTool implements Tool {
 
     const skill = loaded.skill;
 
-    // Validate recursive includes (fail-closed)
+    // Load catalog for include validation and child metadata output
+    let catalogIndex: Map<string, SkillSummary> | undefined;
     if (skill.includes && skill.includes.length > 0) {
       const catalog = loadSkillCatalog();
-      const catalogIndex = indexCatalogById(catalog);
+      catalogIndex = indexCatalogById(catalog);
+
+      // Validate recursive includes (fail-closed)
       const validation = validateIncludes(skill.id, catalogIndex);
       if (!validation.ok) {
         if (validation.error === 'missing') {
@@ -68,6 +72,21 @@ export class SkillLoadTool implements Tool {
 
     const body = skill.body.length > 0 ? skill.body : '(No body content)';
 
+    // Build immediate children metadata section
+    let immediateChildrenSection: string;
+    if (skill.includes && skill.includes.length > 0 && catalogIndex) {
+      const childLines: string[] = [];
+      for (const childId of skill.includes) {
+        const child = catalogIndex.get(childId);
+        if (child) {
+          childLines.push(`  - ${child.id}: ${child.name} — ${child.description} (${child.skillFilePath})`);
+        }
+      }
+      immediateChildrenSection = `Included Skills (immediate):\n${childLines.join('\n')}`;
+    } else {
+      immediateChildrenSection = 'Included Skills (immediate): none';
+    }
+
     let versionHash: string | undefined;
     try {
       versionHash = computeSkillVersionHash(skill.directoryPath);
@@ -84,6 +103,8 @@ export class SkillLoadTool implements Tool {
         `Path: ${skill.skillFilePath}`,
         '',
         body,
+        '',
+        immediateChildrenSection,
         '',
         `<loaded_skill id="${skill.id}"${versionAttr} />`,
       ].join('\n'),


### PR DESCRIPTION
Successful skill_load output now includes an 'Included Skills (immediate)' section showing child ID, name, description, and path. Shows 'none' for skills without includes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
