### PR TITLE
Add hover-revealed report button on assistant messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -795,9 +795,15 @@ private struct ChatBubble: View {
     let isActivityPanelOpen: Bool
     var onReportMessage: ((String?) -> Void)?
 
+    @State private var isHovered = false
     @State private var isRegenerateHovered = false
 
     private var isUser: Bool { message.role == .user }
+    private var canReportMessage: Bool {
+        !isUser
+            && onReportMessage != nil
+            && FeatureFlagManager.shared.isEnabled(.monitoringExport)
+    }
 
     private var statusLabel: String? {
         switch message.status {
@@ -864,7 +870,7 @@ private struct ChatBubble: View {
 
 
     var body: some View {
-        HStack {
+        HStack(spacing: VSpacing.sm) {
             if isUser { Spacer(minLength: 0) }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
@@ -900,15 +906,51 @@ private struct ChatBubble: View {
             // trailing tool-chip to overlap long text content.
             .fixedSize(horizontal: false, vertical: true)
             .contextMenu {
-                if !isUser, let onReportMessage,
-                   FeatureFlagManager.shared.isEnabled(.monitoringExport) {
+                if canReportMessage, let onReportMessage {
                     Button("Report this response") {
                         onReportMessage(message.daemonMessageId)
                     }
                 }
             }
 
+            if canReportMessage {
+                VStack {
+                    Menu {
+                        if let onReportMessage {
+                            Button("Report this response") {
+                                onReportMessage(message.daemonMessageId)
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .rotationEffect(.degrees(90))
+                            .frame(width: 24, height: 24)
+                            .contentShape(Rectangle())
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .frame(width: 24, height: 24)
+                    .opacity(isHovered ? 1 : 0)
+                    .allowsHitTesting(isHovered)
+                    .accessibilityLabel("Message actions")
+                    .animation(VAnimation.fast, value: isHovered)
+
+                    Spacer(minLength: 0)
+                }
+                .frame(width: 24)
+            }
+
             if !isUser { Spacer(minLength: 0) }
+        }
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            if canReportMessage {
+                isHovered = hovering
+            } else if isHovered {
+                isHovered = false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- `.contextMenu` on assistant message text is overridden by `.textSelection(.enabled)` which installs its own NSTextView context menu
- Added a visible "..." `Menu` button that appears on hover next to assistant messages
- Uses `HStack` layout with `.onHover` on the full row so the button stays visible while the cursor moves toward it
- Gated behind the `.monitoringExport` feature flag

## Test plan
- [ ] Enable `VELLUM_FLAG_MONITORING_EXPORT=1` in `.env`
- [ ] Hover over an assistant message — "..." button appears on the right
- [ ] Move cursor toward the button — it stays visible
- [ ] Click button → "Report this response" menu item appears
- [ ] Click "Report this response" → diagnostics export triggers
- [ ] Verify button does NOT appear on user messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
