### PR TITLE
fix: propagate sourceChannel through runtime HTTP callbacks

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -1,0 +1,315 @@
+import { describe, test, expect } from 'bun:test';
+import type { Message } from '../providers/types.js';
+import {
+  applyRuntimeInjections,
+  injectChannelCapabilityContext,
+  resolveChannelCapabilities,
+  stripChannelCapabilityContext,
+} from '../daemon/session-runtime-assembly.js';
+import type { ChannelCapabilities } from '../daemon/session-runtime-assembly.js';
+import { buildChannelAwarenessSection } from '../config/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// resolveChannelCapabilities
+// ---------------------------------------------------------------------------
+
+describe('resolveChannelCapabilities', () => {
+  test('defaults to dashboard when no source channel is provided', () => {
+    const caps = resolveChannelCapabilities();
+    expect(caps.channel).toBe('dashboard');
+    expect(caps.dashboardCapable).toBe(true);
+    expect(caps.supportsDynamicUi).toBe(true);
+    expect(caps.supportsVoiceInput).toBe(true);
+  });
+
+  test('defaults to dashboard for null source channel', () => {
+    const caps = resolveChannelCapabilities(null);
+    expect(caps.channel).toBe('dashboard');
+    expect(caps.dashboardCapable).toBe(true);
+  });
+
+  test('resolves "dashboard" as dashboard-capable', () => {
+    const caps = resolveChannelCapabilities('dashboard');
+    expect(caps.channel).toBe('dashboard');
+    expect(caps.dashboardCapable).toBe(true);
+    expect(caps.supportsDynamicUi).toBe(true);
+    expect(caps.supportsVoiceInput).toBe(true);
+  });
+
+  test('resolves "telegram" as non-dashboard-capable', () => {
+    const caps = resolveChannelCapabilities('telegram');
+    expect(caps.channel).toBe('telegram');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+
+  test('resolves "http-api" as non-dashboard-capable', () => {
+    const caps = resolveChannelCapabilities('http-api');
+    expect(caps.channel).toBe('http-api');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// injectChannelCapabilityContext
+// ---------------------------------------------------------------------------
+
+describe('injectChannelCapabilityContext', () => {
+  const baseUserMessage: Message = {
+    role: 'user',
+    content: [{ type: 'text', text: 'Hello' }],
+  };
+
+  test('injects channel capabilities block for dashboard channel', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'dashboard',
+      dashboardCapable: true,
+      supportsDynamicUi: true,
+      supportsVoiceInput: true,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+
+    // Should prepend a text block with channel_capabilities
+    expect(result.content.length).toBe(2);
+    const injected = result.content[0];
+    expect(injected.type).toBe('text');
+    expect((injected as { type: 'text'; text: string }).text).toContain('<channel_capabilities>');
+    expect((injected as { type: 'text'; text: string }).text).toContain('dashboard_capable: true');
+    expect((injected as { type: 'text'; text: string }).text).toContain('supports_dynamic_ui: true');
+    expect((injected as { type: 'text'; text: string }).text).toContain('</channel_capabilities>');
+    // Should NOT contain constraint rules for dashboard
+    expect((injected as { type: 'text'; text: string }).text).not.toContain('CHANNEL CONSTRAINTS');
+  });
+
+  test('injects constraint rules for non-dashboard channel', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+
+    const injected = result.content[0];
+    const text = (injected as { type: 'text'; text: string }).text;
+    expect(text).toContain('CHANNEL CONSTRAINTS');
+    expect(text).toContain('Do NOT reference the dashboard UI');
+    expect(text).toContain('Do NOT use ui_show');
+    expect(text).toContain('Do NOT ask the user to use voice');
+    expect(text).toContain('dashboard_capable: false');
+  });
+
+  test('preserves original message content after injection', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+
+    // Original content should be at the end
+    const lastBlock = result.content[result.content.length - 1];
+    expect((lastBlock as { type: 'text'; text: string }).text).toBe('Hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripChannelCapabilityContext
+// ---------------------------------------------------------------------------
+
+describe('stripChannelCapabilityContext', () => {
+  test('strips channel_capabilities blocks from user messages', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<channel_capabilities>\nchannel: telegram\n</channel_capabilities>' },
+          { type: 'text', text: 'Hello' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi there' }],
+      },
+    ];
+
+    const result = stripChannelCapabilityContext(messages);
+
+    expect(result.length).toBe(2);
+    expect(result[0].content.length).toBe(1);
+    expect((result[0].content[0] as { type: 'text'; text: string }).text).toBe('Hello');
+    // Assistant message untouched
+    expect(result[1].content.length).toBe(1);
+  });
+
+  test('removes user messages that only contain channel_capabilities', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<channel_capabilities>\nchannel: telegram\n</channel_capabilities>' },
+        ],
+      },
+    ];
+
+    const result = stripChannelCapabilityContext(messages);
+    expect(result.length).toBe(0);
+  });
+
+  test('leaves messages without channel_capabilities untouched', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Normal message' }],
+      },
+    ];
+
+    const result = stripChannelCapabilityContext(messages);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(messages[0]); // Same reference — untouched
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRuntimeInjections with channelCapabilities
+// ---------------------------------------------------------------------------
+
+describe('applyRuntimeInjections with channelCapabilities', () => {
+  const baseMessages: Message[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'What can you do?' }],
+    },
+  ];
+
+  test('injects channel capabilities when provided', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = applyRuntimeInjections(baseMessages, {
+      channelCapabilities: caps,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(2);
+    const injected = result[0].content[0];
+    expect((injected as { type: 'text'; text: string }).text).toContain('<channel_capabilities>');
+  });
+
+  test('does not inject when channelCapabilities is null', () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      channelCapabilities: null,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+  });
+
+  test('does not inject when channelCapabilities is omitted', () => {
+    const result = applyRuntimeInjections(baseMessages, {});
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+  });
+
+  test('combines with other injections', () => {
+    const caps: ChannelCapabilities = {
+      channel: 'telegram',
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = applyRuntimeInjections(baseMessages, {
+      softConflictInstruction: 'What is your name?',
+      channelCapabilities: caps,
+    });
+
+    expect(result.length).toBe(1);
+    // softConflictInstruction appends, channelCapabilities prepends
+    expect(result[0].content.length).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildChannelAwarenessSection
+// ---------------------------------------------------------------------------
+
+describe('buildChannelAwarenessSection', () => {
+  test('includes channel awareness heading', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('## Channel Awareness & Trust Gating');
+  });
+
+  test('includes channel-specific rules', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('dashboard_capable');
+    expect(section).toContain('supports_dynamic_ui');
+    expect(section).toContain('supports_voice_input');
+  });
+
+  test('includes trust gating rules for permission asks', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('firstConversationComplete');
+    expect(section).toContain('Permission ask trust gating');
+    expect(section).toContain('Do NOT proactively ask for elevated permissions');
+  });
+
+  test('gates microphone permissions on voice capability', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('Do not ask for microphone permissions');
+  });
+
+  test('gates computer-control on dashboard channel', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('computer-control permissions on non-dashboard');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust-gating behavior: channel constraints for permission asks
+// ---------------------------------------------------------------------------
+
+describe('trust-gating via channel capabilities', () => {
+  test('dashboard channel does not add constraint rules', () => {
+    const caps = resolveChannelCapabilities('dashboard');
+    const message: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'Enable my microphone' }],
+    };
+
+    const result = injectChannelCapabilityContext(message, caps);
+    const injected = (result.content[0] as { type: 'text'; text: string }).text;
+
+    expect(injected).not.toContain('CHANNEL CONSTRAINTS');
+    expect(injected).toContain('dashboard_capable: true');
+  });
+
+  test('non-dashboard channel adds constraint rules preventing UI references', () => {
+    const caps = resolveChannelCapabilities('slack');
+    const message: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'Show me a chart' }],
+    };
+
+    const result = injectChannelCapabilityContext(message, caps);
+    const injected = (result.content[0] as { type: 'text'; text: string }).text;
+
+    expect(injected).toContain('CHANNEL CONSTRAINTS');
+    expect(injected).toContain('Do NOT reference the dashboard UI');
+    expect(injected).toContain('Do NOT use ui_show, ui_update, or app_create');
+    expect(injected).toContain('Present information as well-formatted text');
+    expect(injected).toContain('desktop app');
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -113,6 +113,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildDocumentCreationSection());
   parts.push(buildToolPermissionSection());
   parts.push(buildSystemPermissionSection());
+  parts.push(buildChannelAwarenessSection());
   parts.push(buildSwarmGuidanceSection());
   parts.push(buildIntegrationSection());
   parts.push(buildWorkspaceReflectionSection());
@@ -382,6 +383,27 @@ function buildSystemPermissionSection(): string {
     '- Accessibility / UI automation → `accessibility`',
     '',
     'Do NOT explain how to open System Settings manually — the tool handles it with a clickable button.',
+  ].join('\n');
+}
+
+export function buildChannelAwarenessSection(): string {
+  return [
+    '## Channel Awareness & Trust Gating',
+    '',
+    'Each turn may include a `<channel_capabilities>` block in the user message describing what the current channel supports. Use this to adapt your behaviour:',
+    '',
+    '### Channel-specific rules',
+    '- When `dashboard_capable` is `false`, never reference the dashboard UI, settings panels, dynamic pages, or visual pickers. Present data as formatted text.',
+    '- When `supports_dynamic_ui` is `false`, do not call `ui_show`, `ui_update`, or `app_create`.',
+    '- When `supports_voice_input` is `false`, do not ask the user to speak or use their microphone.',
+    '- Non-dashboard channels should defer dashboard-specific actions. Tell the user they can complete those steps later from the desktop app.',
+    '',
+    '### Permission ask trust gating',
+    '- Do NOT proactively ask for elevated permissions (microphone, computer control, file access) until the trust stage field `firstConversationComplete` in USER.md is `true`.',
+    '- Even after `firstConversationComplete`, only ask for permissions that are relevant to the current channel capabilities.',
+    '- Do not ask for microphone permissions on channels where `supports_voice_input` is `false`.',
+    '- Do not ask for computer-control permissions on non-dashboard channels.',
+    '- When you do request a permission, be transparent about what it enables and why you need it.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -325,10 +325,10 @@ export async function runDaemon(): Promise<void> {
         port,
         hostname,
         bearerToken,
-        processMessage: (assistantId, conversationId, content, attachmentIds, options) =>
-          server.processMessage(assistantId, conversationId, content, attachmentIds, options),
-        persistAndProcessMessage: (assistantId, conversationId, content, attachmentIds, options) =>
-          server.persistAndProcessMessage(assistantId, conversationId, content, attachmentIds, options),
+        processMessage: (assistantId, conversationId, content, attachmentIds, options, sourceChannel) =>
+          server.processMessage(assistantId, conversationId, content, attachmentIds, options, sourceChannel),
+        persistAndProcessMessage: (assistantId, conversationId, content, attachmentIds, options, sourceChannel) =>
+          server.persistAndProcessMessage(assistantId, conversationId, content, attachmentIds, options, sourceChannel),
         runOrchestrator: server.createRunOrchestrator(),
         interfacesDir: getInterfacesDir(),
       });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -17,6 +17,7 @@ import { clearEmbeddingBackendCache } from '../memory/embedding-backend.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session } from './session.js';
