### PR TITLE
fix: narrow credit card regex and remove redundant PII comments

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -3,9 +3,9 @@ import { APP_VERSION } from "./version.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
 const PII_PATTERNS = [
-  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, // email
-  /\b(?:\d[ -]*?){13,19}\b/g, // credit card
-  /\b\d{3}-\d{2}-\d{4}\b/g, // SSN
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+  /\b(?:\d{4}[- ]){3}\d{1,7}\b/g,
+  /\b\d{3}-\d{2}-\d{4}\b/g,
 ];
 
 function redactString(value: string): string {


### PR DESCRIPTION
Addresses review feedback from PR #3749:

- Replace overly broad credit card regex that matched any 13-19 digit sequence (timestamps, trace IDs, etc.) with a pattern requiring digit grouping typical of formatted card numbers
- Remove what-only inline comments (email, credit card, SSN) per repo comment policy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
