### PR TITLE
fix: return .unknown for unrecognized image extensions instead of .notImage

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
@@ -44,6 +44,6 @@ enum ImageURLClassifier {
             return .image
         }
 
-        return .notImage
+        return .unknown
     }
 }

--- a/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
+++ b/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
@@ -104,21 +104,21 @@ final class ImageURLClassifierExtensionTests: XCTestCase {
         XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
     }
 
-    // MARK: - Non-image extensions
+    // MARK: - Unrecognized extensions return unknown (eligible for MIME probe)
 
-    func testHTMLReturnsNotImage() {
+    func testHTMLReturnsUnknown() {
         let url = URL(string: "https://example.com/page.html")!
-        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
     }
 
-    func testPDFReturnsNotImage() {
+    func testPDFReturnsUnknown() {
         let url = URL(string: "https://example.com/document.pdf")!
-        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
     }
 
-    func testZIPReturnsNotImage() {
+    func testZIPReturnsUnknown() {
         let url = URL(string: "https://example.com/archive.zip")!
-        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
+        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
     }
 
     // MARK: - No extension returns unknown


### PR DESCRIPTION
Addresses feedback from PR #3990. Returns .unknown for URLs with unrecognized extensions so they can still be probed via HEAD-based MIME detection instead of being prematurely classified as non-images.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
