### PR TITLE
SettingsPanel: Add media embed toggle + domain allowlist UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -25,6 +25,7 @@ struct SettingsPanel: View {
     @State private var showModelDropdown = false
     @State private var mouseDownMonitor: Any?
     @State private var modelDropdownFrame: CGRect = .zero
+    @State private var newAllowlistDomain = ""
 
     var body: some View {
         VSidePanel(title: "Settings", onClose: onClose) {
@@ -274,6 +275,91 @@ struct SettingsPanel: View {
                         .frame(width: 200)
                     }
 
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+
+                // MEDIA EMBEDS section
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("MEDIA EMBEDS")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        Text("Auto media embeds")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { store.mediaEmbedsEnabled },
+                            set: { store.setMediaEmbedsEnabled($0) }
+                        ))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                    }
+
+                    Text("Automatically embed images, videos, and other media shared in chat messages.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    if store.mediaEmbedsEnabled {
+                        Divider()
+                            .background(VColor.surfaceBorder)
+
+                        Text("Video Domain Allowlist")
+                            .font(VFont.bodyBold)
+                            .foregroundColor(VColor.textSecondary)
+
+                        HStack(spacing: VSpacing.sm) {
+                            TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
+                                .textFieldStyle(.plain)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                                .padding(VSpacing.md)
+                                .background(VColor.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: VRadius.md)
+                                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                                )
+
+                            VButton(label: "Add", style: .primary) {
+                                let domain = newAllowlistDomain
+                                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                                guard !domain.isEmpty else { return }
+                                var domains = store.mediaEmbedVideoAllowlistDomains
+                                domains.append(domain)
+                                store.setMediaEmbedVideoAllowlistDomains(domains)
+                                newAllowlistDomain = ""
+                            }
+                        }
+
+                        ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in
+                            HStack {
+                                Text(domain)
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textSecondary)
+                                Spacer()
+                                Button {
+                                    var domains = store.mediaEmbedVideoAllowlistDomains
+                                    domains.removeAll { $0 == domain }
+                                    store.setMediaEmbedVideoAllowlistDomains(domains)
+                                } label: {
+                                    Image(systemName: "trash")
+                                        .foregroundColor(VColor.error)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                            .padding(.vertical, VSpacing.xs)
+                        }
+
+                        HStack {
+                            Spacer()
+                            VButton(label: "Reset to Defaults", style: .ghost) {
+                                store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
+                            }
+                        }
+                    }
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)

--- a/clients/macos/vellum-assistantTests/SettingsPanelMediaControlsTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelMediaControlsTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class SettingsPanelMediaControlsTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private var configPath: String {
+        tempDir.appendingPathComponent("config.json").path
+    }
+
+    private func seed(_ json: String) {
+        let url = URL(fileURLWithPath: configPath)
+        try! json.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makeStore(enabled: Bool, domains: [String]? = nil) -> SettingsStore {
+        if let domains {
+            let domainsJSON = domains.map { #""\#($0)""# }.joined(separator: ",")
+            seed(#"{"ui":{"mediaEmbeds":{"enabled":\#(enabled),"videoAllowlistDomains":[\#(domainsJSON)]}}}"#)
+        } else {
+            seed(#"{"ui":{"mediaEmbeds":{"enabled":\#(enabled)}}}"#)
+        }
+        return SettingsStore(configPath: configPath)
+    }
+
+    // MARK: - Toggle updates store
+
+    func testToggleEnablesMediaEmbeds() {
+        let store = makeStore(enabled: false)
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+
+        store.setMediaEmbedsEnabled(true)
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+    }
+
+    func testToggleDisablesMediaEmbeds() {
+        let store = makeStore(enabled: true)
+        XCTAssertTrue(store.mediaEmbedsEnabled)
+
+        store.setMediaEmbedsEnabled(false)
+        XCTAssertFalse(store.mediaEmbedsEnabled)
+    }
+
+    // MARK: - Domain add/remove updates store
+
+    func testAddDomainUpdatesStore() {
+        let store = makeStore(enabled: true, domains: ["youtube.com"])
+
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.append("example.com")
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "example.com"])
+    }
+
+    func testRemoveDomainUpdatesStore() {
+        let store = makeStore(enabled: true, domains: ["youtube.com", "vimeo.com", "loom.com"])
+
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.removeAll { $0 == "vimeo.com" }
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "loom.com"])
+    }
+
+    func testResetToDefaultsUpdatesStore() {
+        let store = makeStore(enabled: true, domains: ["custom.org"])
+
+        store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
+
+        XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - Both surfaces stay in sync through shared store
+
+    func testBothSurfacesShareStoreToggle() {
+        // A single SettingsStore instance drives both SettingsView and
+        // SettingsPanel. Toggling via the store API should be visible to
+        // any view observing that store.
+        let store = makeStore(enabled: false)
+
+        // Simulate SettingsPanel toggling embeds on
+        store.setMediaEmbedsEnabled(true)
+
+        // SettingsView reading the same store sees the updated value
+        let view = SettingsView(store: store)
+        XCTAssertTrue(view.store.mediaEmbedsEnabled)
+    }
+
+    func testBothSurfacesShareStoreDomains() {
+        let store = makeStore(enabled: true, domains: ["youtube.com"])
+
+        // Simulate SettingsPanel adding a domain
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.append("newsite.com")
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+
+        // SettingsView reading the same store sees the updated domains
+        let view = SettingsView(store: store)
+        XCTAssertEqual(view.store.mediaEmbedVideoAllowlistDomains, ["youtube.com", "newsite.com"])
+    }
+
+    func testToggleChangePersistedAndReloadable() {
+        let store = makeStore(enabled: false)
+
+        store.setMediaEmbedsEnabled(true)
+
+        // Reload from the same config path to verify persistence
+        let reloaded = SettingsStore(configPath: configPath)
+        XCTAssertTrue(reloaded.mediaEmbedsEnabled)
+    }
+
+    func testDomainChangePersistedAndReloadable() {
+        let store = makeStore(enabled: true, domains: ["youtube.com"])
+
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.append("newdomain.com")
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+
+        let reloaded = SettingsStore(configPath: configPath)
+        XCTAssertEqual(reloaded.mediaEmbedVideoAllowlistDomains, ["youtube.com", "newdomain.com"])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a **MEDIA EMBEDS** section to `SettingsPanel.swift` (the main-window side panel) with:
  - Toggle for "Auto media embeds" bound to `settingsStore.setMediaEmbedsEnabled(_:)`
  - Domain allowlist editor (text field + Add button, domain list with delete, Reset to Defaults) — shown only when embeds are enabled
- Both `SettingsView` (standalone window) and `SettingsPanel` (side panel) stay in sync through the shared `SettingsStore` instance
- Follows existing SettingsPanel card patterns (`VStack` + `vCard` + `VButton` + design tokens)

## Test plan
- [x] `swift test --filter SettingsPanelMediaControlsTests` — 9 tests, all passing
  - Toggle enable/disable updates store
  - Domain add/remove updates store
  - Reset to defaults works
  - Both surfaces share store state (toggle and domains)
  - Changes persist and are reloadable from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
