### PR TITLE
fix: restore explicit error-type assertions in include-graph tests

### DIFF
--- a/assistant/src/__tests__/skill-include-graph.test.ts
+++ b/assistant/src/__tests__/skill-include-graph.test.ts
@@ -158,10 +158,13 @@ describe('validateIncludes — missing detection', () => {
     const index = indexCatalogById(catalog);
     const result = validateIncludes('root', index);
     expect(result.ok).toBe(false);
-    if (!result.ok && result.error === 'missing') {
-      expect(result.missingChildId).toBe('missing-child');
-      expect(result.parentId).toBe('root');
-      expect(result.path).toEqual(['root']);
+    if (!result.ok) {
+      expect(result.error).toBe('missing');
+      if (result.error === 'missing') {
+        expect(result.missingChildId).toBe('missing-child');
+        expect(result.parentId).toBe('root');
+        expect(result.path).toEqual(['root']);
+      }
     }
   });
 
@@ -173,10 +176,13 @@ describe('validateIncludes — missing detection', () => {
     const index = indexCatalogById(catalog);
     const result = validateIncludes('root', index);
     expect(result.ok).toBe(false);
-    if (!result.ok && result.error === 'missing') {
-      expect(result.missingChildId).toBe('missing-leaf');
-      expect(result.parentId).toBe('mid');
-      expect(result.path).toEqual(['root', 'mid']);
+    if (!result.ok) {
+      expect(result.error).toBe('missing');
+      if (result.error === 'missing') {
+        expect(result.missingChildId).toBe('missing-leaf');
+        expect(result.parentId).toBe('mid');
+        expect(result.path).toEqual(['root', 'mid']);
+      }
     }
   });
 
@@ -187,8 +193,11 @@ describe('validateIncludes — missing detection', () => {
     const index = indexCatalogById(catalog);
     const result = validateIncludes('root', index);
     expect(result.ok).toBe(false);
-    if (!result.ok && result.error === 'missing') {
-      expect(result.missingChildId).toBe('missing-a');
+    if (!result.ok) {
+      expect(result.error).toBe('missing');
+      if (result.error === 'missing') {
+        expect(result.missingChildId).toBe('missing-a');
+      }
     }
   });
 


### PR DESCRIPTION
Keep expect(result.error).toBe('missing') assertions for regression coverage while using a nested type guard for TypeScript narrowing. Addresses review feedback on #3799.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
