### PR TITLE
private-threads: map IPC thread type to ThreadKind in session restorer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -94,11 +94,13 @@ final class ThreadSessionRestorer {
 
         var restoredThreads: [ThreadModel] = []
         for session in recentSessions {
+            let kind: ThreadKind = session.threadType == "private" ? .private : .standard
             let thread = ThreadModel(
                 title: session.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 sessionId: session.id,
-                isArchived: delegate.isSessionArchived(session.id)
+                isArchived: delegate.isSessionArchived(session.id),
+                kind: kind
             )
             let viewModel = delegate.makeViewModel()
             viewModel.sessionId = session.id

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -60,13 +60,22 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
 // MARK: - Helpers
 
 /// Build an IPCSessionListResponse via JSON round-trip.
-private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int)]) -> SessionListResponseMessage {
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?)]) -> SessionListResponseMessage {
     let sessionDicts = sessions.map { session -> [String: Any] in
-        ["id": session.id, "title": session.title, "updatedAt": session.updatedAt]
+        var dict: [String: Any] = ["id": session.id, "title": session.title, "updatedAt": session.updatedAt]
+        if let threadType = session.threadType {
+            dict["threadType"] = threadType
+        }
+        return dict
     }
     let dict: [String: Any] = ["type": "session_list_response", "sessions": sessionDicts]
     let data = try! JSONSerialization.data(withJSONObject: dict)
     return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
+}
+
+/// Convenience overload without threadType for existing tests.
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int)]) -> SessionListResponseMessage {
+    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, nil) })
 }
 
 /// Build an IPCHistoryResponse via JSON round-trip.
@@ -352,5 +361,68 @@ struct ThreadSessionRestorerTests {
         #expect(delegate.createThreadCallCount == 0)
         #expect(delegate.threads.count == 2)
         #expect(delegate.threads.contains(where: { $0.id == activeThread.id }))
+    }
+
+    // MARK: - Thread Type Mapping
+
+    @Test @MainActor
+    func privateThreadTypeRestoresAsPrivateKind() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Private Chat", updatedAt: 2000, threadType: "private"),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        #expect(delegate.threads.count == 1)
+        #expect(delegate.threads[0].kind == .private)
+        #expect(delegate.threads[0].sessionId == "s1")
+    }
+
+    @Test @MainActor
+    func nilThreadTypeRestoresAsStandardKind() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Regular Chat", updatedAt: 2000, threadType: nil),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        #expect(delegate.threads.count == 1)
+        #expect(delegate.threads[0].kind == .standard)
+    }
+
+    @Test @MainActor
+    func standardThreadTypeRestoresAsStandardKind() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Standard Chat", updatedAt: 2000, threadType: "standard"),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        #expect(delegate.threads.count == 1)
+        #expect(delegate.threads[0].kind == .standard)
     }
 }


### PR DESCRIPTION
## Summary
- Map `threadType` from the IPC `session_list_response` to `ThreadKind` when restoring threads in `ThreadSessionRestorer`
- Sessions with `threadType: "private"` are restored as `.private`; all others (nil, "standard", etc.) default to `.standard`
- Add three tests verifying the mapping for private, nil, and standard thread types

## Test plan
- [x] Build passes (`./build.sh`)
- [ ] Verify private threads restored from daemon sessions appear with correct `ThreadKind`
- [ ] Run `ThreadSessionRestorerTests` to confirm new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
