### PR TITLE
fix: add fallback instruction for missing onboarding sections in USER.md

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -430,6 +430,12 @@ describe('buildOnboardingGuidanceSection', () => {
     expect(section).toContain('firstConversationComplete');
   });
 
+  test('includes fallback instruction for missing sections', () => {
+    const section = buildOnboardingGuidanceSection();
+    expect(section).toContain('does not yet exist in USER.md');
+    expect(section).toContain('create it with the default values');
+  });
+
   test('does not contain platform-specific logic', () => {
     const section = buildOnboardingGuidanceSection();
     expect(section).not.toContain('macOS');

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -248,6 +248,8 @@ export function buildOnboardingGuidanceSection(): string {
     '',
     'USER.md contains structured onboarding sections that you must keep up to date as you learn about the user. These sections are client-agnostic and persist across sessions.',
     '',
+    'If a section referenced below does not yet exist in USER.md, create it with the default values shown here before updating. Legacy USER.md files from earlier installations may be missing these sections.',
+    '',
     '### Locale',
     'When the user mentions where they live, their timezone, or their language preferences, update the `## Locale` section in USER.md with the relevant fields (`city`, `region`, `country`, `timezone`, `localeId`). Set `confidence` to `low`, `medium`, or `high` based on how explicit the information was.',
     '',


### PR DESCRIPTION
## Summary
- Adds a fallback instruction in `buildOnboardingGuidanceSection()` telling the model to create missing onboarding sections (Locale, Dashboard Color Preference, Onboarding Tasks, Trust Stage) with default values before updating them
- This handles legacy `USER.md` files from existing installations that were never updated with the new onboarding schema sections
- Adds a test to verify the fallback instruction is present

## Context
Addresses Codex P2 feedback on PR #2879: `ensurePromptFiles()` only copies templates when files are missing, so upgraded users keep their old `USER.md` without the new sections. The prompt now instructs the model to create any missing sections before attempting to update them.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All 42 system-prompt tests pass, including the new `includes fallback instruction for missing sections` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
