### PR TITLE
feat: add InlineVideoEmbedCard placeholder UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Static placeholder card for a video embed intent.
+///
+/// Shows a play icon and provider badge on a themed card background.
+/// No actual playback — that will be wired in a later PR once the
+/// WebView-based player is ready.
+struct InlineVideoEmbedCard: View {
+    let provider: String
+    let videoID: String
+    let embedURL: URL
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 0.5)
+                )
+
+            VStack(spacing: VSpacing.sm) {
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 44))
+                    .foregroundStyle(VColor.textSecondary)
+
+                Text(provider.capitalized)
+                    .font(VFont.caption)
+                    .foregroundStyle(VColor.textSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 180)
+    }
+}
+
+#if DEBUG
+#Preview("InlineVideoEmbedCard") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: VSpacing.lg) {
+            InlineVideoEmbedCard(
+                provider: "youtube",
+                videoID: "dQw4w9WgXcQ",
+                embedURL: URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ")!
+            )
+            InlineVideoEmbedCard(
+                provider: "vimeo",
+                videoID: "76979871",
+                embedURL: URL(string: "https://player.vimeo.com/video/76979871")!
+            )
+            InlineVideoEmbedCard(
+                provider: "loom",
+                videoID: "abc123def456",
+                embedURL: URL(string: "https://www.loom.com/embed/abc123def456")!
+            )
+        }
+        .padding()
+    }
+    .frame(width: 400, height: 640)
+}
+#endif

--- a/clients/macos/vellum-assistantTests/InlineVideoEmbedCardTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoEmbedCardTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineVideoEmbedCardTests: XCTestCase {
+
+    // MARK: - Instantiation & property storage
+
+    func testYouTubeCardStoresProperties() {
+        let url = URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ")!
+        let card = InlineVideoEmbedCard(
+            provider: "youtube",
+            videoID: "dQw4w9WgXcQ",
+            embedURL: url
+        )
+
+        XCTAssertEqual(card.provider, "youtube")
+        XCTAssertEqual(card.videoID, "dQw4w9WgXcQ")
+        XCTAssertEqual(card.embedURL, url)
+    }
+
+    func testVimeoCardStoresProperties() {
+        let url = URL(string: "https://player.vimeo.com/video/76979871")!
+        let card = InlineVideoEmbedCard(
+            provider: "vimeo",
+            videoID: "76979871",
+            embedURL: url
+        )
+
+        XCTAssertEqual(card.provider, "vimeo")
+        XCTAssertEqual(card.videoID, "76979871")
+        XCTAssertEqual(card.embedURL, url)
+    }
+
+    func testLoomCardStoresProperties() {
+        let url = URL(string: "https://www.loom.com/embed/abc123def456")!
+        let card = InlineVideoEmbedCard(
+            provider: "loom",
+            videoID: "abc123def456",
+            embedURL: url
+        )
+
+        XCTAssertEqual(card.provider, "loom")
+        XCTAssertEqual(card.videoID, "abc123def456")
+        XCTAssertEqual(card.embedURL, url)
+    }
+
+    // MARK: - Different embed URLs
+
+    func testEmbedURLPreservedExactly() {
+        let urlString = "https://custom-player.example.com/embed/vid-999?autoplay=0"
+        let url = URL(string: urlString)!
+        let card = InlineVideoEmbedCard(
+            provider: "custom",
+            videoID: "vid-999",
+            embedURL: url
+        )
+
+        XCTAssertEqual(card.embedURL.absoluteString, urlString)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `InlineVideoEmbedCard`, a static SwiftUI placeholder card for video embed intents
- Shows a centered play icon (`play.circle.fill`) and provider badge (YouTube, Vimeo, Loom, etc.) on a themed card background
- Uses the project's design tokens (`VColor`, `VRadius`, `VFont`, `VSpacing`) for visual consistency
- No playback in this PR -- the card will be wired to a WebView-based player in PR 30

## Test plan
- [x] `InlineVideoEmbedCardTests` verifies property storage for YouTube, Vimeo, and Loom providers
- [x] Tests confirm embed URL is preserved exactly as passed
- [x] All 4 tests pass: `swift test --filter InlineVideoEmbedCardTests`

Part of the inline media embeds rollout (PR 27).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
