### PR TITLE
PR 15: Exclude Code Spans and Code Fences from Extraction

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -83,11 +83,46 @@ enum MessageURLExtractor {
         return results
     }
 
+    // Matches fenced code blocks: ``` with optional language id, content, closing ```
+    // Uses dotMatchesLineSeparators so `.` spans newlines.
+    private static let fencedCodeBlockPattern: NSRegularExpression = {
+        let pattern = "```[^`\\n]*\\n[\\s\\S]*?```"
+        return try! NSRegularExpression(pattern: pattern, options: [])
+    }()
+
+    // Matches inline code spans: `...` (single backtick, no nesting).
+    // Avoids matching empty backtick pairs or fenced blocks.
+    private static let inlineCodePattern: NSRegularExpression = {
+        let pattern = "`[^`]+`"
+        return try! NSRegularExpression(pattern: pattern, options: [])
+    }()
+
+    /// Removes fenced code blocks and inline code spans so that URLs
+    /// inside them are not picked up by extraction. Fenced blocks are
+    /// stripped first so that backticks inside fences don't interfere
+    /// with inline-code matching.
+    static func stripCodeRegions(from text: String) -> String {
+        let mutable = NSMutableString(string: text)
+        let fullRange = NSRange(location: 0, length: mutable.length)
+
+        // Strip fenced blocks first (they may contain backticks).
+        fencedCodeBlockPattern.replaceMatches(in: mutable, options: [], range: fullRange, withTemplate: "")
+
+        // Then strip inline code spans from what remains.
+        let updatedRange = NSRange(location: 0, length: mutable.length)
+        inlineCodePattern.replaceMatches(in: mutable, options: [], range: updatedRange, withTemplate: "")
+
+        return mutable as String
+    }
+
     /// Combines plain-text and markdown-link URL extraction, returning a
     /// deduplicated list in first-occurrence order across both sources.
+    /// URLs inside inline code spans and fenced code blocks are excluded.
     static func extractAllURLs(from text: String) -> [URL] {
-        let plain = extractPlainURLs(from: text)
-        let markdown = extractMarkdownLinkURLs(from: text)
+        let stripped = stripCodeRegions(from: text)
+
+        let plain = extractPlainURLs(from: stripped)
+        let markdown = extractMarkdownLinkURLs(from: stripped)
 
         var seen = Set<String>()
         var results: [URL] = []

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorCodeExclusionTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorCodeExclusionTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class MessageURLExtractorCodeExclusionTests: XCTestCase {
+
+    // MARK: - Inline code spans
+
+    func testURLInsideInlineCodeIsNotExtracted() {
+        let text = "Run `curl https://example.com/api` to test"
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    func testURLOutsideInlineCodeIsExtracted() {
+        let text = "Visit https://example.com and run `echo hello`"
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://example.com")
+    }
+
+    func testMixedInlineCodeAndPlainURL() {
+        let text = "See `https://code.example.com` and also https://real.example.com for info"
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://real.example.com")
+    }
+
+    // MARK: - Fenced code blocks
+
+    func testURLInsideFencedCodeBlockIsNotExtracted() {
+        let text = """
+        Here is an example:
+        ```
+        curl https://api.example.com/v1/data
+        ```
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    func testURLInsideFencedCodeBlockWithLanguageIsNotExtracted() {
+        let text = """
+        ```bash
+        wget https://downloads.example.com/file.tar.gz
+        ```
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    func testMultiLineCodeBlockWithMultipleURLsNotExtracted() {
+        let text = """
+        ```python
+        import requests
+        r1 = requests.get("https://api.example.com/users")
+        r2 = requests.get("https://api.example.com/posts")
+        print(r1.json())
+        ```
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    func testURLOutsideFencedCodeBlockIsExtracted() {
+        let text = """
+        Check https://docs.example.com for usage.
+        ```
+        # this is just a code sample
+        echo "hello"
+        ```
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://docs.example.com")
+    }
+
+    // MARK: - Mixed scenarios
+
+    func testURLInCodeAndURLInTextOnlyTextExtracted() {
+        let text = """
+        Visit https://real.example.com for details.
+        ```
+        curl https://fake.example.com/api
+        ```
+        Also check `https://also-fake.example.com` in code.
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://real.example.com")
+    }
+
+    func testMultipleCodeBlocksWithURLsBetween() {
+        let text = """
+        ```
+        https://block1.example.com
+        ```
+        Real link: https://middle.example.com
+        ```
+        https://block2.example.com
+        ```
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://middle.example.com")
+    }
+
+    // MARK: - Nested backticks
+
+    func testCodeBlockContainingBacktickCharacters() {
+        let text = """
+        ```
+        echo `https://nested.example.com`
+        ```
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    // MARK: - Markdown links inside code
+
+    func testMarkdownLinkInsideInlineCodeNotExtracted() {
+        let text = "Use `[link](https://example.com)` syntax for links"
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    func testMarkdownLinkInsideFencedBlockNotExtracted() {
+        let text = """
+        ```markdown
+        [Click here](https://example.com/page)
+        ```
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyCodeSpanDoesNotAffectExtraction() {
+        let text = "See `` and https://example.com"
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://example.com")
+    }
+
+    func testNoCodeRegionsExtractsNormally() {
+        let text = "Visit https://example.com and https://other.com"
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 2)
+        XCTAssertEqual(urls[0].absoluteString, "https://example.com")
+        XCTAssertEqual(urls[1].absoluteString, "https://other.com")
+    }
+
+    func testStripCodeRegionsDirectly() {
+        let text = "Hello `code here` world"
+        let stripped = MessageURLExtractor.stripCodeRegions(from: text)
+        XCTAssertEqual(stripped, "Hello  world")
+    }
+
+    func testStripFencedCodeRegionsDirectly() {
+        let text = """
+        Before
+        ```
+        inside fence
+        ```
+        After
+        """
+        let stripped = MessageURLExtractor.stripCodeRegions(from: text)
+        XCTAssertTrue(stripped.contains("Before"))
+        XCTAssertTrue(stripped.contains("After"))
+        XCTAssertFalse(stripped.contains("inside fence"))
+    }
+}


### PR DESCRIPTION
## Summary
- Prevents false-positive embeds from URLs inside code blocks and inline code
- Strips fenced code blocks (``` ```) and inline code spans (backticks) before URL extraction
- Adds `stripCodeRegions(from:)` helper that removes code regions before `extractAllURLs` runs

## Test plan
- [x] All 16 MessageURLExtractorCodeExclusionTests pass
- [x] All existing MessageURLExtractor tests continue to pass (54 total)

PR 15 of 42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
