### PR TITLE
fix: address review feedback on PR #3875

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1113,14 +1113,20 @@ struct MainWindowView: View {
                 onBundleAndShare: bundleAndShare,
                 isChatDockOpen: windowState.isChatDockOpen,
                 onToggleChatDock: {
-                    if case .appEditing(_, let threadId) = windowState.selection {
+                    if case .appEditing = windowState.selection {
                         // Toggle off: close app, keep thread visible
-                        windowState.selection = .thread(threadId)
+                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
+                        if let threadId {
+                            windowState.selection = .thread(threadId)
+                        } else {
+                            windowState.selection = nil
+                        }
                     } else if case .app(let appId) = windowState.selection {
                         // Toggle on: find most recent thread and enter editing mode
-                        if let thread = threadManager.visibleThreads.first {
-                            threadManager.selectThread(id: thread.id)
-                            windowState.setAppEditing(appId: appId, threadId: thread.id)
+                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
+                        if let threadId {
+                            threadManager.selectThread(id: threadId)
+                            windowState.setAppEditing(appId: appId, threadId: threadId)
                         }
                     }
                 },


### PR DESCRIPTION
Uses activeThreadId instead of visibleThreads.first when entering edit mode. Validates threadId when exiting edit mode to handle archived threads. Part of #3869.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
