### PR TITLE
feat: add isSideEffectTool classifier utility in executor

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -89,7 +89,7 @@ mock.module('../tools/terminal/sandbox.js', () => ({
   wrapCommand: () => ({ command: '', sandboxed: false }),
 }));
 
-import { ToolExecutor } from '../tools/executor.js';
+import { ToolExecutor, isSideEffectTool } from '../tools/executor.js';
 import type { ToolContext } from '../tools/types.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import * as trustStore from '../permissions/trust-store.js';
@@ -899,6 +899,57 @@ describe('ToolExecutor strict mode + high-risk integration (PR 25)', () => {
     expect(options.principalId).toBe('admin-skill');
     expect(options.principalVersion).toBe('sha256-admin-v2');
     expect(options.executionTarget).toBe('host');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSideEffectTool classifier
+// ---------------------------------------------------------------------------
+
+describe('isSideEffectTool', () => {
+  describe('returns true for side-effect tools', () => {
+    const sideEffectTools = [
+      'file_write',
+      'file_edit',
+      'host_file_write',
+      'host_file_edit',
+      'bash',
+      'host_bash',
+      'web_fetch',
+      'browser_navigate',
+    ];
+
+    for (const toolName of sideEffectTools) {
+      test(toolName, () => {
+        expect(isSideEffectTool(toolName)).toBe(true);
+      });
+    }
+  });
+
+  describe('returns false for non-side-effect tools', () => {
+    const readOnlyTools = [
+      'file_read',
+      'memory_search',
+      'memory_save',
+      'web_search',
+      'browser_snapshot',
+      'browser_screenshot',
+      'browser_close',
+      'skill_load',
+      'schedule_list',
+      'evaluate_typescript_code',
+    ];
+
+    for (const toolName of readOnlyTools) {
+      test(toolName, () => {
+        expect(isSideEffectTool(toolName)).toBe(false);
+      });
+    }
+  });
+
+  test('returns false for unknown tool names', () => {
+    expect(isSideEffectTool('nonexistent_tool')).toBe(false);
+    expect(isSideEffectTool('')).toBe(false);
   });
 });
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -504,6 +504,32 @@ export class ToolExecutor {
   }
 }
 
+// ── Side-effect tool classifier ─────────────────────────────────────
+// Tools that modify state outside the assistant (filesystem writes,
+// shell commands, network requests that trigger actions, etc.).
+// Used by private-thread gating to decide whether a tool invocation
+// should be blocked in a read-only thread context.
+
+const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
+  'file_write',
+  'file_edit',
+  'host_file_write',
+  'host_file_edit',
+  'bash',
+  'host_bash',
+  'web_fetch',
+  'browser_navigate',
+]);
+
+/**
+ * Returns `true` if the given tool name is classified as having side effects
+ * (i.e. it can modify the filesystem, execute arbitrary commands, or trigger
+ * external actions). Read-only and informational tools return `false`.
+ */
+export function isSideEffectTool(toolName: string): boolean {
+  return SIDE_EFFECT_TOOLS.has(toolName);
+}
+
 const TIMEOUT_SENTINEL = Symbol('tool-timeout');
 
 const DEFAULT_TOOL_TIMEOUT_SEC = 120;


### PR DESCRIPTION
## Summary
- Adds `isSideEffectTool(toolName: string): boolean` exported function to `assistant/src/tools/executor.ts`
- Classifies tools that modify external state (filesystem writes, shell commands, network actions) for private-thread gating
- Covers: `file_write`, `file_edit`, `host_file_write`, `host_file_edit`, `bash`, `host_bash`, `web_fetch`, `browser_navigate`
- No decision flow changes — just the classifier utility

## Test plan
- [x] Unit tests for all 8 side-effect tools returning `true`
- [x] Unit tests for 10 non-side-effect tools returning `false`
- [x] Edge case test for unknown/empty tool names returning `false`
- [x] All 47 tests pass in `tool-executor.test.ts`

PR 29/39 of the Private Threads feature plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
