### PR TITLE
Add document tool definitions

### DIFF
--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,0 +1,222 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import * as appStore from '../../memory/app-store.js';
+import { randomUUID } from 'node:crypto';
+
+// ── document_create ──────────────────────────────────────────────────
+
+export class DocumentCreateTool implements Tool {
+  name = 'document_create';
+  description =
+    'Create a new long-form document with a rich text editor. Use this when the user asks to write a blog post, article, or any long-form content. The editor opens in workspace mode with chat docked to the side.';
+  category = 'document';
+  defaultRiskLevel = RiskLevel.Low;
+  executionMode: 'local' = 'local';
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Initial title for the document (optional, can be updated later)',
+          },
+          initial_content: {
+            type: 'string',
+            description: 'Initial Markdown content to populate the editor (optional)',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const title = (input.title as string | undefined) || 'Untitled Document';
+    const initialContent = (input.initial_content as string | undefined) || '';
+    const appId = `doc-${randomUUID()}`;
+
+    // Note: HTML template generation will be implemented in PR 2
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+  <title>${escapeHtml(title)}</title>
+  <meta charset="UTF-8">
+</head>
+<body>
+  <h1>Document Editor Placeholder</h1>
+  <p>Full editor implementation coming in PR 2</p>
+  <p>Title: ${escapeHtml(title)}</p>
+  <pre>${escapeHtml(initialContent)}</pre>
+</body>
+</html>`;
+
+    // Create the document app in the app store
+    const wordCount = initialContent.split(/\s+/).filter((w) => w.length > 0).length;
+    const app = appStore.createApp({
+      name: title,
+      description: `Document with ${wordCount} words`,
+      icon: '📝',
+      preview: initialContent.slice(0, 200),
+      htmlDefinition: html,
+      schemaJson: JSON.stringify({
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          content: { type: 'string' },
+          wordCount: { type: 'number' },
+          documentType: { type: 'string', const: 'document' },
+        },
+      }),
+      appType: 'app',
+    });
+
+    // Open the document via the proxy resolver if available
+    if (context.proxyToolResolver) {
+      try {
+        const openResult = await context.proxyToolResolver('app_open', {
+          app_id: app.id,
+          preview: {
+            title,
+            subtitle: 'Document',
+            description: 'Long-form document with rich text editor',
+            icon: '📝',
+            metrics: [{ label: 'Words', value: String(wordCount) }],
+          },
+        });
+
+        return {
+          content: JSON.stringify({
+            app_id: appId,
+            surface_id: app.id, // For now, use app ID as surface ID
+            title,
+            opened: true,
+            open_result: openResult.content,
+          }),
+          isError: false,
+        };
+      } catch (err) {
+        return {
+          content: JSON.stringify({
+            app_id: appId,
+            title,
+            opened: false,
+            error: 'Failed to open document editor',
+          }),
+          isError: false,
+        };
+      }
+    }
+
+    return {
+      content: JSON.stringify({
+        app_id: appId,
+        title,
+        message: 'Document created but could not be opened (no proxy resolver available)',
+      }),
+      isError: false,
+    };
+  }
+}
+
+// ── document_update ──────────────────────────────────────────────────
+
+export class DocumentUpdateTool implements Tool {
+  name = 'document_update';
+  description =
+    'Update content in an open document editor. Use this to stream generated content or apply edits.';
+  category = 'document';
+  defaultRiskLevel = RiskLevel.Low;
+  executionMode: 'local' = 'local';
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          surface_id: {
+            type: 'string',
+            description: 'The ID of the document surface to update',
+          },
+          content: {
+            type: 'string',
+            description: 'Markdown content to set or append',
+          },
+          mode: {
+            type: 'string',
+            enum: ['replace', 'append'],
+            description: 'Whether to replace all content or append to the end. Defaults to append.',
+          },
+        },
+        required: ['surface_id', 'content'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const surfaceId = input.surface_id as string;
+    const content = input.content as string;
+    const mode = (input.mode as string | undefined) || 'append';
+
+    // Use the proxy resolver to call ui_update
+    if (context.proxyToolResolver) {
+      try {
+        const updateResult = await context.proxyToolResolver('ui_update', {
+          surface_id: surfaceId,
+          data: {
+            markdown: content,
+            updateMode: mode,
+          },
+        });
+
+        return {
+          content: JSON.stringify({
+            success: true,
+            surface_id: surfaceId,
+            mode,
+            update_result: updateResult.content,
+          }),
+          isError: false,
+        };
+      } catch (err) {
+        return {
+          content: JSON.stringify({
+            success: false,
+            error: 'Failed to update document content',
+            details: err instanceof Error ? err.message : String(err),
+          }),
+          isError: true,
+        };
+      }
+    }
+
+    return {
+      content: JSON.stringify({
+        success: false,
+        error: 'No proxy resolver available to update document',
+      }),
+      isError: true,
+    };
+  }
+}
+
+// ── Utilities ────────────────────────────────────────────────────────
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+// ── Exported tool instances ──────────────────────────────────────────
+
+export const documentCreateTool = new DocumentCreateTool();
+export const documentUpdateTool = new DocumentUpdateTool();

--- a/assistant/src/tools/document/index.ts
+++ b/assistant/src/tools/document/index.ts
@@ -1,0 +1,5 @@
+export * from './document-tool.js';
+
+import { documentCreateTool, documentUpdateTool } from './document-tool.js';
+
+export const allDocumentTools = [documentCreateTool, documentUpdateTool];

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -16,6 +16,7 @@ import { reminderTool } from './reminder/reminder.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { integrationManageTool } from './integrations/manage.js';
+import { documentCreateTool, documentUpdateTool } from './document/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -51,6 +52,8 @@ export const explicitTools: Tool[] = [
   screenWatchTool,
   vellumSkillsCatalogTool,
   integrationManageTool,
+  documentCreateTool,
+  documentUpdateTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `document_create` and `document_update` tools
- Register tools in tool manifest
- Store documents as apps with document-specific schema

Part 1 of 7 for implementing rich text editor for long-form content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
