### PR TITLE
Add client-side document content update support

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -786,6 +786,49 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             }
         }
 
+        /// Send a content update to the web view via window.vellum.onContentUpdate().
+        /// Used by document editor to receive content updates from the daemon.
+        func sendContentUpdate(_ data: [String: Any]) {
+            guard let webView = webView else {
+                log.warning("sendContentUpdate: no webView available")
+                return
+            }
+
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: data),
+                  let jsonString = String(data: jsonData, encoding: .utf8) else {
+                log.error("sendContentUpdate: failed to serialize data to JSON")
+                return
+            }
+
+            let safeJSON = jsonString
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\r", with: "\\r")
+
+            let script = """
+                (function() {
+                    try {
+                        if (typeof window.vellum !== 'undefined' &&
+                            typeof window.vellum.onContentUpdate === 'function') {
+                            var data = JSON.parse('\(safeJSON)');
+                            window.vellum.onContentUpdate(data);
+                        }
+                    } catch(e) {
+                        console.error('onContentUpdate error:', e);
+                    }
+                })();
+                """
+
+            webView.evaluateJavaScript(script) { result, error in
+                if let error = error {
+                    log.error("sendContentUpdate: JS eval error: \(error.localizedDescription, privacy: .public)")
+                } else {
+                    log.debug("sendContentUpdate: successfully sent update")
+                }
+            }
+        }
+
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             // Restore scroll position if this load was a refinement update.
             if let scrollJSON = pendingScrollRestore {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -282,6 +282,16 @@ final class SurfaceManager: ObservableObject {
 
         activeSurfaces[message.surfaceId] = updated
 
+        // If there's a coordinator and the update contains document-specific fields,
+        // send the update directly to the web view via window.vellum.onContentUpdate()
+        if let coordinator = surfaceCoordinators[message.surfaceId] {
+            let dataDict = message.data.value as? [String: Any] ?? [:]
+            if dataDict["markdown"] != nil || dataDict["updateMode"] != nil {
+                coordinator.sendContentUpdate(dataDict)
+                log.info("Sent content update to coordinator for surface: \(message.surfaceId)")
+            }
+        }
+
         if workspaceRoutedSurfaces.contains(message.surfaceId) {
             // Notify the workspace view so it can re-render with updated data.
             NotificationCenter.default.post(


### PR DESCRIPTION
## Summary
- Add `sendContentUpdate` method to DynamicPageSurfaceView.Coordinator
- Call `window.vellum.onContentUpdate()` from Swift to update document editor
- Handle document-specific updates in SurfaceManager
- Route markdown/updateMode updates directly to web view coordinator

Part 5 of 7 for implementing rich text editor for long-form content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
