### PR TITLE
feat: add "Check for Updates" menu item to macOS app menu

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -9,5 +9,13 @@ struct VellumAssistantApp: App {
         Settings {
             SettingsView(store: appDelegate.services.settingsStore, daemonClient: appDelegate.services.daemonClient)
         }
+        .commands {
+            CommandGroup(after: .appInfo) {
+                Button("Check for Updates...") {
+                    appDelegate.updateManager.checkForUpdates()
+                }
+                .disabled(!appDelegate.updateManager.canCheckForUpdates)
+            }
+        }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -87,7 +87,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var thinkingWindow: ThinkingIndicatorWindow?
     public let services = AppServices()
     private let daemonLauncher = DaemonLauncher()
-    let updateManager = UpdateManager()
+    public let updateManager = UpdateManager()
 
     // Forwarding accessors — ownership lives in `services`, these keep
     // existing internal references working without a mass-rename.

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -9,7 +9,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// The appcast URL points to the public releases repo where CI publishes
 /// signed ZIPs alongside an `appcast.xml`.
 @MainActor
-final class UpdateManager: NSObject, SPUUpdaterDelegate {
+public final class UpdateManager: NSObject, SPUUpdaterDelegate {
 
     private var updaterController: SPUStandardUpdaterController!
 
@@ -37,18 +37,18 @@ final class UpdateManager: NSObject, SPUUpdaterDelegate {
     }
 
     /// Manually trigger "Check for Updates…" (shows UI).
-    func checkForUpdates() {
+    public func checkForUpdates() {
         updaterController.checkForUpdates(nil)
     }
 
     /// Whether the "Check for Updates…" menu item should be enabled.
-    var canCheckForUpdates: Bool {
+    public var canCheckForUpdates: Bool {
         updaterController.updater.canCheckForUpdates
     }
 
     // MARK: - SPUUpdaterDelegate
 
-    nonisolated func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+    nonisolated public func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
         Task { @MainActor in
             log.info("Will install update \(item.displayVersionString)")
             onWillInstallUpdate?()


### PR DESCRIPTION
## Summary
- Adds a "Check for Updates..." menu item to the macOS app menu (after "About"), wired to Sparkle's `checkForUpdates` action
- Makes `UpdateManager` and its relevant members `public` so the app target can access them

## Test plan
- [ ] Build the app and verify "Check for Updates..." appears in the app menu after "About"
- [ ] Click the menu item and verify Sparkle's update check UI appears
- [ ] Verify the menu item is disabled when an update check is already in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
