### PR TITLE
feat: ThreadManager createPrivateThread() with immediate persistence

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -103,6 +103,28 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Created thread \(thread.id) with title \"\(thread.title)\"")
     }
 
+    func createPrivateThread() {
+        let thread = ThreadModel(kind: .private)
+        let viewModel = makeViewModel()
+        let threadId = thread.id
+        viewModel.onFirstUserMessage = { [weak self] text in
+            self?.updateThreadTitle(id: threadId, title: "Untitled")
+            self?.updateLastInteracted(threadId: threadId)
+            Task { @MainActor in
+                await self?.generateTitle(for: threadId, userMessage: text)
+            }
+        }
+        threads.insert(thread, at: 0)
+        chatViewModels[thread.id] = viewModel
+        activeThreadId = thread.id
+
+        // Immediately create a daemon session so the thread is persisted
+        // before the user sends any messages.
+        viewModel.createSessionIfNeeded(threadType: "private")
+
+        log.info("Created private thread \(thread.id)")
+    }
+
     func closeThread(id: UUID) {
         // No-op if only 1 thread remains
         guard threads.count > 1 else { return }

--- a/clients/macos/vellum-assistantTests/ThreadManagerPrivateThreadTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerPrivateThreadTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ThreadManagerPrivateThreadTests: XCTestCase {
+
+    private var daemonClient: DaemonClient!
+    private var threadManager: ThreadManager!
+    private var capturedMessages: [Any]!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        capturedMessages = []
+        daemonClient.sendOverride = { [weak self] msg in
+            self?.capturedMessages.append(msg)
+        }
+        threadManager = ThreadManager(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        threadManager = nil
+        capturedMessages = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - createPrivateThread
+
+    func testCreatePrivateThreadAddsThreadWithPrivateKind() {
+        threadManager.createPrivateThread()
+
+        // init creates a default standard thread, so we expect 2 threads total
+        XCTAssertEqual(threadManager.threads.count, 2)
+        let privateThread = threadManager.threads.first!
+        XCTAssertEqual(privateThread.kind, .private, "New thread should have kind .private")
+    }
+
+    func testCreatePrivateThreadSetsActiveThread() {
+        threadManager.createPrivateThread()
+
+        let privateThread = threadManager.threads.first!
+        XCTAssertEqual(threadManager.activeThreadId, privateThread.id)
+    }
+
+    func testCreatePrivateThreadCallsCreateSessionIfNeeded() {
+        threadManager.createPrivateThread()
+
+        let vm = threadManager.activeViewModel!
+        XCTAssertTrue(vm.isSending, "Should be in sending state from createSessionIfNeeded bootstrap")
+        XCTAssertTrue(vm.isBootstrapping, "Should be bootstrapping a session")
+        XCTAssertEqual(vm.threadType, "private", "threadType should be set to private")
+    }
+
+    func testCreatePrivateThreadSendsSessionCreate() {
+        threadManager.createPrivateThread()
+
+        // Allow the async Task in bootstrapSession to execute
+        let expectation = XCTestExpectation(description: "session_create sent")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        let sessionCreates = capturedMessages.compactMap { $0 as? SessionCreateMessage }
+        XCTAssertEqual(sessionCreates.count, 1, "Should send exactly one session_create")
+        XCTAssertEqual(sessionCreates.first?.threadType, "private", "session_create should include private threadType")
+        XCTAssertNotNil(sessionCreates.first?.correlationId, "session_create should include correlationId")
+    }
+
+    func testCreatePrivateThreadDoesNotReuseEmptyStandardThread() {
+        // init already creates an empty standard thread — createPrivateThread
+        // should NOT reuse it (unlike createThread which skips if active is empty).
+        let standardThreadId = threadManager.activeThreadId
+        threadManager.createPrivateThread()
+
+        XCTAssertNotEqual(threadManager.activeThreadId, standardThreadId,
+                          "Should create a new thread, not reuse the empty standard one")
+        XCTAssertEqual(threadManager.threads.count, 2)
+    }
+
+    // MARK: - Session backfill
+
+    func testPrivateThreadSessionBackfill() {
+        threadManager.createPrivateThread()
+        let privateThread = threadManager.threads.first!
+        let vm = threadManager.activeViewModel!
+        let correlationId = vm.bootstrapCorrelationId!
+
+        // Simulate daemon responding with session_info
+        let info = SessionInfoMessage(sessionId: "private-session-42", title: "Test", correlationId: correlationId)
+        vm.handleServerMessage(.sessionInfo(info))
+
+        // The thread's sessionId should be backfilled via onSessionCreated
+        let updatedThread = threadManager.threads.first(where: { $0.id == privateThread.id })!
+        XCTAssertEqual(updatedThread.sessionId, "private-session-42", "Session ID should be backfilled into the ThreadModel")
+        XCTAssertEqual(vm.sessionId, "private-session-42")
+        XCTAssertFalse(vm.isSending, "Should reset isSending after session_info for message-less create")
+        XCTAssertFalse(vm.isBootstrapping, "Should no longer be bootstrapping after session_info")
+    }
+
+    func testPrivateThreadTitleCallbackStillWorks() {
+        threadManager.createPrivateThread()
+        let privateThread = threadManager.threads.first!
+        let vm = threadManager.activeViewModel!
+        let correlationId = vm.bootstrapCorrelationId!
+
+        // Complete the session bootstrap
+        let info = SessionInfoMessage(sessionId: "private-sess", title: "Test", correlationId: correlationId)
+        vm.handleServerMessage(.sessionInfo(info))
+
+        // Simulate the user sending a message — the onFirstUserMessage callback
+        // should still fire and set the title to "Untitled" as a placeholder.
+        vm.inputText = "Hello private thread"
+        vm.sendMessage()
+
+        let updatedThread = threadManager.threads.first(where: { $0.id == privateThread.id })!
+        XCTAssertEqual(updatedThread.title, "Untitled", "First user message should trigger title update")
+    }
+
+    func testCreatePrivateThreadSetsOnSessionCreatedCallback() {
+        threadManager.createPrivateThread()
+        let vm = threadManager.activeViewModel!
+        XCTAssertNotNil(vm.onSessionCreated, "onSessionCreated should be set for session ID backfill")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `createPrivateThread()` method to `ThreadManager` that creates a `ThreadModel(kind: .private)` and immediately calls `createSessionIfNeeded(threadType: "private")` to persist the session on the daemon before the user sends any messages.
- Unlike `createThread()`, this method does not reuse empty standard threads since private threads are a distinct kind.
- Add `ThreadManagerPrivateThreadTests` covering private thread creation, session bootstrap, session ID backfill via `onSessionCreated`, and title callback behavior.

## Context
- PR 32 added `ThreadKind` enum (`.standard`, `.private`) to `ThreadModel`.
- PR 34 added `createSessionIfNeeded(threadType:)` to `ChatViewModel`.
- This PR wires them together at the ThreadManager level.

## Test plan
- [x] Private thread creation sets `kind: .private` on the ThreadModel
- [x] Private thread creation calls `createSessionIfNeeded(threadType: "private")` immediately
- [x] Session ID backfill works after daemon responds with `session_info`
- [x] Title callback still fires on first user message
- [x] Does not reuse empty standard threads
- [ ] Not build-verified (no Xcode CLI available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
