### PR TITLE
fix: clear persisted onboarding state before replay

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -744,6 +744,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             setupDaemonClient()
         }
 
+        // Clear persisted step so replay always starts at step 0
+        OnboardingState.clearPersistedState()
+
         let onboarding = OnboardingWindow(daemonClient: daemonClient, authManager: authManager)
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()


### PR DESCRIPTION
## Summary
- Call `OnboardingState.clearPersistedState()` before creating `OnboardingWindow` in `replayOnboarding()` so it always starts at step 0

Previously `clearPersistedState()` was only called in `onComplete`, so replay would resume at the last saved step.

## Test plan
- [ ] Complete onboarding past step 0 → use Replay Onboarding → verify it starts at step 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
