### PR TITLE
fix: gate 'Wake up, my friend' message to first-time onboarding only

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -161,7 +161,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hasSetupApp = false
     private var hasSetupDaemon = false
 
-    private func proceedToApp() {
+    private func proceedToApp(isFirstLaunch: Bool = false) {
         authWindow?.close()
         authWindow = nil
 
@@ -184,7 +184,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupWindowObserver()
         setupNotifications()
         setupAutoUpdate()
-        showMainWindow(initialMessage: "Wake up, my friend")
+        showMainWindow(initialMessage: isFirstLaunch ? "Wake up, my friend" : nil)
     }
 
     private func showAuthWindow() {
@@ -803,7 +803,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // By this point the user has either entered an API key (steps 0→1→2)
             // or authenticated via Vellum Account (WorkOS). Proceed directly —
             // don't re-check auth, which would show the auth gate again.
-            self?.proceedToApp()
+            self?.proceedToApp(isFirstLaunch: true)
         }
         onboarding.show()
         onboardingWindow = onboarding


### PR DESCRIPTION
## Summary
Addresses feedback from #3948: the `initialMessage` was firing on every app launch because `hasSetupApp` is an in-memory flag that resets per-process. 

Adds `isFirstLaunch` parameter to `proceedToApp()` (defaults to `false`). Only the `showOnboarding()` completion handler passes `true`, so the greeting only fires after completing onboarding for the first time — not on normal app starts or auth gate re-entries.

## Test plan
- [ ] Fresh install → complete onboarding → see "Wake up, my friend"
- [ ] Quit and relaunch (already onboarded) → no "Wake up, my friend"
- [ ] Logout and re-authenticate → no "Wake up, my friend"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
