### PR TITLE
fix: strict includes validation and accurate type comment

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -151,13 +151,52 @@ describe('scaffold_managed_skill tool', () => {
       name: 'Normalized',
       description: 'Tests normalization',
       body_markdown: 'Body.',
-      includes: ['  child-a  ', 'child-b', 'child-a', '', '  '],
+      includes: ['  child-a  ', 'child-b', 'child-a'],
     }, makeContext());
 
     expect(result.isError).toBe(false);
     const skillFile = join(TEST_DIR, 'skills', 'norm-skill', 'SKILL.md');
     const content = readFileSync(skillFile, 'utf-8');
     expect(content).toContain('includes: ["child-a","child-b"]');
+  });
+
+  test('rejects includes with non-string elements', async () => {
+    const result = await tool.execute({
+      skill_id: 'bad-includes',
+      name: 'Bad',
+      description: 'Has non-string',
+      body_markdown: 'Body.',
+      includes: ['child-a', 42],
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('non-empty string');
+  });
+
+  test('rejects includes with empty string elements', async () => {
+    const result = await tool.execute({
+      skill_id: 'empty-includes',
+      name: 'Empty',
+      description: 'Has empty string',
+      body_markdown: 'Body.',
+      includes: ['', 'child-a'],
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('non-empty string');
+  });
+
+  test('rejects includes with whitespace-only elements', async () => {
+    const result = await tool.execute({
+      skill_id: 'ws-includes',
+      name: 'Whitespace',
+      description: 'Has whitespace-only',
+      body_markdown: 'Body.',
+      includes: ['child-a', '  '],
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('non-empty string');
   });
 
   test('omits includes when not provided', async () => {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -55,7 +55,7 @@ export interface SkillSummary {
   metadata?: VellumMetadata;
   /** Parsed tool manifest metadata, if the skill has a valid TOOLS.json. */
   toolManifest?: SkillToolManifestMeta;
-  /** IDs of child skills that this skill includes (composed into its prompt). */
+  /** IDs of child skills that this skill includes (metadata-only, not auto-activated). */
   includes?: string[];
 }
 

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -96,10 +96,17 @@ export class ScaffoldManagedSkillTool implements Tool {
       if (!Array.isArray(input.includes)) {
         return { content: 'Error: includes must be an array of strings', isError: true };
       }
+      for (const item of input.includes) {
+        if (typeof item !== 'string') {
+          return { content: 'Error: each element in includes must be a non-empty string', isError: true };
+        }
+        if (!item.trim()) {
+          return { content: 'Error: each element in includes must be a non-empty string', isError: true };
+        }
+      }
       const normalized: string[] = [];
       const seen = new Set<string>();
-      for (const item of input.includes) {
-        if (typeof item !== 'string' || !item.trim()) continue;
+      for (const item of input.includes as string[]) {
         const trimmed = item.trim();
         if (seen.has(trimmed)) continue;
         seen.add(trimmed);


### PR DESCRIPTION
## Summary
- `scaffold_managed_skill` now rejects non-string and empty-string elements in `includes` with `isError: true` instead of silently dropping them (P2 review finding)
- Updated `SkillSummary.includes` comment from "composed into its prompt" to "metadata-only, not auto-activated" (P3 review finding)
- Added 3 new tests: non-string elements, empty strings, whitespace-only strings
- Updated existing normalization test to only test valid inputs (trim + dedupe)

## Test plan
- [x] `bun test src/__tests__/scaffold-managed-skill-tool.test.ts` — all pass
- [x] `bun test src/__tests__/skill-load-tool.test.ts src/__tests__/skills.test.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
