### PR TITLE
fix: guard realpathSync(appDir) with existsSync to prevent ENOENT

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -133,7 +133,7 @@ function validateFilePath(appId: string, path: string): string {
       }
     }
   }
-  const realAppDir = realpathSync(appDir);
+  const realAppDir = existsSync(appDir) ? realpathSync(appDir) : appDir;
   if (!realResolved.startsWith(realAppDir + '/') && realResolved !== realAppDir) {
     throw new Error(`Invalid file path: symlink resolves outside app directory`);
   }


### PR DESCRIPTION
When the app directory does not exist on disk (e.g. externally deleted), the unconditional realpathSync(appDir) call throws ENOENT. Guard it with existsSync so it falls back to the unresolved path. Addresses feedback from PR #3826.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
