### PR TITLE
fix: correct credential security chip text in FormSurfaceView

### DIFF
--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -145,7 +145,7 @@ public struct FormSurfaceView: View {
             HStack(spacing: VSpacing.xs) {
                 Image(systemName: "lock.shield.fill")
                     .font(VFont.caption)
-                Text("Stored securely")
+                Text("Secured input")
                     .font(VFont.caption)
             }
             .foregroundColor(VColor.textSecondary)
@@ -157,10 +157,10 @@ public struct FormSurfaceView: View {
         .buttonStyle(.plain)
         .popover(isPresented: $showingSecurityInfo) {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("Credential Security")
+                Text("Password Security")
                     .font(VFont.captionMedium)
                     .foregroundColor(VColor.textPrimary)
-                Text("Credentials are saved to the macOS Keychain. If unavailable, they're stored in an encrypted local file (~/.vellum/protected/). Values are never logged.")
+                Text("Password values are masked in the UI using a secure text field. Submitted values are sent to the assistant for processing and are not logged.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Address Codex P1 feedback on PR #3950: the popover incorrectly claimed password values are stored in macOS Keychain. In reality, form password fields use SecureField for masked input but values are sent to the assistant as regular surface action data. Updated chip label from 'Stored securely' to 'Secured input' and popover text to accurately describe the security posture.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
