### PR TITLE
feat: add /models slash command with persistent table UI

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -27,10 +27,13 @@ import { log, type HandlerContext } from './shared.js';
 
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
+  const configured = Object.keys(config.apiKeys).filter((k) => !!config.apiKeys[k]);
+  if (!configured.includes('ollama')) configured.push('ollama');
   ctx.send(socket, {
     type: 'model_info',
     model: config.model,
     provider: config.provider,
+    configuredProviders: configured,
   });
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -912,6 +912,7 @@ export interface ModelInfo {
   type: 'model_info';
   model: string;
   provider: string;
+  configuredProviders?: string[];
 }
 
 export interface HistoryResponseToolCall {

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -128,8 +128,34 @@ function resolveProviderModelCommand(content: string): SlashResolution | null {
   };
 }
 
+function resolveModelList(): SlashResolution {
+  const config = getConfig();
+  const lines = ['Available models:\n'];
+
+  for (const [cmd, { provider, model, displayName }] of Object.entries(PROVIDER_MODEL_SHORTCUTS)) {
+    const hasKey = provider === 'ollama' || !!config.apiKeys[provider];
+    const isCurrent = config.provider === provider && config.model === model;
+    const status = hasKey ? '✓' : '✗';
+    const current = isCurrent ? ' **[current]**' : '';
+    lines.push(`- **${displayName}** (/${cmd}) ${status}${current}`);
+  }
+
+  lines.push('\n✓ = API key configured, ✗ = not configured');
+  lines.push('\nTip: Configure a provider with `config set apiKeys.<provider> <key>`');
+
+  return {
+    kind: 'unknown',
+    message: lines.join('\n'),
+  };
+}
+
 function resolveModelCommand(content: string): SlashResolution | null {
   const trimmed = content.trim();
+  // Match /models → route to list
+  if (trimmed === '/models') {
+    return resolveModelList();
+  }
+
   if (!trimmed.startsWith('/model')) return null;
   // Ensure it's exactly "/model" or "/model " (not "/modelsomething")
   if (trimmed.length > 6 && trimmed[6] !== ' ') return null;
@@ -150,25 +176,7 @@ function resolveModelCommand(content: string): SlashResolution | null {
 
   // Handle /model list
   if (args === 'list') {
-    const config = getConfig();
-    const lines = ['Available models:\n'];
-
-    // Group by provider
-    for (const [cmd, { provider, model, displayName }] of Object.entries(PROVIDER_MODEL_SHORTCUTS)) {
-      const hasKey = provider === 'ollama' || !!config.apiKeys[provider];
-      const isCurrent = config.provider === provider && config.model === model;
-      const status = hasKey ? '✓' : '✗';
-      const current = isCurrent ? ' **[current]**' : '';
-      lines.push(`- **${displayName}** (/${cmd}) ${status}${current}`);
-    }
-
-    lines.push('\n✓ = API key configured, ✗ = not configured');
-    lines.push('\nTip: Configure a provider with `config set apiKeys.<provider> <key>`');
-
-    return {
-      kind: 'unknown',
-      message: lines.join('\n'),
-    };
+    return resolveModelList();
   }
 
   // Try to match the model name

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -75,6 +75,7 @@ struct ChatView: View {
     let onMicrophoneToggle: () -> Void
     var onModelPickerSelect: ((UUID, String) -> Void)?
     var selectedModel: String = ""
+    var configuredProviders: Set<String> = []
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
     let onAddTrustRule: (String, String, String, String) -> Bool
@@ -296,6 +297,10 @@ struct ChatView: View {
         )
     }
 
+    private func modelListView(for message: ChatMessage) -> some View {
+        ModelListBubble(currentModel: selectedModel, configuredProviders: configuredProviders)
+    }
+
     @MainActor private var composerOverlay: some View {
         VStack(spacing: 0) {
             if let watchSession, watchSession.state == .capturing {
@@ -498,6 +503,10 @@ struct ChatView: View {
                             }
                         } else if message.modelPicker != nil {
                             modelPickerView(for: message)
+                                .id(message.id)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        } else if message.modelList != nil {
+                            modelListView(for: message)
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                         } else {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -11,6 +11,7 @@ struct SlashCommand {
 
     static let all: [SlashCommand] = [
         SlashCommand(name: "model", description: "Switch the active model", icon: "cpu"),
+        SlashCommand(name: "models", description: "List all available models", icon: "list.bullet"),
     ]
 }
 
@@ -503,6 +504,9 @@ struct ComposerView: View {
         slashSelectedIndex = 0
         if command.name == "model" {
             inputText = "/model"
+            onSend()
+        } else if command.name == "models" {
+            inputText = "/models"
             onSend()
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1414,6 +1414,7 @@ private struct ActiveChatViewWrapper: View {
                 }
             },
             selectedModel: settingsStore.selectedModel,
+            configuredProviders: settingsStore.configuredProviders,
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
             onAddTrustRule: { toolName, pattern, scope, decision in return viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -17,6 +17,7 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Model Selection
 
     @Published var selectedModel: String = "claude-opus-4-6"
+    @Published var configuredProviders: Set<String> = ["ollama"]
 
     static let availableModels: [String] = [
         "claude-opus-4-6",
@@ -112,6 +113,9 @@ public final class SettingsStore: ObservableObject {
             guard let self else { return }
             self.lastDaemonModel = response.model
             self.selectedModel = response.model
+            if let providers = response.configuredProviders {
+                self.configuredProviders = Set(providers)
+            }
         }
 
         // Refresh Vercel key state on init

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -425,6 +425,10 @@ public struct ModelPickerData: Equatable {
     public init() {}
 }
 
+public struct ModelListData: Equatable {
+    public init() {}
+}
+
 public struct SkillInvocationData: Equatable {
     public let name: String
     public let emoji: String?
@@ -456,6 +460,7 @@ public struct ChatMessage: Identifiable {
     public var confirmation: ToolConfirmationData?
     public var skillInvocation: SkillInvocationData?
     public var modelPicker: ModelPickerData?
+    public var modelList: ModelListData?
     public var attachments: [ChatAttachment]
     public var toolCalls: [ToolCallData]
     public var inlineSurfaces: [InlineSurfaceData]

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -282,7 +282,6 @@ extension ChatViewModel {
             cancelTimeoutTask = nil
             isCancelling = false
             isThinking = false
-            currentTurnUserText = nil
             // Only clear isSending if no messages are still queued
             if pendingQueuedCount == 0 {
                 isSending = false
@@ -353,6 +352,7 @@ extension ChatViewModel {
                 }
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
             // Reset processing messages to sent
@@ -379,6 +379,7 @@ extension ChatViewModel {
                 messages.removeSubrange((lastUserIndex + 1)...)
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
 
@@ -414,6 +415,7 @@ extension ChatViewModel {
                 messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
             // Reset processing messages to sent
@@ -468,6 +470,7 @@ extension ChatViewModel {
                 messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
             // Reset processing messages to sent
@@ -494,6 +497,7 @@ extension ChatViewModel {
                 messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
             if !wasCancelling {
@@ -803,6 +807,7 @@ extension ChatViewModel {
                 messages[index].streamingCodeToolName = nil
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
             // When the user intentionally cancelled, suppress both the typed

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -348,12 +348,17 @@ extension ChatViewModel {
                     completedToolCalls = toolCalls
                 }
             }
-            // Tag assistant message with modelList if it follows a "/models" user message
-            // so the client renders the table UI instead of plain markdown.
-            if let lastUserMsg = messages.last(where: { $0.role == .user }),
-               lastUserMsg.text.trimmingCharacters(in: .whitespacesAndNewlines) == "/models",
-               let assistantIndex = messages.lastIndex(where: { $0.role == .assistant }) {
-                messages[assistantIndex].modelList = ModelListData()
+            // Tag assistant message with modelList if the preceding user message is "/models".
+            // Use currentAssistantMessageId to find the correct assistant message and look
+            // backwards for the user message that triggered it, avoiding false matches when
+            // a newer message is queued.
+            if let assistantId = currentAssistantMessageId,
+               let assistantIdx = messages.firstIndex(where: { $0.id == assistantId }) {
+                let precedingUser = messages[..<assistantIdx].last(where: { $0.role == .user })
+                let userText = precedingUser?.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if userText == "/models" {
+                    messages[assistantIdx].modelList = ModelListData()
+                }
             }
             currentAssistantMessageId = nil
             currentAssistantHasText = false

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -259,8 +259,7 @@ extension ChatViewModel {
             } else {
                 // Create new assistant message
                 var msg = ChatMessage(role: .assistant, text: delta.text, isStreaming: true)
-                if messages.last(where: { $0.role == .user })?.text
-                    .trimmingCharacters(in: .whitespacesAndNewlines) == "/models" {
+                if currentTurnUserText == "/models" {
                     msg.modelList = ModelListData()
                 }
                 currentAssistantMessageId = msg.id
@@ -283,6 +282,7 @@ extension ChatViewModel {
             cancelTimeoutTask = nil
             isCancelling = false
             isThinking = false
+            currentTurnUserText = nil
             // Only clear isSending if no messages are still queued
             if pendingQueuedCount == 0 {
                 isSending = false
@@ -438,10 +438,12 @@ extension ChatViewModel {
         case .messageDequeued(let msg):
             guard belongsToSession(msg.sessionId) else { return }
             pendingQueuedCount = max(0, pendingQueuedCount - 1)
-            // Mark the associated user message as processing
+            // Mark the associated user message as processing and track its text
+            // so assistantTextDelta tags the response correctly.
             if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId),
                let index = messages.firstIndex(where: { $0.id == messageId }) {
                 messages[index].status = .processing
+                currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
             }
             // Recompute positions for remaining queued messages
             for i in messages.indices {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -258,7 +258,11 @@ extension ChatViewModel {
                 }
             } else {
                 // Create new assistant message
-                let msg = ChatMessage(role: .assistant, text: delta.text, isStreaming: true)
+                var msg = ChatMessage(role: .assistant, text: delta.text, isStreaming: true)
+                if messages.last(where: { $0.role == .user })?.text
+                    .trimmingCharacters(in: .whitespacesAndNewlines) == "/models" {
+                    msg.modelList = ModelListData()
+                }
                 currentAssistantMessageId = msg.id
                 messages.append(msg)
                 lastContentWasToolCall = false
@@ -346,18 +350,6 @@ extension ChatViewModel {
                 let toolCalls = messages[index].toolCalls
                 if !toolCalls.isEmpty && toolCalls.allSatisfy({ $0.isComplete }) {
                     completedToolCalls = toolCalls
-                }
-            }
-            // Tag assistant message with modelList if the preceding user message is "/models".
-            // Use currentAssistantMessageId to find the correct assistant message and look
-            // backwards for the user message that triggered it, avoiding false matches when
-            // a newer message is queued.
-            if let assistantId = currentAssistantMessageId,
-               let assistantIdx = messages.firstIndex(where: { $0.id == assistantId }) {
-                let precedingUser = messages[..<assistantIdx].last(where: { $0.role == .user })
-                let userText = precedingUser?.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                if userText == "/models" {
-                    messages[assistantIdx].modelList = ModelListData()
                 }
             }
             currentAssistantMessageId = nil

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -348,6 +348,13 @@ extension ChatViewModel {
                     completedToolCalls = toolCalls
                 }
             }
+            // Tag assistant message with modelList if it follows a "/models" user message
+            // so the client renders the table UI instead of plain markdown.
+            if let lastUserMsg = messages.last(where: { $0.role == .user }),
+               lastUserMsg.text.trimmingCharacters(in: .whitespacesAndNewlines) == "/models",
+               let assistantIndex = messages.lastIndex(where: { $0.role == .assistant }) {
+                messages[assistantIndex].modelList = ModelListData()
+            }
             currentAssistantMessageId = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -86,6 +86,10 @@ public final class ChatViewModel: ObservableObject {
     /// tasks so that a cancelled loop's cleanup doesn't clear a newer replacement.
     private var messageLoopGeneration: UInt64 = 0
     var currentAssistantMessageId: UUID?
+    /// The trimmed user text that initiated the current assistant turn.
+    /// Used to tag the assistant message (e.g. modelList for "/models") without
+    /// scanning the whole transcript, which would be fragile under queued messages.
+    var currentTurnUserText: String?
     /// Tracks whether the current assistant message has received any text content.
     /// Used to determine `arrivedBeforeText` for each tool call in the message.
     var currentAssistantHasText: Bool = false
@@ -251,6 +255,13 @@ public final class ChatViewModel: ObservableObject {
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+        }
+
+        // Track the user text for this turn so assistantTextDelta can tag the
+        // response correctly (e.g. modelList for "/models") without scanning the
+        // whole transcript. For queued messages this is set in messageDequeued.
+        if !willBeQueued {
+            currentTurnUserText = text
         }
 
         if sessionId == nil {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -197,6 +197,11 @@ public final class ChatViewModel: ObservableObject {
             return
         }
 
+        // When "/models" is sent, also refresh configuredProviders so the table UI has fresh data
+        if text == "/models" && !hasSkillInvocation {
+            try? daemonClient.send(ModelGetRequestMessage())
+        }
+
         // Fire auto-title callback on the first user message
         if !text.isEmpty, let callback = onFirstUserMessage {
             onFirstUserMessage = nil
@@ -988,6 +993,15 @@ public final class ChatViewModel: ObservableObject {
             }
 
             chatMessages.append(chatMsg)
+        }
+
+        // Tag assistant messages that follow a "/models" user message so
+        // the client renders the table UI instead of plain markdown.
+        for i in chatMessages.indices {
+            if chatMessages[i].role == .user && chatMessages[i].text.trimmingCharacters(in: .whitespacesAndNewlines) == "/models",
+               i + 1 < chatMessages.count && chatMessages[i + 1].role == .assistant {
+                chatMessages[i + 1].modelList = ModelListData()
+            }
         }
 
         let hasUserSentMessages = messages.contains { $0.role == .user }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -527,6 +527,7 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
             pendingQueuedCount = 0
@@ -568,6 +569,7 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
             currentAssistantMessageId = nil
+            currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
             pendingQueuedCount = 0
@@ -622,6 +624,7 @@ public final class ChatViewModel: ObservableObject {
             self.isCancelling = false
             self.isSending = false
             self.currentAssistantMessageId = nil
+            self.currentTurnUserText = nil
             self.currentAssistantHasText = false
             self.lastContentWasToolCall = false
             self.pendingQueuedCount = 0

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+public struct ModelListBubble: View {
+    struct ProviderGroup: Identifiable {
+        let id: String
+        let name: String
+        let hasKey: Bool
+        let models: [ModelEntry]
+    }
+
+    struct ModelEntry: Identifiable {
+        let id: String // shortcut command
+        let displayName: String
+        let isCurrent: Bool
+    }
+
+    let currentModel: String
+    let configuredProviders: Set<String>
+
+    private static let providerGroups: [(key: String, name: String, models: [(cmd: String, model: String, display: String)])] = [
+        ("anthropic", "Anthropic", [
+            ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
+            ("sonnet", "claude-sonnet-4-5-20250929", "Claude Sonnet 4.5"),
+            ("haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
+        ]),
+        ("openai", "OpenAI", [
+            ("gpt4", "gpt-4", "GPT-4"),
+            ("gpt4o", "gpt-4o", "GPT-4o"),
+            ("gpt5", "gpt-5.2", "GPT-5.2"),
+        ]),
+        ("gemini", "Google", [
+            ("gemini", "gemini-3-flash", "Gemini 3 Flash"),
+        ]),
+        ("ollama", "Ollama", [
+            ("ollama", "llama3.2", "Llama 3.2"),
+        ]),
+        ("fireworks", "Fireworks", [
+            ("fireworks", "accounts/fireworks/models/kimi-k2p5", "Kimi K2.5"),
+        ]),
+    ]
+
+    private var groups: [ProviderGroup] {
+        Self.providerGroups.map { provider in
+            let hasKey = configuredProviders.contains(provider.key)
+            let entries = provider.models.map { m in
+                ModelEntry(
+                    id: m.cmd,
+                    displayName: m.display,
+                    isCurrent: currentModel == m.model
+                )
+            }
+            return ProviderGroup(id: provider.key, name: provider.name, hasKey: hasKey, models: entries)
+        }
+    }
+
+    public init(currentModel: String, configuredProviders: Set<String>) {
+        self.currentModel = currentModel
+        self.configuredProviders = configuredProviders
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(groups) { group in
+                // Provider header
+                HStack(spacing: VSpacing.sm) {
+                    Text(group.name.uppercased())
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                        .tracking(0.5)
+                    Spacer()
+                    if group.hasKey {
+                        Text("connected")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.success)
+                    } else {
+                        Text("no key")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.warning)
+                    }
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.top, group.id == groups.first?.id ? VSpacing.sm : VSpacing.md)
+                .padding(.bottom, VSpacing.xs)
+
+                // Model rows
+                ForEach(group.models) { model in
+                    HStack(spacing: VSpacing.sm) {
+                        if model.isCurrent {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundColor(VColor.accent)
+                                .frame(width: 16)
+                        } else {
+                            Color.clear.frame(width: 16, height: 1)
+                        }
+
+                        Text(model.displayName)
+                            .font(model.isCurrent ? VFont.bodyBold : VFont.body)
+                            .foregroundColor(group.hasKey ? VColor.textPrimary : VColor.textMuted)
+
+                        Spacer()
+
+                        Text("/\(model.id)")
+                            .font(VFont.monoSmall)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.xs + 2)
+                }
+            }
+
+            // Footer
+            Text("Switch with /shortcut or `config set apiKeys.<provider> <key>` to add a provider.")
+                .font(VFont.small)
+                .foregroundColor(VColor.textMuted)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.top, VSpacing.md)
+                .padding(.bottom, VSpacing.sm)
+        }
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .frame(maxWidth: 480)
+    }
+}

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -746,6 +746,7 @@ public struct IPCModelInfo: Codable, Sendable {
     public let type: String
     public let model: String
     public let provider: String
+    public let configuredProviders: [String]?
 }
 
 public struct IPCModelSetRequest: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Add top-level `/models` slash command that displays a read-only table of all available models grouped by provider with connection status
- Extract `resolveModelList()` in daemon (reused by `/models` and `/model list`)
- Add `configuredProviders` to `model_info` IPC response so the client can show "connected" / "no key" per provider
- Table UI persists across app restarts by detecting `/models` in history and rendering the SwiftUI component

## Test plan
- [ ] Type `/models` → table UI shows all models grouped by provider with key status
- [ ] Select `/models` from slash command menu → same result
- [ ] Restart app → `/models` table UI persists in chat history
- [ ] `/model list` still works and shows same markdown output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
