### PR TITLE
private-threads: add ThreadKind enum to macOS ThreadModel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+enum ThreadKind: String, Hashable, Sendable {
+    case standard
+    case `private`
+}
+
 struct ThreadModel: Identifiable, Hashable {
     let id: UUID
     var title: String
@@ -11,8 +16,9 @@ struct ThreadModel: Identifiable, Hashable {
     var isPinned: Bool
     var pinnedOrder: Int?
     var lastInteractedAt: Date
+    var kind: ThreadKind
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -21,5 +27,6 @@ struct ThreadModel: Identifiable, Hashable {
         self.isPinned = isPinned
         self.pinnedOrder = pinnedOrder
         self.lastInteractedAt = lastInteractedAt ?? createdAt
+        self.kind = kind
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `ThreadKind` enum (`standard` / `private`) in `ThreadModel.swift`
- Add `kind` property to `ThreadModel` with default `.standard` for backward compatibility
- All existing call sites (including tests) continue to compile without changes

## Test plan
- [x] Verified macOS project builds successfully with `build.sh`
- [x] Confirmed all existing `ThreadModel()` call sites in tests use named params with defaults — no breakage

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
