### PR TITLE
feat: add DomainAllowlistMatcher for video embed URL validation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/DomainAllowlistMatcher.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/DomainAllowlistMatcher.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum DomainAllowlistMatcher {
+    /// Returns true if the URL's host matches any domain in the allowlist.
+    /// Supports exact and subdomain matching (e.g., "youtube.com" matches "www.youtube.com").
+    static func isAllowed(_ url: URL, allowedDomains: [String]) -> Bool {
+        guard url.scheme == "https",
+              let host = url.host?.lowercased() else { return false }
+
+        for domain in allowedDomains {
+            let normalizedDomain = domain.lowercased()
+            if host == normalizedDomain || host.hasSuffix(".\(normalizedDomain)") {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/clients/macos/vellum-assistantTests/DomainAllowlistMatcherTests.swift
+++ b/clients/macos/vellum-assistantTests/DomainAllowlistMatcherTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class DomainAllowlistMatcherTests: XCTestCase {
+
+    // MARK: - Exact match
+
+    func testExactMatch() {
+        let url = URL(string: "https://youtube.com/watch?v=abc")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
+    // MARK: - Subdomain match
+
+    func testSubdomainMatch() {
+        let url = URL(string: "https://www.youtube.com/watch?v=abc")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
+    func testDeepSubdomainMatch() {
+        let url = URL(string: "https://a.b.youtube.com/watch?v=abc")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
+    // MARK: - No match
+
+    func testNoMatch() {
+        let url = URL(string: "https://google.com/search")!
+        XCTAssertFalse(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
+    func testPartialMatchRejection() {
+        let url = URL(string: "https://notyoutube.com/watch")!
+        XCTAssertFalse(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
+    // MARK: - Case insensitivity
+
+    func testCaseInsensitivity() {
+        let url = URL(string: "https://WWW.YouTube.COM/watch?v=abc")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["YOUTUBE.COM"]))
+    }
+
+    // MARK: - Empty allowlist
+
+    func testEmptyAllowlistReturnsFalse() {
+        let url = URL(string: "https://youtube.com/watch?v=abc")!
+        XCTAssertFalse(DomainAllowlistMatcher.isAllowed(url, allowedDomains: []))
+    }
+
+    // MARK: - Non-https URL
+
+    func testNonHttpsReturnsFalse() {
+        let url = URL(string: "http://youtube.com/watch?v=abc")!
+        XCTAssertFalse(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
+    // MARK: - URL with no host
+
+    func testNoHostReturnsFalse() {
+        let url = URL(string: "https://")!
+        XCTAssertFalse(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
+    // MARK: - Multiple domains
+
+    func testMultipleDomainsInAllowlist() {
+        let domains = ["youtube.com", "vimeo.com", "loom.com"]
+
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=abc")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(youtubeURL, allowedDomains: domains))
+
+        let vimeoURL = URL(string: "https://vimeo.com/123456")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(vimeoURL, allowedDomains: domains))
+
+        let loomURL = URL(string: "https://www.loom.com/share/abc")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(loomURL, allowedDomains: domains))
+
+        let otherURL = URL(string: "https://dailymotion.com/video/abc")!
+        XCTAssertFalse(DomainAllowlistMatcher.isAllowed(otherURL, allowedDomains: domains))
+    }
+
+    // MARK: - Real provider domains
+
+    func testRealProviderDomains() {
+        let providers = ["youtube.com", "youtu.be", "vimeo.com", "loom.com"]
+
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(
+            URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")!, allowedDomains: providers))
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(
+            URL(string: "https://youtu.be/dQw4w9WgXcQ")!, allowedDomains: providers))
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(
+            URL(string: "https://vimeo.com/76979871")!, allowedDomains: providers))
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(
+            URL(string: "https://www.loom.com/share/abc123")!, allowedDomains: providers))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DomainAllowlistMatcher` enum with a static `isAllowed(_:allowedDomains:)` method that checks whether a URL's host matches any domain in a configurable allowlist
- Supports exact host matching and subdomain matching (e.g., `youtube.com` in the allowlist also matches `www.youtube.com`, `m.youtube.com`, etc.)
- Rejects non-HTTPS URLs and URLs with no host for security
- Includes 11 comprehensive tests covering exact match, subdomain match, deep subdomain, partial match rejection, case insensitivity, empty allowlist, non-HTTPS, no-host, multiple domains, and real provider domains

## Test plan
- [x] `swift test --filter DomainAllowlistMatcherTests` — all 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
