### PR TITLE
private-threads: ChatViewModel message-less session create

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2011,4 +2011,132 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking, "Thinking should clear on message complete")
         XCTAssertFalse(viewModel.isSending)
     }
+
+    // MARK: - createSessionIfNeeded (Message-less Session Create)
+
+    func testCreateSessionIfNeededSetsBootstrapping() {
+        viewModel.createSessionIfNeeded(threadType: "private")
+        XCTAssertTrue(viewModel.isSending, "Should enter sending state during bootstrap")
+        XCTAssertFalse(viewModel.isThinking, "Should not show thinking for message-less session create")
+        XCTAssertNotNil(viewModel.bootstrapCorrelationId, "Should set correlation ID")
+        XCTAssertEqual(viewModel.threadType, "private")
+        XCTAssertTrue(viewModel.isBootstrapping)
+    }
+
+    func testCreateSessionIfNeededNoOpWhenSessionExists() {
+        viewModel.sessionId = "existing-session"
+        viewModel.createSessionIfNeeded(threadType: "private")
+        XCTAssertNil(viewModel.bootstrapCorrelationId, "Should not bootstrap when session already exists")
+    }
+
+    func testCreateSessionIfNeededNoOpWhenAlreadyBootstrapping() {
+        // Start a normal send which bootstraps
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        XCTAssertTrue(viewModel.isSending)
+        let originalCorrelationId = viewModel.bootstrapCorrelationId
+
+        // Calling createSessionIfNeeded should be a no-op
+        viewModel.createSessionIfNeeded(threadType: "private")
+        XCTAssertEqual(viewModel.bootstrapCorrelationId, originalCorrelationId, "Should not overwrite existing bootstrap")
+    }
+
+    func testCreateSessionIfNeededSessionInfoResetsState() {
+        viewModel.createSessionIfNeeded(threadType: "private")
+        let correlationId = viewModel.bootstrapCorrelationId!
+
+        // Simulate daemon responding with session_info
+        let info = SessionInfoMessage(sessionId: "new-session-123", title: "Test", correlationId: correlationId)
+        viewModel.handleServerMessage(.sessionInfo(info))
+
+        XCTAssertEqual(viewModel.sessionId, "new-session-123")
+        XCTAssertFalse(viewModel.isSending, "Should reset isSending for message-less create")
+        XCTAssertFalse(viewModel.isThinking, "Should reset isThinking for message-less create")
+        XCTAssertNil(viewModel.bootstrapCorrelationId, "Should clear correlation ID")
+        XCTAssertFalse(viewModel.isBootstrapping)
+    }
+
+    func testCreateSessionIfNeededOnSessionCreatedCallback() {
+        var callbackSessionId: String?
+        viewModel.onSessionCreated = { sessionId in
+            callbackSessionId = sessionId
+        }
+
+        viewModel.createSessionIfNeeded(threadType: "private")
+        let correlationId = viewModel.bootstrapCorrelationId!
+
+        let info = SessionInfoMessage(sessionId: "callback-session", title: "Test", correlationId: correlationId)
+        viewModel.handleServerMessage(.sessionInfo(info))
+
+        XCTAssertEqual(callbackSessionId, "callback-session", "Should fire onSessionCreated callback")
+    }
+
+    func testCreateSessionIfNeededSendsThreadTypeInIPC() {
+        var capturedMessages: [Any] = []
+        daemonClient.sendOverride = { msg in
+            capturedMessages.append(msg)
+        }
+
+        viewModel.createSessionIfNeeded(threadType: "private")
+
+        // Allow the async Task in bootstrapSession to execute
+        let expectation = XCTestExpectation(description: "session_create sent")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        let sessionCreates = capturedMessages.compactMap { $0 as? SessionCreateMessage }
+        XCTAssertEqual(sessionCreates.count, 1, "Should send exactly one session_create")
+        XCTAssertEqual(sessionCreates.first?.threadType, "private", "session_create should include threadType")
+        XCTAssertNotNil(sessionCreates.first?.correlationId, "session_create should include correlationId")
+    }
+
+    func testCreateSessionIfNeededWithoutThreadType() {
+        viewModel.createSessionIfNeeded()
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertNil(viewModel.threadType, "threadType should remain nil when not specified")
+    }
+
+    func testThreadTypePassedThroughNormalSend() {
+        var capturedMessages: [Any] = []
+        daemonClient.sendOverride = { msg in
+            capturedMessages.append(msg)
+        }
+
+        // Set threadType before sending
+        viewModel.threadType = "private"
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        // Allow the async Task in bootstrapSession to execute
+        let expectation = XCTestExpectation(description: "session_create sent")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        let sessionCreates = capturedMessages.compactMap { $0 as? SessionCreateMessage }
+        XCTAssertEqual(sessionCreates.count, 1)
+        XCTAssertEqual(sessionCreates.first?.threadType, "private", "Normal send should also pass threadType")
+    }
+
+    func testCreateSessionThenSendMessageUsesClaimedSession() {
+        // Create session without message
+        viewModel.createSessionIfNeeded(threadType: "private")
+        let correlationId = viewModel.bootstrapCorrelationId!
+
+        // Daemon responds with session_info
+        let info = SessionInfoMessage(sessionId: "pre-created-session", title: "Test", correlationId: correlationId)
+        viewModel.handleServerMessage(.sessionInfo(info))
+
+        // Now send a message — should go directly via sendUserMessage, not bootstrapSession
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.sessionId, "pre-created-session", "Should use the pre-created session")
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].role, .user)
+        XCTAssertEqual(viewModel.messages[0].text, "Hello")
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -195,7 +195,8 @@ extension ChatViewModel {
                 onSessionCreated?(info.sessionId)
                 log.info("Chat session created: \(info.sessionId)")
 
-                // Send the queued user message
+                // Send the queued user message, or finalize a message-less
+                // session create by clearing the bootstrap sending state.
                 if let pending = pendingUserMessage {
                     let attachments = pendingUserAttachments
                     pendingUserMessage = nil
@@ -214,6 +215,11 @@ extension ChatViewModel {
                         isThinking = false
                         errorText = "Failed to send message."
                     }
+                } else {
+                    // Message-less session create (e.g. private thread
+                    // pre-allocation) — session is claimed, reset UI state.
+                    isSending = false
+                    isThinking = false
                 }
             }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -73,6 +73,10 @@ public final class ChatViewModel: ObservableObject {
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?
+    /// Thread type sent with `session_create` (e.g. "private").
+    /// Set by `createSessionIfNeeded(threadType:)` and included in the IPC
+    /// message so the daemon can persist the correct thread kind.
+    public var threadType: String?
     /// Whether this view model is currently bootstrapping a new session
     /// (session_create sent, awaiting session_info). Used by ThreadManager
     /// to decide whether it's safe to release the VM on archive.
@@ -253,9 +257,13 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func bootstrapSession(userMessage: String, attachments: [IPCAttachment]?) {
+    private func bootstrapSession(userMessage: String?, attachments: [IPCAttachment]?) {
         isSending = true
-        isThinking = true
+        // Only show thinking indicator when there's an actual user message
+        // to process; message-less session creates are silent.
+        if userMessage != nil {
+            isThinking = true
+        }
         pendingUserMessage = userMessage
         pendingUserAttachments = attachments
 
@@ -287,9 +295,9 @@ public final class ChatViewModel: ObservableObject {
             // Subscribe to daemon stream
             self.startMessageLoop()
 
-            // Send session_create with correlation ID
+            // Send session_create with correlation ID and thread type
             do {
-                try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId))
+                try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId, threadType: self.threadType))
             } catch {
                 log.error("Failed to send session_create: \(error.localizedDescription)")
                 self.isThinking = false
@@ -417,6 +425,18 @@ public final class ChatViewModel: ObservableObject {
             sendUserMessage(text)
         }
         return true
+    }
+
+    /// Create a daemon session immediately, without a user message.
+    /// Used by private threads that need a persistent session ID right away
+    /// (e.g. to store the thread in the database before the user types anything).
+    /// No-op if a session already exists or a bootstrap is already in flight.
+    public func createSessionIfNeeded(threadType: String? = nil) {
+        guard sessionId == nil, !isSending else { return }
+        if let threadType {
+            self.threadType = threadType
+        }
+        bootstrapSession(userMessage: nil, attachments: nil)
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- Add `createSessionIfNeeded(threadType:)` public API to `ChatViewModel` for creating daemon sessions without a user message
- Add `threadType` property that flows through to the `session_create` IPC message
- Handle message-less session claiming in the `session_info` handler (reset UI state without sending a user_message)
- Add 9 unit tests covering the new flow: bootstrapping state, no-ops, session claiming, callbacks, IPC payload, and the send-after-create sequence

## Context
This is PR 34 of the private threads feature plan. It enables immediate DB persistence for private thread creation — the session is allocated as soon as the thread is created, not when the first message is sent.

Depends on:
- PR 5: `SessionCreateRequest` already has `threadType` field
- PR 32: `ThreadKind` enum on `ThreadModel` (not yet merged, this PR uses `String?` to match the IPC contract)
- PR 33: Session restorer maps IPC `threadType` to `ThreadKind`

## Test plan
- [x] Build passes (`./build.sh`)
- [x] `createSessionIfNeeded(threadType:)` sets bootstrapping state without thinking indicator
- [x] No-op when session already exists or bootstrap in flight
- [x] `session_info` response resets `isSending`/`isThinking` for message-less creates
- [x] `onSessionCreated` callback fires correctly
- [x] `threadType` is included in the `session_create` IPC message
- [x] Normal `sendMessage()` still passes `threadType` when set
- [x] Sending a message after `createSessionIfNeeded` uses the pre-created session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
