### PR TITLE
feat: add InlineVideoWebView with ephemeral data store

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import WebKit
+
+/// Isolated WKWebView wrapper for inline video embeds.
+///
+/// Uses an ephemeral (non-persistent) data store so no cookies, local storage,
+/// or cache persist between sessions — important for privacy when embedding
+/// third-party video players.
+struct InlineVideoWebView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> WKWebView {
+        let webView = Self.makeConfiguredWebView()
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    /// Build a WKWebView with the privacy-hardened configuration used for embeds.
+    /// Factored out so policy tests can verify settings without a full SwiftUI context.
+    static func makeConfiguredWebView() -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.allowsLinkPreview = false
+
+        return webView
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        // Navigation policy will be added in a later PR
+    }
+}

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewPolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewPolicyTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import WebKit
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineVideoWebViewPolicyTests: XCTestCase {
+
+    // MARK: - Ephemeral data store
+
+    func testConfigurationUsesNonPersistentDataStore() {
+        let webView = InlineVideoWebView.makeConfiguredWebView()
+
+        XCTAssertFalse(
+            webView.configuration.websiteDataStore.isPersistent,
+            "Data store must be non-persistent (ephemeral)"
+        )
+    }
+
+    // MARK: - Link preview disabled
+
+    func testLinkPreviewIsDisabled() {
+        let webView = InlineVideoWebView.makeConfiguredWebView()
+
+        XCTAssertFalse(
+            webView.allowsLinkPreview,
+            "Link previews must be disabled for inline video embeds"
+        )
+    }
+
+    // MARK: - URL property
+
+    func testURLIsStoredCorrectly() {
+        let url = URL(string: "https://player.vimeo.com/video/76979871")!
+        let view = InlineVideoWebView(url: url)
+
+        XCTAssertEqual(view.url, url)
+    }
+
+    func testURLPreservesQueryParameters() {
+        let url = URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=0&mute=1")!
+        let view = InlineVideoWebView(url: url)
+
+        XCTAssertEqual(view.url.absoluteString, url.absoluteString)
+    }
+
+    // MARK: - Coordinator
+
+    func testCoordinatorConformsToWKNavigationDelegate() {
+        let view = InlineVideoWebView(url: URL(string: "https://example.com")!)
+        let coordinator = view.makeCoordinator()
+
+        // Verify the coordinator can be used as a WKNavigationDelegate
+        let delegate: WKNavigationDelegate = coordinator
+        XCTAssertNotNil(delegate)
+    }
+
+    // MARK: - Multiple instances are independent
+
+    func testMultipleWebViewsHaveIndependentDataStores() {
+        let webViewA = InlineVideoWebView.makeConfiguredWebView()
+        let webViewB = InlineVideoWebView.makeConfiguredWebView()
+
+        XCTAssertFalse(webViewA.configuration.websiteDataStore.isPersistent)
+        XCTAssertFalse(webViewB.configuration.websiteDataStore.isPersistent)
+
+        // Each non-persistent store is a separate instance
+        XCTAssertTrue(
+            webViewA.configuration.websiteDataStore !== webViewB.configuration.websiteDataStore,
+            "Each webview should get its own ephemeral data store"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add `InlineVideoWebView`, an `NSViewRepresentable` wrapper around `WKWebView` for inline video embeds
- Uses `WKWebsiteDataStore.nonPersistent()` for ephemeral storage — no cookies, cache, or local storage persists between sessions
- Disables link previews (`allowsLinkPreview = false`)
- Includes a `WKNavigationDelegate` coordinator stub for future navigation policy (PR 33)
- Configuration logic exposed via `makeConfiguredWebView()` static factory for testability

## Test plan
- [x] `testConfigurationUsesNonPersistentDataStore` — verifies ephemeral data store
- [x] `testLinkPreviewIsDisabled` — verifies link previews are off
- [x] `testURLIsStoredCorrectly` — verifies URL property storage
- [x] `testURLPreservesQueryParameters` — verifies query string preservation
- [x] `testCoordinatorConformsToWKNavigationDelegate` — verifies delegate conformance
- [x] `testMultipleWebViewsHaveIndependentDataStores` — verifies isolation between instances
- All 6 tests pass: `swift test --filter InlineVideoWebViewPolicyTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
