### PR TITLE
fix: persist dashboard theme directly to UserDefaults for chat-mode durability

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardTaskModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Dashboard/DashboardTaskModel.swift
@@ -51,6 +51,10 @@ extension DashboardTask {
     ]
 
     /// Deferred permission tasks that unlock additional capabilities.
+    /// Note: The kickoff IDs (`enable_voice`, `enable_computer_control`) are
+    /// intentional placeholders for future implementation. They are not yet
+    /// handled by the assistant's starter-task playbook and will be wired up
+    /// when the corresponding permission flows are built.
     static let deferredPermissionTasks: [DashboardTask] = [
         DashboardTask(
             id: "enable_voice",

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -211,9 +211,15 @@ final class MainWindow {
     // MARK: - Dashboard Message Handlers
 
     /// Apply a theme/color update from the daemon to the dashboard.
-    /// Persists the color in `@AppStorage` via a notification so that
-    /// `DashboardView` can pick it up reactively.
+    /// Writes directly to `UserDefaults` so the values persist even when
+    /// `DashboardView` is not mounted (e.g. user is in chat mode during
+    /// the "Make it yours" flow). The `@AppStorage` properties in
+    /// `DashboardView` will pick up the new values automatically when
+    /// the view is next mounted. The notification is still posted for any
+    /// live observers.
     private func handleDashboardThemeUpdate(_ msg: DashboardThemeUpdateMessage) {
+        UserDefaults.standard.set(msg.colorHex, forKey: "dashboardAccentColorHex")
+        UserDefaults.standard.set(msg.colorName, forKey: "dashboardAccentColorName")
         NotificationCenter.default.post(
             name: .dashboardThemeDidUpdate,
             object: nil,


### PR DESCRIPTION
Addresses feedback on PR #2902. Writes theme color hex and name directly to UserDefaults in handleDashboardThemeUpdate before posting the notification, ensuring values persist even when DashboardView is not mounted (e.g., user is in chat mode during 'Make it yours' flow). Also adds clarifying comment about placeholder kickoff IDs for deferred permission cards.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
