### PR TITLE
feat: SettingsView global auto-embed toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -170,6 +170,17 @@ public struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Media Embeds") {
+                Toggle("Auto media embeds", isOn: Binding(
+                    get: { store.mediaEmbedsEnabled },
+                    set: { store.setMediaEmbedsEnabled($0) }
+                ))
+
+                Text("Automatically embed images, videos, and other media shared in chat messages.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Permissions") {
                 HStack {
                     Image(systemName: accessibilityGranted ? "checkmark.circle.fill" : "xmark.circle.fill")

--- a/clients/macos/vellum-assistantTests/SettingsViewMediaToggleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsViewMediaToggleTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class SettingsViewMediaToggleTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private var configPath: String {
+        tempDir.appendingPathComponent("config.json").path
+    }
+
+    private func seed(_ json: String) {
+        let url = URL(fileURLWithPath: configPath)
+        try! json.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makeStore(enabled: Bool) -> SettingsStore {
+        seed(#"{"ui":{"mediaEmbeds":{"enabled":\#(enabled)}}}"#)
+        return SettingsStore(configPath: configPath)
+    }
+
+    // MARK: - Toggle reflects the store's current state
+
+    func testToggleReflectsStoreEnabledTrue() {
+        let store = makeStore(enabled: true)
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+    }
+
+    func testToggleReflectsStoreEnabledFalse() {
+        let store = makeStore(enabled: false)
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+    }
+
+    // MARK: - Toggling updates the store
+
+    func testTogglingOnUpdatesStore() {
+        let store = makeStore(enabled: false)
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+
+        store.setMediaEmbedsEnabled(true)
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+    }
+
+    func testTogglingOffUpdatesStore() {
+        let store = makeStore(enabled: true)
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+
+        store.setMediaEmbedsEnabled(false)
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+    }
+
+    // MARK: - SettingsView creates without error when store has media embeds
+
+    func testSettingsViewInitializesWithMediaEmbedsStore() {
+        let store = makeStore(enabled: true)
+        let view = SettingsView(store: store)
+        // The view should initialize without crashing; the store should
+        // still reflect the expected state after being wired up.
+        XCTAssertTrue(view.store.mediaEmbedsEnabled)
+    }
+
+    func testSettingsViewInitializesWithMediaEmbedsDisabled() {
+        let store = makeStore(enabled: false)
+        let view = SettingsView(store: store)
+        XCTAssertFalse(view.store.mediaEmbedsEnabled)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a "Media Embeds" section to the standalone Settings window with an "Auto media embeds" toggle
- Toggle is bound to `settingsStore.mediaEmbedsEnabled` and calls `settingsStore.setMediaEmbedsEnabled(_:)` on change
- Follows existing UI pattern (same spacing, fonts, section style as the Notifications toggle)
- No allowlist UI yet — just the global on/off toggle

## Test plan
- [x] `swift test --filter SettingsViewMediaToggleTests` — 6 tests, all passing
- [ ] Manual: open Settings window, verify toggle appears in "Media Embeds" section
- [ ] Manual: toggle on/off and confirm state persists across Settings window reopens

PR 10 of the inline media embeds rollout plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
