### PR TITLE
PR 06: Add Media Embed Defaults Model

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Centralized defaults and helpers for the media-embed feature.
+/// Later PRs will wire these into SettingsStore and the embed pipeline;
+/// for now this is a pure-value model with no side effects.
+public enum MediaEmbedSettings {
+
+    /// Whether media embeds are turned on by default for new installs.
+    public static let defaultEnabled = true
+
+    /// Domains whose URLs are eligible for inline embed rendering.
+    public static let defaultDomains: [String] = [
+        "youtube.com",
+        "youtu.be",
+        "vimeo.com",
+        "loom.com",
+    ]
+
+    /// Returns the current date, suitable for persisting the moment the user
+    /// enabled embeds so we only embed links from messages created after that point.
+    public static func enabledSinceNow() -> Date {
+        Date()
+    }
+
+    /// Normalizes a user-provided domain list: trims whitespace, lowercases,
+    /// removes empty strings, and deduplicates while preserving first-occurrence order.
+    public static func normalizeDomains(_ domains: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for domain in domains {
+            let normalized = domain.trimmingCharacters(in: .whitespaces).lowercased()
+            guard !normalized.isEmpty, !seen.contains(normalized) else { continue }
+            seen.insert(normalized)
+            result.append(normalized)
+        }
+        return result
+    }
+}

--- a/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class MediaEmbedSettingsDefaultsTests: XCTestCase {
+
+    // MARK: - Default enabled
+
+    func testDefaultEnabledIsTrue() {
+        XCTAssertTrue(MediaEmbedSettings.defaultEnabled)
+    }
+
+    // MARK: - Default domains
+
+    func testDefaultDomainsContainAllExpectedProviders() {
+        let domains = MediaEmbedSettings.defaultDomains
+        XCTAssertTrue(domains.contains("youtube.com"), "Should include youtube.com")
+        XCTAssertTrue(domains.contains("youtu.be"), "Should include youtu.be")
+        XCTAssertTrue(domains.contains("vimeo.com"), "Should include vimeo.com")
+        XCTAssertTrue(domains.contains("loom.com"), "Should include loom.com")
+        XCTAssertEqual(domains.count, 4, "Should contain exactly 4 default domains")
+    }
+
+    // MARK: - enabledSinceNow
+
+    func testEnabledSinceNowReturnsDateCloseToNow() {
+        let before = Date()
+        let result = MediaEmbedSettings.enabledSinceNow()
+        let after = Date()
+
+        XCTAssertGreaterThanOrEqual(result.timeIntervalSince1970, before.timeIntervalSince1970,
+                                     "Returned date should not be before the call")
+        XCTAssertLessThanOrEqual(result.timeIntervalSince1970, after.timeIntervalSince1970,
+                                  "Returned date should not be after the call returns")
+    }
+
+    // MARK: - normalizeDomains
+
+    func testNormalizeDomainsTrimsWhitespace() {
+        let result = MediaEmbedSettings.normalizeDomains(["  youtube.com  ", " vimeo.com"])
+        XCTAssertEqual(result, ["youtube.com", "vimeo.com"])
+    }
+
+    func testNormalizeDomainsLowercases() {
+        let result = MediaEmbedSettings.normalizeDomains(["YouTube.COM", "Vimeo.Com"])
+        XCTAssertEqual(result, ["youtube.com", "vimeo.com"])
+    }
+
+    func testNormalizeDomainsDeduplicates() {
+        let result = MediaEmbedSettings.normalizeDomains(["youtube.com", "YOUTUBE.COM", "youtube.com"])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
+
+    func testNormalizeDomainsRemovesEmptyStrings() {
+        let result = MediaEmbedSettings.normalizeDomains(["", "youtube.com", "  ", "vimeo.com", ""])
+        XCTAssertEqual(result, ["youtube.com", "vimeo.com"])
+    }
+
+    func testNormalizeDomainsPreservesFirstOccurrenceOrder() {
+        let result = MediaEmbedSettings.normalizeDomains(["loom.com", "youtube.com", "vimeo.com"])
+        XCTAssertEqual(result, ["loom.com", "youtube.com", "vimeo.com"])
+    }
+
+    func testNormalizeDomainsHandlesEmptyInput() {
+        let result = MediaEmbedSettings.normalizeDomains([])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testNormalizeDomainsHandlesAllEmptyStrings() {
+        let result = MediaEmbedSettings.normalizeDomains(["", "  ", "   "])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testNormalizeDomainsDeduplicatesAcrossCaseAndWhitespace() {
+        let result = MediaEmbedSettings.normalizeDomains(["  YouTube.com ", "youtube.com", " YOUTUBE.COM  "])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MediaEmbedSettings` enum with centralized defaults for embed toggle, domain allowlist, and `enabledSince` date factory
- Adds `normalizeDomains` helper that trims, lowercases, deduplicates, and filters empty strings

## Test plan
- [x] All 11 MediaEmbedSettingsDefaultsTests pass

PR 06 of 42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
