### PR TITLE
PR 05: Add Workspace Config Writer Utility (Atomic Merge)

### DIFF
--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -1,11 +1,10 @@
 import Foundation
 
-/// Read-only utility for loading the workspace configuration file at
+/// Utility for reading and writing the workspace configuration file at
 /// `~/.vellum/workspace/config.json`.
 ///
 /// All read errors (missing file, malformed JSON, non-object root) are
 /// treated as recoverable — the caller simply gets an empty dictionary.
-/// A write API will be added in a later PR.
 public enum WorkspaceConfigIO {
 
     /// Default path: `~/.vellum/workspace/config.json`.
@@ -38,5 +37,55 @@ public enum WorkspaceConfigIO {
         }
 
         return dict
+    }
+
+    /// Atomically merges the given key-value pairs into the config file.
+    ///
+    /// Performs a read-merge-write cycle so that keys not present in
+    /// `values` are preserved. If the file or its parent directory does
+    /// not exist, they are created.
+    ///
+    /// Atomicity is achieved by writing to a temporary file in the same
+    /// directory and then renaming it over the target, so a crash mid-write
+    /// cannot leave a truncated config on disk.
+    ///
+    /// - Parameters:
+    ///   - values: Top-level keys to set or overwrite.
+    ///   - path: Override the file path (useful for testing).
+    /// - Throws: If serialisation or filesystem operations fail.
+    public static func merge(_ values: [String: Any], into path: String? = nil) throws {
+        let filePath = path ?? defaultPath
+        let fileURL = URL(fileURLWithPath: filePath)
+        let directory = fileURL.deletingLastPathComponent()
+
+        // Ensure the parent directory exists.
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+
+        // Read existing config (empty dict on any error).
+        var config = read(from: filePath)
+
+        // Merge new values on top.
+        for (key, value) in values {
+            config[key] = value
+        }
+
+        let data = try JSONSerialization.data(
+            withJSONObject: config,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+
+        // Write to a temp file in the same directory, then rename for atomicity.
+        let tempURL = directory.appendingPathComponent(".\(UUID().uuidString).tmp")
+        try data.write(to: tempURL)
+
+        // Replace or move into place.
+        if FileManager.default.fileExists(atPath: filePath) {
+            _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+        } else {
+            try FileManager.default.moveItem(at: tempURL, to: fileURL)
+        }
     }
 }

