### PR TITLE
private-threads: retriever scope policy override option

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3002,4 +3002,262 @@ describe('Memory regressions', () => {
     expect(rows[0].lastSeenAt).toBe(1_700_000_200_000);
     expect(rows[0].evidence).toBe('Atlas currently depends on Qdrant');
   });
+
+  // ── scopePolicyOverride tests ───────────────────────────────────────
+
+  test('scopePolicyOverride with fallbackToDefault includes both scopes even when global policy is strict', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = 'conv-scope-override-fallback';
+
+    db.insert(conversations).values({
+      id: convId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-override-fallback',
+      conversationId: convId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'override fallback test' }]),
+      createdAt: now,
+    }).run();
+
+    // Insert segment in default scope
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-default', 'msg-override-fallback', '${convId}', 'user', 0, 'Global memory about microservices architecture patterns', 10, 'default', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-default', 'Global memory about microservices architecture patterns')`);
+
+    // Insert segment in private thread scope
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-private', 'msg-override-fallback', '${convId}', 'user', 1, 'Private thread memory about microservices architecture patterns', 10, 'private-thread-42', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-private', 'Private thread memory about microservices architecture patterns')`);
+
+    // Global policy is strict, but override requests fallback to default
+    const strictConfig = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        embeddings: { ...TEST_CONFIG.memory.embeddings, required: false },
+        retrieval: {
+          ...TEST_CONFIG.memory.retrieval,
+          scopePolicy: 'strict' as const,
+        },
+      },
+    };
+
+    const result = await buildMemoryRecall('microservices architecture', convId, strictConfig, {
+      scopePolicyOverride: {
+        scopeId: 'private-thread-42',
+        fallbackToDefault: true,
+      },
+    });
+    const keys = result.topCandidates.map((c) => c.key);
+
+    // Override should include both private and default scope despite strict global policy
+    expect(keys).toContain('segment:seg-ovr-default');
+    expect(keys).toContain('segment:seg-ovr-private');
+  });
+
+  test('scopePolicyOverride without fallback excludes default scope even when global policy is allow_global_fallback', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = 'conv-scope-override-nofallback';
+
+    db.insert(conversations).values({
+      id: convId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-override-nofallback',
+      conversationId: convId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'override no fallback' }]),
+      createdAt: now,
+    }).run();
+
+    // Insert segment in default scope
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-nf-default', 'msg-override-nofallback', '${convId}', 'user', 0, 'Global memory about container orchestration strategies', 10, 'default', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-nf-default', 'Global memory about container orchestration strategies')`);
+
+    // Insert segment in isolated scope
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-nf-isolated', 'msg-override-nofallback', '${convId}', 'user', 1, 'Isolated memory about container orchestration strategies', 10, 'isolated-scope', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-nf-isolated', 'Isolated memory about container orchestration strategies')`);
+
+    // Global policy allows fallback, but override says no fallback
+    const fallbackConfig = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        embeddings: { ...TEST_CONFIG.memory.embeddings, required: false },
+        retrieval: {
+          ...TEST_CONFIG.memory.retrieval,
+          scopePolicy: 'allow_global_fallback' as const,
+        },
+      },
+    };
+
+    const result = await buildMemoryRecall('container orchestration', convId, fallbackConfig, {
+      scopePolicyOverride: {
+        scopeId: 'isolated-scope',
+        fallbackToDefault: false,
+      },
+    });
+    const keys = result.topCandidates.map((c) => c.key);
+
+    // Override disables fallback — only isolated scope should appear
+    expect(keys).not.toContain('segment:seg-ovr-nf-default');
+    expect(keys).toContain('segment:seg-ovr-nf-isolated');
+  });
+
+  test('scopePolicyOverride takes precedence over scopeId option', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = 'conv-scope-override-precedence';
+
+    db.insert(conversations).values({
+      id: convId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-override-precedence',
+      conversationId: convId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'precedence test' }]),
+      createdAt: now,
+    }).run();
+
+    // Insert segment in scope-a (what scopeId would resolve to)
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-prec-a', 'msg-override-precedence', '${convId}', 'user', 0, 'Scope A memory about distributed caching patterns', 10, 'scope-a', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-prec-a', 'Scope A memory about distributed caching patterns')`);
+
+    // Insert segment in scope-b (what the override targets)
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-prec-b', 'msg-override-precedence', '${convId}', 'user', 1, 'Scope B memory about distributed caching patterns', 10, 'scope-b', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-prec-b', 'Scope B memory about distributed caching patterns')`);
+
+    const config = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        embeddings: { ...TEST_CONFIG.memory.embeddings, required: false },
+        retrieval: {
+          ...TEST_CONFIG.memory.retrieval,
+          scopePolicy: 'strict' as const,
+        },
+      },
+    };
+
+    // scopeId says 'scope-a', but override says 'scope-b' — override wins
+    const result = await buildMemoryRecall('distributed caching', convId, config, {
+      scopeId: 'scope-a',
+      scopePolicyOverride: {
+        scopeId: 'scope-b',
+        fallbackToDefault: false,
+      },
+    });
+    const keys = result.topCandidates.map((c) => c.key);
+
+    expect(keys).not.toContain('segment:seg-ovr-prec-a');
+    expect(keys).toContain('segment:seg-ovr-prec-b');
+  });
+
+  test('scopePolicyOverride with default as primary scope and fallback=true returns only default', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = 'conv-scope-override-default-primary';
+
+    db.insert(conversations).values({
+      id: convId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-override-default-primary',
+      conversationId: convId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'default primary' }]),
+      createdAt: now,
+    }).run();
+
+    // Insert segment in default scope
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-dp-default', 'msg-override-default-primary', '${convId}', 'user', 0, 'Default scope memory about event driven design', 10, 'default', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-dp-default', 'Default scope memory about event driven design')`);
+
+    // Insert segment in other scope
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-ovr-dp-other', 'msg-override-default-primary', '${convId}', 'user', 1, 'Other scope memory about event driven design', 10, 'other-scope', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-ovr-dp-other', 'Other scope memory about event driven design')`);
+
+    const config = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        embeddings: { ...TEST_CONFIG.memory.embeddings, required: false },
+      },
+    };
+
+    // When primary scope IS 'default' with fallback=true, no duplication —
+    // just ['default'] is used
+    const result = await buildMemoryRecall('event driven design', convId, config, {
+      scopePolicyOverride: {
+        scopeId: 'default',
+        fallbackToDefault: true,
+      },
+    });
+    const keys = result.topCandidates.map((c) => c.key);
+
+    expect(keys).toContain('segment:seg-ovr-dp-default');
+    expect(keys).not.toContain('segment:seg-ovr-dp-other');
+  });
 });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -12,6 +12,7 @@ import type {
   MemoryRecallOptions,
   MemoryRecallResult,
   MemorySearchResult,
+  ScopePolicyOverride,
 } from './search/types.js';
 import { lexicalSearch, recencySearch, directItemSearch } from './search/lexical.js';
 import { semanticSearch, isQdrantConnectionError } from './search/semantic.js';
