### PR TITLE
feat: add ImageMIMEProbe for async HEAD-based image detection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Probes URLs via HTTP HEAD to determine whether they serve image content.
+///
+/// This is the second stage of image detection, used for extensionless URLs
+/// that `ImageURLClassifier` returns `.unknown` for. Results are cached
+/// in-memory to avoid redundant network requests.
+final class ImageMIMEProbe {
+    static let shared = ImageMIMEProbe()
+
+    private let cache = NSCache<NSString, CacheEntry>()
+    private let session: URLSession
+
+    /// Wraps the classification value so it can be stored in `NSCache`.
+    private class CacheEntry: NSObject {
+        let value: ImageURLClassification
+        init(_ value: ImageURLClassification) {
+            self.value = value
+        }
+    }
+
+    init(session: URLSession = .shared) {
+        self.session = session
+        cache.countLimit = 500
+    }
+
+    /// Sends an HTTP HEAD request and classifies the response content type.
+    ///
+    /// Returns `.image` when the Content-Type starts with `image/`,
+    /// `.notImage` for any other content type, and `.unknown` on
+    /// network errors or timeouts. Never throws.
+    func probe(_ url: URL) async -> ImageURLClassification {
+        guard url.scheme?.lowercased() == "https" else {
+            return .notImage
+        }
+
+        let key = url.absoluteString as NSString
+
+        if let cached = cache.object(forKey: key) {
+            return cached.value
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        request.timeoutInterval = 5
+
+        let result: ImageURLClassification
+        do {
+            let (_, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")?.lowercased()
+            else {
+                result = .unknown
+                cache.setObject(CacheEntry(result), forKey: key)
+                return result
+            }
+            result = contentType.hasPrefix("image/") ? .image : .notImage
+        } catch {
+            result = .unknown
+        }
+
+        cache.setObject(CacheEntry(result), forKey: key)
+        return result
+    }
+
+    func clearCache() {
+        cache.removeAllObjects()
+    }
+}

--- a/clients/macos/vellum-assistantTests/ImageMIMEProbeTests.swift
+++ b/clients/macos/vellum-assistantTests/ImageMIMEProbeTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import VellumAssistantLib
+
+// MARK: - Mock URLProtocol
+
+private class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+@MainActor
+final class ImageMIMEProbeTests: XCTestCase {
+
+    private var probe: ImageMIMEProbe!
+    private var mockSession: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        mockSession = URLSession(configuration: config)
+        probe = ImageMIMEProbe(session: mockSession)
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        probe = nil
+        mockSession = nil
+        super.tearDown()
+    }
+
+    // MARK: - Content-Type classification
+
+    func testImageContentTypeReturnsImage() async {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "HEAD")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "https://example.com/photo")!
+        let result = await probe.probe(url)
+        XCTAssertEqual(result, .image)
+    }
+
+    func testImageJPEGContentTypeReturnsImage() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/jpeg; charset=utf-8"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "https://example.com/photo")!
+        let result = await probe.probe(url)
+        XCTAssertEqual(result, .image)
+    }
+
+    func testNonImageContentTypeReturnsNotImage() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "https://example.com/page")!
+        let result = await probe.probe(url)
+        XCTAssertEqual(result, .notImage)
+    }
+
+    func testApplicationJSONReturnsNotImage() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "https://example.com/api/data")!
+        let result = await probe.probe(url)
+        XCTAssertEqual(result, .notImage)
+    }
+
+    // MARK: - Error handling
+
+    func testNetworkErrorReturnsUnknown() async {
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let url = URL(string: "https://example.com/photo")!
+        let result = await probe.probe(url)
+        XCTAssertEqual(result, .unknown)
+    }
+
+    func testTimeoutReturnsUnknown() async {
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.timedOut)
+        }
+
+        let url = URL(string: "https://example.com/slow")!
+        let result = await probe.probe(url)
+        XCTAssertEqual(result, .unknown)
+    }
+
+    func testMissingContentTypeReturnsUnknown() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [:]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "https://example.com/mystery")!
+        let result = await probe.probe(url)
+        XCTAssertEqual(result, .unknown)
+    }
+
+    // MARK: - Caching
+
+    func testCacheHitSkipsNetwork() async {
+        var callCount = 0
+        MockURLProtocol.requestHandler = { request in
+            callCount += 1
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "https://example.com/cached")!
+        let first = await probe.probe(url)
+        let second = await probe.probe(url)
+
+        XCTAssertEqual(first, .image)
+        XCTAssertEqual(second, .image)
+        XCTAssertEqual(callCount, 1, "Second probe should use cache, not make a network call")
+    }
+
+    func testClearCacheResetsCache() async {
+        var callCount = 0
+        MockURLProtocol.requestHandler = { request in
+            callCount += 1
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/webp"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "https://example.com/cleared")!
+        _ = await probe.probe(url)
+        XCTAssertEqual(callCount, 1)
+
+        probe.clearCache()
+
+        _ = await probe.probe(url)
+        XCTAssertEqual(callCount, 2, "After clearing cache, probe should make a new network call")
+    }
+
+    // MARK: - Scheme enforcement
+
+    func testNonHTTPSReturnsNotImageWithoutProbing() async {
+        var wasCalled = false
+        MockURLProtocol.requestHandler = { _ in
+            wasCalled = true
+            let response = HTTPURLResponse(
+                url: URL(string: "http://example.com")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "http://example.com/photo.png")!
+        let result = await probe.probe(url)
+
+        XCTAssertEqual(result, .notImage)
+        XCTAssertFalse(wasCalled, "HTTP URL should be rejected without making a network request")
+    }
+
+    func testFTPSchemeReturnsNotImageWithoutProbing() async {
+        var wasCalled = false
+        MockURLProtocol.requestHandler = { _ in
+            wasCalled = true
+            let response = HTTPURLResponse(
+                url: URL(string: "https://example.com")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, Data())
+        }
+
+        let url = URL(string: "ftp://example.com/photo.png")!
+        let result = await probe.probe(url)
+
+        XCTAssertEqual(result, .notImage)
+        XCTAssertFalse(wasCalled, "FTP URL should be rejected without making a network request")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ImageMIMEProbe` class that sends HTTP HEAD requests to classify extensionless URLs by Content-Type header
- Uses `NSCache` (limit 500 entries) to avoid redundant probes; thread-safe by design
- Only probes `https` URLs with a 5-second timeout; returns `.unknown` on errors (never throws)
- Reuses the existing `ImageURLClassification` enum from `ImageURLClassifier.swift`

## Test plan
- [x] `testImageContentTypeReturnsImage` — image/png Content-Type returns `.image`
- [x] `testImageJPEGContentTypeReturnsImage` — image/jpeg with charset returns `.image`
- [x] `testNonImageContentTypeReturnsNotImage` — text/html returns `.notImage`
- [x] `testApplicationJSONReturnsNotImage` — application/json returns `.notImage`
- [x] `testNetworkErrorReturnsUnknown` — connection error returns `.unknown`
- [x] `testTimeoutReturnsUnknown` — timeout returns `.unknown`
- [x] `testMissingContentTypeReturnsUnknown` — no Content-Type header returns `.unknown`
- [x] `testCacheHitSkipsNetwork` — second probe uses cache, no network call
- [x] `testClearCacheResetsCache` — clearing cache forces re-probe
- [x] `testNonHTTPSReturnsNotImageWithoutProbing` — HTTP URL rejected without network call
- [x] `testFTPSchemeReturnsNotImageWithoutProbing` — FTP URL rejected without network call
- All 11 tests pass: `swift test --filter ImageMIMEProbeTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
