### PR TITLE
Limit post-anchor buffer to usage events only

### DIFF
--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -110,9 +110,12 @@ export async function handleDiagnosticsExport(
     // Use the preceding user message timestamp as the range start,
     // or fall back to the anchor message timestamp if none found
     const rangeStart = precedingUserMessage?.createdAt ?? anchorMessage.createdAt;
-    // Add a 5-second buffer to capture usage events recorded after the
-    // assistant message is persisted (usage logging is async)
-    const rangeEnd = anchorMessage.createdAt + 5000;
+    const rangeEnd = anchorMessage.createdAt;
+    // Usage events are recorded asynchronously after the assistant message
+    // is persisted, so their createdAt can be slightly later. Use a separate
+    // extended bound for the usage query only to avoid pulling in unrelated
+    // messages or tool invocations from the next turn.
+    const usageRangeEnd = anchorMessage.createdAt + 5000;
 
     // 3. Query all messages in the range
     const rangeMessages = db
@@ -150,7 +153,7 @@ export async function handleDiagnosticsExport(
         and(
           eq(llmUsageEvents.conversationId, conversationId),
           gte(llmUsageEvents.createdAt, rangeStart),
-          lte(llmUsageEvents.createdAt, rangeEnd),
+          lte(llmUsageEvents.createdAt, usageRangeEnd),
         ),
       )
       .orderBy(llmUsageEvents.createdAt)


### PR DESCRIPTION
## Summary
Fixes an issue from #3868 where the 5-second `rangeEnd` buffer was applied to all three diagnostic queries (messages, tool invocations, usage events). If a user replies within 5 seconds, the export would include the next turn's messages and tool calls — contaminating the diagnostic bundle with unrelated content.

Now:
- `rangeEnd` = exact anchor message timestamp (used for messages + tool invocations)
- `usageRangeEnd` = anchor + 5 seconds (used only for usage events, since `recordUsage()` runs asynchronously after `addMessage()` in session.ts)

## Test plan
- [ ] Verify type-check passes
- [ ] Export diagnostics on a conversation with quick follow-up messages — confirm only the anchor turn's messages/tools appear, but usage events are still captured
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
