### PR TITLE
feat: add Private Thread button to Settings panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -364,6 +364,31 @@ struct SettingsPanel: View {
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
 
+                // PRIVATE THREAD section
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("PRIVATE THREAD")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("New Private Thread")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("Private threads are excluded from memory and never appear in your thread history")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "New Thread", style: .primary) {
+                            threadManager.createPrivateThread()
+                            onClose()
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+
                 // ARCHIVED THREADS section
                 if !threadManager.archivedThreads.isEmpty {
                     VStack(alignment: .leading, spacing: VSpacing.md) {


### PR DESCRIPTION
## Summary
- Adds a "PRIVATE THREAD" section card to the Settings panel with a description explaining that private threads are excluded from memory and never appear in thread history.
- Includes a "New Thread" action button that calls `threadManager.createPrivateThread()` and closes the settings panel.
- Follows the existing section card pattern used by Scheduled Tasks, Reminders, and Trust Rules sections.

Part of the Private Threads feature (PR 36/39).

## Test plan
- [ ] No Swift tests can run (no Xcode CLI tools available). Manual verification required.
- [ ] Open Settings panel and verify the "PRIVATE THREAD" section appears between "MEDIA EMBEDS" and "ARCHIVED THREADS".
- [ ] Click "New Thread" and verify a private thread is created and the settings panel closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
