### PR TITLE
fix: defer Sentry.init() until after dotenv loads

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -26,6 +26,7 @@ import { ensurePromptFiles } from '../config/system-prompt.js';
 import { DaemonServer } from './server.js';
 import { getLogger, initLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
+import { initSentry } from '../instrument.js';
 import { startMemoryJobsWorker } from '../memory/jobs-worker.js';
 import { QdrantManager } from '../memory/qdrant-manager.js';
 import { initQdrantClient } from '../memory/qdrant-client.js';
@@ -220,6 +221,7 @@ function loadDotEnv(): void {
 // Entry point for the daemon process itself
 export async function runDaemon(): Promise<void> {
   loadDotEnv();
+  initSentry();
 
   // Migration order matters: first move legacy flat files into the data dir
   // structure, then relocate the data dir into the active workspace, and

--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bun
-import '../instrument.js';
 import * as Sentry from '@sentry/node';
 import { runDaemon } from './lifecycle.js';
 

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -30,28 +30,31 @@ function redactObject(obj: unknown): unknown {
   return obj;
 }
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  release: `vellum-assistant@${APP_VERSION}`,
-  environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
-  sendDefaultPii: false,
-  beforeSend(event) {
-    if (event.exception?.values) {
-      event.exception.values = event.exception.values.map((ex) => ({
-        ...ex,
-        value: ex.value ? redactString(ex.value) : ex.value,
-      }));
-    }
-    if (event.breadcrumbs) {
-      event.breadcrumbs = event.breadcrumbs.map((bc) => ({
-        ...bc,
-        message: bc.message ? redactString(bc.message) : bc.message,
-        data: bc.data ? (redactObject(bc.data) as Record<string, unknown>) : bc.data,
-      }));
-    }
-    if (event.extra) {
-      event.extra = redactObject(event.extra) as Record<string, unknown>;
-    }
-    return event;
-  },
-});
+/** Call after dotenv has loaded so process.env.SENTRY_DSN is available. */
+export function initSentry(): void {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: `vellum-assistant@${APP_VERSION}`,
+    environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
+    sendDefaultPii: false,
+    beforeSend(event) {
+      if (event.exception?.values) {
+        event.exception.values = event.exception.values.map((ex) => ({
+          ...ex,
+          value: ex.value ? redactString(ex.value) : ex.value,
+        }));
+      }
+      if (event.breadcrumbs) {
+        event.breadcrumbs = event.breadcrumbs.map((bc) => ({
+          ...bc,
+          message: bc.message ? redactString(bc.message) : bc.message,
+          data: bc.data ? (redactObject(bc.data) as Record<string, unknown>) : bc.data,
+        }));
+      }
+      if (event.extra) {
+        event.extra = redactObject(event.extra) as Record<string, unknown>;
+      }
+      return event;
+    },
+  });
+}


### PR DESCRIPTION
The previous env-gate PR (#3747) moved the DSN to process.env.SENTRY_DSN, but instrument.ts was imported as a side-effect before runDaemon() called loadDotEnv(). This meant SENTRY_DSN from ~/.vellum/.env was always undefined at init time, silently disabling Sentry.

Fix: wrap Sentry.init() in an exported initSentry() function and call it from runDaemon() immediately after loadDotEnv().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
