### PR TITLE
M5: Chat UX parity — stop, retry, markdown, step indicator

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -12,24 +12,6 @@ struct ChatTabView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Error banner
-            if let errorText = viewModel.errorText {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.error)
-                    Text(errorText)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                    Button(action: { viewModel.errorText = nil }) {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundColor(VColor.textSecondary)
-                    }
-                }
-                .padding(VSpacing.md)
-                .background(VColor.error.opacity(0.1))
-            }
-
             // Messages list
             ScrollViewReader { proxy in
                 ScrollView {
@@ -42,9 +24,22 @@ struct ChatTabView: View {
                                 },
                                 onSurfaceAction: { surfaceId, actionId, data in
                                     viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
-                                }
+                                },
+                                onRegenerate: viewModel.isSending ? nil : { viewModel.regenerateLastMessage() }
                             )
                             .id(message.id)
+                        }
+
+                        // Current step indicator shown while generating
+                        if viewModel.isSending {
+                            let allToolCalls = viewModel.messages.last?.toolCalls ?? []
+                            CurrentStepIndicator(
+                                toolCalls: allToolCalls,
+                                isStreaming: viewModel.isSending,
+                                onTap: {}
+                            )
+                            .padding(.horizontal, VSpacing.lg)
+                            .id("step-indicator")
                         }
                     }
                     .padding(VSpacing.lg)
@@ -61,6 +56,50 @@ struct ChatTabView: View {
                         scrollToBottom(proxy: proxy, animated: false)
                     }
                 }
+                .onChange(of: viewModel.isSending) { _, isSending in
+                    if isSending {
+                        withAnimation(.easeOut(duration: 0.3)) {
+                            proxy.scrollTo("step-indicator", anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            // Session error banner
+            if let sessionError = viewModel.sessionError {
+                sessionErrorBanner(sessionError)
+            } else if let errorText = viewModel.errorText {
+                // Generic error banner with optional retry
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.white)
+                        .font(VFont.caption)
+                    Text(errorText)
+                        .font(VFont.caption)
+                        .foregroundColor(.white)
+                        .lineLimit(2)
+                    Spacer()
+                    if viewModel.isRetryableError {
+                        Button(action: { viewModel.retryLastMessage() }) {
+                            Text("Retry")
+                                .font(VFont.captionMedium)
+                                .foregroundColor(.white)
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, VSpacing.xs)
+                                .background(Color.white.opacity(0.25))
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        }
+                    }
+                    Button(action: { viewModel.dismissError() }) {
+                        Image(systemName: "xmark")
+                            .font(VFont.caption)
+                            .foregroundColor(.white)
+                    }
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.error)
+                .transition(.move(edge: .top).combined(with: .opacity))
             }
 
             // Input bar
@@ -68,12 +107,100 @@ struct ChatTabView: View {
                 text: $viewModel.inputText,
                 isInputFocused: $isInputFocused,
                 isGenerating: viewModel.isSending || viewModel.isThinking,
-                onSend: viewModel.sendMessage
+                isCancelling: viewModel.isCancelling,
+                onSend: viewModel.sendMessage,
+                onStop: viewModel.stopGenerating
             )
         }
         .background(VColor.background)
         .navigationTitle("Chat")
         .navigationBarTitleDisplayMode(.inline)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.sessionError != nil)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.errorText)
