### PR TITLE
feat: ToolContext exposes session memory scope

### DIFF
--- a/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
@@ -65,6 +65,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
     enqueueMessage: () => ({ queued: false, requestId: 'r' }),
     getQueueDepth: () => 0,
     processMessage: async () => '',
+    memoryPolicy: { scopeId: 'default' },
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/session-tool-setup-memory-scope.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-memory-scope.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests that createToolExecutor propagates memoryScopeId from the session's
+ * memory policy into the ToolContext passed to the underlying executor.
+ */
+
+import { describe, test, expect, mock } from 'bun:test';
+import type { ToolExecutionResult, ToolContext } from '../tools/types.js';
+import type { ToolSetupContext } from '../daemon/session-tool-setup.js';
+import type { SurfaceType, SurfaceData } from '../daemon/ipc-protocol.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module('../daemon/session-surfaces.js', () => ({
+  refreshSurfacesForApp: mock(() => {}),
+  surfaceProxyResolver: mock(() => Promise.resolve({ content: '', isError: false })),
+}));
+
+mock.module('../services/published-app-updater.js', () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+
+mock.module('../tools/browser/browser-screencast.js', () => ({
+  registerSessionSender: mock(() => {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { createToolExecutor } from '../daemon/session-tool-setup.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
+  return {
+    conversationId: 'conv-scope',
+    currentRequestId: 'req-1',
+    workingDir: '/tmp/test',
+    abortController: null,
+    traceEmitter: { emit: () => {} },
+    sendToClient: mock(() => {}),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>(),
+    surfaceUndoStacks: new Map(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: 'r' }),
+    getQueueDepth: () => 0,
+    processMessage: async () => '',
+    memoryPolicy: { scopeId: 'default' },
+    ...overrides,
+  };
+}
+
+/** Executor spy that captures the ToolContext passed to execute(). */
+function makeCapturingExecutor(result: ToolExecutionResult = { content: 'ok', isError: false }) {
+  let captured: ToolContext | undefined;
+  return {
+    executor: {
+      execute: mock(async (_name: string, _input: Record<string, unknown>, ctx: ToolContext) => {
+        captured = ctx;
+        return result;
+      }),
+    },
+    getCaptured: () => captured,
+  };
+}
+
+const noopPrompter = { prompt: mock(async () => ({ decision: 'allow' as const })) } as any;
+const noopSecretPrompter = { prompt: mock(async () => ({ cancelled: true })) } as any;
+const noopLifecycleHandler = mock(() => {});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('session-tool-setup memoryScopeId propagation', () => {
+  test('passes default memoryScopeId to executor context', async () => {
+    const ctx = makeCtx({ memoryPolicy: { scopeId: 'default' } });
+    const { executor, getCaptured } = makeCapturingExecutor();
+
+    const toolFn = createToolExecutor(
+      executor as any,
+      noopPrompter,
+      noopSecretPrompter,
+      ctx,
+      noopLifecycleHandler,
+    );
+
+    await toolFn('some_tool', { key: 'value' });
+
+    expect(getCaptured()).toBeDefined();
+    expect(getCaptured()!.memoryScopeId).toBe('default');
+  });
+
+  test('passes custom memoryScopeId from session memory policy', async () => {
+    const ctx = makeCtx({ memoryPolicy: { scopeId: 'private-thread-abc' } });
+    const { executor, getCaptured } = makeCapturingExecutor();
+
+    const toolFn = createToolExecutor(
+      executor as any,
+      noopPrompter,
+      noopSecretPrompter,
+      ctx,
+      noopLifecycleHandler,
+    );
+
+    await toolFn('memory_write', { content: 'test' });
+
+    expect(getCaptured()!.memoryScopeId).toBe('private-thread-abc');
+  });
+
+  test('reads memoryScopeId at call time, not construction time', async () => {
+    const ctx = makeCtx({ memoryPolicy: { scopeId: 'initial' } });
+    const { executor, getCaptured } = makeCapturingExecutor();
+
+    const toolFn = createToolExecutor(
+      executor as any,
+      noopPrompter,
+      noopSecretPrompter,
+      ctx,
+      noopLifecycleHandler,
+    );
+
+    // Mutate the memory policy after construction
+    ctx.memoryPolicy = { scopeId: 'updated-scope' };
+
+    await toolFn('some_tool', {});
+
+    expect(getCaptured()!.memoryScopeId).toBe('updated-scope');
+  });
+});

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -41,6 +41,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   abortController: AbortController | null;
   /** When set, only tools in this set may execute during the current turn. */
   allowedToolNames?: Set<string>;
+  /** Session memory policy — used to propagate scopeId into ToolContext. */
+  memoryPolicy: { scopeId: string };
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -89,6 +91,7 @@ export function createToolExecutor(
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,
       allowedToolNames: ctx.allowedToolNames,
+      memoryScopeId: ctx.memoryPolicy.scopeId,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => ctx.sendToClient(msg as any),
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -126,6 +126,8 @@ export interface ToolContext {
   }) => Promise<SecretPromptResult>;
   /** Optional callback to send a message to the connected IPC client (e.g. open_url). */
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
+  /** Memory scope ID from the session's memory policy, so memory tools can target the correct scope. */
+  memoryScopeId?: string;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Add `memoryScopeId?: string` to the `ToolContext` interface in `types.ts`
- Add `memoryPolicy: { scopeId: string }` to `ToolSetupContext` interface in `session-tool-setup.ts`
- Populate `memoryScopeId` from `ctx.memoryPolicy.scopeId` at tool invocation time (not construction time) so memory tools can operate on the correct session scope
- Add tests verifying default scope, custom scope, and late-binding behavior

## Test plan
- [x] New test file `session-tool-setup-memory-scope.test.ts` with 3 tests covering default scope, custom scope, and live reads at call time
- [x] Existing `session-tool-setup-app-refresh.test.ts` updated with `memoryPolicy` in ctx stub — all 18 tests pass
- [x] `tool-executor.test.ts` — 47 tests pass (no regressions)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
