### PR TITLE
fix: clean up temp file when replaceItemAt or moveItem throws

### DIFF
--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -82,10 +82,15 @@ public enum WorkspaceConfigIO {
         try data.write(to: tempURL)
 
         // Replace or move into place.
-        if FileManager.default.fileExists(atPath: filePath) {
-            _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
-        } else {
-            try FileManager.default.moveItem(at: tempURL, to: fileURL)
+        do {
+            if FileManager.default.fileExists(atPath: filePath) {
+                _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+            } else {
+                try FileManager.default.moveItem(at: tempURL, to: fileURL)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
         }
     }
 }


### PR DESCRIPTION
Addresses feedback from PR #3979. Wraps the file replace/move operation in a do/catch that removes the temp file before re-throwing, preventing orphaned .tmp files on filesystem errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
