### PR TITLE
feat: SettingsStore persist toggle + enabledSince semantics

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -58,6 +58,7 @@ public final class SettingsStore: ObservableObject {
 
     private weak var daemonClient: DaemonClient?
     private var cancellables = Set<AnyCancellable>()
+    private let configPath: String?
 
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle sessions.
@@ -65,6 +66,7 @@ public final class SettingsStore: ObservableObject {
 
     init(daemonClient: DaemonClient? = nil, configPath: String? = nil) {
         self.daemonClient = daemonClient
+        self.configPath = configPath
 
         // Seed from UserDefaults / Keychain
         let anthropicKey = APIKeyManager.getKey()
@@ -197,6 +199,53 @@ public final class SettingsStore: ObservableObject {
         } catch {
             // Send failed — don't update lastDaemonModel so the next attempt isn't suppressed
         }
+    }
+
+    // MARK: - Media Embed Actions
+
+    /// Toggles media embeds on or off and persists the change to the workspace config.
+    ///
+    /// When turning ON from OFF, `mediaEmbedsEnabledSince` is reset to the current
+    /// date so that only messages created after this moment are eligible for embeds.
+    /// When turning OFF, the existing `enabledSince` timestamp is preserved so a
+    /// subsequent re-enable doesn't accidentally surface old links.
+    func setMediaEmbedsEnabled(_ enabled: Bool) {
+        if enabled {
+            guard !mediaEmbedsEnabled else { return }
+            mediaEmbedsEnabled = true
+            mediaEmbedsEnabledSince = MediaEmbedSettings.enabledSinceNow()
+            persistMediaEmbedState()
+        } else {
+            guard mediaEmbedsEnabled else { return }
+            mediaEmbedsEnabled = false
+            persistMediaEmbedState()
+        }
+    }
+
+    /// Writes the current `mediaEmbedsEnabled` and `mediaEmbedsEnabledSince` to
+    /// the workspace config under `ui.mediaEmbeds`.
+    private func persistMediaEmbedState() {
+        var mediaEmbedsDict: [String: Any] = [
+            "enabled": mediaEmbedsEnabled,
+        ]
+
+        if let since = mediaEmbedsEnabledSince {
+            let formatter = ISO8601DateFormatter()
+            mediaEmbedsDict["enabledSince"] = formatter.string(from: since)
+        }
+
+        // Read existing config to preserve sibling keys inside ui and ui.mediaEmbeds
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var existingUI = existingConfig["ui"] as? [String: Any] ?? [:]
+        var existingMediaEmbeds = existingUI["mediaEmbeds"] as? [String: Any] ?? [:]
+
+        // Merge our changes on top of whatever is already in mediaEmbeds
+        for (key, value) in mediaEmbedsDict {
+            existingMediaEmbeds[key] = value
+        }
+        existingUI["mediaEmbeds"] = existingMediaEmbeds
+
+        try? WorkspaceConfigIO.merge(["ui": existingUI], into: configPath)
     }
 
     // MARK: - Media Embed Loading

--- a/clients/macos/vellum-assistantTests/SettingsStoreMediaToggleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreMediaToggleTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class SettingsStoreMediaToggleTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private var configPath: String {
+        tempDir.appendingPathComponent("config.json").path
+    }
+
+    /// Write JSON to the config file for pre-population.
+    private func seed(_ json: String) {
+        let url = URL(fileURLWithPath: configPath)
+        try! json.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// Read the persisted config back as a dictionary.
+    private func readPersistedConfig() -> [String: Any] {
+        WorkspaceConfigIO.read(from: configPath)
+    }
+
+    /// Extract the `ui.mediaEmbeds` sub-dictionary from the persisted config.
+    private func readPersistedMediaEmbeds() -> [String: Any]? {
+        let config = readPersistedConfig()
+        guard let ui = config["ui"] as? [String: Any] else { return nil }
+        return ui["mediaEmbeds"] as? [String: Any]
+    }
+
+    // MARK: - OFF -> ON sets enabled=true and enabledSince to ~now
+
+    func testToggleOffToOnSetsEnabledAndTimestamp() {
+        seed(#"{"ui":{"mediaEmbeds":{"enabled":false}}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+        XCTAssertNil(store.mediaEmbedsEnabledSince)
+
+        let before = Date()
+        store.setMediaEmbedsEnabled(true)
+        let after = Date()
+
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince)
+
+        // Timestamp should be approximately now
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
+    }
+
+    // MARK: - ON -> OFF sets enabled=false, preserves enabledSince
+
+    func testToggleOnToOffPreservesTimestamp() {
+        let isoString = "2026-01-15T12:00:00Z"
+        seed("""
+        {"ui":{"mediaEmbeds":{"enabled":true,"enabledSince":"\(isoString)"}}}
+        """)
+        let store = SettingsStore(configPath: configPath)
+
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+        let originalSince = store.mediaEmbedsEnabledSince
+
+        store.setMediaEmbedsEnabled(false)
+
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+        // enabledSince should be unchanged in memory
+        XCTAssertEqual(store.mediaEmbedsEnabledSince, originalSince)
+    }
+
+    // MARK: - OFF -> ON -> OFF -> ON resets enabledSince each time
+
+    func testToggleCycleResetsTimestampEachEnable() {
+        seed(#"{"ui":{"mediaEmbeds":{"enabled":false}}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        // First toggle ON
+        store.setMediaEmbedsEnabled(true)
+        let firstSince = store.mediaEmbedsEnabledSince
+        XCTAssertNotNil(firstSince)
+
+        // Toggle OFF
+        store.setMediaEmbedsEnabled(false)
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+
+        // Small delay to ensure timestamps differ
+        Thread.sleep(forTimeInterval: 0.01)
+
+        // Second toggle ON — timestamp should be newer
+        store.setMediaEmbedsEnabled(true)
+        let secondSince = store.mediaEmbedsEnabledSince
+        XCTAssertNotNil(secondSince)
+        XCTAssertGreaterThan(secondSince!, firstSince!)
+    }
+
+    // MARK: - ON when already ON is a no-op for enabledSince
+
+    func testToggleOnWhenAlreadyOnIsNoOp() {
+        let isoString = "2026-01-15T12:00:00Z"
+        seed("""
+        {"ui":{"mediaEmbeds":{"enabled":true,"enabledSince":"\(isoString)"}}}
+        """)
+        let store = SettingsStore(configPath: configPath)
+
+        let originalSince = store.mediaEmbedsEnabledSince
+
+        // Calling setMediaEmbedsEnabled(true) when already on should not change timestamp
+        store.setMediaEmbedsEnabled(true)
+
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+        XCTAssertEqual(store.mediaEmbedsEnabledSince, originalSince)
+    }
+
+    // MARK: - OFF when already OFF is a no-op
+
+    func testToggleOffWhenAlreadyOffIsNoOp() {
+        seed(#"{"ui":{"mediaEmbeds":{"enabled":false}}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+
+        // Should not crash or change state
+        store.setMediaEmbedsEnabled(false)
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+    }
+
+    // MARK: - Toggle persists to config file (enabled)
+
+    func testToggleOnPersistsToConfigFile() {
+        seed(#"{"ui":{"mediaEmbeds":{"enabled":false}}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        store.setMediaEmbedsEnabled(true)
+
+        let mediaEmbeds = readPersistedMediaEmbeds()
+        XCTAssertNotNil(mediaEmbeds)
+        XCTAssertEqual(mediaEmbeds?["enabled"] as? Bool, true)
+        XCTAssertNotNil(mediaEmbeds?["enabledSince"] as? String)
+
+        // Verify the persisted ISO string parses to a valid date
+        let isoString = mediaEmbeds!["enabledSince"] as! String
+        let formatter = ISO8601DateFormatter()
+        XCTAssertNotNil(formatter.date(from: isoString))
+    }
+
+    // MARK: - Toggle OFF persists enabled=false to config file
+
+    func testToggleOffPersistsToConfigFile() {
+        let isoString = "2026-01-15T12:00:00Z"
+        seed("""
+        {"ui":{"mediaEmbeds":{"enabled":true,"enabledSince":"\(isoString)"}}}
+        """)
+        let store = SettingsStore(configPath: configPath)
+
+        store.setMediaEmbedsEnabled(false)
+
+        let mediaEmbeds = readPersistedMediaEmbeds()
+        XCTAssertNotNil(mediaEmbeds)
+        XCTAssertEqual(mediaEmbeds?["enabled"] as? Bool, false)
+        // enabledSince should still be in the config
+        XCTAssertEqual(mediaEmbeds?["enabledSince"] as? String, isoString)
+    }
+
+    // MARK: - Toggle preserves sibling config keys
+
+    func testTogglePreservesSiblingConfigKeys() {
+        seed(#"{"ui":{"mediaEmbeds":{"enabled":false,"videoAllowlistDomains":["example.com"]}},"other":"data"}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        store.setMediaEmbedsEnabled(true)
+
+        let config = readPersistedConfig()
+        // Top-level sibling key preserved
+        XCTAssertEqual(config["other"] as? String, "data")
+
+        // videoAllowlistDomains inside mediaEmbeds preserved
+        let mediaEmbeds = readPersistedMediaEmbeds()
+        XCTAssertNotNil(mediaEmbeds)
+        let domains = mediaEmbeds?["videoAllowlistDomains"] as? [String]
+        XCTAssertEqual(domains, ["example.com"])
+    }
+
+    // MARK: - Toggle persists correctly when read back by a new store
+
+    func testPersistedStateRoundTrips() {
+        seed(#"{"ui":{"mediaEmbeds":{"enabled":false}}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        store.setMediaEmbedsEnabled(true)
+        let persistedSince = store.mediaEmbedsEnabledSince
+
+        // Create a new store from the same config — it should pick up persisted values
+        let reloaded = SettingsStore(configPath: configPath)
+        XCTAssertTrue(reloaded.mediaEmbedsEnabled)
+        XCTAssertNotNil(reloaded.mediaEmbedsEnabledSince)
+
+        // Timestamps should match (within ISO8601 second precision)
+        let diff = abs(reloaded.mediaEmbedsEnabledSince!.timeIntervalSince(persistedSince!))
+        XCTAssertLessThan(diff, 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `setMediaEmbedsEnabled(_:)` method to `SettingsStore` that toggles the media embeds feature and persists the change to `ui.mediaEmbeds` in the workspace config
- When toggled ON (from OFF), resets `enabledSince` to the current date so only future messages get inline embeds
- When toggled OFF, preserves the existing `enabledSince` timestamp for correct behavior on re-enable
- Deep-merges into the config to avoid clobbering sibling keys (e.g. `videoAllowlistDomains`)
- Stores `configPath` as an instance property so the toggle method can persist to the correct file (also enables test isolation)

## Test plan
- [x] Test OFF->ON sets `enabled=true` and `enabledSince` to approximately now
- [x] Test ON->OFF sets `enabled=false` and preserves `enabledSince`
- [x] Test OFF->ON->OFF->ON resets `enabledSince` each re-enable
- [x] Test ON when already ON is a no-op for `enabledSince`
- [x] Test OFF when already OFF is a no-op
- [x] Test toggle ON persists `enabled` and `enabledSince` to config file
- [x] Test toggle OFF persists `enabled=false` and keeps `enabledSince` in config
- [x] Test toggle preserves sibling config keys (`other`, `videoAllowlistDomains`)
- [x] Test persisted state round-trips through a new `SettingsStore` instance
- [x] All 9 tests pass: `swift test --filter SettingsStoreMediaToggleTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
