### PR TITLE
feat: prefer API/CLI over browser for business system interactions

### DIFF
--- a/assistant/src/__tests__/cli-discover.test.ts
+++ b/assistant/src/__tests__/cli-discover.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+const { cliDiscoverTool } = await import('../tools/host-terminal/cli-discover.js');
+
+const stubContext = {
+  workingDir: '/tmp',
+  sessionId: 'test',
+  conversationId: 'test',
+};
+
+describe('cliDiscoverTool', () => {
+  test('has correct metadata', () => {
+    expect(cliDiscoverTool.name).toBe('cli_discover');
+    expect(cliDiscoverTool.category).toBe('host-terminal');
+    expect(cliDiscoverTool.defaultRiskLevel).toBe('low');
+  });
+
+  test('definition has expected schema', () => {
+    const def = cliDiscoverTool.getDefinition();
+    expect(def.name).toBe('cli_discover');
+    expect(def.input_schema).toBeDefined();
+    const props = (def.input_schema as { properties: Record<string, unknown> }).properties;
+    expect(props.names).toBeDefined();
+    expect(props.check_auth).toBeDefined();
+  });
+
+  test('discovers git (universally available)', async () => {
+    const result = await cliDiscoverTool.execute(
+      { names: ['git'], check_auth: false },
+      stubContext,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('**git**');
+    expect(result.content).toContain('Available CLIs');
+  });
+
+  test('reports missing CLIs', async () => {
+    const result = await cliDiscoverTool.execute(
+      { names: ['__nonexistent_cli_xyz__'], check_auth: false },
+      stubContext,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Not found');
+    expect(result.content).toContain('__nonexistent_cli_xyz__');
+  });
+
+  test('handles mix of found and missing CLIs', async () => {
+    const result = await cliDiscoverTool.execute(
+      { names: ['git', '__nonexistent_cli_xyz__'], check_auth: false },
+      stubContext,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Available CLIs');
+    expect(result.content).toContain('**git**');
+    expect(result.content).toContain('Not found');
+    expect(result.content).toContain('__nonexistent_cli_xyz__');
+  });
+
+  test('uses default CLI list when names not provided', async () => {
+    const result = await cliDiscoverTool.execute(
+      { check_auth: false },
+      stubContext,
+    );
+    expect(result.isError).toBe(false);
+    // Should at least find git which is nearly universally available
+    expect(result.content).toContain('**git**');
+  });
+
+  test('includes version info for found CLIs', async () => {
+    const result = await cliDiscoverTool.execute(
+      { names: ['git'], check_auth: false },
+      stubContext,
+    );
+    expect(result.isError).toBe(false);
+    // git --version outputs something like "git version 2.x.x"
+    expect(result.content).toMatch(/git version/i);
+  });
+});

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -160,6 +160,13 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('swarm_delegate');
   });
 
+  test('includes external service access preference section', () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain('## External Service Access Preference');
+    expect(result).toContain('CLI tools via host_bash');
+    expect(result).toContain('Browser automation as last resort');
+  });
+
   test('config section uses workspace directory from platform util', () => {
     const result = buildSystemPrompt();
     expect(result).toContain(`Your workspace is mounted at \`/workspace/\` inside the Docker sandbox (host path: \`${TEST_DIR}/\`)`);

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -116,6 +116,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildSystemPermissionSection());
   parts.push(buildChannelAwarenessSection());
   parts.push(buildSwarmGuidanceSection());
+  parts.push(buildAccessPreferenceSection());
   parts.push(buildIntegrationSection());
   parts.push(buildWorkspaceReflectionSection());
   parts.push(buildPostToolResponseSection());
@@ -463,6 +464,31 @@ export function buildSwarmGuidanceSection(): string {
     '## Parallel Task Orchestration',
     '',
     'Use `swarm_delegate` only when a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"). For single-focus tasks, work directly — do not decompose them into a swarm.',
+  ].join('\n');
+}
+
+function buildAccessPreferenceSection(): string {
+  return [
+    '## External Service Access Preference',
+    '',
+    'When interacting with external services (GitHub, Slack, Linear, Jira, cloud providers, etc.),',
+    'follow this priority order:',
+    '',
+    '1. **CLI tools via host_bash** — If a CLI is installed on the user\'s machine (gh, slack, linear,',
+    '   jira, aws, gcloud, etc.), use it. CLIs handle auth, pagination, and output formatting.',
+    '   Use --json or equivalent flags for structured output when available.',
+    '2. **Direct API calls via host_bash** — Use curl/httpie with API tokens from credential_store.',
+    '   Faster and more reliable than browser automation.',
+    '3. **web_fetch** — For public endpoints or simple API calls that don\'t need auth.',
+    '4. **Browser automation as last resort** — Only when the task genuinely requires a browser',
+    '   (e.g., no API exists, visual interaction needed, or OAuth consent screen).',
+    '',
+    'Before using browser tools for a business system, ask yourself:',
+    '- Is there a CLI installed? (Check with `cli_discover` or `which <tool>` via host_bash)',
+    '- Does the service have a public API I can call with curl?',
+    '- Can I get the data via web_fetch?',
+    '',
+    'If yes to any of these, use that path instead of the browser.',
   ].join('\n');
 }
 

