### PR TITLE
fix: address codex feedback on integration_manage tool

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -417,7 +417,7 @@ function buildIntegrationSection(): string {
 
     let line = `- **${def.name}**: ${state}`;
     if (!configured && def.setupSkillId) {
-      line += `. Use \`integration_manage\` to check status and \`skill_load\` with id "${def.setupSkillId}" to help set it up.`;
+      line += `. Use \`integration_manage\` to check status. To set it up, first install the skill via \`vellum_skills_catalog\` (search for "${def.setupSkillId}"), then load it with \`skill_load\`.`;
     }
     lines.push(line);
   }

--- a/assistant/src/tools/integrations/manage.ts
+++ b/assistant/src/tools/integrations/manage.ts
@@ -1,6 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
 import {
   getStatus,
   listStatuses,
@@ -131,4 +132,4 @@ class IntegrationManageTool implements Tool {
   }
 }
 
-export const integrationManageTool = new IntegrationManageTool();
+registerTool(new IntegrationManageTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -15,7 +15,6 @@ import { accountManageTool } from './credentials/account-registry.js';
 import { reminderTool } from './reminder/reminder.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
-import { integrationManageTool } from './integrations/manage.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
@@ -36,6 +35,7 @@ export const eagerModules: string[] = [
   './schedule/list.js',
   './schedule/update.js',
   './schedule/delete.js',
+  './integrations/manage.js',
 ];
 
 // Tool names registered by the eager modules above.  Listed explicitly so
@@ -66,6 +66,7 @@ export const eagerModuleToolNames: string[] = [
   'schedule_list',
   'schedule_update',
   'schedule_delete',
+  'integration_manage',
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────
@@ -81,7 +82,6 @@ export const explicitTools: Tool[] = [
   reminderTool,
   screenWatchTool,
   vellumSkillsCatalogTool,
-  integrationManageTool,
   documentCreateTool,
   documentUpdateTool,
 ];


### PR DESCRIPTION
Fix two Codex P1 findings from PR #3634: (1) Update system prompt to instruct AI to install google-oauth-setup via vellum_skills_catalog before skill_load. (2) Migrate integration_manage from explicit class export to registerTool() side-effect pattern per AGENTS.md guidance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
