### PR TITLE
Add Toast UI Editor HTML template for documents

### DIFF
--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import * as appStore from '../../memory/app-store.js';
 import { randomUUID } from 'node:crypto';
+import { generateEditorHTML } from './editor-template.js';
 
 // ── document_create ──────────────────────────────────────────────────
 
@@ -39,20 +40,8 @@ export class DocumentCreateTool implements Tool {
     const initialContent = (input.initial_content as string | undefined) || '';
     const appId = `doc-${randomUUID()}`;
 
-    // Note: HTML template generation will be implemented in PR 2
-    const html = `<!DOCTYPE html>
-<html>
-<head>
-  <title>${escapeHtml(title)}</title>
-  <meta charset="UTF-8">
-</head>
-<body>
-  <h1>Document Editor Placeholder</h1>
-  <p>Full editor implementation coming in PR 2</p>
-  <p>Title: ${escapeHtml(title)}</p>
-  <pre>${escapeHtml(initialContent)}</pre>
-</body>
-</html>`;
+    // Generate the Toast UI Editor HTML
+    const html = generateEditorHTML(title, initialContent);
 
     // Create the document app in the app store
     const wordCount = initialContent.split(/\s+/).filter((w) => w.length > 0).length;
@@ -203,17 +192,6 @@ export class DocumentUpdateTool implements Tool {
       isError: true,
     };
   }
-}
-
-// ── Utilities ────────────────────────────────────────────────────────
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
 }
 
 // ── Exported tool instances ──────────────────────────────────────────

