### PR TITLE
test: output scope guard — parent lists child but not grandchild

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -292,4 +292,33 @@ describe('skill_load tool', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Included Skills (immediate): none');
   });
+
+  test('parent skill lists only immediate children, not transitive grandchildren', async () => {
+    // 3-level hierarchy: grandparent -> child -> grandchild
+    writeSkill('grandchild', 'Grandchild Skill', 'Leaf skill', 'Grandchild body');
+    writeSkillWithIncludes('child', 'Child Skill', 'Mid-level', 'Child body', ['grandchild']);
+    writeSkillWithIncludes('grandparent', 'Grandparent Skill', 'Top-level', 'Grandparent body', ['child']);
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- grandparent\n- child\n- grandchild\n',
+    );
+
+    const result = await executeSkillLoad({ skill: 'grandparent' });
+    expect(result.isError).toBe(false);
+
+    // The immediate children section must list the direct child
+    expect(result.content).toContain('Included Skills (immediate):');
+    expect(result.content).toContain('child');
+
+    // Extract only the "Included Skills (immediate)" section to verify
+    // grandchild is NOT listed there (it's a transitive dependency)
+    const immediateSection = result.content.match(
+      /Included Skills \(immediate\):[\s\S]*?(?=\n\n|<loaded_skill)/,
+    );
+    expect(immediateSection).not.toBeNull();
+    expect(immediateSection![0]).not.toContain('grandchild');
+
+    // Loaded-skill marker must be present (validation passed)
+    expect(result.content).toMatch(/<loaded_skill id="grandparent" version="v1:[a-f0-9]{64}" \/>/);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a 3-level fixture (grandparent → child → grandchild) to skill-load-tool tests
- Asserts the "Included Skills (immediate)" section only renders direct children
- Confirms transitive descendants (grandchild) are never leaked into the output

## Test plan
- [x] `bun test src/__tests__/skill-load-tool.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
