### PR TITLE
Remove monitoringExport feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -800,9 +800,7 @@ private struct ChatBubble: View {
 
     private var isUser: Bool { message.role == .user }
     private var canReportMessage: Bool {
-        !isUser
-            && onReportMessage != nil
-            && FeatureFlagManager.shared.isEnabled(.monitoringExport)
+        !isUser && onReportMessage != nil
     }
 
     private var statusLabel: String? {

--- a/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
@@ -207,65 +207,32 @@ final class FeatureFlagManagerTests: XCTestCase {
     /// Tests that env var keys are normalized by lowercasing and removing underscores.
     func testEnvKeyNormalizationRemovesUnderscores() {
         // GIVEN an environment with an underscore-separated flag name
-        let env = ["VELLUM_FLAG_MONITORING_EXPORT": "1"]
+        let env = ["VELLUM_FLAG_DARK_MODE": "1"]
 
         // WHEN we create a manager from that environment
         let manager = FeatureFlagManager(environment: env)
 
-        // THEN the flag is accessible via the camelCase enum rawValue
-        XCTAssertTrue(manager.isEnabled(.monitoringExport))
-
-        // AND via the camelCase string directly
-        XCTAssertTrue(manager.isEnabled("monitoringExport"))
+        // THEN the flag is accessible via the camelCase string directly
+        XCTAssertTrue(manager.isEnabled("darkMode"))
 
         // AND via the underscore-separated string (normalization strips underscores)
-        XCTAssertTrue(manager.isEnabled("monitoring_export"))
+        XCTAssertTrue(manager.isEnabled("dark_mode"))
     }
 
     /// Tests that flag lookup is case-insensitive after normalization.
     func testNormalizationIsCaseInsensitive() {
         // GIVEN an environment with a mixed-case flag name
-        let env = ["VELLUM_FLAG_MONITORING_EXPORT": "true"]
+        let env = ["VELLUM_FLAG_DARK_MODE": "true"]
 
         // WHEN we create a manager from that environment
         let manager = FeatureFlagManager(environment: env)
 
         // THEN various casings all resolve to the same flag
-        XCTAssertTrue(manager.isEnabled("MONITORING_EXPORT"))
-        XCTAssertTrue(manager.isEnabled("Monitoring_Export"))
-        XCTAssertTrue(manager.isEnabled("monitoringexport"))
-        XCTAssertTrue(manager.isEnabled("MonitoringExport"))
-        XCTAssertTrue(manager.isEnabled("MONITORINGEXPORT"))
-    }
-
-    /// Tests that the monitoringExport FeatureFlag enum case works end-to-end.
-    func testMonitoringExportFlag() {
-        // GIVEN an environment with the monitoring export flag enabled
-        let env = ["VELLUM_FLAG_MONITORING_EXPORT": "1"]
-
-        // WHEN we create a manager from that environment
-        let manager = FeatureFlagManager(environment: env)
-
-        // THEN the typed enum flag is enabled
-        XCTAssertTrue(manager.isEnabled(.monitoringExport))
-    }
-
-    /// Tests that setOverride and removeOverride work with the monitoringExport flag.
-    func testMonitoringExportOverride() {
-        // GIVEN a manager with no flags
-        let manager = FeatureFlagManager(environment: [:])
-
-        // WHEN we set the monitoringExport override
-        manager.setOverride(.monitoringExport, enabled: true)
-
-        // THEN it is enabled
-        XCTAssertTrue(manager.isEnabled(.monitoringExport))
-
-        // WHEN we remove the override
-        manager.removeOverride(.monitoringExport)
-
-        // THEN it is disabled again
-        XCTAssertFalse(manager.isEnabled(.monitoringExport))
+        XCTAssertTrue(manager.isEnabled("DARK_MODE"))
+        XCTAssertTrue(manager.isEnabled("Dark_Mode"))
+        XCTAssertTrue(manager.isEnabled("darkmode"))
+        XCTAssertTrue(manager.isEnabled("DarkMode"))
+        XCTAssertTrue(manager.isEnabled("DARKMODE"))
     }
 
 }

--- a/clients/shared/Utilities/FeatureFlagManager.swift
+++ b/clients/shared/Utilities/FeatureFlagManager.swift
@@ -4,7 +4,6 @@ private let flagPrefix = "VELLUM_FLAG_"
 
 public enum FeatureFlag: String {
     case demo
-    case monitoringExport
 }
 
 public final class FeatureFlagManager: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Removes `monitoringExport` from the `FeatureFlag` enum
- Diagnostics export hover button is now always visible on assistant messages (no flag check)
- Updates tests to use generic flag names instead of `monitoringExport`

## Test plan
- [ ] Hover an assistant message — "..." button appears without setting any env var
- [ ] Click "..." → "Export response for diagnostics" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
