### PR TITLE
feat: auto-approve low/medium tool confirmations during CU sessions

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -638,6 +638,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         daemonClient.onConfirmationRequest = { [weak self] msg in
             guard let self else { return }
             Task { @MainActor in
+                // Auto-approve low/medium risk tool confirmations during CU sessions
+                if self.currentSession?.autoApproveTools == true,
+                   msg.riskLevel == "low" || msg.riskLevel == "medium" {
+                    do {
+                        try self.daemonClient.sendConfirmationResponse(
+                            requestId: msg.requestId,
+                            decision: "allow"
+                        )
+                        self.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
+                            requestId: msg.requestId,
+                            decision: "allow"
+                        )
+                    } catch {
+                        log.error("Failed to auto-approve confirmation: \(error.localizedDescription)")
+                    }
+                    return
+                }
+
                 let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)
                 // If the inline chat path already forwarded the response, skip
                 // the duplicate IPC send and state update.

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -22,6 +22,7 @@ enum SessionState: Equatable {
 final class ComputerUseSession: ObservableObject {
     @Published var state: SessionState = .idle
     @Published var undoCount = 0
+    @Published var autoApproveTools = false
 
     let task: String
     let id: String

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayView.swift
@@ -171,6 +171,7 @@ struct SessionOverlayView: View {
         case .running, .thinking:
             HStack(spacing: 8) {
                 undoButton
+                autoApproveButton
                 Spacer()
                 Button("Pause") {
                     session.pause()
@@ -212,6 +213,20 @@ struct SessionOverlayView: View {
         default:
             EmptyView()
         }
+    }
+
+    private var autoApproveButton: some View {
+        Button {
+            session.autoApproveTools.toggle()
+        } label: {
+            Label(
+                session.autoApproveTools ? "Auto-approve" : "Auto-approve",
+                systemImage: session.autoApproveTools ? "checkmark.shield.fill" : "shield"
+            )
+        }
+        .buttonStyle(.bordered)
+        .tint(session.autoApproveTools ? .green : nil)
+        .controlSize(.small)
     }
 
     private var undoButton: some View {


### PR DESCRIPTION
## Summary
- Adds `autoApproveTools` session-scoped flag to `ComputerUseSession`
- Auto-approves low/medium risk daemon tool confirmations when the toggle is active, skipping notifications and inline bubbles
- Adds "Auto-approve" toggle button to the session overlay (visible during running/thinking states)
- High-risk actions still prompt as before; ActionVerifier local safety checks are unchanged

Closes #3929
Part of #3928

## Test plan
- [ ] Start a CU session, verify "Auto-approve" button appears in overlay alongside Pause/Stop
- [ ] Click "Auto-approve" — button turns green with checkmark icon
- [ ] Trigger low/medium risk tool actions — they should auto-approve without notifications
- [ ] Trigger a high-risk tool action — should still show confirmation prompt
- [ ] Toggle off auto-approve — confirmations should resume for all risk levels
- [ ] Verify the toggle resets when a new session starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
