### PR TITLE
PR 6: Split core app proxy vs data tool sets

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -16,7 +16,7 @@ import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js'
 import { generateScopeOptions } from '../permissions/checker.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
-import { allAppTools } from '../tools/apps/definitions.js';
+import { coreAppProxyTools } from '../tools/apps/definitions.js';
 import { requestComputerControlTool } from '../tools/computer-use/request-computer-control.js';
 import {
   refreshSurfacesForApp,
@@ -54,7 +54,7 @@ export function buildToolDefinitions(): ToolDefinition[] {
   return [
     ...getAllToolDefinitions(),
     ...allUiSurfaceTools.map((t) => t.getDefinition()),
-    ...allAppTools.filter((t) => t.executionMode === 'proxy').map((t) => t.getDefinition()),
+    ...coreAppProxyTools.map((t) => t.getDefinition()),
     // Escalation tool: allows text_qa sessions to hand off to computer use
     requestComputerControlTool.getDefinition(),
   ];

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -507,12 +507,17 @@ export const appFileWriteTool: Tool = {
 };
 
 // ---------------------------------------------------------------------------
-// All tools exported as array for convenience
+// Proxy-only tools (always core, never migrated to skill)
 // ---------------------------------------------------------------------------
 
-export const allAppTools: Tool[] = [
+export const coreAppProxyTools: Tool[] = [appOpenTool];
+
+// ---------------------------------------------------------------------------
+// Non-proxy data tools (will migrate to skill in a later PR)
+// ---------------------------------------------------------------------------
+
+export const coreAppDataTools: Tool[] = [
   appCreateTool,
-  appOpenTool,
   appListTool,
   appQueryTool,
   appUpdateTool,
@@ -522,3 +527,9 @@ export const allAppTools: Tool[] = [
   appFileEditTool,
   appFileWriteTool,
 ];
+
+// ---------------------------------------------------------------------------
+// Combined for backwards compatibility during migration
+// ---------------------------------------------------------------------------
+
+export const allAppTools: Tool[] = [...coreAppProxyTools, ...coreAppDataTools];


### PR DESCRIPTION
## Summary
- Exports explicit `coreAppProxyTools` and `coreAppDataTools` arrays from `definitions.ts`
- Keeps `allAppTools` as a combined array for backward compatibility during migration
- `session-tool-setup.ts` now references `coreAppProxyTools` directly instead of filtering `allAppTools` by `executionMode`
- No behavior change

## Test plan
- [x] Registry tests pass (34/34)
- [x] Starter task flow tests pass (5/5)
- [x] `bun test` green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
