### PR TITLE
feat: thread scopeId from extraction job into item extractor

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3366,4 +3366,41 @@ describe('Memory regressions', () => {
       : 'default';
     expect(resolvedScope).toBe('default');
   });
+
+  // PR-19: extractItemsJob forwards scopeId to extractAndUpsertMemoryItemsForMessage
+  test('extractAndUpsertMemoryItemsForMessage accepts optional scopeId without breaking', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(conversations).values({
+      id: 'conv-scope-pass',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      threadType: 'standard',
+      memoryScopeId: 'default',
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-scope-pass',
+      conversationId: 'conv-scope-pass',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'I prefer TypeScript over JavaScript for all new projects.' }]),
+      createdAt: now,
+    }).run();
+
+    // Call without scopeId — backward compat: should work exactly as before
+    const withoutScope = await extractAndUpsertMemoryItemsForMessage('msg-scope-pass');
+    expect(withoutScope).toBeGreaterThan(0);
+
+    // Call with explicit scopeId — should also succeed (scopeId is threaded but not yet used)
+    db.insert(messages).values({
+      id: 'msg-scope-pass-2',
+      conversationId: 'conv-scope-pass',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'I dislike using var in JavaScript, prefer const and let.' }]),
+      createdAt: now + 1,
+    }).run();
+    const withScope = await extractAndUpsertMemoryItemsForMessage('msg-scope-pass-2', 'private:thread-42');
+    expect(withScope).toBeGreaterThan(0);
+  });
 });

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -222,7 +222,7 @@ async function extractItemsWithLLM(
 
 // ── Public API ─────────────────────────────────────────────────────────
 
-export async function extractAndUpsertMemoryItemsForMessage(messageId: string): Promise<number> {
+export async function extractAndUpsertMemoryItemsForMessage(messageId: string, scopeId?: string): Promise<number> {
   const db = getDb();
   const message = db
     .select({

--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -25,7 +25,7 @@ export async function extractItemsJob(job: MemoryJob): Promise<void> {
   const scopeId = typeof job.payload.scopeId === 'string' && job.payload.scopeId
     ? job.payload.scopeId
     : 'default';
-  await extractAndUpsertMemoryItemsForMessage(messageId);
+  await extractAndUpsertMemoryItemsForMessage(messageId, scopeId);
   // Queue entity extraction for this message after items are extracted
   const config = getConfig();
   if (config.memory.entity.enabled) {


### PR DESCRIPTION
## Summary
- Add optional `scopeId` parameter to `extractAndUpsertMemoryItemsForMessage` in `items-extractor.ts`
- Forward the already-parsed `scopeId` from `extractItemsJob` to the item extractor (previously it was parsed but not passed)
- Add backward-compatibility test verifying both no-arg and explicit-scope call paths work

## Context
PR 18 added `scopeId` parsing to the extraction job handler but stopped short of passing it downstream. This PR threads it through so PR 20 can use it to scope items on insert.

## Test plan
- [x] Existing 73 memory regression tests still pass
- [x] New test `extractAndUpsertMemoryItemsForMessage accepts optional scopeId without breaking` passes
- [x] No new TypeScript errors introduced in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
