### PR TITLE
feat: add editable video domain allowlist to SettingsView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ public struct SettingsView: View {
     @State private var showingPrivacy = false
     @State private var showingSkills = false
     @State private var showingTrustRules = false
+    @State private var newAllowlistDomain = ""
     @State private var skillsViewModel: SkillsSettingsViewModel?
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var activationKey: ActivationKey = {
@@ -179,6 +180,54 @@ public struct SettingsView: View {
                 Text("Automatically embed images, videos, and other media shared in chat messages.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                if store.mediaEmbedsEnabled {
+                    Divider()
+
+                    Text("Video Domain Allowlist")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    HStack {
+                        TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
+                            .textFieldStyle(.roundedBorder)
+                        Button("Add") {
+                            let domain = newAllowlistDomain
+                                .trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !domain.isEmpty else { return }
+                            var domains = store.mediaEmbedVideoAllowlistDomains
+                            domains.append(domain)
+                            store.setMediaEmbedVideoAllowlistDomains(domains)
+                            newAllowlistDomain = ""
+                        }
+                        .disabled(newAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+
+                    ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in
+                        HStack {
+                            Text(domain)
+                                .font(.body)
+                            Spacer()
+                            Button {
+                                var domains = store.mediaEmbedVideoAllowlistDomains
+                                domains.removeAll { $0 == domain }
+                                store.setMediaEmbedVideoAllowlistDomains(domains)
+                            } label: {
+                                Image(systemName: "trash")
+                                    .foregroundStyle(.red)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    }
+
+                    HStack {
+                        Spacer()
+                        Button("Reset to Defaults") {
+                            store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
+                        }
+                        .font(.caption)
+                    }
+                }
             }
 
             Section("Permissions") {

--- a/clients/macos/vellum-assistantTests/SettingsViewMediaAllowlistTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsViewMediaAllowlistTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class SettingsViewMediaAllowlistTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private var configPath: String {
+        tempDir.appendingPathComponent("config.json").path
+    }
+
+    private func seed(_ json: String) {
+        let url = URL(fileURLWithPath: configPath)
+        try! json.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makeStore(enabled: Bool, domains: [String]? = nil) -> SettingsStore {
+        if let domains {
+            let domainsJSON = domains.map { #""\#($0)""# }.joined(separator: ",")
+            seed(#"{"ui":{"mediaEmbeds":{"enabled":\#(enabled),"videoAllowlistDomains":[\#(domainsJSON)]}}}"#)
+        } else {
+            seed(#"{"ui":{"mediaEmbeds":{"enabled":\#(enabled)}}}"#)
+        }
+        return SettingsStore(configPath: configPath)
+    }
+
+    // MARK: - Allowlist domains from store are accessible via SettingsView
+
+    func testAllowlistDomainsAccessibleThroughView() {
+        let store = makeStore(enabled: true, domains: ["youtube.com", "vimeo.com"])
+        let view = SettingsView(store: store)
+        XCTAssertEqual(view.store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "vimeo.com"])
+    }
+
+    func testDefaultDomainsLoadedWhenNoneConfigured() {
+        let store = makeStore(enabled: true)
+        let view = SettingsView(store: store)
+        XCTAssertEqual(view.store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - Adding a domain updates the store
+
+    func testAddingDomainUpdatesStore() {
+        let store = makeStore(enabled: true, domains: ["youtube.com"])
+
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.append("newsite.com")
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "newsite.com"])
+    }
+
+    func testAddingDuplicateDomainIsDeduped() {
+        let store = makeStore(enabled: true, domains: ["youtube.com"])
+
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.append("YouTube.COM")
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com"])
+    }
+
+    // MARK: - Removing a domain updates the store
+
+    func testRemovingDomainUpdatesStore() {
+        let store = makeStore(enabled: true, domains: ["youtube.com", "vimeo.com", "loom.com"])
+
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.removeAll { $0 == "vimeo.com" }
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "loom.com"])
+    }
+
+    func testRemovingAllDomainsResultsInEmptyList() {
+        let store = makeStore(enabled: true, domains: ["youtube.com"])
+
+        store.setMediaEmbedVideoAllowlistDomains([])
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, [])
+    }
+
+    // MARK: - Resetting to defaults
+
+    func testResetToDefaultsRestoresDefaultDomains() {
+        let store = makeStore(enabled: true, domains: ["custom.com", "other.org"])
+
+        store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    func testResetToDefaultsPersistsCorrectly() {
+        let store = makeStore(enabled: true, domains: ["custom.com"])
+
+        store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
+
+        // Reload from the same config to verify persistence
+        let reloaded = SettingsStore(configPath: configPath)
+        XCTAssertEqual(reloaded.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - Allowlist section relevance when embeds are disabled
+
+    func testAllowlistStillAccessibleWhenEmbedsDisabled() {
+        // The store still holds the domains even when embeds are off;
+        // the UI hides the editor, but the data remains intact.
+        let store = makeStore(enabled: false, domains: ["youtube.com", "custom.com"])
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "custom.com"])
+    }
+
+    func testDisablingEmbedsPreservesAllowlistDomains() {
+        let store = makeStore(enabled: true, domains: ["youtube.com", "custom.com"])
+
+        store.setMediaEmbedsEnabled(false)
+
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "custom.com"])
+    }
+
+    func testReEnablingEmbedsPreservesAllowlistDomains() {
+        let store = makeStore(enabled: true, domains: ["custom.com"])
+
+        store.setMediaEmbedsEnabled(false)
+        store.setMediaEmbedsEnabled(true)
+
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["custom.com"])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a domain list editor to the **Media Embeds** section of `SettingsView`, visible only when auto-embeds are enabled
- Users can add new domains via a text field, delete existing domains with a trash button, and reset to defaults
- All changes persist through `SettingsStore.setMediaEmbedVideoAllowlistDomains`
- New test suite (`SettingsViewMediaAllowlistTests`) covers add, remove, reset, persistence, and interaction with the enable/disable toggle

## Test plan
- [x] `swift test --filter SettingsViewMediaAllowlistTests` — 11 tests, all passing
- [ ] Manual: open Settings, toggle Media Embeds on, verify allowlist editor appears
- [ ] Manual: add a domain, verify it appears in the list
- [ ] Manual: delete a domain, verify it disappears
- [ ] Manual: click "Reset to Defaults", verify defaults are restored
- [ ] Manual: toggle Media Embeds off, verify allowlist editor hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
