### PR TITLE
test: e2e scaffold + load with includes metadata

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -185,4 +185,36 @@ describe('scaffold_managed_skill tool', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('traversal');
   });
+
+  test('e2e: scaffold child then parent with includes, verify files and index', async () => {
+    // 1. Scaffold a child skill
+    const childResult = await tool.execute({
+      skill_id: 'e2e-child',
+      name: 'E2E Child',
+      description: 'Child for e2e test',
+      body_markdown: 'Child instructions.',
+    }, makeContext());
+    expect(childResult.isError).toBe(false);
+
+    // 2. Scaffold a parent skill that includes the child
+    const parentResult = await tool.execute({
+      skill_id: 'e2e-parent',
+      name: 'E2E Parent',
+      description: 'Parent with includes',
+      body_markdown: 'Parent instructions.',
+      includes: ['e2e-child'],
+    }, makeContext());
+    expect(parentResult.isError).toBe(false);
+
+    // 3. Read the parent SKILL.md and verify it contains includes metadata
+    const parentSkillFile = join(TEST_DIR, 'skills', 'e2e-parent', 'SKILL.md');
+    expect(existsSync(parentSkillFile)).toBe(true);
+    const parentContent = readFileSync(parentSkillFile, 'utf-8');
+    expect(parentContent).toContain('includes: ["e2e-child"]');
+
+    // 4. Read the SKILLS.md index and verify both skills are listed
+    const indexContent = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    expect(indexContent).toContain('- e2e-child');
+    expect(indexContent).toContain('- e2e-parent');
+  });
 });

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -293,6 +293,31 @@ describe('skill_load tool', () => {
     expect(result.content).toContain('Included Skills (immediate): none');
   });
 
+  test('e2e: load parent with includes shows child metadata and emits only parent marker', async () => {
+    // Set up a parent + child fixture using the helpers
+    writeSkill('e2e-child', 'E2E Child', 'Child for e2e test', 'Child instructions.');
+    writeSkillWithIncludes('e2e-parent', 'E2E Parent', 'Parent with includes', 'Parent instructions.', ['e2e-child']);
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- e2e-parent\n- e2e-child\n');
+
+    // Load the parent
+    const result = await executeSkillLoad({ skill: 'e2e-parent' });
+
+    // Should succeed
+    expect(result.isError).toBe(false);
+
+    // Output should contain the immediate children metadata section with the child
+    expect(result.content).toContain('Included Skills (immediate):');
+    expect(result.content).toContain('e2e-child: E2E Child');
+
+    // Should emit exactly one <loaded_skill> marker — for the parent only
+    const markers = result.content.match(/<loaded_skill/g) || [];
+    expect(markers.length).toBe(1);
+    expect(result.content).toMatch(/<loaded_skill id="e2e-parent" version="v1:[a-f0-9]{64}" \/>/);
+
+    // Should NOT contain a loaded_skill marker for the child
+    expect(result.content).not.toContain('<loaded_skill id="e2e-child"');
+  });
+
   test('parent skill lists only immediate children, not transitive grandchildren', async () => {
     // 3-level hierarchy: grandparent -> child -> grandchild
     writeSkill('grandchild', 'Grandchild Skill', 'Leaf skill', 'Grandchild body');


### PR DESCRIPTION
## Summary
- Adds e2e test to scaffold-managed-skill-tool.test.ts: scaffold child + parent with includes, verify SKILL.md content and SKILLS.md index
- Adds e2e test to skill-load-tool.test.ts: load parent with includes, verify child metadata output and single marker emission
- Locks the managed-skill authoring → runtime loading contract

## Test plan
- [x] `bun test src/__tests__/scaffold-managed-skill-tool.test.ts src/__tests__/skill-load-tool.test.ts` passes (27 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
