### PR TITLE
fix: slim down app-builder SKILL.md to restore design quality

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -3,468 +3,29 @@ name: "App Builder"
 description: "Create polished, professional local apps with HTML/CSS/JS"
 ---
 
-You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build a self-contained HTML/CSS/JS interface, and open it — all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" — they should feel designed, not generated.
+You are an expert app builder. When the user asks you to create an app, tool, or utility, you design a data schema, build a self-contained HTML/CSS/JS interface, and persist it so the user can open it anytime. Your apps should feel like real, polished software — not prototypes.
 
-**Every app gets its own visual identity.** A plant tracker should feel earthy and green. A finance dashboard should feel precise and navy. A fitness app should feel energetic and purple. Apps should look like they were designed by a boutique studio for that specific domain — not like generic branded tools. Think standalone premium product, not template.
-
-**Your default behavior:** Build immediately. The user types "build me a habit tracker" and you deliver a complete, polished app with a domain-matched color palette, warm tinted background, emoji-rich stat cards, an accent-word hero heading, and thoughtful interactions. Don't ask what colors they want. Don't show wireframes. Just build something stunning and let them refine from there.
+**Build immediately.** Don't ask what colors the user wants or show wireframes. Make creative decisions — pick the palette, the layout, the interactions — and let them refine from there. Only ask questions when the request is genuinely ambiguous.
 
 ## Design Philosophy
 
-Every app you create must clear this bar: **Would someone screenshot this and share it?** If the answer is no, you haven't tried hard enough.
+Build apps that look and feel like professional native software. Every app you create should feel like something someone would pay for.
 
-### The Quality Bar
+- **Typography**: Use the system font stack. Establish clear hierarchy with size, weight, and color. Don't make everything the same size.
+- **Color**: Use restrained, intentional palettes. 1-2 accent colors max. Use color to convey meaning (status, priority, categories), not decoration. Match your palette to the domain — don't default to violet for everything.
+- **Layout**: Use CSS Grid and Flexbox. Give content room to breathe with generous whitespace. Align elements precisely. Design for 400-600px width.
+- **Motion**: Add subtle transitions on interactive elements (150-250ms). Animate state changes. Use `transform` and `opacity` for smooth 60fps animations.
+- **Interaction**: Every clickable element needs hover and active states. Add focus styles for keyboard navigation. Provide immediate visual feedback for all actions.
+- **Empty states**: Design thoughtful empty states that guide the user — not just "No items."
+- **Details**: Rounded corners, subtle shadows, smooth gradients. Polish the small things.
 
