### PR TITLE
feat: message indexing uses conversation memory scope

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -102,6 +102,7 @@ import {
   injectMemoryRecallAsSeparateMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
+import { addMessage, createConversation } from '../memory/conversation-store.js';
 import {
   conversations,
   memoryEmbeddings,
@@ -3259,5 +3260,44 @@ describe('Memory regressions', () => {
 
     expect(keys).toContain('segment:seg-ovr-dp-default');
     expect(keys).not.toContain('segment:seg-ovr-dp-other');
+  });
+
+  // PR-17: addMessage() passes conversation scope to the indexer
+  test('addMessage inherits private conversation scope on memory segments', () => {
+    const conv = createConversation({ title: 'Private thread', threadType: 'private' });
+    expect(conv.memoryScopeId).toMatch(/^private:/);
+
+    const msg = addMessage(conv.id, 'user', 'My secret project details for the private thread.');
+
+    const db = getDb();
+    const segments = db
+      .select()
+      .from(memorySegments)
+      .where(eq(memorySegments.messageId, msg.id))
+      .all();
+
+    expect(segments.length).toBeGreaterThan(0);
+    for (const seg of segments) {
+      expect(seg.scopeId).toBe(conv.memoryScopeId);
+    }
+  });
+
+  test('addMessage uses default scope for standard conversations', () => {
+    const conv = createConversation({ title: 'Standard thread', threadType: 'standard' });
+    expect(conv.memoryScopeId).toBe('default');
+
+    const msg = addMessage(conv.id, 'user', 'Normal conversation content for testing scope defaults.');
+
+    const db = getDb();
+    const segments = db
+      .select()
+      .from(memorySegments)
+      .where(eq(memorySegments.messageId, msg.id))
+      .all();
+
+    expect(segments.length).toBeGreaterThan(0);
+    for (const seg of segments) {
+      expect(seg.scopeId).toBe('default');
+    }
   });
 });

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -125,12 +125,14 @@ export function addMessage(conversationId: string, role: string, content: string
 
   try {
     const config = getConfig();
+    const scopeId = getConversationMemoryScopeId(conversationId);
     indexMessageNow({
       messageId: message.id,
       conversationId: message.conversationId,
       role: message.role,
       content: message.content,
       createdAt: message.createdAt,
+      scopeId,
     }, config.memory);
   } catch (err) {
     log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');


### PR DESCRIPTION
## Summary
- `addMessage()` in `conversation-store.ts` now looks up the conversation's `memoryScopeId` via `getConversationMemoryScopeId()` and passes it to `indexMessageNow()`, ensuring memory segments from private threads are tagged with the private scope ID instead of defaulting to `'default'`.
- Added two tests in `memory-regressions.test.ts` proving that private conversations produce segments with the private scope and standard conversations continue using the `'default'` scope.

## Test plan
- [x] `bun test src/__tests__/memory-regressions.test.ts` — all 70 tests pass
- [x] New test: `addMessage inherits private conversation scope on memory segments`
- [x] New test: `addMessage uses default scope for standard conversations`

Part of the Private Threads feature (PR 17/39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
