### PR TITLE
fix: remove ? and : from URL trailing punctuation trim set

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -9,7 +9,7 @@ enum MessageURLExtractor {
 
     // Characters that commonly trail a URL in natural prose but aren't
     // part of the URL itself.
-    private static let trailingPunctuationToTrim: CharacterSet = CharacterSet(charactersIn: ".,;:!?)>\"'")
+    private static let trailingPunctuationToTrim: CharacterSet = CharacterSet(charactersIn: ".,;!>\"')")
 
     /// Extracts all distinct `http(s)://` URLs from `text`, returned in
     /// first-occurrence order. Duplicates are suppressed (first wins).

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorPlainTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorPlainTests.swift
@@ -142,6 +142,26 @@ final class MessageURLExtractorPlainTests: XCTestCase {
         XCTAssertEqual(urls.first?.absoluteString, "https://example.com/docs/api/v2/users")
     }
 
+    // MARK: - URL-valid characters not stripped
+
+    func testURLWithPortIsPreserved() {
+        let urls = MessageURLExtractor.extractPlainURLs(from: "Connect to https://example.com:8080/api")
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://example.com:8080/api")
+    }
+
+    func testURLWithQueryParamQuestionMarkPreserved() {
+        let urls = MessageURLExtractor.extractPlainURLs(from: "Open https://example.com/search?q=test now")
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://example.com/search?q=test")
+    }
+
+    func testWikipediaURLWithParensPreserved() {
+        let urls = MessageURLExtractor.extractPlainURLs(from: "See https://en.wikipedia.org/wiki/Swift_(programming_language) for info")
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://en.wikipedia.org/wiki/Swift_(programming_language)")
+    }
+
     // MARK: - Non-HTTP schemes are excluded
 
     func testFTPSchemeIsExcluded() {


### PR DESCRIPTION
Addresses URL trimming feedback from PR #3976. Removes ? and : from the trailingPunctuationToTrim character set in MessageURLExtractor, as these are valid URL characters (query string delimiters, port numbers). Adds test coverage for URLs with ports, query params, and balanced parens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
