### PR TITLE
fix: address review feedback — button race, auth text, persistence

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -196,6 +196,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         OnboardingState.clearPersistedState()
         let state = OnboardingState()
+        state.shouldPersist = false
         let authView = OnboardingFlowView(
             state: state,
             daemonClient: daemonClient,
@@ -203,7 +204,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             onComplete: { [weak self] in
                 self?.proceedToApp()
             },
-            onOpenSettings: {}
+            onOpenSettings: {},
+            wakeUpTitle: "Sign in to continue",
+            wakeUpSubtitle: "Sign in with your Vellum account to get started."
         )
 
         let hostingController = NSHostingController(rootView: authView)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -9,6 +9,10 @@ struct OnboardingFlowView: View {
     var onComplete: () -> Void
     var onOpenSettings: () -> Void
 
+    // Optional text overrides for WakeUpStepView (used by auth gate)
+    var wakeUpTitle: String?
+    var wakeUpSubtitle: String?
+
     @State private var isAdvancingFromWakeUp = false
 
     var body: some View {
@@ -48,6 +52,9 @@ struct OnboardingFlowView: View {
                             WakeUpStepView(
                                 state: state,
                                 authManager: authManager,
+                                title: wakeUpTitle ?? "Create your Velly",
+                                subtitle: wakeUpSubtitle ?? "The safest way to create your personal assistant.",
+                                isAdvancing: isAdvancingFromWakeUp,
                                 onStartWithAPIKey: {
                                     guard !isAdvancingFromWakeUp else { return }
                                     isAdvancingFromWakeUp = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -39,6 +39,9 @@ final class OnboardingState {
     var interviewCompleted: Bool = false
     var onboardingVariant: OnboardingVariant = .default
 
+    /// When false, step changes are not written to UserDefaults (used by auth gate).
+    var shouldPersist: Bool = true
+
     // First-meeting-specific state
     var firstMeetingCrackProgress: CGFloat = 0.0
     var conversationCompleted: Bool = false
@@ -122,7 +125,7 @@ final class OnboardingState {
             // Previous flow skipped step 1 (naming) with: if currentStep == 1 { currentStep = 2 }
             // Trimmed flow uses step 1 for APIKey, so no skip needed.
         }
-        persist()
+        if shouldPersist { persist() }
     }
 
     /// Persist progress so we can resume after a forced restart.

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -16,6 +16,9 @@ struct WakeUpStepView: View {
     var subtitle: String = "The safest way to create your personal assistant."
     var questionPrompt: String = "How would you like to start?"
 
+    /// When true, disables all option cards (e.g. during 0.3s advance delay).
+    var isAdvancing: Bool = false
+
     // Callbacks
     var onStartWithAPIKey: () -> Void = {}
     var onContinueWithVellum: () -> Void = {}
@@ -87,7 +90,7 @@ struct WakeUpStepView: View {
         .padding(.bottom, VSpacing.lg)
         .opacity(showButtons ? 1 : 0)
         .offset(y: showButtons ? 0 : 12)
-        .disabled(authManager?.isSubmitting == true)
+        .disabled(isAdvancing || authManager?.isSubmitting == true)
         .onAppear {
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true


### PR DESCRIPTION
Three fixes from PR #3900 review feedback:

1. **Button race condition** — Added `isAdvancing` param to WakeUpStepView, combined with `.disabled(isAdvancing || authManager?.isSubmitting)`. OnboardingFlowView passes `isAdvancingFromWakeUp` so both cards are disabled during the 0.3s advance delay.

2. **Auth gate text** — Added `wakeUpTitle`/`wakeUpSubtitle` optional overrides to OnboardingFlowView. AppDelegate passes "Sign in to continue" / "Sign in with your Vellum account to get started." for the auth gate context.

3. **Persistence guard** — Added `shouldPersist` flag to OnboardingState (default true), guarding `persist()`. Auth gate sets `shouldPersist = false` so step changes aren't written to UserDefaults, preventing wrong start step on relaunch after interrupted auth flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
