### PR TITLE
fix: assert embed intent checks specific URL, not just non-empty surfaces

### DIFF
--- a/clients/macos/vellum-assistantTests/TestSupport/ChatMediaTestHarness.swift
+++ b/clients/macos/vellum-assistantTests/TestSupport/ChatMediaTestHarness.swift
@@ -136,21 +136,20 @@ enum ChatMediaAssertions {
         )
     }
 
-    /// Asserts that the message has an inline surface whose ID or type indicates
-    /// an embed intent for the given URL. This is a placeholder that will gain
-    /// real logic once embed surfaces are introduced in later PRs.
+    /// Asserts that the message has an inline surface whose ID contains the
+    /// given URL, indicating an embed intent for that specific resource.
     static func assertContainsEmbedIntent(
         _ url: String,
         in message: ChatMessage,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        // Future PRs will check for a specific InlineSurfaceData entry
-        // whose embed URL matches `url`. For now, verify the surface list
-        // is non-empty as a structural stand-in.
-        XCTAssertFalse(
-            message.inlineSurfaces.isEmpty,
-            "Expected at least one inline surface (embed intent) for URL \"\(url)\" but found none",
+        let match = message.inlineSurfaces.contains { surface in
+            surface.id.contains(url)
+        }
+        XCTAssertTrue(
+            match,
+            "Expected an inline surface with ID containing URL \"\(url)\" but found: \(message.inlineSurfaces.map(\.id))",
             file: file,
             line: line
         )


### PR DESCRIPTION
Addresses feedback from PR #3966. Updates assertContainsEmbedIntent to verify the URL parameter matches an inline surface ID, rather than just checking that inlineSurfaces is non-empty.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
