### PR TITLE
fix: address sidebar IA review feedback (#3785)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -242,6 +242,7 @@ extension AppDelegate {
     @objc func openAppById(_ sender: NSMenuItem) {
         guard let appId = sender.representedObject as? String else { return }
         showMainWindow()
+        mainWindow?.appListManager.recordAppOpen(id: appId, name: sender.title)
         try? daemonClient.sendAppOpen(appId: appId)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -96,25 +96,29 @@ final class AppListManager: ObservableObject {
     }
 
     /// Move an app to a new position (for drag-and-drop reorder).
-    func moveApp(sourceId: String, beforeId: String) {
+    /// Returns `true` if the reorder was actually performed.
+    @discardableResult
+    func moveApp(sourceId: String, beforeId: String) -> Bool {
         guard let sourceIdx = apps.firstIndex(where: { $0.id == sourceId }),
-              let targetIdx = apps.firstIndex(where: { $0.id == beforeId }) else { return }
+              let targetIdx = apps.firstIndex(where: { $0.id == beforeId }) else { return false }
         let targetApp = apps[targetIdx]
 
-        if targetApp.isPinned {
-            if !apps[sourceIdx].isPinned {
-                apps[sourceIdx].isPinned = true
-            }
-            let targetOrder = targetApp.pinnedOrder ?? 0
-            apps[sourceIdx].pinnedOrder = targetOrder
-            for i in apps.indices where apps[i].isPinned && apps[i].id != sourceId {
-                if let order = apps[i].pinnedOrder, order >= targetOrder {
-                    apps[i].pinnedOrder = order + 1
-                }
-            }
-            recompactPinnedOrders()
+        // Only reorder when the drop target is pinned
+        guard targetApp.isPinned else { return false }
+
+        if !apps[sourceIdx].isPinned {
+            apps[sourceIdx].isPinned = true
         }
+        let targetOrder = targetApp.pinnedOrder ?? 0
+        apps[sourceIdx].pinnedOrder = targetOrder
+        for i in apps.indices where apps[i].isPinned && apps[i].id != sourceId {
+            if let order = apps[i].pinnedOrder, order >= targetOrder {
+                apps[i].pinnedOrder = order + 1
+            }
+        }
+        recompactPinnedOrders()
         save()
+        return true
     }
 
     // MARK: - Persistence

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -144,6 +144,11 @@ struct MainWindowView: View {
             if let activePanel = self.windowState.activePanel, activePanel != .generated {
                 return
             }
+            self.appListManager.recordAppOpen(
+                id: homeBase.appId,
+                name: homeBase.preview.title,
+                icon: homeBase.preview.icon
+            )
             try? self.daemonClient.sendAppOpen(appId: homeBase.appId)
         }
 
@@ -481,8 +486,7 @@ struct MainWindowView: View {
                                     guard let droppedId = items.first,
                                           let sourceUUID = UUID(uuidString: droppedId),
                                           sourceUUID != thread.id else { return false }
-                                    threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
-                                    return true
+                                    return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
                                 } isTargeted: { _ in }
                         }
 
@@ -511,8 +515,7 @@ struct MainWindowView: View {
                                     .dropDestination(for: String.self) { items, _ in
                                         guard let droppedId = items.first,
                                               droppedId != app.id else { return false }
-                                        appListManager.moveApp(sourceId: droppedId, beforeId: app.id)
-                                        return true
+                                        return appListManager.moveApp(sourceId: droppedId, beforeId: app.id)
                                     } isTargeted: { _ in }
                             }
 
@@ -630,7 +633,7 @@ struct MainWindowView: View {
                 }
             }
             Button("Open") {
-                try? daemonClient.sendAppOpen(appId: app.id)
+                openAppInWorkspace(app: app)
             }
             Divider()
             Button("Remove from Recents", role: .destructive) {
@@ -790,6 +793,9 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
                     windowState.activePanel = .generated
                     windowState.isDynamicExpanded = true
+                },
+                onRecordAppOpen: { id, name, icon, appType in
+                    appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
                 }
             )
         case .generated:
@@ -800,6 +806,9 @@ struct MainWindowView: View {
                 onOpenApp: { surfaceMsg in
                     windowState.activeDynamicSurface = surfaceMsg
                     windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
+                },
+                onRecordAppOpen: { id, name, icon, appType in
+                    appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
                 }
             )
         case .threadList:
@@ -849,6 +858,9 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
                     windowState.activePanel = .generated
                     windowState.isDynamicExpanded = true
+                },
+                onRecordAppOpen: { id, name, icon, appType in
+                    appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
                 }
             )
         } else if windowState.isDynamicExpanded && windowState.activePanel == .generated {
@@ -873,6 +885,9 @@ struct MainWindowView: View {
                     onOpenApp: { surfaceMsg in
                         windowState.activeDynamicSurface = surfaceMsg
                         windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
+                    },
+                    onRecordAppOpen: { id, name, icon, appType in
+                        appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
                     }
                 )
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -6,6 +6,8 @@ struct AppDirectoryView: View {
     let daemonClient: DaemonClient
     let onBack: () -> Void
     let onOpenApp: (UiSurfaceShowMessage) -> Void
+    /// Called to record an app open in the sidebar's recent apps list.
+    var onRecordAppOpen: ((_ id: String, _ name: String, _ icon: String?, _ appType: String?) -> Void)?
 
     @State private var searchText = ""
     @State private var displayItems: [DirectoryAppItem] = []
@@ -302,6 +304,7 @@ struct AppDirectoryView: View {
 
     @MainActor private func openApp(_ item: DirectoryAppItem) {
         if let localId = item.localAppId {
+            onRecordAppOpen?(localId, item.name, item.icon, item.appType)
             try? daemonClient.sendAppOpen(appId: localId)
         } else if let uuid = item.sharedUUID {
             let safeName = htmlEscape(item.name)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -28,6 +28,8 @@ struct GeneratedPanel: View {
     let daemonClient: DaemonClient
     /// When set, app opens route to the workspace instead of a floating NSPanel.
     var onOpenApp: ((UiSurfaceShowMessage) -> Void)?
+    /// Called to record an app open in the sidebar's recent apps list.
+    var onRecordAppOpen: ((_ id: String, _ name: String, _ icon: String?, _ appType: String?) -> Void)?
 
     @State private var searchText = ""
     @State private var displayItems: [DisplayAppItem] = []
@@ -46,11 +48,12 @@ struct GeneratedPanel: View {
     @State private var slackSharingAppId: String?
     @State private var slackShareResult: (appId: String, success: Bool)?
 
-    init(onClose: @escaping () -> Void, isExpanded: Binding<Bool> = .constant(false), daemonClient: DaemonClient, onOpenApp: ((UiSurfaceShowMessage) -> Void)? = nil) {
+    init(onClose: @escaping () -> Void, isExpanded: Binding<Bool> = .constant(false), daemonClient: DaemonClient, onOpenApp: ((UiSurfaceShowMessage) -> Void)? = nil, onRecordAppOpen: ((_ id: String, _ name: String, _ icon: String?, _ appType: String?) -> Void)? = nil) {
         self.onClose = onClose
         self._isExpanded = isExpanded
         self.daemonClient = daemonClient
         self.onOpenApp = onOpenApp
+        self.onRecordAppOpen = onRecordAppOpen
     }
 
     var body: some View {
@@ -569,6 +572,7 @@ struct GeneratedPanel: View {
             // Local apps: ask the daemon to open via ui_surface_show.
             // When onOpenApp is set, the daemon's response will be intercepted
             // by SurfaceManager and routed to the workspace (see PR 5).
+            onRecordAppOpen?(localId, item.name, item.icon, item.appType)
             try? daemonClient.sendAppOpen(appId: localId)
         } else if let uuid = item.sharedUUID {
             // Shared apps: construct surface from unpacked files on disk

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -92,6 +92,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         let threadId = thread.id
         viewModel.onFirstUserMessage = { [weak self] text in
             self?.updateThreadTitle(id: threadId, title: "Untitled")
+            self?.updateLastInteracted(threadId: threadId)
             Task { @MainActor in
                 await self?.generateTitle(for: threadId, userMessage: text)
             }
@@ -218,6 +219,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func selectThread(id: UUID) {
         guard threads.contains(where: { $0.id == id }) else { return }
         activeThreadId = id
+        updateLastInteracted(threadId: id)
     }
 
     /// Returns true if the thread has at least one user message.
@@ -283,27 +285,29 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Move a thread to a new position in the visible list (for drag-and-drop reorder).
     /// If the source thread is pinned, reorder among pinned items.
     /// If unpinned, pin it and insert at the target position.
-    func moveThread(sourceId: UUID, beforeId: UUID) {
+    @discardableResult
+    func moveThread(sourceId: UUID, beforeId: UUID) -> Bool {
         guard let sourceIdx = threads.firstIndex(where: { $0.id == sourceId }),
-              let targetIdx = threads.firstIndex(where: { $0.id == beforeId }) else { return }
+              let targetIdx = threads.firstIndex(where: { $0.id == beforeId }) else { return false }
         let targetThread = threads[targetIdx]
 
-        // If dropping onto a pinned item, pin the source too and reorder
-        if targetThread.isPinned {
-            if !threads[sourceIdx].isPinned {
-                threads[sourceIdx].isPinned = true
-            }
-            // Set pinnedOrder to place before the target
-            let targetOrder = targetThread.pinnedOrder ?? 0
-            threads[sourceIdx].pinnedOrder = targetOrder
-            // Bump all pinned items at or after targetOrder (except source)
-            for i in threads.indices where threads[i].isPinned && threads[i].id != sourceId {
-                if let order = threads[i].pinnedOrder, order >= targetOrder {
-                    threads[i].pinnedOrder = order + 1
-                }
-            }
-            recompactPinnedOrders()
+        // Only reorder when the drop target is pinned
+        guard targetThread.isPinned else { return false }
+
+        if !threads[sourceIdx].isPinned {
+            threads[sourceIdx].isPinned = true
         }
+        // Set pinnedOrder to place before the target
+        let targetOrder = targetThread.pinnedOrder ?? 0
+        threads[sourceIdx].pinnedOrder = targetOrder
+        // Bump all pinned items at or after targetOrder (except source)
+        for i in threads.indices where threads[i].isPinned && threads[i].id != sourceId {
+            if let order = threads[i].pinnedOrder, order >= targetOrder {
+                threads[i].pinnedOrder = order + 1
+            }
+        }
+        recompactPinnedOrders()
+        return true
     }
 
     private func recompactPinnedOrders() {


### PR DESCRIPTION
Addresses reviewer feedback from #3785:

1. Wire recordAppOpen to all app-open entry points so sidebar Apps section populates from any source
2. Call updateLastInteracted when threads are interacted with so recents sort correctly  
3. Make moveThread/moveApp return Bool and use in drop handlers to avoid false-positive drop animations

Feedback PR for #3785
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
