### PR TITLE
Fix diagnostics export error handling, range buffer, and collision safety

### DIFF
--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { mkdirSync, writeFileSync, rmSync, createWriteStream } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
 import { eq, and, desc, gte, lte } from 'drizzle-orm';
 import archiver from 'archiver';
 import { getDb } from '../../memory/db.js';
@@ -109,7 +110,9 @@ export async function handleDiagnosticsExport(
     // Use the preceding user message timestamp as the range start,
     // or fall back to the anchor message timestamp if none found
     const rangeStart = precedingUserMessage?.createdAt ?? anchorMessage.createdAt;
-    const rangeEnd = anchorMessage.createdAt;
+    // Add a 5-second buffer to capture usage events recorded after the
+    // assistant message is persisted (usage logging is async)
+    const rangeEnd = anchorMessage.createdAt + 5000;
 
     // 3. Query all messages in the range
     const rangeMessages = db
@@ -154,7 +157,7 @@ export async function handleDiagnosticsExport(
       .all();
 
     // 6. Write export files to a temp directory
-    const exportId = `diagnostics-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+    const exportId = `diagnostics-${new Date().toISOString().replace(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
     const tempDir = join(tmpdir(), exportId);
     mkdirSync(tempDir, { recursive: true });
 
@@ -226,7 +229,11 @@ export async function handleDiagnosticsExport(
         const archive = archiver('zip', { zlib: { level: 9 } });
 
         output.on('close', () => resolve());
+        output.on('error', (err: Error) => reject(err));
         archive.on('error', (err: Error) => reject(err));
+        archive.on('warning', (err: Error) => {
+          log.warn({ err }, 'Archiver warning during diagnostics export');
+        });
 
         archive.pipe(output);
         archive.directory(tempDir, false);


### PR DESCRIPTION
## Summary
Addresses review feedback from #3858:
- **Write stream error handling**: Added `output.on('error')` handler so the archiver promise rejects (instead of hanging forever) when the `WriteStream` fails (disk full, permission denied). Also added `archive.on('warning')` to log non-fatal warnings.
- **Usage event range buffer**: Expanded `rangeEnd` by 5 seconds beyond the anchor message timestamp to capture LLM usage events that are recorded asynchronously after the assistant message is persisted.
- **Export ID collision safety**: Appended `randomBytes(4).toString('hex')` (8 hex chars) to the export ID so concurrent exports can't collide on the same millisecond timestamp.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Trigger a diagnostics export and confirm the zip is created with a random suffix in the filename
- [ ] Confirm usage.jsonl includes events recorded shortly after the anchor message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
