### PR TITLE
fix: route confirmation responses to computer-use sessions

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -73,6 +73,7 @@ export class ComputerUseSession {
   }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
   private terminalNotified = false;
+  private prompter: PermissionPrompter | null = null;
 
   // Tracks the agent loop promise so callers can await session completion
   private loopPromise: Promise<void> | null = null;
@@ -223,7 +224,8 @@ export class ComputerUseSession {
         .map((t) => t.getDefinition()),
     ];
 
-    const prompter = new PermissionPrompter(this.sendToClient);
+    this.prompter = new PermissionPrompter(this.sendToClient);
+    const prompter = this.prompter;
     const secretPrompter = new SecretPrompter(this.sendToClient);
     const executor = new ToolExecutor(prompter);
 
@@ -791,5 +793,18 @@ export class ComputerUseSession {
       lines.push(`Capture display ID: ${obs.captureDisplayId}`);
     }
     return lines;
+  }
+
+  hasPendingConfirmation(requestId: string): boolean {
+    return this.prompter?.hasPendingRequest(requestId) ?? false;
+  }
+
+  handleConfirmationResponse(
+    requestId: string,
+    decision: 'allow' | 'always_allow' | 'deny',
+    selectedPattern?: string,
+    selectedScope?: string,
+  ): void {
+    this.prompter?.resolveConfirmation(requestId, decision, selectedPattern, selectedScope);
   }
 }

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -169,6 +169,9 @@ export class ComputerUseSession {
       this.pendingObservation = null;
     }
 
+    // Dispose prompter to clear pending permission timers and reject promises
+    this.prompter?.dispose();
+
     // Resolve any pending surface actions
     for (const [, pending] of this.pendingSurfaceActions) {
       pending.resolve({ content: 'Session aborted', isError: true });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -143,6 +143,20 @@ export function handleConfirmationResponse(
       return;
     }
   }
+
+  // Also check computer-use sessions — they have their own PermissionPrompter
+  for (const [, cuSession] of ctx.cuSessions) {
+    if (cuSession.hasPendingConfirmation(msg.requestId)) {
+      cuSession.handleConfirmationResponse(
+        msg.requestId,
+        msg.decision as 'allow' | 'always_allow' | 'deny',
+        msg.selectedPattern,
+        msg.selectedScope,
+      );
+      return;
+    }
+  }
+
   log.warn({ requestId: msg.requestId }, 'No session found with pending confirmation for requestId');
 }
 


### PR DESCRIPTION
## Summary
- `handleConfirmationResponse` only checked Q&A sessions (`ctx.sessions`), never CU sessions (`ctx.cuSessions`)
- When a CU tool like `computer_use_open_app` triggered a permission prompt, the user's approval was silently dropped — the `PermissionPrompter` promise hung forever and the session stuck on step 1
- Store the `PermissionPrompter` on `ComputerUseSession` and expose `hasPendingConfirmation`/`handleConfirmationResponse` so the handler routes confirmations to CU sessions too

## Test plan
- [x] Reproduce: start a CU session that triggers a confirmation (e.g. open Chrome) → verify it no longer hangs after approving
- [ ] Verify Q&A session confirmations still work as before
- [ ] Verify denying a CU confirmation properly rejects the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
