### PR TITLE
Add diagnostics_export IPC message types

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -556,6 +556,14 @@ exports[`IPC message snapshots ClientMessage types integration_disconnect serial
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types diagnostics_export_request serializes to expected JSON 1`] = `
+{
+  "anchorMessageId": "msg-042",
+  "conversationId": "conv-001",
+  "type": "diagnostics_export_request",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types accept_starter_bundle serializes to expected JSON 1`] = `
 {
   "type": "accept_starter_bundle",
@@ -1601,6 +1609,14 @@ exports[`IPC message snapshots ServerMessage types browser_frame serializes to e
   "sessionId": "sess-001",
   "surfaceId": "surface-001",
   "type": "browser_frame",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types diagnostics_export_response serializes to expected JSON 1`] = `
+{
+  "filePath": "/tmp/diagnostics-conv-001.zip",
+  "success": true,
+  "type": "diagnostics_export_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -353,6 +353,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'integration_disconnect',
     integrationId: 'gmail',
   },
+  diagnostics_export_request: {
+    type: 'diagnostics_export_request',
+    conversationId: 'conv-001',
+    anchorMessageId: 'msg-042',
+  },
   accept_starter_bundle: {
     type: 'accept_starter_bundle',
   },
@@ -1026,6 +1031,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     surfaceId: 'surface-001',
     frame: 'base64-jpeg-data',
     metadata: { offsetTop: 0, pageScaleFactor: 1, scrollOffsetX: 0, scrollOffsetY: 0, timestamp: 1700000000 },
