### PR TITLE
private-threads: extend SessionCreateOptions with memory policy fields

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -86,6 +86,9 @@ export interface SessionCreateOptions {
   systemPromptOverride?: string;
   maxResponseTokens?: number;
   transport?: SessionTransportMetadata;
+  memoryScopeId?: string;
+  isPrivateThread?: boolean;
+  strictPrivateSideEffects?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `memoryScopeId`, `isPrivateThread`, and `strictPrivateSideEffects` optional fields to `SessionCreateOptions` interface in `shared.ts`
- Type-level change only — prepares the internal API surface for scoped session behavior without any runtime behavior changes
- The `sessionOptions` map in `server.ts` already uses `SessionCreateOptions`, so the new fields flow through the type system automatically

## Test plan
- [x] Existing daemon-server session init tests pass (4/4)
- [x] No runtime behavior changes — type-only addition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
