### PR TITLE
fix: pass memoryScopeId to memory_search to prevent cross-scope leaks

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -16,6 +16,7 @@ const log = getLogger('memory-tools');
 export async function handleMemorySearch(
   args: Record<string, unknown>,
   config: AssistantConfig,
+  scopeId?: string,
 ): Promise<ToolExecutionResult> {
   const query = args.query;
   if (typeof query !== 'string' || query.trim().length === 0) {
@@ -27,7 +28,7 @@ export async function handleMemorySearch(
     : 5;
 
   try {
-    const results = await searchMemoryItems(query, limit, config);
+    const results = await searchMemoryItems(query, limit, config, scopeId);
 
     if (results.length === 0) {
       return { content: 'No matching memories found.', isError: false };

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -17,9 +17,9 @@ class MemorySearchTool implements Tool {
     return memorySearchDefinition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const config = getConfig();
-    return handleMemorySearch(input, config);
+    return handleMemorySearch(input, config, context.memoryScopeId);
   }
 }
 


### PR DESCRIPTION
## Summary
- Forwards `context.memoryScopeId` from `MemorySearchTool.execute()` through `handleMemorySearch()` to `searchMemoryItems()`, so that the memory_search tool respects the session's memory scope policy.
- When no scope ID is set (default behavior), the search remains unscoped -- preserving backward compatibility.

## Test plan
- [x] All 73 non-experimental memory regression tests pass
- [x] All 3 session-tool-setup-memory-scope tests pass
- [x] TypeScript type check passes for modified files
- [x] Verified `searchMemoryItems` already accepts `scopeId` as optional 4th param

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
