### PR TITLE
feat: add Vimeo URL parser

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/VimeoParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/VimeoParser.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Parses Vimeo URLs in various formats and produces a canonical embed URL.
+///
+/// Supported patterns:
+/// - `vimeo.com/VIDEO_ID`                        (standard)
+/// - `www.vimeo.com/VIDEO_ID`                    (www subdomain)
+/// - `player.vimeo.com/video/VIDEO_ID`           (player embed)
+/// - `vimeo.com/channels/CHANNEL/VIDEO_ID`       (channel)
+/// - `vimeo.com/groups/GROUP/videos/VIDEO_ID`    (group)
+///
+/// Only `https` URLs are accepted. Video IDs must be numeric.
+enum VimeoParser {
+
+    private static let vimeoHosts: Set<String> = [
+        "vimeo.com",
+        "www.vimeo.com",
+        "player.vimeo.com"
+    ]
+
+    static func parse(_ url: URL) -> VideoParseResult? {
+        guard url.scheme?.lowercased() == "https" else { return nil }
+
+        guard let host = url.host?.lowercased() else { return nil }
+        guard vimeoHosts.contains(host) else { return nil }
+
+        let videoID: String?
+
+        if host == "player.vimeo.com" {
+            videoID = parsePlayerURL(url)
+        } else {
+            videoID = parseStandardURL(url)
+        }
+
+        guard let id = videoID, !id.isEmpty else { return nil }
+
+        // Vimeo video IDs are strictly numeric
+        guard id.allSatisfy(\.isNumber) else { return nil }
+
+        guard let embedURL = URL(string: "https://player.vimeo.com/video/\(id)") else {
+            return nil
+        }
+
+        return VideoParseResult(
+            videoID: id,
+            provider: "vimeo",
+            embedURL: embedURL
+        )
+    }
+
+    // MARK: - Private helpers
+
+    /// Extracts the video ID from `player.vimeo.com/video/VIDEO_ID`.
+    private static func parsePlayerURL(_ url: URL) -> String? {
+        let path = url.path
+        let prefix = "/video/"
+        guard path.hasPrefix(prefix) else { return nil }
+        let id = String(path.dropFirst(prefix.count))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return id.isEmpty ? nil : id
+    }
+
+    /// Extracts the video ID from standard vimeo.com URL patterns:
+    /// `/VIDEO_ID`, `/channels/NAME/VIDEO_ID`, `/groups/NAME/videos/VIDEO_ID`.
+    private static func parseStandardURL(_ url: URL) -> String? {
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard !components.isEmpty else { return nil }
+
+        // /channels/NAME/VIDEO_ID
+        if components.count >= 3 && components[0] == "channels" {
+            return components[2]
+        }
+
+        // /groups/NAME/videos/VIDEO_ID
+        if components.count >= 4 && components[0] == "groups" && components[2] == "videos" {
+            return components[3]
+        }
+
+        // /VIDEO_ID (single path component, must be numeric — checked by caller)
+        if components.count == 1 {
+            return components[0]
+        }
+
+        return nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/VimeoParserTests.swift
+++ b/clients/macos/vellum-assistantTests/VimeoParserTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class VimeoParserTests: XCTestCase {
+
+    // MARK: - Standard URL
+
+    func testStandardURL() {
+        let url = URL(string: "https://vimeo.com/123456")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "123456")
+        XCTAssertEqual(result?.provider, "vimeo")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://player.vimeo.com/video/123456")
+    }
+
+    // MARK: - WWW subdomain
+
+    func testWWWSubdomain() {
+        let url = URL(string: "https://www.vimeo.com/789012")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "789012")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://player.vimeo.com/video/789012")
+    }
+
+    // MARK: - Player embed URL
+
+    func testPlayerEmbedURL() {
+        let url = URL(string: "https://player.vimeo.com/video/456789")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "456789")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://player.vimeo.com/video/456789")
+    }
+
+    // MARK: - Channel URL
+
+    func testChannelURL() {
+        let url = URL(string: "https://vimeo.com/channels/staffpicks/123456")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "123456")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://player.vimeo.com/video/123456")
+    }
+
+    // MARK: - Group URL
+
+    func testGroupURL() {
+        let url = URL(string: "https://vimeo.com/groups/shortfilms/videos/987654")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "987654")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://player.vimeo.com/video/987654")
+    }
+
+    // MARK: - Non-Vimeo URL returns nil
+
+    func testNonVimeoURLReturnsNil() {
+        let url = URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testRandomWebsiteReturnsNil() {
+        let url = URL(string: "https://example.com/123456")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - HTTP URL returns nil (security)
+
+    func testHTTPSchemeReturnsNil() {
+        let url = URL(string: "http://vimeo.com/123456")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Invalid / non-numeric video ID returns nil
+
+    func testNonNumericVideoIDReturnsNil() {
+        let url = URL(string: "https://vimeo.com/abcdef")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testAlphanumericVideoIDReturnsNil() {
+        let url = URL(string: "https://vimeo.com/abc123")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Vimeo homepage (no video ID) returns nil
+
+    func testVimeoHomepageReturnsNil() {
+        let url = URL(string: "https://vimeo.com/")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testVimeoHomepageNoTrailingSlashReturnsNil() {
+        let url = URL(string: "https://vimeo.com")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Provider is "vimeo"
+
+    func testProviderIsVimeo() {
+        let url = URL(string: "https://vimeo.com/111222")!
+        let result = VimeoParser.parse(url)
+        XCTAssertEqual(result?.provider, "vimeo")
+    }
+
+    // MARK: - Embed URL format is correct
+
+    func testEmbedURLIsCanonicalForAllFormats() {
+        let urls = [
+            "https://vimeo.com/100200",
+            "https://www.vimeo.com/100200",
+            "https://player.vimeo.com/video/100200",
+            "https://vimeo.com/channels/staffpicks/100200",
+            "https://vimeo.com/groups/shortfilms/videos/100200",
+        ]
+        for urlString in urls {
+            let result = VimeoParser.parse(URL(string: urlString)!)
+            XCTAssertEqual(
+                result?.embedURL.absoluteString,
+                "https://player.vimeo.com/video/100200",
+                "Canonical embed URL mismatch for input: \(urlString)"
+            )
+        }
+    }
+
+    // MARK: - Extra query parameters are handled
+
+    func testURLWithQueryParameters() {
+        let url = URL(string: "https://vimeo.com/123456?autoplay=1&color=ffffff")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "123456")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://player.vimeo.com/video/123456")
+    }
+
+    func testPlayerURLWithQueryParameters() {
+        let url = URL(string: "https://player.vimeo.com/video/456789?title=0&byline=0")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "456789")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://player.vimeo.com/video/456789")
+    }
+
+    // MARK: - Player URL edge cases
+
+    func testPlayerURLWithoutVideoPathReturnsNil() {
+        let url = URL(string: "https://player.vimeo.com/123456")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testPlayerURLWithEmptyVideoIDReturnsNil() {
+        let url = URL(string: "https://player.vimeo.com/video/")!
+        let result = VimeoParser.parse(url)
+        XCTAssertNil(result)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `VimeoParser` enum that parses five Vimeo URL patterns (standard, www, player embed, channel, group) and generates canonical `player.vimeo.com/video/VIDEO_ID` embed URLs
- Reuses the existing `VideoParseResult` struct from `YouTubeParser.swift`
- Requires HTTPS scheme and strictly numeric video IDs
- Includes 18 tests covering all URL patterns, edge cases, and security constraints

## Test plan
- [x] `swift test --filter VimeoParserTests` — all 18 tests pass
- [ ] Verify standard URL parsing (`vimeo.com/123456`)
- [ ] Verify www URL parsing (`www.vimeo.com/123456`)
- [ ] Verify player embed URL parsing (`player.vimeo.com/video/123456`)
- [ ] Verify channel URL parsing (`vimeo.com/channels/staffpicks/123456`)
- [ ] Verify group URL parsing (`vimeo.com/groups/name/videos/123456`)
- [ ] Verify non-Vimeo URLs return nil
- [ ] Verify HTTP URLs are rejected
- [ ] Verify non-numeric video IDs are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
