### PR TITLE
fix: pop-out close docks chat, settings from popout, observer leak

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWindow.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 @MainActor
 final class ChatWindow {
     private var window: NSWindow?
+    private var closeObserver: NSObjectProtocol?
     private let threadManager: ThreadManager
     private let windowState: MainWindowState
     private let ambientAgent: AmbientAgent
@@ -82,7 +83,7 @@ final class ChatWindow {
         window.setFrameAutosaveName("ChatPopOutWindow")
 
         // Observe the window closing to revert to docked mode
-        NotificationCenter.default.addObserver(
+        closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: window,
             queue: .main
@@ -100,6 +101,10 @@ final class ChatWindow {
     }
 
     func close() {
+        if let observer = closeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            closeObserver = nil
+        }
         window?.close()
         window = nil
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ChatPanelView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ChatPanelView.swift
@@ -31,6 +31,14 @@ struct ChatPanelView: View {
                     isRecording: viewModel.isRecording,
                     onOpenSettings: {
                         windowState.activePanel = .settings
+                        if windowState.isChatPoppedOut {
+                            // When chat is popped out, the main window is in
+                            // dashboard mode which doesn't render side panels.
+                            // Switch to chat mode so the settings panel is
+                            // visible, and bring the main window forward.
+                            windowState.contentMode = .chat
+                            Self.bringMainWindowToFront()
+                        }
                     },
                     onSend: viewModel.sendMessage,
                     onStop: viewModel.stopGenerating,
@@ -80,6 +88,17 @@ struct ChatPanelView: View {
                 .background(VColor.chatBackground)
             }
         }
+    }
+
+    /// Bring the main window to the front so the user can see the settings
+    /// panel that was just opened. Used when opening settings from pop-out mode.
+    @MainActor
+    private static func bringMainWindowToFront() {
+        for window in NSApp.windows where window.frameAutosaveName == "MainWindow" {
+            window.makeKeyAndOrderFront(nil)
+            break
+        }
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     @MainActor

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -190,6 +190,7 @@ final class MainWindow {
             onMicrophoneToggle: onMicrophoneToggle ?? {},
             onClose: { [weak self] in
                 self?.windowState.isChatPoppedOut = false
+                self?.windowState.contentMode = .chat
                 self?.chatWindow = nil
             }
         )


### PR DESCRIPTION
Addresses feedback on PR #2891. Three fixes: (1) onClose callback in popOutChat() now sets contentMode = .chat so closing the pop-out window properly switches back to chat mode, (2) settings open from pop-out chat switches contentMode to .chat and brings the main window forward so the settings panel is visible, (3) ChatWindow observer token stored in closeObserver property and removed on close to prevent leak.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
