### PR TITLE
test: add post-swap app surface refresh regression tests

### DIFF
--- a/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Regression tests for app surface refresh and eventing side effects in
+ * createToolExecutor (session-tool-setup.ts).
+ *
+ * After the App Builder tools source swap (PR 8), app tools like app_update,
+ * app_file_edit, and app_file_write are provided by the app-builder skill
+ * rather than core registration. The afterExecute hooks in createToolExecutor
+ * fire based on tool *name* matching, so they must continue to work for
+ * skill-origin tools. These tests verify that contract.
+ */
+
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { ToolExecutionResult } from '../tools/types.js';
+import type { ToolSetupContext } from '../daemon/session-tool-setup.js';
+import type { ServerMessage, SurfaceType, SurfaceData } from '../daemon/ipc-protocol.js';
+
+// ---------------------------------------------------------------------------
+// Spies for side-effect verification
+// ---------------------------------------------------------------------------
+
+const refreshSpy = mock(() => {});
+const updatePublishedSpy = mock(() => Promise.resolve());
+
+// Mock session-surfaces so refreshSurfacesForApp is captured
+mock.module('../daemon/session-surfaces.js', () => ({
+  refreshSurfacesForApp: refreshSpy,
+  surfaceProxyResolver: mock(() => Promise.resolve({ content: '', isError: false })),
+}));
+
+// Mock published-app-updater to prevent real deployment calls
+mock.module('../services/published-app-updater.js', () => ({
+  updatePublishedAppDeployment: updatePublishedSpy,
+}));
+
+// Mock browser-screencast registration (no-op)
+mock.module('../tools/browser/browser-screencast.js', () => ({
+  registerSessionSender: mock(() => {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Import createToolExecutor after mocks are in place
+// ---------------------------------------------------------------------------
+
+import { createToolExecutor } from '../daemon/session-tool-setup.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ToolSetupContext stub. */
+function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
+  return {
+    conversationId: 'conv-test',
+    currentRequestId: 'req-1',
+    workingDir: '/tmp/test',
+    abortController: null,
+    traceEmitter: { emit: () => {} },
+    sendToClient: mock(() => {}),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>(),
+    surfaceUndoStacks: new Map(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: 'r' }),
+    getQueueDepth: () => 0,
+    processMessage: async () => '',
+    ...overrides,
+  };
+}
+
+/** Fake ToolExecutor whose execute() returns a controlled result. */
+function makeFakeExecutor(result: ToolExecutionResult = { content: '{}', isError: false }) {
+  return {
+    execute: mock(async () => result),
+  };
+}
+
+/** No-op prompter stubs. */
+const noopPrompter = { prompt: mock(async () => ({ decision: 'allow' as const })) } as any;
+const noopSecretPrompter = { prompt: mock(async () => ({ cancelled: true })) } as any;
+const noopLifecycleHandler = mock(() => {});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('session-tool-setup app refresh side effects', () => {
+  beforeEach(() => {
+    refreshSpy.mockClear();
+    updatePublishedSpy.mockClear();
+  });
+
+  // ── app_update ──────────────────────────────────────────────────────
+
+  describe('app_update', () => {
+    test('triggers refreshSurfacesForApp when result is not an error', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{"id":"app-1"}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn('app_update', { app_id: 'app-1', name: 'New Name' });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy.mock.calls[0][0]).toBe(ctx);
+      expect(refreshSpy.mock.calls[0][1]).toBe('app-1');
+    });
+
+    test('broadcasts app_files_changed with correct appId', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_update', { app_id: 'app-42' });
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect(broadcastSpy.mock.calls[0][0]).toEqual({
+        type: 'app_files_changed',
+        appId: 'app-42',
+      });
+    });
+
+    test('calls updatePublishedAppDeployment', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, mock(() => {}),
+      );
+
+      await toolFn('app_update', { app_id: 'app-publish' });
+
+      // updatePublishedAppDeployment is called with void (fire-and-forget),
+      // so just verify it was invoked.
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect(updatePublishedSpy.mock.calls[0][0]).toBe('app-publish');
+    });
+
+    test('skips side effects when result is an error', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: 'Error: not found', isError: true });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_update', { app_id: 'app-err' });
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+
+    test('skips side effects when app_id is missing', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_update', {});
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── app_file_edit ───────────────────────────────────────────────────
+
+  describe('app_file_edit', () => {
+    test('triggers refreshSurfacesForApp with fileChange flag', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{"ok":true}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_file_edit', {
+        app_id: 'app-edit',
+        path: 'index.html',
+        old_string: 'old',
+        new_string: 'new',
+      });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy.mock.calls[0][1]).toBe('app-edit');
+      // Verify opts include fileChange: true
+      expect(refreshSpy.mock.calls[0][2]).toEqual({ fileChange: true, status: undefined });
+    });
+
+    test('propagates status field through refresh opts', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{"ok":true}', isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, mock(() => {}),
+      );
+
+      await toolFn('app_file_edit', {
+        app_id: 'app-status',
+        path: 'styles.css',
+        old_string: 'x',
+        new_string: 'y',
+        status: 'updating styles',
+      });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy.mock.calls[0][2]).toEqual({
+        fileChange: true,
+        status: 'updating styles',
+      });
+    });
+
+    test('broadcasts app_files_changed for file edit', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_file_edit', { app_id: 'app-edit-bc', path: 'f', old_string: 'a', new_string: 'b' });
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect(broadcastSpy.mock.calls[0][0]).toEqual({
+        type: 'app_files_changed',
+        appId: 'app-edit-bc',
+      });
+    });
+
+    test('calls updatePublishedAppDeployment for file edit', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, mock(() => {}),
+      );
+
+      await toolFn('app_file_edit', { app_id: 'app-pub-edit', path: 'f', old_string: 'a', new_string: 'b' });
+
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect(updatePublishedSpy.mock.calls[0][0]).toBe('app-pub-edit');
+    });
+
+    test('skips side effects when result is an error', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: 'Error', isError: true });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_file_edit', { app_id: 'app-err', path: 'f', old_string: 'a', new_string: 'b' });
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── app_file_write ──────────────────────────────────────────────────
+
+  describe('app_file_write', () => {
+    test('triggers refreshSurfacesForApp with fileChange flag', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{"written":true}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_file_write', {
+        app_id: 'app-write',
+        path: 'new.html',
+        content: '<div/>',
+      });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy.mock.calls[0][1]).toBe('app-write');
+      expect(refreshSpy.mock.calls[0][2]).toEqual({ fileChange: true, status: undefined });
+    });
+
+    test('propagates status field through refresh opts', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{"written":true}', isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, mock(() => {}),
+      );
+
+      await toolFn('app_file_write', {
+        app_id: 'app-ws',
+        path: 'f.txt',
+        content: 'hi',
+        status: 'adding dark mode',
+      });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy.mock.calls[0][2]).toEqual({
+        fileChange: true,
+        status: 'adding dark mode',
+      });
+    });
+
+    test('broadcasts app_files_changed for file write', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_file_write', { app_id: 'app-write-bc', path: 'f', content: 'x' });
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect(broadcastSpy.mock.calls[0][0]).toEqual({
+        type: 'app_files_changed',
+        appId: 'app-write-bc',
+      });
+    });
+
+    test('calls updatePublishedAppDeployment for file write', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, mock(() => {}),
+      );
+
+      await toolFn('app_file_write', { app_id: 'app-pub-write', path: 'f', content: 'x' });
+
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect(updatePublishedSpy.mock.calls[0][0]).toBe('app-pub-write');
+    });
+
+    test('skips side effects when result is an error', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: 'Error', isError: true });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      await toolFn('app_file_write', { app_id: 'app-err', path: 'f', content: 'x' });
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Name-based hook targeting (skill-origin tools) ──────────────────
+
+  describe('name-based hooks fire for skill-origin tools', () => {
+    test('hooks fire purely on tool name, regardless of tool origin', async () => {
+      // The key invariant: createToolExecutor uses `name === 'app_update'`
+      // string comparison, not tool metadata or origin. This means skill-
+      // projected tools with the same name trigger the same afterExecute
+      // hooks as core tools.
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      // Simulate calling each app tool by name (as the agent loop does)
+      for (const toolName of ['app_update', 'app_file_edit', 'app_file_write']) {
+        refreshSpy.mockClear();
+        broadcastSpy.mockClear();
+        updatePublishedSpy.mockClear();
+
+        await toolFn(toolName, { app_id: 'skill-app', path: 'f', old_string: 'a', new_string: 'b', content: 'x' });
+
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+        expect(broadcastSpy).toHaveBeenCalledTimes(1);
+        expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  // ── Non-app tools do not trigger hooks ──────────────────────────────
+
+  describe('non-app tools', () => {
+    test('other tool names do not trigger app refresh side effects', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler, broadcastSpy,
+      );
+
+      for (const toolName of ['read_file', 'write_file', 'shell', 'app_create', 'app_list', 'app_delete']) {
+        refreshSpy.mockClear();
+        broadcastSpy.mockClear();
+        updatePublishedSpy.mockClear();
+
+        await toolFn(toolName, { app_id: 'app-1' });
+
+        expect(refreshSpy).not.toHaveBeenCalled();
+        expect(broadcastSpy).not.toHaveBeenCalled();
+        expect(updatePublishedSpy).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  // ── broadcastToAllClients optional ──────────────────────────────────
+
+  describe('broadcastToAllClients is optional', () => {
+    test('side effects work without broadcastToAllClients callback', async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: '{}', isError: false });
+
+      // No broadcast callback provided
+      const toolFn = createToolExecutor(
+        executor as any, noopPrompter, noopSecretPrompter,
+        ctx, noopLifecycleHandler,
+      );
+
+      // Should not throw even though broadcastToAllClients is undefined
+      const result = await toolFn('app_update', { app_id: 'app-no-bc' });
+
+      expect(result.isError).toBe(false);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
PR 9/11 of the App Builder Tools migration plan. Adds regression tests verifying that app surface refresh and eventing side effects (refreshSurfacesForApp, app_files_changed broadcast, publish-update) continue to fire correctly for skill-origin app tools after the source swap.

## Summary

- Tests `app_update` afterExecute triggers `refreshSurfacesForApp`, broadcasts `app_files_changed`, and calls `updatePublishedAppDeployment`
- Tests `app_file_edit` and `app_file_write` trigger the same side effects with `fileChange` flag and `status` propagation
- Verifies hooks fire on tool name matching (not origin), confirming skill-projected tools work identically
- Verifies non-app tools (`read_file`, `app_create`, etc.) do not trigger refresh hooks
- Verifies side effects are skipped on error results and missing `app_id`
- 18 tests, all passing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
