### PR TITLE
fix: match contiguous PANs in credit card PII regex

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -4,7 +4,7 @@ import { APP_VERSION } from "./version.js";
 /** Patterns that match sensitive data in Sentry event values. */
 const PII_PATTERNS = [
   /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
-  /\b(?:\d{4}[- ]){3}\d{1,7}\b/g,
+  /\b(?:\d{4}[- ]){3}\d{1,7}\b|\b\d{13,19}\b/g,
   /\b\d{3}-\d{2}-\d{4}\b/g,
 ];
 


### PR DESCRIPTION
Add alternation to the credit card regex to match both formatted (with separators) and contiguous 13-19 digit PANs. Prevents PII leakage of unformatted card numbers to Sentry. Addresses review feedback on #3818.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
