### PR TITLE
fix: add fallback return in include validation for fail-closed behavior

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -67,6 +67,10 @@ export class SkillLoadTool implements Tool {
             isError: true,
           };
         }
+        return {
+          content: `Error: skill "${skill.id}" has an invalid include graph`,
+          isError: true,
+        };
       }
     }
 


### PR DESCRIPTION
Add a fallback error return after the known error variant checks in skill_load's include validation block. Without it, an unknown validation error variant would silently fall through to the success path, violating the stated fail-closed contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
