### PR TITLE
feat: carry scopeId through extract_items job payload

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3300,4 +3300,70 @@ describe('Memory regressions', () => {
       expect(seg.scopeId).toBe('default');
     }
   });
+
+  // PR-18: extract_items jobs carry scopeId through the async pipeline
+  test('extract_items job payload includes scopeId from private conversation', () => {
+    const conv = createConversation({ title: 'Private scope job test', threadType: 'private' });
+    expect(conv.memoryScopeId).toMatch(/^private:/);
+
+    addMessage(conv.id, 'user', 'Important data that should trigger extraction in private scope.');
+
+    const db = getDb();
+    const extractJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all();
+
+    expect(extractJobs.length).toBeGreaterThan(0);
+    const lastJob = extractJobs[extractJobs.length - 1];
+    const payload = JSON.parse(lastJob.payload) as Record<string, unknown>;
+    expect(payload.scopeId).toBe(conv.memoryScopeId);
+  });
+
+  test('extract_items job payload defaults scopeId to default for standard conversations', () => {
+    const conv = createConversation({ title: 'Standard scope job test', threadType: 'standard' });
+    expect(conv.memoryScopeId).toBe('default');
+
+    addMessage(conv.id, 'user', 'Regular content for extraction in default scope.');
+
+    const db = getDb();
+    const extractJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all();
+
+    expect(extractJobs.length).toBeGreaterThan(0);
+    const lastJob = extractJobs[extractJobs.length - 1];
+    const payload = JSON.parse(lastJob.payload) as Record<string, unknown>;
+    expect(payload.scopeId).toBe('default');
+  });
+
+  test('extract_items backward compat: old payloads without scopeId default to default', () => {
+    // Simulate an old-style extract_items job without scopeId
+    const jobId = enqueueMemoryJob('extract_items', { messageId: 'legacy-msg-id' });
+
+    const db = getDb();
+    const job = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, jobId))
+      .get();
+
+    expect(job).toBeTruthy();
+    const payload = JSON.parse(job!.payload) as Record<string, unknown>;
+    // Old payloads will not have scopeId — consumers must default to 'default'
+    expect(payload.scopeId).toBeUndefined();
+
+    // Verify the job handler's backward-compat logic: claim and inspect
+    const claimed = claimMemoryJobs(100);
+    const claimedJob = claimed.find((j) => j.id === jobId);
+    expect(claimedJob).toBeTruthy();
+    // The parsed payload should not have scopeId (it was never set)
+    const resolvedScope = typeof claimedJob!.payload.scopeId === 'string' && claimedJob!.payload.scopeId
+      ? claimedJob!.payload.scopeId
+      : 'default';
+    expect(resolvedScope).toBe('default');
+  });
 });

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -96,7 +96,7 @@ export function indexMessageNow(
     }
 
     if (shouldExtract) {
-      enqueueMemoryJob('extract_items', { messageId: input.messageId }, Date.now(), tx);
+      enqueueMemoryJob('extract_items', { messageId: input.messageId, scopeId: input.scopeId ?? 'default' }, Date.now(), tx);
     }
     if (shouldResolveConflicts) {
       enqueueResolvePendingConflictsForMessageJob(input.messageId, input.scopeId ?? 'default', tx);

--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -21,11 +21,15 @@ const log = getLogger('memory-jobs-worker');
 export async function extractItemsJob(job: MemoryJob): Promise<void> {
   const messageId = asString(job.payload.messageId);
   if (!messageId) return;
+  // Backward compat: old payloads may lack scopeId — default to 'default'
+  const scopeId = typeof job.payload.scopeId === 'string' && job.payload.scopeId
+    ? job.payload.scopeId
+    : 'default';
   await extractAndUpsertMemoryItemsForMessage(messageId);
   // Queue entity extraction for this message after items are extracted
   const config = getConfig();
   if (config.memory.entity.enabled) {
-    enqueueMemoryJob('extract_entities', { messageId });
+    enqueueMemoryJob('extract_entities', { messageId, scopeId });
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `scopeId` to the `extract_items` job payload in the indexer, preserving memory scope through the async job pipeline
- Updates `extractItemsJob` handler to read `scopeId` from the payload (defaulting to `'default'` for backward compat with old payloads) and forward it to `extract_entities` jobs
- Adds tests verifying scope propagation for private conversations, default scope for standard conversations, and backward compatibility with legacy payloads missing `scopeId`

## Test plan
- [x] `bun test src/__tests__/memory-regressions.test.ts` — all 73 tests pass
- [x] Private conversation extract_items jobs carry the `private:*` scopeId
- [x] Standard conversation extract_items jobs carry `default` scopeId
- [x] Old payloads without scopeId gracefully resolve to `default`

Part of the private-threads rollout (PR 18/39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
