### PR TITLE
fix: include computer-use, ui-surface, and app tools in manifest name set

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -3,8 +3,12 @@ import type { Tool, ToolContext, ToolExecutionResult } from './types.js';
 import type { ToolDefinition } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import { registerComputerUseTools } from './computer-use/registry.js';
+import { allComputerUseTools } from './computer-use/definitions.js';
+import { requestComputerControlTool } from './computer-use/request-computer-control.js';
 import { registerUiSurfaceTools } from './ui-surface/registry.js';
+import { allUiSurfaceTools } from './ui-surface/definitions.js';
 import { registerAppTools } from './apps/registry.js';
+import { allAppTools } from './apps/definitions.js';
 import { hostFileReadTool } from './host-filesystem/read.js';
 import { hostFileWriteTool } from './host-filesystem/write.js';
 import { hostFileEditTool } from './host-filesystem/edit.js';
@@ -240,6 +244,10 @@ export async function initializeTools(): Promise<void> {
       ...explicitTools.map((t: Tool) => t.name),
       ...lazyTools.map((t: LazyToolDescriptor) => t.name),
       ...hostTools.map((t: Tool) => t.name),
+      ...allComputerUseTools.map((t: Tool) => t.name),
+      requestComputerControlTool.name,
+      ...allUiSurfaceTools.map((t: Tool) => t.name),
+      ...allAppTools.map((t: Tool) => t.name),
     ]);
 
     coreToolsSnapshot = new Map<string, Tool>();


### PR DESCRIPTION
The coreToolsSnapshot excluded tools registered by registerComputerUseTools(), registerUiSurfaceTools(), and registerAppTools() from the manifest name whitelist. If a test pre-registered any of those tools, they'd be incorrectly dropped from the snapshot. Addresses feedback from PR #3834.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
