### PR TITLE
Implement diagnostics export builder

### DIFF
--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -1,0 +1,261 @@
+import * as net from 'node:net';
+import { homedir } from 'node:os';
+import { mkdirSync, writeFileSync, rmSync, createWriteStream } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { eq, and, desc, gte, lte } from 'drizzle-orm';
+import archiver from 'archiver';
+import { getDb } from '../../memory/db.js';
+import { messages, toolInvocations, llmUsageEvents } from '../../memory/schema.js';
+import type { DiagnosticsExportRequest } from '../ipc-protocol.js';
+import { log, type HandlerContext } from './shared.js';
+
+const MAX_CONTENT_LENGTH = 500;
+
+/**
+ * Regex patterns for redacting potentially sensitive data.
+ * Matches common API key formats, email addresses, and bearer tokens.
+ */
+const REDACT_PATTERNS = [
+  // API keys: sk-..., key-..., api_key_..., etc.
+  /\b(sk|key|api[_-]?key|token|secret|password|passwd|credential)[_\-]?[a-zA-Z0-9]{16,}\b/gi,
+  // Bearer tokens
+  /Bearer\s+[A-Za-z0-9\-._~+\/]+=*/gi,
+  // Email addresses
+  /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g,
+  // AWS-style keys
+  /\b(AKIA|ASIA)[A-Z0-9]{16}\b/g,
+  // Generic hex/base64 secrets (32+ chars)
+  /\b[A-Fa-f0-9]{32,}\b/g,
+];
+
+function redact(text: string): string {
+  let result = text;
+  for (const pattern of REDACT_PATTERNS) {
+    result = result.replace(pattern, '[REDACTED]');
+  }
+  return result;
+}
+
+function truncateAndRedact(text: string): string {
+  const truncated = text.length > MAX_CONTENT_LENGTH
+    ? text.slice(0, MAX_CONTENT_LENGTH) + '...[truncated]'
+    : text;
+  return redact(truncated);
+}
+
+export async function handleDiagnosticsExport(
+  msg: DiagnosticsExportRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    const db = getDb();
+    const { conversationId } = msg;
+
+    // 1. Find the anchor message
+    let anchorMessage;
+    if (msg.anchorMessageId) {
+      anchorMessage = db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.id, msg.anchorMessageId),
+            eq(messages.conversationId, conversationId),
+          ),
+        )
+        .get();
+    } else {
+      // Find the latest assistant message in the conversation
+      anchorMessage = db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.conversationId, conversationId),
+            eq(messages.role, 'assistant'),
+          ),
+        )
+        .orderBy(desc(messages.createdAt))
+        .limit(1)
+        .get();
+    }
+
+    if (!anchorMessage) {
+      ctx.send(socket, {
+        type: 'diagnostics_export_response',
+        success: false,
+        error: 'Anchor message not found',
+      });
+      return;
+    }
+
+    // 2. Find the preceding user message
+    const precedingUserMessage = db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          eq(messages.role, 'user'),
+          lte(messages.createdAt, anchorMessage.createdAt),
+        ),
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(1)
+      .get();
+
+    // Use the preceding user message timestamp as the range start,
+    // or fall back to the anchor message timestamp if none found
+    const rangeStart = precedingUserMessage?.createdAt ?? anchorMessage.createdAt;
+    const rangeEnd = anchorMessage.createdAt;
+
+    // 3. Query all messages in the range
+    const rangeMessages = db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          gte(messages.createdAt, rangeStart),
+          lte(messages.createdAt, rangeEnd),
+        ),
+      )
+      .orderBy(messages.createdAt)
+      .all();
+
+    // 4. Query tool invocations in the range
+    const rangeToolInvocations = db
+      .select()
+      .from(toolInvocations)
+      .where(
+        and(
+          eq(toolInvocations.conversationId, conversationId),
+          gte(toolInvocations.createdAt, rangeStart),
+          lte(toolInvocations.createdAt, rangeEnd),
+        ),
+      )
+      .orderBy(toolInvocations.createdAt)
+      .all();
+
+    // 5. Query LLM usage events in the range
+    const rangeUsageEvents = db
+      .select()
+      .from(llmUsageEvents)
+      .where(
+        and(
+          eq(llmUsageEvents.conversationId, conversationId),
+          gte(llmUsageEvents.createdAt, rangeStart),
+          lte(llmUsageEvents.createdAt, rangeEnd),
+        ),
+      )
+      .orderBy(llmUsageEvents.createdAt)
+      .all();
+
+    // 6. Write export files to a temp directory
+    const exportId = `diagnostics-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+    const tempDir = join(tmpdir(), exportId);
+    mkdirSync(tempDir, { recursive: true });
+
+    try {
+      // manifest.json
+      const manifest = {
+        version: '1.0',
+        exportedAt: new Date().toISOString(),
+        conversationId,
+        anchorMessageId: anchorMessage.id,
+      };
+      writeFileSync(join(tempDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+      // messages.jsonl
+      const messagesLines = rangeMessages.map((m) =>
+        JSON.stringify({
+          id: m.id,
+          conversationId: m.conversationId,
+          role: m.role,
+          content: truncateAndRedact(m.content),
+          createdAt: m.createdAt,
+        }),
+      );
+      writeFileSync(join(tempDir, 'messages.jsonl'), messagesLines.join('\n') + (messagesLines.length > 0 ? '\n' : ''));
+
+      // tool_invocations.jsonl
+      const toolLines = rangeToolInvocations.map((t) =>
+        JSON.stringify({
+          id: t.id,
+          conversationId: t.conversationId,
+          toolName: t.toolName,
+          input: truncateAndRedact(t.input),
+          result: truncateAndRedact(t.result),
+          decision: t.decision,
+          riskLevel: t.riskLevel,
+          durationMs: t.durationMs,
+          createdAt: t.createdAt,
+        }),
+      );
+      writeFileSync(join(tempDir, 'tool_invocations.jsonl'), toolLines.join('\n') + (toolLines.length > 0 ? '\n' : ''));
+
+      // usage.jsonl
+      const usageLines = rangeUsageEvents.map((u) =>
+        JSON.stringify({
+          id: u.id,
+          conversationId: u.conversationId,
+          actor: u.actor,
+          provider: u.provider,
+          model: u.model,
+          inputTokens: u.inputTokens,
+          outputTokens: u.outputTokens,
+          cacheCreationInputTokens: u.cacheCreationInputTokens,
+          cacheReadInputTokens: u.cacheReadInputTokens,
+          estimatedCostUsd: u.estimatedCostUsd,
+          pricingStatus: u.pricingStatus,
+          createdAt: u.createdAt,
+        }),
+      );
+      writeFileSync(join(tempDir, 'usage.jsonl'), usageLines.join('\n') + (usageLines.length > 0 ? '\n' : ''));
+
+      // 7. Zip the temp directory
+      const downloadsDir = join(homedir(), 'Downloads');
+      mkdirSync(downloadsDir, { recursive: true });
+      const zipFilename = `${exportId}.zip`;
+      const zipPath = join(downloadsDir, zipFilename);
+
+      await new Promise<void>((resolve, reject) => {
+        const output = createWriteStream(zipPath);
+        const archive = archiver('zip', { zlib: { level: 9 } });
+
+        output.on('close', () => resolve());
+        archive.on('error', (err: Error) => reject(err));
+
+        archive.pipe(output);
+        archive.directory(tempDir, false);
+        archive.finalize();
+      });
+
+      // 8. Send success response
+      ctx.send(socket, {
+        type: 'diagnostics_export_response',
+        success: true,
+        filePath: zipPath,
+      });
+
+      log.info({ conversationId, zipPath, messageCount: rangeMessages.length }, 'Diagnostics export completed');
+    } finally {
+      // Clean up temp directory
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log.error({ err, conversationId: msg.conversationId }, 'Failed to export diagnostics');
+    ctx.send(socket, {
+      type: 'diagnostics_export_response',
+      success: false,
+      error: `Failed to export diagnostics: ${errorMessage}`,
+    });
+  }
+}

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -82,6 +82,7 @@ import {
   handleUnpublishPage,
 } from './publish.js';
 import { handleHomeBaseGet } from './home-base.js';
+import { handleDiagnosticsExport } from './diagnostics.js';
 
 import {
   handleTaskSubmit,
@@ -235,10 +236,7 @@ const handlers: DispatchMap = {
   integration_disconnect: (msg, socket, ctx) => {
     handleIntegrationDisconnect(msg as IntegrationDisconnectRequest, socket, ctx);
   },
-  diagnostics_export_request: (_msg, socket, ctx) => {
-    // TODO: implement diagnostics export handler
-    ctx.send(socket, { type: 'diagnostics_export_response', success: false, error: 'Not implemented' });
-  },
+  diagnostics_export_request: handleDiagnosticsExport,
 };
 
 export function handleMessage(


### PR DESCRIPTION
Replaces the stub `diagnostics_export_request` handler with a real implementation that:

- Finds the anchor message (by ID or latest assistant message)
- Locates the preceding user message to define the time range
- Queries messages, tool invocations, and LLM usage events within that range
- Redacts sensitive content (API keys, emails, bearer tokens, AWS keys)
- Truncates message content to 500 chars max
- Writes structured export files: `manifest.json`, `messages.jsonl`, `tool_invocations.jsonl`, `usage.jsonl`
- Zips everything to `~/Downloads/diagnostics-<timestamp>.zip`
- Returns the file path in the IPC response

Closes the TODO left by #3856.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
