### PR TITLE
feat: wire image embeds for user messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -881,9 +881,9 @@ private struct ChatBubble: View {
         return hasText || !message.attachments.isEmpty
     }
 
-    /// Image embed intents resolved for assistant messages when the feature is enabled.
+    /// Image embed intents resolved for the message when the feature is enabled.
     private var imageEmbedIntents: [MediaEmbedIntent] {
-        guard !isUser, let settings = mediaEmbedSettings else { return [] }
+        guard let settings = mediaEmbedSettings else { return [] }
         return MediaEmbedResolver.resolve(message: message, settings: settings)
             .filter { if case .image = $0 { return true } else { return false } }
     }
@@ -908,7 +908,7 @@ private struct ChatBubble: View {
                     }
                 }
 
-                // Image embeds rendered below the text for assistant messages
+                // Image embeds rendered below the text
                 ForEach(imageEmbedIntents.indices, id: \.self) { idx in
                     if case .image(let url) = imageEmbedIntents[idx] {
                         InlineImageEmbedView(url: url)

--- a/clients/macos/vellum-assistantTests/ChatImageEmbedUserTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatImageEmbedUserTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatImageEmbedUserTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeUserMessage(
+        _ text: String,
+        timestamp: Date = Date()
+    ) -> ChatMessage {
+        ChatMessage(role: .user, text: text, timestamp: timestamp)
+    }
+
+    private func enabledSettings(
+        enabledSince: Date? = nil
+    ) -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(
+            enabled: true,
+            enabledSince: enabledSince,
+            allowedDomains: ["youtube.com", "youtu.be", "vimeo.com", "loom.com"]
+        )
+    }
+
+    private func disabledSettings() -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(enabled: false, enabledSince: nil, allowedDomains: [])
+    }
+
+    // MARK: - User message with image URL
+
+    func testUserMessageWithImageURLReturnsImageIntent() {
+        let message = makeUserMessage("Check this out: https://example.com/photo.png")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+            .filter { if case .image = $0 { return true } else { return false } }
+        XCTAssertEqual(result.count, 1)
+        if case .image(let url) = result.first {
+            XCTAssertEqual(url.absoluteString, "https://example.com/photo.png")
+        } else {
+            XCTFail("Expected image intent")
+        }
+    }
+
+    // MARK: - User message with no URLs
+
+    func testUserMessageWithNoURLsReturnsEmpty() {
+        let message = makeUserMessage("Just a plain text message, no links here.")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Disabled feature returns empty for user messages
+
+    func testUserMessageWithDisabledSettingsReturnsEmpty() {
+        let message = makeUserMessage("Here is an image: https://example.com/img.jpg")
+        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - enabledSince gating for user messages
+
+    func testUserMessageBeforeEnabledSinceReturnsEmpty() {
+        let cutoff = Date()
+        let oldTimestamp = cutoff.addingTimeInterval(-60)
+        let message = makeUserMessage(
+            "https://example.com/old-screenshot.png",
+            timestamp: oldTimestamp
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result, [])
+    }
+
+    func testUserMessageAfterEnabledSinceReturnsImageIntent() {
+        let cutoff = Date().addingTimeInterval(-120)
+        let message = makeUserMessage(
+            "https://example.com/new-screenshot.png",
+            timestamp: Date()
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+            .filter { if case .image = $0 { return true } else { return false } }
+        XCTAssertEqual(result.count, 1)
+        if case .image(let url) = result.first {
+            XCTAssertTrue(url.absoluteString.contains("new-screenshot.png"))
+        } else {
+            XCTFail("Expected image intent for user message after enabledSince")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Removes the `!isUser` guard from the `imageEmbedIntents` computed property in `ChatBubble`, enabling inline image previews for user messages (previously only assistant messages rendered them).
- The `MediaEmbedResolver` was already role-agnostic — this change lifts the rendering-side gating.
- Adds `ChatImageEmbedUserTests` with 5 tests covering: image URL detection for user messages, empty results for no URLs, disabled feature gating, and `enabledSince` date gating.

## Test plan
- [x] `swift test --filter ChatImageEmbedUserTests` — all 5 tests pass
- [ ] Manual: send a user message containing an image URL (e.g. `https://example.com/photo.png`) and verify the inline preview renders below the message bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
