### PR TITLE
Load feature flags from repo root .env at app startup

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -125,6 +125,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     @AppStorage("themePreference") private var themePreference: String = "system"
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
+        if let envPath = FeatureFlagManager.findRepoEnvFile() {
+            FeatureFlagManager.shared.loadFromFile(at: envPath)
+        }
+
         applyThemePreference()
         registerBundledFonts()
         AvatarAppearanceManager.shared.start()

--- a/clients/shared/Utilities/FeatureFlagManager.swift
+++ b/clients/shared/Utilities/FeatureFlagManager.swift
@@ -60,6 +60,43 @@ public final class FeatureFlagManager: @unchecked Sendable {
         removeOverride(flag.rawValue)
     }
 
+    /// Load VELLUM_FLAG_* entries from a `.env` file and apply them as overrides.
+    public func loadFromFile(at path: String) {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        for line in contents.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            let key = String(parts[0]).trimmingCharacters(in: .whitespaces)
+            guard key.hasPrefix(flagPrefix) else { continue }
+            let name = String(key.dropFirst(flagPrefix.count)).lowercased().replacingOccurrences(of: "_", with: "")
+            guard !name.isEmpty else { continue }
+            let value = String(parts[1]).trimmingCharacters(in: .whitespaces)
+            flags[name] = Self.parseBool(value)
+        }
+    }
+
+    /// Walk up from the app executable to find the repo root `.env` file.
+    public static func findRepoEnvFile() -> String? {
+        guard let execURL = Bundle.main.executableURL else { return nil }
+        var dir = execURL.deletingLastPathComponent()
+        for _ in 0..<10 {
+            let candidate = dir.appendingPathComponent(".env")
+            let gitDir = dir.appendingPathComponent(".git")
+            if FileManager.default.fileExists(atPath: gitDir.path),
+               FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate.path
+            }
+            let parent = dir.deletingLastPathComponent()
+            if parent.path == dir.path { break }
+            dir = parent
+        }
+        return nil
+    }
+
     private static func normalize(_ name: String) -> String {
         name.lowercased().replacingOccurrences(of: "_", with: "")
     }


### PR DESCRIPTION
## Summary
Adds `.env` file loading directly in the Swift app so feature flags work regardless of how the app is launched (Finder, Xcode, `open` command, etc.).

- **`FeatureFlagManager.loadFromFile(at:)`** — parses `VELLUM_FLAG_*` entries from a `.env` file and applies them as flag overrides
- **`FeatureFlagManager.findRepoEnvFile()`** — walks up from the executable to find the repo root `.env` (detects repo root by looking for a sibling `.git` directory)
- Called early in `applicationDidFinishLaunching` before any `isEnabled()` checks

This complements the build.sh approach (PR #TBD) which uses `launchctl setenv` — this PR covers the case where the app is launched outside of `build.sh`.

## Test plan
- [ ] Create `.env` at repo root with `VELLUM_FLAG_DEMO=1`
- [ ] Build and launch the app via Finder (double-click `dist/Vellum.app`) — confirm demo overlay appears
- [ ] Remove the flag, rebuild — confirm overlay is gone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
