### PR TITLE
fix: silence implicit coercion and actor isolation build warnings

### DIFF
--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -183,14 +183,14 @@ final class BrowserPiPManager: ObservableObject {
             object: panel,
             queue: .main
         ) { [weak self] _ in
-            self?.savePosition()
+            Task { @MainActor in self?.savePosition() }
         }
         resizeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResizeNotification,
             object: panel,
             queue: .main
         ) { [weak self] _ in
-            self?.savePosition()
+            Task { @MainActor in self?.savePosition() }
         }
 
         self.panel = panel

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -967,10 +967,10 @@ public extension Surface {
         var highlights: [BrowserHighlight]?
         if let highlightsArray = dict["highlights"] as? [[String: Any?]] {
             highlights = highlightsArray.compactMap { item in
-                guard let x = asDouble(item["x"]),
-                      let y = asDouble(item["y"]),
-                      let w = asDouble(item["w"]),
-                      let h = asDouble(item["h"]),
+                guard let x = asDouble(item["x"] as Any?),
+                      let y = asDouble(item["y"] as Any?),
+                      let w = asDouble(item["w"] as Any?),
+                      let h = asDouble(item["h"] as Any?),
                       let label = item["label"] as? String else { return nil }
                 return BrowserHighlight(x: x, y: y, w: w, h: h, label: label)
             }
@@ -1008,10 +1008,10 @@ public extension Surface {
         if update.keys.contains("highlights") {
             if let highlightsArray = update["highlights"] as? [[String: Any?]] {
                 highlights = highlightsArray.compactMap { item in
-                    guard let x = asDouble(item["x"]),
-                          let y = asDouble(item["y"]),
-                          let w = asDouble(item["w"]),
-                          let h = asDouble(item["h"]),
+                    guard let x = asDouble(item["x"] as Any?),
+                          let y = asDouble(item["y"] as Any?),
+                          let w = asDouble(item["w"] as Any?),
+                          let h = asDouble(item["h"] as Any?),
                           let label = item["label"] as? String else { return nil }
                     return BrowserHighlight(x: x, y: y, w: w, h: h, label: label)
                 }


### PR DESCRIPTION
## Summary
- Fix `Any??` to `Any?` implicit coercion warnings in `SurfaceTypes.swift` by adding explicit `as Any?` casts on dictionary subscripts
- Fix actor isolation warnings in `BrowserPiPManager.swift` by wrapping `savePosition()` calls in `Task { @MainActor in }` inside NotificationCenter observer closures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
