### PR TITLE
feat: sidebar visual distinction for private threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -408,6 +408,11 @@ struct MainWindowView: View {
                         .foregroundColor(VColor.textMuted)
                         .rotationEffect(.degrees(-45))
                 }
+                if thread.kind == .private {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(VColor.accent.opacity(0.7))
+                }
                 Text(thread.title)
                     .font(.system(size: 13))
                     .foregroundColor(VColor.textPrimary)
@@ -417,7 +422,15 @@ struct MainWindowView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
-            .background(isSelected || isHoveredThread == thread.id ? VColor.hoverOverlay.opacity(0.08) : Color.clear)
+            .background {
+                if isSelected || isHoveredThread == thread.id {
+                    VColor.hoverOverlay.opacity(0.08)
+                } else if thread.kind == .private {
+                    VColor.accent.opacity(0.04)
+                } else {
+                    Color.clear
+                }
+            }
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }


### PR DESCRIPTION
## Summary
- Adds a `lock.fill` icon (accent-tinted) next to the thread title for private threads in the sidebar
- Applies a subtle accent background tint (`VColor.accent.opacity(0.04)`) to private thread rows when not selected/hovered
- Selection and hover states remain unchanged for readability and accessibility

## Context
Part of the private threads feature rollout (PR 37 of 39). Builds on PR 32 (ThreadKind enum) and PR 36 (private thread creation in settings).

## Test plan
- [ ] Verify private threads show a lock icon in the sidebar thread list
- [ ] Verify private thread rows have a subtle violet-tinted background when not selected
- [ ] Verify selection and hover states still work correctly on private thread rows
- [ ] Verify standard threads are visually unchanged
- [ ] Verify pinned private threads show both the pin and lock icons

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
