### PR TITLE
fix: remove dead useThreadDrawer setting from SettingsPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -16,7 +16,6 @@ struct SettingsPanel: View {
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var connectingIntegration: String?
     @State private var integrationError: (id: String, message: String)?
-    @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var accessibilityGranted: Bool = false
     @State private var screenRecordingGranted: Bool = false
@@ -237,18 +236,6 @@ struct SettingsPanel: View {
                         .frame(width: 200)
                     }
 
-                    HStack {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Show thread list drawer")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Text("Access chat history from a left-side drawer instead of tabs")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        Spacer()
-                        VToggle(isOn: $useThreadDrawer)
-                    }
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
- Remove vestigial `useThreadDrawer` AppStorage and toggle from SettingsPanel
- Tab mode (ThreadTabBar) was removed in #3785; this setting no longer does anything
- Addresses review feedback from #3781 (bot reviewers flagged tab-mode archive path as broken, which was resolved by #3785 removing tab mode entirely — this cleans up the leftover dead code)

## Test plan
- Build compiles successfully
- Settings panel no longer shows the 'Show thread list drawer' toggle
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
