### PR TITLE
feat: scope-salted fingerprint in memory extractor

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3490,15 +3490,62 @@ describe('Memory regressions', () => {
     expect(defaultItems.length).toBeGreaterThan(0);
     expect(privateItems.length).toBeGreaterThan(0);
 
-    // The items should have the same fingerprint but different IDs
+    // Scope-salted fingerprints: same content in different scopes yields distinct fingerprints
     const defaultFingerprints = new Set(defaultItems.map(i => i.fingerprint));
     const matchingPrivate = privateItems.filter(i => defaultFingerprints.has(i.fingerprint));
-    expect(matchingPrivate.length).toBeGreaterThan(0);
-    for (const pi of matchingPrivate) {
-      const di = defaultItems.find(i => i.fingerprint === pi.fingerprint);
-      expect(di).toBeDefined();
-      expect(pi.id).not.toBe(di!.id);
-    }
+    expect(matchingPrivate.length).toBe(0);
+  });
+
+  // PR-21: identical fact in default vs private scopes gets distinct fingerprints
+  test('identical content in different scopes produces distinct fingerprints', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const statement = 'I prefer using Vim keybindings in all my text editors.';
+
+    db.insert(conversations).values({
+      id: 'conv-fp-salt',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      threadType: 'standard',
+      memoryScopeId: 'default',
+    }).run();
+
+    db.insert(messages).values({
+      id: 'msg-fp-salt-default',
+      conversationId: 'conv-fp-salt',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: statement }]),
+      createdAt: now,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-fp-salt-private',
+      conversationId: 'conv-fp-salt',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: statement }]),
+      createdAt: now + 1,
+    }).run();
+
+    await extractAndUpsertMemoryItemsForMessage('msg-fp-salt-default');
+    await extractAndUpsertMemoryItemsForMessage('msg-fp-salt-private', 'private:fp-test');
+
+    const defaultItems = db.select().from(memoryItems)
+      .where(eq(memoryItems.scopeId, 'default'))
+      .all()
+      .filter(i => i.statement === statement);
+    const privateItems = db.select().from(memoryItems)
+      .where(eq(memoryItems.scopeId, 'private:fp-test'))
+      .all()
+      .filter(i => i.statement === statement);
+
+    expect(defaultItems.length).toBe(1);
+    expect(privateItems.length).toBe(1);
+    // Same content, different scopes — fingerprints must differ
+    expect(defaultItems[0].fingerprint).not.toBe(privateItems[0].fingerprint);
+    // But the actual content should be identical
+    expect(defaultItems[0].kind).toBe(privateItems[0].kind);
+    expect(defaultItems[0].subject).toBe(privateItems[0].subject);
+    expect(defaultItems[0].statement).toBe(privateItems[0].statement);
   });
 
   // PR-20: default scope items are not affected by private scope operations

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -109,12 +109,13 @@ interface LLMExtractedItem {
 async function extractItemsWithLLM(
   text: string,
   extractionConfig: MemoryExtractionConfig,
+  scopeId: string,
 ): Promise<ExtractedItem[]> {
   const config = getConfig();
   const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     log.debug('No Anthropic API key available for LLM extraction, falling back to pattern-based');
-    return extractItemsPatternBased(text);
+    return extractItemsPatternBased(text, scopeId);
   }
 
   try {
@@ -200,7 +201,7 @@ async function extractItemsWithLLM(
       const statement = String(raw.statement).slice(0, 500);
       const confidence = clamp(parseScore(raw.confidence, 0.5), 0, 1);
       const importance = clamp(parseScore(raw.importance, 0.5), 0, 1);
-      const normalized = `${raw.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
+      const normalized = `${scopeId}|${raw.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
       const fingerprint = createHash('sha256').update(normalized).digest('hex');
       items.push({
         kind: raw.kind as MemoryItemKind,
@@ -216,7 +217,7 @@ async function extractItemsWithLLM(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err: message }, 'LLM extraction failed, falling back to pattern-based');
-    return extractItemsPatternBased(text);
+    return extractItemsPatternBased(text, scopeId);
   }
 }
 
@@ -245,16 +246,16 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
 
   const config = getConfig();
   const extractionConfig = config.memory.extraction;
+  const effectiveScopeId = scopeId ?? 'default';
   const extracted = extractionConfig.useLLM
-    ? await extractItemsWithLLM(text, extractionConfig)
-    : extractItemsPatternBased(text);
+    ? await extractItemsWithLLM(text, extractionConfig, effectiveScopeId)
+    : extractItemsPatternBased(text, effectiveScopeId);
 
   if (extracted.length === 0) return 0;
 
   // Determine verification state from message role
   const verificationState = message.role === 'user' ? 'user_reported' : 'assistant_inferred';
 
-  const effectiveScopeId = scopeId ?? 'default';
   let upserted = 0;
   for (const item of extracted) {
     const now = Date.now();
@@ -349,7 +350,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
 
 // ── Pattern-based extraction (fallback) ────────────────────────────────
 
-function extractItemsPatternBased(text: string): ExtractedItem[] {
+function extractItemsPatternBased(text: string, scopeId: string): ExtractedItem[] {
   const sentences = text
     .split(/[\n\r]+|(?<=[.!?])\s+/)
     .map((s) => s.trim())
@@ -362,7 +363,7 @@ function extractItemsPatternBased(text: string): ExtractedItem[] {
     if (!classification) continue;
     const subject = inferSubject(sentence, classification.kind);
     const statement = sentence.replace(/\s+/g, ' ').trim();
-    const normalized = `${classification.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
+    const normalized = `${scopeId}|${classification.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
     const fingerprint = createHash('sha256').update(normalized).digest('hex');
     items.push({
       kind: classification.kind,


### PR DESCRIPTION
## Summary
- Includes the scope ID in the fingerprint normalization input (`scopeId|kind|subject|statement`) in both LLM and pattern-based extraction paths
- Prevents cross-scope deduplication collisions: identical content in different scopes now produces distinct fingerprint hashes
- Updates the existing PR-20 test expectation (fingerprints should differ across scopes, not match) and adds a dedicated regression test

## Test plan
- [x] All 78 existing memory-regressions tests pass
- [x] New test: `identical content in different scopes produces distinct fingerprints` — verifies same statement extracted into `default` and `private:fp-test` scopes gets different fingerprints but identical content fields
- [x] Updated test: `same statement in different scopes produces separate active memory items` — now asserts zero fingerprint overlap instead of matching fingerprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
