### PR TITLE
feat: add offscreen teardown for inline video embed webviews

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -43,6 +43,13 @@ struct InlineVideoEmbedCard: View {
         .frame(maxWidth: .infinity)
         .frame(height: isExpanded ? 315 : 180)
         .animation(.easeInOut(duration: 0.25), value: isExpanded)
+        .onDisappear {
+            // Tear down active/loading webviews when scrolled offscreen
+            // to prevent memory leaks and background audio playback.
+            if stateManager.state == .playing || stateManager.state == .initializing {
+                stateManager.reset()
+            }
+        }
     }
 
     // MARK: - State-driven content

--- a/clients/macos/vellum-assistantTests/InlineVideoOffscreenTeardownTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoOffscreenTeardownTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineVideoOffscreenTeardownTests: XCTestCase {
+
+    private var sut: InlineVideoEmbedStateManager!
+
+    override func setUp() {
+        super.setUp()
+        sut = InlineVideoEmbedStateManager()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Reset from playing
+
+    func testResetFromPlayingReturnsToPlaceholder() {
+        sut.requestPlay()
+        sut.didStartPlaying()
+        XCTAssertEqual(sut.state, .playing)
+
+        sut.reset()
+        XCTAssertEqual(sut.state, .placeholder)
+    }
+
+    // MARK: - Reset from initializing
+
+    func testResetFromInitializingReturnsToPlaceholder() {
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .initializing)
+
+        sut.reset()
+        XCTAssertEqual(sut.state, .placeholder)
+    }
+
+    // MARK: - Reset from placeholder (no-op)
+
+    func testResetFromPlaceholderRemainsPlaceholder() {
+        XCTAssertEqual(sut.state, .placeholder)
+
+        sut.reset()
+        XCTAssertEqual(sut.state, .placeholder)
+    }
+
+    // MARK: - Reset from failed
+
+    func testResetFromFailedReturnsToPlaceholder() {
+        sut.didFail("Load error")
+        XCTAssertEqual(sut.state, .failed("Load error"))
+
+        sut.reset()
+        XCTAssertEqual(sut.state, .placeholder)
+    }
+
+    // MARK: - Full lifecycle: play → teardown → replay
+
+    func testPlayTeardownReplayCycle() {
+        // First play cycle
+        sut.requestPlay()
+        sut.didStartPlaying()
+        XCTAssertEqual(sut.state, .playing)
+
+        // Simulate offscreen teardown
+        sut.reset()
+        XCTAssertEqual(sut.state, .placeholder)
+
+        // Replay after scrolling back onscreen
+        sut.requestPlay()
+        XCTAssertEqual(sut.state, .initializing)
+
+        sut.didStartPlaying()
+        XCTAssertEqual(sut.state, .playing)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `.onDisappear` modifier to `InlineVideoEmbedCard` that resets active or initializing video players back to the placeholder state when scrolled offscreen
- This removes the webview from the view tree, stopping playback and freeing resources to prevent memory leaks and background audio
- Add `InlineVideoOffscreenTeardownTests` covering reset from all states and a full play-teardown-replay lifecycle

## Test plan
- [x] `swift test --filter InlineVideoOffscreenTeardownTests` — 5 tests pass
- [ ] Manual: scroll a playing video offscreen, verify playback stops and state resets to placeholder
- [ ] Manual: scroll back onscreen, verify tapping play restarts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
