### PR TITLE
fix: add missing secretDetection mock config and browser_frame snapshot

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1588,6 +1588,22 @@ exports[`IPC message snapshots ServerMessage types app_files_changed serializes 
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types browser_frame serializes to expected JSON 1`] = `
+{
+  "frame": "base64-jpeg-data",
+  "metadata": {
+    "offsetTop": 0,
+    "pageScaleFactor": 1,
+    "scrollOffsetX": 0,
+    "scrollOffsetY": 0,
+    "timestamp": 1700000000,
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "browser_frame",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types accept_starter_bundle_response serializes to expected JSON 1`] = `
 {
   "accepted": true,

--- a/assistant/src/__tests__/runtime-runs-http.test.ts
+++ b/assistant/src/__tests__/runtime-runs-http.test.ts
@@ -39,6 +39,7 @@ mock.module('../config/loader.js', () => ({
     apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
   }),
 }));
 


### PR DESCRIPTION
## Summary
- Add `secretDetection: { enabled: false }` to the mock config in `runtime-runs-http.test.ts` — the test was crashing with `TypeError: undefined is not an object (evaluating 'config.secretDetection.enabled')` because `checkIngressForSecrets` reads `config.secretDetection` which was missing from the mock.
- Add the missing `browser_frame` snapshot to `ipc-snapshot.test.ts.snap` — the test fixture was added but the snapshot was never generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
