### PR TITLE
fix: use byte length for upload body size check

### DIFF
--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -8,15 +8,15 @@ import { validateAttachmentUpload, AttachmentUploadError } from '../../memory/at
 const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
 
 export async function handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
-  const rawText = await req.text();
-  if (rawText.length > MAX_UPLOAD_BODY_BYTES) {
+  const rawBody = await req.arrayBuffer();
+  if (rawBody.byteLength > MAX_UPLOAD_BODY_BYTES) {
     return Response.json(
       { error: `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)` },
       { status: 413 },
     );
   }
 
-  const body = JSON.parse(rawText) as {
+  const body = JSON.parse(new TextDecoder().decode(rawBody)) as {
     filename?: string;
     mimeType?: string;
     data?: string;


### PR DESCRIPTION
Use req.arrayBuffer() + byteLength instead of rawText.length for accurate byte-level size checking in handleUploadAttachment, consistent with handleShareApp. Addresses review feedback on #3803.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
