### PR TITLE
private-threads: extend IPC contract with threadType

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -34,6 +34,7 @@ exports[`IPC message snapshots ClientMessage types session_list serializes to ex
 exports[`IPC message snapshots ClientMessage types session_create serializes to expected JSON 1`] = `
 {
   "correlationId": "corr-001",
+  "threadType": "standard",
   "title": "New session",
   "transport": {
     "channelId": "desktop",
@@ -722,6 +723,7 @@ exports[`IPC message snapshots ServerMessage types session_info serializes to ex
 {
   "correlationId": "corr-001",
   "sessionId": "sess-001",
+  "threadType": "standard",
   "title": "My session",
   "type": "session_info",
 }
@@ -732,11 +734,13 @@ exports[`IPC message snapshots ServerMessage types session_list_response seriali
   "sessions": [
     {
       "id": "sess-001",
+      "threadType": "standard",
       "title": "First session",
       "updatedAt": 1700000000,
     },
     {
       "id": "sess-002",
+      "threadType": "standard",
       "title": "Second session",
       "updatedAt": 1700001000,
     },

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -46,6 +46,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
       hints: ['dashboard-capable'],
       uxBrief: 'Prefer dashboard-first onboarding.',
     },
+    threadType: 'standard',
   },
   session_switch: {
     type: 'session_switch',
@@ -466,12 +467,13 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     sessionId: 'sess-001',
     title: 'My session',
     correlationId: 'corr-001',
+    threadType: 'standard',
   },
   session_list_response: {
     type: 'session_list_response',
     sessions: [
-      { id: 'sess-001', title: 'First session', updatedAt: 1700000000 },
-      { id: 'sess-002', title: 'Second session', updatedAt: 1700001000 },
+      { id: 'sess-001', title: 'First session', updatedAt: 1700000000, threadType: 'standard' },
+      { id: 'sess-002', title: 'Second session', updatedAt: 1700001000, threadType: 'standard' },
     ],
   },
   sessions_clear_response: {
@@ -1226,22 +1228,25 @@ describe('IPC message snapshots', () => {
     });
   });
 
-  // Baseline: session contract has no thread type metadata today
-  describe('thread type baselines (pre-private-threads)', () => {
-    test('session_create request has no threadType field', () => {
+  // Baseline: session contract includes threadType metadata
+  describe('thread type baselines', () => {
+    test('session_create request includes threadType field', () => {
       const req = clientMessages.session_create;
-      expect('threadType' in req).toBe(false);
+      expect('threadType' in req).toBe(true);
+      expect((req as Record<string, unknown>).threadType).toBe('standard');
     });
 
-    test('session_info response has no threadType field', () => {
+    test('session_info response includes threadType field', () => {
       const info = serverMessages.session_info;
-      expect('threadType' in info).toBe(false);
+      expect('threadType' in info).toBe(true);
+      expect((info as Record<string, unknown>).threadType).toBe('standard');
     });
 
-    test('session_list_response sessions have no threadType field', () => {
+    test('session_list_response sessions include threadType field', () => {
       const list = serverMessages.session_list_response;
       for (const s of list.sessions) {
-        expect('threadType' in s).toBe(false);
+        expect('threadType' in s).toBe(true);
+        expect((s as Record<string, unknown>).threadType).toBe('standard');
       }
     });
   });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -73,6 +73,7 @@ export interface SessionCreateRequest {
   maxResponseTokens?: number;
   correlationId?: string;
   transport?: SessionTransportMetadata;
+  threadType?: 'standard' | 'private';
 }
 
 export interface SessionSwitchRequest {
@@ -855,11 +856,12 @@ export interface SessionInfo {
   sessionId: string;
   title: string;
   correlationId?: string;
+  threadType?: string;
 }
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: string }>;
 }
 
 export interface SessionsClearResponse {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -966,6 +966,7 @@ public struct IPCSessionCreateRequest: Codable, Sendable {
     public let correlationId: String?
     /// Lightweight session transport metadata for channel identity and natural-language guidance.
     public let transport: IPCSessionTransportMetadata?
+    public let threadType: String?
 }
 
 public struct IPCSessionInfo: Codable, Sendable {
@@ -973,6 +974,7 @@ public struct IPCSessionInfo: Codable, Sendable {
     public let sessionId: String
     public let title: String
     public let correlationId: String?
+    public let threadType: String?
 }
 
 public struct IPCSessionListRequest: Codable, Sendable {
@@ -988,6 +990,7 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     public let id: String
     public let title: String
     public let updatedAt: Int
+    public let threadType: String?
 }
 
 public struct IPCSessionsClearRequest: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Add optional `threadType` to `SessionCreateRequest` (client -> server)
- Add optional `threadType` to `SessionInfo` (server -> client)
- Add optional `threadType` to `SessionListResponse` session items
- Update IPC snapshot fixtures and expectations
- Regenerate Swift IPC models

PR 5/39 of the Private Threads rollout plan.

## Test plan
- [x] IPC snapshot tests pass with updated fixtures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
