### PR TITLE
fix: update lastDaemonModel only after successful IPC send

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -179,7 +179,11 @@ public final class SettingsStore: ObservableObject {
 
     func setModel(_ model: String) {
         guard model != lastDaemonModel else { return }
-        lastDaemonModel = model
-        try? daemonClient?.sendModelSet(model: model)
+        do {
+            try daemonClient?.sendModelSet(model: model)
+            lastDaemonModel = model
+        } catch {
+            // Send failed — don't update lastDaemonModel so the next attempt isn't suppressed
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Moved `lastDaemonModel = model` from before `sendModelSet` to after successful send
- Prevents a transient IPC disconnect from permanently blocking model selection retries

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3506
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
