### PR TITLE
fix: use non-secret gcloud auth check in cli-discover

### DIFF
--- a/assistant/src/tools/host-terminal/cli-discover.ts
+++ b/assistant/src/tools/host-terminal/cli-discover.ts
@@ -36,7 +36,7 @@ const DEFAULT_CLIS = [
 const AUTH_CHECK_COMMANDS: Record<string, string[]> = {
   gh: ['gh', 'auth', 'status'],
   aws: ['aws', 'sts', 'get-caller-identity'],
-  gcloud: ['gcloud', 'auth', 'print-access-token'],
+  gcloud: ['gcloud', 'auth', 'list', '--filter=status:ACTIVE', '--format=value(account)'],
   az: ['az', 'account', 'show'],
   vercel: ['vercel', 'whoami'],
   netlify: ['netlify', 'status'],


### PR DESCRIPTION
Replace gcloud auth print-access-token with gcloud auth list in AUTH_CHECK_COMMANDS to prevent leaking live OAuth2 tokens into tool output. Both Codex and Devin flagged this security issue in PR #3975.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
