### PR TITLE
M11: Tests + deployment prep

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
             name: "VellumAssistantShared",
             dependencies: [],
             path: "shared",
+            exclude: ["Tests"],
             swiftSettings: [
                 .enableUpcomingFeature("BareSlashRegexLiterals")
             ],
@@ -86,7 +87,7 @@ let package = Package(
             name: "vellum-assistant-ios",
             dependencies: ["VellumAssistantShared"],
             path: "ios",
-            exclude: ["Resources/Info.plist"],
+            exclude: ["Resources/Info.plist", "README.md"],
             resources: [
                 .process("Resources/Assets.xcassets")
             ],
@@ -94,6 +95,11 @@ let package = Package(
                 .linkedFramework("UIKit", .when(platforms: [.iOS])),
                 .linkedFramework("SwiftUI", .when(platforms: [.iOS]))
             ]
+        ),
+        .testTarget(
+            name: "VellumAssistantSharedTests",
+            dependencies: ["VellumAssistantShared"],
+            path: "shared/Tests"
         )
     ]
 )

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -1,0 +1,58 @@
+# iOS App — vellum-assistant-ios
+
+The iOS target (`vellum-assistant-ios`) is part of the multi-platform Swift Package at `clients/Package.swift`.
+
+## iOS Build
+
+The iOS app requires Xcode to build for a device or simulator.
+
+To build for CI using xcodebuild:
+
+```bash
+xcodebuild \
+  -scheme vellum-assistant-ios \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  build \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+### Development
+
+1. Open `clients/Package.swift` in Xcode
+2. Select the `vellum-assistant-ios` scheme
+3. Choose an iOS Simulator as destination
+4. Build and Run (⌘R)
+
+## Running Tests
+
+The `VellumAssistantSharedTests` target covers shared IPC logic (e.g. `MockDaemonClient`) and
+can be run on macOS without a simulator:
+
+```bash
+cd clients/macos
+./build.sh test
+```
+
+Or directly via SPM from the `clients/` directory:
+
+```bash
+cd clients
+swift test --filter VellumAssistantSharedTests
+```
+
+## Configuration
+
+The iOS app connects to the Vellum daemon over TCP.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Host    | `localhost` | Daemon hostname (configure in Settings for real device) |
+| Port    | `8765` | Daemon TCP port |
+
+For simulator testing the daemon runs on the host Mac, so `localhost` works out of the box.
+For real device testing, configure the daemon's network-accessible IP in the app's Settings screen.
+
+## Dependencies
+
+The iOS app depends only on `VellumAssistantShared`. It must **not** import `VellumAssistantLib`,
+which links macOS-only frameworks (AppKit, ScreenCaptureKit, etc.).

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -11,6 +11,7 @@ import Combine
 @MainActor
 final class MockDaemonClient: DaemonClientProtocol {
     var sentMessages: [Any] = []
+    var isConnected: Bool = false
     var isBlobTransportAvailable: Bool = false
     private var testContinuation: AsyncStream<ServerMessage>.Continuation?
     private var _messages: AsyncStream<ServerMessage>
@@ -35,6 +36,14 @@ final class MockDaemonClient: DaemonClientProtocol {
 
     func send<T: Encodable>(_ message: T) throws {
         sentMessages.append(message)
+    }
+
+    func connect() async throws {
+        isConnected = true
+    }
+
+    func disconnect() {
+        isConnected = false
     }
 }
 

--- a/clients/shared/Tests/MockDaemonClientTests.swift
+++ b/clients/shared/Tests/MockDaemonClientTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Unit tests for MockDaemonClient — verifies initial state, connect/disconnect lifecycle,
+/// send recording, and emit-to-subscriber delivery.
+@MainActor
+final class MockDaemonClientTests: XCTestCase {
+
+    // MARK: - Initial State
+
+    func testInitialStateIsDisconnected() {
+        let client = MockDaemonClient()
+        XCTAssertFalse(client.isConnected, "New client should start disconnected")
+    }
+
+    func testInitialBlobTransportUnavailable() {
+        let client = MockDaemonClient()
+        XCTAssertFalse(client.isBlobTransportAvailable, "Blob transport should be unavailable on init")
+    }
+
+    func testInitialSentMessagesIsEmpty() {
+        let client = MockDaemonClient()
+        XCTAssertTrue(client.sentMessages.isEmpty, "No messages should be recorded before any sends")
+    }
+
+    // MARK: - Connect / Disconnect
+
+    func testConnectSetsIsConnected() async throws {
+        let client = MockDaemonClient()
+        try await client.connect()
+        XCTAssertTrue(client.isConnected, "connect() should set isConnected to true")
+    }
+
+    func testDisconnectClearsIsConnected() async throws {
+        let client = MockDaemonClient()
+        try await client.connect()
+        XCTAssertTrue(client.isConnected)
+        client.disconnect()
+        XCTAssertFalse(client.isConnected, "disconnect() should set isConnected to false")
+    }
+
+    func testDisconnectWithoutConnectIsNoOp() {
+        let client = MockDaemonClient()
+        // Should not crash or throw
+        client.disconnect()
+        XCTAssertFalse(client.isConnected, "disconnect() on an already-disconnected client should be a no-op")
+    }
+
+    // MARK: - Send Recording
+
+    func testSendRecordsSingleMessage() throws {
+        let client = MockDaemonClient()
+        let msg = PingMessage()
+        try client.send(msg)
+        XCTAssertEqual(client.sentMessages.count, 1, "One send should record exactly one message")
+    }
+
+    func testSendRecordsMultipleMessages() throws {
+        let client = MockDaemonClient()
+        try client.send(PingMessage())
+        try client.send(PingMessage())
+        try client.send(PingMessage())
+        XCTAssertEqual(client.sentMessages.count, 3, "Three sends should record three messages")
+    }
+
+    func testSendRecordsSessionCreateMessage() throws {
+        let client = MockDaemonClient()
+        let msg = SessionCreateMessage(title: "Test session")
+        try client.send(msg)
+        XCTAssertEqual(client.sentMessages.count, 1)
+    }
+
+    func testSendRecordsCancelMessage() throws {
+        let client = MockDaemonClient()
+        let msg = CancelMessage(sessionId: "sess-abc")
+        try client.send(msg)
+        XCTAssertEqual(client.sentMessages.count, 1)
+    }
+
+    // MARK: - Subscribe / Emit
+
+    func testSubscribeReturnsStream() {
+        let client = MockDaemonClient()
+        let stream = client.subscribe()
+        // Simply verify subscribe() returns without crashing; stream is non-nil (value type)
+        _ = stream
+    }
+
+    func testEmitDeliversToSubscriber() async {
+        let client = MockDaemonClient()
+        let stream = client.subscribe()
+
+        // Collect one message from the stream
+        let expectation = XCTestExpectation(description: "Subscriber receives emitted message")
+        var receivedMessage: ServerMessage?
+
+        let task = Task {
+            for await message in stream {
+                receivedMessage = message
+                expectation.fulfill()
+                break
+            }
+        }
+
+        // Give the task a moment to start waiting on the stream
+        await Task.yield()
+
+        // Emit a message
+        let delta = AssistantTextDeltaMessage(text: "Hello from emit")
+        client.emit(.assistantTextDelta(delta))
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        task.cancel()
+
+        if case .assistantTextDelta(let received) = receivedMessage {
+            XCTAssertEqual(received.text, "Hello from emit")
+        } else {
+            XCTFail("Expected .assistantTextDelta, got \(String(describing: receivedMessage))")
+        }
+    }
+
+    func testEmitDeliversToMultipleSubscribers() async {
+        let client = MockDaemonClient()
+
+        let stream1 = client.subscribe()
+        let stream2 = client.subscribe()
+
+        let exp1 = XCTestExpectation(description: "Subscriber 1 receives message")
+        let exp2 = XCTestExpectation(description: "Subscriber 2 receives message")
+
+        var received1: ServerMessage?
+        var received2: ServerMessage?
+
+        let task1 = Task {
+            for await msg in stream1 {
+                received1 = msg
+                exp1.fulfill()
+                break
+            }
+        }
+
+        let task2 = Task {
+            for await msg in stream2 {
+                received2 = msg
+                exp2.fulfill()
+                break
+            }
+        }
+
+        await Task.yield()
+
+        client.emit(.messageComplete(MessageCompleteMessage()))
+
+        await fulfillment(of: [exp1, exp2], timeout: 2.0)
+        task1.cancel()
+        task2.cancel()
+
+        if case .messageComplete = received1 {} else {
+            XCTFail("Subscriber 1 expected .messageComplete, got \(String(describing: received1))")
+        }
+        if case .messageComplete = received2 {} else {
+            XCTFail("Subscriber 2 expected .messageComplete, got \(String(describing: received2))")
+        }
+    }
+
+    // MARK: - Multiple Connect/Disconnect Cycles
+
+    func testMultipleConnectDisconnectCycles() async throws {
+        let client = MockDaemonClient()
+
+        try await client.connect()
+        XCTAssertTrue(client.isConnected)
+
+        client.disconnect()
+        XCTAssertFalse(client.isConnected)
+
+        try await client.connect()
+        XCTAssertTrue(client.isConnected, "Should be able to reconnect after disconnect")
+
+        client.disconnect()
+        XCTAssertFalse(client.isConnected)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `VellumAssistantSharedTests` SPM test target with 14 unit tests for `MockDaemonClient`
- Create `clients/ios/README.md` with iOS build instructions including xcodebuild CI command
- Fix pre-existing `DaemonClientProtocol` conformance gap in `SessionTests.swift` that broke the test suite since the protocol was widened in an earlier PR

## Implementation

### Package.swift changes
- Add `VellumAssistantSharedTests` test target pointing at `shared/Tests`
- Add `exclude: ["Tests"]` to `VellumAssistantShared` to prevent overlapping-sources SPM error
- Exclude `ios/README.md` from the `vellum-assistant-ios` target to suppress unhandled-file warning

### MockDaemonClientTests.swift (new — `shared/Tests/`)
14 tests covering:
- **Initial state**: `isConnected`, `isBlobTransportAvailable`, and `sentMessages` all start at their zero values
- **Connect/disconnect lifecycle**: `connect()` sets `isConnected`, `disconnect()` clears it; double-disconnect is a no-op; multiple cycles work correctly
- **Send recording**: single/multiple sends recorded in `sentMessages`; works for `PingMessage`, `SessionCreateMessage`, `CancelMessage`
- **Subscribe/emit**: `subscribe()` returns a stream; `emit()` delivers to a single subscriber; `emit()` broadcasts to multiple concurrent subscribers

### iOS README (new — `clients/ios/README.md`)
Documents the `xcodebuild` CI command, Xcode development workflow, test runner instructions, TCP connection configuration (simulator vs real device), and the `VellumAssistantLib` dependency restriction.

### SessionTests.swift fix
The local `MockDaemonClient` was missing `isConnected`, `connect()`, and `disconnect()` which were added to `DaemonClientProtocol` in the prior widening PR (`#3884`). Added the three stubs to restore conformance.

## Key Technical Choices

- Used `XCTest` (not Swift Testing `@Suite`) to match the pattern in the existing `vellum-assistantTests` target; the shared tests run on macOS via SPM so `#if DEBUG` guards on `MockDaemonClient` are respected
- The `exclude: ["Tests"]` approach avoids changing the `VellumAssistantShared` source root; an alternative would have been placing tests in a peer directory, but this keeps tests co-located with the shared source

## Files Changed

- `clients/Package.swift` — add test target, exclude Tests from shared, exclude README from ios
- `clients/shared/Tests/MockDaemonClientTests.swift` (new) — 14 unit tests for MockDaemonClient
- `clients/ios/README.md` (new) — iOS build docs and xcodebuild CI command
- `clients/macos/vellum-assistantTests/SessionTests.swift` — fix pre-existing protocol conformance gap

## Testing

```bash
# All new tests pass:
cd clients
swift test --filter VellumAssistantSharedTests

# macOS build clean:
cd clients/macos
bash build.sh 2>&1 | grep "error:"
```

## Dependencies

- Depends on: M2 (MockDaemonClient), M3 (DirectClaudeClient)

Closes #3846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