+import { resolveChannelCapabilities } from './session-runtime-assembly.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import {
   serialize,
@@ -818,6 +819,7 @@ export class DaemonServer {
     content: string,
     attachmentIds?: string[],
     options?: SessionCreateOptions,
+    sourceChannel?: string,
   ): Promise<{ messageId: string }> {
     // Block inbound content that contains secrets — mirrors the IPC check in sessions.ts
     const ingressCheck = checkIngressForSecrets(content);
@@ -836,6 +838,7 @@ export class DaemonServer {
     // Set assistantId AFTER the isProcessing check so a rejected request
     // doesn't mutate the session state visible to an in-flight request.
     session.setAssistantId(assistantId);
+    session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
@@ -871,6 +874,7 @@ export class DaemonServer {
     content: string,
     attachmentIds?: string[],
     options?: SessionCreateOptions,
+    sourceChannel?: string,
   ): Promise<{ messageId: string }> {
     // Block inbound content that contains secrets — mirrors the IPC check in sessions.ts
     const ingressCheck = checkIngressForSecrets(content);
@@ -887,6 +891,7 @@ export class DaemonServer {
     // Set assistantId AFTER the isProcessing check so a rejected request
     // doesn't mutate the session state visible to an in-flight request.
     session.setAssistantId(assistantId);
+    session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -10,6 +10,33 @@ import { listAppFiles, getAppsDir } from '../memory/app-store.js';
 import { statSync } from 'node:fs';
 import { join } from 'node:path';
 
+/**
+ * Describes the capabilities of the channel through which the user is
+ * interacting.  Used to gate UI-specific references and permission asks.
+ */
+export interface ChannelCapabilities {
+  /** The raw channel identifier (e.g. "dashboard", "telegram", "http-api"). */
+  channel: string;
+  /** Whether this channel can render the dashboard UI (apps, dynamic pages). */
+  dashboardCapable: boolean;
+  /** Whether the channel supports dynamic UI surfaces (ui_show / ui_update). */
+  supportsDynamicUi: boolean;
+  /** Whether the channel supports voice/microphone input. */
+  supportsVoiceInput: boolean;
+}
+
+/** Derive channel capabilities from a raw source channel identifier. */
+export function resolveChannelCapabilities(sourceChannel?: string | null): ChannelCapabilities {
+  const channel = sourceChannel ?? 'dashboard';
+  const isDashboard = channel === 'dashboard';
+  return {
+    channel,
+    dashboardCapable: isDashboard,
+    supportsDynamicUi: isDashboard,
+    supportsVoiceInput: isDashboard,
+  };
+}
+
 /** Context about the active workspace surface, passed to applyRuntimeInjections. */
 export interface ActiveSurfaceContext {
   surfaceId: string;
@@ -199,6 +226,60 @@ export function injectActiveSurfaceContext(message: Message, ctx: ActiveSurfaceC
 }
 
 /**
+ * Prepend channel capability context to the last user message so the
+ * model knows what the current channel can and cannot do.
+ */
+export function injectChannelCapabilityContext(message: Message, caps: ChannelCapabilities): Message {
+  const lines: string[] = ['<channel_capabilities>'];
+  lines.push(`channel: ${caps.channel}`);
+  lines.push(`dashboard_capable: ${caps.dashboardCapable}`);
+  lines.push(`supports_dynamic_ui: ${caps.supportsDynamicUi}`);
+  lines.push(`supports_voice_input: ${caps.supportsVoiceInput}`);
+
+  if (!caps.dashboardCapable) {
+    lines.push('');
+    lines.push('CHANNEL CONSTRAINTS:');
+    lines.push('- Do NOT reference the dashboard UI, settings panels, or visual preference pickers.');
+    lines.push('- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.');
+    lines.push('- Present information as well-formatted text instead of dynamic UI.');
+    lines.push('- Defer dashboard-specific actions (e.g. accent color selection) by telling the user');
+    lines.push('  they can complete those steps later from the desktop app.');
+  }
+
+  if (!caps.supportsVoiceInput) {
+    lines.push('- Do NOT ask the user to use voice or microphone input.');
+  }
+
+  lines.push('</channel_capabilities>');
+
+  const block = lines.join('\n');
+  return {
+    ...message,
+    content: [
+      { type: 'text', text: block },
+      ...message.content,
+    ],
+  };
+}
+
+/**
+ * Strip `<channel_capabilities>` blocks injected by
+ * `injectChannelCapabilityContext`.
+ */
+export function stripChannelCapabilityContext(messages: Message[]): Message[] {
+  return messages.map((message) => {
+    if (message.role !== 'user') return message;
+    const nextContent = message.content.filter((block) => {
+      if (block.type !== 'text') return true;
+      return !block.text.startsWith('<channel_capabilities>');
+    });
+    if (nextContent.length === message.content.length) return message;
+    if (nextContent.length === 0) return null;
+    return { ...message, content: nextContent };
+  }).filter((message): message is NonNullable<typeof message> => message !== null);
+}
+
+/**
  * Prepend workspace top-level directory context to a user message.
  */
 export function injectWorkspaceTopLevelContext(message: Message, contextText: string): Message {
@@ -260,6 +341,7 @@ export function applyRuntimeInjections(
     softConflictInstruction?: string | null;
     activeSurface?: ActiveSurfaceContext | null;
     workspaceTopLevelContext?: string | null;
+    channelCapabilities?: ChannelCapabilities | null;
   },
 ): Message[] {
   let result = runMessages;
@@ -280,6 +362,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectActiveSurfaceContext(userTail, options.activeSurface),
+      ];
+    }
+  }
+
+  if (options.channelCapabilities) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === 'user') {
+      result = [
+        ...result.slice(0, -1),
+        injectChannelCapabilityContext(userTail, options.channelCapabilities),
       ];
     }
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -51,9 +51,11 @@ import {
   applyRuntimeInjections,
   stripActiveSurfaceContext,
   stripWorkspaceTopLevelContext,
+  stripChannelCapabilityContext,
 } from './session-runtime-assembly.js';
 import type {
   ActiveSurfaceContext,
+  ChannelCapabilities,
 } from './session-runtime-assembly.js';
 import {
   cleanAssistantContent,
@@ -149,6 +151,7 @@ export class Session {
   currentActiveSurfaceId?: string;
   /** @internal — exposed for session-process.ts module functions. */
   currentPage?: string;
+  private channelCapabilities?: ChannelCapabilities;
   /** @internal — exposed for session-surfaces.ts module functions. */
   pendingSurfaceActions = new Map<string, {
     surfaceType: SurfaceType;
@@ -530,6 +533,10 @@ export class Session {
     this.assistantId = assistantId;
   }
 
+  setChannelCapabilities(caps: ChannelCapabilities): void {
+    this.channelCapabilities = caps;
+  }
+
   private async approveHostAttachmentReadImpl(filePath: string): Promise<boolean> {
     return approveHostAttachmentRead(filePath, this.workingDir, this.prompter, this.conversationId, this.hasNoClient);
   }
@@ -759,6 +766,7 @@ export class Session {
         softConflictInstruction,
         activeSurface,
         workspaceTopLevelContext: this.workspaceTopLevelContext,
+        channelCapabilities: this.channelCapabilities ?? null,
       });
 
       // Pre-run repair: fix any message ordering issues before sending to provider.
@@ -1079,9 +1087,11 @@ export class Session {
       });
       const restoredHistory = [...preRepairMessages, ...newMessages];
       const recallStripped = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
-      this.messages = stripWorkspaceTopLevelContext(
-        stripActiveSurfaceContext(
-          stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+      this.messages = stripChannelCapabilityContext(
+        stripWorkspaceTopLevelContext(
+          stripActiveSurfaceContext(
+            stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+          ),
         ),
       );
 

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -17,6 +17,7 @@ export type MessageProcessor = (
   content: string,
   attachmentIds?: string[],
   options?: RuntimeMessageSessionOptions,
+  sourceChannel?: string,
 ) => Promise<{ messageId: string }>;
 
 /**
@@ -30,6 +31,7 @@ export type NonBlockingMessageProcessor = (
   content: string,
   attachmentIds?: string[],
   options?: RuntimeMessageSessionOptions,
+  sourceChannel?: string,
 ) => Promise<{ messageId: string }>;
 
 export interface RuntimeHttpServerOptions {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -221,6 +221,7 @@ export async function handleChannelInbound(
             uxBrief: metadataUxBrief,
           },
         },
+        sourceChannel,
       );
       // Link the user message to the inbound event so edits can find it later
       channelDeliveryStore.linkMessage(result.eventId, userMessageId);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -140,9 +140,10 @@ export async function handleSendMessage(
     conversationKey?: string;
     content?: string;
     attachmentIds?: string[];
+    sourceChannel?: string;
   };
 
-  const { conversationKey, content, attachmentIds } = body;
+  const { conversationKey, content, attachmentIds, sourceChannel } = body;
 
   if (!conversationKey) {
     return Response.json(
@@ -195,6 +196,8 @@ export async function handleSendMessage(
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
+      undefined,
+      sourceChannel,
     );
     return Response.json({ accepted: true, messageId: result.messageId });
   } catch (err) {


### PR DESCRIPTION
Addresses Codex P1 feedback on PR #2882. Propagates sourceChannel through the lifecycle/runtime callback chain so non-dashboard channel constraints and permission gating are applied correctly for runtime HTTP traffic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
