### PR TITLE
Normalize feature flag env keys and add monitoringExport flag

### DIFF
--- a/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
@@ -204,4 +204,68 @@ final class FeatureFlagManagerTests: XCTestCase {
         XCTAssertTrue(manager.isEnabled("padded"))
     }
 
+    /// Tests that env var keys are normalized by lowercasing and removing underscores.
+    func testEnvKeyNormalizationRemovesUnderscores() {
+        // GIVEN an environment with an underscore-separated flag name
+        let env = ["VELLUM_FLAG_MONITORING_EXPORT": "1"]
+
+        // WHEN we create a manager from that environment
+        let manager = FeatureFlagManager(environment: env)
+
+        // THEN the flag is accessible via the camelCase enum rawValue
+        XCTAssertTrue(manager.isEnabled(.monitoringExport))
+
+        // AND via the camelCase string directly
+        XCTAssertTrue(manager.isEnabled("monitoringExport"))
+
+        // AND via the underscore-separated string (normalization strips underscores)
+        XCTAssertTrue(manager.isEnabled("monitoring_export"))
+    }
+
+    /// Tests that flag lookup is case-insensitive after normalization.
+    func testNormalizationIsCaseInsensitive() {
+        // GIVEN an environment with a mixed-case flag name
+        let env = ["VELLUM_FLAG_MONITORING_EXPORT": "true"]
+
+        // WHEN we create a manager from that environment
+        let manager = FeatureFlagManager(environment: env)
+
+        // THEN various casings all resolve to the same flag
+        XCTAssertTrue(manager.isEnabled("MONITORING_EXPORT"))
+        XCTAssertTrue(manager.isEnabled("Monitoring_Export"))
+        XCTAssertTrue(manager.isEnabled("monitoringexport"))
+        XCTAssertTrue(manager.isEnabled("MonitoringExport"))
+        XCTAssertTrue(manager.isEnabled("MONITORINGEXPORT"))
+    }
+
+    /// Tests that the monitoringExport FeatureFlag enum case works end-to-end.
+    func testMonitoringExportFlag() {
+        // GIVEN an environment with the monitoring export flag enabled
+        let env = ["VELLUM_FLAG_MONITORING_EXPORT": "1"]
+
+        // WHEN we create a manager from that environment
+        let manager = FeatureFlagManager(environment: env)
+
+        // THEN the typed enum flag is enabled
+        XCTAssertTrue(manager.isEnabled(.monitoringExport))
+    }
+
+    /// Tests that setOverride and removeOverride work with the monitoringExport flag.
+    func testMonitoringExportOverride() {
+        // GIVEN a manager with no flags
+        let manager = FeatureFlagManager(environment: [:])
+
+        // WHEN we set the monitoringExport override
+        manager.setOverride(.monitoringExport, enabled: true)
+
+        // THEN it is enabled
+        XCTAssertTrue(manager.isEnabled(.monitoringExport))
+
+        // WHEN we remove the override
+        manager.removeOverride(.monitoringExport)
+
+        // THEN it is disabled again
+        XCTAssertFalse(manager.isEnabled(.monitoringExport))
+    }
+
 }

--- a/clients/shared/Utilities/FeatureFlagManager.swift
+++ b/clients/shared/Utilities/FeatureFlagManager.swift
@@ -4,6 +4,7 @@ private let flagPrefix = "VELLUM_FLAG_"
 
 public enum FeatureFlag: String {
     case demo
+    case monitoringExport
 }
 
 public final class FeatureFlagManager: @unchecked Sendable {
@@ -16,7 +17,7 @@ public final class FeatureFlagManager: @unchecked Sendable {
         let env = environment ?? ProcessInfo.processInfo.environment
         var loaded: [String: Bool] = [:]
         for (key, value) in env where key.hasPrefix(flagPrefix) {
-            let name = String(key.dropFirst(flagPrefix.count)).lowercased()
+            let name = String(key.dropFirst(flagPrefix.count)).lowercased().replacingOccurrences(of: "_", with: "")
             guard !name.isEmpty else { continue }
             loaded[name] = Self.parseBool(value)
         }
@@ -26,7 +27,7 @@ public final class FeatureFlagManager: @unchecked Sendable {
     public func isEnabled(_ flag: String) -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        return flags[flag.lowercased()] ?? false
+        return flags[Self.normalize(flag)] ?? false
     }
 
     public func isEnabled(_ flag: FeatureFlag) -> Bool {
@@ -42,7 +43,7 @@ public final class FeatureFlagManager: @unchecked Sendable {
     public func setOverride(_ flag: String, enabled: Bool) {
         lock.lock()
         defer { lock.unlock() }
-        flags[flag.lowercased()] = enabled
+        flags[Self.normalize(flag)] = enabled
     }
 
     public func setOverride(_ flag: FeatureFlag, enabled: Bool) {
@@ -52,11 +53,15 @@ public final class FeatureFlagManager: @unchecked Sendable {
     public func removeOverride(_ flag: String) {
         lock.lock()
         defer { lock.unlock() }
-        flags.removeValue(forKey: flag.lowercased())
+        flags.removeValue(forKey: Self.normalize(flag))
     }
 
     public func removeOverride(_ flag: FeatureFlag) {
         removeOverride(flag.rawValue)
+    }
+
+    private static func normalize(_ name: String) -> String {
+        name.lowercased().replacingOccurrences(of: "_", with: "")
     }
 
     private static func parseBool(_ value: String) -> Bool {


### PR DESCRIPTION
## Summary
- Normalizes `VELLUM_FLAG_*` environment variable keys by lowercasing and stripping underscores, enabling case-insensitive and separator-agnostic flag matching (e.g., `VELLUM_FLAG_MONITORING_EXPORT=1` maps to `FeatureFlag.monitoringExport`)
- Adds `FeatureFlag.monitoringExport` enum case for gating the diagnostics export feature
- Introduces a shared `normalize()` helper used consistently across `isEnabled`, `setOverride`, and `removeOverride`

## Test plan
- [x] Added `testEnvKeyNormalizationRemovesUnderscores` — verifies env key normalization strips underscores and matches camelCase enum rawValue
- [x] Added `testNormalizationIsCaseInsensitive` — verifies various casings (`MONITORING_EXPORT`, `MonitoringExport`, `monitoringexport`, etc.) all resolve correctly
- [x] Added `testMonitoringExportFlag` — end-to-end test for the new `.monitoringExport` enum case
- [x] Added `testMonitoringExportOverride` — verifies `setOverride` and `removeOverride` work with the new flag
- [x] All 19 FeatureFlagManager tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
