### PR TITLE
M1: Introduce ViewSelection enum and refactor content rendering

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -232,7 +232,7 @@ extension AppDelegate {
 
     @objc func openAppCollection() {
         showMainWindow()
-        mainWindow?.windowState.activePanel = .directory
+        mainWindow?.windowState.selection = .panel(.directory)
     }
 
     @objc func checkForUpdates() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 import VellumAssistantShared
 
+/// Represents what is currently displayed in the main content area.
+enum ViewSelection: Equatable {
+    case thread(UUID)
+    case app(String)  // app ID
+    case appEditing(appId: String, threadId: UUID)
+    case panel(SidePanelType)
+}
+
 /// Cross-view UI state for the main window, extracted from `MainWindowView`
 /// to make it explicit, injectable, and easier to preview.
 @MainActor
@@ -8,50 +16,150 @@ final class MainWindowState: ObservableObject {
     @AppStorage("lastActivePanel") private var lastActivePanelString: String?
     @AppStorage("homeBaseDashboardDefaultEnabled") private var homeBaseDashboardDefaultEnabled: Bool = false
     @AppStorage("chatDockOpen") private var chatDockOpen = false
-    @Published var activePanel: SidePanelType? {
-        didSet {
-            // Persist non-activity panels only (activity is message-specific)
-            if let activePanel, activePanel != .activity {
-                lastActivePanelString = String(describing: activePanel)
-            } else if activePanel == nil {
-                lastActivePanelString = nil
-            }
-        }
-    }
-    @Published var isDynamicExpanded = false
+
+    /// The single source of truth for what the main content area displays.
+    @Published var selection: ViewSelection?
+
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?
     @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
-    @Published var isChatDockOpen = UserDefaults.standard.bool(forKey: "chatDockOpen") {
-        didSet { chatDockOpen = isChatDockOpen }
-    }
     @Published var activityMessageId: UUID?
     @Published var layoutConfig: LayoutConfig
     @Published var toastInfo: ToastInfo?
+
+    // MARK: - Backward-Compatible Computed Properties
+
+    /// Derived from `selection` for backward compatibility.
+    var activePanel: SidePanelType? {
+        get {
+            switch selection {
+            case .panel(let type): return type
+            case .app, .appEditing: return .generated
+            default: return nil
+            }
+        }
+        set {
+            if let panel = newValue {
+                selection = .panel(panel)
+            } else {
+                // Only clear if currently showing a panel
+                if case .panel = selection {
+                    selection = nil
+                } else if newValue == nil && activePanel != nil {
+                    // Explicit nil set — clear selection
+                    selection = nil
+                }
+            }
+            // Persist non-activity panels
+            if let newValue, newValue != .activity {
+                lastActivePanelString = String(describing: newValue)
+            } else if newValue == nil {
+                lastActivePanelString = nil
+            }
+        }
+    }
+
+    /// Whether the dynamic workspace (app view) is expanded.
+    var isDynamicExpanded: Bool {
+        get {
+            switch selection {
+            case .app, .appEditing: return true
+            default: return false
+            }
+        }
+        set {
+            if !newValue {
+                // Collapsing: if we were showing an app, clear
+                if case .app = selection { selection = nil }
+                if case .appEditing = selection { selection = nil }
+            }
+            // Setting to true is handled by setting selection to .app(...)
+        }
+    }
+
+    /// Whether the chat dock is open alongside an app workspace.
+    var isChatDockOpen: Bool {
+        get {
+            if case .appEditing = selection { return true }
+            return false
+        }
+        set {
+            if newValue {
+                // Opening chat dock: transition from .app to .appEditing
+                if case .app(let appId) = selection {
+                    // We need a thread ID; use nil-coalesced placeholder
+                    // The caller should also wire up the thread
+                    // For now, keep as .app — .appEditing requires a threadId
+                    // which will be set by the caller
+                    _ = appId // keep .app for now, caller sets .appEditing
+                }
+            } else {
+                // Closing chat dock: transition from .appEditing to .app
+                if case .appEditing(let appId, _) = selection {
+                    selection = .app(appId)
+                }
+            }
+            chatDockOpen = newValue
+        }
+    }
 
     init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
         self.hasAPIKey = hasAPIKey
         self.layoutConfig = LayoutConfigStore.load()
     }
 
+    // MARK: - Selection Helpers
+
+    func select(_ newSelection: ViewSelection) {
+        selection = newSelection
+    }
+
+    /// Whether an app is currently shown (either standalone or editing)
+    var activeAppId: String? {
+        switch selection {
+        case .app(let id): return id
+        case .appEditing(let appId, _): return appId
+        default: return nil
+        }
+    }
+
+    /// Whether a thread is currently active (either standalone or editing alongside app)
+    var activeEditingThreadId: UUID? {
+        switch selection {
+        case .thread(let id): return id
+        case .appEditing(_, let threadId): return threadId
+        default: return nil
+        }
+    }
+
+    // MARK: - Panel Toggling
+
     func toggleActivityPanel(with messageId: UUID) {
-        if activePanel == .activity && activityMessageId == messageId {
+        if case .panel(.activity) = selection, activityMessageId == messageId {
             // Close if already open with the same message
-            activePanel = nil
+            selection = nil
             activityMessageId = nil
         } else {
             // Open with new message or update to different message
             self.activityMessageId = messageId
-            self.activePanel = .activity
+            self.selection = .panel(.activity)
         }
     }
 
     func togglePanel(_ panel: SidePanelType) {
-        if activePanel == panel {
-            activePanel = nil
+        if case .panel(let current) = selection, current == panel {
+            selection = nil
         } else {
-            activePanel = panel
+            selection = .panel(panel)
+        }
+        // Persist non-activity panels
+        if panel != .activity {
+            if case .panel(let p) = selection, p == panel {
+                lastActivePanelString = String(describing: panel)
+            } else {
+                lastActivePanelString = nil
+            }
         }
     }
 
@@ -67,14 +175,29 @@ final class MainWindowState: ObservableObject {
     /// Reset all dynamic workspace state. Callers should also reset
     /// view-local state like `showSharePicker` separately.
     func closeDynamicPanel() {
-        activePanel = nil
-        isDynamicExpanded = false
+        selection = nil
         activeDynamicSurface = nil
         activeDynamicParsedSurface = nil
     }
 
     func toggleChatDock() {
-        isChatDockOpen.toggle()
+        if case .appEditing(let appId, _) = selection {
+            // Currently editing -> close chat dock
+            selection = .app(appId)
+            chatDockOpen = false
+        } else if case .app(let appId) = selection {
+            // Currently app only -> open chat dock (needs thread)
+            // The view layer will wire the thread ID via setAppEditing
+            // For now, mark intent by keeping .app and letting the view handle transition
+            _ = appId
+            chatDockOpen = true
+        }
+    }
+
+    /// Transition to appEditing with a specific thread
+    func setAppEditing(appId: String, threadId: UUID) {
+        selection = .appEditing(appId: appId, threadId: threadId)
+        chatDockOpen = true
     }
 
     func resetLayout() {
@@ -103,7 +226,7 @@ final class MainWindowState: ObservableObject {
         // Don't restore activity panel (it's session-specific)
         guard panel != .activity else { return }
 
-        activePanel = panel
+        selection = .panel(panel)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -162,17 +162,45 @@ struct MainWindowView: View {
 
     var body: some View {
         coreLayoutView
-            .onChange(of: windowState.isDynamicExpanded) { _, expanded in
+            .onChange(of: windowState.selection) { oldSelection, newSelection in
+                // Sync surface and chat dock state when selection changes
+                let expanded = windowState.isDynamicExpanded
+                let docked = windowState.isChatDockOpen
                 threadManager.activeViewModel?.activeSurfaceId = expanded ? windowState.activeDynamicSurface?.surfaceId : nil
-                threadManager.activeViewModel?.isChatDockedToSide = expanded && windowState.isChatDockOpen
+                threadManager.activeViewModel?.isChatDockedToSide = expanded && docked
+
+                // Reset expanded state and active surface when navigating away from app/generated
+                let oldIsApp: Bool = {
+                    switch oldSelection {
+                    case .app, .appEditing: return true
+                    case .panel(.generated): return true
+                    default: return false
+                    }
+                }()
+                let newIsApp: Bool = {
+                    switch newSelection {
+                    case .app, .appEditing: return true
+                    case .panel(.generated): return true
+                    default: return false
+                    }
+                }()
+                if oldIsApp && !newIsApp {
+                    showSharePicker = false
+                    windowState.activeDynamicSurface = nil
+                    windowState.activeDynamicParsedSurface = nil
+                }
+
+                // Close the left sidebar when the activity panel opens to avoid crowding
+                if case .panel(.activity) = newSelection, sidebarOpen {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        sidebarOpen = false
+                    }
+                }
             }
             .onChange(of: windowState.activeDynamicSurface?.surfaceId) { _, surfaceId in
                 if windowState.isDynamicExpanded {
                     threadManager.activeViewModel?.activeSurfaceId = surfaceId
                 }
-            }
-            .onChange(of: windowState.isChatDockOpen) { _, docked in
-                threadManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && docked
             }
             .onChange(of: threadManager.activeViewModel?.messages.count) { _, _ in
                 // Close activity panel if the referenced message no longer exists
@@ -182,7 +210,7 @@ struct MainWindowView: View {
                    let viewModel = threadManager.activeViewModel {
                     let messageExists = viewModel.messages.contains(where: { $0.id == messageId })
                     if !messageExists {
-                        windowState.activePanel = nil
+                        windowState.selection = nil
                         windowState.activityMessageId = nil
                     }
                 }
@@ -277,16 +305,6 @@ struct MainWindowView: View {
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
             requestHomeBaseDashboardIfNeeded()
         }
-        .onChange(of: windowState.activePanel) { _, newPanel in
-            // Reset expanded state and active surface when navigating away from the
-            // Dynamic panel via sidebar or Control Center buttons, which only modify activePanel.
-            if newPanel != .generated {
-                showSharePicker = false
-                windowState.isDynamicExpanded = false
-                windowState.activeDynamicSurface = nil
-                windowState.activeDynamicParsedSurface = nil
-            }
-        }
         .onChange(of: selectedThreadId) { _, newId in
             if let newId = newId {
                 threadManager.selectThread(id: newId)
@@ -297,11 +315,11 @@ struct MainWindowView: View {
             selectedThreadId = newId
             // Close the activity panel when switching threads — the stored messageId
             // belongs to the previous thread and won't exist in the new one.
-            if windowState.activePanel == .activity {
-                windowState.activePanel = nil
+            if case .panel(.activity) = windowState.selection {
+                windowState.selection = nil
                 windowState.activityMessageId = nil
-            } else if windowState.activePanel == .identity {
-                windowState.activePanel = nil
+            } else if case .panel(.identity) = windowState.selection {
+                windowState.selection = nil
             }
             // Clear stale activeSurfaceId on the old thread and sync the new one
             if let oldId {
@@ -310,20 +328,18 @@ struct MainWindowView: View {
             threadManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
             threadManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && windowState.isChatDockOpen
         }
-        .onChange(of: windowState.activePanel) { _, newPanel in
-            // Close the left sidebar when the activity panel opens to avoid crowding
-            if newPanel == .activity && sidebarOpen {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                    sidebarOpen = false
-                }
-            }
-        }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
                 windowState.activeDynamicSurface = msg
                 windowState.activeDynamicParsedSurface = Surface.from(msg)
-                windowState.activePanel = .generated
-                windowState.isDynamicExpanded = true
+                // Determine the app ID from the surface if available
+                if let surface = windowState.activeDynamicParsedSurface,
+                   case .dynamicPage(let dpData) = surface.data,
+                   let appId = dpData.appId {
+                    windowState.selection = .app(appId)
+                } else {
+                    windowState.selection = .app(msg.surfaceId)
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .updateDynamicWorkspace)) { notification in
@@ -337,22 +353,12 @@ struct MainWindowView: View {
             if let surfaceId = notification.userInfo?["surfaceId"] as? String {
                 if windowState.activeDynamicSurface?.surfaceId == surfaceId {
                     showSharePicker = false
-                    if windowState.activePanel == .generated {
-                        windowState.activePanel = nil
-                    }
-                    windowState.isDynamicExpanded = false
-                    windowState.activeDynamicSurface = nil
-                    windowState.activeDynamicParsedSurface = nil
+                    windowState.closeDynamicPanel()
                 }
             } else {
                 // Bulk dismiss (dismissAll)
                 showSharePicker = false
-                if windowState.activePanel == .generated {
-                    windowState.activePanel = nil
-                }
-                windowState.isDynamicExpanded = false
-                windowState.activeDynamicSurface = nil
-                windowState.activeDynamicParsedSurface = nil
+                windowState.closeDynamicPanel()
             }
         }
         .onChange(of: isHoveredThread) { _, newValue in
@@ -367,13 +373,8 @@ struct MainWindowView: View {
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected = thread.id == threadManager.activeThreadId
         Button(action: {
+            windowState.selection = .thread(thread.id)
             threadManager.selectThread(id: thread.id)
-            switch windowState.activePanel {
-            case .settings, .agent, .directory, .debug, .doctor, .identity:
-                windowState.activePanel = nil
-            default:
-                break
-            }
         }) {
             HStack(spacing: VSpacing.sm) {
                 if thread.isPinned {
@@ -493,7 +494,7 @@ struct MainWindowView: View {
             .padding(.trailing, VSpacing.sm)
             .frame(height: 36)
 
-            NewConversationButton(action: { windowState.activePanel = nil; threadManager.createThread() })
+            NewConversationButton(action: { windowState.selection = nil; threadManager.createThread() })
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.top, VSpacing.md)
                 .padding(.bottom, VSpacing.sm)
@@ -588,10 +589,13 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private func sidebarAppItem(_ app: AppListManager.AppItem) -> some View {
-        let isSelected = windowState.isDynamicExpanded
+        let isSelected = windowState.activeAppId == app.id || (
+            windowState.isDynamicExpanded
             && windowState.activeDynamicSurface?.surfaceId != nil
             && isAppSurfaceActive(appId: app.id)
+        )
         Button(action: {
+            windowState.selection = .app(app.id)
             openAppInWorkspace(app: app)
         }) {
             HStack(spacing: VSpacing.sm) {
@@ -787,13 +791,13 @@ struct MainWindowView: View {
                 ActivityPanel(
                     viewModel: viewModel,
                     messageId: messageId,
-                    onClose: { windowState.activePanel = nil }
+                    onClose: { windowState.selection = nil }
                 )
             }
         case .settings:
-            SettingsPanel(onClose: { windowState.activePanel = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
+            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
         case .agent:
-            AgentPanel(onClose: { windowState.activePanel = nil }, onInvokeSkill: { skill in
+            AgentPanel(onClose: { windowState.selection = nil }, onInvokeSkill: { skill in
                 if threadManager.activeViewModel == nil {
                     threadManager.createThread()
                 }
@@ -807,26 +811,31 @@ struct MainWindowView: View {
                     viewModel.sendMessage()
                     viewModel.pendingSkillInvocation = nil
                 }
-                windowState.activePanel = nil
+                windowState.selection = nil
             }, daemonClient: daemonClient)
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
                 daemonClient: daemonClient,
                 activeSessionId: threadManager.activeViewModel?.sessionId,
-                onClose: { windowState.activePanel = nil }
+                onClose: { windowState.selection = nil }
             )
         case .doctor:
-            DoctorPanel(onClose: { windowState.activePanel = nil })
+            DoctorPanel(onClose: { windowState.selection = nil })
         case .directory:
             AppDirectoryView(
                 daemonClient: daemonClient,
-                onBack: { windowState.activePanel = nil },
+                onBack: { windowState.selection = nil },
                 onOpenApp: { surfaceMsg in
                     windowState.activeDynamicSurface = surfaceMsg
                     windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
-                    windowState.activePanel = .generated
-                    windowState.isDynamicExpanded = true
+                    if let surface = windowState.activeDynamicParsedSurface,
+                       case .dynamicPage(let dpData) = surface.data,
+                       let appId = dpData.appId {
+                        windowState.selection = .app(appId)
+                    } else {
+                        windowState.selection = .app(surfaceMsg.surfaceId)
+                    }
                 },
                 onRecordAppOpen: { id, name, icon, appType in
                     appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
@@ -835,7 +844,10 @@ struct MainWindowView: View {
         case .generated:
             GeneratedPanel(
                 onClose: { showSharePicker = false; windowState.closeDynamicPanel() },
-                isExpanded: $windowState.isDynamicExpanded,
+                isExpanded: Binding(
+                    get: { windowState.isDynamicExpanded },
+                    set: { windowState.isDynamicExpanded = $0 }
+                ),
                 daemonClient: daemonClient,
                 onOpenApp: { surfaceMsg in
                     windowState.activeDynamicSurface = surfaceMsg
@@ -848,7 +860,7 @@ struct MainWindowView: View {
         case .threadList:
             sidebarView
         case .identity:
-            IdentityPanel(onClose: { windowState.activePanel = nil }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
         }
     }
 
@@ -883,38 +895,23 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private func chatContentView(geometry: GeometryProxy) -> some View {
-        if windowState.activePanel == .directory {
-            AppDirectoryView(
-                daemonClient: daemonClient,
-                onBack: { windowState.activePanel = nil },
-                onOpenApp: { surfaceMsg in
-                    windowState.activeDynamicSurface = surfaceMsg
-                    windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
-                    windowState.activePanel = .generated
-                    windowState.isDynamicExpanded = true
-                },
-                onRecordAppOpen: { id, name, icon, appType in
-                    appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
-                }
-            )
-        } else if windowState.isDynamicExpanded && windowState.activePanel == .generated {
+        switch windowState.selection {
+        case .thread:
+            // Show chat for this thread (threadManager.activeViewModel is synced)
+            defaultChatLayout
+        case .app:
+            // App workspace: full width (no chat dock)
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
-                VSplitView(
-                    panelWidth: $sidePanelWidth,
-                    showPanel: windowState.isChatDockOpen,
-                    main: {
-                        dynamicWorkspaceView(surface: surface, data: dpData)
-                    },
-                    panel: {
-                        chatView
-                    }
-                )
+                dynamicWorkspaceView(surface: surface, data: dpData)
             } else {
-                // Gallery mode: existing behavior, with workspace routing
+                // Gallery mode fallback
                 GeneratedPanel(
                     onClose: { showSharePicker = false; windowState.closeDynamicPanel() },
-                    isExpanded: $windowState.isDynamicExpanded,
+                    isExpanded: Binding(
+                        get: { windowState.isDynamicExpanded },
+                        set: { windowState.isDynamicExpanded = $0 }
+                    ),
                     daemonClient: daemonClient,
                     onOpenApp: { surfaceMsg in
                         windowState.activeDynamicSurface = surfaceMsg
@@ -925,35 +922,92 @@ struct MainWindowView: View {
                     }
                 )
             }
-        } else if let panel = windowState.activePanel, panel != .activity {
-            // Full-window panels: settings, skills, debug, doctor
-            fullWindowPanel(panel)
-        } else {
-            let config = windowState.layoutConfig
-            let showActivity = windowState.activePanel == .activity
-                && threadManager.activeViewModel != nil
-                && windowState.activityMessageId != nil
-            let showConfigPanel = config.right.visible && config.right.content != .empty
-
-            VSplitView(
-                panelWidth: $sidePanelWidth,
-                showPanel: showActivity || showConfigPanel,
-                main: { slotView(for: config.center.content) },
-                panel: {
-                    if showActivity,
-                       let viewModel = threadManager.activeViewModel,
-                       let messageId = windowState.activityMessageId {
-                        ActivityPanel(
-                            viewModel: viewModel,
-                            messageId: messageId,
-                            onClose: { windowState.activePanel = nil }
-                        )
-                    } else {
-                        slotView(for: config.right.content)
+        case .appEditing:
+            // VSplitView: workspace + ChatView
+            if let surface = windowState.activeDynamicParsedSurface,
+               case .dynamicPage(let dpData) = surface.data {
+                VSplitView(
+                    panelWidth: $sidePanelWidth,
+                    showPanel: true,
+                    main: {
+                        dynamicWorkspaceView(surface: surface, data: dpData)
+                    },
+                    panel: {
+                        chatView
                     }
-                }
-            )
+                )
+            } else {
+                defaultChatLayout
+            }
+        case .panel(let panelType):
+            if panelType == .directory {
+                AppDirectoryView(
+                    daemonClient: daemonClient,
+                    onBack: { windowState.selection = nil },
+                    onOpenApp: { surfaceMsg in
+                        windowState.activeDynamicSurface = surfaceMsg
+                        windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
+                        if let surface = windowState.activeDynamicParsedSurface,
+                           case .dynamicPage(let dpData) = surface.data,
+                           let appId = dpData.appId {
+                            windowState.selection = .app(appId)
+                        } else {
+                            windowState.selection = .app(surfaceMsg.surfaceId)
+                        }
+                    },
+                    onRecordAppOpen: { id, name, icon, appType in
+                        appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                    }
+                )
+            } else if panelType == .activity {
+                // Activity panel shown as side panel alongside chat
+                let config = windowState.layoutConfig
+                let showActivity = threadManager.activeViewModel != nil
+                    && windowState.activityMessageId != nil
+                let showConfigPanel = config.right.visible && config.right.content != .empty
+
+                VSplitView(
+                    panelWidth: $sidePanelWidth,
+                    showPanel: showActivity || showConfigPanel,
+                    main: { slotView(for: config.center.content) },
+                    panel: {
+                        if showActivity,
+                           let viewModel = threadManager.activeViewModel,
+                           let messageId = windowState.activityMessageId {
+                            ActivityPanel(
+                                viewModel: viewModel,
+                                messageId: messageId,
+                                onClose: { windowState.selection = nil }
+                            )
+                        } else {
+                            slotView(for: config.right.content)
+                        }
+                    }
+                )
+            } else {
+                // Full-window panels: settings, skills, debug, doctor, identity
+                fullWindowPanel(panelType)
+            }
+        case nil:
+            // Default: show chat for active thread
+            defaultChatLayout
         }
+    }
+
+    /// The default chat layout used when showing a thread or no specific selection.
+    @ViewBuilder
+    private var defaultChatLayout: some View {
+        let config = windowState.layoutConfig
+        let showConfigPanel = config.right.visible && config.right.content != .empty
+
+        VSplitView(
+            panelWidth: $sidePanelWidth,
+            showPanel: showConfigPanel,
+            main: { slotView(for: config.center.content) },
+            panel: {
+                slotView(for: config.right.content)
+            }
+        )
     }
 
     @ViewBuilder
@@ -976,9 +1030,9 @@ struct MainWindowView: View {
     private func fullWindowPanel(_ panel: SidePanelType) -> some View {
         switch panel {
         case .settings:
-            SettingsPanel(onClose: { windowState.activePanel = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
+            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
         case .agent:
-            AgentPanel(onClose: { windowState.activePanel = nil }, onInvokeSkill: { skill in
+            AgentPanel(onClose: { windowState.selection = nil }, onInvokeSkill: { skill in
                 if threadManager.activeViewModel == nil {
                     threadManager.createThread()
                 }
@@ -992,25 +1046,25 @@ struct MainWindowView: View {
                     viewModel.sendMessage()
                     viewModel.pendingSkillInvocation = nil
                 }
-                windowState.activePanel = nil
+                windowState.selection = nil
             }, daemonClient: daemonClient)
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
                 daemonClient: daemonClient,
                 activeSessionId: threadManager.activeViewModel?.sessionId,
-                onClose: { windowState.activePanel = nil }
+                onClose: { windowState.selection = nil }
             )
         case .doctor:
-            DoctorPanel(onClose: { windowState.activePanel = nil })
+            DoctorPanel(onClose: { windowState.selection = nil })
         case .identity:
-            IdentityPanel(onClose: { windowState.activePanel = nil }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;
-            // if we reach here, isDynamicExpanded is false — clear activePanel so
+            // if we reach here, isDynamicExpanded is false — clear selection so
             // the user falls back to the chat view instead of seeing a blank screen.
             Color.clear.frame(width: 0, height: 0)
-                .onAppear { windowState.activePanel = nil }
+                .onAppear { windowState.selection = nil }
         default:
             EmptyView()
         }
@@ -1039,9 +1093,19 @@ struct MainWindowView: View {
                 onPublishPage: publishPage,
                 onBundleAndShare: bundleAndShare,
                 isChatDockOpen: windowState.isChatDockOpen,
-                onToggleChatDock: { windowState.toggleChatDock() },
-                onMicrophoneToggle: onMicrophoneToggle,
-                onClose: { windowState.closeDynamicPanel() }
+                onToggleChatDock: {
+                    if let appId = windowState.activeAppId,
+                       let threadId = threadManager.activeThreadId {
+                        if windowState.isChatDockOpen {
+                            // Close: transition from appEditing to app
+                            windowState.selection = .app(appId)
+                        } else {
+                            // Open: transition from app to appEditing
+                            windowState.setAppEditing(appId: appId, threadId: threadId)
+                        }
+                    }
+                },
+                onMicrophoneToggle: onMicrophoneToggle
             )
         }
     }
@@ -1297,7 +1361,7 @@ private struct ActiveChatViewWrapper: View {
             pendingAttachments: viewModel.pendingAttachments,
             isRecording: viewModel.isRecording,
             onOpenSettings: {
-                windowState.activePanel = .settings
+                windowState.selection = .panel(.settings)
             },
             onSend: viewModel.sendMessage,
             onStop: viewModel.stopGenerating,
@@ -1335,7 +1399,7 @@ private struct ActiveChatViewWrapper: View {
             onOpenActivity: { messageId in
                 windowState.toggleActivityPanel(with: messageId)
             },
-            isActivityPanelOpen: windowState.activePanel == .activity,
+            isActivityPanelOpen: { if case .panel(.activity) = windowState.selection { return true } else { return false } }(),
             onReportMessage: { daemonMessageId in
                 guard let sessionId = viewModel.sessionId else { return }
                 do {
@@ -1375,7 +1439,6 @@ private struct DynamicWorkspaceWrapper: View {
     let isChatDockOpen: Bool
     let onToggleChatDock: () -> Void
     let onMicrophoneToggle: () -> Void
-    var onClose: (() -> Void)?
 
     private var composerReservedHeight: CGFloat {
         guard !isChatDockOpen else { return 0 }
@@ -1585,22 +1648,6 @@ private struct DynamicWorkspaceWrapper: View {
                             )
                             .frame(width: 1, height: 1)
                         )
-                    }
-
-                    if onClose != nil {
-                        Button(action: { onClose?() }) {
-                            Image(systemName: "xmark")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundColor(VColor.textPrimary)
-                                .frame(width: 32, height: 32)
-                                .background(
-                                    Circle()
-                                        .fill(VColor.surface.opacity(0.85))
-                                        .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
-                                )
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Close dashboard")
                     }
                 }
                 .padding(.leading, trafficLightPadding)


### PR DESCRIPTION
Adds a unified ViewSelection enum to MainWindowState that drives all content rendering. Sidebar clicks set selection, content area switches on selection, X/close buttons removed. Part of #3869.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
