### PR TITLE
private-threads: derive session memory policy from conversation metadata

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -1,6 +1,18 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type * as net from 'node:net';
 
+interface MockMemoryPolicy {
+  scopeId: string;
+  includeDefaultFallback: boolean;
+  strictSideEffects: boolean;
+}
+
+const MOCK_DEFAULT_MEMORY_POLICY: MockMemoryPolicy = {
+  scopeId: 'default',
+  includeDefaultFallback: false,
+  strictSideEffects: false,
+};
+
 const conversation = {
   id: 'conv-1',
   title: 'Test Conversation',
@@ -9,12 +21,15 @@ const conversation = {
   totalOutputTokens: 0,
   totalEstimatedCost: 0,
   threadType: 'standard' as string,
+  memoryScopeId: 'default' as string,
 };
 
 let lastCreatedWorkingDir: string | undefined;
+let lastCreatedMemoryPolicy: MockMemoryPolicy | undefined;
 
 class MockSession {
   public readonly conversationId: string;
+  public memoryPolicy: MockMemoryPolicy;
   public updateClientCalls = 0;
   public setSandboxOverrideCalls = 0;
   private stale = false;
@@ -27,9 +42,13 @@ class MockSession {
     _maxResponseTokens?: number,
     _sendToClient?: unknown,
     workingDir?: string,
+    _broadcastToAllClients?: unknown,
+    memoryPolicy?: MockMemoryPolicy,
   ) {
     this.conversationId = conversationId;
     lastCreatedWorkingDir = workingDir;
+    this.memoryPolicy = memoryPolicy ?? MOCK_DEFAULT_MEMORY_POLICY;
+    lastCreatedMemoryPolicy = this.memoryPolicy;
   }
 
   async loadFromDb(): Promise<void> {}
@@ -55,6 +74,8 @@ class MockSession {
   }
 
   abort(): void {}
+
+  dispose(): void {}
 
   hasEscalationHandler(): boolean {
     return true;
@@ -134,12 +155,21 @@ mock.module('../memory/conversation-store.js', () => ({
   getLatestConversation: () => conversation,
   createConversation: () => conversation,
   getConversation: (id: string) => (id === conversation.id ? conversation : null),
+  getConversationThreadType: (id: string) => {
+    if (id === conversation.id) return conversation.threadType === 'private' ? 'private' : 'standard';
+    return 'standard';
+  },
+  getConversationMemoryScopeId: (id: string) => {
+    if (id === conversation.id) return conversation.memoryScopeId;
+    return 'default';
+  },
   getMessages: () => [],
   listConversations: () => [conversation],
 }));
 
 mock.module('../daemon/session.js', () => ({
   Session: MockSession,
+  DEFAULT_MEMORY_POLICY: MOCK_DEFAULT_MEMORY_POLICY,
 }));
 
 import { DaemonServer } from '../daemon/server.js';
@@ -178,7 +208,10 @@ function decodeMessages(writes: string[]): Array<Record<string, unknown>> {
 describe('DaemonServer initial session hydration', () => {
   beforeEach(() => {
     conversation.updatedAt = Date.now();
+    conversation.threadType = 'standard';
+    conversation.memoryScopeId = 'default';
     lastCreatedWorkingDir = undefined;
+    lastCreatedMemoryPolicy = undefined;
   });
 
   test('hydrates latest session before session_info so undo works after reconnect', async () => {
@@ -322,5 +355,91 @@ describe('DaemonServer initial session hydration', () => {
     for (const session of sessions) {
       expect(session.threadType).toBe('private');
     }
+  });
+
+  test('session for private conversation derives strict memory policy', async () => {
+    conversation.threadType = 'private';
+    conversation.memoryScopeId = 'private:conv-1';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket } = createFakeSocket();
+
+    await internal.sendInitialSession(socket);
+
+    const session = internal.sessions.get(conversation.id);
+    expect(session).toBeDefined();
+    expect(session!.memoryPolicy).toEqual({
+      scopeId: 'private:conv-1',
+      includeDefaultFallback: true,
+      strictSideEffects: true,
+    });
+  });
+
+  test('session for standard conversation uses default memory policy', async () => {
+    conversation.threadType = 'standard';
+    conversation.memoryScopeId = 'default';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket } = createFakeSocket();
+
+    await internal.sendInitialSession(socket);
+
+    const session = internal.sessions.get(conversation.id);
+    expect(session).toBeDefined();
+    expect(session!.memoryPolicy).toEqual(MOCK_DEFAULT_MEMORY_POLICY);
+  });
+
+  test('session_switch to private conversation derives correct policy on fresh session', async () => {
+    // Start with standard conversation
+    conversation.threadType = 'standard';
+    conversation.memoryScopeId = 'default';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket } = createFakeSocket();
+
+    await internal.sendInitialSession(socket);
+
+    // Now switch the conversation metadata to private before the switch
+    conversation.threadType = 'private';
+    conversation.memoryScopeId = 'private:conv-1';
+
+    // Evict the existing session so the switch recreates it
+    const existingSession = internal.sessions.get(conversation.id);
+    if (existingSession) {
+      existingSession.markStale();
+    }
+
+    internal.dispatchMessage({ type: 'session_switch', sessionId: conversation.id }, socket);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The recreated session should have the private policy
+    expect(lastCreatedMemoryPolicy).toEqual({
+      scopeId: 'private:conv-1',
+      includeDefaultFallback: true,
+      strictSideEffects: true,
+    });
+  });
+
+  test('session_create with private threadType derives correct policy', async () => {
+    conversation.threadType = 'private';
+    conversation.memoryScopeId = 'private:conv-1';
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket } = createFakeSocket();
+
+    internal.dispatchMessage({
+      type: 'session_create',
+      title: 'Private Thread',
+      threadType: 'private',
+    }, socket);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const session = internal.sessions.get(conversation.id);
+    expect(session).toBeDefined();
+    expect(session!.memoryPolicy).toEqual({
+      scopeId: 'private:conv-1',
+      includeDefaultFallback: true,
+      strictSideEffects: true,
+    });
   });
 });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -16,7 +16,7 @@ import { IngressBlockedError } from '../util/errors.js';
 import { clearEmbeddingBackendCache } from '../memory/embedding-backend.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
-import { Session } from './session.js';
+import { Session, DEFAULT_MEMORY_POLICY, type SessionMemoryPolicy } from './session.js';
 import { resolveChannelCapabilities } from './session-runtime-assembly.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import {
@@ -69,6 +69,24 @@ export class DaemonServer {
   private authenticatedSockets = new Set<net.Socket>();
   private authTimeouts = new Map<net.Socket, ReturnType<typeof setTimeout>>();
   private evictor: SessionEvictor;
+
+  /**
+   * Derive a SessionMemoryPolicy from the conversation's thread type and
+   * memory scope. Private conversations get an isolated scope with strict
+   * side-effect controls and default-fallback recall; standard conversations
+   * use the shared default scope with no restrictions.
+   */
+  private deriveMemoryPolicy(conversationId: string): SessionMemoryPolicy {
+    const threadType = conversationStore.getConversationThreadType(conversationId);
+    if (threadType === 'private') {
+      return {
+        scopeId: conversationStore.getConversationMemoryScopeId(conversationId),
+        includeDefaultFallback: true,
+        strictSideEffects: true,
+      };
+    }
+    return DEFAULT_MEMORY_POLICY;
+  }
 
   private applyTransportMetadata(_session: Session, options: SessionCreateOptions | undefined): void {
     const transport = options?.transport;
@@ -728,6 +746,7 @@ export class DaemonServer {
         const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt();
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;
 
+        const memoryPolicy = this.deriveMemoryPolicy(conversationId);
         const newSession = new Session(
           conversationId,
           provider,
@@ -736,6 +755,7 @@ export class DaemonServer {
           rebindClient ? sendToClient : () => {},
           workingDir,
           (msg) => this.broadcast(msg, socket),
+          memoryPolicy,
         );
         // When created without a socket (HTTP path), mark the session
         // so interactive prompts (e.g. host attachment reads) can fail


### PR DESCRIPTION
## Summary
- Adds `deriveMemoryPolicy()` helper to `DaemonServer` that reads conversation `threadType` and `memoryScopeId` from DB via existing `getConversationThreadType()` / `getConversationMemoryScopeId()` helpers
- Private conversations get `{ scopeId: 'private:<id>', includeDefaultFallback: true, strictSideEffects: true }`; standard conversations use `DEFAULT_MEMORY_POLICY`
- Policy is passed to `Session` constructor in `getOrCreateSession`, covering all entry points: `handleSessionCreate`, `handleSessionSwitch`, and `sendInitialSession`

## Test plan
- [x] Verified session for private conversation derives strict memory policy (scopeId=private:xxx, includeDefaultFallback=true, strictSideEffects=true)
- [x] Verified session for standard conversation uses DEFAULT_MEMORY_POLICY
- [x] Verified session_switch to a private conversation recreates session with correct policy
- [x] Verified session_create with private threadType derives correct policy
- [x] All existing daemon-server-session-init tests pass
- [x] All IPC snapshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
