### PR TITLE
feat: inline archive confirm button in sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -349,21 +349,11 @@ struct MainWindowView: View {
                 windowState.activeDynamicParsedSurface = nil
             }
         }
-        .alert("Delete Conversation?", isPresented: Binding(
-            get: { threadPendingDeletion != nil },
-            set: { if !$0 { threadPendingDeletion = nil } }
-        )) {
-            Button("Cancel", role: .cancel) {
+        .onChange(of: isHoveredThread) { _, newValue in
+            // Cancel pending archive when hover leaves the row
+            if let pending = threadPendingDeletion, newValue != pending {
                 threadPendingDeletion = nil
             }
-            Button("Delete", role: .destructive) {
-                if let threadId = threadPendingDeletion {
-                    threadManager.archiveThread(id: threadId)
-                    threadPendingDeletion = nil
-                }
-            }
-        } message: {
-            Text("This conversation will be archived. You can restore it from Settings.")
         }
     }
 
@@ -390,20 +380,37 @@ struct MainWindowView: View {
             }
             .buttonStyle(.plain)
 
-            Button {
-                threadPendingDeletion = thread.id
-            } label: {
-                Image(systemName: "archivebox")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(VColor.textSecondary)
-                    .frame(width: 24, height: 24)
-                    .contentShape(Rectangle())
+            if threadPendingDeletion == thread.id {
+                Button {
+                    threadManager.archiveThread(id: thread.id)
+                    threadPendingDeletion = nil
+                } label: {
+                    Text("Confirm")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                        .background(VColor.surface)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Confirm archive \(thread.title)")
+            } else {
+                Button {
+                    threadPendingDeletion = thread.id
+                } label: {
+                    Image(systemName: "archivebox")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .frame(width: 24)
+                .opacity(isHoveredThread == thread.id ? 1 : 0)
+                .allowsHitTesting(isHoveredThread == thread.id)
+                .accessibilityLabel("Archive \(thread.title)")
             }
-            .buttonStyle(.plain)
-            .frame(width: 24)
-            .opacity(isHoveredThread == thread.id ? 1 : 0)
-            .allowsHitTesting(isHoveredThread == thread.id)
-            .accessibilityLabel("Archive \(thread.title)")
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)


### PR DESCRIPTION
## Summary
- Replace the modal alert dialog with an inline "Confirm" pill button that appears in-place when clicking the archive icon
- Confirm button uses error color text in a capsule-shaped surface background, matching the reference design
- Pending confirmation auto-cancels when the cursor leaves the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
