### PR TITLE
fix: precompute resultIsDiff once per result instead of per line

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -145,13 +145,14 @@ struct ActivityStepView: View {
 
                     // Result
                     if let result = toolCall.result, !result.isEmpty {
+                        let isDiff = resultIsDiff
                         ZStack(alignment: .topTrailing) {
                             ScrollView {
                                 VStack(alignment: .leading, spacing: 0) {
                                     ForEach(Array(result.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
                                         Text(line)
                                             .font(VFont.monoSmall)
-                                            .foregroundColor(diffLineColor(line))
+                                            .foregroundColor(diffLineColor(line, isDiff: isDiff))
                                             .frame(maxWidth: .infinity, alignment: .leading)
                                     }
                                 }
@@ -212,9 +213,9 @@ struct ActivityStepView: View {
         return result.contains("@@") && result.contains("---") && result.contains("+++")
     }
 
-    private func diffLineColor(_ line: String) -> Color {
+    private func diffLineColor(_ line: String, isDiff: Bool) -> Color {
         if toolCall.isError { return VColor.error }
-        guard resultIsDiff else { return VColor.textSecondary }
+        guard isDiff else { return VColor.textSecondary }
         if line.hasPrefix("+") { return Emerald._400 }
         if line.hasPrefix("-") { return Rose._400 }
         if line.hasPrefix("@@") { return VColor.textMuted }


### PR DESCRIPTION
## Summary
- Evaluate `resultIsDiff` once in the result section and pass as a parameter to `diffLineColor`
- Avoids repeated full-string scans (3x `contains` calls) per displayed line for long tool outputs

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3508
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
