### PR TITLE
fix: use ancestor-path set for symlink cycle detection in version hash

### DIFF
--- a/assistant/src/__tests__/skill-version-hash.test.ts
+++ b/assistant/src/__tests__/skill-version-hash.test.ts
@@ -163,4 +163,20 @@ describe('computeSkillVersionHash', () => {
 
     expect(hash1).not.toBe(hash2);
   });
+
+  test('two symlinks to same external dir both contribute to hash', () => {
+    const dir = makeTempSkill();
+    const external = makeTempSkill();
+    writeFileSync(join(external, 'lib.ts'), 'export const x = 1;');
+
+    // Only one symlink alias
+    symlinkSync(external, join(dir, 'alias-a'));
+    const hash1 = computeSkillVersionHash(dir);
+
+    // Add a second symlink alias to the same external dir
+    symlinkSync(external, join(dir, 'alias-b'));
+    const hash2 = computeSkillVersionHash(dir);
+
+    expect(hash1).not.toBe(hash2);
+  });
 });

--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -16,9 +16,11 @@ const EXCLUDED_NAMES = new Set([
 
 /**
  * Collect all files under `dir` in sorted order, excluding transient entries.
- * Uses a `visited` set of real directory paths to prevent all symlink cycle types.
+ * Uses an `ancestors` set of real directory paths currently on the recursion
+ * stack to detect symlink cycles without suppressing legitimate duplicate
+ * symlink targets reached via different paths.
  */
-function collectFiles(dir: string, base: string, visited: Set<string> = new Set()): string[] {
+function collectFiles(dir: string, base: string, ancestors: Set<string> = new Set()): string[] {
   const entries: string[] = [];
 
   let realDir: string;
@@ -27,13 +29,14 @@ function collectFiles(dir: string, base: string, visited: Set<string> = new Set(
   } catch {
     return entries;
   }
-  if (visited.has(realDir)) return entries;
-  visited.add(realDir);
+  if (ancestors.has(realDir)) return entries;
+  ancestors.add(realDir);
 
   let items: string[];
   try {
     items = readdirSync(dir).sort();
   } catch {
+    ancestors.delete(realDir);
     return entries;
   }
 
@@ -60,19 +63,20 @@ function collectFiles(dir: string, base: string, visited: Set<string> = new Set(
         continue;
       }
       if (resolvedStat.isDirectory()) {
-        entries.push(...collectFiles(full, base, visited));
+        entries.push(...collectFiles(full, base, ancestors));
       } else if (resolvedStat.isFile()) {
         entries.push(relative(base, full));
       }
       continue;
     }
     if (stat.isDirectory()) {
-      entries.push(...collectFiles(full, base, visited));
+      entries.push(...collectFiles(full, base, ancestors));
     } else if (stat.isFile()) {
       entries.push(relative(base, full));
     }
   }
 
+  ancestors.delete(realDir);
   return entries;
 }
 


### PR DESCRIPTION
Switches collectFiles from a global visited set to an ancestor-path set that only tracks directories on the current recursion stack. This prevents the bug where two independent symlinks to the same external directory (e.g. alias-a -> ext, alias-b -> ext) would only count the first alias, since the second was incorrectly skipped as already visited. The ancestor-path approach still detects true cycles (symlinks back to an ancestor) while allowing legitimate duplicate targets via different paths. Adds a test verifying both symlink aliases contribute to the hash.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
