### PR TITLE
fix: close symlink-based path escape in app-store validateFilePath

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -19,6 +19,7 @@ import {
   unlinkSync,
   rmSync,
   statSync,
+  realpathSync,
 } from 'node:fs';
 import { join, resolve, relative, isAbsolute } from 'node:path';
 import { getDataDir } from '../util/platform.js';
@@ -109,6 +110,16 @@ function validateFilePath(appId: string, path: string): string {
   // Ensure the resolved path is still within the app directory
   if (!resolved.startsWith(appDir + '/') && resolved !== appDir) {
     throw new Error(`Invalid file path: resolves outside app directory`);
+  }
+  // Follow symlinks to the real path so a symlink inside the app directory
+  // cannot escape the boundary. Only check when the target already exists;
+  // writes to new (non-existent) paths are fine — resolve() already handled them.
+  if (existsSync(resolved)) {
+    const real = realpathSync(resolved);
+    const realAppDir = realpathSync(appDir);
+    if (!real.startsWith(realAppDir + '/') && real !== realAppDir) {
+      throw new Error(`Invalid file path: symlink resolves outside app directory`);
+    }
   }
   return resolved;
 }


### PR DESCRIPTION
## Summary
- Add `realpathSync` boundary check in `validateFilePath()` so that symlinks inside app directories cannot escape the intended directory boundary
- Only applies when the target path already exists (new file writes are unaffected since `resolve()` already handles them)
- Follows the same pattern used in `docker.ts` for sandbox root validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
