### PR TITLE
fix: use OnboardingFlowView in auth gate for step progression

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -194,50 +194,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let onStartWithAPIKey: () -> Void = { [weak self] in
-            self?.proceedToApp()
-        }
-        let onContinueWithVellum: () -> Void = { [weak self] in
-            Task {
-                await self?.authManager.startWorkOSLogin()
-                if self?.authManager.isAuthenticated == true {
-                    self?.proceedToApp()
-                }
-            }
-        }
-        let authView = ZStack {
-            VColor.background.ignoresSafeArea()
-
-            VStack(spacing: 0) {
-                Spacer()
-
-                Group {
-                    if let url = ResourceBundle.bundle.url(forResource: "stage-3", withExtension: "png"),
-                       let nsImage = NSImage(contentsOf: url) {
-                        Image(nsImage: nsImage)
-                            .resizable()
-                            .interpolation(.none)
-                            .aspectRatio(contentMode: .fit)
-                    } else {
-                        Image("VellyLogo")
-                            .resizable()
-                            .interpolation(.none)
-                            .aspectRatio(contentMode: .fit)
-                    }
-                }
-                .frame(width: 128, height: 128)
-                .padding(.bottom, VSpacing.xxl)
-
-                WakeUpStepView(
-                    authManager: authManager,
-                    title: "Sign in to continue",
-                    subtitle: "Sign in with your Vellum account to get started.",
-                    onStartWithAPIKey: onStartWithAPIKey,
-                    onContinueWithVellum: onContinueWithVellum
-                )
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+        let state = OnboardingState()
+        let authView = OnboardingFlowView(
+            state: state,
+            daemonClient: daemonClient,
+            authManager: authManager,
+            onComplete: { [weak self] in
+                self?.proceedToApp()
+            },
+            onOpenSettings: {}
+        )
 
         let hostingController = NSHostingController(rootView: authView)
         let window = NSWindow(


### PR DESCRIPTION
Replace standalone WakeUpStepView in AppDelegate's auth gate with OnboardingFlowView so users go through the full step 0→1→2 flow (WakeUp → API Key → Model Selection) before entering the app.

Previously, clicking "Own API Key" on the auth gate called proceedToApp() immediately, bypassing the API key and model selection steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
