### PR TITLE
M9: Daemon TCP listener + TLS + token auth

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     let daemonClient: DaemonClient
 
     override init() {
-        self.daemonClient = DaemonClient(config: .default)
+        self.daemonClient = DaemonClient(config: .fromUserDefaults())
         super.init()
     }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -353,6 +353,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #if os(macOS)
         log.info("Connecting to daemon socket at \(self.config.socketPath)")
         let endpoint = NWEndpoint.unix(path: self.config.socketPath)
+        let parameters = NWParameters()
+        parameters.defaultProtocolStack.transportProtocol = NWProtocolTCP.Options()
         #elseif os(iOS)
         // Check UserDefaults first to pick up runtime changes, fall back to config
         // This allows reconnects to pick up changed settings while preserving custom configs for tests
@@ -372,17 +374,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             port = self.config.port
         }
 
-        log.info("Connecting to daemon at \(hostname):\(port)")
+        log.info("Connecting to daemon at \(hostname):\(port) (tls=\(self.config.tlsEnabled))")
         let endpoint = NWEndpoint.hostPort(
             host: NWEndpoint.Host(hostname),
             port: NWEndpoint.Port(integerLiteral: port)
         )
+        let parameters: NWParameters = self.config.tlsEnabled ? .tls : .tcp
         #else
         #error("DaemonClient is only supported on macOS and iOS")
         #endif
-
-        let parameters = NWParameters()
-        parameters.defaultProtocolStack.transportProtocol = NWProtocolTCP.Options()
 
         let conn = NWConnection(to: endpoint, using: parameters)
         self.connection = conn
@@ -421,6 +421,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                                 do {
                                     #if os(macOS)
                                     try await self.authenticate()
+                                    #elseif os(iOS)
+                                    try await self.authenticateIfNeeded()
                                     #else
                                     self.isAuthenticated = true
                                     #endif
@@ -489,6 +491,48 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     private func authenticate() async throws {
         guard let token = readSessionToken() else {
             throw AuthError.missingToken
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            authContinuation?.resume(throwing: AuthError.rejected("Authentication superseded"))
+            authContinuation = continuation
+
+            authTimeoutTask?.cancel()
+            authTimeoutTask = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(Self.authTimeout * 1_000_000_000))
+                } catch {
+                    return
+                }
+                guard let self, let pending = self.authContinuation else { return }
+                self.authContinuation = nil
+                self.authTimeoutTask = nil
+                self.isAuthenticated = false
+                pending.resume(throwing: AuthError.timeout)
+            }
+
+            do {
+                try self.send(AuthMessage(token: token))
+            } catch {
+                authContinuation = nil
+                authTimeoutTask?.cancel()
+                authTimeoutTask = nil
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+    #endif
+
+    #if os(iOS)
+    /// Perform token-based authentication if `config.authToken` is set.
+    /// Sends an `AuthMessage` and waits for an `auth_result` response before
+    /// allowing the connection to be marked as ready.
+    /// If no token is configured, marks the connection as authenticated immediately.
+    private func authenticateIfNeeded() async throws {
+        guard let token = config.authToken else {
+            // No token configured — treat as unauthenticated (plain TCP, no handshake).
+            isAuthenticated = true
+            return
         }
 
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
@@ -951,7 +995,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         reconnectTask?.cancel()
         reconnectTask = nil
         stopPingTimer()
-        #if os(macOS)
+        #if os(macOS) || os(iOS)
         if let pending = authContinuation {
             authContinuation = nil
             authTimeoutTask?.cancel()
@@ -1192,7 +1236,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     private func handleAuthResult(_ result: AuthResultMessage) {
-        #if os(macOS)
+        #if os(macOS) || os(iOS)
         isAuthenticated = result.success
         if let pending = authContinuation {
             authContinuation = nil

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -16,18 +16,34 @@ public struct DaemonConfig {
     public let hostname: String
     public let port: UInt16
 
-    public init(hostname: String, port: UInt16) {
+    /// Whether to use TLS for the TCP connection (iOS only).
+    public var tlsEnabled: Bool
+
+    /// Authentication token for the daemon TCP handshake (iOS only).
+    public var authToken: String?
+
+    public init(hostname: String, port: UInt16, tlsEnabled: Bool = false, authToken: String? = nil) {
         self.hostname = hostname
         self.port = port
+        self.tlsEnabled = tlsEnabled
+        self.authToken = authToken
     }
 
     public static var `default`: DaemonConfig {
+        return DaemonConfig(hostname: "localhost", port: 8765)
+    }
+
+    /// Create a `DaemonConfig` populated from UserDefaults, falling back to safe defaults.
+    /// Reads: `daemon_hostname`, `daemon_port`, `daemon_tls_enabled`, `daemon_auth_token`.
+    public static func fromUserDefaults() -> DaemonConfig {
         // Treat empty string as nil to ensure fallback to "localhost"
         let hostname = UserDefaults.standard.string(forKey: "daemon_hostname").flatMap { $0.isEmpty ? nil : $0 } ?? "localhost"
         let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
         // Validate port is in valid UInt16 range (1-65535) before converting to avoid crash
         let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
-        return DaemonConfig(hostname: hostname, port: finalPort)
+        let tlsEnabled = UserDefaults.standard.bool(forKey: "daemon_tls_enabled")
+        let authToken = UserDefaults.standard.string(forKey: "daemon_auth_token")
+        return DaemonConfig(hostname: hostname, port: finalPort, tlsEnabled: tlsEnabled, authToken: authToken.flatMap { $0.isEmpty ? nil : $0 })
     }
     #else
     #error("Unsupported platform")


### PR DESCRIPTION
## Context
Part of #3832: iOS/macOS feature parity

## Changes
- **`DaemonConfig.swift`**: Added `tlsEnabled` and `authToken` fields to the iOS section of `DaemonConfig`; added `fromUserDefaults()` factory method that reads `daemon_tls_enabled` and `daemon_auth_token` from UserDefaults
- **`DaemonClient.swift`**: iOS TCP path now uses `NWParameters.tls` when `config.tlsEnabled` is true; added `authenticateIfNeeded()` for iOS that sends an `AuthMessage` and waits for `auth_result` when `config.authToken` is set; updated `handleAuthResult` and `disconnectInternal` to handle iOS auth state
- **`AppDelegate.swift`**: Uses `DaemonConfig.fromUserDefaults()` instead of `.default`

## Why
Without TLS/auth, the iOS client cannot securely connect to a Mac daemon over the network. These fields enable encrypted connections and token-based authentication without breaking existing local development setups (tlsEnabled defaults to false, authToken defaults to nil).

## Dependencies
- Depends on: M1
- Blocks: M10 (push notifications require authenticated daemon connection)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
