### PR TITLE
fix: catch AttachmentUploadError in session-attachments to prevent turn abort

### DIFF
--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -3,7 +3,7 @@ import type { UserMessageAttachment } from './ipc-protocol.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { addRule } from '../permissions/trust-store.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
-import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
+import { uploadAttachment, linkAttachmentToMessage, AttachmentUploadError } from '../memory/attachments-store.js';
 import {
   resolveDirectives,
   contentBlocksToDrafts,
@@ -115,12 +115,22 @@ export async function resolveAssistantAttachments(
   if (assistantAttachments.length > 0 && lastAssistantMessageId) {
     for (let i = 0; i < assistantAttachments.length; i++) {
       const draft = assistantAttachments[i];
-      const stored = uploadAttachment(
-        assistantScope,
-        draft.filename,
-        draft.mimeType,
-        draft.dataBase64,
-      );
+      let stored;
+      try {
+        stored = uploadAttachment(
+          assistantScope,
+          draft.filename,
+          draft.mimeType,
+          draft.dataBase64,
+        );
+      } catch (err) {
+        if (err instanceof AttachmentUploadError) {
+          log.warn({ filename: draft.filename, error: err.message }, 'Skipping attachment upload');
+          directiveWarnings.push(`Attachment ${draft.filename} skipped: ${err.message}`);
+          continue;
+        }
+        throw err;
+      }
       linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
       emittedAttachments.push({
         id: stored.id,


### PR DESCRIPTION
The uploadAttachment function can throw AttachmentUploadError for invalid base64 or oversized payloads (added in #3735), but the caller in resolveAssistantAttachments did not catch it. This meant a single bad attachment could abort the entire conversation turn. Wraps the call in a try-catch that logs a warning, adds it to directiveWarnings, and continues processing remaining attachments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
