### PR TITLE
fix: increase share link token entropy from 72 to 128 bits

### DIFF
--- a/assistant/src/memory/shared-app-links-store.ts
+++ b/assistant/src/memory/shared-app-links-store.ts
@@ -24,7 +24,9 @@ export interface SharedAppLinkRecord {
 const SHARE_LINK_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
 function generateShareToken(): string {
-  return randomBytes(9).toString('base64url').slice(0, 12);
+  // 16 bytes = 128 bits of entropy (matches UUID standard), base64url-encoded
+  // to a 22-character URL-safe string.
+  return randomBytes(16).toString('base64url');
 }
 
 /** Delete all rows whose effective expiry has passed (including legacy NULL rows). */


### PR DESCRIPTION
## Summary
- Increase share link token from 9 bytes (72 bits / 12 chars) to 16 bytes (128 bits / 22 chars)
- Matches the entropy standard used by UUIDs throughout the codebase
- No schema migration needed — the `share_token` column is `text` with no length constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
