### PR TITLE
M2: Replace AuthWindowView with WakeUpStepView in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -194,15 +194,51 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let authView = AuthWindowView(
-            authManager: authManager,
-            onStartWithAPIKey: { [weak self] in
-                self?.proceedToApp()
-            },
-            onAuthenticated: { [weak self] in
-                self?.proceedToApp()
+        let onStartWithAPIKey: () -> Void = { [weak self] in
+            self?.proceedToApp()
+        }
+        let onContinueWithVellum: () -> Void = { [weak self] in
+            Task {
+                await self?.authManager.startWorkOSLogin()
+                if self?.authManager.isAuthenticated == true {
+                    self?.proceedToApp()
+                }
             }
-        )
+        }
+        let authView = ZStack {
+            VColor.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer()
+
+                Group {
+                    if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
+                       let nsImage = NSImage(contentsOf: url) {
+                        Image(nsImage: nsImage)
+                            .resizable()
+                            .interpolation(.none)
+                            .aspectRatio(contentMode: .fit)
+                    } else {
+                        Image("VellyLogo")
+                            .resizable()
+                            .interpolation(.none)
+                            .aspectRatio(contentMode: .fit)
+                    }
+                }
+                .frame(width: 128, height: 128)
+                .padding(.bottom, VSpacing.xxl)
+
+                WakeUpStepView(
+                    authManager: authManager,
+                    title: "Sign in to continue",
+                    subtitle: "Sign in with your Vellum account to get started.",
+                    onStartWithAPIKey: onStartWithAPIKey,
+                    onContinueWithVellum: onContinueWithVellum,
+                    showFooter: false
+                )
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
 
         let hostingController = NSHostingController(rootView: authView)
         let window = NSWindow(
@@ -278,117 +314,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             hasSetupApp = false
             hasSetupDaemon = false
             showAuthWindow()
-        }
-    }
-
-    /// Standalone auth window shown when user needs to sign in outside of onboarding.
-    /// Displays a simple "Continue with Vellum" button that triggers WorkOS AuthKit.
-    @MainActor
-    struct AuthWindowView: View {
-        @Bindable var authManager: AuthManager
-        var onStartWithAPIKey: () -> Void = {}
-        var onAuthenticated: () -> Void = {}
-
-        var body: some View {
-            ZStack {
-                VColor.background
-                    .ignoresSafeArea()
-
-                VStack(spacing: 0) {
-                    Spacer()
-
-                    Group {
-                        if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
-                           let nsImage = NSImage(contentsOf: url) {
-                            Image(nsImage: nsImage)
-                                .resizable()
-                                .interpolation(.none)
-                                .aspectRatio(contentMode: .fit)
-                        } else {
-                            Image("VellyLogo")
-                                .resizable()
-                                .interpolation(.none)
-                                .aspectRatio(contentMode: .fit)
-                        }
-                    }
-                    .frame(width: 128, height: 128)
-                    .padding(.bottom, VSpacing.xxl)
-
-                    Text("Sign in to continue")
-                        .font(.system(size: 32, weight: .regular, design: .serif))
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.bottom, VSpacing.md)
-
-                    Text("Sign in with your Vellum account to get started.")
-                        .font(.system(size: 16))
-                        .foregroundColor(VColor.textSecondary)
-
-                    Spacer()
-
-                    VStack(spacing: VSpacing.md) {
-                        Button(action: { onStartWithAPIKey() }) {
-                            Text("Start with an API key")
-                                .font(.system(size: 15, weight: .medium))
-                                .foregroundColor(.white)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, VSpacing.lg)
-                                .background(
-                                    RoundedRectangle(cornerRadius: VRadius.lg)
-                                        .fill(adaptiveColor(
-                                            light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
-                                            dark: Violet._600
-                                        ))
-                                )
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(authManager.isSubmitting)
-                        .onHover { hovering in
-                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
-
-                        Button(action: {
-                            Task {
-                                await authManager.startWorkOSLogin()
-                                if authManager.isAuthenticated {
-                                    onAuthenticated()
-                                }
-                            }
-                        }) {
-                            HStack(spacing: VSpacing.sm) {
-                                if authManager.isSubmitting {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                        .progressViewStyle(.circular)
-                                }
-                                Text(authManager.isSubmitting ? "Signing in..." : "Continue with Vellum")
-                                    .font(.system(size: 15, weight: .medium))
-                            }
-                            .foregroundColor(VColor.textPrimary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, VSpacing.lg)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .fill(adaptiveColor(light: .white, dark: VColor.surface))
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(authManager.isSubmitting)
-                        .onHover { hovering in
-                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
-
-                        if let error = authManager.errorMessage {
-                            Text(error)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.error)
-                                .multilineTextAlignment(.center)
-                        }
-                    }
-                    .padding(.horizontal, VSpacing.xxl)
-                    .padding(.bottom, VSpacing.xxl)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
         }
     }
 


### PR DESCRIPTION
Replaces the standalone AuthWindowView with the refactored WakeUpStepView, eliminating duplicate UI code. The auth gate now uses the same card-based layout as the onboarding step. Part of #3894.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