@@ -24,6 +25,7 @@ export type {
   MemoryRecallCandiateDebug,
   MemoryRecallResult,
   MemorySearchResult,
+  ScopePolicyOverride,
 } from './search/types.js';
 export {
   escapeXmlTags,
@@ -35,6 +37,10 @@ const log = getLogger('memory-retriever');
 
 /**
  * Build the list of scope IDs to include in queries.
+ * - If a `scopePolicyOverride` is provided, it takes precedence over both
+ *   `scopeId` and `scopePolicy` — the override's `scopeId` is used as the
+ *   primary scope and `fallbackToDefault` controls whether 'default' is
+ *   included.
  * - If no scopeId is provided, returns undefined (no filtering).
  * - If scopePolicy is 'allow_global_fallback', includes both the
  *   requested scope and the 'default' scope.
@@ -43,7 +49,17 @@ const log = getLogger('memory-retriever');
 function buildScopeFilter(
   scopeId: string | undefined,
   scopePolicy: string,
+  scopePolicyOverride?: ScopePolicyOverride,
 ): string[] | undefined {
+  // Per-call override takes precedence over global config
+  if (scopePolicyOverride) {
+    const primary = scopePolicyOverride.scopeId;
+    if (scopePolicyOverride.fallbackToDefault && primary !== 'default') {
+      return [primary, 'default'];
+    }
+    return [primary];
+  }
+
   if (!scopeId) return undefined;
   if (scopePolicy === 'allow_global_fallback') {
     return scopeId === 'default' ? ['default'] : [scopeId, 'default'];
@@ -67,14 +83,16 @@ async function collectAndMergeCandidates(
     conversationId?: string;
     excludeMessageIds?: string[];
     scopeId?: string;
+    scopePolicyOverride?: ScopePolicyOverride;
   },
 ): Promise<CollectedCandidates> {
   const queryVector = opts?.queryVector ?? null;
   const excludeMessageIds = opts?.excludeMessageIds ?? [];
   const scopeId = opts?.scopeId;
   const scopePolicy = config.memory.retrieval.scopePolicy;
-  // Build the list of scope IDs to include in queries
-  const scopeIds = buildScopeFilter(scopeId, scopePolicy);
+  // Build the list of scope IDs to include in queries.
+  // A per-call scopePolicyOverride takes precedence over the global policy.
+  const scopeIds = buildScopeFilter(scopeId, scopePolicy, opts?.scopePolicyOverride);
 
   // -- Phase 1: cheap local searches (always run) --
   const lexical = lexicalSearch(query, config.memory.retrieval.lexicalTopK, excludeMessageIds, scopeIds);
@@ -274,6 +292,7 @@ export async function buildMemoryRecall(
       conversationId,
       excludeMessageIds,
       scopeId: options?.scopeId,
+      scopePolicyOverride: options?.scopePolicyOverride,
     });
   } catch (err) {
     if (signal?.aborted || isAbortError(err)) {

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -57,10 +57,30 @@ export interface MemoryRecallResult {
   topCandidates: MemoryRecallCandiateDebug[];
 }
 
+/**
+ * Override the global scope policy for a single retrieval call.
+ * Private threads use this to guarantee they always read from their own
+ * scope AND fall back to 'default', regardless of what the global config says.
+ */
+export interface ScopePolicyOverride {
+  /** The primary scope to query (e.g. a private thread's scope ID). */
+  scopeId: string;
+  /** When true, results from the 'default' scope are included alongside
+   *  the primary scope. Equivalent to 'allow_global_fallback' behavior
+   *  but controlled per-call instead of globally. */
+  fallbackToDefault: boolean;
+}
+
 export interface MemoryRecallOptions {
   excludeMessageIds?: string[];
   signal?: AbortSignal;
   scopeId?: string;
+  /**
+   * When set, overrides both `scopeId` and the global `scopePolicy` config
+   * for this retrieval call. Designed for private threads that need to
+   * guarantee private+default fallback independent of global settings.
+   */
+  scopePolicyOverride?: ScopePolicyOverride;
   maxInjectTokensOverride?: number;
 }
 


### PR DESCRIPTION
## Summary
- Adds `ScopePolicyOverride` interface to `MemoryRecallOptions` that lets callers specify an explicit scope ID and whether to fall back to the default scope, independent of the global `scopePolicy` config
- `buildScopeFilter` now accepts an optional override that takes precedence over both `scopeId` and `config.memory.retrieval.scopePolicy`
- Passes the override through `collectAndMergeCandidates` and `buildMemoryRecall` so the full retrieval pipeline respects it
- Re-exports `ScopePolicyOverride` from the retriever barrel for downstream consumers

## Test plan
- [x] Override with `fallbackToDefault: true` includes both private and default scope even when global policy is `strict`
- [x] Override with `fallbackToDefault: false` excludes default scope even when global policy is `allow_global_fallback`
- [x] Override takes precedence over `scopeId` when both are provided
- [x] Override with `scopeId: 'default'` and `fallbackToDefault: true` deduplicates to just `['default']`
- [x] All 68 existing memory-regressions tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
