### PR TITLE
feat: memory_save scoped writes + fingerprint salting

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -559,6 +559,43 @@ describe('Memory regressions', () => {
     expect(saved!.verificationState).toBe('user_confirmed');
   });
 
+  test('memory_save in different scopes creates separate items', async () => {
+    const { handleMemorySave } = await import('../tools/memory/handlers.js');
+
+    const sharedArgs = { statement: 'I prefer dark mode', kind: 'preference' };
+
+    // Save in the default scope
+    const r1 = await handleMemorySave(sharedArgs, DEFAULT_CONFIG, 'conv-scope-1', 'msg-scope-1', 'default');
+    expect(r1.isError).toBe(false);
+    expect(r1.content).toContain('Saved to memory');
+
+    // Save the identical statement in a private scope
+    const r2 = await handleMemorySave(sharedArgs, DEFAULT_CONFIG, 'conv-scope-2', 'msg-scope-2', 'private-abc');
+    expect(r2.isError).toBe(false);
+    expect(r2.content).toContain('Saved to memory');
+
+    // Both items should exist with distinct IDs
+    const db = getDb();
+    const items = db.select().from(memoryItems)
+      .where(eq(memoryItems.statement, 'I prefer dark mode'))
+      .all();
+    expect(items.length).toBe(2);
+
+    const scopes = new Set(items.map((i) => i.scopeId));
+    expect(scopes.has('default')).toBe(true);
+    expect(scopes.has('private-abc')).toBe(true);
+
+    // Saving the same statement again in default scope should dedup (not create a third)
+    const r3 = await handleMemorySave(sharedArgs, DEFAULT_CONFIG, 'conv-scope-3', 'msg-scope-3', 'default');
+    expect(r3.isError).toBe(false);
+    expect(r3.content).toContain('already exists');
+
+    const afterDedup = db.select().from(memoryItems)
+      .where(eq(memoryItems.statement, 'I prefer dark mode'))
+      .all();
+    expect(afterDedup.length).toBe(2);
+  });
+
   test('memory_update promotes verificationState to user_confirmed', async () => {
     const db = getDb();
     const now = Date.now();

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
@@ -56,6 +56,7 @@ export async function handleMemorySave(
   _config: AssistantConfig,
   conversationId: string,
   messageId: string | undefined,
+  scopeId: string = 'default',
 ): Promise<ToolExecutionResult> {
   const statement = args.statement;
   if (typeof statement !== 'string' || statement.trim().length === 0) {
@@ -84,14 +85,15 @@ export async function handleMemorySave(
     const now = Date.now();
     const trimmedStatement = statement.trim().slice(0, 500);
 
-    // Build fingerprint for dedup consistency with items-extractor
-    const normalized = `${kind}|${subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
+    // Build fingerprint for dedup — salt with scopeId so identical statements
+    // in different scopes produce distinct fingerprints and stay separate.
+    const normalized = `${scopeId}|${kind}|${subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
     const fingerprint = createHash('sha256').update(normalized).digest('hex');
 
     const existing = db
       .select()
       .from(memoryItems)
-      .where(eq(memoryItems.fingerprint, fingerprint))
+      .where(and(eq(memoryItems.fingerprint, fingerprint), eq(memoryItems.scopeId, scopeId)))
       .get();
 
     if (existing) {
@@ -122,6 +124,7 @@ export async function handleMemorySave(
       importance: 0.8,       // explicit saves are high importance
       fingerprint,
       verificationState: 'user_confirmed',
+      scopeId,
       firstSeenAt: now,
       lastSeenAt: now,
       lastUsedAt: null,

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -37,7 +37,7 @@ class MemorySaveTool implements Tool {
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const config = getConfig();
-    return handleMemorySave(input, config, context.conversationId, context.requestId);
+    return handleMemorySave(input, config, context.conversationId, context.requestId, context.memoryScopeId);
   }
 }
 


### PR DESCRIPTION
## Summary
- `memory_save` now uses `context.memoryScopeId` when saving items, so private-thread saves stay isolated from standard-thread saves.
- The fingerprint computation is salted with the scope ID, ensuring identical statements in different scopes produce distinct fingerprints and create separate memory items.
- The existing-item dedup lookup is constrained by `scopeId`, preventing cross-scope deduplication.

## Test plan
- [x] New test: saving the same statement in `default` and `private-abc` scopes creates two separate items
- [x] New test: re-saving the same statement in the same scope correctly deduplicates (returns "already exists")
- [x] All 75 existing `memory-regressions.test.ts` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
