### PR TITLE
fix: read avatar appearance reactively in slash menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -70,8 +70,6 @@ struct ComposerView: View {
     @State private var showModelSubmenu = false
     @State private var modelSelectedIndex = 0
     @State private var avatarSeed: String = "default"
-    @State private var avatarPalette: DinoPalette = .violet
-    @State private var avatarOutfit: DinoOutfit = .none
 
     /// The portion of the suggestion that extends beyond the current input.
     /// Returns nil when the composer content exceeds the max height (200pt) because
@@ -107,8 +105,8 @@ struct ComposerView: View {
                     selectedIndex: slashSelectedIndex,
                     onSelect: { command in selectSlashCommand(command) },
                     avatarSeed: avatarSeed,
-                    avatarPalette: avatarPalette,
-                    avatarOutfit: avatarOutfit
+                    avatarPalette: AvatarAppearanceManager.shared.palette,
+                    avatarOutfit: AvatarAppearanceManager.shared.outfit
                 )
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
@@ -182,9 +180,6 @@ struct ComposerView: View {
             composerFocusRequestID += 1
             let identity = IdentityInfo.load()
             avatarSeed = identity?.name ?? "default"
-            let appearance = AvatarAppearanceManager.shared
-            avatarPalette = appearance.palette
-            avatarOutfit = appearance.outfit
         }
     }
 


### PR DESCRIPTION
## Summary
- Read `palette` and `outfit` directly from `AvatarAppearanceManager.shared` (which is `@Observable`) instead of snapshotting into `@State` on `onAppear`
- Removes stale `avatarPalette` / `avatarOutfit` `@State` vars from `ComposerView`
- Ensures slash-menu avatar updates reactively when LOOKS.md changes mid-session

## Test plan
- [ ] Change avatar appearance in LOOKS.md while the app is running
- [ ] Open slash command menu and verify the avatar reflects the updated appearance
- [ ] Confirm slash commands still render correctly with proper avatar styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
