### PR TITLE
feat: add VideoEmbedURLBuilder for provider-specific embed URLs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoEmbedURLBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoEmbedURLBuilder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Builds provider-specific embed URLs with playback parameters.
+///
+/// The parsers (`YouTubeParser`, `VimeoParser`, `LoomParser`) extract video IDs
+/// and produce bare embed URLs. This builder adds player query parameters
+/// (autoplay, rel suppression, etc.) that are provider-specific.
+enum VideoEmbedURLBuilder {
+
+    static func buildEmbedURL(provider: String, videoID: String) -> URL? {
+        switch provider.lowercased() {
+        case "youtube":
+            return URL(string: "https://www.youtube.com/embed/\(videoID)?autoplay=1&rel=0")
+        case "vimeo":
+            return URL(string: "https://player.vimeo.com/video/\(videoID)?autoplay=1")
+        case "loom":
+            return URL(string: "https://www.loom.com/embed/\(videoID)?autoplay=1")
+        default:
+            return nil
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/VideoEmbedURLBuilderTests.swift
+++ b/clients/macos/vellum-assistantTests/VideoEmbedURLBuilderTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class VideoEmbedURLBuilderTests: XCTestCase {
+
+    // MARK: - YouTube
+
+    func testYouTubeEmbedURLFormat() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "dQw4w9WgXcQ")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0"
+        )
+    }
+
+    func testYouTubeEmbedURLHasAutoplayAndRel() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "abc123")!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "autoplay" && $0.value == "1" }))
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "rel" && $0.value == "0" }))
+    }
+
+    // MARK: - Vimeo
+
+    func testVimeoEmbedURLFormat() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "vimeo", videoID: "76979871")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://player.vimeo.com/video/76979871?autoplay=1"
+        )
+    }
+
+    func testVimeoEmbedURLHasAutoplay() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "vimeo", videoID: "76979871")!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "autoplay" && $0.value == "1" }))
+    }
+
+    // MARK: - Loom
+
+    func testLoomEmbedURLFormat() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "loom", videoID: "abc123def456")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://www.loom.com/embed/abc123def456?autoplay=1"
+        )
+    }
+
+    func testLoomEmbedURLHasAutoplay() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "loom", videoID: "abc123def456")!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "autoplay" && $0.value == "1" }))
+    }
+
+    // MARK: - Unknown provider
+
+    func testUnknownProviderReturnsNil() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "dailymotion", videoID: "x12345")
+        XCTAssertNil(url)
+    }
+
+    // MARK: - Case insensitivity
+
+    func testUppercaseProviderName() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "YOUTUBE", videoID: "testID")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://www.youtube.com/embed/testID?autoplay=1&rel=0"
+        )
+    }
+
+    func testMixedCaseProviderName() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "YouTube", videoID: "testID")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://www.youtube.com/embed/testID?autoplay=1&rel=0"
+        )
+    }
+
+    // MARK: - Special characters in video ID
+
+    func testVideoIDWithHyphensAndUnderscores() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "a-b_c-d_e")
+        XCTAssertNotNil(url)
+        XCTAssertTrue(url!.absoluteString.contains("a-b_c-d_e"))
+    }
+
+    // MARK: - Empty video ID
+
+    func testEmptyVideoIDStillProducesURL() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "")
+        // Should not crash; URL(string:) can still produce a valid URL
+        XCTAssertNotNil(url)
+    }
+
+    // MARK: - No mute parameter (unmuted defaults for v1)
+
+    func testYouTubeDoesNotIncludeMuteParameter() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "abc")!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+
+        XCTAssertFalse(queryItems.contains(where: { $0.name == "mute" }))
+    }
+
+    func testVimeoDoesNotIncludeMutedParameter() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "vimeo", videoID: "123")!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+
+        XCTAssertFalse(queryItems.contains(where: { $0.name == "muted" }))
+    }
+
+    func testLoomDoesNotIncludeMuteParameter() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "loom", videoID: "xyz")!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+
+        XCTAssertFalse(queryItems.contains(where: { $0.name == "mute" }))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `VideoEmbedURLBuilder` enum that generates provider-specific embed URLs with playback parameters (autoplay, rel suppression)
- Supports YouTube (`autoplay=1&rel=0`), Vimeo (`autoplay=1`), and Loom (`autoplay=1`) with unmuted defaults for v1
- Separates embed URL generation from the parser and view layers, keeping URL construction pure and testable

## Test plan
- [x] `VideoEmbedURLBuilderTests` — 14 tests covering:
  - YouTube/Vimeo/Loom embed URL format and query parameters
  - Unknown provider returns nil
  - Case insensitivity (YOUTUBE, YouTube)
  - Video IDs with special characters (hyphens, underscores)
  - Empty video ID does not crash
  - No mute parameter present (unmuted defaults for v1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
