### PR TITLE
M6: Shared components + voice input

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -68,7 +68,10 @@ struct ChatTabView: View {
                 text: $viewModel.inputText,
                 isInputFocused: $isInputFocused,
                 isGenerating: viewModel.isSending || viewModel.isThinking,
-                onSend: viewModel.sendMessage
+                onSend: viewModel.sendMessage,
+                onVoiceResult: { _ in
+                    viewModel.pendingVoiceMessage = true
+                }
             )
         }
         .background(VColor.background)

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -1,6 +1,8 @@
 #if canImport(UIKit)
 import os
 import SwiftUI
+import Speech
+import AVFoundation
 import VellumAssistantShared
 
 private let log = Logger(
@@ -13,6 +15,12 @@ struct InputBarView: View {
     var isInputFocused: FocusState<Bool>.Binding
     let isGenerating: Bool
     let onSend: () -> Void
+    var onVoiceResult: ((String) -> Void)?
+
+    @State private var isRecording = false
+    @State private var recognitionTask: SFSpeechRecognitionTask?
+    @State private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    @State private var audioEngine = AVAudioEngine()
 
     var body: some View {
         HStack(spacing: VSpacing.md) {
@@ -25,6 +33,14 @@ struct InputBarView: View {
                 .background(VColor.surface)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .focused(isInputFocused)
+
+            // Mic button
+            Button(action: toggleVoiceInput) {
+                Image(systemName: isRecording ? "mic.fill" : "mic")
+                    .font(.system(size: 22))
+                    .foregroundColor(isRecording ? .red : VColor.textMuted)
+            }
+            .buttonStyle(.plain)
 
             // Send button
             Button(action: onSend) {
@@ -40,6 +56,117 @@ struct InputBarView: View {
 
     private var canSend: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isGenerating
+    }
+
+    // MARK: - Voice Input
+
+    private func toggleVoiceInput() {
+        if isRecording {
+            stopRecording()
+        } else {
+            requestPermissionsAndRecord()
+        }
+    }
+
+    private func requestPermissionsAndRecord() {
+        // Request microphone access
+        AVAudioSession.sharedInstance().requestRecordPermission { granted in
+            guard granted else {
+                log.warning("Microphone access denied")
+                return
+            }
+            // Request speech recognition access
+            SFSpeechRecognizer.requestAuthorization { status in
+                DispatchQueue.main.async {
+                    guard status == .authorized else {
+                        log.warning("Speech recognition not authorized: \(String(describing: status))")
+                        return
+                    }
+                    beginRecording()
+                }
+            }
+        }
+    }
+
+    private func beginRecording() {
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            log.error("Speech recognizer not available")
+            return
+        }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            log.error("Failed to configure AVAudioSession: \(error.localizedDescription)")
+            return
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        recognitionRequest = request
+
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        guard recordingFormat.channelCount > 0 else {
+            log.error("No audio input channels available")
+            return
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            request.append(buffer)
+        }
+
+        recognitionTask = recognizer.recognitionTask(with: request) { result, error in
+            DispatchQueue.main.async {
+                if let result = result {
+                    let transcribed = result.bestTranscription.formattedString
+                    if result.isFinal {
+                        log.info("Voice transcription final: \(transcribed, privacy: .public)")
+                        text = transcribed
+                        onVoiceResult?(transcribed)
+                        stopRecording()
+                    }
+                }
+                if let error = error {
+                    // Code 1110 is "no speech detected" — not an error worth logging at error level
+                    let nsError = error as NSError
+                    if nsError.code != 1110 {
+                        log.error("Recognition error: \(error.localizedDescription)")
+                    }
+                    stopRecording()
+                }
+            }
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+            isRecording = true
+            log.info("Voice recording started")
+        } catch {
+            log.error("Audio engine failed to start: \(error.localizedDescription)")
+            cleanupRecognition()
+        }
+    }
+
+    private func stopRecording() {
+        guard isRecording else { return }
+        log.info("Voice recording stopped")
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        cleanupRecognition()
+        isRecording = false
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func cleanupRecognition() {
+        recognitionRequest = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
     }
 }
 

--- a/clients/shared/Features/Chat/ChatErrorBanner.swift
+++ b/clients/shared/Features/Chat/ChatErrorBanner.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Dismissible banner shown when a non-retryable session error occurs.
+public struct ChatErrorBanner: View {
+    public let message: String
+    public var onDismiss: (() -> Void)?
+
+    public init(message: String, onDismiss: (() -> Void)? = nil) {
+        self.message = message
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.primary)
+            Spacer()
+            if let onDismiss {
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal)
+    }
+}


### PR DESCRIPTION
## Context
Part of #3832: iOS/macOS feature parity

## Changes
- **`ChatErrorBanner.swift`** (new): Dismissible error banner for session errors
- **`InputBarView.swift`**: Added microphone button using SFSpeechRecognizer; populates inputText and sets pendingVoiceMessage flag
- **`Info.plist`**: Added NSMicrophoneUsageDescription and NSSpeechRecognitionUsageDescription

## Dependencies
- Depends on: M1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
