### PR TITLE
feat: polish slash command rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -985,8 +985,8 @@ private struct SlashCommandPopup: View {
     let selectedIndex: Int
     let onSelect: (SlashCommand) -> Void
     private let avatarSeed: String
-    private let avatarPalette: DinoFaceView.Palette
-    private let avatarOutfit: DinoFaceView.Outfit
+    private let avatarPalette: DinoPalette
+    private let avatarOutfit: DinoOutfit
 
     init(commands: [SlashCommand], selectedIndex: Int, onSelect: @escaping (SlashCommand) -> Void) {
         self.commands = commands
@@ -1028,8 +1028,8 @@ private struct SlashCommandRow: View {
     let isSelected: Bool
     let onSelect: () -> Void
     let avatarSeed: String
-    let avatarPalette: DinoFaceView.Palette
-    let avatarOutfit: DinoFaceView.Outfit
+    let avatarPalette: DinoPalette
+    let avatarOutfit: DinoOutfit
     @State private var isHovered = false
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -69,6 +69,9 @@ struct ComposerView: View {
     @State private var slashSelectedIndex = 0
     @State private var showModelSubmenu = false
     @State private var modelSelectedIndex = 0
+    @State private var avatarSeed: String = "default"
+    @State private var avatarPalette: DinoPalette = .violet
+    @State private var avatarOutfit: DinoOutfit = .none
 
     /// The portion of the suggestion that extends beyond the current input.
     /// Returns nil when the composer content exceeds the max height (200pt) because
@@ -102,7 +105,10 @@ struct ComposerView: View {
                 SlashCommandPopup(
                     commands: filteredSlashCommands(slashFilter),
                     selectedIndex: slashSelectedIndex,
-                    onSelect: { command in selectSlashCommand(command) }
+                    onSelect: { command in selectSlashCommand(command) },
+                    avatarSeed: avatarSeed,
+                    avatarPalette: avatarPalette,
+                    avatarOutfit: avatarOutfit
                 )
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
@@ -172,7 +178,14 @@ struct ComposerView: View {
         .animation(VAnimation.fast, value: editorContentHeight)
         .animation(VAnimation.fast, value: isComposerExpanded)
         .animation(VAnimation.fast, value: isComposerFocused)
-        .onAppear { composerFocusRequestID += 1 }
+        .onAppear {
+            composerFocusRequestID += 1
+            let identity = IdentityInfo.load()
+            avatarSeed = identity?.name ?? "default"
+            let appearance = AvatarAppearanceManager.shared
+            avatarPalette = appearance.palette
+            avatarOutfit = appearance.outfit
+        }
     }
 
     // isComposerExpanded is a @Binding — sticky latch set true when text
@@ -984,20 +997,9 @@ private struct SlashCommandPopup: View {
     let commands: [SlashCommand]
     let selectedIndex: Int
     let onSelect: (SlashCommand) -> Void
-    private let avatarSeed: String
-    private let avatarPalette: DinoPalette
-    private let avatarOutfit: DinoOutfit
-
-    init(commands: [SlashCommand], selectedIndex: Int, onSelect: @escaping (SlashCommand) -> Void) {
-        self.commands = commands
-        self.selectedIndex = selectedIndex
-        self.onSelect = onSelect
-        let identity = IdentityInfo.load()
-        self.avatarSeed = identity?.name ?? "default"
-        let appearance = AvatarAppearanceManager.shared
-        self.avatarPalette = appearance.palette
-        self.avatarOutfit = appearance.outfit
-    }
+    let avatarSeed: String
+    let avatarPalette: DinoPalette
+    let avatarOutfit: DinoOutfit
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -1011,18 +1011,27 @@ private struct SlashCommandRow: View {
     let isSelected: Bool
     let onSelect: () -> Void
     @State private var isHovered = false
+    private let identity = IdentityInfo.load()
+    private let appearance = AvatarAppearanceManager.shared
 
     var body: some View {
         Button(action: onSelect) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("/\(command.name)")
-                    .font(VFont.bodyBold)
-                    .foregroundColor(VColor.textPrimary)
-                Text(command.description)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+            HStack(spacing: VSpacing.md) {
+                DinoFaceView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                    .frame(width: 28, height: 28)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    .allowsHitTesting(false)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("/\(command.name)")
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.textPrimary)
+                    Text(command.description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
             .background(isSelected || isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -984,6 +984,20 @@ private struct SlashCommandPopup: View {
     let commands: [SlashCommand]
     let selectedIndex: Int
     let onSelect: (SlashCommand) -> Void
+    private let avatarSeed: String
+    private let avatarPalette: DinoFaceView.Palette
+    private let avatarOutfit: DinoFaceView.Outfit
+
+    init(commands: [SlashCommand], selectedIndex: Int, onSelect: @escaping (SlashCommand) -> Void) {
+        self.commands = commands
+        self.selectedIndex = selectedIndex
+        self.onSelect = onSelect
+        let identity = IdentityInfo.load()
+        self.avatarSeed = identity?.name ?? "default"
+        let appearance = AvatarAppearanceManager.shared
+        self.avatarPalette = appearance.palette
+        self.avatarOutfit = appearance.outfit
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -991,7 +1005,10 @@ private struct SlashCommandPopup: View {
                 SlashCommandRow(
                     command: command,
                     isSelected: index == selectedIndex,
-                    onSelect: { onSelect(command) }
+                    onSelect: { onSelect(command) },
+                    avatarSeed: avatarSeed,
+                    avatarPalette: avatarPalette,
+                    avatarOutfit: avatarOutfit
                 )
             }
         }
@@ -1010,14 +1027,15 @@ private struct SlashCommandRow: View {
     let command: SlashCommand
     let isSelected: Bool
     let onSelect: () -> Void
+    let avatarSeed: String
+    let avatarPalette: DinoFaceView.Palette
+    let avatarOutfit: DinoFaceView.Outfit
     @State private var isHovered = false
-    private let identity = IdentityInfo.load()
-    private let appearance = AvatarAppearanceManager.shared
 
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: VSpacing.md) {
-                DinoFaceView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                DinoFaceView(seed: avatarSeed, palette: avatarPalette, outfit: avatarOutfit)
                     .frame(width: 28, height: 28)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                     .allowsHitTesting(false)


### PR DESCRIPTION
## Summary
- Add dino avatar to slash command popup rows for visual consistency with the rest of the app
- Replace native macOS `Picker` with custom styled dropdown in settings panel to match the Vellum design system (hover states, checkmark indicators, animated transitions)

## Test plan
- [ ] Open composer, type `/` — verify dino avatar appears next to each slash command
- [ ] Open Settings panel — verify model picker shows custom dropdown instead of native macOS picker
- [ ] Select a different model — verify selection works and dropdown closes with animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
