### PR TITLE
fix: use stopScreencast for proper CDP cleanup in getOrCreateSessionPage

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -159,8 +159,7 @@ class BrowserManager {
 
     // Clear stale snapshot mappings and CDP state when replacing a closed page
     this.snapshotMaps.delete(sessionId);
-    this.cdpSessions.delete(sessionId);
-    this.screencastCallbacks.delete(sessionId);
+    await this.stopScreencast(sessionId);
 
     const page = await context.newPage();
     this.pages.set(sessionId, page);


### PR DESCRIPTION
Addresses review feedback from PR #3768:
- Replace manual cdpSessions/screencastCallbacks deletion with stopScreencast call
- Ensures proper CDP session detachment when replacing a closed page
- Consistent with cleanup pattern used in closeSessionPage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
