### PR TITLE
fix: update /release command to reference correct publish repo

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -77,4 +77,4 @@ Output:
 - The version number
 - The release notes
 - A link to the running workflow
-- Remind the user that the build takes ~15-20 minutes and will auto-publish to `alex-nork/vellum-assistant-macos-updates` when done
+- Remind the user that the build takes ~15-20 minutes and will auto-publish to `vellum-ai/velly` when done


### PR DESCRIPTION
## Summary
- The `/release` command referenced the outdated `alex-nork/vellum-assistant-macos-updates` repo, but the workflow actually publishes to `vellum-ai/velly`

## Test plan
- [x] Verified `.github/workflows/build-and-release-macos.yml` uses `vellum-ai/velly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
