### PR TITLE
feat: add InlineImageEmbedView component for inline image embeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineImageEmbedView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineImageEmbedView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import AppKit
+
+/// Renders a remote image inline within a chat bubble.
+///
+/// Uses `AsyncImage` with three states: a loading spinner while the
+/// image downloads, the fitted image on success, and an invisible
+/// `EmptyView` on failure (the surrounding link text remains visible,
+/// so silent failure avoids a broken-image placeholder).
+///
+/// Tapping the image opens the URL in the user's default browser.
+struct InlineImageEmbedView: View {
+    let url: URL
+
+    var body: some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .empty:
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.15))
+                    .frame(height: 120)
+                    .overlay(ProgressView())
+            case .success(let image):
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            case .failure:
+                EmptyView()
+            @unknown default:
+                EmptyView()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: 300)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .onTapGesture {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/InlineImageEmbedViewTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineImageEmbedViewTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import SwiftUI
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineImageEmbedViewTests: XCTestCase {
+
+    // MARK: - Instantiation
+
+    func testViewCanBeInstantiatedWithURL() {
+        let url = URL(string: "https://example.com/photo.png")!
+        let view = InlineImageEmbedView(url: url)
+        XCTAssertEqual(view.url, url)
+    }
+
+    func testViewStoresCorrectURL() {
+        let url = URL(string: "https://cdn.example.com/images/chart.jpg")!
+        let view = InlineImageEmbedView(url: url)
+        XCTAssertEqual(view.url.absoluteString, "https://cdn.example.com/images/chart.jpg")
+    }
+
+    func testViewPreservesURLWithQueryParameters() {
+        let url = URL(string: "https://example.com/img.png?width=800&format=webp")!
+        let view = InlineImageEmbedView(url: url)
+        XCTAssertEqual(view.url.query, "width=800&format=webp")
+    }
+
+    func testViewPreservesURLWithFragment() {
+        let url = URL(string: "https://example.com/photo.png#section")!
+        let view = InlineImageEmbedView(url: url)
+        XCTAssertEqual(view.url.fragment, "section")
+    }
+
+    // MARK: - Body renders without crashing
+
+    func testBodyDoesNotThrow() {
+        let url = URL(string: "https://example.com/photo.png")!
+        let view = InlineImageEmbedView(url: url)
+        // Accessing body forces SwiftUI to evaluate the view tree.
+        // If the view graph is malformed this will trap at runtime.
+        _ = view.body
+    }
+
+    func testMultipleInstancesAreIndependent() {
+        let urlA = URL(string: "https://example.com/a.png")!
+        let urlB = URL(string: "https://example.com/b.jpg")!
+        let viewA = InlineImageEmbedView(url: urlA)
+        let viewB = InlineImageEmbedView(url: urlB)
+        XCTAssertNotEqual(viewA.url, viewB.url)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `InlineImageEmbedView`, an isolated SwiftUI component that renders images inline within chat bubbles
- Uses `AsyncImage` with three states: loading spinner placeholder, fitted image on success, and silent `EmptyView` on failure
- Constrains images to fill available width with a 300pt max height, 8pt corner radius, and `.scaledToFit` aspect ratio
- Tapping the image opens the URL in the default browser via `NSWorkspace.shared.open(url)`
- Includes 6 unit tests validating instantiation, URL preservation, body rendering, and instance independence

## Test plan
- [x] `swift test --filter InlineImageEmbedViewTests` — all 6 tests pass
- [ ] Visual verification: component renders loading state, loaded image, and handles broken URLs gracefully
- [ ] Tap gesture opens URL in browser

Part of the inline media embeds rollout (PR 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
