### PR TITLE
Add Documents section to Generated panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -145,9 +145,51 @@ struct GeneratedPanel: View {
                         )
                         .frame(height: 100)
                     } else {
-                        VStack(spacing: VSpacing.md) {
-                            ForEach(filteredItems) { item in
-                                appRow(item)
+                        VStack(alignment: .leading, spacing: VSpacing.lg) {
+                            // Documents section
+                            if !documentItems.isEmpty {
+                                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                                    HStack {
+                                        Text("DOCUMENTS")
+                                            .font(VFont.display)
+                                            .foregroundColor(VColor.textMuted)
+                                        Spacer()
+                                        Text("\(documentItems.count)")
+                                            .font(VFont.caption)
+                                            .foregroundColor(VColor.textMuted)
+                                    }
+                                    .padding(.horizontal, VSpacing.xs)
+
+                                    VStack(spacing: VSpacing.md) {
+                                        ForEach(documentItems) { item in
+                                            appRow(item)
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Dynamic pages section
+                            if !otherItems.isEmpty {
+                                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                                    if !documentItems.isEmpty {
+                                        HStack {
+                                            Text("PAGES")
+                                                .font(VFont.display)
+                                                .foregroundColor(VColor.textMuted)
+                                            Spacer()
+                                            Text("\(otherItems.count)")
+                                                .font(VFont.caption)
+                                                .foregroundColor(VColor.textMuted)
+                                        }
+                                        .padding(.horizontal, VSpacing.xs)
+                                    }
+
+                                    VStack(spacing: VSpacing.md) {
+                                        ForEach(otherItems) { item in
+                                            appRow(item)
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -172,6 +214,16 @@ struct GeneratedPanel: View {
         }
     }
 
+    /// Document apps (appId starts with "doc-")
+    private var documentItems: [DisplayAppItem] {
+        filteredItems.filter { $0.localAppId?.starts(with: "doc-") ?? false }
+    }
+
+    /// Non-document apps
+    private var otherItems: [DisplayAppItem] {
+        filteredItems.filter { !($0.localAppId?.starts(with: "doc-") ?? false) }
+    }
+
     // MARK: - App Row
 
     private func appRow(_ item: DisplayAppItem) -> some View {
@@ -189,7 +241,8 @@ struct GeneratedPanel: View {
                     .frame(width: 48, height: 48)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             } else {
-                Text(item.icon ?? "\u{1F4F1}")
+                let isDocument = item.localAppId?.starts(with: "doc-") ?? false
+                Text(isDocument ? "📝" : (item.icon ?? "\u{1F4F1}"))
                     .font(.system(size: 20))
                     .frame(width: 28, height: 28)
             }


### PR DESCRIPTION
## Summary
- Add dedicated Documents section in Generated panel
- Separate documents from other dynamic pages with section headers
- Show document and page counts
- Use 📝 emoji icon for document apps  
- Filter documents by appId prefix "doc-"

Part 6 of 7 for implementing rich text editor for long-form content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
