### PR TITLE
fix: avoid appending truncation suffix when no content was removed

### DIFF
--- a/assistant/src/__tests__/tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/tool-result-truncation.test.ts
@@ -78,6 +78,27 @@ describe("truncateToolResultText", () => {
     const result = truncateToolResultText(text, 1_000);
     expect(result.endsWith(TRUNCATION_SUFFIX)).toBe(true);
   });
+
+  test("does not append suffix when text fits within effectiveMax (maxChars < MIN_KEEP_CHARS)", () => {
+    // When maxChars < MIN_KEEP_CHARS, effectiveMax becomes MIN_KEEP_CHARS.
+    // If the text is longer than maxChars but shorter than the cutPoint
+    // derived from effectiveMax, sliceEnd covers the full text and nothing
+    // is actually removed. The function should return the original text
+    // without appending the suffix.
+    const maxChars = 100;
+    const textLength = MIN_KEEP_CHARS - TRUNCATION_SUFFIX.length - 10;
+    const text = "a".repeat(textLength);
+
+    // Sanity: text exceeds maxChars but fits within the effective budget
+    expect(text.length).toBeGreaterThan(maxChars);
+    expect(text.length).toBeLessThan(MIN_KEEP_CHARS);
+
+    const result = truncateToolResultText(text, maxChars);
+
+    // Should return original text unchanged — no suffix appended
+    expect(result).toBe(text);
+    expect(result).not.toContain(TRUNCATION_SUFFIX);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/context/tool-result-truncation.ts
+++ b/assistant/src/context/tool-result-truncation.ts
@@ -47,6 +47,12 @@ export function truncateToolResultText(
   const sliceEnd =
     lastNewline >= threshold ? lastNewline : cutPoint;
 
+  // If sliceEnd covers the full text, nothing was actually removed — return
+  // the original text without appending the suffix.
+  if (sliceEnd >= text.length) {
+    return text;
+  }
+
   return text.slice(0, sliceEnd) + TRUNCATION_SUFFIX;
 }
 


### PR DESCRIPTION
Addresses Codex P2 feedback on PR #3923. When effectiveMax exceeds text length (due to MIN_KEEP_CHARS), sliceEnd covers the full text and nothing is removed — now returns original text without appending TRUNCATION_SUFFIX.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
