### PR TITLE
fix: harden bundle sandbox link stripping and scheme handler file-type checks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -123,20 +123,34 @@ enum BundleSandbox {
         var removed: [String] = []
 
         for case let fileURL as URL in enumerator {
-            let absURL = root.appendingPathComponent(fileURL.relativePath)
+            // Use the enumerated URL directly — when .producesRelativePathURLs
+            // is not honored the enumerator returns absolute URLs, and
+            // re-appending relativePath to root would build a wrong path.
+            let absURL = fileURL.baseURL != nil
+                ? root.appendingPathComponent(fileURL.relativePath)
+                : fileURL
 
-            let values = try absURL.resourceValues(forKeys: [.isSymbolicLinkKey, .isRegularFileKey, .linkCountKey])
+            let label = fileURL.relativePath
+
+            // Treat unreadable files as suspicious — if resourceValues throws
+            // (I/O error, permissions, etc.) we must not skip the file and
+            // leave a potentially unsafe link on disk unchecked.
+            guard let values = try? absURL.resourceValues(forKeys: [.isSymbolicLinkKey, .isRegularFileKey, .linkCountKey]) else {
+                removed.append(label)
+                try? fm.removeItem(at: absURL)
+                continue
+            }
 
             if values.isSymbolicLink == true {
                 // Resolve and check containment
                 let target = absURL.resolvingSymlinksInPath().path
                 if target != rootReal && !target.hasPrefix(rootReal + "/") {
-                    removed.append(fileURL.relativePath)
+                    removed.append(label)
                     try? fm.removeItem(at: absURL)
                 }
             } else if values.isRegularFile == true, let linkCount = values.linkCount, linkCount > 1 {
                 // Hardlink — can't verify target containment, reject outright
-                removed.append(fileURL.relativePath)
+                removed.append(label)
                 try? fm.removeItem(at: absURL)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
@@ -63,9 +63,12 @@ final class VellumAppSchemeHandler: NSObject, WKURLSchemeHandler {
                 return nil
             }
 
-            // Must be a regular file (not a symlink, device, pipe, etc.)
-            var isDir: ObjCBool = false
-            guard FileManager.default.fileExists(atPath: realPath, isDirectory: &isDir), !isDir.boolValue else {
+            // Must be a regular file — reject directories, symlinks, FIFOs,
+            // device nodes, and anything else that could block or behave
+            // unexpectedly when read via Data(contentsOf:).
+            let realURL = URL(fileURLWithPath: realPath)
+            guard let rv = try? realURL.resourceValues(forKeys: [.isRegularFileKey]),
+                  rv.isRegularFile == true else {
                 return nil
             }
 


### PR DESCRIPTION
Addresses review feedback from PR #3714:

1. **resourceValues throw bypass** (Devin): Changed bare `try` to `try?` in `stripUnsafeLinks` — files where `resourceValues` fails are now treated as suspicious, removed, and added to the unsafe list. This prevents a malicious bundle from using an early I/O error to bypass detection of later symlinks.

2. **Enumerator URL reconstruction** (Codex): When `.producesRelativePathURLs` is not honored by the Foundation implementation, the enumerator returns absolute URLs. The old code unconditionally appended `relativePath` to `root`, building a non-existent path. Now checks `baseURL` to determine whether re-appending is needed.

3. **Regular-file type enforcement** (Codex): Replaced `fileExists(atPath:isDirectory:)` with `resourceValues(forKeys: [.isRegularFileKey])` in `VellumAppSchemeHandler`. The old check only excluded directories; the new check rejects FIFOs, device nodes, sockets, and any non-regular file that could block or behave unexpectedly when read.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
