### PR TITLE
feat: add click-to-initialize video player state machine

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -1,15 +1,17 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Static placeholder card for a video embed intent.
+/// Card for a video embed that transitions through click-to-play states.
 ///
-/// Shows a play icon and provider badge on a themed card background.
-/// No actual playback — that will be wired in a later PR once the
-/// WebView-based player is ready.
+/// Shows a play-button placeholder, a loading spinner while initializing,
+/// a "playing" label once active, or an error with retry. Actual WebView
+/// playback will be wired in a later PR.
 struct InlineVideoEmbedCard: View {
     let provider: String
     let videoID: String
     let embedURL: URL
+
+    @StateObject private var stateManager = InlineVideoEmbedStateManager()
 
     var body: some View {
         ZStack {
@@ -20,18 +22,75 @@ struct InlineVideoEmbedCard: View {
                         .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 0.5)
                 )
 
-            VStack(spacing: VSpacing.sm) {
-                Image(systemName: "play.circle.fill")
-                    .font(.system(size: 44))
-                    .foregroundStyle(VColor.textSecondary)
-
-                Text(provider.capitalized)
-                    .font(VFont.caption)
-                    .foregroundStyle(VColor.textSecondary)
-            }
+            stateContent
         }
         .frame(maxWidth: .infinity)
         .frame(height: 180)
+    }
+
+    // MARK: - State-driven content
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch stateManager.state {
+        case .placeholder:
+            placeholderView
+        case .initializing:
+            initializingView
+        case .playing:
+            playingView
+        case .failed(let message):
+            failedView(message)
+        }
+    }
+
+    private var placeholderView: some View {
+        VStack(spacing: VSpacing.sm) {
+            Image(systemName: "play.circle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(VColor.textSecondary)
+
+            Text(provider.capitalized)
+                .font(VFont.caption)
+                .foregroundStyle(VColor.textSecondary)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            stateManager.requestPlay()
+        }
+    }
+
+    private var initializingView: some View {
+        ProgressView()
+            .controlSize(.large)
+    }
+
+    private var playingView: some View {
+        // Placeholder for the future WebView player mount point
+        Text("Playing")
+            .font(VFont.caption)
+            .foregroundStyle(VColor.textSecondary)
+    }
+
+    private func failedView(_ message: String) -> some View {
+        VStack(spacing: VSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 32))
+                .foregroundStyle(VColor.textSecondary)
+
+            Text(message)
+                .font(VFont.caption)
+                .foregroundStyle(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Text("Tap to retry")
+                .font(VFont.caption)
+                .foregroundStyle(VColor.textSecondary.opacity(0.7))
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            stateManager.requestPlay()
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Lifecycle states for an inline video embed player.
+///
+/// Transitions: placeholder → initializing → playing (or failed).
+/// A reset from any state returns to placeholder.
+enum InlineVideoEmbedState: Equatable {
+    case placeholder
+    case initializing
+    case playing
+    case failed(String)
+}
+
+/// Drives the UI state for a single inline video embed.
+///
+/// All mutations are main-actor–isolated because the state
+/// feeds directly into SwiftUI views.
+@MainActor
+final class InlineVideoEmbedStateManager: ObservableObject {
+    @Published private(set) var state: InlineVideoEmbedState = .placeholder
+
+    /// Request the transition from placeholder (or failed) to initializing.
+    ///
+    /// Ignored when already initializing or playing — tapping play
+    /// on an active player is a no-op.
+    func requestPlay() {
+        switch state {
+        case .placeholder, .failed:
+            state = .initializing
+        case .initializing, .playing:
+            break
+        }
+    }
+
+    func didStartPlaying() {
+        state = .playing
+    }
+
+    func didFail(_ message: String) {
+        state = .failed(message)
+    }
+
+    func reset() {
+        state = .placeholder
+    }
+}

--- a/clients/macos/vellum-assistantTests/InlineVideoEmbedStateTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoEmbedStateTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineVideoEmbedStateTests: XCTestCase {
+
+    private var sut: InlineVideoEmbedStateManager!
+
+    override func setUp() {
+        super.setUp()
+        sut = InlineVideoEmbedStateManager()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial state
+
+    func testInitialStateIsPlaceholder() {
+        XCTAssertEqual(sut.state, .placeholder)
+    }
+
+    // MARK: - requestPlay
+
+    func testRequestPlayTransitionsToInitializing() {
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .initializing)
+    }
+
+    func testRequestPlayFromPlayingIsIgnored() {
+        sut.requestPlay()
+        sut.didStartPlaying()
+        XCTAssertEqual(sut.state, .playing)
+
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .playing)
+    }
+
+    func testRequestPlayFromInitializingIsIgnored() {
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .initializing)
+
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .initializing)
+    }
+
+    func testRequestPlayFromFailedTransitionsToInitializing() {
+        sut.didFail("Network error")
+        XCTAssertEqual(sut.state, .failed("Network error"))
+
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .initializing)
+    }
+
+    // MARK: - didStartPlaying
+
+    func testDidStartPlayingTransitionsToPlaying() {
+        sut.requestPlay()
+        sut.didStartPlaying()
+        XCTAssertEqual(sut.state, .playing)
+    }
+
+    // MARK: - didFail
+
+    func testDidFailTransitionsToFailedWithMessage() {
+        sut.requestPlay()
+        sut.didFail("Timed out")
+        XCTAssertEqual(sut.state, .failed("Timed out"))
+    }
+
+    // MARK: - reset
+
+    func testResetReturnsToPlaceholder() {
+        sut.requestPlay()
+        sut.didStartPlaying()
+        XCTAssertEqual(sut.state, .playing)
+
+        sut.reset()
+        XCTAssertEqual(sut.state, .placeholder)
+    }
+
+    // MARK: - Full lifecycle
+
+    func testFullLifecycle() {
+        XCTAssertEqual(sut.state, .placeholder)
+
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .initializing)
+
+        sut.didStartPlaying()
+        XCTAssertEqual(sut.state, .playing)
+
+        sut.reset()
+        XCTAssertEqual(sut.state, .placeholder)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `InlineVideoEmbedState` enum with four lifecycle states: `placeholder`, `initializing`, `playing`, and `failed(String)`.
- Add `InlineVideoEmbedStateManager` ObservableObject to drive state transitions with `requestPlay()`, `didStartPlaying()`, `didFail(_:)`, and `reset()` methods.
- Wire state manager into `InlineVideoEmbedCard` — placeholder shows tap-to-play, initializing shows spinner, failed shows error with retry. No WebView mount yet (state only).

## Test plan
- [x] `testInitialStateIsPlaceholder` — verifies default state
- [x] `testRequestPlayTransitionsToInitializing` — placeholder to initializing
- [x] `testRequestPlayFromPlayingIsIgnored` — stays in playing
- [x] `testRequestPlayFromInitializingIsIgnored` — stays in initializing
- [x] `testRequestPlayFromFailedTransitionsToInitializing` — retry support
- [x] `testDidStartPlayingTransitionsToPlaying` — initializing to playing
- [x] `testDidFailTransitionsToFailedWithMessage` — captures error message
- [x] `testResetReturnsToPlaceholder` — returns to initial state
- [x] `testFullLifecycle` — placeholder → initializing → playing → reset → placeholder

All 9 tests pass: `swift test --filter InlineVideoEmbedStateTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
