### PR TITLE
private-threads: conversation creation API accepts thread type

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -342,3 +342,44 @@ describe('conversation thread metadata defaults', () => {
     expect(loaded!.memoryScopeId).toBe('default');
   });
 });
+
+describe('createConversation with thread type option', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test('standard create with string title uses defaults', () => {
+    const conv = createConversation('hello');
+    expect(conv.title).toBe('hello');
+    expect(conv.threadType).toBe('standard');
+    expect(conv.memoryScopeId).toBe('default');
+  });
+
+  test('standard create with options object uses defaults', () => {
+    const conv = createConversation({ title: 'hello', threadType: 'standard' });
+    expect(conv.threadType).toBe('standard');
+    expect(conv.memoryScopeId).toBe('default');
+  });
+
+  test('private create sets threadType and derives memoryScopeId', () => {
+    const conv = createConversation({ title: 'secret', threadType: 'private' });
+    expect(conv.threadType).toBe('private');
+    expect(conv.memoryScopeId).toBe(`private:${conv.id}`);
+  });
+
+  test('private create memoryScopeId is persisted', () => {
+    const conv = createConversation({ threadType: 'private' });
+    const loaded = getConversation(conv.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.threadType).toBe('private');
+    expect(loaded!.memoryScopeId).toBe(`private:${conv.id}`);
+  });
+
+  test('no-arg create uses defaults', () => {
+    const conv = createConversation();
+    expect(conv.threadType).toBe('standard');
+    expect(conv.memoryScopeId).toBe('default');
+  });
+});

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -23,12 +23,16 @@ function monotonicNow(): number {
   return lastTimestamp;
 }
 
-export function createConversation(title?: string) {
+export function createConversation(titleOrOpts?: string | { title?: string; threadType?: 'standard' | 'private' }) {
   const db = getDb();
   const now = Date.now();
+  const opts = typeof titleOrOpts === 'string' ? { title: titleOrOpts } : (titleOrOpts ?? {});
+  const threadType = opts.threadType ?? 'standard';
+  const id = uuid();
+  const memoryScopeId = threadType === 'private' ? `private:${id}` : 'default';
   const conversation = {
-    id: uuid(),
-    title: title ?? null,
+    id,
+    title: opts.title ?? null,
     createdAt: now,
     updatedAt: now,
     totalInputTokens: 0,
@@ -37,8 +41,8 @@ export function createConversation(title?: string) {
     contextSummary: null as string | null,
     contextCompactedMessageCount: 0,
     contextCompactedAt: null as number | null,
-    threadType: 'standard',
-    memoryScopeId: 'default',
+    threadType,
+    memoryScopeId,
   };
   db.insert(conversations).values(conversation).run();
   return conversation;


### PR DESCRIPTION
## Summary
- Extend `createConversation` to accept an options object with `threadType` (`'standard' | 'private'`) while maintaining backward compatibility with the existing string-title signature.
- Private threads derive `memoryScopeId` as `private:<conversationId>` for memory isolation; standard threads continue to use `'default'`.
- Add tests covering all call signatures (no-arg, string, options object) and persistence of private thread metadata.

## Test plan
- [x] All 23 conversation-store tests pass (including 5 new tests for thread type options)
- [x] Backward compatibility: existing callers passing a string title or no args continue to work identically
- [x] Private thread memoryScopeId is correctly derived and persisted to DB

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
