### PR TITLE
refactor: remove text configurability from WakeUpStepView

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -204,9 +204,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             onComplete: { [weak self] in
                 self?.proceedToApp()
             },
-            onOpenSettings: {},
-            wakeUpTitle: "Sign in to continue",
-            wakeUpSubtitle: "Sign in with your Vellum account to get started."
+            onOpenSettings: {}
         )
 
         let hostingController = NSHostingController(rootView: authView)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -9,10 +9,6 @@ struct OnboardingFlowView: View {
     var onComplete: () -> Void
     var onOpenSettings: () -> Void
 
-    // Optional text overrides for WakeUpStepView (used by auth gate)
-    var wakeUpTitle: String?
-    var wakeUpSubtitle: String?
-
     @State private var isAdvancingFromWakeUp = false
 
     var body: some View {
@@ -52,8 +48,6 @@ struct OnboardingFlowView: View {
                             WakeUpStepView(
                                 state: state,
                                 authManager: authManager,
-                                title: wakeUpTitle ?? "Create your Velly",
-                                subtitle: wakeUpSubtitle ?? "The safest way to create your personal assistant.",
                                 isAdvancing: isAdvancingFromWakeUp,
                                 onStartWithAPIKey: {
                                     guard !isAdvancingFromWakeUp else { return }

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -11,11 +11,6 @@ struct WakeUpStepView: View {
     /// Optional auth manager for showing loading/error state on the Vellum card.
     var authManager: AuthManager?
 
-    // Configurable text
-    var title: String = "Create your Velly"
-    var subtitle: String = "The safest way to create your personal assistant."
-    var questionPrompt: String = "How would you like to start?"
-
     /// When true, disables all option cards (e.g. during 0.3s advance delay).
     var isAdvancing: Bool = false
 
@@ -35,7 +30,7 @@ struct WakeUpStepView: View {
 
     var body: some View {
         // Title
-        Text(title)
+        Text("Create your Velly")
             .font(.system(size: 32, weight: .regular, design: .serif))
             .foregroundColor(VColor.textPrimary)
             .opacity(showTitle ? 1 : 0)
@@ -43,7 +38,7 @@ struct WakeUpStepView: View {
             .padding(.bottom, VSpacing.md)
 
         // Subtitle
-        Text(subtitle)
+        Text("The safest way to create your personal assistant.")
             .font(.system(size: 16, design: .monospaced))
             .foregroundColor(VColor.textSecondary)
             .multilineTextAlignment(.center)
@@ -51,7 +46,7 @@ struct WakeUpStepView: View {
             .offset(y: showSubtext ? 0 : 8)
 
         // Question prompt
-        Text(questionPrompt)
+        Text("How would you like to start?")
             .font(.system(size: 16, weight: .medium, design: .monospaced))
             .foregroundColor(VColor.textPrimary)
             .opacity(showSubtext ? 1 : 0)
@@ -177,23 +172,3 @@ struct WakeUpStepView: View {
     .frame(width: 520, height: 580)
 }
 
-#Preview("Auth gate context") {
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VStack(spacing: 0) {
-            Spacer()
-            Image("VellyLogo")
-                .resizable()
-                .interpolation(.none)
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 128, height: 128)
-                .padding(.bottom, VSpacing.xxl)
-            WakeUpStepView(
-                title: "Sign in to continue",
-                subtitle: "Sign in with your Vellum account to get started.",
-                questionPrompt: "How would you like to start?"
-            )
-        }
-    }
-    .frame(width: 520, height: 580)
-}


### PR DESCRIPTION
## Summary
- Remove `title`, `subtitle`, `questionPrompt` params from WakeUpStepView — hardcode the strings directly
- Remove `wakeUpTitle`, `wakeUpSubtitle` from OnboardingFlowView
- Remove custom text args from AppDelegate's `showAuthWindow()`
- Remove the "Auth gate context" preview (was only testing custom text)

Both onboarding and auth gate now use the same OnboardingFlowView with the same steps, so having different text was unnecessary complexity.

## Test plan
- [ ] Verify onboarding shows "Create your Velly" on step 0
- [ ] Verify auth gate shows "Create your Velly" on step 0
- [ ] Verify both flows progress through steps correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
