### PR TITLE
feat: wire video placeholders for user messages

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatVideoPlaceholderUserTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatVideoPlaceholderUserTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatVideoPlaceholderUserTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeUserMessage(
+        _ text: String,
+        timestamp: Date = Date()
+    ) -> ChatMessage {
+        ChatMessage(role: .user, text: text, timestamp: timestamp)
+    }
+
+    private func enabledSettings(
+        enabledSince: Date? = nil,
+        allowedDomains: [String] = ["youtube.com", "youtu.be", "vimeo.com", "loom.com"]
+    ) -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(
+            enabled: true,
+            enabledSince: enabledSince,
+            allowedDomains: allowedDomains
+        )
+    }
+
+    private func disabledSettings() -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(enabled: false, enabledSince: nil, allowedDomains: [])
+    }
+
+    // MARK: - Video intents for user messages
+
+    func testUserMessageWithYouTubeURLReturnsVideoIntent() {
+        let message = makeUserMessage("Check this out: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+        if case .video(let provider, let videoID, _) = videos.first {
+            XCTAssertEqual(provider, "youtube")
+            XCTAssertEqual(videoID, "dQw4w9WgXcQ")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    func testUserMessageWithVimeoURLReturnsVideoIntent() {
+        let message = makeUserMessage("Watch this: https://vimeo.com/76979871")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+        if case .video(let provider, let videoID, _) = videos.first {
+            XCTAssertEqual(provider, "vimeo")
+            XCTAssertEqual(videoID, "76979871")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    func testUserMessageWithLoomURLReturnsVideoIntent() {
+        let message = makeUserMessage("Here's my recording: https://www.loom.com/share/abc123def456")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+        if case .video(let provider, let videoID, _) = videos.first {
+            XCTAssertEqual(provider, "loom")
+            XCTAssertEqual(videoID, "abc123def456")
+        } else {
+            XCTFail("Expected video intent")
+        }
+    }
+
+    // MARK: - Non-video URLs
+
+    func testUserMessageWithNoVideoURLsReturnsNoVideoIntents() {
+        let message = makeUserMessage("Check https://example.com/page for details")
+        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos, [])
+    }
+
+    // MARK: - Feature disabled
+
+    func testDisabledSettingsReturnsEmptyForUserVideo() {
+        let message = makeUserMessage("Watch: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - enabledSince gating
+
+    func testUserVideoBeforeEnabledSinceReturnsEmpty() {
+        let cutoff = Date()
+        let oldTimestamp = cutoff.addingTimeInterval(-60)
+        let message = makeUserMessage(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            timestamp: oldTimestamp
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        XCTAssertEqual(result, [])
+    }
+
+    func testUserVideoAfterEnabledSinceReturnsVideoIntent() {
+        let cutoff = Date().addingTimeInterval(-120)
+        let message = makeUserMessage(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            timestamp: Date()
+        )
+        let settings = enabledSettings(enabledSince: cutoff)
+        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let videos = result.filter { if case .video = $0 { return true } else { return false } }
+        XCTAssertEqual(videos.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Confirms that `MediaEmbedResolver` and `ChatView.videoEmbedIntents` are already role-agnostic (no production code changes needed)
- Adds `ChatVideoPlaceholderUserTests` with 7 tests covering video placeholder resolution for user messages:
  - YouTube, Vimeo, and Loom URL detection
  - No video URLs returns empty
  - Feature disabled returns empty
  - `enabledSince` gating (before and after cutoff)

## Test plan
- [x] `swift test --filter ChatVideoPlaceholderUserTests` passes (7/7 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
