### PR TITLE
fix: enforce exact Loom path shape before extracting video ID

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/LoomParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/LoomParser.swift
@@ -23,7 +23,7 @@ enum LoomParser {
         let pathComponents = url.pathComponents.filter { $0 != "/" }
 
         // Expect ["share"|"embed", VIDEO_ID]
-        guard pathComponents.count >= 2,
+        guard pathComponents.count == 2,
               ["share", "embed"].contains(pathComponents[0]),
               !pathComponents[1].isEmpty else { return nil }
 

--- a/clients/macos/vellum-assistantTests/LoomParserTests.swift
+++ b/clients/macos/vellum-assistantTests/LoomParserTests.swift
@@ -130,6 +130,20 @@ final class LoomParserTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    // MARK: - Extra path segments return nil
+
+    func testExtraPathSegmentsReturnNil() {
+        let url = URL(string: "https://www.loom.com/share/abc123def456/extra")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
+    func testEmbedWithExtraPathSegmentsReturnNil() {
+        let url = URL(string: "https://www.loom.com/embed/abc123/extra/segments")!
+        let result = LoomParser.parse(url)
+        XCTAssertNil(result)
+    }
+
     // MARK: - Embed URL is canonical for all input formats
 
     func testEmbedURLIsCanonicalForAllFormats() {


### PR DESCRIPTION
Addresses feedback from PR #3999. Validates that Loom URLs have exactly the expected path segment count (/share/ID or /embed/ID) to prevent misclassifying URLs with extra path components.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
