### PR TITLE
fix: use canonical skill ID for auto-enable on install

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -209,8 +209,12 @@ export async function handleSkillsInstall(
     // Reload skill catalog so the newly installed skill is picked up
     loadSkillCatalog();
 
-    // Auto-enable the newly installed skill so it's immediately usable
-    const skillId = result.skillName ?? msg.slug;
+    // Auto-enable the newly installed skill so it's immediately usable.
+    // Use basename of slug to match the catalog ID (directory basename), since
+    // install slugs can be namespaced (e.g. "org/name") but skill state keys use
+    // the bare directory name.
+    const rawId = result.skillName ?? msg.slug;
+    const skillId = rawId.includes('/') ? rawId.split('/').pop()! : rawId;
     try {
       const raw = loadRawConfig();
       ensureSkillEntry(raw, skillId).enabled = true;


### PR DESCRIPTION
## Summary
- Extract basename from install slug before writing to skill config, since install slugs can be namespaced (e.g. `org/name`) but runtime skill state resolves by catalog ID (directory basename)
- Prevents reinstalling a previously disabled namespaced skill from staying disabled

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3503
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
