### PR TITLE
fix: dismiss orphaned browser surface when screencast startup fails

### DIFF
--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -69,6 +69,12 @@ export async function ensureScreencast(
       } satisfies BrowserFrame);
     });
   } catch (err) {
+    // Dismiss the surface we already showed so the client doesn't have an orphaned panel
+    sendToClient({
+      type: 'ui_surface_dismiss',
+      sessionId,
+      surfaceId,
+    });
     // Roll back so future calls can retry
     activeScreencasts.delete(sessionId);
     throw err;


### PR DESCRIPTION
Addresses review feedback from PR #3772:
- If startScreencast throws after ui_surface_show was sent, the catch block now sends ui_surface_dismiss before cleaning up
- Prevents orphaned PiP panels in the client when screencast initialization fails
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
