### PR TITLE
private-threads: session info parity for initial/switch flows

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -8,6 +8,7 @@ const conversation = {
   totalInputTokens: 0,
   totalOutputTokens: 0,
   totalEstimatedCost: 0,
+  threadType: 'standard' as string,
 };
 
 let lastCreatedWorkingDir: string | undefined;
@@ -54,6 +55,12 @@ class MockSession {
   }
 
   abort(): void {}
+
+  hasEscalationHandler(): boolean {
+    return true;
+  }
+
+  setEscalationHandler(): void {}
 
   handleConfirmationResponse(): void {}
 
@@ -228,5 +235,53 @@ describe('DaemonServer initial session hydration', () => {
     internal.dispatchMessage({ type: 'sandbox_set', enabled: false }, socket);
 
     expect(session!.setSandboxOverrideCalls).toBe(0);
+  });
+
+  test('sendInitialSession includes threadType in session_info', async () => {
+    conversation.threadType = 'private';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket, writes } = createFakeSocket();
+
+    await internal.sendInitialSession(socket);
+
+    const messages = decodeMessages(writes);
+    const sessionInfo = messages.find((msg) => msg.type === 'session_info');
+    expect(sessionInfo).toBeDefined();
+    expect(sessionInfo!.threadType).toBe('private');
+  });
+
+  test('sendInitialSession includes standard threadType by default', async () => {
+    conversation.threadType = 'standard';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket, writes } = createFakeSocket();
+
+    await internal.sendInitialSession(socket);
+
+    const messages = decodeMessages(writes);
+    const sessionInfo = messages.find((msg) => msg.type === 'session_info');
+    expect(sessionInfo).toBeDefined();
+    expect(sessionInfo!.threadType).toBe('standard');
+  });
+
+  test('session_switch includes threadType in session_info', async () => {
+    conversation.threadType = 'private';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket, writes } = createFakeSocket();
+
+    // Hydrate the session first so switch has something to find
+    await internal.sendInitialSession(socket);
+    writes.length = 0;
+
+    internal.dispatchMessage({ type: 'session_switch', sessionId: conversation.id }, socket);
+    // Allow async handler to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    const messages = decodeMessages(writes);
+    const sessionInfo = messages.find((msg) => msg.type === 'session_info');
+    expect(sessionInfo).toBeDefined();
+    expect(sessionInfo!.threadType).toBe('private');
   });
 });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -275,6 +275,7 @@ export async function handleSessionSwitch(
     type: 'session_info',
     sessionId: conversation.id,
     title: conversation.title ?? 'Untitled',
+    threadType: conversation.threadType,
   });
 }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -663,6 +663,7 @@ export class DaemonServer {
       type: 'session_info',
       sessionId: conversation.id,
       title: conversation.title ?? 'New Conversation',
+      threadType: conversation.threadType,
     });
 
     this.send(socket, {


### PR DESCRIPTION
## Summary
- Add `threadType` to the `session_info` payload in `sendInitialSession` (server.ts) so clients know the thread type on reconnect
- Add `threadType` to the `session_info` payload in `handleSessionSwitch` (sessions.ts) so clients know the thread type after switching sessions
- Add tests verifying threadType is present in session_info for both the reconnect path (sendInitialSession) and session switch, for both standard and private thread types

## Context
PR 7 already wired `threadType` through `handleSessionCreate` and `handleSessionList`. This PR closes the gap for the remaining two `session_info` emission sites: the initial session handshake on connect/reconnect and the session switch flow.

## Test plan
- [x] `bun test src/__tests__/daemon-server-session-init.test.ts` — 7 tests pass (3 new)
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — 173 tests pass (no regressions)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
