### PR TITLE
test: daemon-level threadType transport tests for create and list

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -284,4 +284,43 @@ describe('DaemonServer initial session hydration', () => {
     expect(sessionInfo).toBeDefined();
     expect(sessionInfo!.threadType).toBe('private');
   });
+
+  test('session_create includes threadType in session_info response', async () => {
+    conversation.threadType = 'private';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket, writes } = createFakeSocket();
+
+    internal.dispatchMessage({
+      type: 'session_create',
+      title: 'Thread-type test',
+      threadType: 'private',
+    }, socket);
+    // Allow async handler to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    const messages = decodeMessages(writes);
+    const sessionInfo = messages.find((msg) => msg.type === 'session_info');
+    expect(sessionInfo).toBeDefined();
+    expect(sessionInfo!.threadType).toBe('private');
+  });
+
+  test('session_list includes threadType on each session row', async () => {
+    conversation.threadType = 'private';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket, writes } = createFakeSocket();
+
+    internal.dispatchMessage({ type: 'session_list' }, socket);
+
+    const messages = decodeMessages(writes);
+    const listResponse = messages.find((msg) => msg.type === 'session_list_response');
+    expect(listResponse).toBeDefined();
+
+    const sessions = listResponse!.sessions as Array<Record<string, unknown>>;
+    expect(sessions.length).toBeGreaterThan(0);
+    for (const session of sessions) {
+      expect(session.threadType).toBe('private');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Adds two daemon-level tests to `daemon-server-session-init.test.ts` for threadType transport coverage:
  - **session_create -> session_info**: dispatches a `session_create` message with `threadType: 'private'` and verifies the resulting `session_info` response includes the correct `threadType`
  - **session_list -> session_list_response**: dispatches a `session_list` message and verifies each session row in the response includes the `threadType` field
- Completes thread-type transport test coverage alongside existing `sendInitialSession` and `session_switch` tests (added in PR 8)
- No production code changes

## Test plan
- [x] `bun test src/__tests__/daemon-server-session-init.test.ts` — 9/9 pass
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — 173/173 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
