### PR TITLE
fix: enforce 0o600 file permissions on trust.json

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { v4 as uuid } from 'uuid';
 import { minimatch } from 'minimatch';
@@ -237,8 +237,11 @@ function saveToDisk(rules: TrustRule[]): void {
     data.starterBundleAccepted = true;
   }
   const tmpPath = path + '.tmp.' + process.pid;
-  writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
   renameSync(tmpPath, path);
+  // Enforce owner-only permissions even if the file already existed with
+  // wider permissions. Matches the pattern used in encrypted-store.ts.
+  chmodSync(path, 0o600);
 }
 
 function getRules(): TrustRule[] {


### PR DESCRIPTION
## Summary
- Enforce owner-only (0o600) file permissions on `trust.json` via `chmodSync` after every write
- Set `mode: 0o600` on the temp file write as well, so the file is never world-readable even briefly
- Matches the security pattern already established in `encrypted-store.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
