### PR TITLE
feat: add CODEOWNERS for system prompt files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# System prompt ownership
+assistant/src/config/system-prompt.ts @awlevin @siddseethepalli @alex-nork
+assistant/src/config/computer-use-prompt.ts @awlevin @siddseethepalli @alex-nork
+assistant/src/config/templates/ @awlevin @siddseethepalli @alex-nork


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` requiring review from @awlevin, @siddseethepalli, and @alex-nork for changes to the system prompt builder, computer-use prompt, and prompt template files.

## Test plan
- [x] Verify CODEOWNERS syntax is valid
- [x] Confirm paths match the actual system prompt file locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
