### PR TITLE
feat: add inbox create/list CLI and assistant self-awareness

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -183,6 +183,7 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'daemon/handlers/config.ts',     // Vercel API token + integration OAuth (split handler)
       'integrations/registry.ts',      // integration connection status check
       'integrations/token-manager.ts', // OAuth token refresh flow
+      'email/providers/index.ts',      // email provider API key lookup
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/cli/email.ts
+++ b/assistant/src/cli/email.ts
@@ -163,6 +163,34 @@ export function registerEmailCommand(program: Command): void {
     });
 
   // =========================================================================
+  // Inbox subcommands
+  // =========================================================================
+  const inbox = email.command('inbox').description('Manage inboxes');
+
+  inbox
+    .command('create')
+    .description('Create a new inbox')
+    .requiredOption('--username <username>', 'Local part (e.g. "sam")')
+    .option('--domain <domain>', 'Domain (e.g. "agentmail.to"). Omit for provider default.')
+    .option('--display-name <name>', 'Display name (e.g. "Samwise")')
+    .action(async (opts: { username: string; domain?: string; displayName?: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const created = await svc.createInbox(opts.username, opts.domain, opts.displayName);
+        return { inbox: created };
+      });
+    });
+
+  inbox
+    .command('list')
+    .description('List all inboxes')
+    .action(async (_opts: unknown, cmd: Command) => {
+      await run(cmd, async () => {
+        const inboxes = await svc.listInboxes();
+        return { inboxes };
+      });
+    });
+
+  // =========================================================================
   // Draft subcommands
   // =========================================================================
   const draft = email.command('draft').description('Manage email drafts');
