### PR TITLE
fix: stable row height for inline archive confirm

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -389,7 +389,7 @@ struct MainWindowView: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.error)
                         .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xxs)
+                        .frame(height: 24)
                         .background(VColor.surface)
                         .clipShape(Capsule())
                 }


### PR DESCRIPTION
## Summary
- Match the Confirm pill button height to the archive icon's 24pt frame so the row doesn't shrink when toggling between the two states

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
