### PR TITLE
fix: exclude pre-registered test tools from core tools snapshot

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -190,7 +190,12 @@ export function getAllToolDefinitions(): ToolDefinition[] {
 }
 
 export async function initializeTools(): Promise<void> {
-  const { eagerModules, explicitTools, lazyTools } = await import('./tool-manifest.js');
+  const { eagerModules, eagerModuleToolNames, explicitTools, lazyTools } = await import('./tool-manifest.js');
+
+  // Capture tool names already in the registry before any manifest
+  // registrations.  In production this is empty; in tests a non-skill tool
+  // may have been registered before the first initializeTools() call.
+  const preExisting = new Set(tools.keys());
 
   // Import tool modules to trigger registration side effects.
   for (const modulePath of eagerModules) {
@@ -221,16 +226,28 @@ export async function initializeTools(): Promise<void> {
     registerLazyTool(descriptor);
   }
 
-  // Snapshot every non-skill tool currently in the registry.  This captures
-  // eager-module tools even when the module was already imported before
-  // initializeTools() ran (ESM cache hit) — their tools are in the registry
-  // regardless of whether the import triggered side effects this time.
-  // Skill-origin tools are excluded since they are session-scoped and
-  // managed separately by registerSkillTools/unregisterSkillTools.
+  // Snapshot core tools for __resetRegistryForTesting().  We include every
+  // non-skill tool that was registered by the manifest, while excluding
+  // arbitrary test tools that were registered before init.
+  //
+  // A pre-existing tool is included only if it is a known manifest tool
+  // (declared in eagerModuleToolNames, explicitTools, lazyTools, or
+  // hostTools).  This handles ESM cache hits where eager-module tools
+  // are already in the registry before init ran.
   if (!coreToolsSnapshot) {
+    const manifestToolNames = new Set<string>([
+      ...eagerModuleToolNames,
+      ...explicitTools.map((t: Tool) => t.name),
+      ...lazyTools.map((t: LazyToolDescriptor) => t.name),
+      ...hostTools.map((t: Tool) => t.name),
+    ]);
+
     coreToolsSnapshot = new Map<string, Tool>();
     for (const [name, tool] of tools) {
-      if (tool.origin !== 'skill') coreToolsSnapshot.set(name, tool);
+      if (tool.origin === 'skill') continue;
+      // Exclude pre-existing tools not declared in the manifest
+      if (preExisting.has(name) && !manifestToolNames.has(name)) continue;
+      coreToolsSnapshot.set(name, tool);
     }
   }
 

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -37,6 +37,36 @@ export const eagerModules: string[] = [
   './schedule/delete.js',
 ];
 
+// Tool names registered by the eager modules above.  Listed explicitly so
+// initializeTools() can recognise ESM-cached eager-module tools that were
+// already in the registry before init ran (e.g. when a test file imports
+// an eager module at the top level).
+export const eagerModuleToolNames: string[] = [
+  'file_read',
+  'file_write',
+  'file_edit',
+  'web_search',
+  'web_fetch',
+  'skill_load',
+  'scaffold_managed_skill',
+  'delete_managed_skill',
+  'browser_navigate',
+  'browser_snapshot',
+  'browser_screenshot',
+  'browser_close',
+  'browser_click',
+  'browser_type',
+  'browser_press_key',
+  'browser_wait_for',
+  'browser_extract',
+  'browser_fill_credential',
+  'request_system_permission',
+  'schedule_create',
+  'schedule_list',
+  'schedule_update',
+  'schedule_delete',
+];
+
 // ── Explicit tool instances ─────────────────────────────────────────
 // Tools exported as instances — registered by initializeTools() without
 // relying on import side effects.


### PR DESCRIPTION
Capture pre-existing tool names before initializeTools() runs and exclude them from coreToolsSnapshot unless they are declared in the manifest (eagerModuleToolNames, explicitTools, lazyTools, hostTools). Adds eagerModuleToolNames to the tool manifest so the snapshot can recognise ESM-cached eager-module tools. Prevents test tools from leaking into the snapshot while still handling ESM cache hits. Addresses review feedback on #3811.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
