### PR TITLE
PR 03: Add Reusable Chat Media Test Harness

### DIFF
--- a/clients/macos/vellum-assistantTests/TestSupport/ChatMediaTestHarness.swift
+++ b/clients/macos/vellum-assistantTests/TestSupport/ChatMediaTestHarness.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - Test Fixtures
+
+/// Reusable URL fixtures for media embed testing across PRs 04-42.
+/// Each fixture provides a representative URL for a specific media provider
+/// or content type, along with surrounding prose to simulate realistic messages.
+enum MediaFixtures {
+
+    // MARK: YouTube
+
+    static let youtubeStandard = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    static let youtubeShort = "https://youtu.be/dQw4w9WgXcQ"
+    static let youtubeEmbed = "https://www.youtube.com/embed/dQw4w9WgXcQ"
+    static let youtubeShorts = "https://www.youtube.com/shorts/dQw4w9WgXcQ"
+
+    // MARK: Vimeo
+
+    static let vimeoStandard = "https://vimeo.com/123456789"
+    static let vimeoPlayer = "https://player.vimeo.com/video/123456789"
+
+    // MARK: Loom
+
+    static let loomShare = "https://www.loom.com/share/abc123def456"
+    static let loomEmbed = "https://www.loom.com/embed/abc123def456"
+
+    // MARK: Image URLs
+
+    static let imagePNG = "https://example.com/photo.png"
+    static let imageJPG = "https://example.com/chart.jpg"
+    static let imageGIF = "https://example.com/animation.gif"
+    static let imageWebP = "https://example.com/modern.webp"
+    static let imageSVG = "https://example.com/diagram.svg"
+
+    // MARK: Non-embeddable URLs (should never trigger embed behavior)
+
+    static let plainHTTPS = "https://example.com/page"
+    static let githubRepo = "https://github.com/vellum-ai/vellum-assistant"
+    static let docsPage = "https://docs.swift.org/swift-book/"
+
+    // MARK: Message templates
+
+    /// An assistant message containing a single YouTube link surrounded by prose.
+    static func assistantMessageWithYouTube(url: String = youtubeStandard) -> ChatMessage {
+        ChatMessage(role: .assistant, text: "Here is a video tutorial: \(url) -- hope it helps!")
+    }
+
+    /// A user message containing a single YouTube link.
+    static func userMessageWithYouTube(url: String = youtubeStandard) -> ChatMessage {
+        ChatMessage(role: .user, text: "Check this out: \(url)")
+    }
+
+    /// An assistant message containing a Vimeo link.
+    static func assistantMessageWithVimeo(url: String = vimeoStandard) -> ChatMessage {
+        ChatMessage(role: .assistant, text: "Watch this presentation: \(url)")
+    }
+
+    /// An assistant message containing a Loom link.
+    static func assistantMessageWithLoom(url: String = loomShare) -> ChatMessage {
+        ChatMessage(role: .assistant, text: "Here's my recording: \(url)")
+    }
+
+    /// An assistant message containing an image URL.
+    static func assistantMessageWithImage(url: String = imagePNG) -> ChatMessage {
+        ChatMessage(role: .assistant, text: "Here's the diagram: \(url)")
+    }
+
+    /// An assistant message containing multiple media URLs of different types.
+    static func assistantMessageWithMixedMedia() -> ChatMessage {
+        ChatMessage(role: .assistant, text: """
+            Here are some resources:
+            - Video: \(youtubeStandard)
+            - Presentation: \(vimeoStandard)
+            - Recording: \(loomShare)
+            - Diagram: \(imagePNG)
+            """)
+    }
+
+    /// A user message containing a mix of embeddable and plain URLs.
+    static func userMessageWithMixedURLs() -> ChatMessage {
+        ChatMessage(role: .user, text: """
+            Links: \(youtubeStandard) and \(plainHTTPS) and \(imageJPG)
+            """)
+    }
+
+    /// A message with markdown-formatted links (e.g. `[text](url)`).
+    static func assistantMessageWithMarkdownLinks() -> ChatMessage {
+        ChatMessage(role: .assistant, text: """
+            Check [this video](\(youtubeStandard)) and [this image](\(imagePNG)).
+            """)
+    }
+
+    /// An assistant message with no URLs at all.
+    static func assistantMessagePlainText() -> ChatMessage {
+        ChatMessage(role: .assistant, text: "This message has no links at all.")
+    }
+
+    /// All video fixture URLs for iteration in parameterized-style tests.
+    static let allVideoURLs: [String] = [
+        youtubeStandard, youtubeShort, youtubeEmbed, youtubeShorts,
+        vimeoStandard, vimeoPlayer,
+        loomShare, loomEmbed,
+    ]
+
+    /// All image fixture URLs for iteration in parameterized-style tests.
+    static let allImageURLs: [String] = [
+        imagePNG, imageJPG, imageGIF, imageWebP, imageSVG,
+    ]
+
+    /// URLs that should never trigger any embed behavior.
+    static let nonEmbeddableURLs: [String] = [
+        plainHTTPS, githubRepo, docsPage,
+    ]
+}
+
+// MARK: - Assertion Helpers
+
+/// Lightweight assertion helpers for media embed tests.
+/// These keep individual test methods concise and consistent.
+enum ChatMediaAssertions {
+
+    /// Asserts that the message text contains the given URL string verbatim.
+    static func assertContainsLinkText(
+        _ url: String,
+        in message: ChatMessage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            message.text.contains(url),
+            "Expected message text to contain URL \"\(url)\" but got: \"\(message.text)\"",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Asserts that the message has an inline surface whose ID or type indicates
+    /// an embed intent for the given URL. This is a placeholder that will gain
+    /// real logic once embed surfaces are introduced in later PRs.
+    static func assertContainsEmbedIntent(
+        _ url: String,
+        in message: ChatMessage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        // Future PRs will check for a specific InlineSurfaceData entry
+        // whose embed URL matches `url`. For now, verify the surface list
+        // is non-empty as a structural stand-in.
+        XCTAssertFalse(
+            message.inlineSurfaces.isEmpty,
+            "Expected at least one inline surface (embed intent) for URL \"\(url)\" but found none",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Asserts that the message has no embed-related side effects:
+    /// no inline surfaces, no synthesized attachments, no synthesized tool calls.
+    static func assertContainsNoEmbedIntent(
+        in message: ChatMessage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            message.inlineSurfaces.isEmpty,
+            "Expected no inline surfaces (embed intents) but found \(message.inlineSurfaces.count)",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            message.attachments.isEmpty,
+            "Expected no synthesized attachments but found \(message.attachments.count)",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            message.toolCalls.isEmpty,
+            "Expected no synthesized tool calls but found \(message.toolCalls.count)",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Asserts that the message role matches the expected role.
+    static func assertRole(
+        _ expected: ChatRole,
+        in message: ChatMessage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            message.role, expected,
+            "Expected role .\(expected) but got .\(message.role)",
+            file: file,
+            line: line
+        )
+    }
+}
+
+// MARK: - Harness Self-Tests
+
+/// Validates the test harness itself: fixtures produce valid messages and
+/// assertion helpers behave correctly. Run these first so later PRs can
+/// trust the harness unconditionally.
+@MainActor
+final class ChatMediaTestHarnessTests: XCTestCase {
+
+    // MARK: Fixture construction
+
+    func testFixtureAssistantYouTubeMessageContainsURL() {
+        let msg = MediaFixtures.assistantMessageWithYouTube()
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.youtubeStandard, in: msg)
+        ChatMediaAssertions.assertRole(.assistant, in: msg)
+    }
+
+    func testFixtureUserYouTubeMessageContainsURL() {
+        let msg = MediaFixtures.userMessageWithYouTube()
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.youtubeStandard, in: msg)
+        ChatMediaAssertions.assertRole(.user, in: msg)
+    }
+
+    func testFixtureVimeoMessageContainsURL() {
+        let msg = MediaFixtures.assistantMessageWithVimeo()
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.vimeoStandard, in: msg)
+    }
+
+    func testFixtureLoomMessageContainsURL() {
+        let msg = MediaFixtures.assistantMessageWithLoom()
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.loomShare, in: msg)
+    }
+
+    func testFixtureImageMessageContainsURL() {
+        let msg = MediaFixtures.assistantMessageWithImage()
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.imagePNG, in: msg)
+    }
+
+    func testFixtureMixedMediaContainsAllURLs() {
+        let msg = MediaFixtures.assistantMessageWithMixedMedia()
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.youtubeStandard, in: msg)
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.vimeoStandard, in: msg)
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.loomShare, in: msg)
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.imagePNG, in: msg)
+    }
+
+    func testFixtureMarkdownLinksContainURLs() {
+        let msg = MediaFixtures.assistantMessageWithMarkdownLinks()
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.youtubeStandard, in: msg)
+        ChatMediaAssertions.assertContainsLinkText(MediaFixtures.imagePNG, in: msg)
+    }
+
+    func testFixturePlainTextMessageHasNoURLs() {
+        let msg = MediaFixtures.assistantMessagePlainText()
+        XCTAssertFalse(msg.text.contains("http"),
+                       "Plain text fixture should not contain any URLs")
+    }
+
+    // MARK: Assertion helpers — no-embed baseline
+
+    func testAssertNoEmbedIntentPassesForPlainMessages() {
+        let msg = MediaFixtures.assistantMessageWithYouTube()
+        // Currently no embed behavior exists, so this should pass
+        ChatMediaAssertions.assertContainsNoEmbedIntent(in: msg)
+    }
+
+    func testAssertNoEmbedIntentPassesForAllVideoFixtures() {
+        for url in MediaFixtures.allVideoURLs {
+            let msg = MediaFixtures.assistantMessageWithYouTube(url: url)
+            ChatMediaAssertions.assertContainsLinkText(url, in: msg)
+            ChatMediaAssertions.assertContainsNoEmbedIntent(in: msg)
+        }
+    }
+
+    func testAssertNoEmbedIntentPassesForAllImageFixtures() {
+        for url in MediaFixtures.allImageURLs {
+            let msg = MediaFixtures.assistantMessageWithImage(url: url)
+            ChatMediaAssertions.assertContainsLinkText(url, in: msg)
+            ChatMediaAssertions.assertContainsNoEmbedIntent(in: msg)
+        }
+    }
+
+    func testAssertNoEmbedIntentPassesForNonEmbeddableURLs() {
+        for url in MediaFixtures.nonEmbeddableURLs {
+            let msg = ChatMessage(role: .assistant, text: "See \(url)")
+            ChatMediaAssertions.assertContainsLinkText(url, in: msg)
+            ChatMediaAssertions.assertContainsNoEmbedIntent(in: msg)
+        }
+    }
+
+    // MARK: Fixture arrays are non-empty
+
+    func testVideoFixtureArrayIsNonEmpty() {
+        XCTAssertFalse(MediaFixtures.allVideoURLs.isEmpty,
+                       "allVideoURLs fixture array must not be empty")
+    }
+
+    func testImageFixtureArrayIsNonEmpty() {
+        XCTAssertFalse(MediaFixtures.allImageURLs.isEmpty,
+                       "allImageURLs fixture array must not be empty")
+    }
+
+    func testNonEmbeddableURLArrayIsNonEmpty() {
+        XCTAssertFalse(MediaFixtures.nonEmbeddableURLs.isEmpty,
+                       "nonEmbeddableURLs fixture array must not be empty")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MediaFixtures` enum with URL constants and factory methods for YouTube, Vimeo, Loom, and image test messages
- Adds `ChatMediaAssertions` enum with reusable assertion helpers (`assertContainsLinkText`, `assertContainsEmbedIntent`, `assertContainsNoEmbedIntent`, `assertRole`)
- Adds `ChatMediaTestHarnessTests` (15 tests) validating the harness itself

## Test plan
- [x] All 15 tests in `ChatMediaTestHarnessTests` pass (0 failures)
- [x] No production code modified

PR 03 of 42 in the media embeds plan.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
