### PR TITLE
fix: honor one-time send delivery in standalone publish credential flow

### DIFF
--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -4,7 +4,7 @@ import { createHash } from 'node:crypto';
 import { deployHtmlToVercel, deleteVercelDeployment } from '../../services/vercel-deploy.js';
 import { createPublishedPage, getPublishedPageByHash, markDeleted, getPublishedPageByDeploymentId, updatePublishedPage } from '../../memory/published-pages-store.js';
 import { setSecureKey } from '../../security/secure-keys.js';
-import { upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import { getCredentialMetadata, upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { credentialBroker } from '../../tools/credentials/broker.js';
 import type {
   PublishPageRequest,
@@ -88,10 +88,19 @@ export async function handlePublishPage(
         return;
       }
 
-      // Store the credential
-      const storageKey = `credential:vercel:api_token`;
-      setSecureKey(storageKey, secretResult.value);
-      upsertCredentialMetadata('vercel', 'api_token', { allowedTools });
+      if (secretResult.delivery === 'transient_send') {
+        // One-time send: inject for single use without persisting to keychain.
+        // Metadata must exist for broker policy checks.
+        if (!getCredentialMetadata('vercel', 'api_token')) {
+          upsertCredentialMetadata('vercel', 'api_token', { allowedTools });
+        }
+        credentialBroker.injectTransient('vercel', 'api_token', secretResult.value);
+      } else {
+        // Default: persist to keychain
+        const storageKey = `credential:vercel:api_token`;
+        setSecureKey(storageKey, secretResult.value);
+        upsertCredentialMetadata('vercel', 'api_token', { allowedTools });
+      }
 
       // Retry with the newly stored credential
       useResult = await credentialBroker.serverUse({


### PR DESCRIPTION
When a user clicks 'Send Once (not saved)' on the standalone secret prompt during publish, the transient_send delivery mode was being ignored — the Vercel token was always persisted via setSecureKey. This aligns the standalone publish flow with the session-based vault flow by checking secretResult.delivery and using credentialBroker.injectTransient for one-time sends instead of persisting to the keychain.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
