### PR TITLE
Fix sidebar archive button not working

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -368,8 +368,10 @@ struct MainWindowView: View {
             }
         }
         .onChange(of: isHoveredThread) { _, newValue in
-            // Cancel pending archive when hover leaves the row
-            if let pending = threadPendingDeletion, newValue != pending {
+            // Cancel pending archive when the user hovers a *different* thread.
+            // Skip clearing when newValue is nil (e.g. menu dismissal triggers
+            // a momentary hover-leave) so the Confirm button stays visible.
+            if let pending = threadPendingDeletion, let newValue, newValue != pending {
                 threadPendingDeletion = nil
             }
         }


### PR DESCRIPTION
## Summary
- Clicking "Archive" from the sidebar thread menu did nothing — the Confirm button appeared but immediately vanished
- Root cause: menu dismissal triggers a momentary hover-leave (`isHoveredThread` → `nil`), and the `onChange` handler treated `nil != pendingId` as a signal to clear `threadPendingDeletion`
- Fix: only clear the pending archive state when hovering a *different* thread, not when hover becomes `nil`

## Test plan
- [ ] Open sidebar, hover a thread, click "..." → Archive
- [ ] Verify the "Confirm" button appears and stays visible
- [ ] Click "Confirm" and verify the thread is archived
- [ ] Hover a different thread while Confirm is showing — verify it dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
