### PR TITLE
Remove diagnostics export from right-click context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -905,13 +905,7 @@ private struct ChatBubble: View {
             // Prevent LazyVStack from compressing the bubble height, which causes the
             // trailing tool-chip to overlap long text content.
             .fixedSize(horizontal: false, vertical: true)
-            .contextMenu {
-                if canReportMessage, let onReportMessage {
-                    Button("Report this response") {
-                        onReportMessage(message.daemonMessageId)
-                    }
-                }
-            }
+            .contextMenu {}
 
             if canReportMessage {
                 VStack {


### PR DESCRIPTION
## Summary
- Removes the "Report this response" item from the `.contextMenu` modifier on assistant messages
- This context menu was never visible because `.textSelection(.enabled)` overrides it with the native NSTextView context menu
- The hover "..." button is the only working entry point for diagnostics export

## Test plan
- [ ] Right-click an assistant message — no "Report this response" in menu (was already broken)
- [ ] Hover "..." button still works for diagnostics export

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
