### PR TITLE
feat: sidebar polish — section icons, aligned styles, more menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -44,7 +44,11 @@ final class AppListManager: ObservableObject {
 
     func recordAppOpen(id: String, name: String, icon: String? = nil, previewBase64: String? = nil, appType: String? = nil) {
         if let index = apps.firstIndex(where: { $0.id == id }) {
-            apps[index].lastOpenedAt = Date()
+            // Don't reshuffle apps that are already visible in the collapsed top-5 sidebar.
+            let top5Ids = Set(displayApps.prefix(5).map(\.id))
+            if !top5Ids.contains(id) {
+                apps[index].lastOpenedAt = Date()
+            }
             apps[index].name = name
             if let icon { apps[index].icon = icon }
             if let previewBase64 { apps[index].previewBase64 = previewBase64 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -416,6 +416,7 @@ struct MainWindowView: View {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(VColor.textSecondary)
+                        .rotationEffect(.degrees(90))
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }
@@ -621,6 +622,7 @@ struct MainWindowView: View {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(VColor.textSecondary)
+                        .rotationEffect(.degrees(90))
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -352,34 +352,37 @@ struct MainWindowView: View {
     @ViewBuilder
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected = thread.id == threadManager.activeThreadId
-        HStack(alignment: .firstTextBaseline, spacing: 0) {
-            Button(action: {
-                threadManager.selectThread(id: thread.id)
-                switch windowState.activePanel {
-                case .settings, .agent, .directory, .debug, .doctor, .identity:
-                    windowState.activePanel = nil
-                default:
-                    break
-                }
-            }) {
-                HStack(spacing: VSpacing.xs) {
-                    if thread.isPinned {
-                        Image(systemName: "pin.fill")
-                            .font(.system(size: 9, weight: .medium))
-                            .foregroundColor(VColor.textMuted)
-                            .rotationEffect(.degrees(-45))
-                    }
-                    Text(thread.title)
-                        .font(.system(size: 13))
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+        Button(action: {
+            threadManager.selectThread(id: thread.id)
+            switch windowState.activePanel {
+            case .settings, .agent, .directory, .debug, .doctor, .identity:
+                windowState.activePanel = nil
+            default:
+                break
             }
-            .buttonStyle(.plain)
-
+        }) {
+            HStack(spacing: VSpacing.xs) {
+                if thread.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(-45))
+                }
+                Text(thread.title)
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.sm)
+        .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(alignment: .trailing) {
             if threadPendingDeletion == thread.id {
                 Button {
                     threadManager.archiveThread(id: thread.id)
@@ -394,28 +397,41 @@ struct MainWindowView: View {
                         .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
+                .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
-            } else {
-                Button {
-                    threadPendingDeletion = thread.id
-                } label: {
-                    Image(systemName: "archivebox")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(width: 24, height: 24)
-                        .contentShape(Rectangle())
+            } else if isHoveredThread == thread.id {
+                HStack(spacing: VSpacing.xxs) {
+                    Button {
+                        if thread.isPinned {
+                            threadManager.unpinThread(id: thread.id)
+                        } else {
+                            threadManager.pinThread(id: thread.id)
+                        }
+                    } label: {
+                        Image(systemName: thread.isPinned ? "pin.slash" : "pin")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 24, height: 24)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+
+                    Button {
+                        threadPendingDeletion = thread.id
+                    } label: {
+                        Image(systemName: "archivebox")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 24, height: 24)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Archive \(thread.title)")
                 }
-                .buttonStyle(.plain)
-                .frame(width: 24)
-                .opacity(isHoveredThread == thread.id ? 1 : 0)
-                .allowsHitTesting(isHoveredThread == thread.id)
-                .accessibilityLabel("Archive \(thread.title)")
+                .padding(.trailing, VSpacing.xs)
             }
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .padding(.horizontal, VSpacing.sm)
         .onHover { hovering in
             if hovering {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -375,13 +375,13 @@ struct MainWindowView: View {
                     .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.sm)
+            .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.sm)
-        .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(alignment: .trailing) {
             if threadPendingDeletion == thread.id {
                 Button {
@@ -400,35 +400,28 @@ struct MainWindowView: View {
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
             } else if isHoveredThread == thread.id {
-                HStack(spacing: VSpacing.xxs) {
-                    Button {
+                Menu {
+                    Button(thread.isPinned ? "Unpin" : "Pin to Top") {
                         if thread.isPinned {
                             threadManager.unpinThread(id: thread.id)
                         } else {
                             threadManager.pinThread(id: thread.id)
                         }
-                    } label: {
-                        Image(systemName: thread.isPinned ? "pin.slash" : "pin")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 24, height: 24)
-                            .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
-
-                    Button {
+                    Divider()
+                    Button("Archive", role: .destructive) {
                         threadPendingDeletion = thread.id
-                    } label: {
-                        Image(systemName: "archivebox")
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 24, height: 24)
-                            .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Archive \(thread.title)")
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
                 }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 24)
                 .padding(.trailing, VSpacing.xs)
             }
         }
@@ -600,13 +593,43 @@ struct MainWindowView: View {
                     .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.sm)
+            .background(isSelected || isHoveredApp == app.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.sm)
-        .background(isSelected || isHoveredApp == app.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(alignment: .trailing) {
+            if isHoveredApp == app.id {
+                Menu {
+                    Button(app.isPinned ? "Unpin" : "Pin to Top") {
+                        if app.isPinned {
+                            appListManager.unpinApp(id: app.id)
+                        } else {
+                            appListManager.pinApp(id: app.id)
+                        }
+                    }
+                    Button("Open") {
+                        openAppInWorkspace(app: app)
+                    }
+                    Divider()
+                    Button("Remove from Recents", role: .destructive) {
+                        appListManager.removeApp(id: app.id)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 24)
+                .padding(.trailing, VSpacing.xs)
+            }
+        }
         .padding(.horizontal, VSpacing.sm)
         .onHover { hovering in
             if hovering {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -361,7 +361,7 @@ struct MainWindowView: View {
                 break
             }
         }) {
-            HStack(spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.sm) {
                 if thread.isPinned {
                     Image(systemName: "pin.fill")
                         .font(.system(size: 9, weight: .medium))
@@ -494,7 +494,7 @@ struct MainWindowView: View {
                 VStack(spacing: VSpacing.xl) {
                     // MARK: Threads Section
                     VStack(spacing: VSpacing.xs) {
-                        SidebarSectionHeader(title: "Threads")
+                        SidebarSectionHeader(title: "Threads", icon: "text.bubble")
 
                         ForEach(displayedThreads) { thread in
                             threadItem(thread)
@@ -524,7 +524,7 @@ struct MainWindowView: View {
                     // MARK: Apps Section
                     if !appListManager.apps.isEmpty {
                         VStack(spacing: VSpacing.xs) {
-                            SidebarSectionHeader(title: "Apps")
+                            SidebarSectionHeader(title: "Apps", icon: "square.grid.2x2")
 
                             ForEach(displayedApps) { app in
                                 sidebarAppItem(app)
@@ -583,49 +583,28 @@ struct MainWindowView: View {
         let isSelected = windowState.isDynamicExpanded
             && windowState.activeDynamicSurface?.surfaceId != nil
             && isAppSurfaceActive(appId: app.id)
-        HStack(spacing: VSpacing.sm) {
-            Button(action: {
-                openAppInWorkspace(app: app)
-            }) {
-                HStack(spacing: VSpacing.sm) {
-                    if app.isPinned {
-                        Image(systemName: "pin.fill")
-                            .font(.system(size: 9, weight: .medium))
-                            .foregroundColor(VColor.textMuted)
-                            .rotationEffect(.degrees(-45))
-                            .frame(width: 14)
-                    }
-                    if let icon = app.icon, !icon.isEmpty {
-                        Text(icon)
-                            .font(.system(size: 14))
-                            .frame(width: 22, height: 22)
-                    } else {
-                        Image(systemName: "square.grid.2x2")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(VColor.textMuted)
-                            .frame(width: 22, height: 22)
-                    }
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text(app.name)
-                            .font(.system(size: 13))
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                        if let appType = app.appType {
-                            Text(appType)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                                .lineLimit(1)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+        Button(action: {
+            openAppInWorkspace(app: app)
+        }) {
+            HStack(spacing: VSpacing.sm) {
+                if app.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(-45))
                 }
-                .contentShape(Rectangle())
+                Text(app.name)
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
-            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
         .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.vertical, VSpacing.sm)
         .background(isSelected || isHoveredApp == app.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .padding(.horizontal, VSpacing.sm)
@@ -1048,15 +1027,23 @@ private struct ZoomIndicatorView: View {
 
 private struct SidebarSectionHeader: View {
     let title: String
+    var icon: String? = nil
 
     var body: some View {
-        Text(title)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundColor(VColor.textMuted)
-            .textCase(.uppercase)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, VSpacing.lg)
-            .padding(.bottom, VSpacing.xs)
+        HStack(spacing: VSpacing.xs) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+            }
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(VColor.textMuted)
+                .textCase(.uppercase)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, VSpacing.lg)
+        .padding(.bottom, VSpacing.xs)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -279,6 +279,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func updateLastInteracted(threadId: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        // Don't reshuffle threads that are already visible in the collapsed top-5 sidebar.
+        let top5Ids = Set(visibleThreads.prefix(5).map(\.id))
+        guard !top5Ids.contains(threadId) else { return }
         threads[index].lastInteractedAt = Date()
     }
 


### PR DESCRIPTION
## Summary
Polish the sidebar IA with improved visual consistency and interaction patterns for Threads and Apps sections.

## Changes
- **Section header icons** — Added `text.bubble` icon to Threads header, `square.grid.2x2` to Apps header via updated `SidebarSectionHeader`
- **Removed per-app icons** — Cleaned up app rows by removing individual icon/emoji and appType subtitle
- **Increased pin-to-name spacing** — From `VSpacing.xs` (4pt) to `VSpacing.sm` (8pt)
- **Aligned thread/app item styles** — Same padding, fonts, hover states, pin indicators, selected backgrounds
- **Fixed click area** — Full padded container is now clickable via `contentShape(Rectangle())` inside the button label
- **Ellipsis "more" menu** — Replaced hover overlay pin/archive buttons with an ellipsis `Menu` button that shows pin/archive options (threads) or pin/open/remove options (apps)
- **Top-5 stability** — `updateLastInteracted` skips threads already visible in the collapsed top-5, preventing unnecessary reordering
- **Overlay-based hover icons baseline** — Moved overlay outside padding bounds so icons sit at the row edge

## Milestone PRs (merged into feature branch)
- #3852: M1 — sidebar baseline (overlay hover icons, padding, top-5 guard)
- #3854: M2 — section header icons, remove app icons, align sidebar styles
- #3855: M3 — replace hover icons with ellipsis more menu, fix click area

## Project issue
Closes #3848

## Test plan
- [ ] Build succeeds (`./build.sh lint`)
- [ ] Threads section shows `text.bubble` icon in header
- [ ] Apps section shows `square.grid.2x2` icon in header
- [ ] App rows show only name text (no per-app icons or subtypes)
- [ ] Pin indicator has proper spacing from name
- [ ] Thread and app rows look visually consistent
- [ ] Full row is clickable (not just text area)
- [ ] Hover shows ellipsis button on the right
- [ ] Ellipsis menu shows Pin/Unpin + Archive for threads
- [ ] Ellipsis menu shows Pin/Unpin + Open + Remove for apps
- [ ] Right-click context menu still works
- [ ] Threads in top-5 don't shuffle when interacted with

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
