### PR TITLE
feat: add MediaEmbedResolver (role-agnostic, dedupe, gating)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -1,0 +1,99 @@
+import Foundation
+import VellumAssistantShared
+
+/// The type of media embed that should be rendered for a URL.
+enum MediaEmbedIntent: Equatable {
+    case image(url: URL)
+    case video(provider: String, videoID: String, embedURL: URL)
+}
+
+/// Snapshot of user-facing settings that gate media embed resolution.
+struct MediaEmbedResolverSettings {
+    let enabled: Bool
+    let enabledSince: Date?
+    let allowedDomains: [String]
+}
+
+/// Assembles URL extraction, video parsing, image classification, and
+/// domain allowlisting into a single pure resolution step.
+///
+/// The resolver is role-agnostic (works for both user and assistant
+/// messages), deduplicates by canonical URL, and respects the feature
+/// gate (`enabled` / `enabledSince`).
+enum MediaEmbedResolver {
+
+    /// Video parsers tried in order for each extracted URL.
+    private static let videoParsers: [(URL) -> VideoParseResult?] = [
+        YouTubeParser.parse,
+        VimeoParser.parse,
+        LoomParser.parse,
+    ]
+
+    /// Resolves all media embed intents for a single chat message.
+    ///
+    /// Returns an empty array when the feature is disabled, when the
+    /// message predates `enabledSince`, or when no embeddable URLs
+    /// are found.
+    static func resolve(
+        message: ChatMessage,
+        settings: MediaEmbedResolverSettings
+    ) -> [MediaEmbedIntent] {
+        guard settings.enabled else { return [] }
+
+        if let enabledSince = settings.enabledSince,
+           message.timestamp < enabledSince {
+            return []
+        }
+
+        let urls = MessageURLExtractor.extractAllURLs(from: message.text)
+        guard !urls.isEmpty else { return [] }
+
+        var seen = Set<String>()
+        var intents: [MediaEmbedIntent] = []
+
+        for url in urls {
+            // Try each video parser in order.
+            if let videoResult = tryVideoParsers(url, allowedDomains: settings.allowedDomains) {
+                let canonical = videoResult.embedURL.absoluteString
+                guard !seen.contains(canonical) else { continue }
+                seen.insert(canonical)
+                intents.append(.video(
+                    provider: videoResult.provider,
+                    videoID: videoResult.videoID,
+                    embedURL: videoResult.embedURL
+                ))
+                continue
+            }
+
+            // Fall back to image classification (extension-based only).
+            let classification = ImageURLClassifier.classify(url)
+            if classification == .image {
+                let canonical = url.absoluteString
+                guard !seen.contains(canonical) else { continue }
+                seen.insert(canonical)
+                intents.append(.image(url: url))
+            }
+        }
+
+        return intents
+    }
+
+    // MARK: - Private helpers
+
+    /// Tries each video parser against the URL. Returns the first
+    /// successful result whose domain passes the allowlist, or nil.
+    private static func tryVideoParsers(
+        _ url: URL,
+        allowedDomains: [String]
+    ) -> VideoParseResult? {
+        for parser in videoParsers {
+            if let result = parser(url) {
+                guard DomainAllowlistMatcher.isAllowed(url, allowedDomains: allowedDomains) else {
+                    return nil
+                }
+                return result
+            }
+        }
+        return nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/MediaEmbedResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedResolverTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class MediaEmbedResolverTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a ChatMessage with the given text, role, and timestamp.
+    private func makeMessage(
+        _ text: String,
+        role: ChatRole = .assistant,
+        timestamp: Date = Date()
+    ) -> ChatMessage {
+        ChatMessage(role: role, text: text, timestamp: timestamp)
+    }
+
+    /// Returns settings with the feature enabled and all common video
+    /// domains allowed. `enabledSince` defaults to nil (allow all).
+    private func enabledSettings(
+        enabledSince: Date? = nil,
+        allowedDomains: [String] = [
+            "youtube.com", "youtu.be",
+            "vimeo.com",
+            "loom.com",
+        ]
+    ) -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(
+            enabled: true,
+            enabledSince: enabledSince,
+            allowedDomains: allowedDomains
+        )
+    }
+
+    private func disabledSettings() -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(enabled: false, enabledSince: nil, allowedDomains: [])
+    }
+
+    // MARK: - Feature gate: disabled
+
+    func testDisabledSettingsReturnsEmpty() {
+        let message = makeMessage("Check https://www.youtube.com/watch?v=abc123")
+        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Feature gate: enabledSince
+
+    func testMessageBeforeEnabledSinceReturnsEmpty() {
+        let cutoff = Date()
+        let oldTimestamp = cutoff.addingTimeInterval(-60)
+        let message = makeMessage(
+            "https://www.youtube.com/watch?v=abc123",
+            timestamp: oldTimestamp
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result, [])
+    }
+
+    func testMessageAfterEnabledSinceResolves() {
+        let cutoff = Date().addingTimeInterval(-120)
+        let message = makeMessage(
+            "https://www.youtube.com/watch?v=abc123",
+            timestamp: Date()
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result.count, 1)
+        if case .video(let provider, let videoID, _) = result.first {
+            XCTAssertEqual(provider, "youtube")
+            XCTAssertEqual(videoID, "abc123")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    func testNilEnabledSinceAllowsAllMessages() {
+        let veryOld = Date.distantPast
+        let message = makeMessage(
+            "https://www.youtube.com/watch?v=old123",
+            timestamp: veryOld
+        )
+        let settings = enabledSettings(enabledSince: nil)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    // MARK: - Video providers
+
+    func testYouTubeURLResolvesToVideoIntent() {
+        let message = makeMessage("Watch this: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+        if case .video(let provider, let videoID, let embedURL) = result.first {
+            XCTAssertEqual(provider, "youtube")
+            XCTAssertEqual(videoID, "dQw4w9WgXcQ")
+            XCTAssertEqual(embedURL.absoluteString, "https://www.youtube.com/embed/dQw4w9WgXcQ")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    func testVimeoURLResolvesToVideoIntent() {
+        let message = makeMessage("See https://vimeo.com/76979871")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+        if case .video(let provider, let videoID, let embedURL) = result.first {
+            XCTAssertEqual(provider, "vimeo")
+            XCTAssertEqual(videoID, "76979871")
+            XCTAssertEqual(embedURL.absoluteString, "https://player.vimeo.com/video/76979871")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    func testLoomURLResolvesToVideoIntent() {
+        let message = makeMessage("Recording: https://www.loom.com/share/abc123def456")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+        if case .video(let provider, let videoID, let embedURL) = result.first {
+            XCTAssertEqual(provider, "loom")
+            XCTAssertEqual(videoID, "abc123def456")
+            XCTAssertEqual(embedURL.absoluteString, "https://www.loom.com/embed/abc123def456")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    // MARK: - Image classification
+
+    func testImageURLResolvesToImageIntent() {
+        let message = makeMessage("Here's a screenshot: https://example.com/photo.png")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+        if case .image(let url) = result.first {
+            XCTAssertEqual(url.absoluteString, "https://example.com/photo.png")
+        } else {
+            XCTFail("Expected image intent")
+        }
+    }
+
+    // MARK: - Domain allowlist
+
+    func testNonAllowedDomainVideoURLIsSkipped() {
+        let message = makeMessage("https://www.youtube.com/watch?v=abc123")
+        // Settings with no allowed domains for video providers
+        let settings = MediaEmbedResolverSettings(
+            enabled: true,
+            enabledSince: nil,
+            allowedDomains: ["example.com"]
+        )
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Mixed URLs
+
+    func testMixedImageAndVideoURLs() {
+        let message = makeMessage(
+            "Video: https://www.youtube.com/watch?v=abc123 and image: https://cdn.example.com/pic.jpg"
+        )
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 2)
+
+        if case .video(let provider, _, _) = result[0] {
+            XCTAssertEqual(provider, "youtube")
+        } else {
+            XCTFail("Expected video intent first")
+        }
+
+        if case .image(let url) = result[1] {
+            XCTAssertTrue(url.absoluteString.contains("pic.jpg"))
+        } else {
+            XCTFail("Expected image intent second")
+        }
+    }
+
+    // MARK: - Deduplication
+
+    func testDuplicateURLsAreDeduped() {
+        let message = makeMessage(
+            "https://www.youtube.com/watch?v=abc123 and again https://www.youtube.com/watch?v=abc123"
+        )
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+    }
+
+    // MARK: - Code blocks excluded
+
+    func testURLsInCodeBlocksAreExcluded() {
+        let message = makeMessage("""
+        Here is some code:
+        ```
+        https://www.youtube.com/watch?v=abc123
+        ```
+        """)
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Plain text, no URLs
+
+    func testPlainTextWithNoURLsReturnsEmpty() {
+        let message = makeMessage("Just a regular message with no links.")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Role-agnostic
+
+    func testUserMessageResolves() {
+        let message = makeMessage(
+            "https://www.youtube.com/watch?v=user123",
+            role: .user
+        )
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+        if case .video(_, let videoID, _) = result.first {
+            XCTAssertEqual(videoID, "user123")
+        } else {
+            XCTFail("Expected video intent for user message")
+        }
+    }
+
+    func testAssistantMessageResolves() {
+        let message = makeMessage(
+            "https://www.youtube.com/watch?v=asst456",
+            role: .assistant
+        )
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+        if case .video(_, let videoID, _) = result.first {
+            XCTAssertEqual(videoID, "asst456")
+        } else {
+            XCTFail("Expected video intent for assistant message")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MediaEmbedResolver` that assembles URL extraction, video parsing (YouTube/Vimeo/Loom), image classification, and domain allowlisting into a single pure resolver
- Introduces `MediaEmbedIntent` enum (`.image` / `.video`) and `MediaEmbedResolverSettings` for feature gating
- The resolver is role-agnostic (works for both user and assistant messages), deduplicates by canonical URL, respects `enabled` and `enabledSince` gates, and checks the domain allowlist for video providers
- 15 tests covering: disabled settings, enabledSince gating, all three video providers, image classification, domain blocking, mixed URLs, deduplication, code block exclusion, plain text, nil enabledSince, and role-agnostic behavior

## Test plan
- [x] `swift test --filter MediaEmbedResolverTests` — 15/15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
