### PR TITLE
fix: eliminate no-explicit-any lint errors in browser and test modules

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -2132,7 +2132,7 @@ describe('includes metadata does not auto-activate child skill tools', () => {
   test('parent with includes — only parent tools projected when only parent marker present', () => {
     // Parent skill declares child in its includes metadata
     const parentSkill = makeSkill('parent-skill');
-    (parentSkill as any).includes = ['child-skill'];
+    parentSkill.includes = ['child-skill'];
 
     mockCatalog = [parentSkill, makeSkill('child-skill')];
     mockManifests = {
@@ -2158,7 +2158,7 @@ describe('includes metadata does not auto-activate child skill tools', () => {
 
   test('child tools appear only after explicit child loaded_skill marker', () => {
     const parentSkill = makeSkill('parent-skill');
-    (parentSkill as any).includes = ['child-skill'];
+    parentSkill.includes = ['child-skill'];
 
     mockCatalog = [parentSkill, makeSkill('child-skill')];
     mockManifests = {
@@ -2180,9 +2180,9 @@ describe('includes metadata does not auto-activate child skill tools', () => {
 
   test('child tools are absent even with deep include chain — only markers matter', () => {
     const grandparent = makeSkill('grandparent');
-    (grandparent as any).includes = ['parent'];
+    grandparent.includes = ['parent'];
     const parent = makeSkill('parent');
-    (parent as any).includes = ['child'];
+    parent.includes = ['child'];
 
     mockCatalog = [grandparent, parent, makeSkill('child')];
     mockManifests = {

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -46,6 +46,24 @@ export type Page = {
   keyboard: { press(key: string): Promise<void> };
 };
 
+type ScreencastFrameMetadata = {
+  offsetTop: number;
+  pageScaleFactor: number;
+  scrollOffsetX: number;
+  scrollOffsetY: number;
+  timestamp: number;
+};
+
+type CDPSession = {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  on(event: string, handler: (params: Record<string, unknown>) => void): void;
+  detach(): Promise<void>;
+};
+
+type RawPlaywrightPage = {
+  context(): { newCDPSession(page: unknown): Promise<CDPSession> };
+};
+
 type LaunchFn = (userDataDir: string, options: { headless: boolean }) => Promise<BrowserContext>;
 
 let launchPersistentContext: LaunchFn | null = null;
@@ -68,9 +86,9 @@ class BrowserManager {
   private contextCreating: Promise<BrowserContext> | null = null;
   private contextCloseHandler: ((...args: unknown[]) => void) | null = null;
   private pages = new Map<string, Page>();
-  private rawPages = new Map<string, any>();
-  private cdpSessions = new Map<string, any>();
-  private screencastCallbacks = new Map<string, (frame: { data: string; metadata: any }) => void>();
+  private rawPages = new Map<string, unknown>();
+  private cdpSessions = new Map<string, CDPSession>();
+  private screencastCallbacks = new Map<string, (frame: { data: string; metadata: ScreencastFrameMetadata }) => void>();
   private snapshotMaps = new Map<string, Map<string, string>>();
 
   private async ensureContext(): Promise<BrowserContext> {
@@ -223,8 +241,8 @@ class BrowserManager {
     }
   }
 
-  async startScreencast(sessionId: string, onFrame: (frame: { data: string; metadata: any }) => void): Promise<void> {
-    const rawPage = this.rawPages.get(sessionId);
+  async startScreencast(sessionId: string, onFrame: (frame: { data: string; metadata: ScreencastFrameMetadata }) => void): Promise<void> {
+    const rawPage = this.rawPages.get(sessionId) as RawPlaywrightPage | undefined;
     if (!rawPage) throw new Error('No page for session');
 
     // Stop any existing screencast before creating a new CDP session
@@ -234,8 +252,8 @@ class BrowserManager {
     this.cdpSessions.set(sessionId, cdp);
     this.screencastCallbacks.set(sessionId, onFrame);
 
-    cdp.on('Page.screencastFrame', (params: any) => {
-      onFrame({ data: params.data, metadata: params.metadata });
+    cdp.on('Page.screencastFrame', (params) => {
+      onFrame({ data: params.data as string, metadata: params.metadata as ScreencastFrameMetadata });
       cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId }).catch(() => {});
     });
 

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,18 +1,18 @@
 import { v4 as uuid } from 'uuid';
 import { browserManager } from './browser-manager.js';
-import type { BrowserViewSurfaceData, BrowserFrame } from '../../daemon/ipc-contract.js';
+import type { BrowserViewSurfaceData, BrowserFrame, ServerMessage } from '../../daemon/ipc-contract.js';
 
 // Track active screencast sessions
 const activeScreencasts = new Map<string, { surfaceId: string }>();
 
 // Registry of sendToClient callbacks per session
-const sessionSenders = new Map<string, (msg: any) => void>();
+const sessionSenders = new Map<string, (msg: ServerMessage) => void>();
 
 /**
  * Register a sendToClient callback for a session.
  * Called from session-tool-setup when the session is created.
  */
-export function registerSessionSender(sessionId: string, sendToClient: (msg: any) => void): void {
+export function registerSessionSender(sessionId: string, sendToClient: (msg: ServerMessage) => void): void {
   sessionSenders.set(sessionId, sendToClient);
 }
 
@@ -23,13 +23,13 @@ export function unregisterSessionSender(sessionId: string): void {
   sessionSenders.delete(sessionId);
 }
 
-function getSender(sessionId: string): ((msg: any) => void) | undefined {
+function getSender(sessionId: string): ((msg: ServerMessage) => void) | undefined {
   return sessionSenders.get(sessionId);
 }
 
 export async function ensureScreencast(
   sessionId: string,
-  sendToClient: (msg: any) => void,
+  sendToClient: (msg: ServerMessage) => void,
 ): Promise<void> {
   if (activeScreencasts.has(sessionId)) return;
 
@@ -83,7 +83,7 @@ export async function ensureScreencast(
 
 export function updateBrowserStatus(
   sessionId: string,
-  sendToClient: (msg: any) => void,
+  sendToClient: (msg: ServerMessage) => void,
   status: 'navigating' | 'idle' | 'interacting',
   actionText?: string,
   currentUrl?: string,
@@ -105,7 +105,7 @@ export function updateBrowserStatus(
 
 export async function updatePagesList(
   sessionId: string,
-  sendToClient: (msg: any) => void,
+  sendToClient: (msg: ServerMessage) => void,
 ): Promise<void> {
   const state = activeScreencasts.get(sessionId);
   if (!state) return;
@@ -127,7 +127,7 @@ export async function updatePagesList(
 
 export async function stopBrowserScreencast(
   sessionId: string,
-  sendToClient: (msg: any) => void,
+  sendToClient: (msg: ServerMessage) => void,
 ): Promise<void> {
   const state = activeScreencasts.get(sessionId);
   if (!state) return;
@@ -172,7 +172,7 @@ export async function getElementBounds(
 
 export function updateHighlights(
   sessionId: string,
-  sendToClient: (msg: any) => void,
+  sendToClient: (msg: ServerMessage) => void,
   highlights: Array<{ x: number; y: number; w: number; h: number; label: string }>,
 ): void {
   const state = activeScreencasts.get(sessionId);


### PR DESCRIPTION
## Summary
- Replace `(msg: any)` with `(msg: ServerMessage)` across all `sendToClient` callbacks in `browser-screencast.ts`
- Add structural types (`CDPSession`, `RawPlaywrightPage`, `ScreencastFrameMetadata`) in `browser-manager.ts` to replace `any` for CDP sessions, raw Playwright pages, and screencast frame metadata
- Remove unnecessary `as any` casts in `session-skill-tools.test.ts` — `includes` is already an optional property on `SkillSummary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
