### PR TITLE
fix: exempt bundled skill tools from interactive permission prompts

### DIFF
--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -165,6 +165,7 @@ export function projectSkillTools(
       skillId,
       skill.directoryPath,
       currentHash,
+      skill.bundled,
     );
 
     if (tools.length > 0) {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -370,12 +370,12 @@ export async function check(
 
   // No matching rule (or High risk with allow rule) → risk-based fallback
 
-  // Skill-origin tools default to prompting when no trust rule matches,
-  // regardless of risk level. This ensures third-party skill tools don't
-  // silently auto-execute even when classified as Low risk.
+  // Third-party skill-origin tools default to prompting when no trust rule
+  // matches, regardless of risk level. Bundled skill tools are first-party
+  // and trusted, so they fall through to the normal risk-based policy.
   if (!matchedRule) {
     const tool = getTool(toolName);
-    if (tool?.origin === 'skill') {
+    if (tool?.origin === 'skill' && !tool.ownerSkillBundled) {
       return { decision: 'prompt', reason: 'Skill tool: requires approval by default' };
     }
   }

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -20,6 +20,7 @@ export function createSkillTool(
   skillId: string,
   skillDir: string,
   versionHash: string,
+  bundled?: boolean,
 ): Tool {
   return {
     name: entry.name,
@@ -30,6 +31,7 @@ export function createSkillTool(
     ownerSkillId: skillId,
     executionTarget: entry.execution_target as ExecutionTarget,
     ownerSkillVersionHash: versionHash,
+    ownerSkillBundled: bundled,
 
     getDefinition(): ToolDefinition {
       return {
@@ -56,6 +58,7 @@ export function createSkillToolsFromManifest(
   skillId: string,
   skillDir: string,
   versionHash: string,
+  bundled?: boolean,
 ): Tool[] {
-  return entries.map(entry => createSkillTool(entry, skillId, skillDir, versionHash));
+  return entries.map(entry => createSkillTool(entry, skillId, skillDir, versionHash, bundled));
 }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -158,6 +158,8 @@ export interface Tool {
   ownerSkillId?: string;
   /** Content-hash of the owning skill's source at registration time. */
   ownerSkillVersionHash?: string;
+  /** Whether the owning skill is bundled with the daemon (trusted first-party). */
+  ownerSkillBundled?: boolean;
   /** Declared execution target from the skill manifest. Used by resolveExecutionTarget
    * to accurately label lifecycle events for skill-provided tools. */
   executionTarget?: ExecutionTarget;


### PR DESCRIPTION
Addresses feedback from PR #3964. When app tools were moved from core to the bundled app-builder skill, the permission checker started treating them as third-party skill tools requiring interactive prompts. This caused timeouts/denials for previously non-interactive flows. The fix threads the skill's `bundled` flag through to the Tool object so the permission checker can distinguish first-party bundled skill tools from third-party ones and apply normal risk-based policy instead of force-prompting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
