### PR TITLE
fix: accept fractional-second ISO8601 timestamps in enabledSince parsing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -291,7 +291,13 @@ public final class SettingsStore: ObservableObject {
         var enabledSince: Date?
         if let isoString = mediaEmbeds["enabledSince"] as? String {
             let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             enabledSince = formatter.date(from: isoString)
+            // Fall back to parsing without fractional seconds
+            if enabledSince == nil {
+                formatter.formatOptions = [.withInternetDateTime]
+                enabledSince = formatter.date(from: isoString)
+            }
         }
 
         let domains: [String]


### PR DESCRIPTION
Addresses feedback from PR #3993. Adds .withFractionalSeconds to the ISO8601DateFormatter options so timestamps like 2025-06-15T12:00:00.000Z are correctly parsed instead of silently falling back to nil. Includes a fallback parse path for timestamps without fractional seconds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
