### PR TITLE
fix: show OnboardingFooter on auth gate screen

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -233,8 +233,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     title: "Sign in to continue",
                     subtitle: "Sign in with your Vellum account to get started.",
                     onStartWithAPIKey: onStartWithAPIKey,
-                    onContinueWithVellum: onContinueWithVellum,
-                    showFooter: false
+                    onContinueWithVellum: onContinueWithVellum
                 )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -100,8 +100,8 @@ struct WakeUpStepView: View {
             }
         }
 
-        if showFooter, let state {
-            OnboardingFooter(currentStep: state.currentStep)
+        if showFooter {
+            OnboardingFooter(currentStep: state?.currentStep ?? 0)
                 .padding(.bottom, VSpacing.lg)
         }
     }
@@ -188,8 +188,7 @@ struct WakeUpStepView: View {
             WakeUpStepView(
                 title: "Sign in to continue",
                 subtitle: "Sign in with your Vellum account to get started.",
-                questionPrompt: "How would you like to start?",
-                showFooter: false
+                questionPrompt: "How would you like to start?"
             )
         }
     }


### PR DESCRIPTION
Show the OnboardingFooter on the AppDelegate auth gate by removing `showFooter: false` and making the footer work without requiring OnboardingState (falls back to step 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
