### PR TITLE
feat: enforce navigation policy + popup blocking in inline video webview

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -12,6 +12,7 @@ struct InlineVideoWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let webView = Self.makeConfiguredWebView()
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         return webView
     }
 
@@ -36,7 +37,42 @@ struct InlineVideoWebView: NSViewRepresentable {
         return webView
     }
 
-    class Coordinator: NSObject, WKNavigationDelegate {
-        // Navigation policy will be added in a later PR
+    class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+
+        // MARK: - WKNavigationDelegate
+
+        /// Only allow programmatic/iframe loads (navigationType == .other) which cover the
+        /// initial embed load and any in-player iframe navigations. All user-initiated
+        /// navigations (link clicks, form submissions, etc.) are blocked and opened
+        /// externally so the webview stays locked to the video player.
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            switch navigationAction.navigationType {
+            case .other:
+                // Programmatic loads — initial embed request + iframe navigations
+                decisionHandler(.allow)
+            default:
+                // User-initiated navigation — open in the default browser instead
+                if let url = navigationAction.request.url {
+                    NSWorkspace.shared.open(url)
+                }
+                decisionHandler(.cancel)
+            }
+        }
+
+        // MARK: - WKUIDelegate
+
+        /// Block all popup windows by returning nil.
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            nil
+        }
     }
 }

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewNavigationTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewNavigationTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import WebKit
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineVideoWebViewNavigationTests: XCTestCase {
+
+    // MARK: - Delegate conformance
+
+    func testCoordinatorConformsToWKNavigationDelegate() {
+        let coordinator = InlineVideoWebView.Coordinator()
+        XCTAssertTrue(coordinator is WKNavigationDelegate)
+    }
+
+    func testCoordinatorConformsToWKUIDelegate() {
+        let coordinator = InlineVideoWebView.Coordinator()
+        XCTAssertTrue(coordinator is WKUIDelegate)
+    }
+
+    // MARK: - Popup blocking
+
+    func testCreateWebViewReturnsNil() {
+        let coordinator = InlineVideoWebView.Coordinator()
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+
+        let action = WKNavigationAction()
+        let features = WKWindowFeatures()
+
+        let result = coordinator.webView(
+            webView,
+            createWebViewWith: config,
+            for: action,
+            windowFeatures: features
+        )
+
+        XCTAssertNil(result, "Popup windows should be blocked by returning nil")
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `WKNavigationDelegate.decidePolicyFor` in `InlineVideoWebView.Coordinator` to only allow programmatic/iframe loads (`navigationType == .other`); all user-initiated navigations are blocked and opened in the default browser via `NSWorkspace.shared.open(url)`.
- Implements `WKUIDelegate.createWebViewWith` returning `nil` to block all popup windows.
- Sets `webView.uiDelegate = context.coordinator` in `makeNSView`.

## Test plan
- [x] `testCoordinatorConformsToWKNavigationDelegate` — verifies delegate conformance
- [x] `testCoordinatorConformsToWKUIDelegate` — verifies delegate conformance
- [x] `testCreateWebViewReturnsNil` — verifies popup blocking returns nil

All 3 tests pass: `swift test --filter InlineVideoWebViewNavigationTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
