### PR TITLE
fix: restore 'Wake up, my friend' initial message on first launch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -184,7 +184,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupWindowObserver()
         setupNotifications()
         setupAutoUpdate()
-        showMainWindow()
+        showMainWindow(initialMessage: "Wake up, my friend")
     }
 
     private func showAuthWindow() {


### PR DESCRIPTION
## Summary
Pass `initialMessage: "Wake up, my friend"` to `showMainWindow()` in the first-time setup path of `proceedToApp()`, so the assistant greets the user after completing onboarding (both WorkOS and Own API Key flows).

Only applies to first-time setup — replay onboarding hits the early return path and does not send the message.

## Test plan
- [ ] Fresh install: complete onboarding via Own API Key → see "Wake up, my friend" as first assistant message
- [ ] Fresh install: complete onboarding via Vellum Account (WorkOS) → see "Wake up, my friend" as first assistant message
- [ ] Replay onboarding → no duplicate "Wake up, my friend" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
