### PR TITLE
feat: add forcePromptSideEffects flag to ToolContext

### DIFF
--- a/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
@@ -65,7 +65,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
     enqueueMessage: () => ({ queued: false, requestId: 'r' }),
     getQueueDepth: () => 0,
     processMessage: async () => '',
-    memoryPolicy: { scopeId: 'default' },
+    memoryPolicy: { scopeId: 'default', strictSideEffects: false },
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/session-tool-setup-side-effect-flag.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-side-effect-flag.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests that createToolExecutor propagates memoryScopeId from the session's
- * memory policy into the ToolContext passed to the underlying executor.
+ * Tests that createToolExecutor propagates forcePromptSideEffects from the
+ * session's memory policy (strictSideEffects) into the ToolContext.
  */
 
 import { describe, test, expect, mock } from 'bun:test';
@@ -37,7 +37,7 @@ import { createToolExecutor } from '../daemon/session-tool-setup.js';
 
 function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
   return {
-    conversationId: 'conv-scope',
+    conversationId: 'conv-side-effect',
     currentRequestId: 'req-1',
     workingDir: '/tmp/test',
     abortController: null,
@@ -79,8 +79,8 @@ const noopLifecycleHandler = mock(() => {});
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('session-tool-setup memoryScopeId propagation', () => {
-  test('passes default memoryScopeId to executor context', async () => {
+describe('session-tool-setup forcePromptSideEffects propagation', () => {
+  test('sets forcePromptSideEffects to false for default sessions', async () => {
     const ctx = makeCtx({ memoryPolicy: { scopeId: 'default', strictSideEffects: false } });
     const { executor, getCaptured } = makeCapturingExecutor();
 
@@ -95,11 +95,11 @@ describe('session-tool-setup memoryScopeId propagation', () => {
     await toolFn('some_tool', { key: 'value' });
 
     expect(getCaptured()).toBeDefined();
-    expect(getCaptured()!.memoryScopeId).toBe('default');
+    expect(getCaptured()!.forcePromptSideEffects).toBe(false);
   });
 
-  test('passes custom memoryScopeId from session memory policy', async () => {
-    const ctx = makeCtx({ memoryPolicy: { scopeId: 'private-thread-abc', strictSideEffects: false } });
+  test('sets forcePromptSideEffects to true for private sessions with strictSideEffects', async () => {
+    const ctx = makeCtx({ memoryPolicy: { scopeId: 'private-thread-123', strictSideEffects: true } });
     const { executor, getCaptured } = makeCapturingExecutor();
 
     const toolFn = createToolExecutor(
@@ -110,12 +110,12 @@ describe('session-tool-setup memoryScopeId propagation', () => {
       noopLifecycleHandler,
     );
 
-    await toolFn('memory_write', { content: 'test' });
+    await toolFn('memory_write', { content: 'secret' });
 
-    expect(getCaptured()!.memoryScopeId).toBe('private-thread-abc');
+    expect(getCaptured()!.forcePromptSideEffects).toBe(true);
   });
 
-  test('reads memoryScopeId at call time, not construction time', async () => {
+  test('reads forcePromptSideEffects at call time, not construction time', async () => {
     const ctx = makeCtx({ memoryPolicy: { scopeId: 'initial', strictSideEffects: false } });
     const { executor, getCaptured } = makeCapturingExecutor();
 
@@ -128,10 +128,10 @@ describe('session-tool-setup memoryScopeId propagation', () => {
     );
 
     // Mutate the memory policy after construction
-    ctx.memoryPolicy = { scopeId: 'updated-scope', strictSideEffects: false };
+    ctx.memoryPolicy = { scopeId: 'initial', strictSideEffects: true };
 
     await toolFn('some_tool', {});
 
-    expect(getCaptured()!.memoryScopeId).toBe('updated-scope');
+    expect(getCaptured()!.forcePromptSideEffects).toBe(true);
   });
 });

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -41,8 +41,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   abortController: AbortController | null;
   /** When set, only tools in this set may execute during the current turn. */
   allowedToolNames?: Set<string>;
-  /** Session memory policy — used to propagate scopeId into ToolContext. */
-  memoryPolicy: { scopeId: string };
+  /** Session memory policy — used to propagate scopeId and strictSideEffects into ToolContext. */
+  memoryPolicy: { scopeId: string; strictSideEffects: boolean };
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -92,6 +92,7 @@ export function createToolExecutor(
       sandboxOverride: ctx.sandboxOverride,
       allowedToolNames: ctx.allowedToolNames,
       memoryScopeId: ctx.memoryPolicy.scopeId,
+      forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => ctx.sendToClient(msg as any),
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -128,6 +128,8 @@ export interface ToolContext {
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
   /** Memory scope ID from the session's memory policy, so memory tools can target the correct scope. */
   memoryScopeId?: string;
+  /** When true, tools with private side-effects should always prompt for confirmation. */
+  forcePromptSideEffects?: boolean;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Adds `forcePromptSideEffects?: boolean` to the `ToolContext` interface in `types.ts`
- Extends `ToolSetupContext.memoryPolicy` to include `strictSideEffects: boolean` and propagates it as `forcePromptSideEffects` in `createToolExecutor`
- Adds tests verifying the flag is correctly propagated for default and private sessions, and that it reads at call time (not construction time)
- Updates existing test files to include `strictSideEffects` in `memoryPolicy` to match the updated type

## Test plan
- [x] New test file `session-tool-setup-side-effect-flag.test.ts` with 3 tests covering default, private, and call-time reads
- [x] Existing `session-tool-setup-memory-scope.test.ts` tests still pass (4 assertions)
- [x] Existing `session-tool-setup-app-refresh.test.ts` tests still pass (66 assertions)
- [x] TypeScript type-check passes for all modified files

This is an execution flag only — no behavior change yet. Downstream PRs will use it to gate side-effect operations in private sessions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
