### PR TITLE
feat: session memory context consumes policy

### DIFF
--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -5,6 +5,8 @@ import type { ServerMessage } from '../daemon/ipc-protocol.js';
 
 let runCalls: Message[][] = [];
 let profileCompilerCalls = 0;
+let profileCompilerArgs: Array<Record<string, unknown>> = [];
+let recallArgs: Array<Record<string, unknown>> = [];
 let profileEnabled = true;
 let memoryEnabled = true;
 let profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles\n</dynamic-user-profile>';
@@ -131,29 +133,32 @@ mock.module('../memory/attachments-store.js', () => ({
 }));
 
 mock.module('../memory/retriever.js', () => ({
-  buildMemoryRecall: async () => ({
-    enabled: true,
-    degraded: false,
-    reason: null,
-    provider: 'mock',
-    model: 'mock',
-    injectedText: '',
-    lexicalHits: 0,
-    semanticHits: 0,
-    recencyHits: 0,
-    entityHits: 0,
-    relationSeedEntityCount: 0,
-    relationTraversedEdgeCount: 0,
-    relationNeighborEntityCount: 0,
-    relationExpandedItemCount: 0,
-    earlyTerminated: false,
-    mergedCount: 0,
-    selectedCount: 0,
-    rerankApplied: false,
-    injectedTokens: 0,
-    latencyMs: 0,
-    topCandidates: [],
-  }),
+  buildMemoryRecall: async (_query: string, _convId: string, _config: unknown, options?: Record<string, unknown>) => {
+    if (options) recallArgs.push(options);
+    return {
+      enabled: true,
+      degraded: false,
+      reason: null,
+      provider: 'mock',
+      model: 'mock',
+      injectedText: '',
+      lexicalHits: 0,
+      semanticHits: 0,
+      recencyHits: 0,
+      entityHits: 0,
+      relationSeedEntityCount: 0,
+      relationTraversedEdgeCount: 0,
+      relationNeighborEntityCount: 0,
+      relationExpandedItemCount: 0,
+      earlyTerminated: false,
+      mergedCount: 0,
+      selectedCount: 0,
+      rerankApplied: false,
+      injectedTokens: 0,
+      latencyMs: 0,
+      topCandidates: [],
+    };
+  },
   injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
   injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
   stripMemoryRecallMessages: (msgs: Message[]) => msgs,
@@ -191,8 +196,9 @@ mock.module('../memory/admin.js', () => ({
 }));
 
 mock.module('../memory/profile-compiler.js', () => ({
-  compileDynamicProfile: () => {
+  compileDynamicProfile: (options?: Record<string, unknown>) => {
     profileCompilerCalls += 1;
+    if (options) profileCompilerArgs.push(options);
     return {
       text: profileText,
       sourceCount: 2,
@@ -223,13 +229,14 @@ mock.module('../agent/loop.js', () => ({
   },
 }));
 
-import { Session } from '../daemon/session.js';
+import { Session, DEFAULT_MEMORY_POLICY } from '../daemon/session.js';
+import type { SessionMemoryPolicy } from '../daemon/session.js';
 import {
   injectDynamicProfileIntoUserMessage,
   stripDynamicProfileMessages,
 } from '../daemon/session-dynamic-profile.js';
 
-function makeSession(): Session {
+function makeSession(memoryPolicy?: SessionMemoryPolicy): Session {
   const provider = {
     name: 'mock',
     async sendMessage(): Promise<ProviderResponse> {
@@ -241,7 +248,7 @@ function makeSession(): Session {
       };
     },
   };
-  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp', undefined, memoryPolicy);
 }
 
 function messageText(message: Message): string {
@@ -256,6 +263,8 @@ describe('Session dynamic profile injection', () => {
     runCalls = [];
     persistedMessages.length = 0;
     profileCompilerCalls = 0;
+    profileCompilerArgs = [];
+    recallArgs = [];
     profileEnabled = true;
     memoryEnabled = true;
     profileText = '<dynamic-user-profile>\n- timezone: America/Los_Angeles\n</dynamic-user-profile>';
@@ -384,5 +393,49 @@ describe('Session dynamic profile injection', () => {
     const runtimeText = messageText(runtimeUser);
     expect(runtimeText).not.toContain('<dynamic-profile-context>');
     expect(profileCompilerCalls).toBe(0);
+  });
+
+  test('private thread session uses private scope + default fallback in profile compile and recall', async () => {
+    const privatePolicy: SessionMemoryPolicy = {
+      scopeId: 'private-thread-abc',
+      includeDefaultFallback: true,
+      strictSideEffects: false,
+    };
+    const session = makeSession(privatePolicy);
+    await session.loadFromDb();
+
+    await session.processMessage('What do I prefer?', [], () => {});
+
+    // Profile compiler should receive the private scope with fallback enabled
+    expect(profileCompilerCalls).toBe(1);
+    expect(profileCompilerArgs).toHaveLength(1);
+    expect(profileCompilerArgs[0].scopeId).toBe('private-thread-abc');
+    expect(profileCompilerArgs[0].includeDefaultFallback).toBe(true);
+
+    // Memory recall should receive a scopePolicyOverride for the private scope
+    expect(recallArgs).toHaveLength(1);
+    expect(recallArgs[0].scopePolicyOverride).toEqual({
+      scopeId: 'private-thread-abc',
+      fallbackToDefault: true,
+    });
+  });
+
+  test('standard thread uses default scope without fallback in profile compile and no scope override in recall', async () => {
+    // Default policy: scopeId='default', includeDefaultFallback=false
+    const session = makeSession(DEFAULT_MEMORY_POLICY);
+    await session.loadFromDb();
+
+    await session.processMessage('Tell me about TypeScript', [], () => {});
+
+    // Profile compiler should receive default scope without fallback
+    expect(profileCompilerCalls).toBe(1);
+    expect(profileCompilerArgs).toHaveLength(1);
+    expect(profileCompilerArgs[0].scopeId).toBe('default');
+    expect(profileCompilerArgs[0].includeDefaultFallback).toBe(false);
+
+    // Memory recall should NOT have a scopePolicyOverride (default scope
+    // relies on the global config policy, not a per-call override)
+    expect(recallArgs).toHaveLength(1);
+    expect(recallArgs[0].scopePolicyOverride).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -7,6 +7,7 @@ import {
   injectMemoryRecallIntoUserMessage,
   injectMemoryRecallAsSeparateMessage,
 } from '../memory/retriever.js';
+import type { ScopePolicyOverride } from '../memory/search/types.js';
 import { buildMemoryQuery } from '../memory/query-builder.js';
 import { computeRecallBudget } from '../memory/retrieval-budget.js';
 import { estimatePromptTokens } from '../context/token-estimator.js';
@@ -32,6 +33,7 @@ export interface MemoryPrepareContext {
   provider: Provider;
   conflictGate: ConflictGate;
   scopeId: string;
+  includeDefaultFallback: boolean;
 }
 
 /**
@@ -97,7 +99,8 @@ export async function prepareMemoryContext(
   const profileConfig = memoryEnabled ? runtimeConfig.memory?.profile : undefined;
   const dynamicProfile = profileConfig?.enabled
     ? compileDynamicProfile({
-        scopeId: 'default',
+        scopeId: ctx.scopeId,
+        includeDefaultFallback: ctx.includeDefaultFallback,
         maxInjectTokensOverride: profileConfig.maxInjectTokens,
       })
     : { text: '' };
@@ -119,10 +122,18 @@ export async function prepareMemoryContext(
         maxInjectTokens: dynamicBudgetConfig.maxInjectTokens,
       })
     : undefined;
+  // Build scope policy override for non-default scopes so retrieval
+  // honours the session's memory policy regardless of the global config.
+  const scopePolicyOverride: ScopePolicyOverride | undefined =
+    ctx.scopeId !== 'default'
+      ? { scopeId: ctx.scopeId, fallbackToDefault: ctx.includeDefaultFallback }
+      : undefined;
+
   const recall = await buildMemoryRecall(recallQuery, ctx.conversationId, runtimeConfig, {
     excludeMessageIds: [userMessageId],
     signal: abortSignal,
     maxInjectTokensOverride: recallBudget,
+    scopePolicyOverride,
   });
   const memoryStatus = getMemoryConflictAndCleanupStats();
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -717,6 +717,7 @@ export class Session {
           provider: this.provider,
           conflictGate: this.conflictGate,
           scopeId: this.memoryPolicy.scopeId,
+          includeDefaultFallback: this.memoryPolicy.includeDefaultFallback,
         },
         content,
         userMessageId,


### PR DESCRIPTION
## Summary
- Wire `SessionMemoryPolicy` fields (`scopeId`, `includeDefaultFallback`) through `prepareMemoryContext` to the profile compiler and memory retrieval pipeline.
- Private thread sessions now pass a `ScopePolicyOverride` to `buildMemoryRecall`, ensuring retrieval honours the per-session scope regardless of global config.
- Profile compiler receives scope fields so dynamic profile queries are scope-aware with optional default fallback.
- Add two new tests verifying private thread uses private scope + default fallback, and standard thread uses default scope without fallback.

## Test plan
- [x] `bun test src/__tests__/session-profile-injection.test.ts` — 8/8 pass (includes 2 new tests)
- [x] `bun test src/__tests__/session-conflict-gate.test.ts` — 20/20 pass (no regressions)
- [x] `bun test src/__tests__/profile-compiler.test.ts` — 7/7 pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
