### PR TITLE
M3: replace hover icons with ellipsis more menu, fix click area (#3851)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -375,13 +375,13 @@ struct MainWindowView: View {
                     .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.sm)
+            .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.sm)
-        .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(alignment: .trailing) {
             if threadPendingDeletion == thread.id {
                 Button {
@@ -400,35 +400,28 @@ struct MainWindowView: View {
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
             } else if isHoveredThread == thread.id {
-                HStack(spacing: VSpacing.xxs) {
-                    Button {
+                Menu {
+                    Button(thread.isPinned ? "Unpin" : "Pin to Top") {
                         if thread.isPinned {
                             threadManager.unpinThread(id: thread.id)
                         } else {
                             threadManager.pinThread(id: thread.id)
                         }
-                    } label: {
-                        Image(systemName: thread.isPinned ? "pin.slash" : "pin")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 24, height: 24)
-                            .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
-
-                    Button {
+                    Divider()
+                    Button("Archive", role: .destructive) {
                         threadPendingDeletion = thread.id
-                    } label: {
-                        Image(systemName: "archivebox")
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 24, height: 24)
-                            .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Archive \(thread.title)")
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
                 }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 24)
                 .padding(.trailing, VSpacing.xs)
             }
         }
@@ -600,13 +593,43 @@ struct MainWindowView: View {
                     .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.sm)
+            .background(isSelected || isHoveredApp == app.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.sm)
-        .background(isSelected || isHoveredApp == app.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(alignment: .trailing) {
+            if isHoveredApp == app.id {
+                Menu {
+                    Button(app.isPinned ? "Unpin" : "Pin to Top") {
+                        if app.isPinned {
+                            appListManager.unpinApp(id: app.id)
+                        } else {
+                            appListManager.pinApp(id: app.id)
+                        }
+                    }
+                    Button("Open") {
+                        openAppInWorkspace(app: app)
+                    }
+                    Divider()
+                    Button("Remove from Recents", role: .destructive) {
+                        appListManager.removeApp(id: app.id)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 24)
+                .padding(.trailing, VSpacing.xs)
+            }
+        }
         .padding(.horizontal, VSpacing.sm)
         .onHover { hovering in
             if hovering {


### PR DESCRIPTION
- Replaced hover overlay pin/archive buttons with an ellipsis Menu button on thread rows
- Added ellipsis Menu button to app rows with pin/open/remove options
- Fixed click area: full padded container is now clickable for both threads and apps
- Kept right-click context menus working alongside the new menu button
- Archive confirmation flow preserved via threadPendingDeletion state

Part of #3848. Closes #3851.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
