### PR TITLE
M2: Client protocol abstraction

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -375,7 +375,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             self?.onInlineConfirmationResponse?(requestId, decision)
         }
         viewModel.onWatchStarted = { [weak self] msg, client in
-            guard let self else { return }
+            guard let self, let concreteClient = client as? DaemonClient else { return }
             let session = WatchSession(
                 watchId: msg.watchId,
                 sessionId: msg.sessionId,
@@ -383,7 +383,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 intervalSeconds: Int(msg.intervalSeconds)
             )
             self.ambientAgent?.activeWatchSession = session
-            session.start(daemonClient: client)
+            session.start(daemonClient: concreteClient)
         }
         viewModel.onWatchCompleteRequest = { [weak self] _ in
             self?.ambientAgent?.activeWatchSession?.stop()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -51,7 +51,7 @@ public final class ChatViewModel: ObservableObject {
     /// Maximum number of attachments per message.
     static let maxAttachments = 5
 
-    let daemonClient: DaemonClient
+    let daemonClient: any DaemonClientProtocol
     public var sessionId: String?
     private var reconnectObserver: NSObjectProtocol?
     var pendingUserMessage: String?
@@ -119,7 +119,7 @@ public final class ChatViewModel: ObservableObject {
     /// Called when the daemon sends a `watch_started` message to begin a watch session.
     /// The closure receives the WatchStartedMessage and the DaemonClient so the macOS
     /// layer can create and start a WatchSession.
-    public var onWatchStarted: ((WatchStartedMessage, DaemonClient) -> Void)?
+    public var onWatchStarted: ((WatchStartedMessage, any DaemonClientProtocol) -> Void)?
 
     /// Called when the daemon sends a `watch_complete_request` to stop the active watch session.
     public var onWatchCompleteRequest: ((WatchCompleteRequestMessage) -> Void)?
@@ -159,7 +159,7 @@ public final class ChatViewModel: ObservableObject {
     /// Set via the onPageChanged callback when the user navigates within a multi-page app.
     public var currentPage: String?
 
-    public init(daemonClient: DaemonClient, onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
+    public init(daemonClient: any DaemonClientProtocol, onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
         self.daemonClient = daemonClient
         self.onToolCallsComplete = onToolCallsComplete
         reconnectObserver = NotificationCenter.default.addObserver(
@@ -592,7 +592,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         do {
-            try daemonClient.sendRegenerate(sessionId: sessionId)
+            try daemonClient.send(RegenerateMessage(sessionId: sessionId))
         } catch {
             log.error("Failed to send regenerate: \(error.localizedDescription)")
             isSending = false
@@ -606,7 +606,7 @@ public final class ChatViewModel: ObservableObject {
         guard let sessionId, let surfaceId = activeSurfaceId else { return }
         guard surfaceUndoCount > 0 else { return }
         do {
-            try daemonClient.sendSurfaceUndo(sessionId: sessionId, surfaceId: surfaceId)
+            try daemonClient.send(UiSurfaceUndoMessage(sessionId: sessionId, surfaceId: surfaceId))
         } catch {
             log.error("Failed to send surface undo: \(error.localizedDescription)")
         }
@@ -732,7 +732,7 @@ public final class ChatViewModel: ObservableObject {
         // This prevents the UI from showing a finalized decision when the IPC
         // message was never delivered (e.g. daemon disconnected).
         do {
-            try daemonClient.sendConfirmationResponse(requestId: requestId, decision: decision)
+            try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil))
         } catch {
             log.error("Failed to send confirmation response: \(error.localizedDescription)")
             errorText = "Failed to send confirmation response."
@@ -769,12 +769,12 @@ public final class ChatViewModel: ObservableObject {
             return false
         }
         do {
-            try daemonClient.sendAddTrustRule(
+            try daemonClient.send(AddTrustRuleMessage(
                 toolName: toolName,
                 pattern: pattern,
                 scope: scope,
                 decision: decision
-            )
+            ))
             return true
         } catch {
             log.error("Failed to send add_trust_rule: \(error.localizedDescription)")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -56,9 +56,12 @@ func readSessionToken(environment: [String: String]? = nil) -> String? {
 /// Protocol for daemon client communication, enabling dependency injection and testing.
 @MainActor
 public protocol DaemonClientProtocol {
+    var isConnected: Bool { get }
     var isBlobTransportAvailable: Bool { get }
     func subscribe() -> AsyncStream<ServerMessage>
     func send<T: Encodable>(_ message: T) throws
+    func connect() async throws
+    func disconnect()
 }
 
 extension Notification.Name {

--- a/clients/shared/IPC/MockDaemonClient.swift
+++ b/clients/shared/IPC/MockDaemonClient.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import Foundation
+
+/// Lightweight in-memory mock for `DaemonClientProtocol`, used in tests and SwiftUI previews.
+@MainActor
+public final class MockDaemonClient: DaemonClientProtocol, ObservableObject {
+    public var isConnected: Bool = false
+    public var isBlobTransportAvailable: Bool = false
+
+    /// Messages recorded by `send(_:)` for assertion in tests.
+    public private(set) var sentMessages: [Any] = []
+
+    /// Continuations to feed messages into active `subscribe()` streams.
+    private var continuations: [AsyncStream<ServerMessage>.Continuation] = []
+
+    public init() {}
+
+    public func subscribe() -> AsyncStream<ServerMessage> {
+        AsyncStream { continuation in
+            self.continuations.append(continuation)
+        }
+    }
+
+    public func send<T: Encodable>(_ message: T) throws {
+        sentMessages.append(message)
+    }
+
+    public func connect() async throws {
+        isConnected = true
+    }
+
+    public func disconnect() {
+        isConnected = false
+    }
+
+    /// Inject a server message into all active subscribers.
+    public func emit(_ message: ServerMessage) {
+        for continuation in continuations {
+            continuation.yield(message)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Context
Part of #3832: iOS/macOS feature parity

## Changes
- **`DaemonClient.swift`**: Added `isConnected`, `connect()`, `disconnect()` to `DaemonClientProtocol`
- **`ChatViewModel.swift`**: Changed `daemonClient` property and init parameter from concrete `DaemonClient` to `any DaemonClientProtocol`
- **`MockDaemonClient.swift`** (new): Lightweight in-memory mock implementing `DaemonClientProtocol` for tests and SwiftUI previews

## Why
ChatViewModel currently holds a concrete `DaemonClient`, preventing use of a `DirectClaudeClient` (needed for standalone iOS mode) or a mock in tests. The protocol already existed but was too narrow to support the full connection lifecycle.

## Dependencies
- Depends on: M1
- Blocks: M3 (DirectClaudeClient), M4 (settings toggle)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
