### PR TITLE
fix: update starter-task test assertion from app_update to app_file_edit

### DIFF
--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -66,9 +66,9 @@ describe('buildStarterTaskPlaybookSection', () => {
     expect(section).toContain('user_selected');
   });
 
-  test('make_it_yours uses app_update instead of invalid ui_show config_update', () => {
+  test('make_it_yours uses app_file_edit instead of invalid ui_show config_update', () => {
     const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain('app_update');
+    expect(section).toContain('app_file_edit');
     expect(section).not.toContain('config_update');
     expect(section).not.toContain('surface_type: "config_update"');
   });


### PR DESCRIPTION
Addresses feedback from PR #3982. Updates the onboarding starter tasks test to assert app_file_edit instead of app_update, matching the system prompt change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
