### PR TITLE
fix: clear persisted onboarding state before auth gate flow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -194,6 +194,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        OnboardingState.clearPersistedState()
         let state = OnboardingState()
         let authView = OnboardingFlowView(
             state: state,


### PR DESCRIPTION
Add `OnboardingState.clearPersistedState()` before creating `OnboardingState()` in `showAuthWindow()` so stale step indices from a previous auth gate session don't cause the user to skip the WakeUpStepView on re-entry (e.g. after logout).

Without this, `OnboardingState.init()` reads the persisted step (e.g. 3), clamps it to maxStep (2), and drops the user into ModelSelectionStepView instead of step 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
