### PR TITLE
PR 01: Baseline Characterization — No Auto Media Embeds Today

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Baseline characterization tests proving the current codebase has no automatic
+/// media embed behavior. When a user or assistant message contains a YouTube,
+/// Vimeo, Loom, or image URL, the text is rendered as-is — no inline video
+/// player, no preview card, no iframe-like embed view is generated.
+///
+/// These tests lock the pre-embed status quo so that future PRs introducing
+/// media embeds can demonstrate the delta.
+@MainActor
+final class ChatMediaEmbedBaselineTests: XCTestCase {
+
+    private var daemonClient: DaemonClient!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        daemonClient.sendOverride = { _ in }
+        viewModel = ChatViewModel(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - User messages with media URLs remain plain text
+
+    func testUserMessageWithYouTubeLinkIsPlainText() {
+        viewModel.sessionId = "sess-1"
+        viewModel.inputText = "Check this out: https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .user)
+        XCTAssertTrue(msg.text.contains("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+                       "YouTube URL should be preserved verbatim in message text")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surface should be created for a YouTube link")
+        XCTAssertTrue(msg.toolCalls.isEmpty,
+                       "No tool call should be created for a YouTube link")
+        XCTAssertTrue(msg.attachments.isEmpty,
+                       "No attachment should be synthesized for a YouTube link")
+    }
+
+    func testUserMessageWithVimeoLinkIsPlainText() {
+        viewModel.sessionId = "sess-1"
+        viewModel.inputText = "Watch: https://vimeo.com/123456789"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .user)
+        XCTAssertTrue(msg.text.contains("https://vimeo.com/123456789"),
+                       "Vimeo URL should be preserved verbatim in message text")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surface should be created for a Vimeo link")
+    }
+
+    func testUserMessageWithLoomLinkIsPlainText() {
+        viewModel.sessionId = "sess-1"
+        viewModel.inputText = "Here's my recording: https://www.loom.com/share/abc123def456"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .user)
+        XCTAssertTrue(msg.text.contains("https://www.loom.com/share/abc123def456"),
+                       "Loom URL should be preserved verbatim in message text")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surface should be created for a Loom link")
+    }
+
+    func testUserMessageWithImageURLIsPlainText() {
+        viewModel.sessionId = "sess-1"
+        viewModel.inputText = "Look at this: https://example.com/photo.png"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .user)
+        XCTAssertTrue(msg.text.contains("https://example.com/photo.png"),
+                       "Image URL should be preserved verbatim in message text")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surface should be created for an image link")
+        XCTAssertTrue(msg.attachments.isEmpty,
+                       "No attachment should be synthesized from a plain image URL")
+    }
+
+    // MARK: - Assistant messages with media URLs remain plain text
+
+    func testAssistantMessageWithYouTubeLinkIsPlainText() {
+        let url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        viewModel.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "Here is a video: \(url)")
+        ))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .assistant)
+        XCTAssertTrue(msg.text.contains(url),
+                       "YouTube URL should be preserved verbatim in assistant text")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surface should be auto-created for a YouTube link in assistant message")
+        XCTAssertTrue(msg.toolCalls.isEmpty,
+                       "No tool call should be synthesized for a YouTube link")
+        XCTAssertTrue(msg.attachments.isEmpty,
+                       "No attachment should be synthesized for a YouTube link")
+    }
+
+    func testAssistantMessageWithVimeoLinkIsPlainText() {
+        let url = "https://vimeo.com/987654321"
+        viewModel.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "Check this video: \(url)")
+        ))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .assistant)
+        XCTAssertTrue(msg.text.contains(url),
+                       "Vimeo URL should be preserved verbatim in assistant text")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surface should be auto-created for a Vimeo link in assistant message")
+    }
+
+    func testAssistantMessageWithLoomLinkIsPlainText() {
+        let url = "https://www.loom.com/share/xyz789"
+        viewModel.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "Recording: \(url)")
+        ))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .assistant)
+        XCTAssertTrue(msg.text.contains(url),
+                       "Loom URL should be preserved verbatim in assistant text")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surface should be auto-created for a Loom link in assistant message")
+    }
+
+    func testAssistantMessageWithImageURLIsPlainText() {
+        let url = "https://example.com/chart.jpg"
+        viewModel.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "Here's the chart: \(url)")
+        ))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.role, .assistant)
+        XCTAssertTrue(msg.text.contains(url),
+                       "Image URL should be preserved verbatim in assistant text")
+        XCTAssertTrue(msg.attachments.isEmpty,
+                       "No attachment should be auto-synthesized from a plain image URL in assistant text")
+    }
+
+    // MARK: - Multiple media URLs in a single message
+
+    func testAssistantMessageWithMultipleMediaURLsHasNoEmbeds() {
+        let text = """
+        Here are some resources:
+        - YouTube: https://www.youtube.com/watch?v=abc123
+        - Vimeo: https://vimeo.com/456789
+        - Loom: https://www.loom.com/share/def012
+        - Image: https://example.com/diagram.png
+        """
+        viewModel.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: text)
+        ))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surfaces should be auto-created for any media URLs")
+        XCTAssertTrue(msg.attachments.isEmpty,
+                       "No attachments should be auto-synthesized from media URLs")
+        XCTAssertTrue(msg.toolCalls.isEmpty,
+                       "No tool calls should be synthesized for media URLs")
+    }
+
+    // MARK: - ChatMessage model has no media embed infrastructure
+
+    func testChatMessageHasNoMediaEmbedProperty() {
+        let message = ChatMessage(role: .assistant, text: "https://www.youtube.com/watch?v=test")
+
+        // Verify the message stores the URL as plain text with no special handling
+        XCTAssertEqual(message.text, "https://www.youtube.com/watch?v=test")
+        XCTAssertTrue(message.inlineSurfaces.isEmpty,
+                       "ChatMessage should not have pre-populated inline surfaces for URLs")
+        XCTAssertTrue(message.attachments.isEmpty,
+                       "ChatMessage should not auto-generate attachments from URL text")
+        XCTAssertEqual(message.textSegments, ["https://www.youtube.com/watch?v=test"],
+                       "URL should be stored as a single plain text segment")
+        XCTAssertEqual(message.contentOrder, [.text(0)],
+                       "Content order should only contain the text block — no embed blocks")
+    }
+
+    // MARK: - History hydration preserves URLs as plain text
+
+    func testPopulateFromHistoryWithMediaURLsHasNoEmbeds() {
+        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+            IPCHistoryResponseMessage(
+                id: nil,
+                role: "assistant",
+                text: "Check out https://www.youtube.com/watch?v=abc and https://vimeo.com/123",
+                timestamp: 1000,
+                toolCalls: nil,
+                toolCallsBeforeText: nil,
+                attachments: nil,
+                textSegments: nil,
+                contentOrder: nil,
+                surfaces: nil
+            ),
+        ]
+
+        viewModel.populateFromHistory(historyItems)
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertTrue(msg.text.contains("https://www.youtube.com/watch?v=abc"),
+                       "YouTube URL should be preserved in history-hydrated message")
+        XCTAssertTrue(msg.text.contains("https://vimeo.com/123"),
+                       "Vimeo URL should be preserved in history-hydrated message")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "No inline surfaces should be auto-created during history hydration")
+        XCTAssertTrue(msg.attachments.isEmpty,
+                       "No attachments should be auto-synthesized during history hydration")
+    }
+
+    // MARK: - Streamed media URLs produce no side-effects
+
+    func testStreamingYouTubeURLProducesNoSideEffects() {
+        // Simulate the URL arriving across multiple text deltas (realistic streaming)
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Link: https://www.")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "youtube.com/watch")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "?v=dQw4w9WgXcQ")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.text, "Link: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        XCTAssertTrue(msg.inlineSurfaces.isEmpty,
+                       "Streaming a YouTube URL should not trigger auto-embed creation")
+        XCTAssertTrue(msg.attachments.isEmpty,
+                       "Streaming a YouTube URL should not trigger attachment synthesis")
+        XCTAssertFalse(msg.isStreaming,
+                        "Message should be finalized after messageComplete")
+    }
+}

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -11,6 +11,7 @@ import Combine
 @MainActor
 final class MockDaemonClient: DaemonClientProtocol {
     var sentMessages: [Any] = []
+    var isConnected: Bool = true
     var isBlobTransportAvailable: Bool = false
     private var testContinuation: AsyncStream<ServerMessage>.Continuation?
     private var _messages: AsyncStream<ServerMessage>
@@ -35,6 +36,14 @@ final class MockDaemonClient: DaemonClientProtocol {
 
     func send<T: Encodable>(_ message: T) throws {
         sentMessages.append(message)
+    }
+
+    func connect() async throws {
+        isConnected = true
+    }
+
+    func disconnect() {
+        isConnected = false
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds 12 baseline characterization tests proving that YouTube, Vimeo, Loom, and image URLs in chat messages are rendered as plain text only — no inline video players, preview cards, or embed views exist in the current codebase.
- Tests cover user messages, assistant messages, streamed deltas, multi-URL messages, ChatMessage model properties, and history hydration — all confirming zero media embed infrastructure.
- Fixes pre-existing `MockDaemonClient` build error (missing `isConnected`, `connect()`, `disconnect()` conformance to updated `DaemonClientProtocol`).

## Test plan
- [x] All 12 tests in `ChatMediaEmbedBaselineTests` pass (0 failures)
- [x] Test target compiles cleanly after `MockDaemonClient` fix

PR 01 of 42 in the media embeds plan. This PR locks the status quo so subsequent PRs can demonstrate the delta when embed behavior is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
