### PR TITLE
private-threads: wire thread type through daemon session create/list

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -196,6 +196,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext): void
       id: c.id,
       title: c.title ?? 'Untitled',
       updatedAt: c.updatedAt,
+      threadType: c.threadType,
     })),
   });
 }
@@ -215,9 +216,10 @@ export async function handleSessionCreate(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const conversation = conversationStore.createConversation(
-    msg.title ?? 'New Conversation',
-  );
+  const conversation = conversationStore.createConversation({
+    title: msg.title ?? 'New Conversation',
+    threadType: msg.threadType as 'standard' | 'private' | undefined,
+  });
   const session = await ctx.getOrCreateSession(conversation.id, socket, true, {
     systemPromptOverride: msg.systemPromptOverride,
     maxResponseTokens: msg.maxResponseTokens,
@@ -236,6 +238,7 @@ export async function handleSessionCreate(
     sessionId: conversation.id,
     title: conversation.title ?? 'New Conversation',
     ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
+    threadType: conversation.threadType,
   });
 
   // Auto-send the initial message if provided, kick-starting the skill.


### PR DESCRIPTION
## Summary
- Pass `threadType` from `SessionCreateRequest` to `createConversation` in `handleSessionCreate`, switching from a plain string arg to an options object.
- Include `threadType` in the `session_info` response from `handleSessionCreate`.
- Include `threadType` in each session entry returned by `handleSessionList`.

## Test plan
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — 173 pass, 155 snapshots
- [x] `bun test src/__tests__/daemon-server-session-init.test.ts` — 4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
