### PR TITLE
fix: move traverseIncludes JSDoc to correct location

### DIFF
--- a/assistant/src/skills/include-graph.ts
+++ b/assistant/src/skills/include-graph.ts
@@ -35,11 +35,6 @@ export function getImmediateChildren(
   return children;
 }
 
-/**
- * Recursively traverse the include graph starting from the given root skill ID.
- * Returns all visited skill IDs in DFS pre-order.
- * Happy-path only — skips missing children silently.
- */
 export interface IncludeValidationSuccess {
   ok: true;
   visited: string[];
@@ -118,6 +113,11 @@ export function validateIncludes(
   return { ok: true, visited };
 }
 
+/**
+ * Recursively traverse the include graph starting from the given root skill ID.
+ * Returns all visited skill IDs in DFS pre-order.
+ * Happy-path only — skips missing children silently.
+ */
 export function traverseIncludes(
   rootId: string,
   catalogIndex: Map<string, SkillSummary>,


### PR DESCRIPTION
Move the JSDoc comment for traverseIncludes from above IncludeValidationSuccess (where it was misplaced in #3766) to directly above the traverseIncludes function. Addresses review feedback on #3766.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
