### PR TITLE
fix(ui): equal-height cards and copyright symbol in WakeUpStepView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -65,7 +65,7 @@ struct WakeUpStepView: View {
             .padding(.top, VSpacing.lg)
 
             // Footer
-            Text("2026 Vellum Inc.")
+            Text("© 2026 Vellum Inc.")
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundColor(VColor.textMuted.opacity(0.5))
         }
@@ -112,7 +112,7 @@ struct WakeUpStepView: View {
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xl)
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
                 .fill(Color.white.opacity(0.02))


### PR DESCRIPTION
## Summary
- Add `maxHeight: .infinity, alignment: .top` to option card frames so both cards stretch to equal height and "Start" buttons align at the bottom
- Add missing `©` symbol to footer text ("© 2026 Vellum Inc.")

## Test plan
- [ ] Verify in Xcode Preview that both option cards have equal height
- [ ] Verify the "Start" buttons are horizontally aligned across both cards
- [ ] Verify footer reads "© 2026 Vellum Inc."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
