### PR TITLE
fix: use install action instead of search for vellum_skills_catalog in system prompt

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -490,7 +490,7 @@ function buildIntegrationSection(): string {
 
     let line = `- **${def.name}**: ${state}`;
     if (!configured && def.setupSkillId) {
-      line += `. Use \`integration_manage\` to check status. To set it up, first install the skill via \`vellum_skills_catalog\` (search for "${def.setupSkillId}"), then load it with \`skill_load\`.`;
+      line += `. Use \`integration_manage\` to check status. To set it up, first install the skill via \`vellum_skills_catalog\` (install with skill_id "${def.setupSkillId}"), then load it with \`skill_load\`.`;
     }
     lines.push(line);
   }


### PR DESCRIPTION
Address Devin feedback on PR #3951: the system prompt told the AI to 'search for' a skill via vellum_skills_catalog, but that tool only supports 'list' and 'install' actions. Changed to 'install with skill_id' to match the actual API. The Codex feedback about the eager module count was already fixed by another PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
