### PR TITLE
PR 4: Extract app open proxy helper

### DIFF
--- a/assistant/src/__tests__/app-open-proxy.test.ts
+++ b/assistant/src/__tests__/app-open-proxy.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from 'bun:test';
+import type { ProxyResolver } from '../tools/apps/executors.js';
+import { openAppViaSurface } from '../tools/apps/open-proxy.js';
+
+describe('openAppViaSurface', () => {
+  test('returns proxy result content on success', async () => {
+    const resolver: ProxyResolver = async (_name, _input) => ({
+      content: 'opened-surface-123',
+      isError: false,
+    });
+
+    const result = await openAppViaSurface('app-1', resolver);
+    expect(result).toBe('opened-surface-123');
+  });
+
+  test('passes app_id and extraInput to the resolver', async () => {
+    let capturedName: string | undefined;
+    let capturedInput: Record<string, unknown> | undefined;
+
+    const resolver: ProxyResolver = async (name, input) => {
+      capturedName = name;
+      capturedInput = input;
+      return { content: 'ok', isError: false };
+    };
+
+    await openAppViaSurface('my-app', resolver, { preview: { title: 'Hello' } });
+
+    expect(capturedName).toBe('app_open');
+    expect(capturedInput).toEqual({
+      app_id: 'my-app',
+      preview: { title: 'Hello' },
+    });
+  });
+
+  test('returns informational message when resolver is undefined', async () => {
+    const result = await openAppViaSurface('app-1', undefined);
+    expect(result).toBe(
+      'App created but could not be opened (no connected client). Use app_open to open it manually.',
+    );
+  });
+
+  test('returns fallback text when resolver throws', async () => {
+    const resolver: ProxyResolver = async () => {
+      throw new Error('connection lost');
+    };
+
+    const result = await openAppViaSurface('app-1', resolver);
+    expect(result).toBe('Failed to auto-open app. Use app_open to open it manually.');
+  });
+
+  test('omits extraInput fields when not provided', async () => {
+    let capturedInput: Record<string, unknown> | undefined;
+
+    const resolver: ProxyResolver = async (_name, input) => {
+      capturedInput = input;
+      return { content: 'ok', isError: false };
+    };
+
+    await openAppViaSurface('app-2', resolver);
+    expect(capturedInput).toEqual({ app_id: 'app-2' });
+  });
+});

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -10,6 +10,7 @@
 
 import type { AppDefinition } from '../../memory/app-store.js';
 import type { EditEngineResult } from '../../memory/app-store.js';
