### PR TITLE
fix: check isError from proxy resolver in openAppViaSurface

### DIFF
--- a/assistant/src/tools/apps/open-proxy.ts
+++ b/assistant/src/tools/apps/open-proxy.ts
@@ -33,6 +33,9 @@ export async function openAppViaSurface(
       app_id: appId,
       ...extraInput,
     });
+    if (result.isError) {
+      return 'Failed to auto-open app. Use app_open to open it manually.';
+    }
     return result.content;
   } catch {
     return 'Failed to auto-open app. Use app_open to open it manually.';


### PR DESCRIPTION
Addresses feedback from PR #3957. Checks result.isError before returning content so callers correctly detect failed app opens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
