### PR TITLE
docs: document include graph validation in ARCHITECTURE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1386,6 +1386,35 @@ graph TB
 - Managed-store writes are atomic (tmp file + rename) to prevent partial `SKILL.md` or `SKILLS.md` files.
 - After persist or delete, the file watcher triggers session eviction; the next turn runs in a fresh session. The model's system prompt instructs it to continue normally.
 - macOS UI shows Inspect and Delete controls for managed skills only (source = "managed").
+- `skill_load` validates the recursive include graph (via `include-graph.ts`) before emitting output. Missing children and cycles produce `isError: true` with no `<loaded_skill>` marker. Valid includes produce an "Included Skills (immediate)" metadata section showing child ID, name, description, and path.
+
+### Include Graph Validation
+
+Skills can declare child relationships via the `includes` frontmatter field (a JSON array of skill IDs). When `skill_load` loads a parent skill, it validates the full recursive include graph before emitting output.
+
+```mermaid
+graph LR
+    LOAD["skill_load(parent)"] --> CATALOG["loadSkillCatalog()"]
+    CATALOG --> INDEX["indexCatalogById()"]
+    INDEX --> VALIDATE["validateIncludes(rootId, index)"]
+    VALIDATE -->|"ok"| OUTPUT["Emit output +<br/>Included Skills (immediate)<br/>+ loaded_skill marker"]
+    VALIDATE -->|"missing child"| ERR_MISSING["isError: true<br/>no loaded_skill marker"]
+    VALIDATE -->|"cycle detected"| ERR_CYCLE["isError: true<br/>no loaded_skill marker"]
+```
+
+**Validation rules:**
+- **Missing children**: If any skill in the recursive graph references an `includes` ID not found in the catalog, validation fails with the full path from root to the missing reference.
+- **Cycles**: Three-state DFS (unseen → visiting → done) detects direct and indirect cycles. The error includes the cycle path.
+- **Fail-closed**: On any validation error, `skill_load` returns `isError: true` with no `<loaded_skill>` marker, preventing the agent from using a skill with broken dependencies.
+
+**Key constraint**: Include metadata is metadata-only. Child skills are **not** auto-activated — the agent must explicitly call `skill_load` for each child. The `projectSkillTools()` function only projects tools for skills with explicit `<loaded_skill>` markers in conversation history.
+
+| Source File | Purpose |
+|---|---|
+| `assistant/src/skills/include-graph.ts` | `indexCatalogById()`, `getImmediateChildren()`, `validateIncludes()`, `traverseIncludes()` |
+| `assistant/src/tools/skills/load.ts` | Include validation integration in `skill_load` execute path |
+| `assistant/src/config/skills.ts` | `includes` field parsing from SKILL.md frontmatter |
+| `assistant/src/skills/managed-store.ts` | `includes` emission in `buildSkillMarkdown()` |
 
 ---
 
@@ -1399,7 +1428,7 @@ Each skill directory (bundled, managed, workspace, or extra) may contain:
 
 ```
 skills/<skill-id>/
-  SKILL.md          # Skill instructions (frontmatter + markdown body)
+  SKILL.md          # Skill instructions (frontmatter + markdown body; optional includes: [...] for child skills)
   TOOLS.json        # Tool manifest (optional — skills without tools are instruction-only)
   tools/            # Executor scripts referenced by TOOLS.json
     my-tool.ts      # Exports run(input, context) → ToolExecutionResult
@@ -1500,6 +1529,7 @@ graph TB
 | `assistant/src/config/bundled-skills/` | Bundled skill directories (gmail, claude-code, weather, etc.) |
 | `assistant/src/skills/tool-manifest.ts` | `TOOLS.json` parser and validator |
 | `assistant/src/skills/active-skill-tools.ts` | `deriveActiveSkillIds()` — scans history for `<loaded_skill>` markers |
+| `assistant/src/skills/include-graph.ts` | Include graph builder: `indexCatalogById()`, `validateIncludes()`, cycle/missing detection |
 | `assistant/src/daemon/session-skill-tools.ts` | `projectSkillTools()` — per-turn projection, register/unregister lifecycle |
 | `assistant/src/tools/skills/skill-tool-factory.ts` | `createSkillToolsFromManifest()` — manifest entries to Tool objects |
 | `assistant/src/tools/skills/skill-script-runner.ts` | Host runner: dynamic import + `run()` call |


### PR DESCRIPTION
## Summary
- Adds "Include Graph Validation" subsection with Mermaid diagram to the Dynamic Skill Authoring section
- Documents validation rules (missing children, cycles, fail-closed behavior)
- Clarifies metadata-only semantics — no auto-activation of child tools
- Updates skill directory structure to mention `includes` frontmatter
- Adds `include-graph.ts` to the source files table

## Test plan
- [x] Manual doc review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
