### PR TITLE
fix: allow inline scripts in CSP for app pages

### DIFF
--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -61,13 +61,12 @@ ${app.htmlDefinition}
 </body>
 </html>`;
 
-  // Strict CSP: inline scripts are blocked (no 'unsafe-inline' in script-src),
-  // inline styles are allowed only via nonce for the design-system CSS,
-  // and resource origins are tightened to HTTPS-only for external loads.
+  // CSP: inline scripts allowed because app HTML definitions contain inline
+  // <script> blocks and event handlers. Other directives are tightened.
   const csp = [
     "default-src 'self'",
     `style-src 'self' 'nonce-${nonce}' 'unsafe-inline'`,
-    "script-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https:",
     "font-src 'self' data: https:",
     "object-src 'none'",


### PR DESCRIPTION
Add 'unsafe-inline' to script-src in the CSP for served app pages since app HTML definitions contain inline scripts and event handlers. Addresses review feedback on #3816.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
