### PR TITLE
private-threads: add includeDefaultFallback to profile compiler

### DIFF
--- a/assistant/src/__tests__/profile-compiler.test.ts
+++ b/assistant/src/__tests__/profile-compiler.test.ts
@@ -218,6 +218,85 @@ describe('profile-compiler', () => {
     expect(limited.selectedCount).toBeLessThan(full.selectedCount);
   });
 
+  test('without includeDefaultFallback, queries only the specified scope', () => {
+    profileEnabled = true;
+
+    // Item in 'default' scope
+    insertItem({
+      id: 'fb-default-only',
+      kind: 'profile',
+      subject: 'timezone',
+      statement: 'Timezone is America/New_York.',
+      verificationState: 'user_confirmed',
+      scopeId: 'default',
+    });
+    // Item in 'project-x' scope
+    insertItem({
+      id: 'fb-project-only',
+      kind: 'preference',
+      subject: 'language',
+      statement: 'Prefers TypeScript.',
+      verificationState: 'user_confirmed',
+      scopeId: 'project-x',
+    });
+
+    // Query project-x WITHOUT fallback — should only see the project-x item
+    const compiled = compileDynamicProfile({ scopeId: 'project-x' });
+    expect(compiled.selectedCount).toBe(1);
+    expect(compiled.text).toContain('language: Prefers TypeScript');
+    expect(compiled.text).not.toContain('timezone');
+  });
+
+  test('includeDefaultFallback: true with non-default scope queries both scopes', () => {
+    profileEnabled = true;
+
+    insertItem({
+      id: 'fb-default-tz',
+      kind: 'profile',
+      subject: 'timezone',
+      statement: 'Timezone is America/New_York.',
+      verificationState: 'user_confirmed',
+      scopeId: 'default',
+    });
+    insertItem({
+      id: 'fb-proj-lang',
+      kind: 'preference',
+      subject: 'language',
+      statement: 'Prefers TypeScript.',
+      verificationState: 'user_confirmed',
+      scopeId: 'project-x',
+    });
+
+    const compiled = compileDynamicProfile({
+      scopeId: 'project-x',
+      includeDefaultFallback: true,
+    });
+    expect(compiled.selectedCount).toBe(2);
+    expect(compiled.text).toContain('timezone: Timezone is America/New_York');
+    expect(compiled.text).toContain('language: Prefers TypeScript');
+  });
+
+  test('includeDefaultFallback: true with default scope does not duplicate', () => {
+    profileEnabled = true;
+
+    insertItem({
+      id: 'fb-default-nodup',
+      kind: 'profile',
+      subject: 'timezone',
+      statement: 'Timezone is America/Chicago.',
+      verificationState: 'user_confirmed',
+      scopeId: 'default',
+    });
+
+    // When scopeId is already 'default', fallback should be a no-op — still just queries 'default'
+    const compiled = compileDynamicProfile({
+      scopeId: 'default',
+      includeDefaultFallback: true,
+    });
+    expect(compiled.selectedCount).toBe(1);
+    expect(compiled.text).toContain('timezone: Timezone is America/Chicago');
+  });
+
   test('uses lower-ranked fallback for same subject when top candidate exceeds budget', () => {
     profileEnabled = true;
 

--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -15,6 +15,8 @@ const TRUST_RANK: Record<string, number> = {
 export interface CompileProfileOptions {
   scopeId?: string;
   maxInjectTokensOverride?: number;
+  /** When true and scopeId is not 'default', query both the given scope and 'default'. */
+  includeDefaultFallback?: boolean;
 }
 
 export interface CompiledProfile {
@@ -46,6 +48,10 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
   }
 
   const db = getDb();
+  const shouldFallback = options?.includeDefaultFallback === true && scopeId !== 'default';
+  const scopeFilter = shouldFallback
+    ? inArray(memoryItems.scopeId, [scopeId, 'default'])
+    : eq(memoryItems.scopeId, scopeId);
   const rows = db
     .select({
       kind: memoryItems.kind,
@@ -59,7 +65,7 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
     })
     .from(memoryItems)
     .where(and(
-      eq(memoryItems.scopeId, scopeId),
+      scopeFilter,
       eq(memoryItems.status, 'active'),
       isNull(memoryItems.invalidAt),
       inArray(memoryItems.kind, [...PROFILE_KIND_ALLOWLIST]),


### PR DESCRIPTION
## Summary
- Adds `includeDefaultFallback?: boolean` option to `CompileProfileOptions`
- When enabled and `scopeId` is not `'default'`, the profile compiler queries both the specified scope and `'default'` for memory items — letting private-thread scopes inherit global user profile data
- No-op when `scopeId` is already `'default'` (avoids duplicate queries)
- Default behavior unchanged (no fallback unless explicitly opted in)

## Test plan
- [x] Existing profile compiler tests still pass (4 tests)
- [x] New test: without `includeDefaultFallback`, only the specified scope is queried
- [x] New test: `includeDefaultFallback: true` with non-default scope queries both scopes
- [x] New test: `includeDefaultFallback: true` with default scope does not duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
