### PR TITLE
fix: gateway sends RUNTIME_BEARER_TOKEN to runtime on all API calls

### DIFF
--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -14,6 +14,7 @@ function withEnv(overrides: Record<string, string | undefined>, fn: () => void) 
     ...Object.keys(overrides),
     "GATEWAY_RUNTIME_PROXY_ENABLED",
     "GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH",
+    "RUNTIME_BEARER_TOKEN",
     "RUNTIME_PROXY_BEARER_TOKEN",
     "GATEWAY_ASSISTANT_ROUTING_JSON",
     "GATEWAY_DEFAULT_ASSISTANT_ID",
@@ -143,5 +144,21 @@ describe("config: runtime proxy flags", () => {
         expect(config.runtimeProxyRequireAuth).toBe(true);
       },
     );
+  });
+});
+
+describe("config: runtime bearer token", () => {
+  test("runtimeBearerToken is undefined when RUNTIME_BEARER_TOKEN is unset", () => {
+    withEnv({}, () => {
+      const config = loadConfig();
+      expect(config.runtimeBearerToken).toBeUndefined();
+    });
+  });
+
+  test("runtimeBearerToken is set from RUNTIME_BEARER_TOKEN env var", () => {
+    withEnv({ RUNTIME_BEARER_TOKEN: "rt-secret" }, () => {
+      const config = loadConfig();
+      expect(config.runtimeBearerToken).toBe("rt-secret");
+    });
   });
 });

--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -12,6 +12,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     unmappedPolicy: "reject",
     port: 7830,
+    runtimeBearerToken: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: undefined,

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -12,6 +12,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     unmappedPolicy: "reject",
     port: 7830,
+    runtimeBearerToken: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: undefined,

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -12,6 +12,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   defaultAssistantId: undefined,
   unmappedPolicy: "reject",
   port: 7830,
+  runtimeBearerToken: undefined,
   runtimeProxyEnabled: false,
   runtimeProxyRequireAuth: true,
   runtimeProxyBearerToken: undefined,
@@ -146,6 +147,36 @@ describe("forwardToRuntime", () => {
     expect(attachments[0].mimeType).toBe("image/png");
     expect(attachments[0].sizeBytes).toBe(1024);
     expect(attachments[0].kind).toBe("generated_image");
+  });
+
+  test("sends Authorization header when runtimeBearerToken is configured", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(successBody), { status: 200 }),
+      ),
+    );
+
+    const config = makeConfig({ runtimeBearerToken: "my-secret-token" });
+    await forwardToRuntime(config, "assistant-a", payload);
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer my-secret-token");
+  });
+
+  test("omits Authorization header when runtimeBearerToken is undefined", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(successBody), { status: 200 }),
+      ),
+    );
+
+    const config = makeConfig();
+    await forwardToRuntime(config, "assistant-a", payload);
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
   });
 });
 

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -14,6 +14,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     unmappedPolicy: "reject",
     port: 7830,
+    runtimeBearerToken: undefined,
     runtimeProxyEnabled: true,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: TOKEN,

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -12,6 +12,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     unmappedPolicy: "reject",
     port: 7830,
+    runtimeBearerToken: undefined,
     runtimeProxyEnabled: true,
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: undefined,

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -12,6 +12,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   defaultAssistantId: undefined,
   unmappedPolicy: "reject",
   port: 7830,
+  runtimeBearerToken: undefined,
   runtimeProxyEnabled: false,
   runtimeProxyRequireAuth: true,
   runtimeProxyBearerToken: undefined,

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -17,6 +17,8 @@ export type GatewayConfig = {
   maxWebhookPayloadBytes: number;
   port: number;
   routingEntries: RoutingEntry[];
+  /** Bearer token sent to the assistant runtime on gateway-to-runtime calls. */
+  runtimeBearerToken: string | undefined;
   runtimeInitialBackoffMs: number;
   runtimeMaxRetries: number;
   runtimeProxyBearerToken: string | undefined;
@@ -114,6 +116,9 @@ export function loadConfig(): GatewayConfig {
     );
   }
   const runtimeProxyRequireAuth = proxyRequireAuthRaw !== "false";
+
+  const runtimeBearerToken =
+    process.env.RUNTIME_BEARER_TOKEN || undefined;
 
   const runtimeProxyBearerToken =
     process.env.RUNTIME_PROXY_BEARER_TOKEN || undefined;
@@ -217,6 +222,7 @@ export function loadConfig(): GatewayConfig {
     maxWebhookPayloadBytes,
     port,
     routingEntries,
+    runtimeBearerToken,
     runtimeInitialBackoffMs,
     runtimeMaxRetries,
     runtimeProxyBearerToken,

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -68,6 +68,11 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
       reqHeaders.delete("authorization");
     }
 
+    // Add the runtime's bearer token so the upstream accepts the request
+    if (config.runtimeBearerToken) {
+      reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+    }
+
     // Use a manual AbortController so the timeout only covers the connection
     // phase (waiting for response headers). Once headers arrive, the timeout is
     // cleared so streaming responses (SSE, chunked) can run indefinitely.

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -3,6 +3,15 @@ import { getLogger } from "../logger.js";
 
 const log = getLogger("runtime-client");
 
+/** Build common headers for runtime requests, including auth when configured. */
+function runtimeHeaders(config: GatewayConfig, extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = { ...extra };
+  if (config.runtimeBearerToken) {
+    headers["Authorization"] = `Bearer ${config.runtimeBearerToken}`;
+  }
+  return headers;
+}
+
 /**
  * Thrown when the assistant rejects an attachment for a non-retriable reason
  * (e.g. unsupported MIME type, dangerous file extension). Callers can use
@@ -72,7 +81,7 @@ export async function forwardToRuntime(
     try {
       const response = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
         body: JSON.stringify(payload),
         signal: AbortSignal.timeout(config.runtimeTimeoutMs),
       });
@@ -130,7 +139,7 @@ export async function resetConversation(
 
   const response = await fetch(url, {
     method: "DELETE",
-    headers: { "Content-Type": "application/json" },
+    headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ sourceChannel, externalChatId }),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
   });
@@ -160,6 +169,7 @@ export async function downloadAttachment(
 
   const response = await fetch(url, {
     method: "GET",
+    headers: runtimeHeaders(config),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
   });
 
@@ -180,7 +190,7 @@ export async function uploadAttachment(
 
   const response = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify(input),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
   });


### PR DESCRIPTION
Addresses feedback from PR #3732: the gateway runtime client and runtime proxy were not sending an Authorization header to the runtime server, causing 401 errors when bearer token auth is enabled.

Changes:
- Add runtimeBearerToken field to GatewayConfig, read from RUNTIME_BEARER_TOKEN env var
- Add Authorization header to all gateway-to-runtime fetch calls (forwardToRuntime, resetConversation, downloadAttachment, uploadAttachment)
- Add Authorization header to runtime proxy upstream requests
- Update all test config objects to include the new field
- Add tests for the new config field and Authorization header behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
