### PR TITLE
fix: check ingress before persisting channel payload

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -7,6 +7,7 @@ import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
 import { renderHistoryContent } from '../../daemon/handlers.js';
+import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 import type {
@@ -191,6 +192,13 @@ export async function handleChannelInbound(
   // For new (non-duplicate) messages, run the agent loop to generate a reply.
   let processingSucceeded = false;
   if (!result.duplicate && processMessage) {
+    // Block secret-bearing content before persisting the payload to the DB
+    const contentToCheck = content ?? '';
+    const ingressCheck = checkIngressForSecrets(contentToCheck);
+    if (ingressCheck.blocked) {
+      throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
+    }
+
     // Persist the raw payload so the event can be replayed on failure
     channelDeliveryStore.storePayload(result.eventId, {
       sourceChannel, externalChatId, externalMessageId, content,


### PR DESCRIPTION
Move checkIngressForSecrets call before channelDeliveryStore.storePayload in handleChannelInbound so secret-bearing payloads are never written to the DB.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
