### PR TITLE
feat: add extension-based image URL classifier

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum ImageURLClassification {
+    case image
+    case notImage
+    case unknown
+}
+
+/// Classifies URLs as image candidates based purely on file extension.
+///
+/// This is the first stage of image detection in the media-embed pipeline.
+/// URLs with unrecognized extensions return `.unknown` so that a later
+/// MIME-probe stage can resolve them via HTTP HEAD.
+enum ImageURLClassifier {
+
+    private static let imageExtensions: Set<String> = [
+        "png", "jpg", "jpeg", "gif", "webp", "svg",
+        "bmp", "ico", "tiff", "tif", "avif", "heic"
+    ]
+
+    static func classify(_ url: URL) -> ImageURLClassification {
+        // Only allow https for security.
+        guard url.scheme?.lowercased() == "https" else {
+            return .notImage
+        }
+
+        // Strip query and fragment by extracting just the path.
+        let path = url.path
+
+        // Find the last path component and check for a dot-separated extension.
+        let lastComponent = (path as NSString).lastPathComponent
+        guard let dotIndex = lastComponent.lastIndex(of: ".") else {
+            return .unknown
+        }
+
+        let ext = String(lastComponent[lastComponent.index(after: dotIndex)...]).lowercased()
+
+        // Empty extension (path ends with ".") is not recognizable.
+        guard !ext.isEmpty else {
+            return .unknown
+        }
+
+        if imageExtensions.contains(ext) {
+            return .image
+        }
+
+        return .notImage
+    }
+}

--- a/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
+++ b/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ImageURLClassifierExtensionTests: XCTestCase {
+
+    // MARK: - Common image extensions
+
+    func testPNG() {
+        let url = URL(string: "https://example.com/photo.png")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testJPG() {
+        let url = URL(string: "https://example.com/photo.jpg")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testJPEG() {
+        let url = URL(string: "https://example.com/photo.jpeg")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testGIF() {
+        let url = URL(string: "https://example.com/animation.gif")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testWebP() {
+        let url = URL(string: "https://example.com/image.webp")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    // MARK: - Less common image extensions
+
+    func testSVG() {
+        let url = URL(string: "https://example.com/icon.svg")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testBMP() {
+        let url = URL(string: "https://example.com/legacy.bmp")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testICO() {
+        let url = URL(string: "https://example.com/favicon.ico")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testTIFF() {
+        let url = URL(string: "https://example.com/scan.tiff")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testTIF() {
+        let url = URL(string: "https://example.com/scan.tif")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testAVIF() {
+        let url = URL(string: "https://example.com/modern.avif")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testHEIC() {
+        let url = URL(string: "https://example.com/apple.heic")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    // MARK: - Case insensitivity
+
+    func testUppercasePNG() {
+        let url = URL(string: "https://example.com/photo.PNG")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testMixedCaseJpG() {
+        let url = URL(string: "https://example.com/photo.JpG")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    // MARK: - Query parameters and fragments
+
+    func testImageExtensionWithQueryParameters() {
+        let url = URL(string: "https://example.com/image.png?w=100&h=200")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testImageExtensionWithFragment() {
+        let url = URL(string: "https://example.com/image.png#section")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    func testImageExtensionWithQueryAndFragment() {
+        let url = URL(string: "https://example.com/image.png?size=large#top")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
+    // MARK: - HTTP rejected for security
+
+    func testHTTPReturnsNotImage() {
+        let url = URL(string: "http://example.com/photo.png")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+    }
+
+    // MARK: - Non-image extensions
+
+    func testHTMLReturnsNotImage() {
+        let url = URL(string: "https://example.com/page.html")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+    }
+
+    func testPDFReturnsNotImage() {
+        let url = URL(string: "https://example.com/document.pdf")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+    }
+
+    func testZIPReturnsNotImage() {
+        let url = URL(string: "https://example.com/archive.zip")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+    }
+
+    // MARK: - No extension returns unknown
+
+    func testNoExtensionReturnsUnknown() {
+        let url = URL(string: "https://example.com/image")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
+    }
+
+    func testExtensionlessPathReturnsUnknown() {
+        let url = URL(string: "https://example.com/photos/12345")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
+    }
+
+    func testRootPathReturnsUnknown() {
+        let url = URL(string: "https://example.com/")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
+    }
+
+    // MARK: - Data URLs
+
+    func testDataURLReturnsNotImage() {
+        let url = URL(string: "data:image/png;base64,iVBOR")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+    }
+
+    // MARK: - Edge cases
+
+    func testFTPSchemeReturnsNotImage() {
+        let url = URL(string: "ftp://example.com/photo.png")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+    }
+
+    func testHostOnlyReturnsUnknown() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ImageURLClassifier` enum with a static `classify(_:)` method that determines whether a URL points to an image based on its file extension
- Supports 12 image formats: png, jpg, jpeg, gif, webp, svg, bmp, ico, tiff, tif, avif, heic
- Requires HTTPS scheme (rejects HTTP for security), strips query parameters and fragments before checking, case-insensitive matching
- Returns `.unknown` for extensionless URLs to allow a future MIME-probe stage to resolve them
- Includes 27 tests covering all extensions, case insensitivity, query/fragment stripping, scheme enforcement, and edge cases

## Test plan
- [x] All 27 tests in `ImageURLClassifierExtensionTests` pass
- [x] `swift test --filter ImageURLClassifierExtensionTests` — 0 failures

PR 16 of the inline media embeds rollout plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
