### PR TITLE
fix: use uniform scale factor for highlight coordinate normalization

### DIFF
--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -152,13 +152,12 @@ export async function getElementBounds(
       })()
     `) as { x: number; y: number; w: number; h: number; vw: number; vh: number } | null;
     if (!result) return null;
-    const scaleX = 800 / result.vw;
-    const scaleY = 600 / result.vh;
+    const scale = Math.min(800 / result.vw, 600 / result.vh);
     return {
-      x: result.x * scaleX,
-      y: result.y * scaleY,
-      w: result.w * scaleX,
-      h: result.h * scaleY,
+      x: result.x * scale,
+      y: result.y * scale,
+      w: result.w * scale,
+      h: result.h * scale,
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #3775
- CDP `Page.startScreencast` preserves the viewport's aspect ratio, so a 16:9 (1280x720) viewport produces 800x450 frames, not 800x600
- Using separate `scaleX` and `scaleY` caused incorrect Y coordinates for non-4:3 viewports
- Now uses a uniform `scale = Math.min(800/vw, 600/vh)` matching CDP's actual scaling behavior

## Test plan
- [ ] Verify highlight overlays align correctly on 16:9 viewports
- [ ] Verify highlight overlays still align correctly on 4:3 viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
