### PR TITLE
fix: constrain threadType to union type and update ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -986,7 +986,7 @@ graph LR
         C1["cu_session_create<br/>task, attachments"]
         C2["cu_observation<br/>axTree, axDiff, screenshot,<br/>secondaryWindows, result/error,<br/>axTreeBlob?, screenshotBlob?"]
         C3["ambient_observation<br/>screenContent, requestId"]
-        C4["session_create<br/>title"]
+        C4["session_create<br/>title, threadType?"]
         C5["user_message<br/>text, attachments"]
         C6["confirmation_response<br/>decision"]
         C7["cancel / undo"]
@@ -1017,6 +1017,8 @@ graph LR
         S15["trace_event<br/>eventId, sessionId, requestId?,<br/>timestampMs, sequence, kind,<br/>status?, summary, attributes?"]
         S16["session_error<br/>sessionId, code,<br/>userMessage, retryable,<br/>debugDetails?"]
         S17["ipc_blob_probe_result<br/>probeId, ok,<br/>observedNonceSha256?, reason?"]
+        S18["session_info<br/>sessionId, title,<br/>correlationId?, threadType?"]
+        S19["session_list_response<br/>sessions[]: id, title,<br/>updatedAt, threadType?"]
     end
 
     C0 --> SOCKET
@@ -1049,6 +1051,8 @@ graph LR
     SOCKET --> S15
     SOCKET --> S16
     SOCKET --> S17
+    SOCKET --> S18
+    SOCKET --> S19
 ```
 
 ---

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -18,6 +18,7 @@ import type {
   UsageRequest,
   SandboxSetRequest,
   ServerMessage,
+  ThreadType,
 } from '../ipc-protocol.js';
 import { getConfig } from '../../config/loader.js';
 import {
@@ -196,7 +197,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext): void
       id: c.id,
       title: c.title ?? 'Untitled',
       updatedAt: c.updatedAt,
-      threadType: c.threadType,
+      threadType: c.threadType as ThreadType,
     })),
   });
 }
@@ -218,7 +219,7 @@ export async function handleSessionCreate(
 ): Promise<void> {
   const conversation = conversationStore.createConversation({
     title: msg.title ?? 'New Conversation',
-    threadType: msg.threadType as 'standard' | 'private' | undefined,
+    threadType: msg.threadType,
   });
   const session = await ctx.getOrCreateSession(conversation.id, socket, true, {
     systemPromptOverride: msg.systemPromptOverride,
@@ -238,7 +239,7 @@ export async function handleSessionCreate(
     sessionId: conversation.id,
     title: conversation.title ?? 'New Conversation',
     ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
-    threadType: conversation.threadType,
+    threadType: conversation.threadType as ThreadType,
   });
 
   // Auto-send the initial message if provided, kick-starting the skill.
@@ -275,7 +276,7 @@ export async function handleSessionSwitch(
     type: 'session_info',
     sessionId: conversation.id,
     title: conversation.title ?? 'Untitled',
-    threadType: conversation.threadType,
+    threadType: conversation.threadType as ThreadType,
   });
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -2,6 +2,8 @@ import type { GalleryManifest } from '../gallery/gallery-manifest.js';
 
 // === Shared types ===
 
+export type ThreadType = 'standard' | 'private';
+
 export interface IpcBlobRef {
   id: string;
   kind: 'ax_tree' | 'screenshot_jpeg';
@@ -73,7 +75,7 @@ export interface SessionCreateRequest {
   maxResponseTokens?: number;
   correlationId?: string;
   transport?: SessionTransportMetadata;
-  threadType?: 'standard' | 'private';
+  threadType?: ThreadType;
   /** Skill IDs to pre-activate in the new session (loaded before the first message). */
   preactivatedSkillIds?: string[];
   /** If provided, automatically sent as the first user message after session creation. */
@@ -860,12 +862,12 @@ export interface SessionInfo {
   sessionId: string;
   title: string;
   correlationId?: string;
-  threadType?: string;
+  threadType?: ThreadType;
 }
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: string }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType }>;
 }
 
 export interface SessionsClearResponse {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -25,6 +25,7 @@ import {
   MAX_LINE_SIZE,
   type ClientMessage,
   type ServerMessage,
+  type ThreadType,
 } from './ipc-protocol.js';
 import { validateClientMessage } from './ipc-validate.js';
 import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
@@ -681,7 +682,7 @@ export class DaemonServer {
       type: 'session_info',
       sessionId: conversation.id,
       title: conversation.title ?? 'New Conversation',
-      threadType: conversation.threadType,
+      threadType: conversation.threadType as ThreadType,
     });
 
     this.send(socket, {


### PR DESCRIPTION
Addresses feedback from PR #3973. Creates a shared ThreadType = 'standard' | 'private' type alias used consistently across SessionCreateRequest, SessionInfo, and SessionListResponse. Updates ARCHITECTURE.md to document the new threadType field in session IPC payloads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
