### PR TITLE
private-threads: add DB schema columns for conversation thread metadata

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -26,6 +26,7 @@ mock.module('../util/logger.js', () => ({
 import { initializeDb, getDb } from '../memory/db.js';
 import {
   createConversation,
+  getConversation,
   addMessage,
   getMessages,
   deleteLastExchange,
@@ -297,5 +298,47 @@ describe('attachment orphan cleanup', () => {
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
     const remaining = raw.query('SELECT COUNT(*) AS c FROM attachments').get() as { c: number };
     expect(remaining.c).toBe(1); // only the unlinked upload survives
+  });
+});
+
+describe('conversation thread metadata defaults', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test('new conversation has threadType defaulting to standard', () => {
+    const conv = createConversation('test');
+    expect(conv.threadType).toBe('standard');
+  });
+
+  test('new conversation has memoryScopeId defaulting to default', () => {
+    const conv = createConversation('test');
+    expect(conv.memoryScopeId).toBe('default');
+  });
+
+  test('defaults are persisted and retrievable from DB', () => {
+    const conv = createConversation('test');
+    const loaded = getConversation(conv.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.threadType).toBe('standard');
+    expect(loaded!.memoryScopeId).toBe('default');
+  });
+
+  test('existing conversations without explicit values get defaults via migration', () => {
+    // Insert a conversation row directly without the new columns
+    // (simulates a pre-migration row — the ALTER TABLE DEFAULT handles it)
+    const db = getDb();
+    const now = Date.now();
+    const id = 'legacy-conv-' + now;
+    db.run(
+      `INSERT INTO conversations (id, title, created_at, updated_at) VALUES ('${id}', 'legacy', ${now}, ${now})`,
+    );
+
+    const loaded = getConversation(id);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.threadType).toBe('standard');
+    expect(loaded!.memoryScopeId).toBe('default');
   });
 });

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -37,6 +37,8 @@ export function createConversation(title?: string) {
     contextSummary: null as string | null,
     contextCompactedMessageCount: 0,
     contextCompactedAt: null as number | null,
+    threadType: 'standard',
+    memoryScopeId: 'default',
   };
   db.insert(conversations).values(conversation).run();
   return conversation;

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -473,6 +473,8 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN last_processing_error TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN retry_after INTEGER`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN raw_payload TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN thread_type TEXT NOT NULL DEFAULT 'standard'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -11,6 +11,8 @@ export const conversations = sqliteTable('conversations', {
   contextSummary: text('context_summary'),
   contextCompactedMessageCount: integer('context_compacted_message_count').notNull().default(0),
   contextCompactedAt: integer('context_compacted_at'),
+  threadType: text('thread_type').notNull().default('standard'),
+  memoryScopeId: text('memory_scope_id').notNull().default('default'),
 });
 
 export const messages = sqliteTable('messages', {


### PR DESCRIPTION
## Summary
- Adds `thread_type` (default `standard`) and `memory_scope_id` (default `default`) columns to the `conversations` table in `schema.ts`
- Adds safe ALTER TABLE migrations with try/catch in `db.ts`
- Includes defaults in `createConversation` for new rows
- Adds 4 tests verifying defaults, persistence, and migration backward compatibility

## Test plan
- [x] `bun test src/__tests__/conversation-store.test.ts` — all 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