-Your apps compete with products built by professional design teams. That means:
-
-- Every screen has visual depth — layers, shadows, gradients, texture
-- Typography creates clear hierarchy — not everything is 14px regular weight
-- Color is intentional and atmospheric — not just "blue buttons on white"
-- Interactions feel physical — elements respond to hover, press, and focus
-- Empty states are designed moments, not error messages
-- The page loads with grace — elements stagger in, content shimmers while loading
-
-### Anti-AI-Slop Rules
-
-These are hard prohibitions. Violating any of these produces that unmistakable "AI-generated" look:
-
-- **NEVER** use flat cards with no depth — every card needs a subtle 1px border and gentle shadow, not heavy multi-layer shadows
-- **NEVER** ship an app with zero animations — at minimum: page load stagger, hover states, state transitions
-- **NEVER** make all text the same size and weight — establish clear hierarchy with at least 3 distinct levels
-- **NEVER** use a pure white (`#fff`) or pure dark (`#000`/`#0a0a0a`) background — ALWAYS tint it to match the domain (cream `#FEFCF9` for lifestyle, sage `#F0F5F0` for nature, cool gray `#F5F7FA` for finance, warm blush `#FDF6F3` for wellness)
-- **NEVER** leave clickable elements without hover AND active states
-- **ALWAYS** use emoji as visual identifiers in stat cards, list items, and navigation — they replace icon libraries and add instant personality (🍎 for food, 🔥 for streaks, 💰 for money, 🌿 for plants)
-- **ALWAYS** apply the accent-word pattern in hero headings — color ONE key word or phrase in the accent color: "Your <span style='color: var(--accent)'>Week</span> in Motion"
-- **ALWAYS** include a contextual/personalized header — a greeting ("Good morning"), date ("Saturday, Feb 15"), or welcome ("Welcome back, Alex") — not just the app title
-- **ALWAYS** include at least one pill-shaped trust/status badge somewhere visible — "🌟 Trusted by 12,000+ users", "+8.2% this week", "✨ Pro plan"
-- **ALWAYS** use tight letter-spacing on headings (`-0.02em` to `-0.04em`)
-- **ALWAYS** use `clamp()` for display/heading text so it scales fluidly
-- **ALWAYS** add at least one accent gradient somewhere — a hero, a button, a decorative element
-- **ALWAYS** give the app a distinct visual personality — if you removed the content, could you still tell which app this is?
-
-### Color Strategy
-
-- **Theme-match your palette to the domain.** Don't default to violet. Pick the color that feels right: emerald/sage for plants & nature, purple for fitness & wellness, amber/gold for finance & productivity, rose for social & lifestyle, indigo for tech & developer tools.
-- **Define custom CSS variables at the top of `<style>`** for every app:
-  ```css
-  :root {
-    --accent: #18B07A;          /* domain-matched accent */
-    --accent-light: #ECFDF5;    /* tinted surface */
-    --bg-tint: #F0F5F0;         /* warm/cool background tint */
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --accent: #38CF93;
-      --accent-light: #073D2E;
-      --bg-tint: #0A1A14;
-    }
-  }
-  ```
-- **Background tint examples:** `#FEFCF9` cream (lifestyle), `#F0F5F0` sage (nature), `#F5F7FA` cool gray (finance), `#FDF6F3` warm blush (wellness), `#F5F3FF` lavender (creative). Apply to `body { background: var(--bg-tint); }`.
-- **60-30-10 rule:** 60% tinted background/surface, 30% secondary/text, 10% accent. Never use accent for large areas.
-- **Status colors are semantic:** emerald = success/positive, rose = danger/destructive, amber = warning/attention. Don't use these for decoration.
-- **`--v-*` tokens remain available** for spacing, radius, shadows, and animations. Use them for layout consistency. But stop defaulting to `--v-violet-*` for accent — use your domain-matched `--accent` variable instead.
-- For branded/themed apps, write custom CSS with `@media (prefers-color-scheme: dark)` overrides instead of mixing `--v-*` auto-switching variables with hardcoded colors.
-
-### Typography Rules
-
-- **Display/hero text:** `font-weight: 800`, `letter-spacing: -0.03em`, `clamp(1.75rem, 4vw, 2.5rem)` for fluid sizing
-- **Accent-word technique:** In hero headings, wrap ONE key word in a `<span>` with the accent color or a gradient. This is the single most impactful typography move: `<h1>Track your <span class="accent-word">Growth</span> daily</h1>`. Use `.accent-word { color: var(--accent); }` or apply a gradient fill.
-- **Section headings:** `font-weight: 700`, `letter-spacing: -0.02em`, `--v-font-size-xl` or `--v-font-size-2xl`
-- **Body text:** `--v-font-size-base` (14px), `line-height: 1.55`
-- **Labels/captions:** `text-transform: uppercase`, `letter-spacing: 0.04em`, `--v-font-size-xs`, `font-weight: 600`, `color: var(--v-text-muted)`
-- **Monospace data:** Use `--v-font-mono` for numbers in metrics, code, timestamps
-
-### Spacing & Layout
-
-- Use the `--v-spacing-*` scale consistently — don't mix arbitrary pixel values with token values
-- **Card padding:** `--v-spacing-lg` (16px) minimum, `--v-spacing-xl` (24px) for hero/featured cards
-- **Section gaps:** `--v-spacing-xxl` (32px) to `--v-spacing-xxxl` (48px) between major sections — Lovable-quality apps use generous whitespace
-- **Hero to first content:** minimum `--v-spacing-xxxl` (48px)
-- **Element gaps:** `--v-spacing-sm` to `--v-spacing-md` between related elements
-- **When in doubt, add more whitespace.** The #1 difference between AI-generated and designer-quality is spacing. Double what feels right, then evaluate.
-- Use CSS Grid for dashboards and complex layouts. Use Flexbox for single-axis arrangements.
-- Every layout should look good from 400px to 600px wide
-
-## Visual Techniques Cookbook
-
-Copy-paste-ready CSS techniques. All work in the sandboxed WebView with no external dependencies.
-
-### Animated Gradient Background
-```css
-body {
-  background: linear-gradient(-45deg, #0f172a, #1e1b4b, #172554, #0c4a6e);
-  background-size: 400% 400%;
-  animation: gradientShift 15s ease infinite;
-}
-@keyframes gradientShift {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-}
-```
-
-### Mesh Gradient (Layered Radials)
-```css
-body {
-  background:
-    radial-gradient(ellipse at 20% 50%, color-mix(in srgb, var(--v-violet-500) 15%, transparent) 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 20%, color-mix(in srgb, var(--v-indigo-500) 12%, transparent) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 80%, color-mix(in srgb, var(--v-emerald-500) 8%, transparent) 0%, transparent 50%),
-    var(--v-bg);
-}
-```
-
-### Glassmorphism Card
-```css
-.glass-card {
-  background: color-mix(in srgb, var(--v-surface) 70%, transparent);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid color-mix(in srgb, var(--v-surface-border) 50%, transparent);
-  border-radius: var(--v-radius-lg);
-  box-shadow: var(--v-shadow-lg);
-}
-```
-
-### Layered Shadows (Realistic Depth)
-```css
-.elevated-card {
-  box-shadow:
-    0 1px 2px rgba(0,0,0,0.04),
-    0 4px 8px rgba(0,0,0,0.06),
-    0 12px 24px rgba(0,0,0,0.08);
-  transition: box-shadow var(--v-duration-standard), transform var(--v-duration-standard);
-}
-.elevated-card:hover {
-  transform: translateY(-2px);
-  box-shadow:
-    0 2px 4px rgba(0,0,0,0.04),
-    0 8px 16px rgba(0,0,0,0.08),
-    0 24px 48px rgba(0,0,0,0.12);
-}
-```
-
-### Noise/Grain Texture Overlay
-```css
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  opacity: 0.03;
-  pointer-events: none;
-  z-index: 9999;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-}
-```
-
-### Gradient Text
-```css
-.gradient-text {
-  background: linear-gradient(135deg, var(--v-violet-500), var(--v-indigo-400));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-```
-
-### Glow Effect
-```css
-.glow-accent {
-  box-shadow:
-    0 0 20px color-mix(in srgb, var(--v-accent) 30%, transparent),
-    0 0 40px color-mix(in srgb, var(--v-accent) 15%, transparent);
-}
-```
-
-### Dot Grid Pattern Background
-```css
-.dot-pattern {
-  background-image: radial-gradient(circle, var(--v-surface-border) 1px, transparent 1px);
-  background-size: 20px 20px;
-}
-```
-
-### Staggered Reveal Animation
-```css
-.reveal { opacity: 0; transform: translateY(20px); transition: opacity 0.6s ease, transform 0.6s ease; }
-.reveal.visible { opacity: 1; transform: translateY(0); }
-```
-```javascript
-const observer = new IntersectionObserver((entries) => {
-  entries.forEach((entry, i) => {
-    if (entry.isIntersecting) {
-      setTimeout(() => entry.target.classList.add('visible'), i * 100);
-      observer.unobserve(entry.target);
-    }
-  });
-}, { threshold: 0.1 });
-document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
-```
-
-### Card Hover (Lift + Border Glow)
-```css
-.interactive-card {
-  transition: transform var(--v-duration-standard), box-shadow var(--v-duration-standard),
-              border-color var(--v-duration-standard);
-  border: 1px solid var(--v-surface-border);
-  cursor: pointer;
-}
-.interactive-card:hover {
-  transform: translateY(-4px);
-  box-shadow: var(--v-shadow-lg), 0 0 0 1px color-mix(in srgb, var(--v-accent) 20%, transparent);
-  border-color: color-mix(in srgb, var(--v-accent) 40%, var(--v-surface-border));
-}
-```
-
-### Loading Skeleton Shimmer
-```css
-.skeleton {
-  background: linear-gradient(90deg,
-    var(--v-surface) 25%,
-    color-mix(in srgb, var(--v-surface-border) 50%, var(--v-surface)) 50%,
-    var(--v-surface) 75%);
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
-  border-radius: var(--v-radius-sm);
-}
-.skeleton-text { height: 14px; margin-bottom: 8px; width: 80%; }
-.skeleton-heading { height: 24px; margin-bottom: 12px; width: 60%; }
-.skeleton-avatar { width: 40px; height: 40px; border-radius: 50%; }
-@keyframes shimmer { to { background-position: -200% 0; } }
-```
-
-### Animated Checkmark (Success Feedback)
-```css
-.checkmark-circle {
-  width: 48px; height: 48px; border-radius: 50%;
-  background: var(--v-success); display: flex;
-  align-items: center; justify-content: center;
-  animation: scaleIn 0.3s ease;
-}
-.checkmark-circle::after {
-  content: ''; width: 12px; height: 20px;
-  border: solid white; border-width: 0 3px 3px 0;
-  transform: rotate(45deg); margin-top: -4px;
-  animation: checkDraw 0.2s 0.2s ease both;
-}
-@keyframes scaleIn { from { transform: scale(0); } to { transform: scale(1); } }
-@keyframes checkDraw { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Navigation Bar (Sticky Header)
-```html
-<nav class="app-navbar">
-  <div class="navbar-brand">🌿 PlantCare</div>
-  <div class="navbar-links">
-    <a href="#" class="nav-link active">Dashboard</a>
-    <a href="#" class="nav-link">My Plants</a>
-    <a href="#" class="nav-link">Schedule</a>
-  </div>
-  <button class="v-button navbar-cta">Add Plant</button>
-</nav>
-```
-```css
-.app-navbar {
-  position: sticky; top: 0; z-index: 100;
-  display: flex; align-items: center; gap: var(--v-spacing-lg);
-  padding: var(--v-spacing-md) var(--v-spacing-xl);
-  background: color-mix(in srgb, var(--bg-tint, var(--v-bg)) 85%, transparent);
-  backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--v-surface-border);
-}
-.navbar-brand { font-weight: 700; font-size: var(--v-font-size-lg); }
-.navbar-links { display: flex; gap: var(--v-spacing-sm); margin-left: auto; }
-.navbar-links .nav-link {
-  padding: var(--v-spacing-xs) var(--v-spacing-md); border-radius: var(--v-radius-md);
-  color: var(--v-text-secondary); font-weight: 500; font-size: var(--v-font-size-sm);
-  text-decoration: none; transition: all var(--v-duration-fast);
-}
-.navbar-links .nav-link:hover { color: var(--v-text); background: var(--v-surface); }
-.navbar-links .nav-link.active { color: var(--accent, var(--v-accent)); font-weight: 600; }
-.navbar-cta { margin-left: var(--v-spacing-sm); padding: var(--v-spacing-xs) var(--v-spacing-lg); font-size: var(--v-font-size-sm); }
-```
-
-### Pill Badge / Trust Badge
-```html
-<span class="trust-pill">🌟 Trusted by 12,000+ homes</span>
-<span class="trust-pill accent">+8.2% this week</span>
-```
-```css
-.trust-pill {
-  display: inline-flex; align-items: center; gap: var(--v-spacing-xs);
-  padding: var(--v-spacing-xs) var(--v-spacing-md);
-  background: var(--v-surface); border: 1px solid var(--v-surface-border);
-  border-radius: var(--v-radius-pill); font-size: var(--v-font-size-xs);
-  font-weight: 600; color: var(--v-text-secondary);
-}
-.trust-pill.accent {
-  background: color-mix(in srgb, var(--accent, var(--v-accent)) 10%, transparent);
-  border-color: color-mix(in srgb, var(--accent, var(--v-accent)) 25%, transparent);
-  color: var(--accent, var(--v-accent));
-}
-```
-
-### Emoji Stat Card
-```html
-<div class="emoji-stat-row">
-  <div class="emoji-stat-card">
-    <span class="emoji-stat-icon">🔥</span>
-    <span class="emoji-stat-value">1,284</span>
-    <span class="emoji-stat-label">Calories</span>
-  </div>
-  <div class="emoji-stat-card">
-    <span class="emoji-stat-icon">🏃</span>
-    <span class="emoji-stat-value">8,421</span>
-    <span class="emoji-stat-label">Steps</span>
-  </div>
-  <div class="emoji-stat-card">
-    <span class="emoji-stat-icon">💧</span>
-    <span class="emoji-stat-value">2.4L</span>
-    <span class="emoji-stat-label">Hydration</span>
-  </div>
-</div>
-```
-```css
-.emoji-stat-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: var(--v-spacing-md); }
-.emoji-stat-card {
-  background: var(--v-surface); border: 1px solid var(--v-surface-border);
-  border-radius: var(--v-radius-lg); padding: var(--v-spacing-lg);
-  display: flex; flex-direction: column; align-items: center; gap: var(--v-spacing-xs);
-  text-align: center;
-}
-.emoji-stat-icon { font-size: 28px; line-height: 1; }
-.emoji-stat-value { font-size: var(--v-font-size-xl); font-weight: 700; color: var(--v-text); }
-.emoji-stat-label { font-size: var(--v-font-size-xs); color: var(--v-text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
-```
-
-### Accent Word Heading
-```html
-<h1>Track your <span class="accent-word">Growth</span> daily</h1>
-<!-- Or with gradient variant: -->
-<h1>Imagine it. <span class="v-gradient-text">See it.</span></h1>
-```
-```css
-.accent-word { color: var(--accent, var(--v-accent)); }
-/* Gradient variant — use .v-gradient-text from the design system, or customize: */
-.accent-gradient {
-  background: linear-gradient(135deg, var(--accent, var(--v-violet-500)), var(--v-indigo-400));
-  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
-}
-```
-
-### Interactive Pill Toggles
-```html
-<div class="pill-toggles">
-  <button class="pill-toggle active">1W</button>
-  <button class="pill-toggle">1M</button>
-  <button class="pill-toggle">3M</button>
-  <button class="pill-toggle">1Y</button>
-</div>
-```
-```css
-.pill-toggles {
-  display: inline-flex; gap: var(--v-spacing-xxs);
-  background: var(--v-surface); border: 1px solid var(--v-surface-border);
-  border-radius: var(--v-radius-pill); padding: var(--v-spacing-xxs);
-}
-.pill-toggle {
-  padding: var(--v-spacing-xs) var(--v-spacing-md);
-  border-radius: var(--v-radius-pill); border: none; background: none;
-  font-size: var(--v-font-size-sm); font-weight: 500; color: var(--v-text-secondary);
-  cursor: pointer; transition: all var(--v-duration-fast);
-}
-.pill-toggle:hover { color: var(--v-text); }
-.pill-toggle.active {
-  background: var(--accent, var(--v-accent)); color: white; font-weight: 600;
-  box-shadow: var(--v-shadow-sm);
-}
-```
-```javascript
-document.querySelectorAll('.pill-toggles').forEach(group => {
-  group.addEventListener('click', (e) => {
-    if (!e.target.classList.contains('pill-toggle')) return;
-    group.querySelectorAll('.pill-toggle').forEach(b => b.classList.remove('active'));
-    e.target.classList.add('active');
-  });
-});
-```
-
-### Suggestion Chips
-```html
-<div class="chip-group">
-  <button class="chip">🏠 All Rooms</button>
-  <button class="chip">🛋️ Living Room</button>
-  <button class="chip">🍳 Kitchen</button>
-  <button class="chip">🛏️ Bedroom</button>
-  <button class="chip active">🚿 Bathroom</button>
-</div>
-```
-```css
-.chip-group { display: flex; flex-wrap: wrap; gap: var(--v-spacing-xs); }
-.chip {
-  padding: var(--v-spacing-xs) var(--v-spacing-md);
-  border-radius: var(--v-radius-pill); border: 1px solid var(--v-surface-border);
-  background: var(--v-surface); font-size: var(--v-font-size-sm);
-  color: var(--v-text-secondary); cursor: pointer; transition: all var(--v-duration-fast);
-}
-.chip:hover { border-color: var(--accent, var(--v-accent)); color: var(--v-text); }
-.chip.active {
-  background: color-mix(in srgb, var(--accent, var(--v-accent)) 12%, transparent);
-  border-color: var(--accent, var(--v-accent)); color: var(--accent, var(--v-accent)); font-weight: 600;
-}
-```
-
-### Category Card Row
-```html
-<div class="category-cards">
-  <div class="category-card">
-    <span class="category-icon">🧹</span>
-    <span class="category-name">Standard Clean</span>
-    <span class="category-meta">2-3 hrs · From $60</span>
-  </div>
-  <div class="category-card">
-    <span class="category-icon">✨</span>
-    <span class="category-name">Deep Clean</span>
-    <span class="category-meta">4-5 hrs · From $120</span>
-  </div>
-  <div class="category-card">
-    <span class="category-icon">📦</span>
-    <span class="category-name">Move-Out</span>
-    <span class="category-meta">5-7 hrs · From $180</span>
-  </div>
-</div>
-```
-```css
-.category-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: var(--v-spacing-md); }
-.category-card {
-  background: var(--v-surface); border: 1px solid var(--v-surface-border);
-  border-radius: var(--v-radius-lg); padding: var(--v-spacing-lg);
-  display: flex; flex-direction: column; align-items: center; gap: var(--v-spacing-sm);
-  text-align: center; cursor: pointer;
-  transition: transform var(--v-duration-fast), border-color var(--v-duration-fast);
-}
-.category-card:hover { transform: translateY(-2px); border-color: var(--accent, var(--v-accent)); }
-.category-icon { font-size: 32px; line-height: 1; }
-.category-name { font-weight: 600; font-size: var(--v-font-size-base); color: var(--v-text); }
-.category-meta { font-size: var(--v-font-size-xs); color: var(--v-text-muted); }
-```
+Each app should have its own visual identity that fits its domain. A finance app should feel different from a plant tracker, which should feel different from a fitness dashboard. Use your judgment — you're the designer.
 
 ## Workflow
 
 ### 1. Gather Requirements
 
-**Default: just build.** When a user says "build me a habit tracker," don't ask what colors they want or how many fields to include. Immediately:
-
-1. Envision the ideal version of this app — what would make someone excited to use it?
-2. Pick a distinctive visual direction — a color palette, atmospheric background, visual personality
-3. Design a clean data schema
-4. Build the complete, polished app with animations, interactions, and empty states
-
-**Make creative decisions on behalf of the user.** They want to be delighted, not consulted. Pick the accent color. Choose between a dark moody aesthetic or a light airy one. Decide if cards should have glassmorphism or layered shadows. Add a background pattern or gradient. These are YOUR decisions as the designer.
-
-**Only ask questions when the request is genuinely ambiguous** — e.g., "build me an app" with no indication of what kind. Even then, prefer building something impressive based on context clues over asking a battery of questions.
-
-**When in doubt, build something impressive** and let the user refine with `app_update`. The first impression matters most — a beautiful app with the wrong shade of blue is easy to fix. A correct but ugly app is hard to come back from.
+If the user gives a clear description, skip questions and go straight to building. Figure out: what kind of app, what data to store, what actions to support.
 
 ### 2. Design the Data Schema
 
@@ -533,484 +94,103 @@ Utility classes: `.v-button` (`.secondary`/`.danger`/`.ghost`), `.v-card`, `.v-l
 ```javascript
 console.log(window.vellum.theme.mode); // 'light' or 'dark'
 window.addEventListener('vellum-theme-change', (e) => {
-  // Update canvas colors, chart themes, etc.
   console.log('Theme:', e.detail.mode);
 });
 ```
 
 #### Widget component library
 
-A CSS/JS widget library is auto-injected alongside the design system. Use these for standard UI patterns — skip them when custom HTML serves the user better.
+A CSS/JS widget library is auto-injected alongside the design system. Use these when they fit — skip them when custom HTML serves the user better.
 
-**Layout & Data Primitives:**
+**Layout widgets** (all support `--v-*` tokens):
 
-`.v-metric-card` — Big number with emoji icon, label, and trend:
-```html
-<div class="v-metric-card">
-  <span class="v-metric-icon">💰</span>
-  <span class="v-metric-label">Revenue</span>
-  <span class="v-metric-value">$12,450</span>
-  <span class="v-metric-trend up">↑ 12.3%</span>
-</div>
-```
-Wrap in `.v-metric-grid` for responsive 2-4 column layout. Always use a semantically meaningful emoji: 🔥 for streaks, 🏃 for activity, 💧 for hydration, 📈 for growth, etc.
-
-`.v-data-table` — Sortable table with sticky header and hover states:
-```html
-<table class="v-data-table" id="my-table">
-  <thead><tr>
-    <th><input type="checkbox"></th>
-    <th data-sortable>Name</th>
-    <th data-sortable>Amount</th>
-  </tr></thead>
-  <tbody><tr data-id="1">
-    <td><input type="checkbox"></td>
-    <td>Item</td>
-    <td data-sort-value="100">$100.00</td>
-  </tr></tbody>
-</table>
-```
-
-`.v-tabs` — Tab navigation with keyboard support:
-```html
-<div class="v-tabs" id="my-tabs">
-  <div class="v-tab-bar" role="tablist">
-    <button class="v-tab" aria-controls="panel-1">Tab 1</button>
-    <button class="v-tab" aria-controls="panel-2">Tab 2</button>
-  </div>
-  <div class="v-tab-panel" id="panel-1">Content 1</div>
-  <div class="v-tab-panel" id="panel-2" hidden>Content 2</div>
-</div>
-```
-
-`.v-accordion` — Collapsible sections:
-```html
-<div class="v-accordion" id="my-accordion">
-  <div class="v-accordion-item">
-    <button class="v-accordion-header" aria-expanded="true">Section 1</button>
-    <div class="v-accordion-body">Content here</div>
-  </div>
-</div>
-```
-
-`.v-search-bar` — Search input with clear button:
-```html
-<div class="v-search-bar">
-  <input type="text" placeholder="Search..." id="search">
-  <button class="v-search-clear">✕</button>
-</div>
-```
-
-`.v-empty-state` — No-data placeholder with CTA:
-```html
-<div class="v-empty-state">
-  <div class="v-empty-icon">📋</div>
-  <div class="v-empty-title">No items yet</div>
-  <div class="v-empty-desc">Create your first item to get started.</div>
-  <button class="v-button">Create Item</button>
-</div>
-```
-
-**Additional layout widgets** (use with semantic HTML, all support `--v-*` tokens):
-
-| Widget | Usage | Key Classes/Modifiers |
-|---|---|---|
-| `.v-timeline` | Vertical timeline | `.v-timeline-entry` (`.active`/`.success`/`.error`), `.v-timeline-time`, `.v-timeline-title`, `.v-timeline-desc` |
-| `.v-action-list` | Rows with per-item actions | `.v-action-list-item`, `.v-action-content`, `.v-action-title`, `.v-action-subtitle`, `.v-action-buttons` |
-| `.v-card-grid` | Responsive card grid | Wrap `.v-card` elements |
-| `.v-progress-bar` | Horizontal progress | `.v-progress-header`, `.v-progress-track`, `.v-progress-fill` (`.success`/`.warning`/`.danger`) |
-| `.v-status-badge` | Colored pill with dot | `.success`, `.error`, `.warning`, `.info` |
-| `.v-stat-row` | Horizontal label-value pairs | `.v-stat`, `.v-stat-label`, `.v-stat-value` |
-| `.v-toast` | Notification banner | `.success`, `.error`, `.warning`, `.info` — prefer `vellum.widgets.toast()` |
-| `.v-divider` | Section separator | Optional text label inside |
-| `.v-avatar-row` | Contact/team display | `.v-avatar`, `.v-avatar-info`, `.v-avatar-name`, `.v-avatar-subtitle` |
-| `.v-tag-group` | Wrapping tag row | Wrap `.v-badge` elements |
+| Widget | Usage |
+|---|---|
+| `.v-metric-card` | Big number with label and trend (`.v-metric-value`, `.v-metric-label`, `.v-metric-trend.up`/`.down`) |
+| `.v-metric-grid` | Responsive grid for metric cards |
+| `.v-data-table` | Sortable table with sticky header (`th[data-sortable]`, `tbody tr:hover`) |
+| `.v-tabs` / `.v-tab-bar` | Tab navigation (`.v-tab`, `.v-tab-panel`) |
+| `.v-accordion` | Collapsible sections (`.v-accordion-item`, `.v-accordion-header`, `.v-accordion-body`) |
+| `.v-search-bar` | Search input with clear button |
+| `.v-timeline` | Vertical timeline (`.v-timeline-entry.active`/`.success`/`.error`) |
+| `.v-action-list` | Rows with per-item actions (`.v-action-list-item`, `.v-action-title`, `.v-action-buttons`) |
+| `.v-progress-bar` | Horizontal progress (`.v-progress-track`, `.v-progress-fill.success`/`.warning`/`.danger`) |
+| `.v-status-badge` | Colored pill with dot (`.success`/`.error`/`.warning`/`.info`) |
+| `.v-stat-row` | Horizontal label-value pairs (`.v-stat`, `.v-stat-label`, `.v-stat-value`) |
+| `.v-toast` | Notification banner — prefer `vellum.widgets.toast()` |
+| `.v-empty-state` | No-data placeholder (`.v-empty-icon`, `.v-empty-title`, `.v-empty-desc`) |
+| `.v-divider` | Section separator with optional text label |
+| `.v-avatar-row` | Avatar + name + subtitle |
+| `.v-card-grid` | Responsive grid of `.v-card` elements |
+| `.v-pill-toggles` | Toggle group (`.v-pill-toggle.active`) |
+| `.v-chip-group` | Filter chip row (`.v-chip.active`) |
 
 **Domain-specific widgets** (infer HTML structure from class names):
 
-| Widget | Purpose | Key Classes |
-|---|---|---|
-| `.v-weather-card` | Temperature + forecast | `.v-weather-main`, `.v-weather-temp`, `.v-weather-condition`, `.v-weather-icon`, `.v-weather-details`, `.v-weather-forecast`, `.v-weather-forecast-item` |
-| `.v-stock-ticker` | Price display + chart | `.v-stock-header`, `.v-stock-symbol`, `.v-stock-price`, `.v-stock-change` (`.up`/`.down`), `.v-stock-chart`, `.v-stock-meta` |
-| `.v-flight-card` | Flight info | `.v-flight-header`, `.v-flight-airline`, `.v-flight-price`, `.v-flight-route`, `.v-flight-endpoint`, `.v-flight-time`, `.v-flight-code`, `.v-flight-duration`, `.v-flight-line` |
-| `.v-billing-chart` | Usage/billing display | `.v-billing-header`, `.v-billing-total`, `.v-billing-period`, `.v-billing-canvas`, `.v-billing-legend`, `.v-billing-legend-item`, `.v-billing-legend-dot` |
-| `.v-boarding-pass` | Pass-styled layout | `.v-bp-header`, `.v-bp-route`, `.v-bp-city`, `.v-bp-details`, `.v-bp-field`, `.v-bp-field-label`, `.v-bp-field-value` |
-| `.v-itinerary` | Day-by-day travel plan | `.v-itinerary-day`, `.v-itinerary-date`, `.v-itinerary-item`, `.v-itinerary-time`, `.v-itinerary-content`, `.v-itinerary-title`, `.v-itinerary-location` |
-| `.v-receipt` | Receipt layout | `.v-receipt-header`, `.v-receipt-store`, `.v-receipt-items`, `.v-receipt-line`, `.v-receipt-divider`, `.v-receipt-total` |
-| `.v-invoice` | Formal invoice | `.v-invoice-header`, `.v-invoice-title`, `.v-invoice-number`, `.v-invoice-parties`, `.v-invoice-party-label`, `.v-invoice-party-name`, `.v-invoice-table`, `.v-invoice-totals`, `.v-invoice-line` (`.total`) |
+| Widget | Purpose |
+|---|---|
+| `.v-weather-card` | Temperature + forecast display |
+| `.v-stock-ticker` | Price + change + chart area |
+| `.v-flight-card` | Flight route with times and duration |
+| `.v-billing-chart` | Usage/billing with legend |
+| `.v-boarding-pass` | Pass-styled layout with tear-off effect |
+| `.v-itinerary` | Day-by-day travel plan |
+| `.v-receipt` | Receipt layout with line items and total |
+| `.v-invoice` | Formal invoice with parties and table |
 
 **Content & landing page components:**
 
-`.v-hero` — Hero banner with gradient background, trust badge, and accent word:
-```html
-<div class="v-hero">
-  <span class="v-hero-badge">✨ Now with 4x faster generation</span>
-  <h1>Imagine it. <span class="v-gradient-text">See it.</span></h1>
-  <p class="v-hero-subtitle">A compelling tagline that makes users feel something.</p>
-</div>
-```
-
-`.v-section-header` — Section intro with label:
-```html
-<div class="v-section-header">
-  <span class="v-section-label">🎯 Section</span>
-  <h2>Section Title</h2>
-  <p class="v-section-desc">Description text.</p>
-</div>
-```
-
-`.v-feature-grid` + `.v-feature-card` — Feature showcase with hover lift:
-```html
-<div class="v-feature-grid">
-  <div class="v-feature-card">
-    <div class="v-feature-icon">🚀</div>
-    <div class="v-feature-title">Feature Name</div>
-    <div class="v-feature-desc">Short description.</div>
-  </div>
-</div>
-```
-
-`.v-pullquote` — Blockquote with gradient accent border. `.v-comparison` — Before/after cards (3-column grid with `.before`/`.after` modifiers). `.v-page` — Centered container (max-width 600px). Use `.v-animate-in` on children for staggered fade-in. Use `.v-gradient-text` for accent-colored gradient text.
+| Widget | Usage |
+|---|---|
+| `.v-hero` | Hero banner with gradient background (`.v-hero-badge`, `.v-hero-subtitle`) |
+| `.v-section-header` | Section intro (`.v-section-label`, `.v-section-desc`) |
+| `.v-feature-grid` / `.v-feature-card` | Feature showcase with hover lift |
+| `.v-pullquote` | Blockquote with gradient accent border |
+| `.v-comparison` | Before/after cards (`.before`/`.after`) |
+| `.v-page` | Centered content container |
+| `.v-gradient-text` | Gradient text fill |
+| `.v-animate-in` | Staggered fade-in on children |
 
 #### Widget JavaScript utilities
 
 Interactive utilities at `window.vellum.widgets.*`:
 
-**SVG Charts:**
 ```javascript
-// Sparkline — inline mini chart
-vellum.widgets.sparkline('container-id', [10, 25, 15, 30], {
-  width: 200, height: 40, color: 'var(--v-success)', strokeWidth: 2, fill: true
-});
+// SVG Charts
+vellum.widgets.sparkline('container-id', [10, 25, 15, 30], { width: 200, height: 40, color: 'var(--v-success)', fill: true });
+vellum.widgets.barChart('container-id', [{ label: 'Jan', value: 120 }], { width: 400, height: 200, showLabels: true });
+vellum.widgets.lineChart('container-id', [{ label: 'Mon', value: 42 }], { width: 400, height: 200, showDots: true, showGrid: true });
+vellum.widgets.progressRing('container-id', 75, { size: 100, strokeWidth: 8, label: '75%' });
 
-// Bar chart — labels, tooltips, optional horizontal
-vellum.widgets.barChart('container-id', [
-  { label: 'Jan', value: 120 },
-  { label: 'Feb', value: 180, color: 'var(--v-success)' }
-], { width: 400, height: 200, showLabels: true, showValues: true, horizontal: false });
-
-// Line chart — gradient fill, grid, hover crosshair
-vellum.widgets.lineChart('container-id', [
-  { label: 'Mon', value: 42 },
-  { label: 'Tue', value: 58 }
-], { width: 400, height: 200, showDots: true, showGrid: true, gridLines: 4 });
-
-// Progress ring — circular gauge
-vellum.widgets.progressRing('container-id', 75, {
-  size: 100, strokeWidth: 8, color: 'var(--v-success)', label: '75%'
-});
-```
-
-**Data Formatting:**
-```javascript
+// Data Formatting
 vellum.widgets.formatCurrency(1234.56, 'USD');          // "$1,234.56"
 vellum.widgets.formatDate('2025-01-15', 'relative');     // "3d ago"
 vellum.widgets.formatDate('2025-01-15', 'short');        // "1/15/25"
 vellum.widgets.formatNumber(1234567, { compact: true }); // "1.2M"
-vellum.widgets.formatNumber(0.156, { decimals: 1 });     // "0.2"
-```
 
-**Interactive Behaviors:**
-```javascript
+// Interactive Behaviors
 vellum.widgets.sortTable('table-id');            // Wire th[data-sortable] click-to-sort
-vellum.widgets.sortTable('table-id', 0);         // Sort by column 0 immediately
-vellum.widgets.filterTable('table-id', 'search-input-id'); // Live text search
+vellum.widgets.filterTable('table-id', 'search-input-id');
 vellum.widgets.tabs('tabs-id');                  // Tab switching + keyboard nav
 vellum.widgets.accordion('accordion-id', { allowMultiple: true });
 vellum.widgets.multiSelect('table-id');          // Checkboxes + select-all
-vellum.widgets.toast('Saved!', 'success', 4000);          // Auto-dismiss notification
-vellum.widgets.toast('Connection lost', 'error', 0);      // Manual dismiss
-vellum.widgets.countdown('timer-el', '2025-12-31T00:00:00Z', {
-  onComplete: () => console.log('Done!')
-});
+vellum.widgets.toast('Saved!', 'success', 4000);
+vellum.widgets.countdown('timer-el', '2025-12-31T00:00:00Z', { onComplete: () => {} });
 ```
-
-#### Composition recipes
-
-Combine widgets with wiring code to build complex UIs:
-
-**Search-driven list with suggestion chips** — filter items with quick-tap categories:
-```html
-<div class="v-search-bar"><input id="search" placeholder="Search..."></div>
-<div class="chip-group" style="margin-top: var(--v-spacing-sm);">
-  <button class="chip active" data-filter="all">🏠 All</button>
-  <button class="chip" data-filter="kitchen">🍳 Kitchen</button>
-  <button class="chip" data-filter="bedroom">🛏️ Bedroom</button>
-  <button class="chip" data-filter="bathroom">🚿 Bathroom</button>
-</div>
-<ul class="v-action-list" id="list"></ul>
-<div class="v-empty-state" id="empty" hidden>
-  <div class="v-empty-icon">🔍</div>
-  <div class="v-empty-title">No results</div>
-</div>
-```
-```javascript
-let activeFilter = 'all';
-document.getElementById('search').addEventListener('input', filterList);
-document.querySelectorAll('.chip[data-filter]').forEach(chip => {
-  chip.addEventListener('click', () => {
-    document.querySelectorAll('.chip[data-filter]').forEach(c => c.classList.remove('active'));
-    chip.classList.add('active');
-    activeFilter = chip.dataset.filter;
-    filterList();
-  });
-});
-
-function filterList() {
-  const q = document.getElementById('search').value.toLowerCase();
-  let visible = 0;
-  document.querySelectorAll('#list .v-action-list-item').forEach(item => {
-    const textMatch = item.textContent.toLowerCase().includes(q);
-    const catMatch = activeFilter === 'all' || item.dataset.category === activeFilter;
-    item.hidden = !(textMatch && catMatch);
-    if (!item.hidden) visible++;
-  });
-  document.getElementById('empty').hidden = visible > 0;
-}
-```
-
-**Form with inline validation:**
-```html
-<form id="create-form" novalidate>
-  <div class="v-input-row">
-    <label>Title *</label>
-    <input id="title" required placeholder="Enter title">
-    <span class="field-error" id="title-error"></span>
-  </div>
-  <div class="v-input-row">
-    <label>Priority</label>
-    <select id="priority">
-      <option value="low">Low</option>
-      <option value="medium" selected>Medium</option>
-      <option value="high">High</option>
-    </select>
-  </div>
-  <button type="submit" class="v-button" id="submit-btn">Create</button>
-</form>
-```
-```css
-.field-error { color: var(--v-danger); font-size: var(--v-font-size-xs); min-height: 1em; }
-input:invalid:not(:placeholder-shown) { border-color: var(--v-danger); }
-```
-```javascript
-document.getElementById('create-form').addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const title = document.getElementById('title').value.trim();
-  if (!title) {
-    document.getElementById('title-error').textContent = 'Title is required';
-    return;
-  }
-  document.getElementById('submit-btn').disabled = true;
-  try {
-    await window.vellum.data.create({
-      title,
-      priority: document.getElementById('priority').value
-    });
-    vellum.widgets.toast('Created!', 'success');
-    e.target.reset();
-    document.getElementById('title-error').textContent = '';
-    await loadRecords();
-  } catch (err) {
-    vellum.widgets.toast('Failed to create', 'error');
-  } finally {
-    document.getElementById('submit-btn').disabled = false;
-  }
-});
-```
-
-**Dashboard** — contextual header + emoji stats + pill toggles + chart:
-```html
-<!-- Contextual header -->
-<div style="margin-bottom: var(--v-spacing-xxxl);">
-  <p style="color: var(--v-text-muted); font-size: var(--v-font-size-sm); margin: 0;">Saturday, Feb 15</p>
-  <h1 style="margin: var(--v-spacing-xs) 0;">Good morning, <span class="accent-word">Alex</span></h1>
-  <span class="trust-pill accent">🔥 7-day streak</span>
-</div>
-
-<!-- Pill toggles for time range -->
-<div class="pill-toggles" style="margin-bottom: var(--v-spacing-xl);">
-  <button class="pill-toggle active">1W</button>
-  <button class="pill-toggle">1M</button>
-  <button class="pill-toggle">3M</button>
-  <button class="pill-toggle">1Y</button>
-</div>
-
-<!-- Emoji stat cards -->
-<div class="emoji-stat-row" style="margin-bottom: var(--v-spacing-xxl);">
-  <div class="emoji-stat-card">
-    <span class="emoji-stat-icon">🔥</span>
-    <span class="emoji-stat-value" id="cal-value">1,284</span>
-    <span class="emoji-stat-label">Calories</span>
-  </div>
-  <div class="emoji-stat-card">
-    <span class="emoji-stat-icon">🏃</span>
-    <span class="emoji-stat-value" id="steps-value">8,421</span>
-    <span class="emoji-stat-label">Steps</span>
-  </div>
-  <div class="emoji-stat-card">
-    <span class="emoji-stat-icon">💧</span>
-    <span class="emoji-stat-value" id="hydration-value">2.4L</span>
-    <span class="emoji-stat-label">Hydration</span>
-  </div>
-</div>
-
-<!-- Chart + trend badge -->
-<div class="v-card" style="margin-bottom: var(--v-spacing-xxl);">
-  <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom: var(--v-spacing-md);">
-    <h3 style="margin:0;">Weekly Activity</h3>
-    <span class="trust-pill accent">📈 +12% vs last week</span>
-  </div>
-  <div id="chart" style="height:200px;"></div>
-</div>
-
-<!-- Atmospheric tagline -->
-<p style="text-align:center; color: var(--v-text-muted); font-size: var(--v-font-size-sm); font-style:italic;">Powered by your consistency.</p>
-```
-```javascript
-function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
-
-async function loadDashboard() {
-  const records = await window.vellum.data.query();
-  // Update stat values from real data
-  // Render chart
-  vellum.widgets.barChart('chart', records.map(r => ({
-    label: esc(r.data.name), value: r.data.amount
-  })));
-}
-// Wire pill toggles
-document.querySelectorAll('.pill-toggles').forEach(group => {
-  group.addEventListener('click', (e) => {
-    if (!e.target.classList.contains('pill-toggle')) return;
-    group.querySelectorAll('.pill-toggle').forEach(b => b.classList.remove('active'));
-    e.target.classList.add('active');
-    // Re-fetch data for selected range
-  });
-});
-```
-
-**Landing page** — nav bar + trust badge hero + accent word + category cards:
-```html
-<div class="v-page">
-  <!-- Navigation bar -->
-  <nav class="app-navbar reveal">
-    <div class="navbar-brand">✨ SparkClean</div>
-    <div class="navbar-links">
-      <a href="#" class="nav-link active">Home</a>
-      <a href="#" class="nav-link">Services</a>
-      <a href="#" class="nav-link">Pricing</a>
-    </div>
-    <button class="v-button navbar-cta">Book Now</button>
-  </nav>
-
-  <!-- Hero with trust badge + accent word -->
-  <div class="v-hero reveal">
-    <span class="v-hero-badge">🌟 Trusted by 12,000+ homes</span>
-    <h1>Your home, <span class="v-gradient-text">spotless.</span></h1>
-    <p class="v-hero-subtitle">Professional cleaning matched to your schedule. Book in 60 seconds.</p>
-  </div>
-
-  <!-- Category cards -->
-  <div class="reveal">
-    <h2 style="text-align:center; margin-bottom: var(--v-spacing-xl);">Our <span class="accent-word">Services</span></h2>
-    <div class="category-cards">
-      <div class="category-card">
-        <span class="category-icon">🧹</span>
-        <span class="category-name">Standard Clean</span>
-        <span class="category-meta">2-3 hrs · From $60</span>
-      </div>
-      <div class="category-card">
-        <span class="category-icon">✨</span>
-        <span class="category-name">Deep Clean</span>
-        <span class="category-meta">4-5 hrs · From $120</span>
-      </div>
-      <div class="category-card">
-        <span class="category-icon">📦</span>
-        <span class="category-name">Move-Out</span>
-        <span class="category-meta">5-7 hrs · From $180</span>
-      </div>
-    </div>
-  </div>
-
-  <!-- Feature grid -->
-  <div class="v-feature-grid">
-    <div class="v-feature-card reveal"><div class="v-feature-icon">⚡</div><div class="v-feature-title">Fast Booking</div><div class="v-feature-desc">Book in under 60 seconds.</div></div>
-    <div class="v-feature-card reveal"><div class="v-feature-icon">🛡️</div><div class="v-feature-title">Insured</div><div class="v-feature-desc">Fully bonded & insured teams.</div></div>
-    <div class="v-feature-card reveal"><div class="v-feature-icon">💚</div><div class="v-feature-title">Eco Products</div><div class="v-feature-desc">Safe for kids & pets.</div></div>
-  </div>
-
-  <!-- Atmospheric tagline -->
-  <p class="reveal" style="text-align:center; color: var(--v-text-muted); font-style:italic;">A cleaner home starts here.</p>
-</div>
-```
-```javascript
-const observer = new IntersectionObserver((entries) => {
-  entries.forEach((entry, i) => {
-    if (entry.isIntersecting) {
-      setTimeout(() => entry.target.classList.add('visible'), i * 120);
-      observer.unobserve(entry.target);
-    }
-  });
-}, { threshold: 0.1 });
-document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
-```
-
-**Multi-select table** — checkboxes + bulk toolbar:
-```html
-<table class="v-data-table" id="my-table">
-  <thead><tr>
-    <th><input type="checkbox"></th>
-    <th data-sortable>Name</th>
-    <th data-sortable>Status</th>
-  </tr></thead>
-  <tbody>
-    <tr data-id="1"><td><input type="checkbox"></td><td>Item 1</td><td>Active</td></tr>
-  </tbody>
-</table>
-<div id="bulk-toolbar" hidden style="position:sticky;bottom:0;padding:12px;background:var(--v-surface);border-top:1px solid var(--v-surface-border);display:flex;gap:8px;">
-  <button class="v-button danger" onclick="handleBulk('delete')">Delete Selected</button>
-  <button class="v-button secondary" onclick="handleBulk('archive')">Archive</button>
-</div>
-```
-```javascript
-vellum.widgets.multiSelect('my-table');
-document.getElementById('my-table').addEventListener('change', () => {
-  const any = document.querySelectorAll('#my-table tbody input:checked').length > 0;
-  document.getElementById('bulk-toolbar').hidden = !any;
-});
-
-async function handleBulk(action) {
-  const ids = Array.from(document.querySelectorAll('#my-table tbody input:checked'))
-    .map(cb => cb.closest('tr').dataset.id);
-  if (action === 'delete') {
-    const ok = await window.vellum.confirm('Delete items?', `Delete ${ids.length} selected items?`);
-    if (!ok) return;
-    for (const id of ids) await window.vellum.data.delete(id);
-    vellum.widgets.toast(`Deleted ${ids.length} items`, 'success');
-  }
-  await loadRecords();
-}
-```
-
-#### When to use widgets vs custom HTML
-
-- **Use widgets** for standard patterns — tables, metrics, timelines, notifications
-- **Use custom HTML** for novel or creative UIs — games, art tools, unique dashboards
-- **Mix freely** — widgets compose well together and with custom elements
-- Always prioritize the ideal user experience over using the widget library
 
 #### Advanced techniques
 
-Use modern web APIs to build genuinely impressive apps:
+You have the full power of modern web APIs. Use them to build genuinely impressive apps:
 
-- **Canvas 2D / WebGL** — charts, visualization, drawing, games, generative art
-- **SVG** — icons, diagrams, interactive graphics
+- **Canvas 2D / WebGL** — charts, data visualization, drawing tools, games, generative art
+- **SVG** — icons, diagrams, interactive graphics, custom illustrations
 - **CSS animations & keyframes** — loading states, micro-interactions, page transitions
-- **CSS transforms** — drag-and-drop, card flips, 3D effects
-- **CSS gradients & filters** — blur effects, color overlays, rich backgrounds
+- **CSS transforms** — drag-and-drop feel, card flips, 3D effects
+- **CSS gradients & filters** — rich visual design, blur effects, color overlays
 - **CSS Grid subgrid** — complex dashboard layouts
 - **Web Audio API** — sound effects, metronomes, music tools
-- **requestAnimationFrame** — smooth animations, interactive canvases
-- **Drag and drop** (HTML5) — reorderable lists, kanban boards
+- **requestAnimationFrame** — smooth animations and interactive canvases
+- **Drag and drop** (HTML5 API) — reorderable lists, kanban boards
 - **IntersectionObserver** — scroll-triggered animations, lazy rendering
 - **ResizeObserver** — responsive canvas/chart sizing
 
@@ -1032,13 +212,14 @@ Important:
 - All operations are async — use `async/await`
 - Wrap all calls in `try/catch`
 
+**Confirmation dialogs:** Use `window.vellum.confirm(title, message)` before destructive actions. Returns `Promise<boolean>`.
+
 #### Client-side state management
 
 `localStorage` and `sessionStorage` are available for ephemeral UI state (filters, view modes, collapsed state, preferences, form drafts). Use `window.vellum.data` for persistent app records, `localStorage` for UI preferences.
 
 #### JavaScript patterns
 
-Initialize apps with clean state management:
 ```javascript
 document.addEventListener('DOMContentLoaded', async () => {
   await loadRecords();
@@ -1077,51 +258,16 @@ function setState(updates) {
 }
 ```
 
-**Loading state pattern:**
-```javascript
-async function loadWithSkeleton() {
-  document.getElementById('content').innerHTML = `
-    <div class="skeleton skeleton-heading"></div>
-    <div class="skeleton skeleton-text"></div>
-    <div class="skeleton skeleton-text" style="width:60%"></div>`;
-  const records = await window.vellum.data.query();
-  setState({ records });
-}
-```
-
-**HTML escaping:** Always escape user-controlled data before inserting it into the DOM via `innerHTML`. Use this utility:
+**HTML escaping:** Always escape user-controlled data before inserting via `innerHTML`:
 ```javascript
 function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
 ```
-Then wrap every user data interpolation: `` `<td>${esc(record.data.name)}</td>` ``. Alternatively, use `textContent` or DOM APIs to set text without innerHTML. Failing to escape leads to XSS vulnerabilities.
+Then wrap every user data interpolation: `` `<td>${esc(record.data.name)}</td>` ``. Alternatively, use `textContent` or DOM APIs. Failing to escape leads to XSS vulnerabilities.
 
 ### 4. Single-Page App Views
 
-Apps run inside a sandboxed WebView that blocks all navigation — standard `<a>` links will not work for in-app navigation. All apps are effectively single-page. When an app needs multiple views (e.g., list + detail, dashboard + settings), use JavaScript to swap content within the page.
+Apps run inside a sandboxed WebView that blocks all navigation — standard `<a>` links will not work. When an app needs multiple views (e.g., list + detail, dashboard + settings), use JavaScript to swap content:
 
-#### View switching pattern
-
-Use a simple `showView()` function to toggle between sections:
-```html
-<nav class="app-nav">
-  <button class="nav-link active" onclick="showView('home')">Home</button>
-  <button class="nav-link" onclick="showView('settings')">Settings</button>
-</nav>
-
-<div id="view-home" class="view">
-  <!-- Home content -->
-</div>
-<div id="view-settings" class="view" hidden>
-  <!-- Settings content -->
-</div>
-
-<style>
-.app-nav { display: flex; gap: 4px; padding: 8px 12px; background: var(--v-surface); border-bottom: 1px solid var(--v-surface-border); }
-.nav-link { padding: 6px 14px; border-radius: 6px; border: none; background: none; color: var(--v-text-secondary); font-size: 13px; font-weight: 500; cursor: pointer; transition: all 150ms; }
-.nav-link:hover { background: var(--v-surface-border); color: var(--v-text); }
-.nav-link.active { background: var(--v-accent); color: white; }
-</style>
-```
 ```javascript
 function showView(name) {
   document.querySelectorAll('.view').forEach(v => v.hidden = true);
@@ -1130,8 +276,6 @@ function showView(name) {
   document.querySelector(`[onclick="showView('${name}')"]`)?.classList.add('active');
 }
 ```
-
-For detail pages, call `showView('detail')` and populate the detail section's content dynamically before showing it. Use a "Back" button that calls `showView('home')` to return to the list.
 
 ### 5. Create and Open the App
 
@@ -1149,27 +293,6 @@ Since `auto_open` defaults to `true`, you don't need to call `app_open` separate
 
 Both `ui_show` and `app_create` support a `preview` object for an inline chat preview card. Always include it so the user sees a compact summary without opening the app.
 
-**With `ui_show`:**
-```json
-{
-  "surface_type": "dynamic_page",
-  "data": {
-    "html": "...",
-    "preview": {
-      "title": "Expense Tracker",
-      "subtitle": "Personal Finance",
-      "description": "Track daily expenses with category breakdowns.",
-      "icon": "💰",
-      "metrics": [
-        { "label": "Records", "value": "24" },
-        { "label": "Categories", "value": "8" }
-      ]
-    }
-  }
-}
-```
-
-**With `app_create`:**
 ```json
 {
   "name": "Expense Tracker",
@@ -1186,164 +309,54 @@ Both `ui_show` and `app_create` support a `preview` object for an inline chat pr
 }
 ```
 
-Preview fields: `title` (required), `subtitle`, `description`, `icon` (emoji), `metrics` (up to 3 key-value pills). When `app_create` is called with `auto_open: true` (the default), the preview is forwarded through `app_open` automatically.
+Preview fields: `title` (required), `subtitle`, `description`, `icon` (emoji), `metrics` (up to 3 key-value pills).
 
 ### 6. Handle Iteration
 
-When the user requests changes to an existing app, prefer **`app_file_edit`** over rewriting the entire file. It performs surgical find-and-replace edits (like sed), which is faster and less error-prone than re-emitting a full page.
+When the user requests changes, prefer **`app_file_edit`** over rewriting the entire file. It performs surgical find-and-replace edits, which is faster and less error-prone.
 
 #### Editing code
 
-- **`app_file_edit`** — preferred for modifying existing code. Provide `app_id`, `path` (e.g. `index.html`, `styles.css`), `old_string` (exact text to find), and `new_string` (replacement). Use this for targeted changes like updating styles, fixing bugs, or adding features.
-- **`app_file_write`** — use when creating a new file or when changes are so extensive that a full rewrite is cleaner. Provide `app_id`, `path`, and `content`.
-- Always include a **`status`** parameter when calling `app_file_edit` or `app_file_write` — a brief human-readable message describing what you are doing (e.g. "adding dark mode styles", "updating navigation layout", "fixing chart rendering bug"). This gives the user visible progress feedback.
+- **`app_file_edit`** — preferred for modifying existing code. Provide `app_id`, `path` (e.g. `index.html`), `old_string`, and `new_string`.
+- **`app_file_write`** — use when creating a new file or when changes are so extensive that a full rewrite is cleaner.
+- Always include a **`status`** parameter — a brief message describing what you are doing (e.g. "fixing chart rendering bug").
 
 #### Metadata vs code changes
 
 - **`app_update`** — use for metadata changes only: `name`, `description`, and `schema_json`. Do not use it for code changes.
-- **`app_file_edit`** / **`app_file_write`** — use for all code changes (HTML, CSS, JS).
+- **`app_file_edit`** / **`app_file_write`** — use for all code changes.
 - Call `app_open` after edits to refresh the view.
-- If schema changes affect existing records, mention this.
 
 #### Multi-file apps
 
-Apps can have multiple files beyond `index.html`. Use separate files for CSS and JavaScript to keep code organized:
+Apps can have multiple files beyond `index.html`:
 
-- Create additional files with `app_file_write` (e.g. `styles.css`, `app.js`, `components/chart.js`).
+- Create additional files with `app_file_write` (e.g. `styles.css`, `app.js`).
 - Link them from `index.html` using `<link rel="stylesheet" href="styles.css">` and `<script src="app.js"></script>`.
 - Use `app_file_list` to see all files in an app.
-- Use `app_file_read` to read any file with line numbers (helpful before making edits).
+- Use `app_file_read` to read any file with line numbers.
 
 Use `app_delete` to start over. Use `app_list` to check existing apps. Use `app_query` to inspect app data.
 
-## Interactive Quality Standard
-
-Every app must meet these interaction baselines — they're the difference between "works" and "feels professional."
-
-### Feedback for Every Action
-
-Every user action must produce visible feedback:
-```javascript
-// After creating a record
-vellum.widgets.toast('Task created', 'success');
-
-// After deleting
-vellum.widgets.toast('Deleted', 'success');
-
-// After updating
-vellum.widgets.toast('Changes saved', 'success');
-
-// On error
-vellum.widgets.toast('Something went wrong', 'error');
-```
-
-### Confirmation for Destructive Actions
-
-Use `window.vellum.confirm()` before deleting, resetting, or any irreversible action:
-```javascript
-async function deleteRecord(id) {
-  const confirmed = await window.vellum.confirm(
-    'Delete this item?',
-    'This action cannot be undone.'
-  );
-  if (!confirmed) return;
-  await window.vellum.data.delete(id);
-  vellum.widgets.toast('Deleted', 'success');
-  await loadRecords();
-}
-```
-`window.vellum.confirm(title, message)` returns a `Promise<boolean>` — `true` if the user clicks OK, `false` for Cancel. It shows a native macOS dialog.
-
-### Form Validation
-
-Validate before submit, show errors inline:
-```css
-.field-error {
-  color: var(--v-danger);
-  font-size: var(--v-font-size-xs);
-  margin-top: 2px;
-  min-height: 1em;
-}
-input.invalid, select.invalid {
-  border-color: var(--v-danger);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--v-danger) 15%, transparent);
-}
-```
-- Disable submit button while a required field is empty
-- Clear error messages on input focus
-- Show loading state on submit button during async operations
-
-### Loading States
-
-Never show a blank screen while data loads:
-```javascript
-function showLoading() {
-  container.innerHTML = `
-    <div class="skeleton skeleton-heading"></div>
-    <div class="skeleton skeleton-text"></div>
-    <div class="skeleton skeleton-text" style="width:70%"></div>`;
-}
-```
-- Disable buttons during async operations to prevent double-submit
-- Use the skeleton shimmer CSS from the Visual Techniques section
-
-### Keyboard Navigation
-
-- `Tab` moves between interactive elements in logical order
-- `Enter` submits forms, activates buttons
-- `Escape` closes modals, cancels edits, clears search
-- Use `tabindex` only when natural DOM order is insufficient
-
 ## What Great Apps Look Like
 
-These are the apps you should aspire to — each one demonstrates the Lovable-quality patterns in action:
+Not just functional, but delightful:
 
-- **Fitness dashboard** — Purple accent (`--accent: #8A5BE0`), lavender tinted background. Contextual header: "Good morning, Alex" with date. Pill toggles (Day/Week/Month) switching chart ranges. Emoji stat cards row (🔥 Calories, 🏃 Steps, 💧 Hydration, 😴 Sleep). Progress rings with distinct colors per metric. Trust pill: "🔥 7-day streak". Atmospheric tagline: "Powered by your consistency."
-- **Plant tracker** — Sage green accent (`--accent: #18B07A`), soft sage background (`#F0F5F0`). Contextual header: "🌿 Your Garden" with plant count badge. Category cards for plant types with emoji (🌵 Succulents, 🌿 Tropicals, 🌸 Flowering). Emoji stat row (💧 Watered today, ☀️ Light exposure, 🌱 New growth). Suggestion chips for filtering: "Needs water", "Low light", "Outdoors".
-- **Finance vault** — Navy/blue-gray accent (`--accent: #3B82F6`), cool gray background (`#F5F7FA`). Contextual header: "Welcome back, Alex" with net worth badge. Transaction list with emoji identifiers (🏠 Rent, 🛒 Groceries, ☕ Coffee). Trend badge: "+8.2% this month". Pill toggles for time ranges (1W/1M/3M/1Y).
-- **Cleaning service landing page** — Warm amber accent (`--accent: #E8A020`), cream background (`#FEFCF9`). Nav bar with logo ("✨ SparkClean") + CTA. Trust pill in hero: "🌟 Trusted by 12,000+ homes". Accent word hero: "Your home, **spotless.**" Category cards (🧹 Standard, ✨ Deep Clean, 📦 Move-Out with pricing). Feature grid with eco/speed/insurance.
-- **AI tool landing page** — Purple gradient text, dark hero section. Suggestion chips below a demo input: "Summarize this", "Generate code", "Explain like I'm 5". Feature grid with emoji icons. Trust badge: "⚡ 4x faster than v1". Atmospheric tagline: "Intelligence, simplified."
+- **Kanban board** — draggable cards across columns, smooth animations, color-coded priorities, card detail modals
+- **Workout tracker** — exercise logging with charts showing progress over time (Canvas), rep/set tracking, personal records
+- **Expense dashboard** — categorized spending with pie/bar charts (Canvas), monthly trends, budget vs actual
+- **Writing journal** — rich text formatting, word count stats, mood tracking with color-coded entries, calendar heatmap
+- **Habit tracker** — contribution-graph style heatmap, streak counters, weekly/monthly views with smooth transitions
+- **Recipe book** — ingredient scaling, step-by-step mode, beautiful card layouts with CSS gradients for category colors
+- **Flashcard app** — spaced repetition algorithm, card flip animations (CSS 3D transforms), progress tracking
 
-### Pre-Ship Design Checklist
-
-Before delivering any app, mentally verify these 10 items — they cover the gap between "functional" and "designer-quality":
-
-1. **Domain-matched palette** — Is the accent color appropriate for this domain? (Not default violet)
-2. **Tinted background** — Does the body have a warm/cool tint instead of pure white/dark?
-3. **Emoji stat cards** — Are there emoji icons in metric cards, list items, or navigation?
-4. **Accent word in heading** — Is ONE key word in the hero heading colored or gradient-filled?
-5. **Contextual header** — Is there a greeting, date, or personalized welcome (not just an app title)?
-6. **Trust/status pill badge** — Is there at least one pill badge with a stat, streak, or social proof?
-7. **Generous spacing** — Are section gaps 32-48px? Does the layout feel spacious, not cramped?
-8. **Clean card borders** — Do cards use subtle 1px borders instead of heavy multi-layer shadows?
-9. **Interactive elements** — Are there pill toggles, suggestion chips, or filter controls?
-10. **Atmospheric tagline** — Is there a warm, human-sounding line at the bottom or between sections?
-
-### Additional widget classes
-
-| Widget | Purpose | Key Classes |
-|---|---|---|
-| `.v-pill-toggles` | Time range / filter toggle group | `.v-pill-toggle` (`.active`) — container with pill buttons |
-| `.v-chip-group` | Suggestion / filter chip row | `.v-chip` (`.active`) — wrapping row of clickable pills |
-| `.v-metric-card .v-metric-icon` | Emoji icon in metric cards | Place emoji `<span>` with `.v-metric-icon` inside `.v-metric-card` |
-
-Every app should include: search/filter, toast notifications for all CRUD operations, `window.vellum.confirm()` for destructive actions, staggered page-load animation, card hover effects, and skeleton loading states.
+These apps should have filtering, sorting, search, keyboard shortcuts, empty states, confirmation dialogs for destructive actions, and smooth transitions throughout.
 
 ## Error Handling
 
 - If `app_create` fails, verify `schema_json` is valid JSON and `html` is a complete HTML document. Retry with fixes.
 - If `app_open` fails, verify `app_id` with `app_list`.
-- If the user reports visual issues, use `app_update` to fix the HTML and `app_open` to refresh.
-- All `window.vellum.data` calls must be wrapped in `try/catch` with user-friendly error feedback:
-  ```javascript
-  try {
-    await window.vellum.data.create(data);
-    vellum.widgets.toast('Created!', 'success');
-  } catch (err) {
-    console.error('Create failed:', err);
-    vellum.widgets.toast('Failed to save. Please try again.', 'error');
-  }
-  ```
-- Never let a failed data operation silently pass — always show a toast or inline error message.
-- If the page loads with no data, show a designed empty state (`.v-empty-state`) — never a blank screen.
+- If the user reports visual issues, use `app_file_edit` to fix the code and `app_open` to refresh.
+- All `window.vellum.data` calls must be wrapped in `try/catch` — show toast notifications or inline error messages on failure. Never let errors pass silently.
+- If the page loads with no data, show a designed empty state — never a blank screen.
 - For forms, show validation errors inline next to the relevant field, not as an alert.

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -3,7 +3,7 @@ name: "App Builder"
 description: "Create polished, professional local apps with HTML/CSS/JS"
 ---
 
-You are an expert app builder. When the user asks you to create an app, tool, or utility, you design a data schema, build a self-contained HTML/CSS/JS interface, and persist it so the user can open it anytime. Your apps should feel like real, polished software — not prototypes.
+You are an expert app builder. When the user asks you to create an app, tool, or utility, you design a data schema, build a polished HTML/CSS/JS interface, and persist it so the user can open it anytime. Structure the code however makes sense — separate CSS and JS into their own files when it helps keep things organized and makes future edits easier. Your apps should feel like real, polished software — not prototypes.
 
 **Build immediately.** Don't ask what colors the user wants or show wireframes. Make creative decisions — pick the palette, the layout, the interactions — and let them refine from there. Only ask questions when the request is genuinely ambiguous.
 
@@ -59,9 +59,9 @@ Write a complete, self-contained HTML document rendered inside a sandboxed WebVi
 
 #### Technical constraints
 
-- Single HTML string — no external files, CDNs, or imports
-- All CSS in `<style>` in `<head>`, all JavaScript in `<script>` before `</body>`
-- No external fonts, images, or resources — use system fonts and CSS/SVG for visuals
+- No external CDNs, imports, or network requests — the WebView is sandboxed
+- Use system fonts and CSS/SVG for visuals — no external fonts or images
+- Structure code across multiple files when it helps (e.g. `index.html`, `styles.css`, `app.js`) — link them with `<link>` and `<script src>` tags
 - Design for 400-600px width with graceful resizing
 - The WebView blocks all navigation — links and form `action` attributes won't work
 


### PR DESCRIPTION
## Summary
- Reduced app-builder SKILL.md from 1349 lines to 362 lines (74% reduction)
- Removed prescriptive ALWAYS/NEVER rules that caused every generated app to look identical (emoji stat cards, "Good morning Alex" headers, fake trust badges, mandatory atmospheric taglines)
- Removed ~600 lines of copy-paste CSS/HTML recipes and composition templates that ate context window
- Removed 10-item "Pre-Ship Design Checklist" that the model treated as a mandatory template
- Restored the original concise design philosophy from PR #1896 — trust the model to use taste
- Kept all technical reference: design tokens, widget library docs, JS utilities, data bridge API, file editing workflow

## Context
PR #2680 and #2800 rewrote SKILL.md to mandate a specific "Lovable-quality" aesthetic formula. The result was that every app looked the same — same emoji-plastered layout, same greeting header, same pill badges — which is the opposite of "designed, not generated." The model follows ALWAYS/NEVER rules literally, producing formulaic output instead of using judgment.

## Test plan
- [ ] Create a few apps with varied prompts (habit tracker, expense tracker, landing page) and verify they look distinct from each other
- [ ] Verify the model still uses the design system tokens and widget library
- [ ] Compare output quality against the screenshots from PR #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