+import { openAppViaSurface } from './open-proxy.js';
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -101,29 +102,32 @@ export async function executeAppCreate(
 
   const app = store.createApp({ name, description, schemaJson, htmlDefinition, pages, appType });
 
-  // Auto-open the app via the proxy resolver if available
+  // Auto-open the app via the shared open-proxy helper
   if (autoOpen && proxyToolResolver) {
-    try {
-      const openResult = await proxyToolResolver('app_open', { app_id: app.id, preview });
+    const extraInput = preview ? { preview } : undefined;
+    const openResultText = await openAppViaSurface(app.id, proxyToolResolver, extraInput);
+
+    // Determine whether the open succeeded by checking for the fallback text
+    const opened = openResultText !== 'Failed to auto-open app. Use app_open to open it manually.';
+    if (opened) {
       return {
         content: JSON.stringify({
           ...app,
           auto_opened: true,
-          open_result: openResult.content,
-        }),
-        isError: false,
-      };
-    } catch {
-      // App was created successfully but auto-open failed; return creation result with a note
-      return {
-        content: JSON.stringify({
-          ...app,
-          auto_opened: false,
-          auto_open_error: 'Failed to auto-open app. Use app_open to open it manually.',
+          open_result: openResultText,
         }),
         isError: false,
       };
     }
+
+    return {
+      content: JSON.stringify({
+        ...app,
+        auto_opened: false,
+        auto_open_error: openResultText,
+      }),
+      isError: false,
+    };
   }
 
   return { content: JSON.stringify(app), isError: false };

--- a/assistant/src/tools/apps/open-proxy.ts
+++ b/assistant/src/tools/apps/open-proxy.ts
@@ -1,0 +1,40 @@
+/**
+ * Centralized helper for resolving and executing the `app_open` proxy tool.
+ *
+ * This encapsulates the proxyToolResolver('app_open', ...) pattern so that
+ * callers (app_create auto-open, document-tool, future skill scripts) share
+ * a single implementation with consistent success/failure messaging.
+ */
+
+import type { ProxyResolver, ExecutorResult } from './executors.js';
+
+/**
+ * Open an app on the connected client via the proxy tool resolver.
+ *
+ * @param appId - The ID of the app to open.
+ * @param proxyToolResolver - Optional proxy resolver from the tool context.
+ *   When undefined (e.g. no macOS client connected), returns an informational
+ *   message rather than throwing.
+ * @param extraInput - Optional additional fields to pass alongside app_id
+ *   (e.g. preview metadata).
+ * @returns A stable result string describing the outcome.
+ */
+export async function openAppViaSurface(
+  appId: string,
+  proxyToolResolver: ProxyResolver | undefined,
+  extraInput?: Record<string, unknown>,
+): Promise<string> {
+  if (!proxyToolResolver) {
+    return 'App created but could not be opened (no connected client). Use app_open to open it manually.';
+  }
+
+  try {
+    const result: ExecutorResult = await proxyToolResolver('app_open', {
+      app_id: appId,
+      ...extraInput,
+    });
+    return result.content;
+  } catch {
+    return 'Failed to auto-open app. Use app_open to open it manually.';
+  }
+}

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -4,6 +4,7 @@ import type { ToolDefinition } from '../../providers/types.js';
 import * as appStore from '../../memory/app-store.js';
 import { randomUUID } from 'node:crypto';
 import { generateEditorHTML } from './editor-template.js';
+import { openAppViaSurface } from '../apps/open-proxy.js';
 
 // ── document_create ──────────────────────────────────────────────────
 
@@ -63,48 +64,55 @@ export class DocumentCreateTool implements Tool {
       appType: 'app',
     });
 
-    // Open the document via the proxy resolver if available
-    if (context.proxyToolResolver) {
-      try {
-        const openResult = await context.proxyToolResolver('app_open', {
-          app_id: app.id,
-          preview: {
-            title,
-            subtitle: 'Document',
-            description: 'Long-form document with rich text editor',
-            icon: '📝',
-            metrics: [{ label: 'Words', value: String(wordCount) }],
-          },
-        });
+    // Open the document via the shared open-proxy helper
+    const openResultText = await openAppViaSurface(
+      app.id,
+      context.proxyToolResolver,
+      {
+        preview: {
+          title,
+          subtitle: 'Document',
+          description: 'Long-form document with rich text editor',
+          icon: '\u{1F4DD}',
+          metrics: [{ label: 'Words', value: String(wordCount) }],
+        },
+      },
+    );
 
-        return {
-          content: JSON.stringify({
-            app_id: appId,
-            surface_id: app.id, // For now, use app ID as surface ID
-            title,
-            opened: true,
-            open_result: openResult.content,
-          }),
-          isError: false,
-        };
-      } catch {
-        return {
-          content: JSON.stringify({
-            app_id: appId,
-            title,
-            opened: false,
-            error: 'Failed to open document editor',
-          }),
-          isError: false,
-        };
-      }
+    // The helper returns fallback text when the resolver is missing or throws
+    const opened = !!context.proxyToolResolver &&
+      openResultText !== 'Failed to auto-open app. Use app_open to open it manually.';
+
+    if (opened) {
+      return {
+        content: JSON.stringify({
+          app_id: appId,
+          surface_id: app.id,
+          title,
+          opened: true,
+          open_result: openResultText,
+        }),
+        isError: false,
+      };
+    }
+
+    if (!context.proxyToolResolver) {
+      return {
+        content: JSON.stringify({
+          app_id: appId,
+          title,
+          message: 'Document created but could not be opened (no proxy resolver available)',
+        }),
+        isError: false,
+      };
     }
 
     return {
       content: JSON.stringify({
         app_id: appId,
         title,
-        message: 'Document created but could not be opened (no proxy resolver available)',
+        opened: false,
+        error: 'Failed to open document editor',
       }),
       isError: false,
     };


### PR DESCRIPTION
## Summary
- Creates `open-proxy.ts` with centralized `openAppViaSurface` helper
- Refactors `app_create` auto-open in `executors.ts` to use shared helper
- Refactors `document-tool.ts` app-open call to use shared helper
- No behavior change

## Test plan
- [x] New open-proxy tests pass (5 tests)
- [x] Registry tests pass (34 tests)
- [x] Executor tests pass (35 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