--- a/clients/macos/vellum-assistantTests/WorkspaceConfigIOWriteTests.swift
+++ b/clients/macos/vellum-assistantTests/WorkspaceConfigIOWriteTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class WorkspaceConfigIOWriteTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private var configPath: String {
+        tempDir.appendingPathComponent("config.json").path
+    }
+
+    /// Write a string to the config file for pre-population.
+    private func seed(_ content: String) {
+        let url = URL(fileURLWithPath: configPath)
+        try! content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Writing to new file
+
+    func testMergeCreatesFileWhenMissing() throws {
+        try WorkspaceConfigIO.merge(["theme": "dark"], into: configPath)
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        XCTAssertEqual(config["theme"] as? String, "dark")
+    }
+
+    func testMergeCreatesValidJson() throws {
+        try WorkspaceConfigIO.merge(["key": "value"], into: configPath)
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: configPath))
+        let json = try JSONSerialization.jsonObject(with: data, options: [])
+        XCTAssertNotNil(json as? [String: Any])
+    }
+
+    // MARK: - Preserving existing keys
+
+    func testMergePreservesExistingKeys() throws {
+        seed(#"{"existing":"keep","count":42}"#)
+
+        try WorkspaceConfigIO.merge(["newKey": "newValue"], into: configPath)
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        XCTAssertEqual(config["existing"] as? String, "keep")
+        XCTAssertEqual(config["count"] as? Int, 42)
+        XCTAssertEqual(config["newKey"] as? String, "newValue")
+    }
+
+    // MARK: - Overwriting a specific key
+
+    func testMergeOverwritesSpecificKey() throws {
+        seed(#"{"theme":"light","fontSize":14}"#)
+
+        try WorkspaceConfigIO.merge(["theme": "dark"], into: configPath)
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        XCTAssertEqual(config["theme"] as? String, "dark")
+        XCTAssertEqual(config["fontSize"] as? Int, 14)
+    }
+
+    // MARK: - Nested values
+
+    func testMergeWritesNestedValues() throws {
+        try WorkspaceConfigIO.merge(
+            ["editor": ["tabSize": 4, "wordWrap": true] as [String: Any]],
+            into: configPath
+        )
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        let editor = config["editor"] as? [String: Any]
+        XCTAssertNotNil(editor)
+        XCTAssertEqual(editor?["tabSize"] as? Int, 4)
+        XCTAssertEqual(editor?["wordWrap"] as? Bool, true)
+    }
+
+    // MARK: - Multiple keys at once
+
+    func testMergeMultipleKeys() throws {
+        try WorkspaceConfigIO.merge(
+            ["a": 1, "b": "two", "c": true],
+            into: configPath
+        )
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        XCTAssertEqual(config["a"] as? Int, 1)
+        XCTAssertEqual(config["b"] as? String, "two")
+        XCTAssertEqual(config["c"] as? Bool, true)
+    }
+
+    // MARK: - Directory creation
+
+    func testMergeCreatesIntermediateDirectories() throws {
+        let nestedPath = tempDir
+            .appendingPathComponent("deep/nested/dir", isDirectory: true)
+            .appendingPathComponent("config.json")
+            .path
+
+        try WorkspaceConfigIO.merge(["key": "value"], into: nestedPath)
+
+        let config = WorkspaceConfigIO.read(from: nestedPath)
+        XCTAssertEqual(config["key"] as? String, "value")
+    }
+
+    // MARK: - Atomic write safety
+
+    func testAtomicWriteDoesNotCorruptExistingFile() throws {
+        seed(#"{"important":"data"}"#)
+
+        // Merge additional data — the original key must survive.
+        try WorkspaceConfigIO.merge(["extra": "info"], into: configPath)
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        XCTAssertEqual(config["important"] as? String, "data")
+        XCTAssertEqual(config["extra"] as? String, "info")
+    }
+
+    func testAtomicWriteNoTempFileLeftBehind() throws {
+        try WorkspaceConfigIO.merge(["key": "value"], into: configPath)
+
+        let contents = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
+        // Only the config file should remain — no .tmp artefacts.
+        XCTAssertEqual(contents.count, 1)
+        XCTAssertEqual(contents.first, "config.json")
+    }
+
+    // MARK: - Empty merge is a no-op on content
+
+    func testMergeEmptyDictPreservesExisting() throws {
+        seed(#"{"keep":"me"}"#)
+
+        try WorkspaceConfigIO.merge([:], into: configPath)
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        XCTAssertEqual(config["keep"] as? String, "me")
+    }
+
+    // MARK: - Overwrites malformed file gracefully
+
+    func testMergeOverwritesMalformedFile() throws {
+        seed("{not valid json!!!")
+
+        try WorkspaceConfigIO.merge(["fresh": "start"], into: configPath)
+
+        let config = WorkspaceConfigIO.read(from: configPath)
+        XCTAssertEqual(config["fresh"] as? String, "start")
+        // Malformed content is replaced; only the merged key should exist.
+        XCTAssertEqual(config.count, 1)
+    }
+}

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -243,13 +243,8 @@ private func buildSessionTransportMetadata(
 }
 
 extension IPCSessionCreateRequest {
-<<<<<<< HEAD
     public init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: IPCSessionTransportMetadata? = nil, threadType: String? = nil) {
         self.init(type: "session_create", title: title, systemPromptOverride: systemPromptOverride, maxResponseTokens: maxResponseTokens, correlationId: correlationId, transport: transport, threadType: threadType)
-=======
-    public init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: IPCSessionTransportMetadata? = nil) {
-        self.init(type: "session_create", title: title, systemPromptOverride: systemPromptOverride, maxResponseTokens: maxResponseTokens, correlationId: correlationId, transport: transport, threadType: nil)
->>>>>>> e3021c06 (feat: add plain URL extractor for media embed pipeline)
     }
 
     public init(


### PR DESCRIPTION
## Summary
- Adds `merge(_:into:)` static method to `WorkspaceConfigIO` that performs a read-merge-write cycle preserving unrelated config keys
- Uses temp-file-then-rename for atomicity so a crash mid-write cannot leave a truncated config on disk
- Creates intermediate directories if they don't exist
- Gracefully handles malformed existing files by treating them as empty

## Test plan
- [x] All 11 WorkspaceConfigIOWriteTests pass
  - Writing to new file creates valid JSON
  - Writing preserves existing keys
  - Writing overwrites specific key
  - Writing nested values
  - Atomic write doesn't corrupt existing file
  - No temp files left behind
  - Directory creation if needed
  - Empty merge preserves existing config
  - Overwrites malformed file gracefully

PR 05 of 42 in the media embeds plan.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
