### PR TITLE
Add 'Report this response' context menu with export toast

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -247,6 +247,28 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self.handleEscalationToComputerUse(routed: routed)
         }
 
+        // Handle diagnostics export response — show a toast in the main window
+        daemonClient.onDiagnosticsExportResponse = { [weak self] response in
+            guard let self else { return }
+            Task { @MainActor in
+                if response.success, let filePath = response.filePath {
+                    self.mainWindow?.windowState.showToast(
+                        message: "Report exported successfully.",
+                        style: .success,
+                        primaryAction: VToastAction(label: "Reveal in Finder") {
+                            NSWorkspace.shared.selectFile(filePath, inFileViewerRootedAtPath: "")
+                        }
+                    )
+                } else {
+                    let errorDetail = response.error ?? "Unknown error"
+                    self.mainWindow?.windowState.showToast(
+                        message: "Failed to export report: \(errorDetail)",
+                        style: .error
+                    )
+                }
+            }
+        }
+
         // Restart DaemonClient connection when the health monitor relaunches
         // the daemon process so we don't wait for the backoff timer to expire.
         daemonLauncher.onDaemonRestarted = { [weak self] in

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -86,6 +86,7 @@ struct ChatView: View {
     let onStopWatch: () -> Void
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
+    var onReportMessage: ((UUID) -> Void)?
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
@@ -513,7 +514,8 @@ struct ChatView: View {
                                 onRegenerate: onRegenerate,
                                 onSurfaceAction: onSurfaceAction,
                                 onOpenActivity: onOpenActivity,
-                                isActivityPanelOpen: isActivityPanelOpen
+                                isActivityPanelOpen: isActivityPanelOpen,
+                                onReportMessage: onReportMessage
                             )
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -787,6 +789,7 @@ private struct ChatBubble: View {
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
+    var onReportMessage: ((UUID) -> Void)?
 
     @State private var isRegenerateHovered = false
 
@@ -892,6 +895,14 @@ private struct ChatBubble: View {
             // Prevent LazyVStack from compressing the bubble height, which causes the
             // trailing tool-chip to overlap long text content.
             .fixedSize(horizontal: false, vertical: true)
+            .contextMenu {
+                if !isUser, let onReportMessage,
+                   FeatureFlagManager.shared.isEnabled(.monitoringExport) {
+                    Button("Report this response") {
+                        onReportMessage(message.id)
+                    }
+                }
+            }
 
             if !isUser { Spacer(minLength: 0) }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -28,6 +28,7 @@ final class MainWindowState: ObservableObject {
     }
     @Published var activityMessageId: UUID?
     @Published var layoutConfig: LayoutConfig
+    @Published var toastInfo: ToastInfo?
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey
@@ -81,6 +82,16 @@ final class MainWindowState: ObservableObject {
         LayoutConfigStore.save(layoutConfig)
     }
 
+    /// Show a toast notification in the main window.
+    func showToast(message: String, style: ToastInfo.Style, primaryAction: VToastAction? = nil) {
+        toastInfo = ToastInfo(message: message, style: style, primaryAction: primaryAction)
+    }
+
+    /// Dismiss the currently displayed toast.
+    func dismissToast() {
+        toastInfo = nil
+    }
+
     /// Restore the last active panel from UserDefaults
     func restoreLastActivePanel() {
         // Dashboard-first mode should always bootstrap into Home Base rather than
@@ -94,4 +105,16 @@ final class MainWindowState: ObservableObject {
 
         activePanel = panel
     }
+}
+
+/// Data model for a toast notification displayed in the main window.
+struct ToastInfo {
+    enum Style {
+        case success
+        case error
+    }
+
+    let message: String
+    let style: Style
+    let primaryAction: VToastAction?
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -251,6 +251,20 @@ struct MainWindowView: View {
             }
         }
         .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
+        .overlay(alignment: .bottom) {
+            if let toast = windowState.toastInfo {
+                VToast(
+                    message: toast.message,
+                    style: toast.style == .success ? .success : .error,
+                    primaryAction: toast.primaryAction,
+                    onDismiss: { windowState.dismissToast() }
+                )
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.bottom, VSpacing.xl)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(VAnimation.standard, value: windowState.toastInfo != nil)
         .onAppear {
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
             selectedThreadId = threadManager.activeThreadId
@@ -928,6 +942,7 @@ struct MainWindowView: View {
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
+                daemonClient: daemonClient,
                 ambientAgent: ambientAgent,
                 onMicrophoneToggle: onMicrophoneToggle
             )
@@ -1234,6 +1249,7 @@ private func openFilePicker(viewModel: ChatViewModel) {
 private struct ActiveChatViewWrapper: View {
     @ObservedObject var viewModel: ChatViewModel
     @ObservedObject var windowState: MainWindowState
+    let daemonClient: DaemonClient
     let ambientAgent: AmbientAgent
     let onMicrophoneToggle: () -> Void
 
@@ -1291,7 +1307,21 @@ private struct ActiveChatViewWrapper: View {
             onOpenActivity: { messageId in
                 windowState.toggleActivityPanel(with: messageId)
             },
-            isActivityPanelOpen: windowState.activePanel == .activity
+            isActivityPanelOpen: windowState.activePanel == .activity,
+            onReportMessage: { messageId in
+                guard let sessionId = viewModel.sessionId else { return }
+                do {
+                    try daemonClient.sendDiagnosticsExportRequest(
+                        conversationId: sessionId,
+                        anchorMessageId: messageId.uuidString
+                    )
+                } catch {
+                    windowState.showToast(
+                        message: "Failed to request report export.",
+                        style: .error
+                    )
+                }
+            }
         )
     }
 }


### PR DESCRIPTION
## Summary
- Adds a "Report this response" context menu item on assistant message bubbles in the macOS chat UI
- Gated behind the `monitoringExport` feature flag (`FeatureFlagManager.shared.isEnabled(.monitoringExport)`)
- Triggers a diagnostics export via `DaemonClient.sendDiagnosticsExportRequest(conversationId:anchorMessageId:)`
- Shows a success toast with "Reveal in Finder" action on successful export, or an error toast on failure
- Introduces `ToastInfo` model and toast overlay infrastructure in `MainWindowState`/`MainWindowView`

## Test plan
- [ ] Enable the `monitoringExport` feature flag via `VELLUM_FLAG_MONITORING_EXPORT=1`
- [ ] Right-click an assistant message bubble and verify "Report this response" appears
- [ ] Click the menu item and verify a diagnostics export request is sent to the daemon
- [ ] Verify success toast appears with "Reveal in Finder" button when export succeeds
- [ ] Verify error toast appears when export fails
- [ ] Verify the context menu item does NOT appear when the feature flag is disabled
- [ ] Verify user message bubbles do NOT show the context menu item

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
