### PR TITLE
fix: address review feedback on PR #3872

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -86,14 +86,8 @@ final class MainWindowState: ObservableObject {
         }
         set {
             if newValue {
-                // Opening chat dock: transition from .app to .appEditing
-                if case .app(let appId) = selection {
-                    // We need a thread ID; use nil-coalesced placeholder
-                    // The caller should also wire up the thread
-                    // For now, keep as .app — .appEditing requires a threadId
-                    // which will be set by the caller
-                    _ = appId // keep .app for now, caller sets .appEditing
-                }
+                // No-op: callers should use setAppEditing(appId:threadId:) directly
+                // since transitioning to .appEditing requires a thread ID.
             } else {
                 // Closing chat dock: transition from .appEditing to .app
                 if case .appEditing(let appId, _) = selection {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -356,9 +356,15 @@ struct MainWindowView: View {
                     windowState.closeDynamicPanel()
                 }
             } else {
-                // Bulk dismiss (dismissAll)
-                showSharePicker = false
-                windowState.closeDynamicPanel()
+                // Bulk dismiss (dismissAll) — only clear if currently showing an app workspace.
+                // Avoid kicking the user out of unrelated panels (Settings, Agent, etc.).
+                if case .app = windowState.selection {
+                    showSharePicker = false
+                    windowState.closeDynamicPanel()
+                } else if case .appEditing = windowState.selection {
+                    showSharePicker = false
+                    windowState.closeDynamicPanel()
+                }
             }
         }
         .onChange(of: isHoveredThread) { _, newValue in
@@ -891,7 +897,10 @@ struct MainWindowView: View {
                 data: dpData,
                 onAction: { actionId, actionData in
                     if !windowState.isChatDockOpen {
-                        windowState.isChatDockOpen = true
+                        let appId = dpData.appId ?? surfaceId
+                        if let threadId = threadManager.activeThreadId {
+                            windowState.setAppEditing(appId: appId, threadId: threadId)
+                        }
                     }
                     surfaceManager.onAction?(surface.sessionId, surface.id, actionId, actionData as? [String: Any])
                 },


### PR DESCRIPTION
Guards dismissDynamicWorkspace handler to only clear app-related selections. Fixes isChatDockOpen setter by updating surface slot call site to use setAppEditing directly. Part of #3869.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
