### PR TITLE
feat: add YouTube URL parser for media embeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct VideoParseResult {
+    let videoID: String
+    let provider: String
+    let embedURL: URL
+}
+
+/// Parses YouTube URLs in various formats and produces a canonical embed URL.
+///
+/// Supported patterns:
+/// - `youtube.com/watch?v=ID`  (with optional www/m subdomain)
+/// - `youtu.be/ID`             (short-link)
+/// - `youtube.com/shorts/ID`
+/// - `youtube.com/embed/ID`
+///
+/// Only `https` URLs are accepted.
+enum YouTubeParser {
+
+    private static let youtubeHosts: Set<String> = [
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com"
+    ]
+
+    static func parse(_ url: URL) -> VideoParseResult? {
+        guard url.scheme?.lowercased() == "https" else { return nil }
+
+        guard let host = url.host?.lowercased() else { return nil }
+
+        let videoID: String?
+
+        if host == "youtu.be" {
+            videoID = parseShortLink(url)
+        } else if youtubeHosts.contains(host) {
+            videoID = parseStandardURL(url)
+        } else {
+            return nil
+        }
+
+        guard let id = videoID, !id.isEmpty else { return nil }
+
+        guard let embedURL = URL(string: "https://www.youtube.com/embed/\(id)") else {
+            return nil
+        }
+
+        return VideoParseResult(
+            videoID: id,
+            provider: "youtube",
+            embedURL: embedURL
+        )
+    }
+
+    // MARK: - Private helpers
+
+    /// Extracts the video ID from a `youtu.be/VIDEO_ID` short link.
+    private static func parseShortLink(_ url: URL) -> String? {
+        let path = url.path
+        guard path.count > 1 else { return nil }
+
+        // Drop the leading "/" to get the video ID. Strip any trailing slash.
+        let id = String(path.dropFirst()).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return id.isEmpty ? nil : id
+    }
+
+    /// Extracts the video ID from standard youtube.com URL patterns:
+    /// `/watch?v=ID`, `/shorts/ID`, `/embed/ID`.
+    private static func parseStandardURL(_ url: URL) -> String? {
+        let path = url.path
+
+        // /shorts/VIDEO_ID or /embed/VIDEO_ID
+        for prefix in ["/shorts/", "/embed/"] {
+            if path.hasPrefix(prefix) {
+                let id = String(path.dropFirst(prefix.count))
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                return id.isEmpty ? nil : id
+            }
+        }
+
+        // /watch?v=VIDEO_ID
+        if path == "/watch" || path == "/watch/" {
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  let queryItems = components.queryItems else {
+                return nil
+            }
+            return queryItems.first(where: { $0.name == "v" })?.value
+        }
+
+        return nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/YouTubeParserTests.swift
+++ b/clients/macos/vellum-assistantTests/YouTubeParserTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class YouTubeParserTests: XCTestCase {
+
+    // MARK: - Standard watch URL
+
+    func testStandardWatchURL() {
+        let url = URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+        XCTAssertEqual(result?.provider, "youtube")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.youtube.com/embed/dQw4w9WgXcQ")
+    }
+
+    // MARK: - Short URL (youtu.be)
+
+    func testShortURL() {
+        let url = URL(string: "https://youtu.be/dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.youtube.com/embed/dQw4w9WgXcQ")
+    }
+
+    // MARK: - Shorts URL
+
+    func testShortsURL() {
+        let url = URL(string: "https://www.youtube.com/shorts/abc123XYZ_-")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123XYZ_-")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.youtube.com/embed/abc123XYZ_-")
+    }
+
+    // MARK: - Embed URL
+
+    func testEmbedURL() {
+        let url = URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.youtube.com/embed/dQw4w9WgXcQ")
+    }
+
+    // MARK: - Mobile URL (m.youtube.com)
+
+    func testMobileURL() {
+        let url = URL(string: "https://m.youtube.com/watch?v=dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.youtube.com/embed/dQw4w9WgXcQ")
+    }
+
+    // MARK: - Extra query parameters
+
+    func testWatchURLWithExtraQueryParams() {
+        let url = URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf&index=2")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.youtube.com/embed/dQw4w9WgXcQ")
+    }
+
+    // MARK: - Timestamp parameter
+
+    func testWatchURLWithTimestamp() {
+        let url = URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+    }
+
+    func testShortURLWithTimestamp() {
+        let url = URL(string: "https://youtu.be/dQw4w9WgXcQ?t=45")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+    }
+
+    // MARK: - www vs no-www
+
+    func testNoWWWSubdomain() {
+        let url = URL(string: "https://youtube.com/watch?v=dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+    }
+
+    func testWWWSubdomain() {
+        let url = URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "dQw4w9WgXcQ")
+    }
+
+    // MARK: - Non-YouTube URL returns nil
+
+    func testNonYouTubeURLReturnsNil() {
+        let url = URL(string: "https://vimeo.com/12345678")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testRandomWebsiteReturnsNil() {
+        let url = URL(string: "https://example.com/watch?v=abc123")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - HTTP URL returns nil (security)
+
+    func testHTTPSchemeReturnsNil() {
+        let url = URL(string: "http://www.youtube.com/watch?v=dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testHTTPShortURLReturnsNil() {
+        let url = URL(string: "http://youtu.be/dQw4w9WgXcQ")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Malformed YouTube URL (no video ID)
+
+    func testWatchURLWithoutVideoID() {
+        let url = URL(string: "https://www.youtube.com/watch")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testWatchURLWithEmptyVideoID() {
+        let url = URL(string: "https://www.youtube.com/watch?v=")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testShortsURLWithNoID() {
+        let url = URL(string: "https://www.youtube.com/shorts/")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testShortLinkWithNoPath() {
+        let url = URL(string: "https://youtu.be/")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testYouTubeHomepage() {
+        let url = URL(string: "https://www.youtube.com/")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Video ID extraction accuracy
+
+    func testVideoIDPreservesExactCharacters() {
+        let url = URL(string: "https://www.youtube.com/watch?v=a1B2c3D4e5F")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertEqual(result?.videoID, "a1B2c3D4e5F")
+    }
+
+    func testVideoIDWithHyphensAndUnderscores() {
+        let url = URL(string: "https://www.youtube.com/watch?v=a-b_c-d_e-f")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertEqual(result?.videoID, "a-b_c-d_e-f")
+    }
+
+    // MARK: - Embed URL is always canonical
+
+    func testEmbedURLIsCanonicalForAllFormats() {
+        let urls = [
+            "https://www.youtube.com/watch?v=testID123",
+            "https://youtu.be/testID123",
+            "https://www.youtube.com/shorts/testID123",
+            "https://www.youtube.com/embed/testID123",
+            "https://m.youtube.com/watch?v=testID123",
+            "https://youtube.com/watch?v=testID123",
+        ]
+        for urlString in urls {
+            let result = YouTubeParser.parse(URL(string: urlString)!)
+            XCTAssertEqual(
+                result?.embedURL.absoluteString,
+                "https://www.youtube.com/embed/testID123",
+                "Canonical embed URL mismatch for input: \(urlString)"
+            )
+        }
+    }
+
+    // MARK: - Unrelated YouTube paths return nil
+
+    func testYouTubeChannelReturnsNil() {
+        let url = URL(string: "https://www.youtube.com/c/SomeChannel")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testYouTubePlaylistReturnsNil() {
+        let url = URL(string: "https://www.youtube.com/playlist?list=PLrAXtmErZgOe")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - No-www shorts and embed
+
+    func testShortsWithoutWWW() {
+        let url = URL(string: "https://youtube.com/shorts/abc123")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123")
+    }
+
+    func testEmbedWithoutWWW() {
+        let url = URL(string: "https://youtube.com/embed/abc123")!
+        let result = YouTubeParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `YouTubeParser` enum that parses YouTube URLs across all common formats (watch, youtu.be, shorts, embed, mobile) and returns a `VideoParseResult` with `videoID`, `provider`, and canonical `embedURL`.
- Only HTTPS URLs are accepted; HTTP is rejected for security.
- Add 26 tests covering all URL patterns, edge cases (extra query params, timestamps, playlists), malformed URLs, and non-YouTube URLs.

## Test plan
- [x] `swift test --filter YouTubeParserTests` — 26/26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
