### PR TITLE
feat: polish sidebar new conversation button and section headers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -516,13 +516,13 @@ struct MainWindowView: View {
             NewConversationButton(action: { windowState.selection = nil; threadManager.createThread() })
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.top, VSpacing.md)
-                .padding(.bottom, VSpacing.sm)
+                .padding(.bottom, VSpacing.lg)
 
             ScrollView {
                 VStack(spacing: VSpacing.xl) {
                     // MARK: Threads Section
                     VStack(spacing: VSpacing.xs) {
-                        SidebarSectionHeader(title: "Threads", icon: "text.bubble")
+                        SidebarSectionHeader(title: "Threads")
 
                         ForEach(displayedThreads) { thread in
                             threadItem(thread)
@@ -552,7 +552,7 @@ struct MainWindowView: View {
                     // MARK: Apps Section
                     if !appListManager.apps.isEmpty {
                         VStack(spacing: VSpacing.xs) {
-                            SidebarSectionHeader(title: "Apps", icon: "square.grid.2x2")
+                            SidebarSectionHeader(title: "Apps")
 
                             ForEach(displayedApps) { app in
                                 sidebarAppItem(app)
@@ -1165,59 +1165,23 @@ private struct ZoomIndicatorView: View {
 
 private struct SidebarSectionHeader: View {
     let title: String
-    var icon: String? = nil
 
     var body: some View {
-        HStack(spacing: VSpacing.xs) {
-            if let icon {
-                Image(systemName: icon)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(VColor.textMuted)
-            }
-            Text(title)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .textCase(.uppercase)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.leading, VSpacing.lg)
-        .padding(.bottom, VSpacing.xs)
+        Text(title)
+            .font(VFont.headline)
+            .foregroundColor(VColor.textSecondary)
+            .textCase(.uppercase)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, VSpacing.lg)
+            .padding(.bottom, VSpacing.xs)
     }
 }
 
 private struct NewConversationButton: View {
     let action: () -> Void
-    @State private var isHovered = false
 
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: VSpacing.md) {
-                Image(systemName: "plus")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(isHovered ? VColor.textPrimary : VColor.textMuted)
-                    .frame(width: 22, height: 22)
-                    .overlay(
-                        Circle()
-                            .stroke(isHovered ? VColor.textMuted : VColor.textMuted.opacity(0.5), lineWidth: 1)
-                    )
-                Text("New conversation")
-                    .font(.system(size: 13, weight: .medium))
-            }
-            .foregroundColor(VColor.textPrimary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.sm)
-            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            withAnimation(VAnimation.fast) {
-                isHovered = hovering
-            }
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        VButton(label: "New conversation", icon: "plus", style: .primary, isFullWidth: true, action: action)
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -7,6 +7,7 @@ public struct VButton: View {
     public enum Style: Hashable { case primary, ghost, danger }
 
     public let label: String
+    public var icon: String? = nil
     public var style: Style = .primary
     public var isFullWidth: Bool = false
     public var isDisabled: Bool = false
@@ -14,8 +15,9 @@ public struct VButton: View {
 
     @State private var isHovered = false
 
-    public init(label: String, style: Style = .primary, isFullWidth: Bool = false, isDisabled: Bool = false, action: @escaping () -> Void) {
+    public init(label: String, icon: String? = nil, style: Style = .primary, isFullWidth: Bool = false, isDisabled: Bool = false, action: @escaping () -> Void) {
         self.label = label
+        self.icon = icon
         self.style = style
         self.isFullWidth = isFullWidth
         self.isDisabled = isDisabled
@@ -24,8 +26,14 @@ public struct VButton: View {
 
     public var body: some View {
         Button(action: action) {
-            Text(label)
-                .font(VFont.monoMedium)
+            HStack(spacing: VSpacing.sm) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                Text(label)
+                    .font(VFont.monoMedium)
+            }
         }
         .buttonStyle(VButtonStyle(style: style, isHovered: isHovered, isFullWidth: isFullWidth))
         #if os(macOS)


### PR DESCRIPTION
## Summary
- New conversation button is now a primary VButton with a plus icon
- Section headers (Threads, Apps) use Silkscreen pixel font
- Added optional `icon` parameter to VButton
- Adjusted sidebar spacing for better visual balance

## Test plan
- [ ] Sidebar shows primary-styled "New conversation" button with plus icon
- [ ] Section headers render in pixel font without icons
- [ ] Button spacing looks balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