+    }
+
+    // MARK: - Session Error Banner
+
+    @ViewBuilder
+    private func sessionErrorBanner(_ error: SessionError) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: sessionErrorIcon(error.category))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(sessionErrorAccent(error.category))
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(error.message)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                Text(error.recoverySuggestion)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if error.isRetryable {
+                Button(action: { viewModel.retryAfterSessionError() }) {
+                    Text("Retry")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(sessionErrorAccent(error.category))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+            }
+
+            Button(action: { viewModel.dismissSessionError() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(sessionErrorAccent(error.category).opacity(0.1))
+        .overlay(
+            Rectangle()
+                .fill(sessionErrorAccent(error.category))
+                .frame(width: 3),
+            alignment: .leading
+        )
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    private func sessionErrorIcon(_ category: SessionErrorCategory) -> String {
+        switch category {
+        case .providerNetwork:
+            return "wifi.exclamationmark"
+        case .rateLimit:
+            return "clock.badge.exclamationmark"
+        case .providerApi:
+            return "exclamationmark.icloud.fill"
+        case .queueFull:
+            return "tray.full.fill"
+        case .sessionAborted:
+            return "stop.circle.fill"
+        case .processingFailed, .regenerateFailed:
+            return "arrow.triangle.2.circlepath"
+        case .unknown:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func sessionErrorAccent(_ category: SessionErrorCategory) -> Color {
+        switch category {
+        case .rateLimit, .queueFull:
+            return VColor.warning
+        case .providerNetwork:
+            return .orange
+        case .sessionAborted:
+            return VColor.textSecondary
+        default:
+            return VColor.error
+        }
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy, animated: Bool) {

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -12,7 +12,9 @@ struct InputBarView: View {
     @Binding var text: String
     var isInputFocused: FocusState<Bool>.Binding
     let isGenerating: Bool
+    let isCancelling: Bool
     let onSend: () -> Void
+    let onStop: () -> Void
 
     var body: some View {
         HStack(spacing: VSpacing.md) {
@@ -26,13 +28,28 @@ struct InputBarView: View {
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .focused(isInputFocused)
 
-            // Send button
-            Button(action: onSend) {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.system(size: 32))
-                    .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+            // Stop button (shown while generating but not yet cancelling)
+            if isGenerating && !isCancelling {
+                Button(action: onStop) {
+                    ZStack {
+                        Circle()
+                            .fill(VColor.textPrimary)
+                            .frame(width: 32, height: 32)
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(VColor.background)
+                            .frame(width: 11, height: 11)
+                    }
+                }
+                .accessibilityLabel("Stop generation")
+            } else {
+                // Send button
+                Button(action: onSend) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 32))
+                        .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                }
+                .disabled(!canSend)
             }
-            .disabled(!canSend)
         }
         .padding(VSpacing.md)
         .background(VColor.backgroundSubtle)
@@ -55,7 +72,9 @@ struct InputBarView_Previews: PreviewProvider {
                     text: $text,
                     isInputFocused: $isFocused,
                     isGenerating: false,
-                    onSend: { log.debug("Send tapped") }
+                    isCancelling: false,
+                    onSend: { log.debug("Send tapped") },
+                    onStop: { log.debug("Stop tapped") }
                 )
             }
             .background(VColor.background)

--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -12,6 +12,9 @@ struct MessageBubbleView: View {
     let message: ChatMessage
     let onConfirmationResponse: ((String, String) -> Void)?
     let onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?
+    /// When non-nil, a "Regenerate" option appears in the long-press context menu
+    /// for the last assistant message. Pass nil when generation is in-flight.
+    let onRegenerate: (() -> Void)?
 
     var body: some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
@@ -46,16 +49,7 @@ struct MessageBubbleView: View {
 
                     // Message text (only shown for non-confirmation messages)
                     if !message.text.isEmpty {
-                        Text(message.text)
-                            .font(VFont.body)
-                            .foregroundColor(message.role == .user ? VColor.background : VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(
-                                message.role == .user
-                                    ? VColor.accent
-                                    : VColor.surface
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        messageBubble(text: message.text, role: message.role)
                     }
 
                     // Post-text tool calls render below the bubble
@@ -147,12 +141,7 @@ struct MessageBubbleView: View {
                 if i < message.textSegments.count {
                     let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
                     if !segmentText.isEmpty {
-                        Text(segmentText)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        messageBubble(text: segmentText, role: message.role)
                     }
                 }
             case .toolCalls(let indices):
@@ -173,6 +162,48 @@ struct MessageBubbleView: View {
         }
     }
 
+    /// Render a message text bubble with markdown for assistant messages.
+    @ViewBuilder
+    private func messageBubble(text: String, role: ChatRole) -> some View {
+        let isUser = role == .user
+        if isUser {
+            Text(text)
+                .font(VFont.body)
+                .foregroundColor(VColor.background)
+                .padding(VSpacing.md)
+                .background(VColor.accent)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .textSelection(.enabled)
+        } else {
+            Text(Self.markdownString(text))
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .tint(VColor.accent)
+                .padding(VSpacing.md)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .textSelection(.enabled)
+                .contextMenu {
+                    if let onRegenerate {
+                        Button {
+                            onRegenerate()
+                        } label: {
+                            Label("Regenerate", systemImage: "arrow.trianglehead.counterclockwise")
+                        }
+                    }
+                }
+        }
+    }
+
+    /// Parse markdown in text using SwiftUI's native AttributedString support.
+    static func markdownString(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: text, options: options))
+            ?? AttributedString(text)
+    }
+
     private func streamingScale(for index: Int, at date: Date) -> CGFloat {
         let time = date.timeIntervalSince1970
         let phase = (time + Double(index) * 0.3).truncatingRemainder(dividingBy: 1.2)
@@ -189,7 +220,8 @@ struct MessageBubbleView: View {
                 text: "Hello! Can you help me with something?"
             ),
             onConfirmationResponse: nil,
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: nil
         )
     }
     .padding()
@@ -201,10 +233,11 @@ struct MessageBubbleView: View {
         MessageBubbleView(
             message: ChatMessage(
                 role: .assistant,
-                text: "Of course! I'd be happy to help. What do you need assistance with?"
+                text: "Of course! I'd be happy to help. What do you need assistance with?\n\n**Bold text** and _italic_ and `code` all render via markdown."
             ),
             onConfirmationResponse: nil,
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: { log.debug("Preview: Regenerate tapped") }
         )
     }
     .padding()
@@ -220,7 +253,8 @@ struct MessageBubbleView: View {
                 isStreaming: true
             ),
             onConfirmationResponse: nil,
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: nil
         )
     }
     .padding()
@@ -244,7 +278,8 @@ struct MessageBubbleView: View {
             onConfirmationResponse: { requestId, decision in
                 log.debug("Preview: Confirmation \(decision) for \(requestId)")
             },
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: nil
         )
     }
     .padding()


### PR DESCRIPTION
## Context
Part of #3832: iOS/macOS feature parity

## Changes
Wire up the iOS chat UI to match macOS behavior:
- Stop button during generation (calls stopGenerating())
- Retry/Regenerate buttons when isRetryableError
- Markdown rendering in assistant message bubbles
- CurrentStepIndicator shown during active generation
- Session error banner when sessionError != nil

All logic is already in ChatViewModel; this PR connects the iOS UI to it.

## Dependencies
- Depends on: M1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
