### PR TITLE
fix: enforce body size limits on actual body instead of Content-Length header

### DIFF
--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -69,15 +69,14 @@ ${app.htmlDefinition}
 const MAX_SHARE_BODY_BYTES = 50 * 1024 * 1024;
 
 export async function handleShareApp(req: Request): Promise<Response> {
-  const contentLength = Number(req.headers.get('content-length'));
-  if (contentLength > MAX_SHARE_BODY_BYTES) {
+  const rawBody = await req.arrayBuffer();
+  if (rawBody.byteLength > MAX_SHARE_BODY_BYTES) {
     return Response.json(
       { error: `Request body too large (limit: ${MAX_SHARE_BODY_BYTES} bytes)` },
       { status: 413 },
     );
   }
 
-  const rawBody = await req.arrayBuffer();
   const bundleData = Buffer.from(rawBody);
 
   if (bundleData.length === 0) {

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -8,15 +8,15 @@ import { validateAttachmentUpload, AttachmentUploadError } from '../../memory/at
 const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
 
 export async function handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
-  const contentLength = Number(req.headers.get('content-length'));
-  if (contentLength > MAX_UPLOAD_BODY_BYTES) {
+  const rawText = await req.text();
+  if (rawText.length > MAX_UPLOAD_BODY_BYTES) {
     return Response.json(
       { error: `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)` },
       { status: 413 },
     );
   }
 
-  const body = await req.json() as {
+  const body = JSON.parse(rawText) as {
     filename?: string;
     mimeType?: string;
     data?: string;


### PR DESCRIPTION
The Content-Length header check in attachment and app upload routes could be bypassed when the header is missing (chunked transfer encoding) or spoofed with a smaller value. This reads the full body first and checks its actual size, ensuring the per-route limits are enforced regardless of headers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
