### PR TITLE
feat: wire video placeholders for assistant messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -888,6 +888,13 @@ private struct ChatBubble: View {
             .filter { if case .image = $0 { return true } else { return false } }
     }
 
+    /// Video embed intents resolved for the message when the feature is enabled.
+    private var videoEmbedIntents: [MediaEmbedIntent] {
+        guard let settings = mediaEmbedSettings else { return [] }
+        return MediaEmbedResolver.resolve(message: message, settings: settings)
+            .filter { if case .video = $0 { return true } else { return false } }
+    }
+
     var body: some View {
         HStack(spacing: VSpacing.sm) {
             if isUser { Spacer(minLength: 0) }
@@ -908,10 +915,15 @@ private struct ChatBubble: View {
                     }
                 }
 
-                // Image embeds rendered below the text
+                // Media embeds rendered below the text
                 ForEach(imageEmbedIntents.indices, id: \.self) { idx in
                     if case .image(let url) = imageEmbedIntents[idx] {
                         InlineImageEmbedView(url: url)
+                    }
+                }
+                ForEach(videoEmbedIntents.indices, id: \.self) { idx in
+                    if case .video(let provider, let videoID, let embedURL) = videoEmbedIntents[idx] {
+                        InlineVideoEmbedCard(provider: provider, videoID: videoID, embedURL: embedURL)
                     }
                 }
 

--- a/clients/macos/vellum-assistantTests/ChatVideoPlaceholderAssistantTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatVideoPlaceholderAssistantTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatVideoPlaceholderAssistantTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeAssistantMessage(
+        _ text: String,
+        timestamp: Date = Date()
+    ) -> ChatMessage {
+        ChatMessage(role: .assistant, text: text, timestamp: timestamp)
+    }
+
+    private func enabledSettings(
+        enabledSince: Date? = nil,
+        allowedDomains: [String] = ["youtube.com", "youtu.be", "vimeo.com", "loom.com"]
+    ) -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(
+            enabled: true,
+            enabledSince: enabledSince,
+            allowedDomains: allowedDomains
+        )
+    }
+
+    private func disabledSettings() -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(enabled: false, enabledSince: nil, allowedDomains: [])
+    }
+
+    // MARK: - Video intents for assistant messages
+
+    func testAssistantMessageWithYouTubeURLReturnsVideoIntent() {
+        let message = makeAssistantMessage("Check this out: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+        if case .video(let provider, let videoID, _) = videos.first {
+            XCTAssertEqual(provider, "youtube")
+            XCTAssertEqual(videoID, "dQw4w9WgXcQ")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    func testAssistantMessageWithVimeoURLReturnsVideoIntent() {
+        let message = makeAssistantMessage("Watch this: https://vimeo.com/76979871")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+        if case .video(let provider, let videoID, _) = videos.first {
+            XCTAssertEqual(provider, "vimeo")
+            XCTAssertEqual(videoID, "76979871")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    func testAssistantMessageWithLoomURLReturnsVideoIntent() {
+        let message = makeAssistantMessage("Here's my recording: https://www.loom.com/share/abc123def456")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+        if case .video(let provider, let videoID, _) = videos.first {
+            XCTAssertEqual(provider, "loom")
+            XCTAssertEqual(videoID, "abc123def456")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    // MARK: - Non-video URLs
+
+    func testAssistantMessageWithNonVideoURLReturnsNoVideoIntents() {
+        let message = makeAssistantMessage("Check https://example.com/page for details")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos, [])
+    }
+
+    // MARK: - Feature disabled
+
+    func testDisabledSettingsReturnsEmptyForVideo() {
+        let message = makeAssistantMessage("Watch: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - enabledSince gating
+
+    func testAssistantVideoBeforeEnabledSinceReturnsEmpty() {
+        let cutoff = Date()
+        let oldTimestamp = cutoff.addingTimeInterval(-60)
+        let message = makeAssistantMessage(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            timestamp: oldTimestamp
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result, [])
+    }
+
+    func testAssistantVideoAfterEnabledSinceReturnsVideoIntent() {
+        let cutoff = Date().addingTimeInterval(-120)
+        let message = makeAssistantMessage(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            timestamp: Date()
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+    }
+
+    // MARK: - Domain allowlist
+
+    func testNonAllowedDomainIsSkipped() {
+        let message = makeAssistantMessage("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        // Only allow vimeo.com — youtube.com should be skipped
+        let settings = enabledSettings(allowedDomains: ["vimeo.com"])
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos, [])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `videoEmbedIntents` computed property to `ChatBubble` that filters resolver results to `.video` cases
- Renders `InlineVideoEmbedCard(provider:videoID:embedURL:)` for each video intent below the message text, alongside existing image embeds
- Includes 8 logic tests (`ChatVideoPlaceholderAssistantTests`) covering YouTube, Vimeo, and Loom URL resolution, feature-gate (`enabled=false`), `enabledSince` gating, non-video URL exclusion, and domain allowlist enforcement

## Test plan
- [x] `swift test --filter ChatVideoPlaceholderAssistantTests` — all 8 tests pass
- [ ] Manual verification: send assistant message containing a YouTube/Vimeo/Loom URL and confirm the video placeholder card renders below the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
