### PR TITLE
fix: dismiss model dropdown on click outside

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -22,6 +22,7 @@ struct SettingsPanel: View {
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var showModelDropdown = false
     @State private var mouseDownMonitor: Any?
+    @State private var modelDropdownFrame: CGRect = .zero
 
     var body: some View {
         VSidePanel(title: "Settings", onClose: onClose) {
@@ -127,6 +128,16 @@ struct SettingsPanel: View {
                             .alignmentGuide(.bottom) { d in d[.top] }
                             .padding(.trailing, VSpacing.lg)
                             .transition(.opacity)
+                            .background(
+                                GeometryReader { geo in
+                                    Color.clear.onAppear {
+                                        modelDropdownFrame = geo.frame(in: .global)
+                                    }
+                                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                                        modelDropdownFrame = newFrame
+                                    }
+                                }
+                            )
                         }
                     }
                     .animation(VAnimation.fast, value: showModelDropdown)
@@ -450,8 +461,23 @@ struct SettingsPanel: View {
             }
             if isOpen {
                 mouseDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                    DispatchQueue.main.async {
-                        withAnimation(VAnimation.fast) { showModelDropdown = false }
+                    // Only dismiss if the click is outside the dropdown.
+                    // SwiftUI .global uses flipped coords (Y=0 at top);
+                    // AppKit locationInWindow uses Y=0 at bottom.
+                    if let window = event.window {
+                        let windowHeight = window.frame.height
+                        let loc = event.locationInWindow
+                        let flippedY = windowHeight - loc.y
+                        let clickPoint = CGPoint(x: loc.x, y: flippedY)
+                        if !self.modelDropdownFrame.contains(clickPoint) {
+                            DispatchQueue.main.async {
+                                withAnimation(VAnimation.fast) { showModelDropdown = false }
+                            }
+                        }
+                    } else {
+                        DispatchQueue.main.async {
+                            withAnimation(VAnimation.fast) { showModelDropdown = false }
+                        }
                     }
                     return event
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -21,6 +21,7 @@ struct SettingsPanel: View {
     @State private var screenRecordingGranted: Bool = false
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var showModelDropdown = false
+    @State private var mouseDownMonitor: Any?
 
     var body: some View {
         VSidePanel(title: "Settings", onClose: onClose) {
@@ -437,6 +438,24 @@ struct SettingsPanel: View {
             daemonClient?.onIntegrationListResponse = nil
             daemonClient?.onIntegrationConnectResult = nil
             permissionCheckTask?.cancel()
+            if let monitor = mouseDownMonitor {
+                NSEvent.removeMonitor(monitor)
+                mouseDownMonitor = nil
+            }
+        }
+        .onChange(of: showModelDropdown) { _, isOpen in
+            if let monitor = mouseDownMonitor {
+                NSEvent.removeMonitor(monitor)
+                mouseDownMonitor = nil
+            }
+            if isOpen {
+                mouseDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                    DispatchQueue.main.async {
+                        withAnimation(VAnimation.fast) { showModelDropdown = false }
+                    }
+                    return event
+                }
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             // Primary mechanism: Check permissions when app becomes active.


### PR DESCRIPTION
## Summary
- Add NSEvent local monitor to dismiss model dropdown when clicking anywhere outside it
- Monitor is installed when dropdown opens, removed when it closes or view disappears
- Click events pass through so dropdown items still work (dismiss is async)

## Test plan
- [ ] Open Settings > MODEL dropdown
- [ ] Click anywhere outside the dropdown — it should dismiss
- [ ] Click on a model item — it should select the model and dismiss
- [ ] Open/close dropdown repeatedly — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
