### PR TITLE
private-threads: add SessionMemoryPolicy to Session class

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -96,6 +96,18 @@ import {
 import { unregisterSessionSender } from '../tools/browser/browser-screencast.js';
 import { projectSkillTools, resetSkillToolProjection } from './session-skill-tools.js';
 
+export interface SessionMemoryPolicy {
+  scopeId: string;
+  includeDefaultFallback: boolean;
+  strictSideEffects: boolean;
+}
+
+export const DEFAULT_MEMORY_POLICY: SessionMemoryPolicy = {
+  scopeId: 'default',
+  includeDefaultFallback: false,
+  strictSideEffects: false,
+};
+
 const log = getLogger('session');
 
 export { MAX_QUEUE_DEPTH, type QueueDrainReason, type QueuePolicy } from './session-queue-manager.js';
@@ -168,6 +180,7 @@ export class Session {
   /** @internal — exposed for session-workspace.ts module functions. */
   workspaceTopLevelDirty = true;
   public readonly traceEmitter: TraceEmitter;
+  public memoryPolicy: SessionMemoryPolicy;
 
   /** Resolved assistant attachment drafts from the most recent exchange. */
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
@@ -182,6 +195,7 @@ export class Session {
     sendToClient: (msg: ServerMessage) => void,
     workingDir: string,
     broadcastToAllClients?: (msg: ServerMessage) => void,
+    memoryPolicy?: SessionMemoryPolicy,
   ) {
     this.conversationId = conversationId;
     this.systemPrompt = systemPrompt;
@@ -189,6 +203,7 @@ export class Session {
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
     this.broadcastToAllClients = broadcastToAllClients;
+    this.memoryPolicy = memoryPolicy ?? DEFAULT_MEMORY_POLICY;
     this.traceEmitter = new TraceEmitter(conversationId, sendToClient);
     this.prompter = new PermissionPrompter(sendToClient);
     this.secretPrompter = new SecretPrompter(sendToClient);


### PR DESCRIPTION
## Summary
- Add `SessionMemoryPolicy` interface with `scopeId`, `includeDefaultFallback`, and `strictSideEffects` fields
- Add `DEFAULT_MEMORY_POLICY` constant (all defaults: scopeId=default, no fallback, no strict)
- Add optional `memoryPolicy` parameter to Session constructor, defaulting to `DEFAULT_MEMORY_POLICY`
- Export both the type and constant for downstream use

## Test plan
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — 173 pass
- [x] `bun test src/__tests__/daemon-server-session-init.test.ts` — 4 pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
