### PR TITLE
fix: prevent optimistic model selection when sendSilently drops the command

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1388,11 +1388,13 @@ private struct ActiveChatViewWrapper: View {
             onPaste: { viewModel.addAttachmentFromPasteboard() },
             onMicrophoneToggle: onMicrophoneToggle,
             onModelPickerSelect: { messageId, modelId in
-                // Update UI immediately so the picker reflects the selection
-                settingsStore.selectedModel = modelId
                 // Send "/model <id>" through the daemon silently (no user bubble)
                 // so the switch is persisted and confirmed by the daemon.
-                viewModel.sendSilently("/model \(modelId)")
+                // Only update UI if the command was actually accepted; sendSilently
+                // returns false when a session bootstrap is already in flight.
+                if viewModel.sendSilently("/model \(modelId)") {
+                    settingsStore.selectedModel = modelId
+                }
             },
             selectedModel: settingsStore.selectedModel,
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -402,17 +402,21 @@ public final class ChatViewModel: ObservableObject {
 
     /// Send a message to the daemon without showing a user bubble in the chat.
     /// Used for automated actions like inline model picker selections.
-    public func sendSilently(_ text: String) {
+    /// Returns `true` if the message was sent (or a session bootstrap was started),
+    /// `false` if the message was silently dropped (e.g. bootstrap already in flight).
+    @discardableResult
+    public func sendSilently(_ text: String) -> Bool {
         // Don't re-enter bootstrap if a session creation is already in progress —
         // that would overwrite pendingUserMessage and orphan the in-flight session.
         if sessionId == nil && isSending {
-            return
+            return false
         }
         if sessionId == nil {
             bootstrapSession(userMessage: text, attachments: nil)
         } else {
             sendUserMessage(text)
         }
+        return true
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- `sendSilently` can silently return without sending when a session bootstrap is already in flight (`sessionId == nil && isSending`), but the inline model picker caller was updating `settingsStore.selectedModel` before the call — leaving the UI out of sync with the daemon.
- `sendSilently` now returns `Bool` (`@discardableResult`) so callers can detect when the command was dropped.
- The model picker callback gates its optimistic UI update on the return value.

## Test plan
- [ ] Open the app, start typing a first message (triggering session bootstrap), and click the model picker before the session is established — the picker should not change models
- [ ] Normal model switching (session already active) continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
