### PR TITLE
private-threads: add conversation metadata lookup helpers

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -27,6 +27,8 @@ import { initializeDb, getDb } from '../memory/db.js';
 import {
   createConversation,
   getConversation,
+  getConversationThreadType,
+  getConversationMemoryScopeId,
   addMessage,
   getMessages,
   deleteLastExchange,
@@ -381,5 +383,41 @@ describe('createConversation with thread type option', () => {
     const conv = createConversation();
     expect(conv.threadType).toBe('standard');
     expect(conv.memoryScopeId).toBe('default');
+  });
+});
+
+describe('conversation metadata read helpers', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test('getConversationThreadType returns standard for standard conversation', () => {
+    const conv = createConversation('test');
+    expect(getConversationThreadType(conv.id)).toBe('standard');
+  });
+
+  test('getConversationThreadType returns private for private conversation', () => {
+    const conv = createConversation({ threadType: 'private' });
+    expect(getConversationThreadType(conv.id)).toBe('private');
+  });
+
+  test('getConversationThreadType returns standard for missing conversation', () => {
+    expect(getConversationThreadType('nonexistent-id')).toBe('standard');
+  });
+
+  test('getConversationMemoryScopeId returns default for standard conversation', () => {
+    const conv = createConversation('test');
+    expect(getConversationMemoryScopeId(conv.id)).toBe('default');
+  });
+
+  test('getConversationMemoryScopeId returns private scope for private conversation', () => {
+    const conv = createConversation({ threadType: 'private' });
+    expect(getConversationMemoryScopeId(conv.id)).toBe(`private:${conv.id}`);
+  });
+
+  test('getConversationMemoryScopeId returns default for missing conversation', () => {
+    expect(getConversationMemoryScopeId('nonexistent-id')).toBe('default');
   });
 });

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -58,6 +58,17 @@ export function getConversation(id: string) {
   return result ?? null;
 }
 
+export function getConversationThreadType(conversationId: string): 'standard' | 'private' {
+  const conv = getConversation(conversationId);
+  const raw = conv?.threadType;
+  return raw === 'private' ? 'private' : 'standard';
+}
+
+export function getConversationMemoryScopeId(conversationId: string): string {
+  const conv = getConversation(conversationId);
+  return conv?.memoryScopeId ?? 'default';
+}
+
 /**
  * Delete a conversation and all its messages.
  * Used for ephemeral conversations (e.g. secret-redirect placeholders)


### PR DESCRIPTION
## Summary
- Add `getConversationThreadType` helper that returns `'standard'` or `'private'` with null-safe fallback to `'standard'` for missing conversations.
- Add `getConversationMemoryScopeId` helper that returns the memory scope ID with null-safe fallback to `'default'` for missing conversations.
- Add 6 tests covering standard, private, and missing conversation cases for both helpers.

These centralize metadata lookup for session policy derivation in upcoming private-threads work.

## Test plan
- [x] All 29 conversation-store tests pass (including 6 new tests for the metadata helpers)
- [x] Verified null-safe defaults for missing conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
