### PR TITLE
feat: add Loom URL parser with canonical embed URL generation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/LoomParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/LoomParser.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Parses Loom URLs and produces a canonical embed URL.
+///
+/// Supported patterns:
+/// - `loom.com/share/VIDEO_ID`  (with optional www subdomain)
+/// - `loom.com/embed/VIDEO_ID`  (with optional www subdomain)
+///
+/// Only `https` URLs are accepted.
+enum LoomParser {
+
+    private static let loomHosts: Set<String> = [
+        "loom.com",
+        "www.loom.com"
+    ]
+
+    static func parse(_ url: URL) -> VideoParseResult? {
+        guard url.scheme?.lowercased() == "https" else { return nil }
+
+        guard let host = url.host?.lowercased() else { return nil }
+        guard loomHosts.contains(host) else { return nil }
+
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+
+        // Expect ["share"|"embed", VIDEO_ID]
+        guard pathComponents.count >= 2,
+              ["share", "embed"].contains(pathComponents[0]),
+              !pathComponents[1].isEmpty else { return nil }
+
+        let videoID = pathComponents[1]
+
+        guard let embedURL = URL(string: "https://www.loom.com/embed/\(videoID)") else {
+            return nil
+        }
+
+        return VideoParseResult(
+            videoID: videoID,
+            provider: "loom",
+            embedURL: embedURL
+        )
+    }
+}

--- a/clients/macos/vellum-assistantTests/LoomParserTests.swift
+++ b/clients/macos/vellum-assistantTests/LoomParserTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class LoomParserTests: XCTestCase {
+
+    // MARK: - Standard share URL
+
+    func testStandardShareURL() {
+        let url = URL(string: "https://loom.com/share/abc123def456789012345678abcdef90")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123def456789012345678abcdef90")
+    }
+
+    func testWWWShareURL() {
+        let url = URL(string: "https://www.loom.com/share/abc123def456789012345678abcdef90")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123def456789012345678abcdef90")
+    }
+
+    // MARK: - Embed URL
+
+    func testEmbedURL() {
+        let url = URL(string: "https://loom.com/embed/abc123def456789012345678abcdef90")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123def456789012345678abcdef90")
+    }
+
+    func testWWWEmbedURL() {
+        let url = URL(string: "https://www.loom.com/embed/abc123def456789012345678abcdef90")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123def456789012345678abcdef90")
+    }
+
+    // MARK: - Non-Loom URL returns nil
+
+    func testNonLoomURLReturnsNil() {
+        let url = URL(string: "https://youtube.com/watch?v=dQw4w9WgXcQ")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testRandomWebsiteReturnsNil() {
+        let url = URL(string: "https://example.com/share/abc123")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - HTTP URL returns nil (security)
+
+    func testHTTPSchemeReturnsNil() {
+        let url = URL(string: "http://www.loom.com/share/abc123def456789012345678abcdef90")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Loom homepage (no video ID) returns nil
+
+    func testLoomHomepageReturnsNil() {
+        let url = URL(string: "https://www.loom.com/")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testLoomShareWithNoID() {
+        let url = URL(string: "https://www.loom.com/share/")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Provider is "loom"
+
+    func testProviderIsLoom() {
+        let url = URL(string: "https://www.loom.com/share/abc123def456")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.provider, "loom")
+    }
+
+    // MARK: - Embed URL format is correct (always uses /embed/)
+
+    func testEmbedURLFormatIsCorrect() {
+        let url = URL(string: "https://www.loom.com/embed/abc123def456")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.loom.com/embed/abc123def456")
+    }
+
+    // MARK: - Share URL converts to embed URL
+
+    func testShareURLConvertsToEmbedURL() {
+        let url = URL(string: "https://www.loom.com/share/abc123def456")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.loom.com/embed/abc123def456")
+    }
+
+    func testShareURLWithoutWWWConvertsToEmbedWithWWW() {
+        let url = URL(string: "https://loom.com/share/abc123def456")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.loom.com/embed/abc123def456")
+    }
+
+    // MARK: - Query parameters
+
+    func testShareURLWithQueryParameters() {
+        let url = URL(string: "https://www.loom.com/share/abc123def456?sid=xyz&t=10")!
+        let result = LoomParser.parse(url)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.videoID, "abc123def456")
+        XCTAssertEqual(result?.embedURL.absoluteString, "https://www.loom.com/embed/abc123def456")
+    }
+
+    // MARK: - Invalid path (no share/embed prefix) returns nil
+
+    func testInvalidPathReturnsNil() {
+        let url = URL(string: "https://www.loom.com/watch/abc123def456")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testLoomMyVideosReturnsNil() {
+        let url = URL(string: "https://www.loom.com/my-videos")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Embed URL is canonical for all input formats
+
+    func testEmbedURLIsCanonicalForAllFormats() {
+        let urls = [
+            "https://www.loom.com/share/testID123",
+            "https://loom.com/share/testID123",
+            "https://www.loom.com/embed/testID123",
+            "https://loom.com/embed/testID123",
+        ]
+        for urlString in urls {
+            let result = LoomParser.parse(URL(string: urlString)!)
+            XCTAssertEqual(
+                result?.embedURL.absoluteString,
+                "https://www.loom.com/embed/testID123",
+                "Canonical embed URL mismatch for input: \(urlString)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LoomParser` enum that parses Loom share and embed URLs (`loom.com/share/ID`, `loom.com/embed/ID`) with optional `www` prefix
- Generates canonical embed URLs in the form `https://www.loom.com/embed/VIDEO_ID`
- Reuses `VideoParseResult` struct from `YouTubeParser.swift`; requires `https` scheme; sets provider to `"loom"`
- 17 tests covering all URL patterns, edge cases (HTTP rejection, missing IDs, invalid paths, query params), and canonical URL generation

## Test plan
- [x] `swift test --filter LoomParserTests` — all 17 tests pass
- [ ] Verify integration with downstream media embed detection (future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/3999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
