### PR TITLE
feat: custom themed model picker in settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -20,6 +20,7 @@ struct SettingsPanel: View {
     @State private var accessibilityGranted: Bool = false
     @State private var screenRecordingGranted: Bool = false
     @State private var permissionCheckTask: Task<Void, Never>?
+    @State private var showModelDropdown = false
 
     var body: some View {
         VSidePanel(title: "Settings", onClose: onClose) {
@@ -91,21 +92,44 @@ struct SettingsPanel: View {
                                 .font(VFont.body)
                                 .foregroundColor(VColor.textSecondary)
                             Spacer()
-                            Picker("", selection: $store.selectedModel) {
-                                ForEach(SettingsStore.availableModels, id: \.self) { model in
-                                    Text(SettingsStore.modelDisplayNames[model] ?? model)
-                                        .tag(model)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .frame(maxWidth: 200)
-                        }
-                        .onChange(of: store.selectedModel) { _, newValue in
-                            store.setModel(newValue)
+                            ModelPickerButton(
+                                store: store,
+                                isOpen: $showModelDropdown
+                            )
                         }
                     }
                     .padding(VSpacing.lg)
                     .vCard(background: VColor.surfaceSubtle)
+                    .overlay(alignment: .bottomTrailing) {
+                        if showModelDropdown {
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(SettingsStore.availableModels, id: \.self) { model in
+                                    ModelPickerItem(
+                                        name: SettingsStore.modelDisplayNames[model] ?? model,
+                                        isSelected: model == store.selectedModel
+                                    ) {
+                                        store.selectedModel = model
+                                        store.setModel(model)
+                                        withAnimation(VAnimation.fast) { showModelDropdown = false }
+                                    }
+                                }
+                            }
+                            .padding(.vertical, VSpacing.xs)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+                            )
+                            .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
+                            .fixedSize(horizontal: true, vertical: true)
+                            .alignmentGuide(.bottom) { d in d[.top] }
+                            .padding(.trailing, VSpacing.lg)
+                            .transition(.opacity)
+                        }
+                    }
+                    .animation(VAnimation.fast, value: showModelDropdown)
+                    .zIndex(showModelDropdown ? 1 : 0)
                 }
 
                 // BRAVE SEARCH section
@@ -611,6 +635,73 @@ struct SettingsPanel: View {
         .padding(.vertical, VSpacing.md)
     }
 
+}
+
+// MARK: - Custom Model Picker
+
+private struct ModelPickerButton: View {
+    @ObservedObject var store: SettingsStore
+    @Binding var isOpen: Bool
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            withAnimation(VAnimation.fast) { isOpen.toggle() }
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                Text(SettingsStore.modelDisplayNames[store.selectedModel] ?? store.selectedModel)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : VColor.surface)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+}
+
+private struct ModelPickerItem: View {
+    let name: String
+    let isSelected: Bool
+    let onSelect: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(isSelected ? VColor.accent : (isHovered ? VColor.textPrimary : VColor.textSecondary))
+                    .frame(width: 18)
+                Text(name)
+                    .font(isSelected ? VFont.bodyBold : VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
 }
 
 struct SettingsPanel_Previews: PreviewProvider {


### PR DESCRIPTION
## Summary
- Replace native macOS `Picker(.menu)` with a custom themed dropdown for model selection in Settings panel
- Native `NSMenu` ignores the app's dark theme, causing a jarring light popup
- Custom dropdown matches the design system with hover states, checkmark selection, and dark styling
- Dropdown overlay positioned outside `.vCard()` to avoid `clipShape` clipping

## Test plan
- [ ] Open Settings panel, verify "Active Model" shows the current model with chevron icon
- [ ] Click the model button — dropdown appears below the card with all 3 models
- [ ] Hover over items — highlight effect visible
- [ ] Select a different model — dropdown closes, model updates
- [ ] Verify dropdown matches dark theme styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
