### PR TITLE
private-threads: add baseline characterization tests

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1225,4 +1225,24 @@ describe('IPC message snapshots', () => {
       expect(complete.type).toBe('message_complete');
     });
   });
+
+  // Baseline: session contract has no thread type metadata today
+  describe('thread type baselines (pre-private-threads)', () => {
+    test('session_create request has no threadType field', () => {
+      const req = clientMessages.session_create;
+      expect('threadType' in req).toBe(false);
+    });
+
+    test('session_info response has no threadType field', () => {
+      const info = serverMessages.session_info;
+      expect('threadType' in info).toBe(false);
+    });
+
+    test('session_list_response sessions have no threadType field', () => {
+      const list = serverMessages.session_list_response;
+      for (const s of list.sessions) {
+        expect('threadType' in s).toBe(false);
+      }
+    });
+  });
 });

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -171,6 +171,49 @@ describe('Memory regressions', () => {
     };
   }
 
+  // Baseline: indexMessageNow without explicit scopeId defaults to 'default'
+  test('baseline: memory segments default to scope "default" when no scopeId given', () => {
+    const db = getDb();
+    const now = Date.now();
+    db.insert(conversations).values({
+      id: 'conv-baseline-scope',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-baseline-scope',
+      conversationId: 'conv-baseline-scope',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'The user likes dark mode.' }]),
+      createdAt: now,
+    }).run();
+
+    // Index without explicit scopeId — should use 'default'
+    indexMessageNow({
+      messageId: 'msg-baseline-scope',
+      conversationId: 'conv-baseline-scope',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'The user likes dark mode.' }]),
+      createdAt: now,
+    }, DEFAULT_CONFIG.memory);
+
+    const segs = db.select().from(memorySegments)
+      .where(eq(memorySegments.messageId, 'msg-baseline-scope'))
+      .all();
+
+    expect(segs.length).toBeGreaterThan(0);
+    for (const seg of segs) {
+      expect(seg.scopeId).toBe('default');
+    }
+  });
+
   test('lexical recall accepts punctuation-heavy user queries without degrading', async () => {
     const db = getDb();
     const createdAt = 1_700_000_000_000;

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -901,3 +901,29 @@ describe('ToolExecutor strict mode + high-risk integration (PR 25)', () => {
     expect(options.executionTarget).toBe('host');
   });
 });
+
+// Baseline: allow rules can auto-allow file_edit for USER.md today (no forced prompting)
+describe('ToolExecutor baseline: allow rule auto-allows file_edit USER.md', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+    lastCheckArgs = undefined;
+    getToolOverride = undefined;
+    checkResultOverride = undefined;
+    if (addRuleSpy) { addRuleSpy.mockRestore(); addRuleSpy = undefined; }
+  });
+
+  test('file_edit to USER.md is auto-allowed when checker says allow', async () => {
+    // checker mock returns { decision: 'allow' } by default
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'file_edit',
+      { path: '/Users/sidd/.vellum/workspace/USER.md', content: 'hello' },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+    // confirm checker was called (not bypassed)
+    expect(lastCheckArgs).toBeDefined();
+    expect(lastCheckArgs!.toolName).toBe('file_edit');
+  });
+});


### PR DESCRIPTION
## Summary
- Add IPC snapshot tests proving session create/info/list have no `threadType` field today
- Add memory regression test proving segments default to `scopeId: 'default'`
- Add tool executor test proving allow rules auto-allow `file_edit` to USER.md

PR 1/39 of the Private Threads rollout plan.

## Test plan
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — 173 pass
- [x] `bun test src/__tests__/memory-regressions.test.ts` — 64 pass
- [x] `bun test src/__tests__/tool-executor.test.ts` — 28 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
