### PR TITLE
PR 5: Add app builder skill script runners (dormant)

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -1,0 +1,290 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { ToolContext, ToolExecutionResult } from '../tools/types.js';
+import type { AppStore, ExecutorResult, ProxyResolver } from '../tools/apps/executors.js';
+import type { AppDefinition } from '../memory/app-store.js';
+import type { EditEngineResult } from '../tools/shared/filesystem/edit-engine.js';
+
+// ---------------------------------------------------------------------------
+// Mock factory helpers
+// ---------------------------------------------------------------------------
+
+function makeApp(overrides: Partial<AppDefinition> = {}): AppDefinition {
+  return {
+    id: 'app-1',
+    name: 'Test App',
+    description: 'A test app',
+    schemaJson: '{}',
+    htmlDefinition: '<h1>Hi</h1>',
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+function makeMockStore(overrides: Partial<AppStore> = {}): AppStore {
+  return {
+    getApp: () => makeApp(),
+    listApps: () => [makeApp()],
+    queryAppRecords: () => [],
+    listAppFiles: () => ['index.html'],
+    readAppFile: () => '<h1>Hi</h1>',
+    createApp: (params) =>
+      makeApp({ name: params.name, description: params.description }),
+    updateApp: (id, updates) => makeApp({ id, ...updates }),
+    deleteApp: () => {},
+    writeAppFile: () => {},
+    editAppFile: () =>
+      ({
+        ok: true,
+        updatedContent: 'new',
+        matchCount: 1,
+        matchMethod: 'exact',
+        similarity: 1,
+        actualOld: 'old',
+        actualNew: 'new',
+      }) as EditEngineResult,
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'session-1',
+    conversationId: 'conv-1',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock the app-store module so that skill scripts import our controllable store
+// ---------------------------------------------------------------------------
+
+const mockStore = makeMockStore();
+
+mock.module('../memory/app-store.js', () => mockStore);
+
+// ---------------------------------------------------------------------------
+// Import skill scripts (after mocking)
+// ---------------------------------------------------------------------------
+
+import * as appCreateScript from '../config/bundled-skills/app-builder/tools/app-create.js';
+import * as appListScript from '../config/bundled-skills/app-builder/tools/app-list.js';
+import * as appQueryScript from '../config/bundled-skills/app-builder/tools/app-query.js';
+import * as appUpdateScript from '../config/bundled-skills/app-builder/tools/app-update.js';
+import * as appDeleteScript from '../config/bundled-skills/app-builder/tools/app-delete.js';
+import * as appFileListScript from '../config/bundled-skills/app-builder/tools/app-file-list.js';
+import * as appFileReadScript from '../config/bundled-skills/app-builder/tools/app-file-read.js';
+import * as appFileEditScript from '../config/bundled-skills/app-builder/tools/app-file-edit.js';
+import * as appFileWriteScript from '../config/bundled-skills/app-builder/tools/app-file-write.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('app-builder skill tool scripts', () => {
+  // ---- app-create --------------------------------------------------------
+
+  describe('app-create', () => {
+    test('exports a run function', () => {
+      expect(typeof appCreateScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppCreate and returns result', async () => {
+      const result = await appCreateScript.run(
+        { name: 'My App', html: '<p>Hello</p>' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.name).toBe('My App');
+    });
+
+    test('passes proxyToolResolver from context for auto-open', async () => {
+      const proxy: ToolContext['proxyToolResolver'] = async () => ({
+        content: 'opened',
+        isError: false,
+      });
+      const result = await appCreateScript.run(
+        { name: 'Auto App', html: '<div/>' },
+        makeContext({ proxyToolResolver: proxy }),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.auto_opened).toBe(true);
+      expect(parsed.open_result).toBe('opened');
+    });
+
+    test('handles missing proxyToolResolver gracefully', async () => {
+      const result = await appCreateScript.run(
+        { name: 'No Proxy', html: '<p/>' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      // No auto-open fields when resolver is absent
+      expect(parsed.auto_opened).toBeUndefined();
+    });
+  });
+
+  // ---- app-list ----------------------------------------------------------
+
+  describe('app-list', () => {
+    test('exports a run function', () => {
+      expect(typeof appListScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppList and returns result', async () => {
+      const result = await appListScript.run({}, makeContext());
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeGreaterThan(0);
+      expect(parsed[0].id).toBe('app-1');
+    });
+  });
+
+  // ---- app-query ---------------------------------------------------------
+
+  describe('app-query', () => {
+    test('exports a run function', () => {
+      expect(typeof appQueryScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppQuery and returns result', async () => {
+      const result = await appQueryScript.run(
+        { app_id: 'app-1' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      expect(JSON.parse(result.content)).toEqual([]);
+    });
+  });
+
+  // ---- app-update --------------------------------------------------------
+
+  describe('app-update', () => {
+    test('exports a run function', () => {
+      expect(typeof appUpdateScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppUpdate and returns result', async () => {
+      const result = await appUpdateScript.run(
+        { app_id: 'app-1', name: 'Updated' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.name).toBe('Updated');
+    });
+  });
+
+  // ---- app-delete --------------------------------------------------------
+
+  describe('app-delete', () => {
+    test('exports a run function', () => {
+      expect(typeof appDeleteScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppDelete and returns result', async () => {
+      const result = await appDeleteScript.run(
+        { app_id: 'app-1' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.deleted).toBe(true);
+      expect(parsed.appId).toBe('app-1');
+    });
+  });
+
+  // ---- app-file-list -----------------------------------------------------
+
+  describe('app-file-list', () => {
+    test('exports a run function', () => {
+      expect(typeof appFileListScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppFileList and returns result', async () => {
+      const result = await appFileListScript.run(
+        { app_id: 'app-1' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      expect(JSON.parse(result.content)).toEqual(['index.html']);
+    });
+  });
+
+  // ---- app-file-read -----------------------------------------------------
+
+  describe('app-file-read', () => {
+    test('exports a run function', () => {
+      expect(typeof appFileReadScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppFileRead and returns formatted content', async () => {
+      const result = await appFileReadScript.run(
+        { app_id: 'app-1', path: 'index.html' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      // Content should include line numbers
+      expect(result.content).toContain('1\t');
+    });
+  });
+
+  // ---- app-file-edit -----------------------------------------------------
+
+  describe('app-file-edit', () => {
+    test('exports a run function', () => {
+      expect(typeof appFileEditScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppFileEdit and returns result', async () => {
+      const result = await appFileEditScript.run(
+        {
+          app_id: 'app-1',
+          path: 'index.html',
+          old_string: 'old',
+          new_string: 'new',
+        },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.ok).toBe(true);
+    });
+
+    test('returns error when old_string is empty', async () => {
+      const result = await appFileEditScript.run(
+        {
+          app_id: 'app-1',
+          path: 'index.html',
+          old_string: '',
+          new_string: 'new',
+        },
+        makeContext(),
+      );
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // ---- app-file-write ----------------------------------------------------
+
+  describe('app-file-write', () => {
+    test('exports a run function', () => {
+      expect(typeof appFileWriteScript.run).toBe('function');
+    });
+
+    test('delegates to executeAppFileWrite and returns result', async () => {
+      const result = await appFileWriteScript.run(
+        { app_id: 'app-1', path: 'new.html', content: '<div/>' },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.written).toBe(true);
+      expect(parsed.path).toBe('new.html');
+    });
+  });
+});

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -1,0 +1,15 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppCreate } from '../../../../tools/apps/executors.js';
+import type { AppCreateInput } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppCreate(
+    input as unknown as AppCreateInput,
+    appStore,
+    context.proxyToolResolver,
+  );
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
@@ -1,0 +1,10 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppDelete } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppDelete({ app_id: input.app_id as string }, appStore);
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-file-edit.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-file-edit.ts
@@ -1,0 +1,11 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppFileEdit } from '../../../../tools/apps/executors.js';
+import type { AppFileEditInput } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppFileEdit(input as unknown as AppFileEditInput, appStore);
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-file-list.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-file-list.ts
@@ -1,0 +1,10 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppFileList } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppFileList({ app_id: input.app_id as string }, appStore);
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-file-read.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-file-read.ts
@@ -1,0 +1,18 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppFileRead } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppFileRead(
+    {
+      app_id: input.app_id as string,
+      path: input.path as string,
+      offset: input.offset as number | undefined,
+      limit: input.limit as number | undefined,
+    },
+    appStore,
+  );
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-file-write.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-file-write.ts
@@ -1,0 +1,11 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppFileWrite } from '../../../../tools/apps/executors.js';
+import type { AppFileWriteInput } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppFileWrite(input as unknown as AppFileWriteInput, appStore);
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-list.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-list.ts
@@ -1,0 +1,10 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppList } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  _input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppList(appStore);
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-query.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-query.ts
@@ -1,0 +1,10 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppQuery } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppQuery({ app_id: input.app_id as string }, appStore);
+}

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
@@ -1,0 +1,20 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import * as appStore from '../../../../memory/app-store.js';
+import { executeAppUpdate } from '../../../../tools/apps/executors.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppUpdate(
+    {
+      app_id: input.app_id as string,
+      name: input.name as string | undefined,
+      description: input.description as string | undefined,
+      schema_json: input.schema_json as string | undefined,
+      html: input.html as string | undefined,
+      pages: input.pages as Record<string, string> | undefined,
+    },
+    appStore,
+  );
+}


### PR DESCRIPTION
## Summary
- Creates 9 skill tool scripts for app-builder skill under `assistant/src/config/bundled-skills/app-builder/tools/`
- Each script exports a `run(input, context)` function that delegates to shared executor functions in `executors.ts`
- No TOOLS.json yet — scripts remain dormant in production
- Includes comprehensive tests (21 tests, all passing)

## Test plan
- [x] All 21 skill script tests pass (`bun test src/__tests__/app-builder-tool-scripts.test.ts`)
- [x] No existing files modified
- [x] bun test green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
