### PR TITLE
Rename anchorMessageId to messageId in diagnostics manifest

### DIFF
--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -170,7 +170,7 @@ export async function handleDiagnosticsExport(
         version: '1.0',
         exportedAt: new Date().toISOString(),
         conversationId,
-        anchorMessageId: anchorMessage.id,
+        messageId: anchorMessage.id,
       };
       writeFileSync(join(tempDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
 


### PR DESCRIPTION
## Summary
- Renames `anchorMessageId` to `messageId` in the exported `manifest.json` for clarity

## Test plan
- [ ] Export diagnostics → check `manifest.json` has `messageId` instead of `anchorMessageId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
