### PR TITLE
docs: update architecture docs for app-builder skill migration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1443,7 +1443,7 @@ The following capabilities ship as bundled skills in `assistant/src/config/bundl
 | `gmail` | Gmail search, archive, send, etc. | Email management via OAuth2 integration |
 | `claude-code` | Claude Code tool | Delegate coding tasks to Claude Code subprocess |
 | `weather` | `get-weather` | Fetch current weather data |
-| `app-builder` | (instruction-only) | Dynamic app authoring guidance |
+| `app-builder` | `app_create`, `app_list`, `app_query`, `app_update`, `app_delete`, `app_file_list`, `app_file_read`, `app_file_edit`, `app_file_write` | Dynamic app authoring — CRUD and file-level editing for persistent apps (activated via `skill_load app-builder`; `app_open` remains a core proxy tool) |
 | `self-upgrade` | (instruction-only) | Self-improvement workflow |
 | `start-the-day` | (instruction-only) | Morning briefing routine |
 


### PR DESCRIPTION
PR 11/11 of the App Builder Tools migration plan.

Updates ARCHITECTURE.md bundled skills table to reflect that `app-builder` is now a **tool-providing** bundled skill (was instruction-only). The 9 non-proxy app tools (`app_create`, `app_list`, `app_query`, `app_update`, `app_delete`, `app_file_list`, `app_file_read`, `app_file_edit`, `app_file_write`) are now listed in the Tools column, with a note that they require `skill_load app-builder` activation and that `app_open` remains a core proxy tool.

No code changes — documentation alignment only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
