### PR TITLE
M8: Multiple chat threads (iOS ThreadManager lite)

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -20,5 +20,15 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         }
         return true
     }
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        config.delegateClass = SceneDelegate.self
+        return config
+    }
 }
 #endif

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     let daemonClient: DaemonClient
 
     override init() {
-        self.daemonClient = DaemonClient(config: .default)
+        self.daemonClient = DaemonClient(config: .fromUserDefaults())
         super.init()
     }
 

--- a/clients/ios/App/SceneDelegate.swift
+++ b/clients/ios/App/SceneDelegate.swift
@@ -1,0 +1,14 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Handles iOS scene lifecycle events, reconnecting the daemon client
+/// whenever the app returns to the foreground from a backgrounded state.
+class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        let client = appDelegate.daemonClient
+        guard !client.isConnected else { return }
+        Task { try? await client.connect() }
+    }
+}
+#endif

--- a/clients/ios/Resources/Info.plist
+++ b/clients/ios/Resources/Info.plist
@@ -24,5 +24,7 @@
     <string>Vellum Assistant needs access to your microphone for voice input.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum Assistant needs access to speech recognition to transcribe your voice input.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Select photos to attach to your message</string>
 </dict>
 </plist>

--- a/clients/ios/Views/AttachmentStripView.swift
+++ b/clients/ios/Views/AttachmentStripView.swift
@@ -1,0 +1,60 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Horizontal strip of thumbnail chips for pending message attachments.
+struct AttachmentStripView: View {
+    @ObservedObject var viewModel: ChatViewModel
+
+    var body: some View {
+        if viewModel.pendingAttachments.isEmpty {
+            EmptyView()
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(viewModel.pendingAttachments) { attachment in
+                        AttachmentChip(attachment: attachment) {
+                            viewModel.removeAttachment(id: attachment.id)
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+            .frame(height: 72)
+        }
+    }
+}
+
+private struct AttachmentChip: View {
+    let attachment: ChatAttachment
+    let onRemove: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            // Thumbnail
+            if let uiImage = attachment.thumbnailImage {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 60, height: 60)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(.quaternary)
+                    .frame(width: 60, height: 60)
+                    .overlay {
+                        Image(systemName: "doc.fill")
+                            .foregroundStyle(.secondary)
+                    }
+            }
+            // Remove button
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .black.opacity(0.6))
+            }
+            .offset(x: 6, y: -6)
+        }
+    }
+}
+#endif

--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -112,7 +112,8 @@ struct ChatTabView: View {
                 onStop: viewModel.stopGenerating,
                 onVoiceResult: { _ in
                     viewModel.pendingVoiceMessage = true
-                }
+                },
+                viewModel: viewModel
             )
         }
         .background(VColor.background)

--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -68,7 +68,10 @@ struct ChatTabView: View {
                 text: $viewModel.inputText,
                 isInputFocused: $isInputFocused,
                 isGenerating: viewModel.isSending || viewModel.isThinking,
-                onSend: viewModel.sendMessage
+                onSend: viewModel.sendMessage,
+                onVoiceResult: { _ in
+                    viewModel.pendingVoiceMessage = true
+                }
             )
         }
         .background(VColor.background)

--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -12,24 +12,6 @@ struct ChatTabView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Error banner
-            if let errorText = viewModel.errorText {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.error)
-                    Text(errorText)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                    Button(action: { viewModel.errorText = nil }) {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundColor(VColor.textSecondary)
-                    }
-                }
-                .padding(VSpacing.md)
-                .background(VColor.error.opacity(0.1))
-            }
-
             // Messages list
             ScrollViewReader { proxy in
                 ScrollView {
@@ -42,9 +24,22 @@ struct ChatTabView: View {
                                 },
                                 onSurfaceAction: { surfaceId, actionId, data in
                                     viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
-                                }
+                                },
+                                onRegenerate: viewModel.isSending ? nil : { viewModel.regenerateLastMessage() }
                             )
                             .id(message.id)
+                        }
+
+                        // Current step indicator shown while generating
+                        if viewModel.isSending {
+                            let allToolCalls = viewModel.messages.last?.toolCalls ?? []
+                            CurrentStepIndicator(
+                                toolCalls: allToolCalls,
+                                isStreaming: viewModel.isSending,
+                                onTap: {}
+                            )
+                            .padding(.horizontal, VSpacing.lg)
+                            .id("step-indicator")
                         }
                     }
                     .padding(VSpacing.lg)
@@ -61,6 +56,50 @@ struct ChatTabView: View {
                         scrollToBottom(proxy: proxy, animated: false)
                     }
                 }
