### PR TITLE
Revert launchctl setenv feature flag loading from build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -380,23 +380,6 @@ if [ "$CMD" = "run" ]; then
     fi
     pkill -x "vellum-assistant" 2>/dev/null || true
     sleep 0.3
-    # Load VELLUM_FLAG_* vars from repo root .env via launchctl setenv
-    # so the app inherits them when launched via `open` (which doesn't
-    # pass shell environment to the child process).
-    ENV_FILE="$SCRIPT_DIR/../../.env"
-    if [ -f "$ENV_FILE" ]; then
-        while IFS='=' read -r key value || [ -n "$key" ]; do
-            key="$(echo "$key" | xargs)"
-            [[ -z "$key" || "$key" =~ ^# ]] && continue
-            value="${value%%#*}"
-            value="$(echo "$value" | xargs)"
-            if [[ "$key" == VELLUM_FLAG_* ]]; then
-                launchctl setenv "$key" "$value"
-            fi
-        done < "$ENV_FILE"
-        echo "Loaded feature flags from .env"
-    fi
-
     # Launch via `open` so Launch Services registers the bundle —
     # this is required for macOS TCC to associate the app with its
     # bundle ID and show it in System Settings > Privacy & Security.


### PR DESCRIPTION
## Summary
Reverts #3886. The Swift-side .env loading (#3887) already covers this — the app reads the repo root `.env` directly at startup, so `launchctl setenv` in build.sh is unnecessary and was an unwanted dependency on a macOS system utility.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
