### PR TITLE
fix: add fail-closed fallback for unhandled include validation errors

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -67,6 +67,10 @@ export class SkillLoadTool implements Tool {
             isError: true,
           };
         }
+        return {
+          content: `Error: skill "${skill.id}" has an invalid include graph`,
+          isError: true,
+        };
       }
     }
 


### PR DESCRIPTION
Adds a generic error return after the known 'missing' and 'cycle' error checks in skill_load's include validation. Without this fallback, if the IncludeValidationResult union is ever extended with a new error variant, the code silently falls through to the success path — violating the stated fail-closed contract. Addresses review feedback from PR #3774.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
