### PR TITLE
fix: don't cache transient probe failures as .unknown

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
@@ -56,7 +56,7 @@ final class ImageMIMEProbe {
             }
             result = contentType.hasPrefix("image/") ? .image : .notImage
         } catch {
-            result = .unknown
+            return .unknown  // Don't cache — allow retry on transient failures
         }
 
         cache.setObject(CacheEntry(result), forKey: key)


### PR DESCRIPTION
Addresses feedback from PR #3995. Returns .unknown immediately on network errors without caching, so URLs can be re-probed on subsequent attempts instead of being permanently classified as unknown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
