### PR TITLE
fix: restore double-tap guard for onStartWithAPIKey

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -9,6 +9,8 @@ struct OnboardingFlowView: View {
     var onComplete: () -> Void
     var onOpenSettings: () -> Void
 
+    @State private var isAdvancingFromWakeUp = false
+
     var body: some View {
         GeometryReader { geometry in
         ZStack {
@@ -47,6 +49,8 @@ struct OnboardingFlowView: View {
                                 state: state,
                                 authManager: authManager,
                                 onStartWithAPIKey: {
+                                    guard !isAdvancingFromWakeUp else { return }
+                                    isAdvancingFromWakeUp = true
                                     state.hasHatched = true
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                                         state.advance()

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -28,8 +28,6 @@ struct WakeUpStepView: View {
     @State private var showTitle = false
     @State private var showSubtext = false
     @State private var showButtons = false
-    @State private var isAdvancing = false
-
     // MARK: - Body
 
     var body: some View {
@@ -89,7 +87,7 @@ struct WakeUpStepView: View {
         .padding(.bottom, VSpacing.lg)
         .opacity(showButtons ? 1 : 0)
         .offset(y: showButtons ? 0 : 12)
-        .disabled(isAdvancing || authManager?.isSubmitting == true)
+        .disabled(authManager?.isSubmitting == true)
         .onAppear {
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true


### PR DESCRIPTION
Addresses review feedback on #3898. Adds `isAdvancingFromWakeUp` guard in OnboardingFlowView to prevent double-tap from skipping steps, and removes the dead `isAdvancing` state from WakeUpStepView.

Part of #3894.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
