### PR TITLE
fix: omit executionTarget from HTTP trust-rule persistence

### DIFF
--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -196,11 +196,13 @@ export async function handleAddTrustRule(
   }
 
   try {
+    // Intentionally omit executionTarget: core tools (bash, file_*, etc.)
+    // have no executionTarget in their PolicyContext, so a rule with one
+    // would never match and users would keep getting re-prompted.
     addRule(confirmation.toolName, pattern, scope, decision, 100, {
       principalKind: confirmation.principalKind,
       principalId: confirmation.principalId,
       principalVersion: confirmation.principalVersion,
-      executionTarget: confirmation.executionTarget,
     });
     log.info(
       { tool: confirmation.toolName, pattern, scope, decision, runId },


### PR DESCRIPTION
Core tools (bash, file_*, etc.) return undefined from buildPolicyContext, so matchesExecutionTarget never matches a rule that has executionTarget set. This caused trust rules created via the /runs/:id/trust-rule endpoint to be non-functional for core tools — users kept getting re-prompted. Removes executionTarget from the addRule call so the rule acts as a wildcard and matches any execution context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
