### PR TITLE
fix: reset double-tap guard on back navigation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -162,6 +162,9 @@ struct OnboardingFlowView: View {
         }
         .ignoresSafeArea()
         .onChange(of: state.currentStep) { _, newStep in
+            if newStep == 0 {
+                isAdvancingFromWakeUp = false
+            }
             // Trimmed flow ends after step 2 (ModelSelection).
             // Previous threshold was > 4 (after FnKey step).
             if newStep > 2 {


### PR DESCRIPTION
Reset isAdvancingFromWakeUp to false when currentStep returns to 0, so the Own API Key button remains functional after navigating back from APIKeyStepView.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
