### PR TITLE
fix: snapshot all non-skill tools to handle preloaded eager modules

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -192,25 +192,14 @@ export function getAllToolDefinitions(): ToolDefinition[] {
 export async function initializeTools(): Promise<void> {
   const { eagerModules, explicitTools, lazyTools } = await import('./tool-manifest.js');
 
-  // Collect names of tools registered by the manifest so the snapshot
-  // captures exactly the canonical core tools — not test helpers or other
-  // tools that may have been registered before initializeTools() ran.
-  const manifestToolNames = new Set<string>();
-
   // Import tool modules to trigger registration side effects.
   for (const modulePath of eagerModules) {
-    const knownBefore = new Set(tools.keys());
     await import(modulePath);
-    // Detect tools added by the side-effect import.
-    for (const name of tools.keys()) {
-      if (!knownBefore.has(name)) manifestToolNames.add(name);
-    }
   }
 
   // Explicit tool instances — no side-effect import required.
   for (const tool of explicitTools) {
     registerTool(tool);
-    manifestToolNames.add(tool.name);
   }
 
   // Host tools are registered explicitly so host access stays opt-in until
@@ -218,34 +207,30 @@ export async function initializeTools(): Promise<void> {
   const hostTools = [hostFileReadTool, hostFileWriteTool, hostFileEditTool, hostShellTool];
   for (const tool of hostTools) {
     registerTool(tool);
-    manifestToolNames.add(tool.name);
   }
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded
   // from getAllToolDefinitions() since regular chat sessions don't use them.
-  const knownBeforeProxies = new Set(tools.keys());
   registerComputerUseTools();
   registerUiSurfaceTools();
   registerAppTools();
-  for (const name of tools.keys()) {
-    if (!knownBeforeProxies.has(name)) manifestToolNames.add(name);
-  }
 
   // Lazy tools — defer module loading until first invocation.
   for (const descriptor of lazyTools) {
     registerLazyTool(descriptor);
-    manifestToolNames.add(descriptor.name);
   }
 
-  // Build the snapshot from exactly the manifest-registered tools.
-  // This avoids capturing test-only or session-specific tools that may
-  // have been registered before initializeTools() ran.
+  // Snapshot every non-skill tool currently in the registry.  This captures
+  // eager-module tools even when the module was already imported before
+  // initializeTools() ran (ESM cache hit) — their tools are in the registry
+  // regardless of whether the import triggered side effects this time.
+  // Skill-origin tools are excluded since they are session-scoped and
+  // managed separately by registerSkillTools/unregisterSkillTools.
   if (!coreToolsSnapshot) {
     coreToolsSnapshot = new Map<string, Tool>();
-    for (const name of manifestToolNames) {
-      const tool = tools.get(name);
-      if (tool) coreToolsSnapshot.set(name, tool);
+    for (const [name, tool] of tools) {
+      if (tool.origin !== 'skill') coreToolsSnapshot.set(name, tool);
     }
   }
 


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on PR #3708.

The previous approach diffed `tools.keys()` before/after each eager module import to detect newly registered tools. This missed tools from modules already imported by test files (e.g. `checker.test.ts` imports `scaffold-managed` and `delete-managed` directly), because ESM caching makes the re-import a no-op — no new tools appear in the diff.

Fixes this by snapshotting all non-skill tools (`origin !== 'skill'`) in the registry after all manifest registrations complete. This correctly captures eager-module tools regardless of whether they were pre-imported, since they're in the registry either way. Skill-origin tools are excluded since they're session-scoped and managed separately.

## Test plan
- [x] `bun test registry.test.ts` — 31/31 pass
- [x] `bun test checker.test.ts` — 277/277 pass (this file pre-imports eager modules)
- [x] `bunx tsc --noEmit` — no type errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