+  },
+  diagnostics_export_response: {
+    type: 'diagnostics_export_response',
+    success: true,
+    filePath: '/tmp/diagnostics-conv-001.zip',
   },
   accept_starter_bundle_response: {
     type: 'accept_starter_bundle_response',

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -235,6 +235,10 @@ const handlers: DispatchMap = {
   integration_disconnect: (msg, socket, ctx) => {
     handleIntegrationDisconnect(msg as IntegrationDisconnectRequest, socket, ctx);
   },
+  diagnostics_export_request: (_msg, socket, ctx) => {
+    // TODO: implement diagnostics export handler
+    ctx.send(socket, { type: 'diagnostics_export_response', success: false, error: 'Not implemented' });
+  },
 };
 
 export function handleMessage(

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -439,6 +439,12 @@ export interface LinkOpenRequest {
   metadata?: Record<string, unknown>;
 }
 
+export interface DiagnosticsExportRequest {
+  type: 'diagnostics_export_request';
+  conversationId: string;
+  anchorMessageId?: string;  // if omitted, use latest assistant message
+}
+
 export interface IpcBlobProbe {
   type: 'ipc_blob_probe';
   probeId: string;
@@ -654,6 +660,13 @@ export interface UnpublishPageResponse {
   error?: string;
 }
 
+export interface DiagnosticsExportResponse {
+  type: 'diagnostics_export_response';
+  success: boolean;
+  filePath?: string;   // path to the zip file on success
+  error?: string;      // error message on failure
+}
+
 export interface AppFilesChanged {
   type: 'app_files_changed';
   appId: string;
@@ -739,7 +752,8 @@ export type ClientMessage =
   | IntegrationConnectRequest
   | IntegrationDisconnectRequest
   | PublishPageRequest
-  | UnpublishPageRequest;
+  | UnpublishPageRequest
+  | DiagnosticsExportRequest;
 
 // === Server → Client messages ===
 
@@ -1616,6 +1630,7 @@ export type ServerMessage =
   | AppUpdatePreviewResponse
   | PublishPageResponse
   | UnpublishPageResponse
+  | DiagnosticsExportResponse
   | AppFilesChanged
   | BrowserFrame;
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -220,6 +220,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `browser_frame` message with a new screenshot frame.
     public var onBrowserFrame: ((BrowserFrameMessage) -> Void)?
 
+    /// Called when the daemon sends a `diagnostics_export_response` message.
+    public var onDiagnosticsExportResponse: ((DiagnosticsExportResponseMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -887,6 +890,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(IPCIntegrationDisconnectRequest(type: "integration_disconnect", integrationId: integrationId))
     }
 
+    // MARK: - Diagnostics Export
+
+    /// Request a diagnostics export (zip) for a conversation.
+    public func sendDiagnosticsExportRequest(conversationId: String, anchorMessageId: String? = nil) throws {
+        try send(DiagnosticsExportRequestMessage(conversationId: conversationId, anchorMessageId: anchorMessageId))
+    }
+
     // MARK: - Link Open
 
     /// Send a link_open_request to the daemon, requesting it open a URL externally.
@@ -1173,6 +1183,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onIntegrationListResponse?(msg)
         case .integrationConnectResult(let msg):
             onIntegrationConnectResult?(msg)
+        case .diagnosticsExportResponse(let msg):
+            onDiagnosticsExportResponse?(msg)
         case .browserFrame(let msg):
             onBrowserFrame?(msg)
         default:

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1505,6 +1505,27 @@ public typealias VercelApiConfigResponseMessage = IPCVercelApiConfigResponse
 /// Backed by generated `IPCAuthResult`.
 public typealias AuthResultMessage = IPCAuthResult
 
+/// Sent to request a diagnostics export (zip) for a conversation.
+/// Wire type: `"diagnostics_export_request"`
+public struct DiagnosticsExportRequestMessage: Encodable, Sendable {
+    public let type: String = "diagnostics_export_request"
+    public let conversationId: String
+    public let anchorMessageId: String?
+
+    public init(conversationId: String, anchorMessageId: String? = nil) {
+        self.conversationId = conversationId
+        self.anchorMessageId = anchorMessageId
+    }
+}
+
+/// Response from a diagnostics export request.
+/// Wire type: `"diagnostics_export_response"`
+public struct DiagnosticsExportResponseMessage: Decodable, Sendable {
+    public let success: Bool
+    public let filePath: String?
+    public let error: String?
+}
+
 /// Browser frame update from the daemon, delivering a new screenshot frame for an active browser session.
 /// Wire type: `"browser_frame"`
 public struct BrowserFrameMessage: Decodable, Sendable {
@@ -1593,6 +1614,7 @@ public enum ServerMessage: Decodable, Sendable {
     case integrationConnectResult(IPCIntegrationConnectResult)
     case appFilesChanged(AppFilesChangedMessage)
     case getSigningIdentity(IPCGetSigningIdentityRequest)
+    case diagnosticsExportResponse(DiagnosticsExportResponseMessage)
     case browserFrame(BrowserFrameMessage)
     case pong
     case unknown(String)
@@ -1819,6 +1841,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "app_files_changed":
             let message = try AppFilesChangedMessage(from: decoder)
             self = .appFilesChanged(message)
+        case "diagnostics_export_response":
+            let message = try DiagnosticsExportResponseMessage(from: decoder)
+            self = .diagnosticsExportResponse(message)
         case "browser_frame":
             let message = try BrowserFrameMessage(from: decoder)
             self = .browserFrame(message)


### PR DESCRIPTION
## Summary
- Adds `DiagnosticsExportRequest` (client->server) and `DiagnosticsExportResponse` (server->client) message types to the IPC contract
- TypeScript: defines interfaces, adds to `ClientMessage`/`ServerMessage` union types, adds stub handler
- Swift: adds `DiagnosticsExportRequestMessage` (Encodable), `DiagnosticsExportResponseMessage` (Decodable), `ServerMessage.diagnosticsExportResponse` enum case, `DaemonClient.sendDiagnosticsExportRequest()` method, and `onDiagnosticsExportResponse` callback

## Test plan
- [x] TypeScript type-checks (`bunx tsc --noEmit`)
- [x] Swift builds (`./build.sh`)
- [x] IPC snapshot tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
