### PR TITLE
chore: add ship-and-merge command

### DIFF
--- a/.claude/commands/ship-and-merge.md
+++ b/.claude/commands/ship-and-merge.md
@@ -1,0 +1,148 @@
+Create a PR from the current uncommitted changes, wait for Codex and Devin reviews, fix any valid feedback, and merge once approved.
+
+If the user passed `$ARGUMENTS`, use it as the PR title. Otherwise, infer a concise title from the changes.
+
+## Repo-specific gotchas
+
+- **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **No piping to tail/head**: `tail` and `head` may not be available in the shell. Don't pipe to them.
+
+## Phase 1: Create the PR
+
+### 1. Check for changes
+
+```bash
+git status
+git diff
+```
+
+If there are no staged or unstaged changes, stop and tell the user there's nothing to ship.
+
+### 2. Create a fresh branch
+
+Always create a fresh branch from main so the PR only contains the uncommitted changes — never reuse an existing non-main branch, which could include unrelated commits.
+
+```bash
+git stash --include-untracked
+git checkout main && git pull
+git checkout -B <slug-from-title>
+git stash pop
+```
+
+### 3. Stage, commit, push, and create the PR
+
+Review the changes and draft a commit message and PR title (use `$ARGUMENTS` as the title if provided).
+
+```bash
+git add -A
+git commit -m "<commit message>
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+git push -u origin HEAD
+gh pr create --base main --title "<PR title>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" --assignee @me
+```
+
+Note the PR number and URL.
+
+## Phase 2: Wait for reviews
+
+Poll for reviews every 60 seconds using `.claude/check-pr-reviews <number>`. Stop polling once both `codex.status` and `devin.status` are no longer `pending`.
+
+```bash
+.claude/check-pr-reviews <number>
+```
+
+- If Codex is `rate_limited`, re-trigger by commenting `@codex review` on the PR, then continue polling.
+- Keep polling until both reviewers have responded (status is `approved`, `changes_requested`, or for Codex `rate_limited` that was re-triggered).
+- Maximum wait: 10 minutes. If neither reviewer responds after 10 minutes, tell the user reviews are still pending and stop.
+
+## Phase 3: Assess feedback
+
+If both reviewers approved, skip to Phase 5 (merge).
+
+If either reviewer requested changes, assess each piece of feedback:
+
+### 1. Read the PR diff
+
+```bash
+gh pr diff <number>
+```
+
+### 2. Evaluate each comment
+
+For each piece of feedback, classify it:
+
+- **Valid feedback**: The suggestion improves the code without regressing intended behavior. Fix it.
+- **Nonsensical feedback**: The reviewer misunderstood the code or the suggestion doesn't apply. Ignore it.
+- **Regression risk**: Addressing the feedback would undo or break desired functionality. Flag to the user and stop — ask whether to fix it, ignore it, or do something else. Do NOT continue until the user responds.
+
+## Phase 4: Fix valid feedback
+
+If there is valid feedback to address:
+
+1. Read the inline comments to understand the requested changes:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | {path: .path, line: .line, body: .body}'
+```
+
+2. Implement the fixes on the same branch.
+
+3. Stage, commit, and push:
+
+```bash
+git add -A
+git commit -m "address review feedback
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+git push
+```
+
+4. Go back to Phase 2 — wait for the reviewers to re-review.
+
+**Loop limit:** Maximum 3 feedback rounds. If reviewers are still requesting changes after 3 rounds, stop and tell the user.
+
+## Phase 5: Merge
+
+Once both reviewers have approved (or their feedback was classified as nonsensical):
+
+```bash
+gh pr merge <number> --squash
+```
+
+Verify the merge:
+
+```bash
+gh pr view <number> --json state,mergedAt
+```
+
+## Phase 6: Clean up
+
+```bash
+git checkout main
+git pull origin main
+git branch -d <branch-name>
+```
+
+If `-d` fails, use `-D` since the PR was already squash-merged.
+
+## Phase 7: Report
+
+Print a summary:
+
+```
+## Shipped
+
+**PR:** #<number> — <title> (<url>)
+**Reviews:** <number of feedback rounds, or "approved on first pass">
+**Branch:** `<branch-name>` — deleted
+
+You're on `main` with the latest changes.
+```

--- a/.claude/commands/ship-and-merge.md
+++ b/.claude/commands/ship-and-merge.md
@@ -26,7 +26,7 @@ Always create a fresh branch from main so the PR only contains the uncommitted c
 ```bash
 git stash --include-untracked
 git checkout main && git pull
-git checkout -B <slug-from-title>
+git checkout -B <user>/<slug-from-title>
 git stash pop
 ```
 
@@ -121,6 +121,13 @@ Verify the merge:
 
 ```bash
 gh pr view <number> --json state,mergedAt
+```
+
+Track the merged PR for review triage:
+
+```bash
+mkdir -p .private
+echo "<pr-url>" >> .private/UNREVIEWED_PRS.md
 ```
 
 ## Phase 6: Clean up

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/safe-blitz <feature>` | Like `/blitz` but merges milestone PRs into a feature branch instead of main, then opens a final PR for manual review. Supports `--auto`, `--workers N`, `--skip-plan`, `--branch NAME`. |
 | `/safe-blitz-done [PR\|branch]` | Finalize a safe-blitz — squash-merge the feature branch PR into main, set the project issue to Done, close the issue, and clean up locally. Auto-detects from current branch, open `feature/*` PRs, or project board. |
 | `/mainline [title]` | Ship the current uncommitted changes to main via a squash-merged PR. |
+| `/ship-and-merge [title]` | Create a PR, wait for Codex and Devin reviews, fix valid feedback (up to 3 rounds), and squash-merge once approved. |
 | `/brainstorm` | Read through the codebase and `.private/TODO.md`, generate a prioritized list of improvements, and update the TODO after user approval. |
 | `/check-reviews` | Check every PR in `.private/UNREVIEWED_PRS.md` for Codex and Devin reviews; add feedback items to TODO and remove fully-reviewed PRs. |
 | `/execute-plan <plan-file>` | Execute a multi-PR rollout plan from `.private/plans/` sequentially — implement, validate, and mainline each PR in order. |

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 | `/do <description>` | Implement a change in an isolated worktree, create a PR, squash-merge it to main, and clean up. |
 | `/safe-do <description>` | Like `/do` but creates a PR without auto-merging — pauses for human review. Keeps the worktree for feedback. |
 | `/mainline` | Ship uncommitted changes already in your working tree to main via a squash-merged PR. |
+| `/ship-and-merge [title]` | Ship uncommitted changes via a PR with automated review feedback loop — waits for Codex/Devin reviews, fixes valid feedback (up to 3 rounds), and squash-merges. |
 | `/work` | Pick up the next task from `.private/TODO.md` (or a task you specify), implement it, PR it, and merge it. |
 
 ### Multi-task / parallel commands


### PR DESCRIPTION
## Summary
- Adds `/ship-and-merge` command that creates a PR, waits for Codex and Devin reviews, fixes valid feedback, and merges once approved
- Supports up to 3 feedback rounds with contextual assessment (valid, nonsensical, regression risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
