### PR TITLE
feat: items extractor writes scoped memory rows

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3403,4 +3403,114 @@ describe('Memory regressions', () => {
     const withScope = await extractAndUpsertMemoryItemsForMessage('msg-scope-pass-2', 'private:thread-42');
     expect(withScope).toBeGreaterThan(0);
   });
+
+  // PR-20: same statement in different scopes produces separate active items
+  test('same statement in different scopes produces separate active memory items', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(conversations).values({
+      id: 'conv-scope-separate',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      threadType: 'standard',
+      memoryScopeId: 'default',
+    }).run();
+
+    // Insert two messages with identical content
+    db.insert(messages).values({
+      id: 'msg-scope-default',
+      conversationId: 'conv-scope-separate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'I prefer dark mode for all my editors and terminals.' }]),
+      createdAt: now,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-scope-private',
+      conversationId: 'conv-scope-separate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'I prefer dark mode for all my editors and terminals.' }]),
+      createdAt: now + 1,
+    }).run();
+
+    // Extract into default scope
+    const defaultCount = await extractAndUpsertMemoryItemsForMessage('msg-scope-default');
+    expect(defaultCount).toBeGreaterThan(0);
+
+    // Extract identical statement into a private scope
+    const privateCount = await extractAndUpsertMemoryItemsForMessage('msg-scope-private', 'private:thread-99');
+    expect(privateCount).toBeGreaterThan(0);
+
+    // Both scopes should have separate active items
+    const defaultItems = db.select().from(memoryItems)
+      .where(and(eq(memoryItems.scopeId, 'default'), eq(memoryItems.status, 'active')))
+      .all();
+    const privateItems = db.select().from(memoryItems)
+      .where(and(eq(memoryItems.scopeId, 'private:thread-99'), eq(memoryItems.status, 'active')))
+      .all();
+
+    expect(defaultItems.length).toBeGreaterThan(0);
+    expect(privateItems.length).toBeGreaterThan(0);
+
+    // The items should have the same fingerprint but different IDs
+    const defaultFingerprints = new Set(defaultItems.map(i => i.fingerprint));
+    const matchingPrivate = privateItems.filter(i => defaultFingerprints.has(i.fingerprint));
+    expect(matchingPrivate.length).toBeGreaterThan(0);
+    for (const pi of matchingPrivate) {
+      const di = defaultItems.find(i => i.fingerprint === pi.fingerprint);
+      expect(di).toBeDefined();
+      expect(pi.id).not.toBe(di!.id);
+    }
+  });
+
+  // PR-20: default scope items are not affected by private scope operations
+  test('default scope items are not superseded by private scope operations', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(conversations).values({
+      id: 'conv-scope-isolate',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      threadType: 'standard',
+      memoryScopeId: 'default',
+    }).run();
+
+    // Insert a decision in the default scope
+    db.insert(messages).values({
+      id: 'msg-decision-default',
+      conversationId: 'conv-scope-isolate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'We decided to use PostgreSQL for the production database.' }]),
+      createdAt: now,
+    }).run();
+    await extractAndUpsertMemoryItemsForMessage('msg-decision-default');
+
+    const defaultBefore = db.select().from(memoryItems)
+      .where(and(eq(memoryItems.scopeId, 'default'), eq(memoryItems.status, 'active')))
+      .all();
+    expect(defaultBefore.length).toBeGreaterThan(0);
+
+    // Now insert a superseding decision in a private scope
+    db.insert(messages).values({
+      id: 'msg-decision-private',
+      conversationId: 'conv-scope-isolate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'We decided to use SQLite for the production database instead.' }]),
+      createdAt: now + 1,
+    }).run();
+    await extractAndUpsertMemoryItemsForMessage('msg-decision-private', 'private:thread-55');
+
+    // The default scope items should still be active — private scope supersede must not affect them
+    const defaultAfter = db.select().from(memoryItems)
+      .where(and(eq(memoryItems.scopeId, 'default'), eq(memoryItems.status, 'active')))
+      .all();
+
+    expect(defaultAfter.length).toBe(defaultBefore.length);
+    for (const item of defaultAfter) {
+      expect(item.status).toBe('active');
+    }
+  });
 });

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -91,7 +91,7 @@ export function initializeDb(): void {
       statement TEXT NOT NULL,
       status TEXT NOT NULL,
       confidence REAL NOT NULL,
-      fingerprint TEXT NOT NULL UNIQUE,
+      fingerprint TEXT NOT NULL,
       first_seen_at INTEGER NOT NULL,
       last_seen_at INTEGER NOT NULL,
       last_used_at INTEGER
@@ -479,6 +479,7 @@ export function initializeDb(): void {
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
   migrateMemoryEntityRelationDedup(database);
+  migrateMemoryItemsFingerprintScopeUnique(database);
 
   // Indexes for query performance on large datasets
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)`);
@@ -497,6 +498,7 @@ export function initializeDb(): void {
     ON memory_item_conflicts(scope_id, existing_item_id, candidate_item_id)
     WHERE status = 'pending_clarification'
   `);
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_items_fingerprint_scope ON memory_items(fingerprint, scope_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_kind_status ON memory_items(kind, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_status_invalid_at ON memory_items(status, invalid_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_scope_status_kind ON memory_items(scope_id, status, kind)`);
@@ -738,5 +740,83 @@ function migrateMemoryEntityRelationDedup(database: ReturnType<typeof drizzle<ty
   } catch (e) {
     try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
     throw e;
+  }
+}
+
+/**
+ * Migrate from a column-level UNIQUE on fingerprint to a compound unique
+ * index on (fingerprint, scope_id) so that the same item can exist in
+ * different scopes independently.
+ */
+function migrateMemoryItemsFingerprintScopeUnique(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+  const checkpointKey = 'migration_memory_items_fingerprint_scope_unique_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  // Check if the old column-level UNIQUE constraint still exists — indicated
+  // by the sqlite_autoindex on fingerprint alone.
+  const autoIdx = raw.query(
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'memory_items' AND name LIKE 'sqlite_autoindex_%'`,
+  ).get() as { name: string } | null;
+  if (!autoIdx) {
+    // No auto-index — either fresh DB (no UNIQUE in CREATE TABLE) or already migrated.
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+    return;
+  }
+
+  // Rebuild the table without the column-level UNIQUE constraint.
+  raw.exec('PRAGMA foreign_keys = OFF');
+  try {
+    raw.exec('BEGIN');
+
+    // Create new table without UNIQUE on fingerprint — all other columns
+    // match the latest schema (including migration-added columns).
+    raw.exec(/*sql*/ `
+      CREATE TABLE memory_items_new (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        statement TEXT NOT NULL,
+        status TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        fingerprint TEXT NOT NULL,
+        first_seen_at INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        importance REAL,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        valid_from INTEGER,
+        invalid_at INTEGER,
+        verification_state TEXT NOT NULL DEFAULT 'assistant_inferred',
+        scope_id TEXT NOT NULL DEFAULT 'default'
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_items_new
+      SELECT id, kind, subject, statement, status, confidence, fingerprint,
+             first_seen_at, last_seen_at, last_used_at, importance, access_count,
+             valid_from, invalid_at, verification_state, scope_id
+      FROM memory_items
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE memory_items`);
+    raw.exec(/*sql*/ `ALTER TABLE memory_items_new RENAME TO memory_items`);
+
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  } finally {
+    raw.exec('PRAGMA foreign_keys = ON');
   }
 }

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -254,6 +254,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
   // Determine verification state from message role
   const verificationState = message.role === 'user' ? 'user_reported' : 'assistant_inferred';
 
+  const effectiveScopeId = scopeId ?? 'default';
   let upserted = 0;
   for (const item of extracted) {
     const now = Date.now();
@@ -261,7 +262,10 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
     const existing = db
       .select()
       .from(memoryItems)
-      .where(eq(memoryItems.fingerprint, item.fingerprint))
+      .where(and(
+        eq(memoryItems.fingerprint, item.fingerprint),
+        eq(memoryItems.scopeId, effectiveScopeId),
+      ))
       .get();
 
     let memoryItemId: string;
@@ -299,6 +303,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
         importance: item.importance,
         fingerprint: item.fingerprint,
         verificationState,
+        scopeId: effectiveScopeId,
         firstSeenAt: message.createdAt,
         lastSeenAt: seenAt,
         lastUsedAt: null,
@@ -317,6 +322,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
           eq(memoryItems.kind, item.kind),
           eq(memoryItems.subject, item.subject),
           eq(memoryItems.status, 'active'),
+          eq(memoryItems.scopeId, effectiveScopeId),
           sql`${memoryItems.id} <> ${memoryItemId}`,
         ))
         .run();


### PR DESCRIPTION
## Summary
- Set `scopeId` on new memory item inserts in `extractAndUpsertMemoryItemsForMessage`, defaulting to `'default'` when not provided
- Constrain fingerprint-based dedup lookups by scope so the same statement in different scopes produces separate items
- Constrain supersede logic by scope so private scope operations don't affect default scope items
- Migrate DB unique constraint from `fingerprint` alone to compound `(fingerprint, scope_id)` via table rebuild migration
- Add two regression tests verifying scope isolation for memory items

## Test plan
- [x] `bun test src/__tests__/memory-regressions.test.ts` — 76 pass, 0 fail
- [x] `bun test src/__tests__/contradiction-checker.test.ts` — 3 pass, 0 fail
- [x] `bun test src/__tests__/conflict-store.test.ts` — 9 pass, 0 fail
- [x] `bun test src/__tests__/profile-compiler.test.ts` — 7 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
