### PR TITLE
fix: always proceed to app after onboarding completes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -800,11 +800,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             onboarding.close()
             self?.onboardingWindow = nil
 
-            if self?.authManager.isAuthenticated == true {
-                self?.proceedToApp()
-            } else {
-                self?.startAuthenticatedFlow()
-            }
+            // By this point the user has either entered an API key (steps 0→1→2)
+            // or authenticated via Vellum Account (WorkOS). Proceed directly —
+            // don't re-check auth, which would show the auth gate again.
+            self?.proceedToApp()
         }
         onboarding.show()
         onboardingWindow = onboarding


### PR DESCRIPTION
## Summary
- After the trimmed onboarding flow (steps 0→1→2), always call `proceedToApp()` instead of re-checking `authManager.isAuthenticated`

The previous code checked `authManager.isAuthenticated` in the onComplete handler. If the user chose "Own API Key" (not WorkOS/Vellum Account), `isAuthenticated` was false, so `startAuthenticatedFlow()` showed the auth gate — sending the user back to step 0 in an infinite loop.

By the time `onComplete` fires, the user has either entered an API key (steps 0→1→2) or authenticated via Vellum Account (WorkOS `onChange` trigger). Either way, they're ready to use the app.

## Test plan
- [ ] `/scrub` → launch → click "Own API Key" → enter key → select model → verify app opens (no step 0 loop)
- [ ] `/scrub` → launch → click "Vellum Account" → authenticate → verify app opens
- [ ] Logout → verify auth gate still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
