### PR TITLE
feat: make conflict gate scope-aware (PR 13)

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -6,6 +6,7 @@ import type { ServerMessage } from '../daemon/ipc-protocol.js';
 let runCalls: Message[][] = [];
 let resolverCallCount = 0;
 let markAskedCalls: string[] = [];
+let conflictScopeCalls: string[] = [];
 let memoryEnabled = true;
 let pendingConflicts: Array<{
   id: string;
@@ -192,7 +193,10 @@ mock.module('../context/window-manager.js', () => ({
 }));
 
 mock.module('../memory/conflict-store.js', () => ({
-  listPendingConflictDetails: () => pendingConflicts,
+  listPendingConflictDetails: (scopeId: string) => {
+    conflictScopeCalls.push(scopeId);
+    return pendingConflicts;
+  },
   markConflictAsked: (conflictId: string) => {
     markAskedCalls.push(conflictId);
     return true;
@@ -234,10 +238,10 @@ mock.module('../agent/loop.js', () => ({
   },
 }));
 
-import { Session } from '../daemon/session.js';
+import { Session, type SessionMemoryPolicy } from '../daemon/session.js';
 import { looksLikeClarificationReply } from '../daemon/session-conflict-gate.js';
 
-function makeSession(): Session {
+function makeSession(memoryPolicy?: SessionMemoryPolicy): Session {
   const provider = {
     name: 'mock',
     async sendMessage(): Promise<ProviderResponse> {
@@ -249,7 +253,7 @@ function makeSession(): Session {
       };
     },
   };
-  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp', undefined, memoryPolicy);
 }
 
 function extractText(message: Message): string {
@@ -264,6 +268,7 @@ describe('Session conflict soft gate', () => {
     runCalls = [];
     resolverCallCount = 0;
     markAskedCalls = [];
+    conflictScopeCalls = [];
     memoryEnabled = true;
     pendingConflicts = [];
     persistedMessages.length = 0;
@@ -545,6 +550,52 @@ describe('Session conflict soft gate', () => {
     expect(firstUserText).toContain('Memory clarification request');
     expect(secondUserText).not.toContain('Memory clarification request');
     expect(markAskedCalls).toEqual(['conflict-cooldown']);
+  });
+
+  test('passes session scopeId through to conflict store queries', async () => {
+    pendingConflicts = [{
+      id: 'conflict-scoped',
+      scopeId: 'thread:private-abc',
+      existingItemId: 'existing-scoped',
+      candidateItemId: 'candidate-scoped',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Do you prefer tabs or spaces?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use tabs for indentation.',
+      candidateStatement: 'Use spaces for indentation.',
+    }];
+
+    const session = makeSession({
+      scopeId: 'thread:private-abc',
+      includeDefaultFallback: false,
+      strictSideEffects: true,
+    });
+    await session.loadFromDb();
+
+    await session.processMessage('tabs or spaces?', [], () => {});
+
+    // Every call to listPendingConflictDetails should use the session's scopeId
+    expect(conflictScopeCalls.length).toBeGreaterThan(0);
+    expect(conflictScopeCalls.every((s) => s === 'thread:private-abc')).toBe(true);
+    // No calls should have used the hardcoded 'default'
+    expect(conflictScopeCalls).not.toContain('default');
+  });
+
+  test('default session uses "default" scopeId for conflict queries', async () => {
+    pendingConflicts = [];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    await session.processMessage('hello', [], () => {});
+
+    // With no custom policy, scopeId should default to 'default'
+    expect(conflictScopeCalls.every((s) => s === 'default')).toBe(true);
   });
 
   test('skips conflict gate when top-level memory.enabled is false', async () => {

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -31,13 +31,14 @@ export class ConflictGate {
       reaskCooldownTurns: number;
       resolverLlmTimeoutMs: number;
     },
+    scopeId = 'default',
   ): Promise<ConflictGateDecision | null> {
     if (!conflictConfig.enabled || conflictConfig.gateMode !== 'soft') return null;
 
     this.turnCounter += 1;
     const threshold = conflictConfig.relevanceThreshold;
     const cooldownTurns = Math.max(1, conflictConfig.reaskCooldownTurns);
-    const pendingBeforeResolve = listPendingConflictDetails('default', 50);
+    const pendingBeforeResolve = listPendingConflictDetails(scopeId, 50);
     const candidatesBeforeResolve = pendingBeforeResolve.filter((conflict) => {
       const relevance = computeConflictRelevance(userMessage, conflict);
       if (relevance >= threshold) return true;
@@ -53,7 +54,7 @@ export class ConflictGate {
       candidatesBeforeResolve,
     );
 
-    const pending = listPendingConflictDetails('default', 50);
+    const pending = listPendingConflictDetails(scopeId, 50);
     if (pending.length === 0) return null;
 
     const scored = pending.map((conflict) => ({

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -31,6 +31,7 @@ export interface MemoryPrepareContext {
   systemPrompt: string;
   provider: Provider;
   conflictGate: ConflictGate;
+  scopeId: string;
 }
 
 /**
@@ -51,7 +52,7 @@ export async function prepareMemoryContext(
   // Conflict gate
   const conflictConfig = memoryEnabled ? runtimeConfig.memory?.conflicts : undefined;
   const conflictGateResult = conflictConfig
-    ? await ctx.conflictGate.evaluate(content, conflictConfig)
+    ? await ctx.conflictGate.evaluate(content, conflictConfig, ctx.scopeId)
     : null;
 
   if (conflictGateResult?.relevant) {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -716,6 +716,7 @@ export class Session {
           systemPrompt: this.systemPrompt,
           provider: this.provider,
           conflictGate: this.conflictGate,
+          scopeId: this.memoryPolicy.scopeId,
         },
         content,
         userMessageId,


### PR DESCRIPTION
## Summary
- `ConflictGate.evaluate()` now accepts a `scopeId` parameter (defaulting to `'default'`) instead of hardcoding `'default'` in calls to `listPendingConflictDetails()`.
- `MemoryPrepareContext` gains a `scopeId` field, plumbed from `session.memoryPolicy.scopeId` so private threads query only their own scope's conflicts.
- Tests updated: mock captures `scopeId` argument, two new tests verify private scope flows through and default scope is used for standard sessions.

## Test plan
- [x] Existing 18 conflict gate tests pass unchanged
- [x] New test: private `scopeId` (`'thread:private-abc'`) flows through to `listPendingConflictDetails`
- [x] New test: default session uses `'default'` scope for conflict queries
- [x] No new TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
