### PR TITLE
feat: skip Devin review after 30-minute timeout

### DIFF
--- a/.claude/check-pr-reviews
+++ b/.claude/check-pr-reviews
@@ -22,7 +22,7 @@ Output is JSON with this structure:
     "has_plus_one_reaction": true|false
   },
   "devin": {
-    "status": "approved|changes_requested|pending",
+    "status": "approved|changes_requested|skipped|pending",
     "reviews": [...],
     "inline_comments": [...]
   }
@@ -38,7 +38,8 @@ Reviewer classification:
   devin (devin-ai-integration[bot]):
     approved          — review containing "No Issues Found"
     changes_requested — review or inline comment (not "No Issues Found")
-    pending           — no review from this user
+    skipped           — no review after 30 minutes (Devin likely errored)
+    pending           — no review from this user (PR < 30 minutes old)
 
 Examples:
   .claude/check-pr-reviews 123
@@ -138,6 +139,9 @@ if [ "$DEVIN_APPROVED" = "true" ]; then
   DEVIN_STATUS="approved"
 elif [ "$DEVIN_REVIEW_COUNT" -gt 0 ] || [ "$DEVIN_INLINE_COUNT" -gt 0 ]; then
   DEVIN_STATUS="changes_requested"
+elif [ "$AGE_SECONDS" -ge 1800 ]; then
+  # Devin sometimes errors out silently — treat as skipped after 30 minutes
+  DEVIN_STATUS="skipped"
 else
   DEVIN_STATUS="pending"
 fi

--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -14,7 +14,7 @@ For each PR, run:
 .claude/check-pr-reviews <number>
 ```
 
-This outputs JSON with `codex.status` and `devin.status` fields (each one of: `approved`, `changes_requested`, `rate_limited`, `pending`), plus the raw review data (`reviews`, `inline_comments`) for contextual assessment. It also includes `age_seconds` for computing the age column.
+This outputs JSON with `codex.status` and `devin.status` fields (each one of: `approved`, `changes_requested`, `rate_limited`, `skipped`, `pending`), plus the raw review data (`reviews`, `inline_comments`) for contextual assessment. It also includes `age_seconds` for computing the age column.
 
 ## Contextual review assessment
 
@@ -53,7 +53,8 @@ Examples of feedback that would cause a regression:
 ## Actions
 
 - **Rate-limited Codex:** If Codex is rate-limited, re-trigger the review by commenting `@codex review` on the PR and keep the PR in UNREVIEWED_PRS.md. Do NOT remove the PR.
-- If either reviewer hasn't reviewed yet, keep the PR in UNREVIEWED_PRS.md for next time.
+- **Skipped Devin:** If Devin's status is `skipped` (pending for 30+ minutes), treat it as if Devin approved — Devin likely errored out and won't review.
+- If either reviewer hasn't reviewed yet (status is `pending`, not `skipped`), keep the PR in UNREVIEWED_PRS.md for next time.
 - If both have reviewed and either review requested changes with **valid feedback**, add `- Address the feedback on <link to PR>` to the **top** of .private/TODO.md (ordered by PR number, lowest first).
 - If all feedback on a PR was classified as nonsensical, treat that reviewer as having approved.
 - If any feedback is classified as **regression risk**, do NOT add it to TODO. Instead, flag it to the user (see output section) and **stop processing further PRs**. Keep the PR in .private/UNREVIEWED_PRS.md so it is revisited on the next run. Wait for the user to decide what to do.
@@ -71,6 +72,7 @@ Display a table with these columns:
   - ✅ Approved
   - ❌ Changes requested
   - ⏳ Pending
+  - 🔇 Skipped (Devin only — timed out after 30 minutes)
   - 🤷 Nonsensical (feedback didn't apply)
   - 🔄 Rate-limited (Codex only — re-triggered via `@codex review` comment)
 - **Verdict**: Use emoji prefixes:

--- a/.claude/commands/safe-check-review.md
+++ b/.claude/commands/safe-check-review.md
@@ -48,7 +48,8 @@ Check for feedback from any reviewer — bots (chatgpt-codex-connector[bot], dev
 
 - **Approved:** Left a PR review containing "No Issues Found"
 - **Requested changes:** Has **unresolved** review threads with comments
-- **Pending:** No review from this user
+- **Skipped:** No review after 30+ minutes (Devin likely errored out) — treat as approved
+- **Pending:** No review from this user (PR < 30 minutes old)
 
 #### Human reviewers
 
@@ -70,7 +71,7 @@ Show a summary table:
 | --- | --- | --- |
 | CI | Passing / Failing / Pending | brief summary |
 | codex | Approved / Changes requested / Pending | brief summary |
-| devin | Approved / Changes requested / Pending | brief summary |
+| devin | Approved / Changes requested / Skipped / Pending | brief summary |
 | <human> | Commented / Approved / Changes requested | brief summary |
 
 ### 5. Address feedback (if any)


### PR DESCRIPTION
## Summary
- Devin sometimes errors out silently while reviewing PRs, leaving them stuck as "pending" forever
- After 30 minutes with no review from Devin, `check-pr-reviews` now reports `skipped` instead of `pending`
- `check-reviews.md` and `safe-check-review.md` treat `skipped` as an implicit approval so PRs aren't blocked indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
