### PR TITLE
fix: emit truncated tool content and pass maxInputTokens from Session

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -304,19 +304,6 @@ export class AgentLoop {
           toolResults = await toolExecutionPromise;
         }
 
-        // Emit tool_result events in deterministic tool_use order after all complete
-        for (const { toolUse, result } of toolResults) {
-          onEvent({
-            type: 'tool_result',
-            toolUseId: toolUse.id,
-            content: result.content,
-            isError: result.isError,
-            diff: result.diff,
-            status: result.status,
-            contentBlocks: result.contentBlocks,
-          });
-        }
-
         // Collect result blocks preserving tool_use order (Promise.all maintains order)
         const rawResultBlocks: ContentBlock[] = toolResults.map(({ toolUse, result }) => ({
           type: 'tool_result' as const,
@@ -333,6 +320,27 @@ export class AgentLoop {
         );
         if (truncatedCount > 0) {
           log.warn(`Truncated ${truncatedCount} oversized tool result(s) to prevent context overflow`);
+        }
+
+        // Emit tool_result events AFTER truncation so downstream consumers
+        // (e.g. session persistence) receive the truncated content.
+        for (const { toolUse, result } of toolResults) {
+          // Look up the (possibly truncated) content from resultBlocks
+          const truncatedBlock = resultBlocks.find(
+            (b) => b.type === 'tool_result' && b.tool_use_id === toolUse.id,
+          );
+          const emitContent = (truncatedBlock && truncatedBlock.type === 'tool_result')
+            ? truncatedBlock.content
+            : result.content;
+          onEvent({
+            type: 'tool_result',
+            toolUseId: toolUse.id,
+            content: emitContent,
+            isError: result.isError,
+            diff: result.diff,
+            status: result.status,
+            contentBlocks: result.contentBlocks,
+          });
         }
 
         // If cancelled during execution, push completed results and stop

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -19,6 +19,7 @@ import { allComputerUseTools } from '../tools/computer-use/definitions.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getSandboxWorkingDir } from '../util/platform.js';
+import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('computer-use-session');
@@ -437,11 +438,13 @@ export class ComputerUseSession {
       },
     };
 
+    const cuConfig = getConfig();
     const agentLoop = new AgentLoop(
       compactingProvider,
       systemPrompt,
       {
         maxTokens: 4096,
+        maxInputTokens: cuConfig.contextWindow.maxInputTokens,
         toolChoice: { type: 'any' },
         // Allow MAX_STEPS non-terminal actions plus one terminal turn
         // (computer_use_done/computer_use_respond), since AgentLoop caps tool turns globally.

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -279,7 +279,7 @@ export class Session {
     this.agentLoop = new AgentLoop(
       provider,
       systemPrompt,
-      { maxTokens, thinking: config.thinking },
+      { maxTokens, maxInputTokens: config.contextWindow.maxInputTokens, thinking: config.thinking },
       toolDefs.length > 0 ? toolDefs : undefined,
       toolDefs.length > 0 ? toolExecutor : undefined,
       resolveTools,


### PR DESCRIPTION
Addresses feedback on PR #3927. (1) Tool result events now emit truncated content instead of raw content, keeping persisted history aligned with in-memory truncation. (2) Session now passes maxInputTokens from config to AgentLoop so truncation respects user-configured context window. (3) Same fix applied to computer-use-session.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
