### PR TITLE
fix: expandable preview and consistent permission labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1261,8 +1261,8 @@ private struct ChatBubble: View {
             }
             .font(.system(size: 12))
 
-            Text(isApproved ? "Permission granted" :
-                 confirmation.state == .denied ? "Permission denied" : "Timed out")
+            Text(isApproved ? "\(confirmation.toolCategory) allowed" :
+                 confirmation.state == .denied ? "\(confirmation.toolCategory) denied" : "Timed out")
                 .font(VFont.caption)
                 .foregroundColor(isApproved ? VColor.success : VColor.textSecondary)
         }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -11,6 +11,7 @@ public struct ToolConfirmationBubble: View {
 
     @State private var showDiff = false
     @State private var showAlwaysAllowMenu = false
+    @State private var isPreviewExpanded = false
 
     public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
         self.confirmation = confirmation
@@ -194,17 +195,35 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private func inlinePreview(_ preview: String) -> some View {
-        Text(preview)
-            .font(VFont.monoSmall)
-            .foregroundColor(VColor.textSecondary)
-            .lineLimit(3)
-            .padding(VSpacing.sm)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(VColor.backgroundSubtle)
-            )
-            .textSelection(.enabled)
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(preview)
+                .font(VFont.monoSmall)
+                .foregroundColor(VColor.textSecondary)
+                .lineLimit(isPreviewExpanded ? nil : 3)
+                .textSelection(.enabled)
+
+            if !isPreviewExpanded {
+                HStack(spacing: 2) {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                    Text("Show more")
+                        .font(.system(size: 10))
+                }
+                .foregroundColor(VColor.textMuted)
+            }
+        }
+        .padding(VSpacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.backgroundSubtle)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(VAnimation.fast) {
+                isPreviewExpanded.toggle()
+            }
+        }
     }
 
     // MARK: - Description Text


### PR DESCRIPTION
Make tool confirmation preview expandable instead of hard-truncated at 3 lines. Update compactPermissionChip to use toolCategory-based labels matching collapsedContent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
