### PR TITLE
Rename "Report this response" to "Export response for diagnostics"

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -907,7 +907,7 @@ private struct ChatBubble: View {
             .fixedSize(horizontal: false, vertical: true)
             .contextMenu {
                 if canReportMessage, let onReportMessage {
-                    Button("Report this response") {
+                    Button("Export response for diagnostics") {
                         onReportMessage(message.daemonMessageId)
                     }
                 }
@@ -917,7 +917,7 @@ private struct ChatBubble: View {
                 VStack {
                     Menu {
                         if let onReportMessage {
-                            Button("Report this response") {
+                            Button("Export response for diagnostics") {
                                 onReportMessage(message.daemonMessageId)
                             }
                         }


### PR DESCRIPTION
## Summary
- Renames the menu item label from "Report this response" to "Export response for diagnostics" in both the context menu and hover button

## Test plan
- [ ] Hover assistant message → "..." button → verify menu says "Export response for diagnostics"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