+                .onChange(of: viewModel.isSending) { _, isSending in
+                    if isSending {
+                        withAnimation(.easeOut(duration: 0.3)) {
+                            proxy.scrollTo("step-indicator", anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            // Session error banner
+            if let sessionError = viewModel.sessionError {
+                sessionErrorBanner(sessionError)
+            } else if let errorText = viewModel.errorText {
+                // Generic error banner with optional retry
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.white)
+                        .font(VFont.caption)
+                    Text(errorText)
+                        .font(VFont.caption)
+                        .foregroundColor(.white)
+                        .lineLimit(2)
+                    Spacer()
+                    if viewModel.isRetryableError {
+                        Button(action: { viewModel.retryLastMessage() }) {
+                            Text("Retry")
+                                .font(VFont.captionMedium)
+                                .foregroundColor(.white)
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, VSpacing.xs)
+                                .background(Color.white.opacity(0.25))
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        }
+                    }
+                    Button(action: { viewModel.dismissError() }) {
+                        Image(systemName: "xmark")
+                            .font(VFont.caption)
+                            .foregroundColor(.white)
+                    }
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.error)
+                .transition(.move(edge: .top).combined(with: .opacity))
             }
 
             // Input bar
@@ -68,7 +107,9 @@ struct ChatTabView: View {
                 text: $viewModel.inputText,
                 isInputFocused: $isInputFocused,
                 isGenerating: viewModel.isSending || viewModel.isThinking,
+                isCancelling: viewModel.isCancelling,
                 onSend: viewModel.sendMessage,
+                onStop: viewModel.stopGenerating,
                 onVoiceResult: { _ in
                     viewModel.pendingVoiceMessage = true
                 }
@@ -77,6 +118,92 @@ struct ChatTabView: View {
         .background(VColor.background)
         .navigationTitle("Chat")
         .navigationBarTitleDisplayMode(.inline)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.sessionError != nil)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.errorText)
+    }
+
+    // MARK: - Session Error Banner
+
+    @ViewBuilder
+    private func sessionErrorBanner(_ error: SessionError) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: sessionErrorIcon(error.category))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(sessionErrorAccent(error.category))
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(error.message)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                Text(error.recoverySuggestion)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if error.isRetryable {
+                Button(action: { viewModel.retryAfterSessionError() }) {
+                    Text("Retry")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(sessionErrorAccent(error.category))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+            }
+
+            Button(action: { viewModel.dismissSessionError() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(sessionErrorAccent(error.category).opacity(0.1))
+        .overlay(
+            Rectangle()
+                .fill(sessionErrorAccent(error.category))
+                .frame(width: 3),
+            alignment: .leading
+        )
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    private func sessionErrorIcon(_ category: SessionErrorCategory) -> String {
+        switch category {
+        case .providerNetwork:
+            return "wifi.exclamationmark"
+        case .rateLimit:
+            return "clock.badge.exclamationmark"
+        case .providerApi:
+            return "exclamationmark.icloud.fill"
+        case .queueFull:
+            return "tray.full.fill"
+        case .sessionAborted:
+            return "stop.circle.fill"
+        case .processingFailed, .regenerateFailed:
+            return "arrow.triangle.2.circlepath"
+        case .unknown:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func sessionErrorAccent(_ category: SessionErrorCategory) -> Color {
+        switch category {
+        case .rateLimit, .queueFull:
+            return VColor.warning
+        case .providerNetwork:
+            return .orange
+        case .sessionAborted:
+            return VColor.textSecondary
+        default:
+            return VColor.error
+        }
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy, animated: Bool) {

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -7,12 +7,10 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
-            NavigationStack {
-                ChatTabView(daemonClient: daemonClient)
-            }
-            .tabItem {
-                Label("Chat", systemImage: "message")
-            }
+            ThreadListView(daemonClient: daemonClient)
+                .tabItem {
+                    Label("Chats", systemImage: "message")
+                }
 
             SettingsView()
                 .tabItem {

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -3,6 +3,8 @@ import os
 import SwiftUI
 import Speech
 import AVFoundation
+import PhotosUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 private let log = Logger(
@@ -18,61 +20,146 @@ struct InputBarView: View {
     let onSend: () -> Void
     let onStop: () -> Void
     var onVoiceResult: ((String) -> Void)?
+    @ObservedObject var viewModel: ChatViewModel
 
     @State private var isRecording = false
     @State private var recognitionTask: SFSpeechRecognitionTask?
     @State private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     @State private var audioEngine = AVAudioEngine()
+    @State private var showPhotosPicker = false
+    @State private var showDocumentPicker = false
+    @State private var selectedPhotoItems: [PhotosPickerItem] = []
 
     var body: some View {
-        HStack(spacing: VSpacing.md) {
-            // Text field
-            TextField("Message...", text: $text, axis: .vertical)
-                .textFieldStyle(.plain)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                .focused(isInputFocused)
+        VStack(spacing: 0) {
+            // Attachment strip (shown only when there are pending attachments)
+            AttachmentStripView(viewModel: viewModel)
 
-            // Stop button (shown while generating but not yet cancelling)
-            if isGenerating && !isCancelling {
-                Button(action: onStop) {
-                    ZStack {
-                        Circle()
-                            .fill(VColor.textPrimary)
-                            .frame(width: 32, height: 32)
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(VColor.background)
-                            .frame(width: 11, height: 11)
+            HStack(spacing: VSpacing.md) {
+                // Attachment button
+                Button(action: {}) {
+                    Image(systemName: "paperclip")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .contextMenu {
+                    Button {
+                        showPhotosPicker = true
+                    } label: {
+                        Label("Photo Library", systemImage: "photo.on.rectangle")
+                    }
+                    Button {
+                        showDocumentPicker = true
+                    } label: {
+                        Label("Files", systemImage: "folder")
                     }
                 }
-                .accessibilityLabel("Stop generation")
-            } else {
-                // Mic button
-                Button(action: toggleVoiceInput) {
-                    Image(systemName: isRecording ? "mic.fill" : "mic")
-                        .font(.system(size: 22))
-                        .foregroundColor(isRecording ? .red : VColor.textMuted)
+                .photosPicker(
+                    isPresented: $showPhotosPicker,
+                    selection: $selectedPhotoItems,
+                    maxSelectionCount: ChatViewModel.maxAttachments,
+                    matching: .images
+                )
+                .fileImporter(
+                    isPresented: $showDocumentPicker,
+                    allowedContentTypes: [.item],
+                    allowsMultipleSelection: true
+                ) { result in
+                    handleFileImportResult(result)
                 }
-                .buttonStyle(.plain)
+                .onChange(of: selectedPhotoItems) { _, newItems in
+                    handlePhotoSelection(newItems)
+                }
 
-                // Send button
-                Button(action: onSend) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: 32))
-                        .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                // Text field
+                TextField("Message...", text: $text, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .focused(isInputFocused)
+
+                // Stop button (shown while generating but not yet cancelling)
+                if isGenerating && !isCancelling {
+                    Button(action: onStop) {
+                        ZStack {
+                            Circle()
+                                .fill(VColor.textPrimary)
+                                .frame(width: 32, height: 32)
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(VColor.background)
+                                .frame(width: 11, height: 11)
+                        }
+                    }
+                    .accessibilityLabel("Stop generation")
+                } else {
+                    // Mic button
+                    Button(action: toggleVoiceInput) {
+                        Image(systemName: isRecording ? "mic.fill" : "mic")
+                            .font(.system(size: 22))
+                            .foregroundColor(isRecording ? .red : VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+
+                    // Send button
+                    Button(action: onSend) {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 32))
+                            .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                    }
+                    .disabled(!canSend)
                 }
-                .disabled(!canSend)
             }
+            .padding(VSpacing.md)
+            .background(VColor.backgroundSubtle)
         }
-        .padding(VSpacing.md)
-        .background(VColor.backgroundSubtle)
     }
 
     private var canSend: Bool {
-        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isGenerating
+        let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasAttachments = !viewModel.pendingAttachments.isEmpty
+        return (hasText || hasAttachments) && !isGenerating
+    }
+
+    private func handlePhotoSelection(_ items: [PhotosPickerItem]) {
+        guard !items.isEmpty else { return }
+        // Clear selection state so the same photos can be re-selected later
+        selectedPhotoItems = []
+        for item in items {
+            item.loadTransferable(type: Data.self) { result in
+                switch result {
+                case .success(let data):
+                    guard let data else { return }
+                    Task { @MainActor in
+                        viewModel.addAttachment(imageData: data, filename: "Photo.jpeg")
+                    }
+                case .failure(let error):
+                    log.error("Failed to load photo: \(error.localizedDescription)")
+                    Task { @MainActor in
+                        viewModel.errorText = "Could not load photo."
+                    }
+                }
+            }
+        }
+    }
+
+    private func handleFileImportResult(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            for url in urls {
+                // Security-scoped resource access is required for files from the Files app
+                let didStartAccessing = url.startAccessingSecurityScopedResource()
+                defer {
+                    if didStartAccessing { url.stopAccessingSecurityScopedResource() }
+                }
+                viewModel.addAttachment(url: url)
+            }
+        case .failure(let error):
+            log.error("File import failed: \(error.localizedDescription)")
+            viewModel.errorText = "Could not import file."
+        }
     }
 
     // MARK: - Voice Input
@@ -201,7 +288,8 @@ struct InputBarView_Previews: PreviewProvider {
                     isGenerating: false,
                     isCancelling: false,
                     onSend: { log.debug("Send tapped") },
-                    onStop: { log.debug("Stop tapped") }
+                    onStop: { log.debug("Stop tapped") },
+                    viewModel: ChatViewModel(daemonClient: DaemonClient(config: .default))
                 )
             }
             .background(VColor.background)

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -1,6 +1,8 @@
 #if canImport(UIKit)
 import os
 import SwiftUI
+import Speech
+import AVFoundation
 import VellumAssistantShared
 
 private let log = Logger(
@@ -13,6 +15,12 @@ struct InputBarView: View {
     var isInputFocused: FocusState<Bool>.Binding
     let isGenerating: Bool
     let onSend: () -> Void
+    var onVoiceResult: ((String) -> Void)?
+
+    @State private var isRecording = false
+    @State private var recognitionTask: SFSpeechRecognitionTask?
+    @State private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    @State private var audioEngine = AVAudioEngine()
 
     var body: some View {
         HStack(spacing: VSpacing.md) {
@@ -25,6 +33,14 @@ struct InputBarView: View {
                 .background(VColor.surface)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .focused(isInputFocused)
+
+            // Mic button
+            Button(action: toggleVoiceInput) {
+                Image(systemName: isRecording ? "mic.fill" : "mic")
+                    .font(.system(size: 22))
+                    .foregroundColor(isRecording ? .red : VColor.textMuted)
+            }
+            .buttonStyle(.plain)
 
             // Send button
             Button(action: onSend) {
@@ -40,6 +56,117 @@ struct InputBarView: View {
 
     private var canSend: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isGenerating
+    }
+
+    // MARK: - Voice Input
+
+    private func toggleVoiceInput() {
+        if isRecording {
+            stopRecording()
+        } else {
+            requestPermissionsAndRecord()
+        }
+    }
+
+    private func requestPermissionsAndRecord() {
+        // Request microphone access
+        AVAudioSession.sharedInstance().requestRecordPermission { granted in
+            guard granted else {
+                log.warning("Microphone access denied")
+                return
+            }
+            // Request speech recognition access
+            SFSpeechRecognizer.requestAuthorization { status in
+                DispatchQueue.main.async {
+                    guard status == .authorized else {
+                        log.warning("Speech recognition not authorized: \(String(describing: status))")
+                        return
+                    }
+                    beginRecording()
+                }
+            }
+        }
+    }
+
+    private func beginRecording() {
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            log.error("Speech recognizer not available")
+            return
+        }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            log.error("Failed to configure AVAudioSession: \(error.localizedDescription)")
+            return
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        recognitionRequest = request
+
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        guard recordingFormat.channelCount > 0 else {
+            log.error("No audio input channels available")
+            return
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            request.append(buffer)
+        }
+
+        recognitionTask = recognizer.recognitionTask(with: request) { result, error in
+            DispatchQueue.main.async {
+                if let result = result {
+                    let transcribed = result.bestTranscription.formattedString
+                    if result.isFinal {
+                        log.info("Voice transcription final: \(transcribed, privacy: .public)")
+                        text = transcribed
+                        onVoiceResult?(transcribed)
+                        stopRecording()
+                    }
+                }
+                if let error = error {
+                    // Code 1110 is "no speech detected" — not an error worth logging at error level
+                    let nsError = error as NSError
+                    if nsError.code != 1110 {
+                        log.error("Recognition error: \(error.localizedDescription)")
+                    }
+                    stopRecording()
+                }
+            }
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+            isRecording = true
+            log.info("Voice recording started")
+        } catch {
+            log.error("Audio engine failed to start: \(error.localizedDescription)")
+            cleanupRecognition()
+        }
+    }
+
+    private func stopRecording() {
+        guard isRecording else { return }
+        log.info("Voice recording stopped")
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        cleanupRecognition()
+        isRecording = false
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func cleanupRecognition() {
+        recognitionRequest = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
     }
 }
 

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -14,7 +14,9 @@ struct InputBarView: View {
     @Binding var text: String
     var isInputFocused: FocusState<Bool>.Binding
     let isGenerating: Bool
+    let isCancelling: Bool
     let onSend: () -> Void
+    let onStop: () -> Void
     var onVoiceResult: ((String) -> Void)?
 
     @State private var isRecording = false
@@ -34,21 +36,36 @@ struct InputBarView: View {
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .focused(isInputFocused)
 
-            // Mic button
-            Button(action: toggleVoiceInput) {
-                Image(systemName: isRecording ? "mic.fill" : "mic")
-                    .font(.system(size: 22))
-                    .foregroundColor(isRecording ? .red : VColor.textMuted)
-            }
-            .buttonStyle(.plain)
+            // Stop button (shown while generating but not yet cancelling)
+            if isGenerating && !isCancelling {
+                Button(action: onStop) {
+                    ZStack {
+                        Circle()
+                            .fill(VColor.textPrimary)
+                            .frame(width: 32, height: 32)
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(VColor.background)
+                            .frame(width: 11, height: 11)
+                    }
+                }
+                .accessibilityLabel("Stop generation")
+            } else {
+                // Mic button
+                Button(action: toggleVoiceInput) {
+                    Image(systemName: isRecording ? "mic.fill" : "mic")
+                        .font(.system(size: 22))
+                        .foregroundColor(isRecording ? .red : VColor.textMuted)
+                }
+                .buttonStyle(.plain)
 
-            // Send button
-            Button(action: onSend) {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.system(size: 32))
-                    .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                // Send button
+                Button(action: onSend) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 32))
+                        .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                }
+                .disabled(!canSend)
             }
-            .disabled(!canSend)
         }
         .padding(VSpacing.md)
         .background(VColor.backgroundSubtle)
@@ -182,7 +199,9 @@ struct InputBarView_Previews: PreviewProvider {
                     text: $text,
                     isInputFocused: $isFocused,
                     isGenerating: false,
-                    onSend: { log.debug("Send tapped") }
+                    isCancelling: false,
+                    onSend: { log.debug("Send tapped") },
+                    onStop: { log.debug("Stop tapped") }
                 )
             }
             .background(VColor.background)

--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -12,6 +12,9 @@ struct MessageBubbleView: View {
     let message: ChatMessage
     let onConfirmationResponse: ((String, String) -> Void)?
     let onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?
+    /// When non-nil, a "Regenerate" option appears in the long-press context menu
+    /// for the last assistant message. Pass nil when generation is in-flight.
+    let onRegenerate: (() -> Void)?
 
     var body: some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
@@ -46,16 +49,7 @@ struct MessageBubbleView: View {
 
                     // Message text (only shown for non-confirmation messages)
                     if !message.text.isEmpty {
-                        Text(message.text)
-                            .font(VFont.body)
-                            .foregroundColor(message.role == .user ? VColor.background : VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(
-                                message.role == .user
-                                    ? VColor.accent
-                                    : VColor.surface
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        messageBubble(text: message.text, role: message.role)
                     }
 
                     // Post-text tool calls render below the bubble
@@ -147,12 +141,7 @@ struct MessageBubbleView: View {
                 if i < message.textSegments.count {
                     let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
                     if !segmentText.isEmpty {
-                        Text(segmentText)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        messageBubble(text: segmentText, role: message.role)
                     }
                 }
             case .toolCalls(let indices):
@@ -173,6 +162,48 @@ struct MessageBubbleView: View {
         }
     }
 
+    /// Render a message text bubble with markdown for assistant messages.
+    @ViewBuilder
+    private func messageBubble(text: String, role: ChatRole) -> some View {
+        let isUser = role == .user
+        if isUser {
+            Text(text)
+                .font(VFont.body)
+                .foregroundColor(VColor.background)
+                .padding(VSpacing.md)
+                .background(VColor.accent)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .textSelection(.enabled)
+        } else {
+            Text(Self.markdownString(text))
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .tint(VColor.accent)
+                .padding(VSpacing.md)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .textSelection(.enabled)
+                .contextMenu {
+                    if let onRegenerate {
+                        Button {
+                            onRegenerate()
+                        } label: {
+                            Label("Regenerate", systemImage: "arrow.trianglehead.counterclockwise")
+                        }
+                    }
+                }
+        }
+    }
+
+    /// Parse markdown in text using SwiftUI's native AttributedString support.
+    static func markdownString(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: text, options: options))
+            ?? AttributedString(text)
+    }
+
     private func streamingScale(for index: Int, at date: Date) -> CGFloat {
         let time = date.timeIntervalSince1970
         let phase = (time + Double(index) * 0.3).truncatingRemainder(dividingBy: 1.2)
@@ -189,7 +220,8 @@ struct MessageBubbleView: View {
                 text: "Hello! Can you help me with something?"
             ),
             onConfirmationResponse: nil,
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: nil
         )
     }
     .padding()
@@ -201,10 +233,11 @@ struct MessageBubbleView: View {
         MessageBubbleView(
             message: ChatMessage(
                 role: .assistant,
-                text: "Of course! I'd be happy to help. What do you need assistance with?"
+                text: "Of course! I'd be happy to help. What do you need assistance with?\n\n**Bold text** and _italic_ and `code` all render via markdown."
             ),
             onConfirmationResponse: nil,
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: { log.debug("Preview: Regenerate tapped") }
         )
     }
     .padding()
@@ -220,7 +253,8 @@ struct MessageBubbleView: View {
                 isStreaming: true
             ),
             onConfirmationResponse: nil,
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: nil
         )
     }
     .padding()
@@ -244,7 +278,8 @@ struct MessageBubbleView: View {
             onConfirmationResponse: { requestId, decision in
                 log.debug("Preview: Confirmation \(decision) for \(requestId)")
             },
-            onSurfaceAction: nil
+            onSurfaceAction: nil,
+            onRegenerate: nil
         )
     }
     .padding()

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -1,0 +1,354 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - IOSThread
+
+/// Represents a single local chat thread on iOS.
+struct IOSThread: Identifiable {
+    let id: UUID
+    var title: String
+
+    init(id: UUID = UUID(), title: String = "New Chat") {
+        self.id = id
+        self.title = title
+    }
+}
+
+// MARK: - IOSThreadStore
+
+/// Manages a list of local in-memory chat threads for iOS.
+/// Each thread owns an independent ChatViewModel instance so threads
+/// do not share message history or sending state.
+@MainActor
+class IOSThreadStore: ObservableObject {
+    @Published var threads: [IOSThread] = []
+
+    /// ViewModels keyed by thread ID, created lazily on first access.
+    private var viewModels: [UUID: ChatViewModel] = [:]
+    private let daemonClient: DaemonClient
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        // Start with one default thread.
+        newThread()
+    }
+
+    /// Return the ChatViewModel for the given thread, creating it if necessary.
+    func viewModel(for threadId: UUID) -> ChatViewModel {
+        if let existing = viewModels[threadId] {
+            return existing
+        }
+        let vm = ChatViewModel(daemonClient: daemonClient)
+        viewModels[threadId] = vm
+        return vm
+    }
+
+    func newThread() {
+        let thread = IOSThread()
+        threads.append(thread)
+    }
+
+    func deleteThread(_ thread: IOSThread) {
+        viewModels.removeValue(forKey: thread.id)
+        threads.removeAll { $0.id == thread.id }
+        // Always keep at least one thread.
+        if threads.isEmpty {
+            newThread()
+        }
+    }
+}
+
+// MARK: - ThreadListView
+
+struct ThreadListView: View {
+    @EnvironmentObject private var daemonClient: DaemonClient
+    @StateObject private var store: IOSThreadStore
+    @State private var selectedThreadId: UUID?
+
+    init() {
+        // Store is initialised with a temporary placeholder; the real
+        // daemonClient is injected via onAppear once the environment is set.
+        // However, @StateObject is only created once, so we use a workaround:
+        // capture the store creation inside a lazy init via _store assignment.
+        // The actual daemonClient is set in `makeStore` via the environment.
+        // Because @StateObject wrappedValue must be set at init time we defer
+        // to the factory pattern below.
+        _store = StateObject(wrappedValue: IOSThreadStore(daemonClient: DaemonClient(config: .fromUserDefaults())))
+    }
+
+    /// Designated factory initialiser used by ContentView so the correct
+    /// DaemonClient is passed before the SwiftUI environment is available.
+    init(daemonClient: DaemonClient) {
+        _store = StateObject(wrappedValue: IOSThreadStore(daemonClient: daemonClient))
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            threadList
+        } detail: {
+            detailView
+        }
+    }
+
+    // MARK: - Sidebar
+
+    private var threadList: some View {
+        List(store.threads, selection: $selectedThreadId) { thread in
+            NavigationLink(value: thread.id) {
+                Label(thread.title, systemImage: "bubble.left")
+            }
+            .swipeActions(edge: .trailing) {
+                Button(role: .destructive) {
+                    store.deleteThread(thread)
+                    if selectedThreadId == thread.id {
+                        selectedThreadId = store.threads.first?.id
+                    }
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
+        .navigationTitle("Chats")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    store.newThread()
+                    // Auto-select the newly created thread.
+                    selectedThreadId = store.threads.last?.id
+                } label: {
+                    Image(systemName: "square.and.pencil")
+                }
+            }
+        }
+        .onAppear {
+            // Select the first thread automatically on launch.
+            if selectedThreadId == nil {
+                selectedThreadId = store.threads.first?.id
+            }
+        }
+    }
+
+    // MARK: - Detail
+
+    @ViewBuilder
+    private var detailView: some View {
+        if let selectedId = selectedThreadId,
+           store.threads.contains(where: { $0.id == selectedId }) {
+            ThreadChatView(viewModel: store.viewModel(for: selectedId))
+        } else {
+            Text("Select a chat")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - ThreadChatView
+
+/// Wraps ChatTabView with a pre-existing ChatViewModel (one per thread).
+struct ThreadChatView: View {
+    @ObservedObject var viewModel: ChatViewModel
+    @FocusState private var isInputFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Messages list
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: VSpacing.md) {
+                        ForEach(viewModel.messages) { message in
+                            MessageBubbleView(
+                                message: message,
+                                onConfirmationResponse: { requestId, decision in
+                                    viewModel.respondToConfirmation(requestId: requestId, decision: decision)
+                                },
+                                onSurfaceAction: { surfaceId, actionId, data in
+                                    viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
+                                },
+                                onRegenerate: viewModel.isSending ? nil : { viewModel.regenerateLastMessage() }
+                            )
+                            .id(message.id)
+                        }
+
+                        // Current step indicator shown while generating
+                        if viewModel.isSending {
+                            let allToolCalls = viewModel.messages.last?.toolCalls ?? []
+                            CurrentStepIndicator(
+                                toolCalls: allToolCalls,
+                                isStreaming: viewModel.isSending,
+                                onTap: {}
+                            )
+                            .padding(.horizontal, VSpacing.lg)
+                            .id("step-indicator")
+                        }
+                    }
+                    .padding(VSpacing.lg)
+                }
+                .scrollDismissesKeyboard(.interactively)
+                .onChange(of: viewModel.messages.count) { _, _ in
+                    scrollToBottom(proxy: proxy, animated: true)
+                }
+                .onChange(of: viewModel.messages.last?.text) { _, _ in
+                    if viewModel.messages.last?.isStreaming == true {
+                        scrollToBottom(proxy: proxy, animated: false)
+                    }
+                }
+                .onChange(of: viewModel.isSending) { _, isSending in
+                    if isSending {
+                        withAnimation(.easeOut(duration: 0.3)) {
+                            proxy.scrollTo("step-indicator", anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            // Error banners
+            if let sessionError = viewModel.sessionError {
+                sessionErrorBanner(sessionError)
+            } else if let errorText = viewModel.errorText {
+                genericErrorBanner(errorText)
+            }
+
+            // Input bar
+            InputBarView(
+                text: $viewModel.inputText,
+                isInputFocused: $isInputFocused,
+                isGenerating: viewModel.isSending || viewModel.isThinking,
+                isCancelling: viewModel.isCancelling,
+                onSend: viewModel.sendMessage,
+                onStop: viewModel.stopGenerating,
+                onVoiceResult: { _ in
+                    viewModel.pendingVoiceMessage = true
+                },
+                viewModel: viewModel
+            )
+        }
+        .background(VColor.background)
+        .navigationTitle("Chat")
+        .navigationBarTitleDisplayMode(.inline)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.sessionError != nil)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.errorText)
+    }
+
+    // MARK: - Error Banners
+
+    @ViewBuilder
+    private func sessionErrorBanner(_ error: SessionError) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: sessionErrorIcon(error.category))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(sessionErrorAccent(error.category))
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(error.message)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                Text(error.recoverySuggestion)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if error.isRetryable {
+                Button(action: { viewModel.retryAfterSessionError() }) {
+                    Text("Retry")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(sessionErrorAccent(error.category))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+            }
+
+            Button(action: { viewModel.dismissSessionError() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(sessionErrorAccent(error.category).opacity(0.1))
+        .overlay(
+            Rectangle()
+                .fill(sessionErrorAccent(error.category))
+                .frame(width: 3),
+            alignment: .leading
+        )
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    @ViewBuilder
+    private func genericErrorBanner(_ errorText: String) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.white)
+                .font(VFont.caption)
+            Text(errorText)
+                .font(VFont.caption)
+                .foregroundColor(.white)
+                .lineLimit(2)
+            Spacer()
+            if viewModel.isRetryableError {
+                Button(action: { viewModel.retryLastMessage() }) {
+                    Text("Retry")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(Color.white.opacity(0.25))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+            }
+            Button(action: { viewModel.dismissError() }) {
+                Image(systemName: "xmark")
+                    .font(VFont.caption)
+                    .foregroundColor(.white)
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.error)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    // MARK: - Helpers
+
+    private func sessionErrorIcon(_ category: SessionErrorCategory) -> String {
+        switch category {
+        case .providerNetwork: return "wifi.exclamationmark"
+        case .rateLimit: return "clock.badge.exclamationmark"
+        case .providerApi: return "exclamationmark.icloud.fill"
+        case .queueFull: return "tray.full.fill"
+        case .sessionAborted: return "stop.circle.fill"
+        case .processingFailed, .regenerateFailed: return "arrow.triangle.2.circlepath"
+        case .unknown: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func sessionErrorAccent(_ category: SessionErrorCategory) -> Color {
+        switch category {
+        case .rateLimit, .queueFull: return VColor.warning
+        case .providerNetwork: return .orange
+        case .sessionAborted: return VColor.textSecondary
+        default: return VColor.error
+        }
+    }
+
+    private func scrollToBottom(proxy: ScrollViewProxy, animated: Bool) {
+        guard let lastMessage = viewModel.messages.last else { return }
+        if animated {
+            withAnimation(.easeOut(duration: 0.3)) {
+                proxy.scrollTo(lastMessage.id, anchor: .bottom)
+            }
+        } else {
+            proxy.scrollTo(lastMessage.id, anchor: .bottom)
+        }
+    }
+}
+
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -375,7 +375,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             self?.onInlineConfirmationResponse?(requestId, decision)
         }
         viewModel.onWatchStarted = { [weak self] msg, client in
-            guard let self else { return }
+            guard let self, let concreteClient = client as? DaemonClient else { return }
             let session = WatchSession(
                 watchId: msg.watchId,
                 sessionId: msg.sessionId,
@@ -383,7 +383,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 intervalSeconds: Int(msg.intervalSeconds)
             )
             self.ambientAgent?.activeWatchSession = session
-            session.start(daemonClient: client)
+            session.start(daemonClient: concreteClient)
         }
         viewModel.onWatchCompleteRequest = { [weak self] _ in
             self?.ambientAgent?.activeWatchSession?.stop()

--- a/clients/shared/Features/Chat/ChatErrorBanner.swift
+++ b/clients/shared/Features/Chat/ChatErrorBanner.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Dismissible banner shown when a non-retryable session error occurs.
+public struct ChatErrorBanner: View {
+    public let message: String
+    public var onDismiss: (() -> Void)?
+
+    public init(message: String, onDismiss: (() -> Void)? = nil) {
+        self.message = message
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.primary)
+            Spacer()
+            if let onDismiss {
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal)
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -53,6 +53,7 @@ public final class ChatViewModel: ObservableObject {
 
     let daemonClient: DaemonClient
     public var sessionId: String?
+    private var reconnectObserver: NSObjectProtocol?
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
@@ -161,6 +162,14 @@ public final class ChatViewModel: ObservableObject {
     public init(daemonClient: DaemonClient, onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
         self.daemonClient = daemonClient
         self.onToolCallsComplete = onToolCallsComplete
+        reconnectObserver = NotificationCenter.default.addObserver(
+            forName: .daemonDidReconnect,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.pendingQueuedCount = 0
+            self?.pendingMessageIds.removeAll()
+        }
     }
 
     // MARK: - Sending
@@ -949,5 +958,8 @@ public final class ChatViewModel: ObservableObject {
 
     deinit {
         messageLoopTask?.cancel()
+        if let observer = reconnectObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -51,7 +51,7 @@ public final class ChatViewModel: ObservableObject {
     /// Maximum number of attachments per message.
     static let maxAttachments = 5
 
-    let daemonClient: DaemonClient
+    let daemonClient: any DaemonClientProtocol
     public var sessionId: String?
     private var reconnectObserver: NSObjectProtocol?
     var pendingUserMessage: String?
@@ -119,7 +119,7 @@ public final class ChatViewModel: ObservableObject {
     /// Called when the daemon sends a `watch_started` message to begin a watch session.
     /// The closure receives the WatchStartedMessage and the DaemonClient so the macOS
     /// layer can create and start a WatchSession.
-    public var onWatchStarted: ((WatchStartedMessage, DaemonClient) -> Void)?
+    public var onWatchStarted: ((WatchStartedMessage, any DaemonClientProtocol) -> Void)?
 
     /// Called when the daemon sends a `watch_complete_request` to stop the active watch session.
     public var onWatchCompleteRequest: ((WatchCompleteRequestMessage) -> Void)?
@@ -159,7 +159,7 @@ public final class ChatViewModel: ObservableObject {
     /// Set via the onPageChanged callback when the user navigates within a multi-page app.
     public var currentPage: String?
 
-    public init(daemonClient: DaemonClient, onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
+    public init(daemonClient: any DaemonClientProtocol, onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
         self.daemonClient = daemonClient
         self.onToolCallsComplete = onToolCallsComplete
         reconnectObserver = NotificationCenter.default.addObserver(
@@ -592,7 +592,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         do {
-            try daemonClient.sendRegenerate(sessionId: sessionId)
+            try daemonClient.send(RegenerateMessage(sessionId: sessionId))
         } catch {
             log.error("Failed to send regenerate: \(error.localizedDescription)")
             isSending = false
@@ -606,7 +606,7 @@ public final class ChatViewModel: ObservableObject {
         guard let sessionId, let surfaceId = activeSurfaceId else { return }
         guard surfaceUndoCount > 0 else { return }
         do {
-            try daemonClient.sendSurfaceUndo(sessionId: sessionId, surfaceId: surfaceId)
+            try daemonClient.send(UiSurfaceUndoMessage(sessionId: sessionId, surfaceId: surfaceId))
         } catch {
             log.error("Failed to send surface undo: \(error.localizedDescription)")
         }
@@ -732,7 +732,7 @@ public final class ChatViewModel: ObservableObject {
         // This prevents the UI from showing a finalized decision when the IPC
         // message was never delivered (e.g. daemon disconnected).
         do {
-            try daemonClient.sendConfirmationResponse(requestId: requestId, decision: decision)
+            try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil))
         } catch {
             log.error("Failed to send confirmation response: \(error.localizedDescription)")
             errorText = "Failed to send confirmation response."
@@ -769,12 +769,12 @@ public final class ChatViewModel: ObservableObject {
             return false
         }
         do {
-            try daemonClient.sendAddTrustRule(
+            try daemonClient.send(AddTrustRuleMessage(
                 toolName: toolName,
                 pattern: pattern,
                 scope: scope,
                 decision: decision
-            )
+            ))
             return true
         } catch {
             log.error("Failed to send add_trust_rule: \(error.localizedDescription)")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -56,9 +56,12 @@ func readSessionToken(environment: [String: String]? = nil) -> String? {
 /// Protocol for daemon client communication, enabling dependency injection and testing.
 @MainActor
 public protocol DaemonClientProtocol {
+    var isConnected: Bool { get }
     var isBlobTransportAvailable: Bool { get }
     func subscribe() -> AsyncStream<ServerMessage>
     func send<T: Encodable>(_ message: T) throws
+    func connect() async throws
+    func disconnect()
 }
 
 extension Notification.Name {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -356,6 +356,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #if os(macOS)
         log.info("Connecting to daemon socket at \(self.config.socketPath)")
         let endpoint = NWEndpoint.unix(path: self.config.socketPath)
+        let parameters = NWParameters()
+        parameters.defaultProtocolStack.transportProtocol = NWProtocolTCP.Options()
         #elseif os(iOS)
         // Check UserDefaults first to pick up runtime changes, fall back to config
         // This allows reconnects to pick up changed settings while preserving custom configs for tests
@@ -375,17 +377,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             port = self.config.port
         }
 
-        log.info("Connecting to daemon at \(hostname):\(port)")
+        log.info("Connecting to daemon at \(hostname):\(port) (tls=\(self.config.tlsEnabled))")
         let endpoint = NWEndpoint.hostPort(
             host: NWEndpoint.Host(hostname),
             port: NWEndpoint.Port(integerLiteral: port)
         )
+        let parameters: NWParameters = self.config.tlsEnabled ? .tls : .tcp
         #else
         #error("DaemonClient is only supported on macOS and iOS")
         #endif
-
-        let parameters = NWParameters()
-        parameters.defaultProtocolStack.transportProtocol = NWProtocolTCP.Options()
 
         let conn = NWConnection(to: endpoint, using: parameters)
         self.connection = conn
@@ -424,6 +424,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                                 do {
                                     #if os(macOS)
                                     try await self.authenticate()
+                                    #elseif os(iOS)
+                                    try await self.authenticateIfNeeded()
                                     #else
                                     self.isAuthenticated = true
                                     #endif
@@ -492,6 +494,48 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     private func authenticate() async throws {
         guard let token = readSessionToken() else {
             throw AuthError.missingToken
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            authContinuation?.resume(throwing: AuthError.rejected("Authentication superseded"))
+            authContinuation = continuation
+
+            authTimeoutTask?.cancel()
+            authTimeoutTask = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(Self.authTimeout * 1_000_000_000))
+                } catch {
+                    return
+                }
+                guard let self, let pending = self.authContinuation else { return }
+                self.authContinuation = nil
+                self.authTimeoutTask = nil
+                self.isAuthenticated = false
+                pending.resume(throwing: AuthError.timeout)
+            }
+
+            do {
+                try self.send(AuthMessage(token: token))
+            } catch {
+                authContinuation = nil
+                authTimeoutTask?.cancel()
+                authTimeoutTask = nil
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+    #endif
+
+    #if os(iOS)
+    /// Perform token-based authentication if `config.authToken` is set.
+    /// Sends an `AuthMessage` and waits for an `auth_result` response before
+    /// allowing the connection to be marked as ready.
+    /// If no token is configured, marks the connection as authenticated immediately.
+    private func authenticateIfNeeded() async throws {
+        guard let token = config.authToken else {
+            // No token configured — treat as unauthenticated (plain TCP, no handshake).
+            isAuthenticated = true
+            return
         }
 
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
@@ -954,7 +998,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         reconnectTask?.cancel()
         reconnectTask = nil
         stopPingTimer()
-        #if os(macOS)
+        #if os(macOS) || os(iOS)
         if let pending = authContinuation {
             authContinuation = nil
             authTimeoutTask?.cancel()
@@ -1195,7 +1239,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     private func handleAuthResult(_ result: AuthResultMessage) {
-        #if os(macOS)
+        #if os(macOS) || os(iOS)
         isAuthenticated = result.success
         if let pending = authContinuation {
             authContinuation = nil

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -61,6 +61,11 @@ public protocol DaemonClientProtocol {
     func send<T: Encodable>(_ message: T) throws
 }
 
+extension Notification.Name {
+    /// Posted by `DaemonClient` on the main actor immediately after `isConnected` transitions to `true`.
+    public static let daemonDidReconnect = Notification.Name("daemonDidReconnect")
+}
+
 /// Platform-agnostic client for communicating with the Vellum daemon.
 ///
 /// **macOS**: Connects via Unix domain socket at `~/.vellum/vellum.sock` (or `VELLUM_DAEMON_SOCKET` env override).
@@ -420,6 +425,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                                     self.isAuthenticated = true
                                     #endif
                                     self.isConnected = true
+                                    NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
                                     self.reconnectDelay = 1.0
                                     self.startPingTimer()
                                     #if os(macOS)

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -16,18 +16,34 @@ public struct DaemonConfig {
     public let hostname: String
     public let port: UInt16
 
-    public init(hostname: String, port: UInt16) {
+    /// Whether to use TLS for the TCP connection (iOS only).
+    public var tlsEnabled: Bool
+
+    /// Authentication token for the daemon TCP handshake (iOS only).
+    public var authToken: String?
+
+    public init(hostname: String, port: UInt16, tlsEnabled: Bool = false, authToken: String? = nil) {
         self.hostname = hostname
         self.port = port
+        self.tlsEnabled = tlsEnabled
+        self.authToken = authToken
     }
 
     public static var `default`: DaemonConfig {
+        return DaemonConfig(hostname: "localhost", port: 8765)
+    }
+
+    /// Create a `DaemonConfig` populated from UserDefaults, falling back to safe defaults.
+    /// Reads: `daemon_hostname`, `daemon_port`, `daemon_tls_enabled`, `daemon_auth_token`.
+    public static func fromUserDefaults() -> DaemonConfig {
         // Treat empty string as nil to ensure fallback to "localhost"
         let hostname = UserDefaults.standard.string(forKey: "daemon_hostname").flatMap { $0.isEmpty ? nil : $0 } ?? "localhost"
         let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
         // Validate port is in valid UInt16 range (1-65535) before converting to avoid crash
         let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
-        return DaemonConfig(hostname: hostname, port: finalPort)
+        let tlsEnabled = UserDefaults.standard.bool(forKey: "daemon_tls_enabled")
+        let authToken = UserDefaults.standard.string(forKey: "daemon_auth_token")
+        return DaemonConfig(hostname: hostname, port: finalPort, tlsEnabled: tlsEnabled, authToken: authToken.flatMap { $0.isEmpty ? nil : $0 })
     }
     #else
     #error("Unsupported platform")

--- a/clients/shared/IPC/MockDaemonClient.swift
+++ b/clients/shared/IPC/MockDaemonClient.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import Foundation
+
+/// Lightweight in-memory mock for `DaemonClientProtocol`, used in tests and SwiftUI previews.
+@MainActor
+public final class MockDaemonClient: DaemonClientProtocol, ObservableObject {
+    public var isConnected: Bool = false
+    public var isBlobTransportAvailable: Bool = false
+
+    /// Messages recorded by `send(_:)` for assertion in tests.
+    public private(set) var sentMessages: [Any] = []
+
+    /// Continuations to feed messages into active `subscribe()` streams.
+    private var continuations: [AsyncStream<ServerMessage>.Continuation] = []
+
+    public init() {}
+
+    public func subscribe() -> AsyncStream<ServerMessage> {
+        AsyncStream { continuation in
+            self.continuations.append(continuation)
+        }
+    }
+
+    public func send<T: Encodable>(_ message: T) throws {
+        sentMessages.append(message)
+    }
+
+    public func connect() async throws {
+        isConnected = true
+    }
+
+    public func disconnect() {
+        isConnected = false
+    }
+
+    /// Inject a server message into all active subscribers.
+    public func emit(_ message: ServerMessage) {
+        for continuation in continuations {
+            continuation.yield(message)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Closes #3843

## Context
Part of #3832: iOS/macOS feature parity

## Changes
- **`ThreadListView.swift`** (new): `NavigationSplitView` with thread list sidebar and `ThreadChatView` detail. Each thread has its own `ChatViewModel` instance, created lazily by `IOSThreadStore`.
- **`IOSThreadStore`** (inline in `ThreadListView.swift`): `@MainActor ObservableObject` managing list of local threads; new thread / delete thread; always keeps at least one thread. ViewModels are keyed by thread UUID.
- **`ThreadChatView`** (inline in `ThreadListView.swift`): Chat view driven by an injected `ChatViewModel` (`@ObservedObject`), mirrors all UI from the existing `ChatTabView`.
- **`ContentView.swift`** (modified): Replaces single `ChatTabView` with `ThreadListView(daemonClient:)` in the Chat tab.

## Design
This is a "lite" version: threads are in-memory only (no daemon sync). Each thread gets an independent `ChatViewModel` sharing the same `DaemonClient` instance. `IOSThreadStore` holds a dictionary of view models keyed by thread `UUID`, creating them lazily on first selection. Thread deletion also removes the corresponding `ChatViewModel`. The store always ensures at least one thread exists.

Compatible with both standalone (`DirectClaudeClient`) and connected (`DaemonClient`) modes since `ChatViewModel` accepts `any DaemonClientProtocol`.

## Testing
1. Launch iOS app — single "New Chat" thread is selected automatically.
2. Tap the compose button (top-right) to add a new thread; verify it is auto-selected.
3. Send a message in one thread, switch to another — messages are isolated per thread.
4. Swipe-left on a thread to delete it; verify the last thread cannot be deleted (a new one is created automatically).
5. Settings tab still works as before.

## Deferred Work
- Thread title auto-update from first message (uses `ChatViewModel.onFirstUserMessage`)
- Persistence across app restarts
- Sync with Mac daemon thread store
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
