### PR TITLE
feat: integrate inline video player into chat embed cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -3,15 +3,31 @@ import VellumAssistantShared
 
 /// Card for a video embed that transitions through click-to-play states.
 ///
-/// Shows a play-button placeholder, a loading spinner while initializing,
-/// a "playing" label once active, or an error with retry. Actual WebView
-/// playback will be wired in a later PR.
+/// Shows a play-button placeholder, then builds an embed URL with autoplay
+/// parameters via `VideoEmbedURLBuilder` and displays the video inside an
+/// `InlineVideoWebView`. The card expands to 16:9 aspect ratio when playing.
 struct InlineVideoEmbedCard: View {
     let provider: String
     let videoID: String
     let embedURL: URL
 
     @StateObject private var stateManager = InlineVideoEmbedStateManager()
+
+    /// The embed URL enriched with autoplay/rel query parameters, built on
+    /// first play request. Falls back to the raw `embedURL` if the provider
+    /// is unrecognised by `VideoEmbedURLBuilder`.
+    private var playerURL: URL {
+        VideoEmbedURLBuilder.buildEmbedURL(provider: provider, videoID: videoID) ?? embedURL
+    }
+
+    private var isExpanded: Bool {
+        switch stateManager.state {
+        case .playing, .initializing:
+            return true
+        case .placeholder, .failed:
+            return false
+        }
+    }
 
     var body: some View {
         ZStack {
@@ -25,7 +41,8 @@ struct InlineVideoEmbedCard: View {
             stateContent
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 180)
+        .frame(height: isExpanded ? 315 : 180)
+        .animation(.easeInOut(duration: 0.25), value: isExpanded)
     }
 
     // MARK: - State-driven content
@@ -61,15 +78,18 @@ struct InlineVideoEmbedCard: View {
     }
 
     private var initializingView: some View {
-        ProgressView()
-            .controlSize(.large)
+        // The webview loads asynchronously, so we transition straight to
+        // .playing and let the embedded player handle its own loading UI.
+        InlineVideoWebView(url: playerURL)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .onAppear {
+                stateManager.didStartPlaying()
+            }
     }
 
     private var playingView: some View {
-        // Placeholder for the future WebView player mount point
-        Text("Playing")
-            .font(VFont.caption)
-            .foregroundStyle(VColor.textSecondary)
+        InlineVideoWebView(url: playerURL)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
     private func failedView(_ message: String) -> some View {

--- a/clients/macos/vellum-assistantTests/InlineVideoPlayerIntegrationTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoPlayerIntegrationTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineVideoPlayerIntegrationTests: XCTestCase {
+
+    // MARK: - VideoEmbedURLBuilder correctness
+
+    func testYouTubeBuilderReturnsAutoplayURL() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "dQw4w9WgXcQ")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0"
+        )
+    }
+
+    func testVimeoBuilderReturnsAutoplayURL() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "vimeo", videoID: "76979871")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://player.vimeo.com/video/76979871?autoplay=1"
+        )
+    }
+
+    func testLoomBuilderReturnsAutoplayURL() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "loom", videoID: "abc123def456")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://www.loom.com/embed/abc123def456?autoplay=1"
+        )
+    }
+
+    func testUnknownProviderBuilderReturnsNil() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "unknown", videoID: "xyz")
+        XCTAssertNil(url)
+    }
+
+    // MARK: - State manager end-to-end transitions
+
+    func testStateManagerPlaceholderToPlayingTransition() {
+        let manager = InlineVideoEmbedStateManager()
+        XCTAssertEqual(manager.state, .placeholder)
+
+        manager.requestPlay()
+        XCTAssertEqual(manager.state, .initializing)
+
+        manager.didStartPlaying()
+        XCTAssertEqual(manager.state, .playing)
+    }
+
+    func testStateManagerFailAndRetryTransition() {
+        let manager = InlineVideoEmbedStateManager()
+
+        manager.requestPlay()
+        manager.didFail("Network error")
+        XCTAssertEqual(manager.state, .failed("Network error"))
+
+        // Retry should go back to initializing
+        manager.requestPlay()
+        XCTAssertEqual(manager.state, .initializing)
+
+        manager.didStartPlaying()
+        XCTAssertEqual(manager.state, .playing)
+    }
+
+    func testStateManagerResetFromPlaying() {
+        let manager = InlineVideoEmbedStateManager()
+
+        manager.requestPlay()
+        manager.didStartPlaying()
+        XCTAssertEqual(manager.state, .playing)
+
+        manager.reset()
+        XCTAssertEqual(manager.state, .placeholder)
+    }
+
+    func testStateManagerDoublePlayIsNoOp() {
+        let manager = InlineVideoEmbedStateManager()
+
+        manager.requestPlay()
+        manager.didStartPlaying()
+        XCTAssertEqual(manager.state, .playing)
+
+        // Second requestPlay while already playing should be ignored
+        manager.requestPlay()
+        XCTAssertEqual(manager.state, .playing)
+    }
+
+    // MARK: - InlineVideoEmbedCard instantiation
+
+    func testCardCanBeInstantiatedWithYouTube() {
+        let url = URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ")!
+        let card = InlineVideoEmbedCard(
+            provider: "youtube",
+            videoID: "dQw4w9WgXcQ",
+            embedURL: url
+        )
+
+        XCTAssertEqual(card.provider, "youtube")
+        XCTAssertEqual(card.videoID, "dQw4w9WgXcQ")
+        XCTAssertEqual(card.embedURL, url)
+    }
+
+    func testCardCanBeInstantiatedWithVimeo() {
+        let url = URL(string: "https://player.vimeo.com/video/76979871")!
+        let card = InlineVideoEmbedCard(
+            provider: "vimeo",
+            videoID: "76979871",
+            embedURL: url
+        )
+
+        XCTAssertEqual(card.provider, "vimeo")
+        XCTAssertEqual(card.videoID, "76979871")
+        XCTAssertEqual(card.embedURL, url)
+    }
+
+    func testCardCanBeInstantiatedWithLoom() {
+        let url = URL(string: "https://www.loom.com/embed/abc123def456")!
+        let card = InlineVideoEmbedCard(
+            provider: "loom",
+            videoID: "abc123def456",
+            embedURL: url
+        )
+
+        XCTAssertEqual(card.provider, "loom")
+        XCTAssertEqual(card.videoID, "abc123def456")
+        XCTAssertEqual(card.embedURL, url)
+    }
+
+    // MARK: - Builder + Card integration
+
+    func testBuilderURLMatchesExpectedFormatForCard() {
+        // Verify the URL the card would use for playback matches what
+        // VideoEmbedURLBuilder produces for each provider.
+        let providers: [(String, String, String)] = [
+            ("youtube", "testVid1", "https://www.youtube.com/embed/testVid1?autoplay=1&rel=0"),
+            ("vimeo", "12345", "https://player.vimeo.com/video/12345?autoplay=1"),
+            ("loom", "aaaabbbb", "https://www.loom.com/embed/aaaabbbb?autoplay=1"),
+        ]
+
+        for (provider, videoID, expectedString) in providers {
+            let builtURL = VideoEmbedURLBuilder.buildEmbedURL(provider: provider, videoID: videoID)
+            XCTAssertNotNil(builtURL, "Expected non-nil URL for provider \(provider)")
+            XCTAssertEqual(builtURL?.absoluteString, expectedString)
+        }
+    }
+
+    func testCardFallsBackToEmbedURLForUnknownProvider() {
+        // When VideoEmbedURLBuilder returns nil for an unknown provider,
+        // the card should use the raw embedURL as a fallback.
+        let fallbackURL = URL(string: "https://custom.example.com/embed/vid99")!
+        let result = VideoEmbedURLBuilder.buildEmbedURL(provider: "custom", videoID: "vid99")
+
+        // Builder returns nil for unknown providers
+        XCTAssertNil(result)
+
+        // Card can still be created — it will use fallbackURL at render time
+        let card = InlineVideoEmbedCard(
+            provider: "custom",
+            videoID: "vid99",
+            embedURL: fallbackURL
+        )
+        XCTAssertEqual(card.embedURL, fallbackURL)
+    }
+}


### PR DESCRIPTION
## Summary
- Wires `InlineVideoWebView` into `InlineVideoEmbedCard` so clicking the play button loads the provider embed URL inside a WKWebView.
- Uses `VideoEmbedURLBuilder.buildEmbedURL(provider:videoID:)` to construct autoplay-enabled embed URLs, with fallback to the raw `embedURL` for unknown providers.
- The `.initializing` state immediately transitions to `.playing` (the webview handles its own async loading internally).
- Card height expands from 180pt to 315pt (~16:9 aspect ratio) when playing/initializing, with a smooth 0.25s ease-in-out animation.
- Adds `InlineVideoPlayerIntegrationTests` (13 tests) covering URL builder correctness, state manager transitions, card instantiation, and builder+card integration.

## Test plan
- [x] `swift test --filter InlineVideoPlayerIntegrationTests` — 13/13 pass
- [ ] Manual: click play on YouTube/Vimeo/Loom cards in chat, verify video loads and card expands
- [ ] Manual: verify retry from failed state re-initializes the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
