### PR TITLE
test: regression tests for private strict prompt policy

### DIFF
--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -401,4 +401,115 @@ describe('ToolExecutor lifecycle events', () => {
 
     await expect(raced).resolves.toEqual({ content: 'ok', isError: false });
   });
+
+  // ── forcePromptSideEffects lifecycle event tests (PR 31) ──────────
+
+  test('emits permission_prompt with private-thread reason when forcePromptSideEffects is true for file_edit', async () => {
+    // check() returns allow — simulating a matched trust rule that would
+    // normally auto-allow. The forcePromptSideEffects flag should promote
+    // this to a prompt.
+    checkerDecision = 'allow';
+    checkerReason = 'Matched trust rule';
+    checkerRisk = 'low';
+    promptDecision = 'allow';
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      'file_edit',
+      { path: '/tmp/project/config.ts', old_string: 'a', new_string: 'b' },
+      {
+        ...makeContext(events),
+        forcePromptSideEffects: true,
+      },
+    );
+
+    expect(result).toEqual({ content: 'ok', isError: false });
+
+    const promptEvent = events.find((e) => e.type === 'permission_prompt');
+    expect(promptEvent).toBeDefined();
+    if (promptEvent?.type !== 'permission_prompt') throw new Error('Expected permission_prompt event');
+    expect(promptEvent.toolName).toBe('file_edit');
+    expect(promptEvent.reason).toBe('Private thread: side-effect tools require explicit approval');
+  });
+
+  test('permission_prompt reason reflects private-thread policy for bash under forcePromptSideEffects', async () => {
+    checkerDecision = 'allow';
+    checkerReason = 'Matched trust rule';
+    checkerRisk = 'low';
+    promptDecision = 'allow';
+    sandboxed = true;
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      'bash',
+      { command: 'npm install' },
+      {
+        ...makeContext(events),
+        forcePromptSideEffects: true,
+      },
+    );
+
+    const promptEvent = events.find((e) => e.type === 'permission_prompt');
+    expect(promptEvent).toBeDefined();
+    if (promptEvent?.type !== 'permission_prompt') throw new Error('Expected permission_prompt event');
+    expect(promptEvent.toolName).toBe('bash');
+    expect(promptEvent.reason).toBe('Private thread: side-effect tools require explicit approval');
+    expect(promptEvent.sandboxed).toBe(true);
+  });
+
+  test('no permission_prompt event for read-only tool even with forcePromptSideEffects', async () => {
+    checkerDecision = 'allow';
+    checkerReason = 'allowed';
+    checkerRisk = 'low';
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      'file_read',
+      { path: '/tmp/project/README.md' },
+      {
+        ...makeContext(events),
+        forcePromptSideEffects: true,
+      },
+    );
+
+    // file_read is not a side-effect tool, so no prompt event should appear
+    const promptEvent = events.find((e) => e.type === 'permission_prompt');
+    expect(promptEvent).toBeUndefined();
+    expect(events.map((e) => e.type)).toEqual(['start', 'executed']);
+  });
+
+  test('file_edit to USER.md emits permission_prompt under forcePromptSideEffects', async () => {
+    // Security invariant: editing USER.md in a private thread must always
+    // prompt, even when a trust rule would auto-allow.
+    checkerDecision = 'allow';
+    checkerReason = 'Matched trust rule: file_edit:*/USER.md';
+    checkerRisk = 'low';
+    promptDecision = 'allow';
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      'file_edit',
+      { path: '/Users/sidd/.vellum/workspace/USER.md', old_string: 'old', new_string: 'new' },
+      {
+        ...makeContext(events),
+        forcePromptSideEffects: true,
+      },
+    );
+
+    expect(result).toEqual({ content: 'ok', isError: false });
+
+    const promptEvent = events.find((e) => e.type === 'permission_prompt');
+    expect(promptEvent).toBeDefined();
+    if (promptEvent?.type !== 'permission_prompt') throw new Error('Expected permission_prompt event');
+    expect(promptEvent.toolName).toBe('file_edit');
+    expect(promptEvent.reason).toBe('Private thread: side-effect tools require explicit approval');
+  });
 });

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1214,4 +1214,38 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
     // when check() already returned 'prompt'
     expect(promptCount).toBe(1);
   });
+
+  // ── USER.md security invariant (PR 31) ──────────
+
+  test('file_edit to USER.md forces prompt in private thread even with matching trust rule', async () => {
+    // This is a key security invariant: USER.md contains the user's persistent
+    // memory. In a private thread (forcePromptSideEffects=true), edits to it
+    // must always require explicit approval, even when a trust rule matches.
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule: file_edit:*/USER.md' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'file_edit',
+      { path: '/Users/sidd/.vellum/workspace/USER.md', old_string: 'old pref', new_string: 'new pref' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    // file_edit is a side-effect tool, so forcePromptSideEffects must trigger prompting
+    expect(promptCalled).toBe(true);
+  });
+
+  test('host_file_edit to USER.md forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'host_file_edit',
+      { path: '/Users/sidd/.vellum/workspace/USER.md', old_string: 'x', new_string: 'y' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Add lifecycle event tests verifying `permission_prompt` events are emitted for side-effect tools (`file_edit`, `bash`) under `forcePromptSideEffects`, with the private-thread reason string
- Add test confirming read-only tools (`file_read`) do NOT emit `permission_prompt` even with `forcePromptSideEffects`
- Add USER.md-specific security invariant tests: editing `USER.md` (via `file_edit` and `host_file_edit`) in a private thread must always prompt, even when a trust rule would auto-allow

## Test plan
- [x] `bun test src/__tests__/tool-executor-lifecycle-events.test.ts` — 17/17 pass (4 new)
- [x] `bun test src/__tests__/tool-executor.test.ts` — 57/57 pass (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
