### PR TITLE
PR 04: Add Workspace Config Reader Utility (Read-Only)

### DIFF
--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Read-only utility for loading the workspace configuration file at
+/// `~/.vellum/workspace/config.json`.
+///
+/// All read errors (missing file, malformed JSON, non-object root) are
+/// treated as recoverable — the caller simply gets an empty dictionary.
+/// A write API will be added in a later PR.
+public enum WorkspaceConfigIO {
+
+    /// Default path: `~/.vellum/workspace/config.json`.
+    public static let defaultPath: String = {
+        let home = NSHomeDirectory()
+        return "\(home)/.vellum/workspace/config.json"
+    }()
+
+    /// Reads the workspace config and returns the top-level dictionary.
+    ///
+    /// Returns an empty dictionary when the file is missing, empty,
+    /// contains malformed JSON, or the root value is not an object.
+    ///
+    /// - Parameter path: Override the file path (useful for testing).
+    public static func read(from path: String? = nil) -> [String: Any] {
+        let filePath = path ?? defaultPath
+
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            return [:]
+        }
+
+        guard let data = FileManager.default.contents(atPath: filePath),
+              !data.isEmpty else {
+            return [:]
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []),
+              let dict = json as? [String: Any] else {
+            return [:]
+        }
+
+        return dict
+    }
+}

--- a/clients/macos/vellum-assistantTests/WorkspaceConfigIOReadTests.swift
+++ b/clients/macos/vellum-assistantTests/WorkspaceConfigIOReadTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class WorkspaceConfigIOReadTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Write a string to a temp file and return its path.
+    private func writeTemp(_ content: String, filename: String = "config.json") -> String {
+        let fileURL = tempDir.appendingPathComponent(filename)
+        try? content.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL.path
+    }
+
+    /// Write raw bytes to a temp file and return its path.
+    private func writeTempData(_ data: Data, filename: String = "config.json") -> String {
+        let fileURL = tempDir.appendingPathComponent(filename)
+        try? data.write(to: fileURL)
+        return fileURL.path
+    }
+
+    // MARK: - Valid JSON
+
+    func testReadValidJsonReturnsExpectedKeys() {
+        let path = writeTemp(#"{"theme":"dark","fontSize":14}"#)
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertEqual(config["theme"] as? String, "dark")
+        XCTAssertEqual(config["fontSize"] as? Int, 14)
+    }
+
+    func testReadValidNestedJsonPreservesStructure() {
+        let path = writeTemp(#"{"editor":{"tabSize":2},"enabled":true}"#)
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertEqual(config.count, 2)
+        XCTAssertEqual(config["enabled"] as? Bool, true)
+
+        let editor = config["editor"] as? [String: Any]
+        XCTAssertNotNil(editor)
+        XCTAssertEqual(editor?["tabSize"] as? Int, 2)
+    }
+
+    func testReadEmptyObjectReturnsEmptyDict() {
+        let path = writeTemp("{}")
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    // MARK: - Missing file
+
+    func testReadMissingFileReturnsEmptyDict() {
+        let bogusPath = tempDir.appendingPathComponent("nonexistent.json").path
+        let config = WorkspaceConfigIO.read(from: bogusPath)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    // MARK: - Empty file
+
+    func testReadEmptyFileReturnsEmptyDict() {
+        let path = writeTempData(Data())
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    // MARK: - Malformed JSON
+
+    func testReadMalformedJsonReturnsEmptyDict() {
+        let path = writeTemp("{not valid json!!!")
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    func testReadTrailingCommaIsTolerated() {
+        // Apple's JSONSerialization is lenient and accepts trailing commas
+        let path = writeTemp(#"{"key": "value",}"#)
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertEqual(config["key"] as? String, "value")
+    }
+
+    // MARK: - Non-object JSON
+
+    func testReadArrayRootReturnsEmptyDict() {
+        let path = writeTemp(#"[1, 2, 3]"#)
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    func testReadStringRootReturnsEmptyDict() {
+        let path = writeTemp(#""just a string""#)
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    func testReadNumberRootReturnsEmptyDict() {
+        let path = writeTemp("42")
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    func testReadBoolRootReturnsEmptyDict() {
+        let path = writeTemp("true")
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    func testReadNullRootReturnsEmptyDict() {
+        let path = writeTemp("null")
+        let config = WorkspaceConfigIO.read(from: path)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    // MARK: - Default path
+
+    func testDefaultPathPointsToExpectedLocation() {
+        let home = NSHomeDirectory()
+        XCTAssertEqual(WorkspaceConfigIO.defaultPath, "\(home)/.vellum/workspace/config.json")
+    }
+}

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -243,8 +243,8 @@ private func buildSessionTransportMetadata(
 }
 
 extension IPCSessionCreateRequest {
-    public init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: IPCSessionTransportMetadata? = nil) {
-        self.init(type: "session_create", title: title, systemPromptOverride: systemPromptOverride, maxResponseTokens: maxResponseTokens, correlationId: correlationId, transport: transport)
+    public init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: IPCSessionTransportMetadata? = nil, threadType: String? = nil) {
+        self.init(type: "session_create", title: title, systemPromptOverride: systemPromptOverride, maxResponseTokens: maxResponseTokens, correlationId: correlationId, transport: transport, threadType: threadType)
     }
 
     public init(
@@ -266,7 +266,8 @@ extension IPCSessionCreateRequest {
                 channelId: transportChannelId,
                 hints: transportHints,
                 uxBrief: transportUxBrief
-            )
+            ),
+            threadType: nil
         )
     }
 }
@@ -705,8 +706,8 @@ extension IPCMessageComplete {
 public typealias SessionInfoMessage = IPCSessionInfo
 
 extension IPCSessionInfo {
-    public init(sessionId: String, title: String, correlationId: String? = nil) {
-        self.init(type: "session_info", sessionId: sessionId, title: title, correlationId: correlationId)
+    public init(sessionId: String, title: String, correlationId: String? = nil, threadType: String? = nil) {
+        self.init(type: "session_info", sessionId: sessionId, title: title, correlationId: correlationId, threadType: threadType)
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `WorkspaceConfigIO` enum with a static `read(from:)` method for safely loading `~/.vellum/workspace/config.json`
- Returns `[String: Any]` dictionary; gracefully handles missing file, empty file, malformed JSON, and non-object root by returning an empty dictionary
- Fixes pre-existing build errors from missing `threadType` parameter in IPC convenience initializers

## Test plan
- [x] All 13 `WorkspaceConfigIOReadTests` pass (valid JSON, nested JSON, empty object, missing file, empty file, malformed JSON, array root, string root, number root, bool root, null root, trailing comma, default path)

PR 04 of 42 in the media embeds plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
