### PR TITLE
fix: conditionally strip auth header in runtime proxy

### DIFF
--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -83,6 +83,25 @@ describe("runtime proxy auth enforcement", () => {
     expect(body.ok).toBe(true);
   });
 
+  test("auth required: strips authorization header from upstream request", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = mock(async (_input: any, init?: any) => {
+      capturedHeaders = init?.headers;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health", {
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    await handler(req);
+
+    expect(capturedHeaders!.has("authorization")).toBe(false);
+  });
+
   test("auth not required: proxies without token", async () => {
     mockUpstream();
     const handler = createRuntimeProxyHandler(

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -193,7 +193,7 @@ describe("runtime proxy handler", () => {
     expect(capturedSignal).toBeInstanceOf(AbortSignal);
   });
 
-  test("does not forward authorization header to upstream", async () => {
+  test("forwards authorization header when auth is not required", async () => {
     let capturedHeaders: Headers | undefined;
     globalThis.fetch = mock(async (_input: any, init?: any) => {
       capturedHeaders = init?.headers;
@@ -202,11 +202,11 @@ describe("runtime proxy handler", () => {
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/health", {
-      headers: { authorization: "Bearer my-secret-token" },
+      headers: { authorization: "Bearer upstream-token" },
     });
     await handler(req);
 
-    expect(capturedHeaders!.has("authorization")).toBe(false);
+    expect(capturedHeaders!.get("authorization")).toBe("Bearer upstream-token");
   });
 
   test("truncates long upstream error bodies in logs", async () => {

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -61,7 +61,12 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");
-    reqHeaders.delete("authorization");
+    // Only strip the authorization header when the gateway consumed it for its
+    // own auth check. When auth is not required, the header may be intended for
+    // the upstream service and must be forwarded.
+    if (config.runtimeProxyRequireAuth) {
+      reqHeaders.delete("authorization");
+    }
 
     // Use a manual AbortController so the timeout only covers the connection
     // phase (waiting for response headers). Once headers arrive, the timeout is


### PR DESCRIPTION
Only strip the Authorization header from upstream proxy requests when the gateway's own auth is enabled (runtimeProxyRequireAuth). When auth is not required, the header is forwarded to the upstream service, allowing authenticated upstream APIs to work through the proxy. Addresses Codex review feedback on #3744.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
