### PR TITLE
feat: add siddseethepalli as codeowner for tools, skills, and memory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,15 @@
 assistant/src/config/system-prompt.ts @awlevin @siddseethepalli @alex-nork
 assistant/src/config/computer-use-prompt.ts @awlevin @siddseethepalli @alex-nork
 assistant/src/config/templates/ @awlevin @siddseethepalli @alex-nork
+
+# Tool definitions and infrastructure
+assistant/src/tools/ @siddseethepalli
+
+# Skill system (loading, runtime, bundled skills)
+assistant/src/skills/ @siddseethepalli
+assistant/src/config/skills.ts @siddseethepalli
+assistant/src/config/skill-state.ts @siddseethepalli
+assistant/src/config/bundled-skills/ @siddseethepalli
+
+# Memory system
+assistant/src/memory/ @siddseethepalli


### PR DESCRIPTION
## Summary
- Add @siddseethepalli as a codeowner for `assistant/src/tools/`, `assistant/src/skills/`, `assistant/src/config/bundled-skills/`, skill config files, and `assistant/src/memory/`
- Existing system prompt ownership entries are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
