### PR TITLE
fix: correct mic permission timing and weather claim in docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ graph TB
 
         subgraph "Dashboard"
             DASH_VIEW["DashboardView<br/>greeting + cards"]
-            DASH_WEATHER["DashboardWeatherCard<br/>locale-aware weather"]
+            DASH_WEATHER["DashboardWeatherCard<br/>weather (Palo Alto fallback)"]
             DASH_TASK["DashboardTaskCard<br/>starter task CTA"]
             DASH_THEME["@AppStorage<br/>dashboardAccentColorHex<br/>dashboardAccentColorName"]
         end
@@ -957,7 +957,7 @@ Main Window (default: dashboard mode)
 │                                             │
 │  DashboardView                              │
 │  ├─ Greeting (time-of-day)                  │
-│  ├─ Weather card (locale-aware)             │
+│  ├─ Weather card (Palo Alto, CA fallback)    │
 │  ├─ Starter task cards                      │
 │  │   ├─ Make It Yours (color flow)          │
 │  │   ├─ Research Something                  │
@@ -1071,7 +1071,7 @@ Use this matrix to validate the dashboard-first UX, trust-earned onboarding, and
 
 - [ ] On first launch, the main window defaults to `DashboardView` (not chat).
 - [ ] The greeting text reflects the current time of day (morning/afternoon/evening).
-- [ ] The weather card displays weather for the user's locale (falls back to Palo Alto, CA when locale is not set).
+- [ ] The weather card displays weather for Palo Alto, CA (locale-aware coordinates are future work).
 - [ ] All three starter task cards are visible: "Make It Yours", "Research Something", "Turn It Into a UI".
 - [ ] Clicking "Make It Yours" sends `[STARTER_TASK:make_it_yours]` to the daemon and the assistant begins the color flow.
 - [ ] After selecting a color, the dashboard accent color updates and is visible immediately.
@@ -1097,9 +1097,8 @@ Use this matrix to validate the dashboard-first UX, trust-earned onboarding, and
 
 ### Locale and Weather Behavior
 
-- [ ] When the user has no locale set in USER.md, the weather card defaults to Palo Alto, CA.
-- [ ] After the user sets their locale during onboarding, the weather card updates to the correct location.
-- [ ] The locale `confidence` field updates appropriately (`low` → `medium` → `high`).
+- [ ] The weather card always displays Palo Alto, CA weather (locale-aware coordinates are future work; see `DashboardWeatherService`).
+- [ ] The locale `confidence` field in USER.md updates appropriately (`low` → `medium` → `high`).
 
 ### Dashboard Color Persistence
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -187,13 +187,13 @@ The app will auto-reconnect if the daemon restarts. For development, `bun run de
 
 ## Permissions
 
-The app requests macOS permissions progressively based on trust stage, not all at once during onboarding:
+The app requests macOS permissions progressively, not all at once during onboarding:
 
 - **Accessibility** — Requested during onboarding (required for reading UI element trees and injecting mouse/keyboard events)
 - **Screen Recording** — Deferred to dashboard task cards (needed for capturing screenshots when AX tree is sparse)
-- **Microphone** — Deferred to dashboard task cards (needed for voice input via speech recognition)
+- **Microphone** — Requested on first voice input attempt (when the user holds the Fn key or taps the mic button, `VoiceInputManager` checks `AVCaptureDevice.authorizationStatus` and triggers the system permission prompt if not yet determined)
 
-Grant these in System Settings → Privacy & Security when prompted. Screen Recording and Microphone are only requested after the user has completed their first conversation (trust-earned, not upfront).
+Grant these in System Settings → Privacy & Security when prompted.
 
 ## Usage
 
@@ -331,7 +331,7 @@ Features/MainWindow/Dashboard/
   DashboardTaskCard   Starter task CTA card
   DashboardTaskModel  Task model and definitions
   DashboardWeatherCard Weather display card
-  DashboardWeatherService Locale-aware weather data
+  DashboardWeatherService Weather data (hardcoded Palo Alto, CA fallback)
 UI/                   SwiftUI views + overlay windows
   Onboarding/         First-launch setup flow (naming, Accessibility — 6 steps)
 Logging/


### PR DESCRIPTION
## Summary
- Fixed microphone permission timing description in `clients/macos/README.md` to match actual `VoiceInputManager.beginRecording()` behavior: mic access is requested on first voice input attempt (Fn key hold or mic button tap), not deferred until after the first conversation.
- Corrected locale-aware weather claims in `ARCHITECTURE.md` QA checklist and diagrams since `DashboardWeatherService` uses hardcoded Palo Alto, CA coordinates (locale wiring is future work).
- Updated `DashboardWeatherService` description in README architecture section.

Addresses Codex P2 feedback on PR #2911.

## Test plan
- [ ] Verify `clients/macos/README.md` Permissions section accurately describes mic permission timing
- [ ] Verify `ARCHITECTURE.md` QA checklist no longer asserts locale-aware weather behavior
- [ ] Verify Mermaid and ASCII diagrams no longer label weather as "locale-aware"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
