### PR TITLE
fix: validate YouTube video ID characters before constructing embed URL

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
@@ -40,6 +40,11 @@ enum YouTubeParser {
 
         guard let id = videoID, !id.isEmpty else { return nil }
 
+        // YouTube video IDs only contain alphanumerics, dashes, and underscores.
+        // Reject anything else to prevent path traversal or fragment injection.
+        let validIDCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        guard id.unicodeScalars.allSatisfy({ validIDCharacters.contains($0) }) else { return nil }
+
         guard let embedURL = URL(string: "https://www.youtube.com/embed/\(id)") else {
             return nil
         }


### PR DESCRIPTION
Addresses feedback from PR #3992. Validates that YouTube video IDs only contain safe characters (alphanumeric, dash, underscore) before interpolating into the embed URL, preventing path traversal and fragment injection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
