### PR TITLE
feat: show thinking indicator between tool calls

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -2294,37 +2294,45 @@ private struct ThinkingIndicator: View {
     @State private var timer: Timer?
 
     var body: some View {
-        HStack(spacing: VSpacing.xs) {
-            Image("OwlIcon")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 12, height: 12)
-                .foregroundColor(VColor.textSecondary)
+        HStack(spacing: VSpacing.sm) {
+            HStack(spacing: 5) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(VColor.textSecondary)
+                        .frame(width: 6, height: 6)
+                        .scaleEffect(dotScale(for: index))
+                        .opacity(dotOpacity(for: index))
+                }
+            }
 
             Text(label)
-                .font(VFont.caption)
+                .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
-
-            ForEach(0..<3, id: \.self) { index in
-                Circle()
-                    .fill(VColor.textSecondary)
-                    .frame(width: 5, height: 5)
-                    .opacity(dotOpacity(for: index))
-            }
 
             Spacer()
         }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.backgroundSubtle.opacity(0.5))
+        )
+        .frame(maxWidth: 160, alignment: .leading)
         .onAppear { startAnimation() }
         .onDisappear { timer?.invalidate() }
     }
 
     private func dotOpacity(for index: Int) -> Double {
-        phase == index ? 1.0 : 0.4
+        phase == index ? 1.0 : 0.35
+    }
+
+    private func dotScale(for index: Int) -> CGFloat {
+        phase == index ? 1.15 : 0.85
     }
 
     private func startAnimation() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
-            withAnimation(.easeInOut(duration: 0.3)) {
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+            withAnimation(.easeInOut(duration: 0.4)) {
                 phase = (phase + 1) % 3
             }
         }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1931,4 +1931,84 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.pendingMessageIds.count, 0,
                         "Retried message should not be tracked when no other send is in progress")
     }
+
+    // MARK: - Thinking Indicator During Tool Execution
+
+    func testToolResultRestoresThinkingState() {
+        // Simulate agent running: text arrived (clears thinking), then tool runs
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Let me check.")))
+        XCTAssertFalse(viewModel.isThinking, "Text delta should clear thinking")
+
+        // Tool starts
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
+        XCTAssertFalse(viewModel.isThinking, "Tool chip is visible, thinking should be false")
+
+        // Tool completes — agent is now processing the result
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "file.txt", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
+        XCTAssertTrue(viewModel.isThinking, "Thinking should restore after tool result while still sending")
+    }
+
+    func testToolResultDoesNotRestoreThinkingWhenNotSending() {
+        // If isSending is false (shouldn't happen normally), don't set thinking
+        viewModel.isSending = false
+        viewModel.isThinking = false
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "ok", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
+        XCTAssertFalse(viewModel.isThinking, "Thinking should not restore when not sending")
+    }
+
+    func testToolResultDoesNotRestoreThinkingWhenCancelling() {
+        viewModel.isSending = true
+        viewModel.isCancelling = true
+        viewModel.isThinking = false
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "ok", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
+        XCTAssertFalse(viewModel.isThinking, "Thinking should not restore during cancellation")
+    }
+
+    func testToolUseStartClearsThinkingState() {
+        viewModel.isThinking = true
+        viewModel.isSending = true
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
+        XCTAssertFalse(viewModel.isThinking, "Tool use start should clear thinking since tool chip shows activity")
+    }
+
+    func testSuppressedToolDoesNotClearThinking() {
+        // ui_show is suppressed (no chip rendered), so thinking should NOT be cleared
+        viewModel.isThinking = true
+        viewModel.isSending = true
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "ui_show", input: [:], sessionId: nil)))
+        XCTAssertTrue(viewModel.isThinking, "Suppressed tools should not clear thinking state")
+    }
+
+    func testThinkingCycleThroughMultipleTools() {
+        // Full cycle: thinking → text → tool1 → result → thinking → tool2 → result → thinking → complete
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Agent writes some text
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Working on it.")))
+        XCTAssertFalse(viewModel.isThinking)
+
+        // First tool starts
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
+        XCTAssertFalse(viewModel.isThinking)
+
+        // First tool completes
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "files", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
+        XCTAssertTrue(viewModel.isThinking, "Thinking should show between tools")
+
+        // Second tool starts
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "file_read", input: ["path": AnyCodable("foo.txt")], sessionId: nil)))
+        XCTAssertFalse(viewModel.isThinking, "Thinking should clear when new tool starts")
+
+        // Second tool completes
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "file_read", result: "contents", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
+        XCTAssertTrue(viewModel.isThinking, "Thinking should show again after second tool")
+
+        // Message completes
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        XCTAssertFalse(viewModel.isThinking, "Thinking should clear on message complete")
+        XCTAssertFalse(viewModel.isSending)
+    }
 }

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -11,6 +11,7 @@ import Combine
 @MainActor
 final class MockDaemonClient: DaemonClientProtocol {
     var sentMessages: [Any] = []
+    var isConnected: Bool = true
     var isBlobTransportAvailable: Bool = false
     private var testContinuation: AsyncStream<ServerMessage>.Continuation?
     private var _messages: AsyncStream<ServerMessage>
@@ -35,6 +36,14 @@ final class MockDaemonClient: DaemonClientProtocol {
 
     func send<T: Encodable>(_ message: T) throws {
         sentMessages.append(message)
+    }
+
+    func connect() async throws {
+        isConnected = true
+    }
+
+    func disconnect() {
+        isConnected = false
     }
 }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -563,6 +563,8 @@ extension ChatViewModel {
             if msg.toolName == "ui_show" || msg.toolName == "ui_update" || msg.toolName == "ui_dismiss" || msg.toolName == "request_file" {
                 break
             }
+            // Tool chip is now visible — hide the thinking indicator
+            isThinking = false
             // Extract building status for app tools
             let buildingStatus: String? = {
                 let appTools: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
@@ -637,6 +639,11 @@ extension ChatViewModel {
                 if let status = msg.status, !status.isEmpty {
                     messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
                 }
+            }
+            // Tool completed — agent is now processing the result. Show
+            // thinking indicator until the next text delta or tool starts.
+            if isSending && !isCancelling {
+                isThinking = true
             }
 
         case .uiSurfaceShow(let msg):


### PR DESCRIPTION
## Summary
- Restore `isThinking` after each tool result so the "Thinking..." bubble reappears while the agent processes results between tool calls
- Clear `isThinking` when a new tool chip appears (the chip itself indicates activity)
- Restyle the ThinkingIndicator as a compact bubble with pulsing animated dots to match the chat conversation aesthetic
- Fix pre-existing `MockDaemonClient` protocol conformance in `SessionTests.swift`

## Test plan
- [x] 6 new unit tests covering the thinking state lifecycle (all passing)
- [ ] Manual test: send a multi-step request and verify "Thinking..." bubble appears between tool executions
- [ ] Verify indicator disappears when text starts streaming or a new tool chip appears
- [ ] Verify no indicator during cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
