### PR TITLE
Fix report export anchoring to use daemon message IDs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -86,7 +86,7 @@ struct ChatView: View {
     let onStopWatch: () -> Void
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
-    var onReportMessage: ((UUID) -> Void)?
+    var onReportMessage: ((String?) -> Void)?
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
@@ -789,7 +789,7 @@ private struct ChatBubble: View {
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
-    var onReportMessage: ((UUID) -> Void)?
+    var onReportMessage: ((String?) -> Void)?
 
     @State private var isRegenerateHovered = false
 
@@ -899,7 +899,7 @@ private struct ChatBubble: View {
                 if !isUser, let onReportMessage,
                    FeatureFlagManager.shared.isEnabled(.monitoringExport) {
                     Button("Report this response") {
-                        onReportMessage(message.id)
+                        onReportMessage(message.daemonMessageId)
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1308,12 +1308,12 @@ private struct ActiveChatViewWrapper: View {
                 windowState.toggleActivityPanel(with: messageId)
             },
             isActivityPanelOpen: windowState.activePanel == .activity,
-            onReportMessage: { messageId in
+            onReportMessage: { daemonMessageId in
                 guard let sessionId = viewModel.sessionId else { return }
                 do {
                     try daemonClient.sendDiagnosticsExportRequest(
                         conversationId: sessionId,
-                        anchorMessageId: messageId.uuidString
+                        anchorMessageId: daemonMessageId
                     )
                 } catch {
                     windowState.showToast(

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -527,6 +527,10 @@ public struct ChatMessage: Identifiable {
     public var streamingCodePreview: String?
     /// Tool name associated with the streaming code preview.
     public var streamingCodeToolName: String?
+    /// The daemon's persisted message ID, populated from history responses.
+    /// Nil for freshly streamed messages that haven't been loaded from history.
+    /// Used for anchoring diagnostics exports so the daemon can locate the message.
+    public var daemonMessageId: String?
 
     /// Concatenated text from all segments. Backward-compatible computed property.
     public var text: String {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -894,6 +894,11 @@ public final class ChatViewModel: ObservableObject {
                 )
             }
 
+            // Store the daemon's persisted message ID so diagnostics exports can
+            // anchor to it. This is the database ID from the daemon, not the
+            // client-side UUID.
+            chatMsg.daemonMessageId = item.id
+
             // Populate inlineSurfaces from history
             chatMsg.inlineSurfaces = inlineSurfaces
 


### PR DESCRIPTION
## Summary

- Adds `daemonMessageId: String?` field to `ChatMessage`, populated from daemon history responses
- Changes "Report this response" context menu to pass `daemonMessageId` (or `nil` for freshly streamed messages) instead of the client-side UUID
- When `nil`, the daemon falls back to the latest assistant message — which is exactly the one the user right-clicked

## Problem

The "Report this response" feature sent `ChatMessage.id.uuidString` as `anchorMessageId`, but `ChatMessage.id` is a client-generated UUID that doesn't exist in the daemon's database. The daemon couldn't find this ID, and because an anchor *was* supplied, it didn't use its fallback logic. The export failed silently for the most common case: reporting a response right after it was generated.

## Test plan

- [ ] Build succeeds (`./build.sh`)
- [ ] Right-click a freshly streamed assistant message → "Report this response" → export should succeed (daemon falls back to latest message)
- [ ] Load a thread from history, right-click an older assistant message → "Report this response" → export anchors to the correct historical message
- [ ] Verify no regressions in chat message rendering or history loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
