### PR TITLE
feat: add tool-result-truncation utility module (#3642)

### DIFF
--- a/assistant/src/__tests__/tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/tool-result-truncation.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect } from "bun:test";
+
+import type { ContentBlock, ToolResultContent } from "../providers/types.js";
+import {
+  truncateToolResultText,
+  calculateMaxToolResultChars,
+  isOversizedToolResult,
+  truncateOversizedToolResults,
+  HARD_MAX_TOOL_RESULT_CHARS,
+  MIN_KEEP_CHARS,
+  TRUNCATION_SUFFIX,
+} from "../context/tool-result-truncation.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToolResult(content: string): ToolResultContent {
+  return {
+    type: "tool_result",
+    tool_use_id: "test-id",
+    content,
+  };
+}
+
+function makeTextBlock(text: string): ContentBlock {
+  return { type: "text", text };
+}
+
+// ---------------------------------------------------------------------------
+// truncateToolResultText
+// ---------------------------------------------------------------------------
+
+describe("truncateToolResultText", () => {
+  test("returns text unchanged when under limit", () => {
+    const text = "hello world";
+    expect(truncateToolResultText(text, 100)).toBe(text);
+  });
+
+  test("truncates text that exceeds limit", () => {
+    const text = "a".repeat(10_000);
+    const result = truncateToolResultText(text, 5_000);
+    expect(result.length).toBeLessThanOrEqual(5_000);
+    expect(result).toContain(TRUNCATION_SUFFIX);
+  });
+
+  test("preserves at least MIN_KEEP_CHARS", () => {
+    const text = "a".repeat(10_000);
+    // Ask for a very small limit — the function should still keep MIN_KEEP_CHARS
+    const result = truncateToolResultText(text, 100);
+    // Content before suffix should be at least MIN_KEEP_CHARS - suffix length
+    const contentBeforeSuffix = result.slice(
+      0,
+      result.indexOf(TRUNCATION_SUFFIX),
+    );
+    expect(contentBeforeSuffix.length).toBeGreaterThanOrEqual(
+      MIN_KEEP_CHARS - TRUNCATION_SUFFIX.length,
+    );
+  });
+
+  test("finds newline boundary for clean cuts", () => {
+    // Build text with newlines, large enough to exceed the maxChars budget
+    // so truncation actually kicks in and can snap to a newline.
+    const lines = Array.from({ length: 1000 }, (_, i) => `line ${i}: ${"x".repeat(20)}`).join(
+      "\n",
+    );
+    const maxChars = 5_000;
+    const result = truncateToolResultText(lines, maxChars);
+    // The content before the suffix should end right before a newline boundary
+    const beforeSuffix = result.slice(0, result.indexOf(TRUNCATION_SUFFIX));
+    // Because we snap to a newline, the next char in the original should be '\n'
+    const nextCharInOriginal = lines[beforeSuffix.length];
+    expect(nextCharInOriginal).toBe("\n");
+  });
+
+  test("appends truncation suffix", () => {
+    const text = "x".repeat(5_000);
+    const result = truncateToolResultText(text, 1_000);
+    expect(result.endsWith(TRUNCATION_SUFFIX)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMaxToolResultChars
+// ---------------------------------------------------------------------------
+
+describe("calculateMaxToolResultChars", () => {
+  test("scales proportionally with context window", () => {
+    const small = calculateMaxToolResultChars(10_000);
+    const large = calculateMaxToolResultChars(50_000);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  test("capped at HARD_MAX_TOOL_RESULT_CHARS for large windows", () => {
+    // A huge context window should still be capped.
+    const result = calculateMaxToolResultChars(10_000_000);
+    expect(result).toBe(HARD_MAX_TOOL_RESULT_CHARS);
+  });
+
+  test("returns reasonable value for 180K context window", () => {
+    const result = calculateMaxToolResultChars(180_000);
+    // 180_000 * 0.3 * 4 = 216_000
+    expect(result).toBe(216_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isOversizedToolResult
+// ---------------------------------------------------------------------------
+
+describe("isOversizedToolResult", () => {
+  test("returns false for small tool results", () => {
+    const block = makeToolResult("small content");
+    expect(isOversizedToolResult(block, 180_000)).toBe(false);
+  });
+
+  test("returns true for oversized tool results", () => {
+    const block = makeToolResult("x".repeat(500_000));
+    expect(isOversizedToolResult(block, 180_000)).toBe(true);
+  });
+
+  test("returns false for non-tool-result blocks (cast safely)", () => {
+    const textBlock = makeTextBlock("hello") as unknown as ToolResultContent;
+    // A text block has no `.content` string of meaningful length, so it
+    // should not be considered oversized. We cast to exercise the function
+    // safely even with unexpected input.
+    expect(isOversizedToolResult(textBlock, 180_000)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// truncateOversizedToolResults
+// ---------------------------------------------------------------------------
+
+describe("truncateOversizedToolResults", () => {
+  const contextWindow = 180_000; // maxChars = 216_000
+
+  test("returns unchanged blocks when nothing is oversized", () => {
+    const blocks: ContentBlock[] = [
+      makeTextBlock("hello"),
+      makeToolResult("short"),
+    ];
+    const { blocks: result, truncatedCount } = truncateOversizedToolResults(
+      blocks,
+      contextWindow,
+    );
+    expect(truncatedCount).toBe(0);
+    expect(result).toEqual(blocks);
+  });
+
+  test("truncates oversized tool results", () => {
+    const big = makeToolResult("y".repeat(500_000));
+    const { blocks: result, truncatedCount } = truncateOversizedToolResults(
+      [big],
+      contextWindow,
+    );
+    expect(truncatedCount).toBe(1);
+    const truncated = result[0] as ToolResultContent;
+    expect(truncated.content.length).toBeLessThan(500_000);
+    expect(truncated.content).toContain(TRUNCATION_SUFFIX);
+  });
+
+  test("preserves non-tool-result blocks unchanged", () => {
+    const text = makeTextBlock("keep me");
+    const big = makeToolResult("z".repeat(500_000));
+    const { blocks: result } = truncateOversizedToolResults(
+      [text, big],
+      contextWindow,
+    );
+    expect(result[0]).toBe(text); // same reference
+  });
+
+  test("reports correct truncatedCount", () => {
+    const small = makeToolResult("ok");
+    const big = makeToolResult("a".repeat(500_000));
+    const { truncatedCount } = truncateOversizedToolResults(
+      [small, big],
+      contextWindow,
+    );
+    expect(truncatedCount).toBe(1);
+  });
+
+  test("handles multiple oversized results", () => {
+    const big1 = makeToolResult("a".repeat(500_000));
+    const big2 = makeToolResult("b".repeat(500_000));
+    const { blocks: result, truncatedCount } = truncateOversizedToolResults(
+      [big1, big2],
+      contextWindow,
+    );
+    expect(truncatedCount).toBe(2);
+    for (const b of result) {
+      const tr = b as ToolResultContent;
+      expect(tr.content).toContain(TRUNCATION_SUFFIX);
+    }
+  });
+});

--- a/assistant/src/context/tool-result-truncation.ts
+++ b/assistant/src/context/tool-result-truncation.ts
@@ -1,0 +1,122 @@
+import type { ContentBlock, ToolResultContent } from "../providers/types.js";
+
+/**
+ * Maximum share of the context window that a single tool result may occupy.
+ */
+export const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
+
+/**
+ * Absolute cap on tool-result characters (~100K tokens).
+ */
+export const HARD_MAX_TOOL_RESULT_CHARS = 400_000;
+
+/**
+ * Minimum number of characters to preserve when truncating.
+ */
+export const MIN_KEEP_CHARS = 2_000;
+
+/**
+ * Suffix appended to truncated tool results.
+ */
+export const TRUNCATION_SUFFIX =
+  "\n\n[Content truncated — original exceeded size limit. Use offset/limit parameters or request specific sections for large content.]";
+
+/**
+ * Truncate text with newline-boundary awareness.
+ *
+ * If `text.length <= maxChars`, the text is returned as-is.
+ * Otherwise we look for the last newline that falls within 80% of the budget
+ * so we get a clean cut. At least `MIN_KEEP_CHARS` characters are always
+ * preserved.
+ */
+export function truncateToolResultText(
+  text: string,
+  maxChars: number,
+): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  const effectiveMax = Math.max(maxChars, MIN_KEEP_CHARS);
+  const cutPoint = effectiveMax - TRUNCATION_SUFFIX.length;
+
+  // Look for a newline within the last 20% of the budget for a clean break.
+  const threshold = Math.floor(cutPoint * 0.8);
+  const lastNewline = text.lastIndexOf("\n", cutPoint);
+
+  const sliceEnd =
+    lastNewline >= threshold ? lastNewline : cutPoint;
+
+  return text.slice(0, sliceEnd) + TRUNCATION_SUFFIX;
+}
+
+/**
+ * Calculate the maximum allowed characters for a tool result based on the
+ * context window size. Uses ~4 chars per token as a rough heuristic.
+ */
+export function calculateMaxToolResultChars(
+  contextWindowTokens: number,
+): number {
+  return Math.min(
+    HARD_MAX_TOOL_RESULT_CHARS,
+    Math.floor(contextWindowTokens * MAX_TOOL_RESULT_CONTEXT_SHARE * 4),
+  );
+}
+
+/**
+ * Check whether a tool-result content block exceeds the computed character
+ * budget for the given context window.
+ */
+export function isOversizedToolResult(
+  block: ToolResultContent,
+  contextWindowTokens: number,
+): boolean {
+  if (typeof block.content !== "string") {
+    return false;
+  }
+  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+  return block.content.length > maxChars;
+}
+
+/**
+ * If the tool-result block is oversized, return a shallow copy with its
+ * `.content` truncated. Otherwise return the block unchanged.
+ */
+export function truncateToolResultBlock(
+  block: ToolResultContent,
+  contextWindowTokens: number,
+): ToolResultContent {
+  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+  if (block.content.length <= maxChars) {
+    return block;
+  }
+  return {
+    ...block,
+    content: truncateToolResultText(block.content, maxChars),
+  };
+}
+
+/**
+ * Map over an array of content blocks, truncating any oversized tool results.
+ * Returns a new array and the number of blocks that were truncated.
+ */
+export function truncateOversizedToolResults(
+  blocks: ContentBlock[],
+  contextWindowTokens: number,
+): { blocks: ContentBlock[]; truncatedCount: number } {
+  let truncatedCount = 0;
+
+  const mapped = blocks.map((block) => {
+    if (block.type !== "tool_result") {
+      return block;
+    }
+    const toolBlock = block as ToolResultContent;
+    if (isOversizedToolResult(toolBlock, contextWindowTokens)) {
+      truncatedCount++;
+      return truncateToolResultBlock(toolBlock, contextWindowTokens);
+    }
+    return block;
+  });
+
+  return { blocks: mapped, truncatedCount };
+}


### PR DESCRIPTION
## Summary
- Add standalone utility module for truncating oversized tool results
- Context-window-proportional sizing (30% max per result, capped at 400K chars)
- Newline-boundary-aware truncation preserving content beginning
- Comprehensive test suite

Closes #3642
Part of #3641
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
