### PR TITLE
feat: load media embed settings into SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -41,6 +41,12 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    // MARK: - Media Embed Settings
+
+    @Published var mediaEmbedsEnabled: Bool
+    @Published var mediaEmbedsEnabledSince: Date?
+    @Published var mediaEmbedVideoAllowlistDomains: [String]
+
     // MARK: - Trust Rules Coordination
 
     /// Whether any settings surface currently has a trust rules sheet open.
@@ -57,7 +63,7 @@ public final class SettingsStore: ObservableObject {
     /// that would otherwise reinitialize providers and evict idle sessions.
     private var lastDaemonModel: String?
 
-    init(daemonClient: DaemonClient? = nil) {
+    init(daemonClient: DaemonClient? = nil, configPath: String? = nil) {
         self.daemonClient = daemonClient
 
         // Seed from UserDefaults / Keychain
@@ -73,6 +79,12 @@ public final class SettingsStore: ObservableObject {
 
         // Default to enabled for notifications
         self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true
+
+        // Load media embed settings from workspace config
+        let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
+        self.mediaEmbedsEnabled = mediaSettings.enabled
+        self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
+        self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
 
         // React to Keychain changes from other surfaces
         NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)
@@ -185,5 +197,49 @@ public final class SettingsStore: ObservableObject {
         } catch {
             // Send failed — don't update lastDaemonModel so the next attempt isn't suppressed
         }
+    }
+
+    // MARK: - Media Embed Loading
+
+    private struct MediaEmbedLoadResult {
+        let enabled: Bool
+        let enabledSince: Date?
+        let domains: [String]
+    }
+
+    /// Reads `ui.mediaEmbeds` from the workspace config and falls back to
+    /// `MediaEmbedSettings` defaults for any missing or invalid values.
+    private static func loadMediaEmbedSettings(from configPath: String? = nil) -> MediaEmbedLoadResult {
+        let config = WorkspaceConfigIO.read(from: configPath)
+
+        guard let ui = config["ui"] as? [String: Any],
+              let mediaEmbeds = ui["mediaEmbeds"] as? [String: Any] else {
+            return MediaEmbedLoadResult(
+                enabled: MediaEmbedSettings.defaultEnabled,
+                enabledSince: nil,
+                domains: MediaEmbedSettings.defaultDomains
+            )
+        }
+
+        let enabled = mediaEmbeds["enabled"] as? Bool ?? MediaEmbedSettings.defaultEnabled
+
+        var enabledSince: Date?
+        if let isoString = mediaEmbeds["enabledSince"] as? String {
+            let formatter = ISO8601DateFormatter()
+            enabledSince = formatter.date(from: isoString)
+        }
+
+        let domains: [String]
+        if let rawDomains = mediaEmbeds["videoAllowlistDomains"] as? [String] {
+            domains = MediaEmbedSettings.normalizeDomains(rawDomains)
+        } else {
+            domains = MediaEmbedSettings.defaultDomains
+        }
+
+        return MediaEmbedLoadResult(
+            enabled: enabled,
+            enabledSince: enabledSince,
+            domains: domains
+        )
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreMediaLoadTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreMediaLoadTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class SettingsStoreMediaLoadTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Write JSON to a temp file and return its path.
+    private func writeConfig(_ json: String) -> String {
+        let fileURL = tempDir.appendingPathComponent("config.json")
+        try! json.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL.path
+    }
+
+    /// Path to a file that does not exist.
+    private var missingConfigPath: String {
+        tempDir.appendingPathComponent("nonexistent.json").path
+    }
+
+    // MARK: - No config file (defaults)
+
+    func testNoConfigFileUsesDefaults() {
+        let store = SettingsStore(configPath: missingConfigPath)
+
+        XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - Empty config file (defaults)
+
+    func testEmptyConfigUsesDefaults() {
+        let path = writeConfig("{}")
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - enabled = false
+
+    func testLoadEnabledFalse() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"enabled":false}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - enabled = true (explicit)
+
+    func testLoadEnabledTrue() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"enabled":true}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+    }
+
+    // MARK: - Custom domains
+
+    func testLoadCustomDomains() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"videoAllowlistDomains":["dailymotion.com","twitch.tv"]}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["dailymotion.com", "twitch.tv"])
+    }
+
+    func testLoadCustomDomainsAreNormalized() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"videoAllowlistDomains":["  YouTube.COM  ","youtube.com","Vimeo.com"]}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "vimeo.com"])
+    }
+
+    // MARK: - Valid enabledSince timestamp
+
+    func testLoadValidEnabledSince() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"enabledSince":"2025-06-15T12:00:00Z"}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince)
+        let formatter = ISO8601DateFormatter()
+        let expected = formatter.date(from: "2025-06-15T12:00:00Z")
+        XCTAssertEqual(store.mediaEmbedsEnabledSince, expected)
+    }
+
+    // MARK: - Invalid enabledSince
+
+    func testLoadInvalidEnabledSinceIsNil() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"enabledSince":"not-a-date"}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+    }
+
+    // MARK: - Missing enabledSince
+
+    func testLoadMissingEnabledSinceIsNil() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"enabled":true}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+    }
+
+    // MARK: - Numeric enabledSince (wrong type)
+
+    func testLoadNumericEnabledSinceIsNil() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"enabledSince":12345}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+    }
+
+    // MARK: - Corrupt config (fallback to defaults)
+
+    func testCorruptConfigFallsBackToDefaults() {
+        let path = writeConfig("{not valid json!!!")
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - Config with ui key but no mediaEmbeds
+
+    func testConfigWithUiButNoMediaEmbedsUsesDefaults() {
+        let path = writeConfig("""
+        {"ui":{"theme":"dark"}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - All fields populated
+
+    func testLoadAllFieldsPopulated() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":{"enabled":false,"enabledSince":"2025-01-01T00:00:00Z","videoAllowlistDomains":["example.com"]}}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+        let formatter = ISO8601DateFormatter()
+        let expected = formatter.date(from: "2025-01-01T00:00:00Z")
+        XCTAssertEqual(store.mediaEmbedsEnabledSince, expected)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["example.com"])
+    }
+
+    // MARK: - mediaEmbeds is wrong type (non-dict)
+
+    func testMediaEmbedsAsStringFallsBackToDefaults() {
+        let path = writeConfig("""
+        {"ui":{"mediaEmbeds":"invalid"}}
+        """)
+        let store = SettingsStore(configPath: path)
+
+        XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds three `@Published` properties to `SettingsStore`: `mediaEmbedsEnabled`, `mediaEmbedsEnabledSince`, and `mediaEmbedVideoAllowlistDomains`
- Loads values from the workspace config file (`ui.mediaEmbeds.*`) at init time via `WorkspaceConfigIO.read()`, falling back to `MediaEmbedSettings` defaults for missing, invalid, or corrupt config
- Adds a `configPath` parameter to `SettingsStore.init` for test injection (defaults to nil, which uses the standard workspace config path)
- Read-only loading only — no save/write behavior in this PR

## Test plan
- [x] `SettingsStoreMediaLoadTests` — 14 tests covering:
  - No config file present (uses defaults)
  - Empty config file (uses defaults)
  - `enabled = false` in config
  - `enabled = true` in config
  - Custom video allowlist domains
  - Domain normalization (dedup, lowercase, trim)
  - Valid ISO8601 `enabledSince` timestamp
  - Invalid `enabledSince` string (falls back to nil)
  - Missing `enabledSince` (nil)
  - Numeric `enabledSince` (wrong type, nil)
  - Corrupt/malformed JSON config (falls back to defaults)
  - Config with `ui` key but no `mediaEmbeds` sub-key
  - All fields populated simultaneously
  - `mediaEmbeds` as wrong type (string instead of dict)

PR 07 of the inline media embeds rollout plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
