### PR TITLE
M1: iOS lifecycle + connection reliability

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -20,5 +20,15 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         }
         return true
     }
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        config.delegateClass = SceneDelegate.self
+        return config
+    }
 }
 #endif

--- a/clients/ios/App/SceneDelegate.swift
+++ b/clients/ios/App/SceneDelegate.swift
@@ -1,0 +1,14 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Handles iOS scene lifecycle events, reconnecting the daemon client
+/// whenever the app returns to the foreground from a backgrounded state.
+class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        let client = appDelegate.daemonClient
+        guard !client.isConnected else { return }
+        Task { try? await client.connect() }
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -53,6 +53,7 @@ public final class ChatViewModel: ObservableObject {
 
     let daemonClient: DaemonClient
     public var sessionId: String?
+    private var reconnectObserver: NSObjectProtocol?
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
@@ -161,6 +162,14 @@ public final class ChatViewModel: ObservableObject {
     public init(daemonClient: DaemonClient, onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
         self.daemonClient = daemonClient
         self.onToolCallsComplete = onToolCallsComplete
+        reconnectObserver = NotificationCenter.default.addObserver(
+            forName: .daemonDidReconnect,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.pendingQueuedCount = 0
+            self?.pendingMessageIds.removeAll()
+        }
     }
 
     // MARK: - Sending
@@ -949,5 +958,8 @@ public final class ChatViewModel: ObservableObject {
 
     deinit {
         messageLoopTask?.cancel()
+        if let observer = reconnectObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -61,6 +61,11 @@ public protocol DaemonClientProtocol {
     func send<T: Encodable>(_ message: T) throws
 }
 
+extension Notification.Name {
+    /// Posted by `DaemonClient` on the main actor immediately after `isConnected` transitions to `true`.
+    public static let daemonDidReconnect = Notification.Name("daemonDidReconnect")
+}
+
 /// Platform-agnostic client for communicating with the Vellum daemon.
 ///
 /// **macOS**: Connects via Unix domain socket at `~/.vellum/vellum.sock` (or `VELLUM_DAEMON_SOCKET` env override).
@@ -420,6 +425,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                                     self.isAuthenticated = true
                                     #endif
                                     self.isConnected = true
+                                    NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
                                     self.reconnectDelay = 1.0
                                     self.startPingTimer()
                                     #if os(macOS)


### PR DESCRIPTION
## Context
Part of #3832: iOS/macOS feature parity

## Changes
- **`AppDelegate.swift`**: registers `SceneDelegate` as the UIWindowSceneDelegate via `application(_:configurationForConnecting:options:)`
- **`SceneDelegate.swift`** (new): calls `daemonClient.connect()` in `sceneWillEnterForeground` when not already connected, fixing silent TCP drops after backgrounding
- **`DaemonClient.swift`**: adds `Notification.Name.daemonDidReconnect` extension; posts it immediately after `isConnected = true` in `connect()`
- **`ChatViewModel.swift`**: observes `daemonDidReconnect` in `init` to reset `pendingQueuedCount` and `pendingMessageIds`; removes observer in `deinit`

## Problem solved
iOS TCP connections silently die when the app is backgrounded. Without a `UIWindowSceneDelegate`, the app never tried to reconnect when returning to the foreground. This also caused `pendingQueuedCount` to drift out of sync after reconnects.

## Dependencies
- Blocks: M2 (protocol abstraction)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
