### PR TITLE
PR 8: Source swap - app-builder skill owns non-proxy app tools

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -236,10 +236,10 @@ describe('baseline characterization: hardcoded tool loading', () => {
 });
 
 describe('baseline characterization: core app tool surface', () => {
-  test('core registry includes all non-proxy app tools', async () => {
+  test('non-proxy app tools are NOT in core registry (now skill-provided)', async () => {
     await initializeTools();
 
-    const expectedAppTools = [
+    const nonProxyAppTools = [
       'app_create',
       'app_list',
       'app_query',
@@ -251,15 +251,14 @@ describe('baseline characterization: core app tool surface', () => {
       'app_file_write',
     ];
 
-    for (const name of expectedAppTools) {
+    for (const name of nonProxyAppTools) {
       const tool = getTool(name);
-      expect(tool).toBeDefined();
-      expect(tool?.executionMode).toBe('local');
+      expect(tool).toBeUndefined();
     }
 
     const definitionNames = getAllToolDefinitions().map((def) => def.name);
-    for (const name of expectedAppTools) {
-      expect(definitionNames).toContain(name);
+    for (const name of nonProxyAppTools) {
+      expect(definitionNames).not.toContain(name);
     }
   });
 
@@ -275,7 +274,7 @@ describe('baseline characterization: core app tool surface', () => {
     expect(definitionNames).not.toContain('app_open');
   });
 
-  test('bundled app-builder skill is instruction-only (no TOOLS.json)', async () => {
+  test('bundled app-builder skill has TOOLS.json manifest', async () => {
     const path = await import('node:path');
     const fs = await import('node:fs');
 
@@ -286,7 +285,7 @@ describe('baseline characterization: core app tool surface', () => {
     );
     const toolsJsonPath = path.join(skillDir, 'TOOLS.json');
 
-    expect(fs.existsSync(toolsJsonPath)).toBe(false);
+    expect(fs.existsSync(toolsJsonPath)).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -1550,6 +1550,90 @@ describe('bundled skill: weather', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Bundled skill: app-builder
+// ---------------------------------------------------------------------------
+
+const APP_BUILDER_TOOL_NAMES = [
+  'app_create',
+  'app_list',
+  'app_query',
+  'app_update',
+  'app_delete',
+  'app_file_list',
+  'app_file_read',
+  'app_file_edit',
+  'app_file_write',
+] as const;
+
+describe('bundled skill: app-builder', () => {
+  let sessionState: Map<string, string>;
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
+    sessionState = new Map<string, string>();
+  });
+
+  test('app-builder skill activation projects all 9 canonical non-proxy tool definitions', () => {
+    mockCatalog = [makeSkill('app-builder', '/path/to/bundled-skills/app-builder')];
+    mockManifests = { 'app-builder': makeManifest([...APP_BUILDER_TOOL_NAMES]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="app-builder" />'),
+    ];
+
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(result.toolDefinitions).toHaveLength(9);
+    expect(result.toolDefinitions.map((d) => d.name)).toEqual([...APP_BUILDER_TOOL_NAMES]);
+    expect(result.allowedToolNames).toEqual(new Set(APP_BUILDER_TOOL_NAMES));
+  });
+
+  test('app-builder tools are NOT available when skill is not in active context', () => {
+    mockCatalog = [makeSkill('app-builder', '/path/to/bundled-skills/app-builder')];
+    mockManifests = { 'app-builder': makeManifest([...APP_BUILDER_TOOL_NAMES]) };
+
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ];
+
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(result.toolDefinitions).toHaveLength(0);
+    expect(result.allowedToolNames.size).toBe(0);
+    for (const name of APP_BUILDER_TOOL_NAMES) {
+      expect(result.allowedToolNames.has(name)).toBe(false);
+    }
+  });
+
+  test('skill-projected app tools use host execution (script runners)', () => {
+    mockCatalog = [makeSkill('app-builder', '/path/to/bundled-skills/app-builder')];
+    mockManifests = { 'app-builder': makeManifest([...APP_BUILDER_TOOL_NAMES]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="app-builder" />'),
+    ];
+
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    const tools = mockRegisteredTools.get('app-builder');
+    expect(tools).toBeDefined();
+    expect(tools!.length).toBe(9);
+
+    // All tools should have skill origin metadata
+    for (const tool of tools!) {
+      expect(tool.origin).toBe('skill');
+      expect(tool.ownerSkillId).toBe('app-builder');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tamper detection regression tests
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -1,0 +1,275 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "app_create",
+      "description": "Create a persistent app with a name, optional description, JSON schema, and HTML definition.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the app"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the app"
+          },
+          "schema_json": {
+            "type": "string",
+            "description": "JSON schema defining the app data structure"
+          },
+          "html": {
+            "type": "string",
+            "description": "HTML definition for rendering the app (main index.html page)"
+          },
+          "pages": {
+            "type": "object",
+            "description": "Optional additional pages as a mapping of filename to HTML content (e.g. {\"settings.html\": \"<html>...</html>\"}). Navigate between pages with <a href=\"settings.html\">. Do not include index.html here — use the html parameter instead.",
+            "additionalProperties": { "type": "string" }
+          },
+          "type": {
+            "type": "string",
+            "enum": ["app", "site"],
+            "description": "Type of creation: 'app' for interactive apps with data/state, 'site' for presentational content (portfolios, landing pages, blogs)"
+          },
+          "auto_open": {
+            "type": "boolean",
+            "description": "Automatically open the app after creation. Defaults to true. When true, the app is immediately displayed in a dynamic_page surface without needing a separate app_open call."
+          },
+          "preview": {
+            "type": "object",
+            "description": "Optional inline preview card shown in chat. Provides a compact summary so the user sees what was built without opening the app.",
+            "properties": {
+              "title": { "type": "string", "description": "Preview card title" },
+              "subtitle": { "type": "string", "description": "Optional subtitle" },
+              "description": { "type": "string", "description": "Optional short description" },
+              "icon": { "type": "string", "description": "Optional emoji icon" },
+              "metrics": {
+                "type": "array",
+                "description": "Optional key-value metrics",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": { "type": "string" },
+                    "value": { "type": "string" }
+                  },
+                  "required": ["label", "value"]
+                }
+              }
+            },
+            "required": ["title"]
+          }
+        },
+        "required": ["name", "html"]
+      },
+      "executor": "tools/app-create.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_list",
+      "description": "List all persistent apps. Returns an array of {id, name, description, updatedAt}.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "executor": "tools/app-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_query",
+      "description": "Query all records for a persistent app. Returns an array of records.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app to query records for"
+          }
+        },
+        "required": ["app_id"]
+      },
+      "executor": "tools/app-query.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_update",
+      "description": "Update a persistent app definition. Provide the app_id and any fields to update (name, description, schema_json, html).",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app to update"
+          },
+          "name": {
+            "type": "string",
+            "description": "Updated name for the app"
+          },
+          "description": {
+            "type": "string",
+            "description": "Updated description for the app"
+          },
+          "schema_json": {
+            "type": "string",
+            "description": "Updated JSON schema"
+          },
+          "html": {
+            "type": "string",
+            "description": "Updated HTML definition"
+          },
+          "pages": {
+            "type": "object",
+            "description": "Updated additional pages as a mapping of filename to HTML content.",
+            "additionalProperties": { "type": "string" }
+          }
+        },
+        "required": ["app_id"]
+      },
+      "executor": "tools/app-update.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_delete",
+      "description": "Delete a persistent app and all its records.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app to delete"
+          }
+        },
+        "required": ["app_id"]
+      },
+      "executor": "tools/app-delete.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_file_list",
+      "description": "List all files in an app. Returns a JSON array of file paths.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app"
+          }
+        },
+        "required": ["app_id"]
+      },
+      "executor": "tools/app-file-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_file_read",
+      "description": "Read the contents of a file in an app. Returns content with line numbers in cat -n format.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app"
+          },
+          "path": {
+            "type": "string",
+            "description": "Relative file path within the app"
+          },
+          "offset": {
+            "type": "number",
+            "description": "1-based line number to start reading from (default: 1)"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of lines to return (default: all)"
+          }
+        },
+        "required": ["app_id", "path"]
+      },
+      "executor": "tools/app-file-read.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_file_edit",
+      "description": "Edit a file in an app by replacing a string. Uses exact match-and-replace.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app"
+          },
+          "path": {
+            "type": "string",
+            "description": "Relative file path within the app"
+          },
+          "old_string": {
+            "type": "string",
+            "description": "The exact string to find and replace"
+          },
+          "new_string": {
+            "type": "string",
+            "description": "The replacement string"
+          },
+          "replace_all": {
+            "type": "boolean",
+            "description": "Replace all occurrences instead of just the first (default: false)"
+          },
+          "status": {
+            "type": "string",
+            "description": "Optional short human-readable progress message shown to the user (e.g. 'adding dark mode styles')"
+          }
+        },
+        "required": ["app_id", "path", "old_string", "new_string"]
+      },
+      "executor": "tools/app-file-edit.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_file_write",
+      "description": "Write (create or overwrite) a file in an app.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app"
+          },
+          "path": {
+            "type": "string",
+            "description": "Relative file path within the app"
+          },
+          "content": {
+            "type": "string",
+            "description": "The content to write to the file"
+          },
+          "status": {
+            "type": "string",
+            "description": "Optional short human-readable progress message shown to the user (e.g. 'adding dark mode styles')"
+          }
+        },
+        "required": ["app_id", "path", "content"]
+      },
+      "executor": "tools/app-file-write.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/tools/apps/registry.ts
+++ b/assistant/src/tools/apps/registry.ts
@@ -1,14 +1,16 @@
 /**
- * Registers all app tools with the daemon's tool registry.
+ * Registers app proxy tools with the daemon's tool registry.
  *
- * Called once at daemon startup via initializeTools().
+ * Called once at daemon startup via initializeTools(). Only proxy tools
+ * (e.g. app_open) are registered here — non-proxy data tools are now
+ * provided by the app-builder skill via its TOOLS.json manifest.
  */
 
 import { registerTool } from '../registry.js';
