### PR TITLE
M1: sidebar baseline — overlay hover icons, padding, top-5 guard (#3849)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -352,34 +352,37 @@ struct MainWindowView: View {
     @ViewBuilder
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected = thread.id == threadManager.activeThreadId
-        HStack(alignment: .firstTextBaseline, spacing: 0) {
-            Button(action: {
-                threadManager.selectThread(id: thread.id)
-                switch windowState.activePanel {
-                case .settings, .agent, .directory, .debug, .doctor, .identity:
-                    windowState.activePanel = nil
-                default:
-                    break
-                }
-            }) {
-                HStack(spacing: VSpacing.xs) {
-                    if thread.isPinned {
-                        Image(systemName: "pin.fill")
-                            .font(.system(size: 9, weight: .medium))
-                            .foregroundColor(VColor.textMuted)
-                            .rotationEffect(.degrees(-45))
-                    }
-                    Text(thread.title)
-                        .font(.system(size: 13))
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+        Button(action: {
+            threadManager.selectThread(id: thread.id)
+            switch windowState.activePanel {
+            case .settings, .agent, .directory, .debug, .doctor, .identity:
+                windowState.activePanel = nil
+            default:
+                break
             }
-            .buttonStyle(.plain)
-
+        }) {
+            HStack(spacing: VSpacing.xs) {
+                if thread.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(-45))
+                }
+                Text(thread.title)
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.sm)
+        .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(alignment: .trailing) {
             if threadPendingDeletion == thread.id {
                 Button {
                     threadManager.archiveThread(id: thread.id)
@@ -394,28 +397,41 @@ struct MainWindowView: View {
                         .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
+                .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
-            } else {
-                Button {
-                    threadPendingDeletion = thread.id
-                } label: {
-                    Image(systemName: "archivebox")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(width: 24, height: 24)
-                        .contentShape(Rectangle())
+            } else if isHoveredThread == thread.id {
+                HStack(spacing: VSpacing.xxs) {
+                    Button {
+                        if thread.isPinned {
+                            threadManager.unpinThread(id: thread.id)
+                        } else {
+                            threadManager.pinThread(id: thread.id)
+                        }
+                    } label: {
+                        Image(systemName: thread.isPinned ? "pin.slash" : "pin")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 24, height: 24)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+
+                    Button {
+                        threadPendingDeletion = thread.id
+                    } label: {
+                        Image(systemName: "archivebox")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 24, height: 24)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Archive \(thread.title)")
                 }
-                .buttonStyle(.plain)
-                .frame(width: 24)
-                .opacity(isHoveredThread == thread.id ? 1 : 0)
-                .allowsHitTesting(isHoveredThread == thread.id)
-                .accessibilityLabel("Archive \(thread.title)")
+                .padding(.trailing, VSpacing.xs)
             }
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .padding(.horizontal, VSpacing.sm)
         .onHover { hovering in
             if hovering {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -279,6 +279,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func updateLastInteracted(threadId: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        // Don't reshuffle threads that are already visible in the collapsed top-5 sidebar.
+        let top5Ids = Set(visibleThreads.prefix(5).map(\.id))
+        guard !top5Ids.contains(threadId) else { return }
         threads[index].lastInteractedAt = Date()
     }
 


### PR DESCRIPTION
Commits the local interactive changes as the baseline for further sidebar polish:

- **MainWindowView.swift**: Restructured threadItem to use overlay-based hover icons (pin/archive) that float over the full-width title instead of pushing it aside. Increased vertical padding. Moved overlay outside padding bounds so icons sit at the row edge.
- **ThreadManager.swift**: Added guard in `updateLastInteracted` to skip threads already in the visible top-5, preventing unnecessary reordering.

Part of #3848. Closes #3849.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