--- a/assistant/src/tools/host-terminal/cli-discover.ts
+++ b/assistant/src/tools/host-terminal/cli-discover.ts
@@ -1,0 +1,179 @@
+import { spawn } from 'node:child_process';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('cli-discover');
+
+/**
+ * Common business CLIs checked when no explicit list is provided.
+ * Kept intentionally broad — the tool only reports what's on PATH.
+ */
+const DEFAULT_CLIS = [
+  // Version control & code hosting
+  'gh', 'git', 'gitlab',
+  // Project management
+  'linear', 'jira',
+  // Communication
+  'slack',
+  // Cloud providers
+  'aws', 'gcloud', 'az',
+  // Containers & infra
+  'docker', 'kubectl', 'terraform',
+  // Package managers / runtimes
+  'node', 'bun', 'deno', 'python3', 'pip3',
+  // HTTP clients
+  'curl', 'httpie',
+  // Misc dev tools
+  'vercel', 'netlify', 'fly', 'heroku', 'railway',
+] as const;
+
+/**
+ * Known auth-check commands. Each entry maps a CLI binary name to the
+ * command + args that report authentication status without side effects.
+ */
+const AUTH_CHECK_COMMANDS: Record<string, string[]> = {
+  gh: ['gh', 'auth', 'status'],
+  aws: ['aws', 'sts', 'get-caller-identity'],
+  gcloud: ['gcloud', 'auth', 'print-access-token'],
+  az: ['az', 'account', 'show'],
+  vercel: ['vercel', 'whoami'],
+  netlify: ['netlify', 'status'],
+  fly: ['fly', 'auth', 'whoami'],
+  heroku: ['heroku', 'auth:whoami'],
+  railway: ['railway', 'whoami'],
+};
+
+interface CliResult {
+  name: string;
+  found: boolean;
+  path?: string;
+  version?: string;
+  authenticated?: boolean;
+  authInfo?: string;
+}
+
+/**
+ * Run a command with a short timeout and return stdout (trimmed) or null on failure.
+ */
+function runQuick(command: string, args: string[], timeoutMs = 5000): Promise<string | null> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: timeoutMs,
+    });
+
+    child.stdout.on('data', (data: Buffer) => chunks.push(data));
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(chunks).toString().trim());
+      } else {
+        resolve(null);
+      }
+    });
+
+    child.on('error', () => resolve(null));
+  });
+}
+
+class CliDiscoverTool implements Tool {
+  name = 'cli_discover';
+  description = 'Discover which CLI tools are installed, their versions, and authentication status';
+  category = 'host-terminal';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          names: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'CLI binary names to check. Defaults to a broad set of common business CLIs if omitted.',
+          },
+          check_auth: {
+            type: 'boolean',
+            description: 'Whether to run auth-status checks for known CLIs (default: true)',
+          },
+        },
+        required: [],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const rawNames = input.names;
+    const names: string[] = Array.isArray(rawNames) && rawNames.every((n) => typeof n === 'string')
+      ? rawNames as string[]
+      : [...DEFAULT_CLIS];
+    const checkAuth = input.check_auth !== false;
+
+    log.info({ count: names.length, checkAuth }, 'Discovering CLIs');
+
+    const results: CliResult[] = [];
+
+    for (const name of names) {
+      const path = Bun.which(name);
+      if (!path) {
+        results.push({ name, found: false });
+        continue;
+      }
+
+      const result: CliResult = { name, found: true, path };
+
+      // Version check
+      const version = await runQuick(name, ['--version']);
+      if (version) {
+        // Take first line only — some tools emit multi-line version info
+        result.version = version.split('\n')[0];
+      }
+
+      // Auth check
+      if (checkAuth && AUTH_CHECK_COMMANDS[name]) {
+        const [cmd, ...args] = AUTH_CHECK_COMMANDS[name];
+        const authOutput = await runQuick(cmd, args);
+        result.authenticated = authOutput !== null;
+        if (authOutput) {
+          // Keep auth info brief — first line, max 200 chars
+          result.authInfo = authOutput.split('\n')[0].slice(0, 200);
+        }
+      }
+
+      results.push(result);
+    }
+
+    const found = results.filter((r) => r.found);
+    const notFound = results.filter((r) => !r.found);
+
+    const lines: string[] = [];
+
+    if (found.length > 0) {
+      lines.push('## Available CLIs\n');
+      for (const r of found) {
+        let line = `- **${r.name}** (${r.path})`;
+        if (r.version) line += ` — ${r.version}`;
+        if (r.authenticated === true) line += ` [authenticated${r.authInfo ? `: ${r.authInfo}` : ''}]`;
+        else if (r.authenticated === false) line += ' [not authenticated]';
+        lines.push(line);
+      }
+    }
+
+    if (notFound.length > 0) {
+      if (lines.length > 0) lines.push('');
+      lines.push(`## Not found: ${notFound.map((r) => r.name).join(', ')}`);
+    }
+
+    return {
+      content: lines.join('\n'),
+      isError: false,
+    };
+  }
+}
+
+export const cliDiscoverTool: Tool = new CliDiscoverTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -16,6 +16,7 @@ import { reminderTool } from './reminder/reminder.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
+import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -84,6 +85,7 @@ export const explicitTools: Tool[] = [
   vellumSkillsCatalogTool,
   documentCreateTool,
   documentUpdateTool,
+  cliDiscoverTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add system prompt section establishing a clear decision hierarchy for external service access: CLI tools > direct API calls > web_fetch > browser automation
- Add `cli_discover` tool (low-risk) that checks which CLIs are installed, their versions, and authentication status via `Bun.which()` and known auth-check commands
- Register `cli_discover` in the tool manifest and add tests for both changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
