### PR TITLE
feat: integrate tool result truncation in agent loop (#3643)

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1031,4 +1031,105 @@ describe('AgentLoop', () => {
     // Empty array should result in undefined tools (same as no-tools behavior)
     expect(calls[0].tools).toBeUndefined();
   });
+
+  // ---------------------------------------------------------------------------
+  // Tool result truncation tests
+  // ---------------------------------------------------------------------------
+
+  // 30. Oversized tool results are truncated before entering history
+  test('truncates oversized tool results before adding to history', async () => {
+    const toolCallId = 'tool-large';
+    const largeContent = 'x'.repeat(500_000);
+
+    const { provider, calls } = createMockProvider([
+      toolUseResponse(toolCallId, 'read_file', { path: '/huge.txt' }),
+      textResponse('Got it.'),
+    ]);
+
+    const toolExecutor = async () => {
+      return { content: largeContent, isError: false };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      'system',
+      { maxInputTokens: 180_000 },
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // The tool result user message is at index 2 in history
+    const toolResultMsg = history[2];
+    expect(toolResultMsg.role).toBe('user');
+
+    const toolResultBlock = toolResultMsg.content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(toolResultBlock).toBeDefined();
+
+    // Content should have been truncated (much shorter than the original 500K)
+    expect(toolResultBlock!.content.length).toBeLessThan(500_000);
+
+    // Content should end with the truncation suffix
+    expect(toolResultBlock!.content).toContain(
+      '[Content truncated',
+    );
+
+    // The second provider call should also have the truncated content in messages
+    const secondCallMessages = calls[1].messages;
+    const lastMsg = secondCallMessages[secondCallMessages.length - 1];
+    const sentBlock = lastMsg.content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(sentBlock).toBeDefined();
+    expect(sentBlock!.content.length).toBeLessThan(500_000);
+  });
+
+  // 31. Non-oversized tool results pass through unchanged
+  test('non-oversized tool results pass through unchanged', async () => {
+    const toolCallId = 'tool-small';
+    const smallContent = 'small content';
+
+    const { provider, calls } = createMockProvider([
+      toolUseResponse(toolCallId, 'read_file', { path: '/small.txt' }),
+      textResponse('Got it.'),
+    ]);
+
+    const toolExecutor = async () => {
+      return { content: smallContent, isError: false };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      'system',
+      { maxInputTokens: 180_000 },
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // The tool result user message is at index 2 in history
+    const toolResultMsg = history[2];
+    expect(toolResultMsg.role).toBe('user');
+
+    const toolResultBlock = toolResultMsg.content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(toolResultBlock).toBeDefined();
+
+    // Content should be exactly the original small content — no truncation
+    expect(toolResultBlock!.content).toBe(smallContent);
+
+    // The second provider call should also have the unchanged content
+    const secondCallMessages = calls[1].messages;
+    const lastMsg = secondCallMessages[secondCallMessages.length - 1];
+    const sentBlock = lastMsg.content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(sentBlock).toBeDefined();
+    expect(sentBlock!.content).toBe(smallContent);
+  });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -2,11 +2,13 @@ import * as Sentry from '@sentry/node';
 import type { Provider, Message, ToolDefinition, ContentBlock } from '../providers/types.js';
 import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
 import { getHookManager } from '../hooks/manager.js';
+import { truncateOversizedToolResults } from '../context/tool-result-truncation.js';
 
 const log = getLogger('agent-loop');
 
 export interface AgentLoopConfig {
   maxTokens: number;
+  maxInputTokens?: number; // context window size for tool result truncation
   thinking?: { enabled: boolean; budgetTokens: number };
   toolChoice?: { type: 'auto' } | { type: 'any' } | { type: 'tool'; name: string };
   maxToolUseTurns?: number;
@@ -316,13 +318,22 @@ export class AgentLoop {
         }
 
         // Collect result blocks preserving tool_use order (Promise.all maintains order)
-        const resultBlocks: ContentBlock[] = toolResults.map(({ toolUse, result }) => ({
+        const rawResultBlocks: ContentBlock[] = toolResults.map(({ toolUse, result }) => ({
           type: 'tool_result' as const,
           tool_use_id: toolUse.id,
           content: result.content,
           is_error: result.isError,
           ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
         }));
+
+        // Pre-emptively truncate oversized tool results to prevent context overflow
+        const { blocks: resultBlocks, truncatedCount } = truncateOversizedToolResults(
+          rawResultBlocks,
+          this.config.maxInputTokens ?? 180_000,
+        );
+        if (truncatedCount > 0) {
+          log.warn(`Truncated ${truncatedCount} oversized tool result(s) to prevent context overflow`);
+        }
 
         // If cancelled during execution, push completed results and stop
         if (signal?.aborted) {


### PR DESCRIPTION
## Summary
- Integrate truncateOversizedToolResults into agent loop tool result collection
- Add maxInputTokens to AgentLoopConfig for context-window-aware truncation
- Pre-emptively cap oversized tool results before they enter conversation history
- Warn log when truncation occurs

Closes #3643
Part of #3641
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
