### PR TITLE
feat: wire image embeds for assistant messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -89,6 +89,7 @@ struct ChatView: View {
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
     var onReportMessage: ((String?) -> Void)?
+    var mediaEmbedSettings: MediaEmbedResolverSettings?
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
@@ -531,7 +532,8 @@ struct ChatView: View {
                                 onSurfaceAction: onSurfaceAction,
                                 onOpenActivity: onOpenActivity,
                                 isActivityPanelOpen: isActivityPanelOpen,
-                                onReportMessage: onReportMessage
+                                onReportMessage: onReportMessage,
+                                mediaEmbedSettings: mediaEmbedSettings
                             )
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -806,6 +808,7 @@ private struct ChatBubble: View {
     let onOpenActivity: (UUID) -> Void
     let isActivityPanelOpen: Bool
     var onReportMessage: ((String?) -> Void)?
+    var mediaEmbedSettings: MediaEmbedResolverSettings?
 
     @State private var isHovered = false
     @State private var isRegenerateHovered = false
@@ -878,6 +881,12 @@ private struct ChatBubble: View {
         return hasText || !message.attachments.isEmpty
     }
 
+    /// Image embed intents resolved for assistant messages when the feature is enabled.
+    private var imageEmbedIntents: [MediaEmbedIntent] {
+        guard !isUser, let settings = mediaEmbedSettings else { return [] }
+        return MediaEmbedResolver.resolve(message: message, settings: settings)
+            .filter { if case .image = $0 { return true } else { return false } }
+    }
 
     var body: some View {
         HStack(spacing: VSpacing.sm) {
@@ -896,6 +905,13 @@ private struct ChatBubble: View {
                         ForEach(message.inlineSurfaces) { surface in
                             InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
                         }
+                    }
+                }
+
+                // Image embeds rendered below the text for assistant messages
+                ForEach(imageEmbedIntents.indices, id: \.self) { idx in
+                    if case .image(let url) = imageEmbedIntents[idx] {
+                        InlineImageEmbedView(url: url)
                     }
                 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1429,7 +1429,12 @@ private struct ActiveChatViewWrapper: View {
                         style: .error
                     )
                 }
-            }
+            },
+            mediaEmbedSettings: MediaEmbedResolverSettings(
+                enabled: settingsStore.mediaEmbedsEnabled,
+                enabledSince: settingsStore.mediaEmbedsEnabledSince,
+                allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
+            )
         )
     }
 }

--- a/clients/macos/vellum-assistantTests/ChatImageEmbedAssistantTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatImageEmbedAssistantTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatImageEmbedAssistantTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeAssistantMessage(
+        _ text: String,
+        timestamp: Date = Date()
+    ) -> ChatMessage {
+        ChatMessage(role: .assistant, text: text, timestamp: timestamp)
+    }
+
+    private func enabledSettings(
+        enabledSince: Date? = nil
+    ) -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(
+            enabled: true,
+            enabledSince: enabledSince,
+            allowedDomains: []
+        )
+    }
+
+    private func disabledSettings() -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(enabled: false, enabledSince: nil, allowedDomains: [])
+    }
+
+    // MARK: - Image intents for assistant messages
+
+    func testAssistantMessageWithImageURLReturnsImageIntent() {
+        let message = makeAssistantMessage("Here is a screenshot: https://example.com/photo.png")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result.count, 1)
+        if case .image(let url) = result.first {
+            XCTAssertEqual(url.absoluteString, "https://example.com/photo.png")
+        } else {
+            XCTFail("Expected image intent")
+        }
+    }
+
+    // MARK: - No URLs
+
+    func testAssistantMessageWithNoURLsReturnsEmpty() {
+        let message = makeAssistantMessage("Just a plain assistant response with no links.")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Feature disabled
+
+    func testDisabledSettingsReturnsEmptyForAssistant() {
+        let message = makeAssistantMessage("Check this image: https://example.com/photo.png")
+        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - enabledSince gating
+
+    func testAssistantMessageBeforeEnabledSinceReturnsEmpty() {
+        let cutoff = Date()
+        let oldTimestamp = cutoff.addingTimeInterval(-60)
+        let message = makeAssistantMessage(
+            "https://example.com/old-photo.png",
+            timestamp: oldTimestamp
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result, [])
+    }
+
+    func testAssistantMessageAfterEnabledSinceReturnsImageIntent() {
+        let cutoff = Date().addingTimeInterval(-120)
+        let message = makeAssistantMessage(
+            "https://example.com/new-photo.jpg",
+            timestamp: Date()
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result.count, 1)
+        if case .image(let url) = result.first {
+            XCTAssertTrue(url.absoluteString.contains("new-photo.jpg"))
+        } else {
+            XCTFail("Expected image intent")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Thread `MediaEmbedResolverSettings` from `SettingsStore` through `ActiveChatViewWrapper` → `ChatView` → `ChatBubble` so the embed pipeline has access to the feature gate, `enabledSince` cutoff, and domain allowlist.
- In `ChatBubble`, resolve image embed intents via `MediaEmbedResolver` for assistant messages and render `InlineImageEmbedView` below the message text (additive — plain link text remains visible).
- Add `ChatImageEmbedAssistantTests` with 5 logic tests covering: image URL detection, no-URL messages, disabled settings, and `enabledSince` gating.

## Test plan
- [x] `swift test --filter ChatImageEmbedAssistantTests` — all 5 tests pass
- [ ] Manual: send an assistant message containing an image URL (e.g. `.png`) and verify the image renders below the text
- [ ] Manual: toggle media embeds off in settings and verify images no longer appear
- [ ] Manual: verify non-image URLs (plain text links) still render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
