### PR TITLE
feat: move /model picker from popup to inline chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -73,7 +73,7 @@ struct ChatView: View {
     let onDropImageData: (Data, String?) -> Void
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
-    var onSelectModel: ((String) -> Void)?
+    var onModelPickerSelect: ((UUID, String) -> Void)?
     var selectedModel: String = ""
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
@@ -234,9 +234,7 @@ struct ChatView: View {
                 onMicrophoneToggle: onMicrophoneToggle,
                 placeholderText: emptyStatePlaceholder,
                 editorContentHeight: $editorContentHeight,
-                isComposerExpanded: $isComposerExpanded,
-                onSelectModel: onSelectModel,
-                selectedModel: selectedModel
+                isComposerExpanded: $isComposerExpanded
             )
             .opacity(emptyStateVisible ? 1 : 0)
             .offset(y: emptyStateVisible ? 0 : 10)
@@ -285,6 +283,18 @@ struct ChatView: View {
         return base + attachments + error + queue
     }
 
+    private func modelPickerView(for message: ChatMessage) -> some View {
+        ModelPickerBubble(
+            models: SettingsStore.availableModels.map { id in
+                (id: id, name: SettingsStore.modelDisplayNames[id] ?? id)
+            },
+            selectedModelId: selectedModel,
+            onSelect: { modelId in
+                onModelPickerSelect?(message.id, modelId)
+            }
+        )
+    }
+
     @MainActor private var composerOverlay: some View {
         VStack(spacing: 0) {
             if let watchSession, watchSession.state == .capturing {
@@ -316,9 +326,7 @@ struct ChatView: View {
                 onMicrophoneToggle: onMicrophoneToggle,
                 placeholderText: "What would you like to do?",
                 editorContentHeight: $editorContentHeight,
-                isComposerExpanded: $isComposerExpanded,
-                onSelectModel: onSelectModel,
-                selectedModel: selectedModel
+                isComposerExpanded: $isComposerExpanded
             )
         }
         .background(
@@ -487,6 +495,10 @@ struct ChatView: View {
                                 // When there IS a preceding assistant message, the decided
                                 // confirmation is rendered as a chip on that bubble — skip here.
                             }
+                        } else if message.modelPicker != nil {
+                            modelPickerView(for: message)
+                                .id(message.id)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
                         } else {
                             // Hide tool call chips when the next message is a pending
                             // confirmation — the tool hasn't been approved yet.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1768,7 +1768,7 @@ private struct ChatBubble: View {
             let length = trimmed.distance(from: slashMatch.lowerBound, to: slashMatch.upperBound)
             let attrStart = parsed.index(parsed.startIndex, offsetByCharacters: offset)
             let attrEnd = parsed.index(attrStart, offsetByCharacters: length)
-            parsed[attrStart..<attrEnd].foregroundColor = Indigo._500
+            parsed[attrStart..<attrEnd].foregroundColor = adaptiveColor(light: Indigo._500, dark: Indigo._300)
         }
 
         // Store in cache (with size limit to prevent unbounded growth)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -52,9 +52,6 @@ struct ComposerView: View {
     /// Exposed to ChatView so composerReservedHeight stays in sync with the
     /// sticky expansion state (set true when text wraps, reset when text clears).
     @Binding var isComposerExpanded: Bool
-    var onSelectModel: ((String) -> Void)?
-    var selectedModel: String = ""
-
     @State private var composerFocusRequestID: Int = 0
     @State private var isStopHovered = false
     @State private var isSendHovered = false
@@ -67,8 +64,6 @@ struct ComposerView: View {
     @State private var showSlashMenu = false
     @State private var slashFilter = ""
     @State private var slashSelectedIndex = 0
-    @State private var showModelSubmenu = false
-    @State private var modelSelectedIndex = 0
     @State private var avatarSeed: String = "default"
 
     /// The portion of the suggestion that extends beyond the current input.
@@ -89,17 +84,7 @@ struct ComposerView: View {
     var body: some View {
         VStack(spacing: VSpacing.sm) {
             // Slash command popup (above the composer)
-            if showModelSubmenu {
-                ModelSubmenuPopup(
-                    models: SettingsStore.availableModels.map { id in
-                        (id: id, name: SettingsStore.modelDisplayNames[id] ?? id)
-                    },
-                    selectedModelId: selectedModel,
-                    highlightedIndex: modelSelectedIndex,
-                    onSelect: { modelId in selectModel(modelId) }
-                )
-                .transition(.opacity.combined(with: .move(edge: .bottom)))
-            } else if showSlashMenu {
+            if showSlashMenu {
                 SlashCommandPopup(
                     commands: filteredSlashCommands(slashFilter),
                     selectedIndex: slashSelectedIndex,
@@ -167,7 +152,6 @@ struct ComposerView: View {
             .shadow(color: VColor.textPrimary.opacity(0.06), radius: 8, x: 0, y: 2)
         }
         .animation(VAnimation.fast, value: showSlashMenu)
-        .animation(VAnimation.fast, value: showModelSubmenu)
         .padding(.horizontal, VSpacing.lg)
         .padding(.top, VSpacing.sm)
         .padding(.bottom, VSpacing.md)
@@ -227,7 +211,7 @@ struct ComposerView: View {
             },
             onAcceptSuggestion: onAcceptSuggestion,
             onPaste: onPaste,
-            isSlashMenuOpen: showSlashMenu || showModelSubmenu,
+            isSlashMenuOpen: showSlashMenu,
             onSlashNavigate: handleSlashNavigation
         )
         .accessibilityLabel("Message")
@@ -251,7 +235,6 @@ struct ComposerView: View {
                 withAnimation(VAnimation.fast) { isComposerExpanded = false }
                 withAnimation(VAnimation.fast) {
                     showSlashMenu = false
-                    showModelSubmenu = false
                 }
             } else {
                 updateSlashState()
@@ -500,17 +483,6 @@ struct ComposerView: View {
     private func updateSlashState() {
         let text = inputText
 
-        if showModelSubmenu {
-            if text != "/model" {
-                withAnimation(VAnimation.fast) {
-                    showModelSubmenu = false
-                    modelSelectedIndex = 0
-                }
-            } else {
-                return
-            }
-        }
-
         if text.hasPrefix("/") && !text.contains(" ") {
             let filter = String(text.dropFirst())
             let filtered = filteredSlashCommands(filter)
@@ -530,41 +502,13 @@ struct ComposerView: View {
         withAnimation(VAnimation.fast) { showSlashMenu = false }
         slashSelectedIndex = 0
         if command.name == "model" {
-            inputText = "/\(command.name)"
-            withAnimation(VAnimation.fast) {
-                showModelSubmenu = true
-                modelSelectedIndex = 0
-            }
+            inputText = "/model"
+            onSend()
         }
-    }
-
-    private func selectModel(_ modelId: String) {
-        onSelectModel?(modelId)
-        withAnimation(VAnimation.fast) {
-            showModelSubmenu = false
-            modelSelectedIndex = 0
-        }
-        inputText = ""
     }
 
     private func handleSlashNavigation(_ action: SlashNavigation) {
-        if showModelSubmenu {
-            let count = SettingsStore.availableModels.count
-            switch action {
-            case .up:
-                modelSelectedIndex = (modelSelectedIndex - 1 + count) % count
-            case .down:
-                modelSelectedIndex = (modelSelectedIndex + 1) % count
-            case .select:
-                selectModel(SettingsStore.availableModels[modelSelectedIndex])
-            case .dismiss:
-                withAnimation(VAnimation.fast) {
-                    showModelSubmenu = false
-                    showSlashMenu = false
-                }
-                inputText = ""
-            }
-        } else if showSlashMenu {
+        if showSlashMenu {
             let filtered = filteredSlashCommands(slashFilter)
             guard !filtered.isEmpty else { return }
             switch action {
@@ -1060,64 +1004,3 @@ private struct SlashCommandRow: View {
     }
 }
 
-// MARK: - Model Submenu Popup
-
-private struct ModelSubmenuPopup: View {
-    let models: [(id: String, name: String)]
-    let selectedModelId: String
-    let highlightedIndex: Int
-    let onSelect: (String) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(models.enumerated()), id: \.element.id) { index, model in
-                ModelSubmenuRow(
-                    name: model.name,
-                    isCurrentModel: model.id == selectedModelId,
-                    isHighlighted: index == highlightedIndex,
-                    onSelect: { onSelect(model.id) }
-                )
-            }
-        }
-        .padding(.vertical, VSpacing.xs)
-        .background(VColor.surface)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.3), radius: 12, y: -4)
-    }
-}
-
-private struct ModelSubmenuRow: View {
-    let name: String
-    let isCurrentModel: Bool
-    let isHighlighted: Bool
-    let onSelect: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: VSpacing.md) {
-                Image(systemName: isCurrentModel ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(isCurrentModel ? VColor.accent : (isHighlighted || isHovered ? VColor.textPrimary : VColor.textSecondary))
-                    .frame(width: 18)
-                Text(name)
-                    .font(isCurrentModel ? VFont.bodyBold : VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-            }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
-            .background(isHighlighted || isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            isHovered = hovering
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-    }
-}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1388,10 +1388,11 @@ private struct ActiveChatViewWrapper: View {
             onPaste: { viewModel.addAttachmentFromPasteboard() },
             onMicrophoneToggle: onMicrophoneToggle,
             onModelPickerSelect: { messageId, modelId in
-                // Send "/model <id>" through the daemon so the switch is persisted
-                // and the daemon responds with its standard confirmation message.
-                viewModel.inputText = "/model \(modelId)"
-                viewModel.sendMessage()
+                // Update UI immediately so the picker reflects the selection
+                settingsStore.selectedModel = modelId
+                // Send "/model <id>" through the daemon silently (no user bubble)
+                // so the switch is persisted and confirmed by the daemon.
+                viewModel.sendSilently("/model \(modelId)")
             },
             selectedModel: settingsStore.selectedModel,
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1387,9 +1387,11 @@ private struct ActiveChatViewWrapper: View {
             },
             onPaste: { viewModel.addAttachmentFromPasteboard() },
             onMicrophoneToggle: onMicrophoneToggle,
-            onSelectModel: { modelId in
-                settingsStore.selectedModel = modelId
-                settingsStore.setModel(modelId)
+            onModelPickerSelect: { messageId, modelId in
+                // Send "/model <id>" through the daemon so the switch is persisted
+                // and the daemon responds with its standard confirmation message.
+                viewModel.inputText = "/model \(modelId)"
+                viewModel.sendMessage()
             },
             selectedModel: settingsStore.selectedModel,
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -412,6 +412,10 @@ public struct ChatAttachment: Identifiable {
     #endif
 }
 
+public struct ModelPickerData: Equatable {
+    public init() {}
+}
+
 public struct SkillInvocationData: Equatable {
     public let name: String
     public let emoji: String?
@@ -442,6 +446,7 @@ public struct ChatMessage: Identifiable {
     /// Non-nil when this message is an inline tool confirmation request.
     public var confirmation: ToolConfirmationData?
     public var skillInvocation: SkillInvocationData?
+    public var modelPicker: ModelPickerData?
     public var attachments: [ChatAttachment]
     public var toolCalls: [ToolCallData]
     public var inlineSurfaces: [InlineSurfaceData]

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -181,7 +181,7 @@ public final class ChatViewModel: ObservableObject {
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
         // Intercept bare "/model" command — show inline picker instead of sending to daemon
-        if text == "/model" && !hasAttachments && !hasSkillInvocation {
+        if text == "/model" && !hasSkillInvocation {
             // Refresh model state from daemon in case it was changed via a text command
             // (e.g. "/model opus") which doesn't notify the client.
             try? daemonClient.send(ModelGetRequestMessage())

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -403,6 +403,11 @@ public final class ChatViewModel: ObservableObject {
     /// Send a message to the daemon without showing a user bubble in the chat.
     /// Used for automated actions like inline model picker selections.
     public func sendSilently(_ text: String) {
+        // Don't re-enter bootstrap if a session creation is already in progress —
+        // that would overwrite pendingUserMessage and orphan the in-flight session.
+        if sessionId == nil && isSending {
+            return
+        }
         if sessionId == nil {
             bootstrapSession(userMessage: text, attachments: nil)
         } else {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -180,6 +180,16 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
+        // Intercept bare "/model" command — show inline picker instead of sending to daemon
+        if text == "/model" && !hasAttachments && !hasSkillInvocation {
+            messages.append(ChatMessage(role: .user, text: "/model"))
+            var pickerMessage = ChatMessage(role: .assistant, text: "")
+            pickerMessage.modelPicker = ModelPickerData()
+            messages.append(pickerMessage)
+            inputText = ""
+            return
+        }
+
         // Fire auto-title callback on the first user message
         if !text.isEmpty, let callback = onFirstUserMessage {
             onFirstUserMessage = nil

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -182,6 +182,9 @@ public final class ChatViewModel: ObservableObject {
 
         // Intercept bare "/model" command — show inline picker instead of sending to daemon
         if text == "/model" && !hasAttachments && !hasSkillInvocation {
+            // Refresh model state from daemon in case it was changed via a text command
+            // (e.g. "/model opus") which doesn't notify the client.
+            try? daemonClient.send(ModelGetRequestMessage())
             messages.append(ChatMessage(role: .user, text: "/model"))
             var pickerMessage = ChatMessage(role: .assistant, text: "")
             pickerMessage.modelPicker = ModelPickerData()
@@ -394,6 +397,16 @@ public final class ChatViewModel: ObservableObject {
             if self?.messageLoopGeneration == generation {
                 self?.messageLoopTask = nil
             }
+        }
+    }
+
+    /// Send a message to the daemon without showing a user bubble in the chat.
+    /// Used for automated actions like inline model picker selections.
+    public func sendSilently(_ text: String) {
+        if sessionId == nil {
+            bootstrapSession(userMessage: text, attachments: nil)
+        } else {
+            sendUserMessage(text)
         }
     }
 

--- a/clients/shared/Features/Chat/ModelPickerBubble.swift
+++ b/clients/shared/Features/Chat/ModelPickerBubble.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
+
+public struct ModelPickerBubble: View {
+    let models: [(id: String, name: String)]
+    let selectedModelId: String
+    let onSelect: (String) -> Void
+
+    @State private var hoveredModelId: String?
+
+    public init(models: [(id: String, name: String)], selectedModelId: String, onSelect: @escaping (String) -> Void) {
+        self.models = models
+        self.selectedModelId = selectedModelId
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(models, id: \.id) { model in
+                modelRow(model)
+            }
+        }
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .frame(maxWidth: 280)
+    }
+
+    private func modelRow(_ model: (id: String, name: String)) -> some View {
+        let isSelected = model.id == selectedModelId
+        let isHovered = hoveredModelId == model.id
+        return Button {
+            onSelect(model.id)
+        } label: {
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(isSelected ? VColor.accent : (isHovered ? VColor.textPrimary : VColor.textSecondary))
+                    .frame(width: 18)
+                Text(model.name)
+                    .font(isSelected ? VFont.bodyBold : VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        #if os(macOS)
+        .onHover { hovering in
+            hoveredModelId = hovering ? model.id : nil
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the popup model submenu (`ModelSubmenuPopup`) with an inline `ModelPickerBubble` rendered directly in the chat message list
- Typing `/model` (bare) intercepts client-side and shows an interactive picker inline; selecting a model sends `/model <id>` through the daemon so the switch is persisted
- `/model opus` (with args) continues to work via the daemon's slash command handler unchanged

## Test plan
- [ ] Type `/model` → inline picker appears in chat (not popup)
- [ ] Click a model → daemon confirms with "Switched Velly to ..." message, picker updates checkmark
- [ ] Click picker again → can re-select a different model
- [ ] Type `/model opus` → still works via daemon (text-based switch)
- [ ] Switch threads and come back → picker is ephemeral (expected), daemon confirmations persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