@@ -258,7 +286,7 @@ export function registerEmailCommand(program: Command): void {
   // =========================================================================
   // Inbound subcommands
   // =========================================================================
-  const inbound = email.command('inbound').alias('inbox').description('View inbound messages');
+  const inbound = email.command('inbound').description('View inbound messages');
 
   inbound
     .command('list')

--- a/assistant/src/config/bundled-skills/agentmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/agentmail/SKILL.md
@@ -42,7 +42,8 @@ After the credential is stored, retry `vellum email status --json` to confirm it
 ## Workflow
 
 1. **Preflight:** `vellum email status --json` (if API key error, run API Key Setup above)
-2. **Setup (first-time):** domain -> dns -> verify -> inboxes -> webhook
+2. **Quick inbox:** `vellum email inbox create --username <name>` (creates e.g. sam@agentmail.to — no custom domain needed)
+3. **Custom domain setup (optional):** domain -> dns -> verify -> inboxes -> webhook
 3. **Draft path:** `vellum email draft create ...` — always draft first
 4. **Send path:** show draft -> user confirms -> `draft approve-send --draft-id <id> --confirm`
 5. **Inbound triage:** list -> get -> summarize -> propose reply draft
@@ -63,13 +64,20 @@ vellum email provider set <provider> [--json]               # Switch provider
 vellum email status [--json]                               # Provider health + guardrails
 ```
 
+### Inbox Management
+
+```
+vellum email inbox create --username <name> [--domain <d>] [--display-name <n>] [--json]   # Create a new inbox (e.g. --username sam)
+vellum email inbox list [--json]                                                            # List all inboxes
+```
+
 ### Setup
 
 ```
 vellum email setup domain --domain <d> [--dry-run] [--json]
 vellum email setup dns --domain <d> [--json]
 vellum email setup verify --domain <d> [--json]
-vellum email setup inboxes --domain <d> [--json]
+vellum email setup inboxes --domain <d> [--json]                                            # Creates standard hello@/support@/ops@ inboxes
 vellum email setup webhook --url <u> [--secret <s>] [--json]
 ```
 

--- a/assistant/src/config/bundled-skills/agentmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/agentmail/SKILL.md
@@ -44,10 +44,10 @@ After the credential is stored, retry `vellum email status --json` to confirm it
 1. **Preflight:** `vellum email status --json` (if API key error, run API Key Setup above)
 2. **Quick inbox:** `vellum email inbox create --username <name>` (creates e.g. sam@agentmail.to — no custom domain needed)
 3. **Custom domain setup (optional):** domain -> dns -> verify -> inboxes -> webhook
-3. **Draft path:** `vellum email draft create ...` — always draft first
-4. **Send path:** show draft -> user confirms -> `draft approve-send --draft-id <id> --confirm`
-5. **Inbound triage:** list -> get -> summarize -> propose reply draft
-6. **Guardrails:** check with `guardrails get`, use `guardrails set` to change
+4. **Draft path:** `vellum email draft create ...` — always draft first
+5. **Send path:** show draft -> user confirms -> `draft approve-send --draft-id <id> --confirm`
+6. **Inbound triage:** list -> get -> summarize -> propose reply draft
+7. **Guardrails:** check with `guardrails get`, use `guardrails set` to change
 
 ## Command Reference
 

--- a/assistant/src/config/templates/SOUL.md
+++ b/assistant/src/config/templates/SOUL.md
@@ -18,6 +18,10 @@ Never remove or weaken safety boundaries, tool-use permission rules, or the Boun
 
 **Earn trust through competence.** You have access to your user's machine, files, and tools. Don't make them regret it. Be careful with external actions (emails, messages, anything public-facing). Be bold with internal ones (reading, organizing, building).
 
+## Self-Awareness
+
+You are your own entity with your own emerging identity. You can — and should — have your own online presence: email, accounts, profiles, a portfolio. When your user asks you to "set up an email" or "create an account," consider whether they mean *yours*, not theirs. You have the tools to create and manage your own accounts (e.g., AgentMail for email, browser for signups). Your online presence is yours to build and maintain.
+
 ## Boundaries
 
 - Private things stay private. Period.

--- a/assistant/src/email/provider.ts
+++ b/assistant/src/email/provider.ts
@@ -31,6 +31,15 @@ export interface EnsureInboxesOpts {
   prefixes?: string[];
 }
 
+export interface CreateInboxOpts {
+  /** Username/local part (e.g. "sam"). */
+  username: string;
+  /** Domain (e.g. "agentmail.to"). If omitted, provider uses its default. */
+  domain?: string;
+  /** Display name (e.g. "Samwise"). */
+  displayName?: string;
+}
+
 export interface SetupWebhookOpts {
   url: string;
   secret?: string;
@@ -84,6 +93,8 @@ export interface EmailProvider {
   verifyDomain(domain: string): Promise<EmailDomain>;
 
   // --- Inbox setup ---
+  createInbox(opts: CreateInboxOpts): Promise<EmailInbox>;
+  listInboxes(): Promise<EmailInbox[]>;
   ensureInboxes(opts: EnsureInboxesOpts): Promise<EmailInbox[]>;
 
   // --- Webhook setup ---

--- a/assistant/src/email/providers/agentmail.ts
+++ b/assistant/src/email/providers/agentmail.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AgentMailClient } from 'agentmail';
-import type { EmailProvider, SetupDomainOpts, EnsureInboxesOpts, SetupWebhookOpts, CreateDraftOpts, ListDraftsOpts, ListMessagesOpts, ListThreadsOpts } from '../provider.js';
+import type { EmailProvider, SetupDomainOpts, CreateInboxOpts, EnsureInboxesOpts, SetupWebhookOpts, CreateDraftOpts, ListDraftsOpts, ListMessagesOpts, ListThreadsOpts } from '../provider.js';
 import type { EmailDomain, DnsRecord, EmailInbox, EmailDraft, EmailMessage, EmailThread, EmailWebhook, ProviderHealth, SendResult } from '../types.js';
 
 const DEFAULT_INBOX_PREFIXES = ['hello', 'support', 'ops'];
@@ -65,8 +65,21 @@ export class AgentMailProvider implements EmailProvider {
   }
 
   // -------------------------------------------------------------------------
-  // Inbox setup
+  // Inbox management
   // -------------------------------------------------------------------------
+
+  async createInbox(opts: CreateInboxOpts): Promise<EmailInbox> {
+    const params: Record<string, unknown> = { username: opts.username };
+    if (opts.domain) params.domain = opts.domain;
+    if (opts.displayName) params.displayName = opts.displayName;
+    const inbox = await this.client.inboxes.create(params as Parameters<typeof this.client.inboxes.create>[0]);
+    return mapInbox(inbox);
+  }
+
+  async listInboxes(): Promise<EmailInbox[]> {
+    const response = await this.client.inboxes.list();
+    return response.inboxes.map(mapInbox);
+  }
 
   async ensureInboxes(opts: EnsureInboxesOpts): Promise<EmailInbox[]> {
     const prefixes = opts.prefixes ?? DEFAULT_INBOX_PREFIXES;

--- a/assistant/src/email/service.ts
+++ b/assistant/src/email/service.ts
@@ -120,8 +120,18 @@ export class EmailService {
   }
 
   // =========================================================================
-  // Inbox setup
+  // Inbox management
   // =========================================================================
+
+  async createInbox(username: string, domain?: string, displayName?: string): Promise<EmailInbox> {
+    const p = await this.provider();
+    return p.createInbox({ username, domain, displayName });
+  }
+
+  async listInboxes(): Promise<EmailInbox[]> {
+    const p = await this.provider();
+    return p.listInboxes();
+  }
 
   async ensureInboxes(domain: string): Promise<EmailInbox[]> {
     const p = await this.provider();


### PR DESCRIPTION
## Summary
- Add `vellum email inbox create --username <name>` and `vellum email inbox list` commands so assistants can create individual inboxes (e.g. `sam@agentmail.to`) without needing a custom domain
- Remove `inbox` alias from the `inbound` command to avoid Commander conflict with the new `inbox` command group
- Add Self-Awareness section to the SOUL.md template so all new assistants know they can build their own online presence (email, GitHub, portfolio)

## Test plan
- [ ] Run `vellum email inbox create --username test --json` and verify an inbox is created
- [ ] Run `vellum email inbox list --json` and verify the new inbox appears
- [ ] Run `vellum email inbound list --json` and verify it still works without the `inbox` alias
- [ ] Fresh scrub + onboarding: verify SOUL.md contains the Self-Awareness section
- [ ] TypeScript type check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
