### PR TITLE
feat: add connect action to integration_manage tool for auto-connect

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -90,6 +90,7 @@ export function createToolExecutor(
       sandboxOverride: ctx.sandboxOverride,
       allowedToolNames: ctx.allowedToolNames,
       onToolLifecycleEvent: handleToolLifecycleEvent,
+      sendToClient: (msg) => ctx.sendToClient(msg as any),
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),
       requestSecret: async (params) => {
         return secretPrompter.prompt(

--- a/assistant/src/tools/integrations/manage.ts
+++ b/assistant/src/tools/integrations/manage.ts
@@ -14,11 +14,15 @@ import {
   saveRawConfig,
   setNestedValue,
   invalidateConfigCache,
+  getConfig,
 } from '../../config/loader.js';
+import { startOAuth2Flow } from '../../integrations/oauth2.js';
+import { setSecureKey } from '../../security/secure-keys.js';
+import { upsertCredentialMetadata } from '../credentials/metadata-store.js';
 
 class IntegrationManageTool implements Tool {
   name = 'integration_manage';
-  description = 'Query integration status, list integrations, or configure integration credentials';
+  description = 'Query integration status, list integrations, configure credentials, or connect an integration';
   category = 'integrations';
   defaultRiskLevel = RiskLevel.Medium;
 
@@ -31,12 +35,12 @@ class IntegrationManageTool implements Tool {
         properties: {
           action: {
             type: 'string',
-            enum: ['status', 'set_client_id', 'list'],
+            enum: ['status', 'set_client_id', 'list', 'connect'],
             description: 'The operation to perform.',
           },
           integration_id: {
             type: 'string',
-            description: 'Integration ID (required for status and set_client_id).',
+            description: 'Integration ID (required for status, set_client_id, and connect).',
           },
           client_id: {
             type: 'string',
@@ -48,7 +52,7 @@ class IntegrationManageTool implements Tool {
     };
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const action = input.action as string;
 
     switch (action) {
@@ -104,6 +108,86 @@ class IntegrationManageTool implements Tool {
           content: `Client ID configured for "${integrationId}". The user can now connect via Settings.`,
           isError: false,
         };
+      }
+
+      case 'connect': {
+        const integrationId = input.integration_id as string | undefined;
+        if (!integrationId) {
+          return { content: 'Error: integration_id is required for connect action', isError: true };
+        }
+
+        const def = getIntegration(integrationId);
+        if (!def) {
+          return { content: `Error: integration "${integrationId}" not found`, isError: true };
+        }
+
+        if (def.authType !== 'oauth2' || !def.oauth2Config) {
+          return { content: `Error: integration "${integrationId}" does not support OAuth2`, isError: true };
+        }
+
+        const config = getConfig();
+        const integrationConfig = config.integrations[integrationId];
+        const clientId = integrationConfig?.clientId || def.oauth2Config.clientId;
+
+        if (!clientId) {
+          return { content: `Error: no clientId configured for "${integrationId}". Run set_client_id first.`, isError: true };
+        }
+
+        try {
+          const oauthConfig = { ...def.oauth2Config, clientId };
+          const { tokens, grantedScopes } = await startOAuth2Flow(oauthConfig, {
+            openUrl: (url) => {
+              if (context.sendToClient) {
+                context.sendToClient({ type: 'open_url', url, title: `Connect ${def.name}` });
+              }
+            },
+          });
+
+          const tokenStored = setSecureKey(`integration:${def.id}:access_token`, tokens.accessToken);
+          if (!tokenStored) {
+            return { content: 'Error: failed to store access token in secure storage', isError: true };
+          }
+
+          const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : undefined;
+
+          let accountInfo: string | undefined;
+          const userinfoUrl = def.oauth2Config.userinfoUrl;
+          if (userinfoUrl && grantedScopes.some((s) => s.includes('userinfo'))) {
+            try {
+              const resp = await fetch(userinfoUrl, {
+                headers: { Authorization: `Bearer ${tokens.accessToken}` },
+              });
+              if (resp.ok) {
+                const info = await resp.json() as { email?: string };
+                accountInfo = info.email;
+              }
+            } catch {
+              // Non-fatal
+            }
+          }
+
+          upsertCredentialMetadata(`integration:${def.id}`, 'access_token', {
+            allowedTools: def.allowedTools,
+            expiresAt,
+            grantedScopes,
+            accountInfo: accountInfo ?? null,
+          });
+
+          if (tokens.refreshToken) {
+            const refreshStored = setSecureKey(`integration:${def.id}:refresh_token`, tokens.refreshToken);
+            if (refreshStored) {
+              upsertCredentialMetadata(`integration:${def.id}`, 'refresh_token', {});
+            }
+          }
+
+          return {
+            content: `Successfully connected "${def.name}"${accountInfo ? ` as ${accountInfo}` : ''}. The integration is now ready to use.`,
+            isError: false,
+          };
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : 'Unknown error during OAuth flow';
+          return { content: `Error connecting "${integrationId}": ${message}`, isError: true };
+        }
       }
 
       case 'list': {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -124,6 +124,8 @@ export interface ToolContext {
     allowedTools?: string[];
     allowedDomains?: string[];
   }) => Promise<SecretPromptResult>;
+  /** Optional callback to send a message to the connected IPC client (e.g. open_url). */
+  sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Adds `connect` action to `integration_manage` tool that triggers the full OAuth2 PKCE flow
- Loads client ID from config, starts OAuth, stores tokens in vault, fetches account info
- Enables the setup skill to auto-connect immediately after credential creation instead of requiring the user to go back to Settings
- Adds `sendToClient` to `ToolContext` to allow tools to send IPC messages (e.g. `open_url`) to the client

## Test plan
- [ ] Call `integration_manage` with `action: "connect"` and `integration_id: "gmail"` after a client ID is configured
- [ ] Verify the OAuth consent screen opens in the browser
- [ ] After authorization, verify tokens are stored and account info is returned
- [ ] Verify error handling when client ID is missing or OAuth fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
