### PR TITLE
feat: improve permission confirmation prompt UX

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -451,7 +451,6 @@ struct ChatView: View {
                                 // Show pending confirmations as inline buttons
                                 ToolConfirmationBubble(
                                     confirmation: confirmation,
-                                    showDescription: true,
                                     onAllow: { onConfirmationAllow(confirmation.requestId) },
                                     onDeny: { onConfirmationDeny(confirmation.requestId) },
                                     onAddTrustRule: onAddTrustRule
@@ -472,7 +471,6 @@ struct ChatView: View {
                                 if !hasPrecedingAssistant {
                                     ToolConfirmationBubble(
                                         confirmation: confirmation,
-                                        showDescription: true,
                                         onAllow: { onConfirmationAllow(confirmation.requestId) },
                                         onDeny: { onConfirmationDeny(confirmation.requestId) },
                                         onAddTrustRule: onAddTrustRule

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -109,6 +109,40 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
+    /// User-facing tool category label (e.g. "Run Command", "Write File").
+    public var toolCategory: String {
+        switch toolName {
+        case "bash", "host_bash":          return "Run Command"
+        case "file_write", "host_file_write": return "Write File"
+        case "file_edit", "host_file_edit":   return "Edit File"
+        case "file_read", "host_file_read":   return "Read File"
+        case "web_fetch":                     return "Fetch URL"
+        case "browser_navigate":              return "Open Page"
+        default:
+            return toolName
+                .replacingOccurrences(of: "_", with: " ")
+                .split(separator: " ")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
+        }
+    }
+
+    /// SF Symbol name for the tool category.
+    public var toolCategoryIcon: String {
+        switch toolName {
+        case "bash", "host_bash":              return "terminal"
+        case "file_write", "host_file_write":  return "doc.badge.plus"
+        case "file_edit", "host_file_edit":    return "pencil.line"
+        case "file_read", "host_file_read":    return "doc.text"
+        case "web_fetch":                      return "arrow.down.circle"
+        case "browser_navigate":               return "globe"
+        default:                               return "puzzlepiece.extension"
+        }
+    }
+
+    /// Whether a diff is available for display.
+    public var hasDiff: Bool { diff != nil }
+
     /// Whether this is a system permission request (TCC).
     public var isSystemPermissionRequest: Bool {
         toolName == "request_system_permission"
@@ -166,158 +200,46 @@ public struct ToolConfirmationData: Equatable {
         return URL(string: urlString)
     }
 
-    /// Friendly, context-aware description for the permission ask.
+    /// Short, direct description of the action being requested.
     public var humanDescription: String {
         switch toolName {
         case "request_system_permission":
             let reason = (input["reason"]?.value as? String) ?? ""
             if reason.isEmpty {
-                return "I need \(permissionFriendlyName) to do this for you."
+                return "Needs \(permissionFriendlyName) to proceed."
             }
             return reason
         case "bash", "host_bash":
-            return Self.describeBashCommand((input["command"]?.value as? String) ?? "")
+            return "Wants to run a shell command."
         case "file_write", "host_file_write":
             let path = (input["path"]?.value as? String) ?? ""
-            if path.isEmpty { return "I\u{2019}d like to save some changes to a file \u{2014} that ok?" }
+            if path.isEmpty { return "Wants to write a file." }
             let name = URL(fileURLWithPath: path).lastPathComponent
-            return "I\u{2019}d like to save some changes to \(name) \u{2014} that ok?"
+            return "Wants to write to \(name)."
         case "file_edit", "host_file_edit":
             let path = (input["path"]?.value as? String) ?? ""
-            if path.isEmpty { return "I need to make a quick edit to a file \u{2014} cool?" }
+            if path.isEmpty { return "Wants to edit a file." }
             let name = URL(fileURLWithPath: path).lastPathComponent
-            return "I need to make a quick edit to \(name) \u{2014} cool?"
+            return "Wants to edit \(name)."
         case "file_read", "host_file_read":
             let path = (input["path"]?.value as? String) ?? ""
-            if path.isEmpty { return "Let me take a peek at a file \u{2014} alright?" }
+            if path.isEmpty { return "Wants to read a file." }
             let name = URL(fileURLWithPath: path).lastPathComponent
-            return "Let me take a peek at \(name) \u{2014} alright?"
+            return "Wants to read \(name)."
         case "web_fetch":
             let url = (input["url"]?.value as? String) ?? ""
             if let host = URL(string: url)?.host {
-                return "I need to grab some info from \(host) \u{2014} that ok?"
+                return "Wants to fetch data from \(host)."
             }
-            return "I need to look something up online \u{2014} that ok?"
+            return "Wants to fetch a URL."
         case "browser_navigate":
             let url = (input["url"]?.value as? String) ?? ""
             if let host = URL(string: url)?.host {
-                return "I want to open \(host) for you \u{2014} cool?"
+                return "Wants to open \(host)."
             }
-            return "I want to open a page for you \u{2014} cool?"
+            return "Wants to open a page."
         default:
-            return "I need to do something on your Mac \u{2014} that ok?"
-        }
-    }
-
-    /// Extracts a friendly folder/file name from a path in a command.
-    private static func friendlyPath(_ command: String) -> String? {
-        // Look for paths like ~/Downloads, /Users/.../folder, ./src, etc.
-        let patterns = command.split(separator: " ").compactMap { token -> String? in
-            let s = String(token)
-            guard s.contains("/") || s.hasPrefix("~") else { return nil }
-            // Clean trailing slashes and pipes
-            let cleaned = s.trimmingCharacters(in: CharacterSet(charactersIn: "/|;&"))
-            if cleaned.isEmpty || cleaned == "~" { return nil }
-            let url = URL(fileURLWithPath: cleaned.replacingOccurrences(of: "~", with: "/Users/you"))
-            let name = url.lastPathComponent
-            return name.isEmpty ? nil : name
-        }
-        return patterns.first
-    }
-
-    private static func describeBashCommand(_ command: String) -> String {
-        let trimmed = command.trimmingCharacters(in: .whitespaces)
-        let words = trimmed.split(separator: " ")
-        let first = words.first.map(String.init) ?? ""
-        let path = friendlyPath(trimmed)
-
-        switch first {
-        case "ls":
-            if let p = path {
-                return "To check your \(p) folder, I need to run a quick command"
-            }
-            return "I need to look through some files \u{2014} that ok?"
-        case "cat", "head", "tail", "less", "more":
-            if let p = path {
-                return "I need to read \(p) \u{2014} that ok?"
-            }
-            return "I need to read a file \u{2014} that ok?"
-        case "mkdir":
-            if let p = path {
-                return "I need to create a \(p) folder \u{2014} cool?"
-            }
-            return "I need to create a new folder \u{2014} cool?"
-        case "rm", "rmdir":
-            if let p = path {
-                return "I need to delete \(p) \u{2014} is that alright?"
-            }
-            return "I need to delete some files \u{2014} is that alright?"
-        case "cp":
-            return "I need to copy some files over \u{2014} that ok?"
-        case "mv":
-            return "I need to move something around \u{2014} that ok?"
-        case "git":
-            let sub = words.dropFirst().first.map(String.init) ?? ""
-            switch sub {
-            case "push": return "I\u{2019}m ready to push your code \u{2014} should I go ahead?"
-            case "pull": return "Let me pull the latest code for you \u{2014} cool?"
-            case "commit": return "I want to commit your changes \u{2014} good to go?"
-            case "clone": return "I need to clone a repo \u{2014} that ok?"
-            case "checkout", "switch": return "I want to switch branches \u{2014} cool?"
-            case "status": return "Let me check what\u{2019}s changed \u{2014} that ok?"
-            case "diff": return "I want to see what\u{2019}s changed in the code"
-            case "add": return "I need to stage some files for commit"
-            case "stash": return "I\u{2019}ll set aside your changes for now \u{2014} ok?"
-            case "merge": return "I want to merge these branches \u{2014} should I?"
-            case "rebase": return "I need to rebase your commits \u{2014} that ok?"
-            case "log": return "Let me check the commit history"
-            case "fetch": return "Let me check for updates from the remote"
-            case "reset": return "I need to reset some files \u{2014} is that alright?"
-            default: return "I need to run a git command \u{2014} that ok?"
-            }
-        case "npm", "npx":
-            let sub = words.dropFirst().first.map(String.init) ?? ""
-            switch sub {
-            case "install", "i", "ci": return "I need to install some packages \u{2014} that ok?"
-            case "run": return "I need to run a project script \u{2014} cool?"
-            case "test": return "Let me run the tests for you"
-            default: return "I need to run an npm command \u{2014} that ok?"
-            }
-        case "bun", "bunx":
-            return "I need to run a Bun command \u{2014} that ok?"
-        case "yarn", "pnpm":
-            return "I need to install some packages \u{2014} that ok?"
-        case "pip", "pip3":
-            return "I need to manage some Python packages \u{2014} cool?"
-        case "brew":
-            return "I need to use Homebrew real quick \u{2014} that ok?"
-        case "curl", "wget":
-            return "I need to download something \u{2014} that ok?"
-        case "python", "python3":
-            return "I need to run a Python script \u{2014} cool?"
-        case "node":
-            return "I need to run a script \u{2014} cool?"
-        case "swift":
-            return "I need to run a Swift command \u{2014} that ok?"
-        case "xcodebuild":
-            return "I need to build the project \u{2014} that ok?"
-        case "open":
-            if let p = path {
-                return "I want to open \(p) for you \u{2014} cool?"
-            }
-            return "I want to open something for you \u{2014} cool?"
-        case "sudo":
-            return "I need admin access to run this \u{2014} is that alright?"
-        case "kill", "pkill", "killall":
-            return "I need to stop a running process \u{2014} ok?"
-        case "docker":
-            return "I need to run a Docker command \u{2014} that ok?"
-        case "ssh":
-            return "I need to connect to a remote server \u{2014} that ok?"
-        case "find", "grep", "rg", "ag":
-            return "I need to search for something \u{2014} that ok?"
-        default:
-            return "I need to run a quick command \u{2014} that ok?"
+            return "Wants to use \(toolCategory)."
         }
     }
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -5,18 +5,15 @@ import AppKit
 
 public struct ToolConfirmationBubble: View {
     public let confirmation: ToolConfirmationData
-    /// When true, show the humanDescription above buttons (used when no assistant text precedes this).
-    public let showDescription: Bool
     public let onAllow: () -> Void
     public let onDeny: () -> Void
     public let onAddTrustRule: (String, String, String, String) -> Bool
 
-    @State private var showDetails = false
+    @State private var showDiff = false
     @State private var showAlwaysAllowMenu = false
 
-    public init(confirmation: ToolConfirmationData, showDescription: Bool = false, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
+    public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
         self.confirmation = confirmation
-        self.showDescription = showDescription
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAddTrustRule = onAddTrustRule
@@ -30,10 +27,20 @@ public struct ToolConfirmationBubble: View {
         confirmation.state != .pending
     }
 
-    /// The raw command/path preview for the details disclosure.
-    private var detailsPreview: String? {
+    /// The raw command/path preview for the inline display.
+    private var inlinePreviewText: String? {
         let preview = confirmation.commandPreview
         return preview.isEmpty ? nil : preview
+    }
+
+    /// Color for the risk level badge.
+    private var riskColor: Color {
+        switch confirmation.riskLevel.lowercased() {
+        case "low":    return VColor.textMuted
+        case "medium": return VColor.warning
+        case "high":   return VColor.error
+        default:       return VColor.textMuted
+        }
     }
 
     public var body: some View {
@@ -136,78 +143,163 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var pendingContent: some View {
-        if showDescription {
-            Text(confirmation.humanDescription)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .frame(maxWidth: 520, alignment: .leading)
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            headerRow
+            if let preview = inlinePreviewText {
+                inlinePreview(preview)
+            }
+            descriptionText
+            if confirmation.hasDiff {
+                diffDisclosure
+            }
+            buttonRow
         }
+    }
 
+    // MARK: - Header Row
+
+    @ViewBuilder
+    private var headerRow: some View {
         HStack(spacing: VSpacing.sm) {
-            VButton(label: "Don\u{2019}t Allow", style: .ghost) {
-                onDeny()
+            Image(systemName: confirmation.toolCategoryIcon)
+                .font(.system(size: 12))
+                .foregroundColor(VColor.textSecondary)
+
+            Text(confirmation.toolCategory)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textPrimary)
+
+            VBadge(
+                style: .label(confirmation.riskLevel.capitalized),
+                color: riskColor
+            )
+
+            if let target = confirmation.normalizedExecutionTarget {
+                Text(target)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        Capsule()
+                            .fill(VColor.backgroundSubtle)
+                    )
             }
 
+            Spacer()
+        }
+    }
+
+    // MARK: - Inline Preview
+
+    @ViewBuilder
+    private func inlinePreview(_ preview: String) -> some View {
+        Text(preview)
+            .font(VFont.monoSmall)
+            .foregroundColor(VColor.textSecondary)
+            .lineLimit(3)
+            .padding(VSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(VColor.backgroundSubtle)
+            )
+            .textSelection(.enabled)
+    }
+
+    // MARK: - Description Text
+
+    @ViewBuilder
+    private var descriptionText: some View {
+        Text(confirmation.humanDescription)
+            .font(VFont.caption)
+            .foregroundColor(VColor.textMuted)
+    }
+
+    // MARK: - Diff Disclosure
+
+    @ViewBuilder
+    private var diffDisclosure: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Button {
+                withAnimation(VAnimation.fast) {
+                    showDiff.toggle()
+                }
+            } label: {
+                HStack(spacing: 3) {
+                    Text("View diff")
+                        .font(.system(size: 10))
+                        .foregroundColor(VColor.textMuted)
+                    Image(systemName: showDiff ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(showDiff ? "Hide diff" : "View diff")
+
+            if showDiff, let diffInfo = confirmation.diff {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(diffInfo.filePath)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textMuted)
+
+                    Text(diffInfo.newContent)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(10)
+                }
+                .padding(VSpacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.backgroundSubtle)
+                )
+                .textSelection(.enabled)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    // MARK: - Button Row
+
+    @ViewBuilder
+    private var buttonRow: some View {
+        HStack(spacing: VSpacing.sm) {
             VButton(label: "Allow", style: .primary) {
                 onAllow()
             }
 
+            VButton(label: "Don\u{2019}t Allow", style: .danger) {
+                onDeny()
+            }
+
             if hasRuleOptions {
-                if confirmation.allowlistOptions.count > 2 {
-                    alwaysAllowDropdown
-                } else {
-                    VButton(label: "Always Allow", style: .ghost) {
-                        let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
-                        let scope = confirmation.scopeOptions.first?.scope ?? ""
-                        if !pattern.isEmpty && !scope.isEmpty {
-                            _ = onAddTrustRule(confirmation.toolName, pattern, scope, "allow")
-                        }
-                        onAllow()
-                    }
-                }
+                alwaysAllowInlineButton
             }
 
             Spacer()
-
-            if detailsPreview != nil {
-                Button {
-                    withAnimation(VAnimation.fast) {
-                        showDetails.toggle()
-                    }
-                } label: {
-                    HStack(spacing: 3) {
-                        Text("Details")
-                            .font(.system(size: 10))
-                            .foregroundColor(VColor.textMuted)
-                        Image(systemName: showDetails ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 8, weight: .semibold))
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(showDetails ? "Hide details" : "Show details")
-            }
         }
+    }
 
-        if showDetails, let preview = detailsPreview {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(confirmation.detailsSummary)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
+    // MARK: - Always Allow Button
 
-                Text(preview)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textSecondary)
-                    .padding(VSpacing.sm)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(VColor.backgroundSubtle)
-                    )
-                    .textSelection(.enabled)
+    @ViewBuilder
+    private var alwaysAllowInlineButton: some View {
+        if confirmation.allowlistOptions.count > 2 {
+            alwaysAllowDropdown
+        } else {
+            let patternDesc = confirmation.allowlistOptions.first?.description ?? ""
+            VButton(label: "Always Allow", style: .ghost) {
+                let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
+                let scope = confirmation.scopeOptions.first?.scope ?? ""
+                if !pattern.isEmpty && !scope.isEmpty {
+                    _ = onAddTrustRule(confirmation.toolName, pattern, scope, "allow")
+                }
+                onAllow()
             }
-            .transition(.opacity.combined(with: .move(edge: .top)))
+            .help(patternDesc.isEmpty ? "Always allow this action" : patternDesc)
         }
     }
 
@@ -265,8 +357,11 @@ public struct ToolConfirmationBubble: View {
             }
             .font(.system(size: 12))
 
-            Text(confirmation.state == .approved ? "Permission granted" :
-                 confirmation.state == .denied ? "Permission denied" : "Timed out")
+            Text(confirmation.state == .approved
+                 ? "\(confirmation.toolCategory) allowed"
+                 : confirmation.state == .denied
+                 ? "\(confirmation.toolCategory) denied"
+                 : "Timed out")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
 
@@ -313,41 +408,44 @@ private struct AlwaysAllowRow: View {
 #if DEBUG
 #Preview("ToolConfirmationBubble") {
     VStack(spacing: VSpacing.lg) {
-        // System permission request (pending)
+        // Bash command — medium risk, pending
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
-                requestId: "test-perm",
-                toolName: "request_system_permission",
-                input: [
-                    "permission_type": AnyCodable("full_disk_access"),
-                    "reason": AnyCodable("I need Full Disk Access to read your Documents folder.")
+                requestId: "test-bash-medium",
+                toolName: "host_bash",
+                input: ["command": AnyCodable("npm install express")],
+                riskLevel: "medium",
+                allowlistOptions: [
+                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "exact", description: "This exact command", pattern: "npm install express"),
                 ],
-                riskLevel: "high"
+                scopeOptions: [
+                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "This project", scope: "project"),
+                ],
+                executionTarget: "host"
             ),
             onAllow: {},
             onDeny: {},
             onAddTrustRule: { _, _, _, _ in true }
         )
-        // System permission (granted)
+
+        // File write — high risk, pending
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
-                requestId: "test-perm-done",
-                toolName: "request_system_permission",
-                input: [
-                    "permission_type": AnyCodable("full_disk_access"),
-                    "reason": AnyCodable("I need Full Disk Access to read your Documents folder.")
-                ],
+                requestId: "test-write-high",
+                toolName: "host_file_write",
+                input: ["path": AnyCodable("/Users/me/project/main.swift")],
                 riskLevel: "high",
-                state: .approved
+                executionTarget: "host"
             ),
             onAllow: {},
             onDeny: {},
             onAddTrustRule: { _, _, _, _ in true }
         )
-        // Tool confirmation (pending)
+
+        // Bash — low risk, pending
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
-                requestId: "test-1",
+                requestId: "test-bash-low",
                 toolName: "host_bash",
                 input: ["command": AnyCodable("ls -lt ~/Downloads/ | head -50")],
                 riskLevel: "low",
@@ -357,7 +455,8 @@ private struct AlwaysAllowRow: View {
             onDeny: {},
             onAddTrustRule: { _, _, _, _ in true }
         )
-        // Tool confirmation with always-allow dropdown (pending)
+
+        // Always-allow dropdown — medium risk
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
                 requestId: "test-dropdown",
@@ -378,20 +477,58 @@ private struct AlwaysAllowRow: View {
             onDeny: {},
             onAddTrustRule: { _, _, _, _ in true }
         )
-        // Tool confirmation (approved)
+
+        // Collapsed — approved
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
-                requestId: "test-2",
+                requestId: "test-approved",
                 toolName: "host_bash",
                 input: ["command": AnyCodable("npm install")],
                 riskLevel: "medium",
-                allowlistOptions: [
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "npm install", description: "This exact command", pattern: "npm install"),
-                ],
-                scopeOptions: [
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "Everywhere", scope: "everywhere"),
-                ],
                 state: .approved
+            ),
+            onAllow: {},
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in true }
+        )
+
+        // Collapsed — denied
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-denied",
+                toolName: "host_file_write",
+                input: ["path": AnyCodable("/etc/hosts")],
+                riskLevel: "high",
+                state: .denied
+            ),
+            onAllow: {},
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in true }
+        )
+
+        // Unknown tool fallback
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-unknown",
+                toolName: "custom_plugin_action",
+                input: ["query": AnyCodable("test")],
+                riskLevel: "medium"
+            ),
+            onAllow: {},
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in true }
+        )
+
+        // System permission request (pending)
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-perm",
+                toolName: "request_system_permission",
+                input: [
+                    "permission_type": AnyCodable("full_disk_access"),
+                    "reason": AnyCodable("I need Full Disk Access to read your Documents folder.")
+                ],
+                riskLevel: "high"
             ),
             onAllow: {},
             onDeny: {},


### PR DESCRIPTION
## Summary
- Redesigned tool confirmation bubble with header row (icon + tool category + risk badge + execution target), always-visible inline command preview, and direct description text
- Replaced casual humanDescription phrasing with direct third-person language; deleted ~110 lines of bash command description helpers
- Reordered buttons to Allow (primary) / Don't Allow (danger) / Always Allow (ghost with tooltip); collapsed state now shows tool category ("Run Command allowed") instead of generic "Permission granted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