-import { allAppTools } from './definitions.js';
+import { coreAppProxyTools } from './definitions.js';
 
 export function registerAppTools(): void {
-  for (const tool of allAppTools) {
+  for (const tool of coreAppProxyTools) {
     registerTool(tool);
   }
 }

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -8,7 +8,7 @@ import { requestComputerControlTool } from './computer-use/request-computer-cont
 import { registerUiSurfaceTools } from './ui-surface/registry.js';
 import { allUiSurfaceTools } from './ui-surface/definitions.js';
 import { registerAppTools } from './apps/registry.js';
-import { allAppTools } from './apps/definitions.js';
+import { coreAppProxyTools } from './apps/definitions.js';
 import { hostFileReadTool } from './host-filesystem/read.js';
 import { hostFileWriteTool } from './host-filesystem/write.js';
 import { hostFileEditTool } from './host-filesystem/edit.js';
@@ -247,7 +247,7 @@ export async function initializeTools(): Promise<void> {
       ...allComputerUseTools.map((t: Tool) => t.name),
       requestComputerControlTool.name,
       ...allUiSurfaceTools.map((t: Tool) => t.name),
-      ...allAppTools.map((t: Tool) => t.name),
+      ...coreAppProxyTools.map((t: Tool) => t.name),
     ]);
 
     coreToolsSnapshot = new Map<string, Tool>();


### PR DESCRIPTION
## Summary
- Adds TOOLS.json manifest to app-builder skill with 9 canonical tool definitions
- Changes core registry to only register app_open proxy (not data tools)
- Non-proxy app tools now come from skill_load app-builder
- Updated baseline and skill projection tests

## Test plan
- [x] Registry tests pass (34/34)
- [x] Skill tool projection tests pass (69/69)
- [x] Starter task flow tests pass (5/5)
- [x] bun test green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