--- a/assistant/src/tools/document/editor-template.ts
+++ b/assistant/src/tools/document/editor-template.ts
@@ -1,0 +1,215 @@
+/**
+ * Generates the Toast UI Editor HTML template for document editing.
+ *
+ * Features:
+ * - WYSIWYG and Markdown source modes
+ * - Dark theme matching Vellum design
+ * - Real-time word count
+ * - Auto-save via Vellum JS bridge
+ * - Code syntax highlighting
+ * - Tables, task lists, and rich formatting
+ */
+
+export function generateEditorHTML(title: string, initialContent: string): string {
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)}</title>
+
+  <!-- Toast UI Editor CSS -->
+  <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css" />
+  <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/theme/toastui-editor-dark.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
+
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+      background: #0f172a;
+      color: #f8fafc;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .header {
+      padding: 16px 24px;
+      border-bottom: 1px solid #334155;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-shrink: 0;
+    }
+
+    .title-input {
+      font-size: 20px;
+      font-weight: 600;
+      background: transparent;
+      border: none;
+      color: #f8fafc;
+      outline: none;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .title-input::placeholder { color: #64748b; }
+
+    .status {
+      font-size: 12px;
+      color: #94a3b8;
+      margin-left: 16px;
+      white-space: nowrap;
+    }
+
+    .editor-container {
+      flex: 1;
+      overflow: hidden;
+      padding: 24px;
+    }
+
+    #editor {
+      height: 100%;
+    }
+
+    /* Override Toast UI Editor dark theme colors to match Vellum */
+    .toastui-editor-defaultUI { border: none !important; }
+    .toastui-editor-toolbar { background: #1e293b !important; border-bottom: 1px solid #334155 !important; }
+    .toastui-editor-toolbar-icons { color: #cbd5e1 !important; }
+    .toastui-editor-toolbar-icons:hover { background: #334155 !important; }
+    .toastui-editor-md-container,
+    .toastui-editor-ww-container { background: #0f172a !important; color: #f8fafc !important; }
+    .toastui-editor-contents { color: #f8fafc !important; }
+    .toastui-editor-contents h1,
+    .toastui-editor-contents h2,
+    .toastui-editor-contents h3 { color: #f8fafc !important; border-bottom-color: #334155 !important; }
+    .toastui-editor-contents pre { background: #1e293b !important; }
+    .toastui-editor-contents code { background: #1e293b !important; color: #e2e8f0 !important; }
+    .toastui-editor-contents blockquote { border-left-color: #7c3aed !important; color: #cbd5e1 !important; }
+    .toastui-editor-contents table td,
+    .toastui-editor-contents table th { border-color: #334155 !important; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <input type="text" class="title-input" placeholder="Untitled Document" value="${escapeHtml(title)}" id="title-input" />
+    <div class="status" id="status">Ready</div>
+  </div>
+
+  <div class="editor-container">
+    <div id="editor"></div>
+  </div>
+
+  <!-- Toast UI Editor JS -->
+  <script src="https://uicdn.toast.com/editor/latest/toastui-editor-all.min.js"></script>
+
+  <script>
+    // Initialize Toast UI Editor
+    const editor = new toastui.Editor({
+      el: document.querySelector('#editor'),
+      height: '100%',
+      initialEditType: 'wysiwyg',
+      previewStyle: 'vertical',
+      theme: 'dark',
+      usageStatistics: false,
+      initialValue: ${JSON.stringify(initialContent)},
+      toolbarItems: [
+        ['heading', 'bold', 'italic', 'strike'],
+        ['hr', 'quote'],
+        ['ul', 'ol', 'task', 'indent', 'outdent'],
+        ['table', 'link', 'image', 'code', 'codeblock']
+      ],
+      hooks: {
+        addImageBlobHook: (blob, callback) => {
+          // Convert image to base64 and insert
+          const reader = new FileReader();
+          reader.onload = (e) => callback(e.target.result, blob.name);
+          reader.readAsDataURL(blob);
+        }
+      }
+    });
+
+    const titleInput = document.getElementById('title-input');
+    const statusEl = document.getElementById('status');
+    let wordCount = 0;
+    let saveTimeout = null;
+
+    // Update word count
+    function updateWordCount() {
+      const text = editor.getMarkdown();
+      wordCount = text.trim().split(/\\s+/).filter(w => w.length > 0).length;
+      statusEl.textContent = \`\${wordCount} words\`;
+    }
+
+    // Notify daemon of content changes (debounced)
+    function notifyContentChanged() {
+      clearTimeout(saveTimeout);
+      statusEl.textContent = 'Saving...';
+
+      saveTimeout = setTimeout(() => {
+        const content = editor.getMarkdown();
+        const title = titleInput.value.trim() || 'Untitled Document';
+
+        if (typeof window.vellum !== 'undefined' && typeof window.vellum.sendAction === 'function') {
+          window.vellum.sendAction('content_changed', {
+            title,
+            content,
+            wordCount
+          });
+        }
+
+        updateWordCount();
+      }, 500);
+    }
+
+    // Listen for content changes
+    editor.on('change', notifyContentChanged);
+    titleInput.addEventListener('input', notifyContentChanged);
+
+    // Vellum bridge: handle content updates from daemon
+    if (typeof window.vellum !== 'undefined') {
+      window.vellum.onContentUpdate = function(data) {
+        if (data.markdown) {
+          const mode = data.updateMode || 'append';
+          const currentContent = editor.getMarkdown();
+
+          if (mode === 'replace') {
+            editor.setMarkdown(data.markdown, false);
+          } else if (mode === 'append') {
+            editor.setMarkdown(currentContent + '\\n\\n' + data.markdown, false);
+            // Scroll to bottom
+            editor.moveCursorToEnd();
+          }
+
+          updateWordCount();
+        }
+
+        if (data.title) {
+          titleInput.value = data.title;
+        }
+      };
+    }
+
+    // Initial word count
+    updateWordCount();
+
+    // Focus editor
+    setTimeout(() => editor.focus(), 100);
+  </script>
+</body>
+</html>
+  `.trim();
+}
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}


### PR DESCRIPTION
## Summary
- Create editor-template.ts with full Toast UI Editor implementation
- Dark theme matching Vellum design system
- Real-time word count and auto-save
- WYSIWYG and Markdown source modes
- Support for tables, code blocks, images, and rich formatting

Part 2 of 7 for implementing rich text editor for long-form content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
