### PR TITLE
fix: validate Vimeo IDs with ASCII digits only

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/VimeoParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/VimeoParser.swift
@@ -35,7 +35,7 @@ enum VimeoParser {
         guard let id = videoID, !id.isEmpty else { return nil }
 
         // Vimeo video IDs are strictly numeric
-        guard id.allSatisfy(\.isNumber) else { return nil }
+        guard id.allSatisfy({ $0.isASCII && $0.isNumber }) else { return nil }
 
         guard let embedURL = URL(string: "https://player.vimeo.com/video/\(id)") else {
             return nil


### PR DESCRIPTION
Addresses feedback from PR #3996. Adds .isASCII check to Vimeo video ID validation so non-ASCII Unicode numerals (vulgar fractions, superscripts, etc.) are rejected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
