### PR TITLE
fix: add path.isEmpty guard in humanDescription for file tools

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -179,14 +179,17 @@ public struct ToolConfirmationData: Equatable {
             return Self.describeBashCommand((input["command"]?.value as? String) ?? "")
         case "file_write", "host_file_write":
             let path = (input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "I\u{2019}d like to save some changes to a file \u{2014} that ok?" }
             let name = URL(fileURLWithPath: path).lastPathComponent
             return "I\u{2019}d like to save some changes to \(name) \u{2014} that ok?"
         case "file_edit", "host_file_edit":
             let path = (input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "I need to make a quick edit to a file \u{2014} cool?" }
             let name = URL(fileURLWithPath: path).lastPathComponent
             return "I need to make a quick edit to \(name) \u{2014} cool?"
         case "file_read", "host_file_read":
             let path = (input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "Let me take a peek at a file \u{2014} alright?" }
             let name = URL(fileURLWithPath: path).lastPathComponent
             return "Let me take a peek at \(name) \u{2014} alright?"
         case "web_fetch":


### PR DESCRIPTION
## Summary
- Added `path.isEmpty` checks in `humanDescription` for `file_write`, `file_edit`, and `file_read` cases
- Same fix as PR #3505 applied to `detailsSummary`, now also applied to `humanDescription` where `URL(fileURLWithPath: "").lastPathComponent` returns the CWD name instead of an empty string

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3505
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
