### PR TITLE
feat: show building statuses inline in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -980,9 +980,9 @@ private struct ChatBubble: View {
         } else if hasActuallyRunningTool && !permissionWasDenied {
             // In progress — show single running indicator for the active tool
             let current = message.toolCalls.first(where: { !$0.isComplete })!
-            let progressive = Self.progressiveLabels(for: current.toolName)
+            let progressive = current.buildingStatus != nil ? [] : Self.progressiveLabels(for: current.toolName)
             RunningIndicator(
-                label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary),
+                label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary, buildingStatus: current.buildingStatus),
                 progressiveLabels: progressive,
                 labelInterval: progressive.isEmpty ? 6 : 15,
                 onTap: { onOpenActivity(message.id) }
@@ -1094,7 +1094,14 @@ private struct ChatBubble: View {
     }
 
     /// Maps tool names to user-friendly present-tense labels for the running state.
-    private static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil) -> String {
+    private static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil, buildingStatus: String? = nil) -> String {
+        // For app file tools, prefer the descriptive building status from tool input
+        if let status = buildingStatus {
+            let lower = toolName.lowercased()
+            if lower == "app file edit" || lower == "app file write" || lower == "app create" || lower == "app update" {
+                return status
+            }
+        }
         switch toolName.lowercased() {
         case "run command":            return "Running a command"
         case "read file":              return "Reading a file"

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -969,9 +969,10 @@ private struct ChatBubble: View {
         if hasStreamingCode {
             let rawName = message.streamingCodeToolName ?? ""
             let displayName = rawName.replacingOccurrences(of: "_", with: " ")
+            let activeBuildingStatus = message.toolCalls.last(where: { !$0.isComplete })?.buildingStatus
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 RunningIndicator(
-                    label: Self.friendlyRunningLabel(displayName),
+                    label: Self.friendlyRunningLabel(displayName, buildingStatus: activeBuildingStatus),
                     onTap: { onOpenActivity(message.id) }
                 )
                 CodePreviewView(code: message.streamingCodePreview!)

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -271,6 +271,8 @@ public struct ToolCallData: Identifiable, Equatable {
     public var completedAt: Date?
     /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
     public var imageData: String?
+    /// Human-readable building status from app tool input (e.g. "Adding dark mode styles").
+    public var buildingStatus: String?
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
     #if os(macOS)
     public var cachedImage: NSImage?
@@ -289,6 +291,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.isComplete == rhs.isComplete
             && lhs.arrivedBeforeText == rhs.arrivedBeforeText
             && lhs.imageData == rhs.imageData
+            && lhs.buildingStatus == rhs.buildingStatus
     }
 
     public init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -570,10 +570,9 @@ extension ChatViewModel {
                 if let status = msg.input["status"]?.value as? String, !status.isEmpty {
                     return status
                 }
-                // Fallback status based on tool name
+                // Fallback status for file tools only; app_create/app_update
+                // rely on friendlyRunningLabel + progressive label cycling
                 switch msg.toolName {
-                case "app_create": return "Building your app"
-                case "app_update": return "Updating your app"
                 case "app_file_edit": return "Editing app files"
                 case "app_file_write": return "Writing app files"
                 default: return nil

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -563,12 +563,29 @@ extension ChatViewModel {
             if msg.toolName == "ui_show" || msg.toolName == "ui_update" || msg.toolName == "ui_dismiss" || msg.toolName == "request_file" {
                 break
             }
-            let toolCall = ToolCallData(
+            // Extract building status for app tools
+            let buildingStatus: String? = {
+                let appTools: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
+                guard appTools.contains(msg.toolName) else { return nil }
+                if let status = msg.input["status"]?.value as? String, !status.isEmpty {
+                    return status
+                }
+                // Fallback status based on tool name
+                switch msg.toolName {
+                case "app_create": return "Building your app"
+                case "app_update": return "Updating your app"
+                case "app_file_edit": return "Editing app files"
+                case "app_file_write": return "Writing app files"
+                default: return nil
+                }
+            }()
+            var toolCall = ToolCallData(
                 toolName: toolDisplayName(msg.toolName),
                 inputSummary: summarizeToolInput(msg.input),
                 arrivedBeforeText: !currentAssistantHasText,
                 startedAt: Date()
             )
+            toolCall.buildingStatus = buildingStatus
             // Add to existing assistant message or create one
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -618,6 +635,9 @@ extension ChatViewModel {
                 messages[msgIndex].toolCalls[tcIndex].completedAt = Date()
                 messages[msgIndex].toolCalls[tcIndex].imageData = msg.imageData
                 messages[msgIndex].toolCalls[tcIndex].cachedImage = ToolCallData.decodeImage(from: msg.imageData)
+                if let status = msg.status, !status.isEmpty {
+                    messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
+                }
             }
 
         case .uiSurfaceShow(let msg):


### PR DESCRIPTION
## Summary
- Extract `status` from app tool inputs (`app_file_edit`, `app_file_write`, `app_create`, `app_update`) and display descriptive messages (e.g. "Adding dark mode styles") in the chat `RunningIndicator` instead of generic labels like "Running app file edit"
- Add `buildingStatus` property to `ToolCallData` and populate it from both `toolUseStart` input and `toolResult` status fields
- Disable progressive label cycling when a real building status is available so the descriptive status stays visible

## Test plan
- [ ] Build macOS client: `cd clients/macos && ./build.sh`
- [ ] Ask the agent to "build me a todo app" and verify `app_create` shows "Building your app"
- [ ] Ask for a change (e.g. "add dark mode") and verify `app_file_edit` shows the status from tool input instead of generic "Running app file edit"
- [ ] Verify non-app tools (bash, file_read, etc.) still show their normal labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
