### PR TITLE
fix: prioritize scoped entries over default fallback in profile compiler

### DIFF
--- a/assistant/src/__tests__/profile-compiler.test.ts
+++ b/assistant/src/__tests__/profile-compiler.test.ts
@@ -297,6 +297,52 @@ describe('profile-compiler', () => {
     expect(compiled.text).toContain('timezone: Timezone is America/Chicago');
   });
 
+  test('includeDefaultFallback: scoped entry wins over default with same subject', () => {
+    profileEnabled = true;
+
+    // Default scope entry — higher trust/importance so it would normally rank first
+    insertItem({
+      id: 'fb-default-lang',
+      kind: 'preference',
+      subject: 'language',
+      statement: 'Prefers JavaScript.',
+      verificationState: 'user_confirmed',
+      scopeId: 'default',
+      importance: 0.95,
+    });
+    // Scoped entry — lower importance but should still win because it is scoped
+    insertItem({
+      id: 'fb-proj-lang',
+      kind: 'preference',
+      subject: 'language',
+      statement: 'Prefers TypeScript.',
+      verificationState: 'assistant_inferred',
+      scopeId: 'project-x',
+      importance: 0.5,
+    });
+    // Default-only entry with no scoped counterpart — should still appear (gap-filling)
+    insertItem({
+      id: 'fb-default-tz',
+      kind: 'profile',
+      subject: 'timezone',
+      statement: 'Timezone is America/New_York.',
+      verificationState: 'user_confirmed',
+      scopeId: 'default',
+    });
+
+    const compiled = compileDynamicProfile({
+      scopeId: 'project-x',
+      includeDefaultFallback: true,
+    });
+
+    // Scoped entry should win deduplication for 'language'
+    expect(compiled.text).toContain('language: Prefers TypeScript');
+    expect(compiled.text).not.toContain('Prefers JavaScript');
+    // Default-only entry should still fill in as fallback
+    expect(compiled.text).toContain('timezone: Timezone is America/New_York');
+    expect(compiled.selectedCount).toBe(2);
+  });
+
   test('uses lower-ranked fallback for same subject when top candidate exceeds budget', () => {
     profileEnabled = true;
 

--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -36,6 +36,7 @@ interface ProfileCandidate {
   importance: number | null;
   lastSeenAt: number;
   firstSeenAt: number;
+  scopeId: string;
 }
 
 export function compileDynamicProfile(options?: CompileProfileOptions): CompiledProfile {
@@ -62,6 +63,7 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
       importance: memoryItems.importance,
       lastSeenAt: memoryItems.lastSeenAt,
       firstSeenAt: memoryItems.firstSeenAt,
+      scopeId: memoryItems.scopeId,
     })
     .from(memoryItems)
     .where(and(
@@ -76,7 +78,7 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
   const nowMs = Date.now();
   const trusted = rows
     .filter((row) => TRUST_RANK[row.verificationState] !== undefined)
-    .sort((a, b) => compareProfileCandidates(a, b, nowMs));
+    .sort((a, b) => compareProfileCandidates(a, b, nowMs, shouldFallback ? scopeId : undefined));
 
   const selectedLines: string[] = [];
   const seenKeys = new Set<string>();
@@ -121,7 +123,21 @@ function candidateRankScore(c: ProfileCandidate, nowMs: number): number {
   return importance * 0.7 + recency * 0.3;
 }
 
-function compareProfileCandidates(left: ProfileCandidate, right: ProfileCandidate, nowMs: number): number {
+function compareProfileCandidates(
+  left: ProfileCandidate,
+  right: ProfileCandidate,
+  nowMs: number,
+  /** When set, entries matching this scope sort before 'default' entries. */
+  preferredScopeId?: string,
+): number {
+  // Scoped entries beat default fallback entries so local overrides win deduplication
+  if (preferredScopeId !== undefined) {
+    const leftIsPreferred = left.scopeId === preferredScopeId;
+    const rightIsPreferred = right.scopeId === preferredScopeId;
+    if (leftIsPreferred && !rightIsPreferred) return -1;
+    if (!leftIsPreferred && rightIsPreferred) return 1;
+  }
+
   const trustDelta = (TRUST_RANK[right.verificationState] ?? 0) - (TRUST_RANK[left.verificationState] ?? 0);
   if (trustDelta !== 0) return trustDelta;
 


### PR DESCRIPTION
Ensures scoped profile entries take priority over default fallback entries during deduplication so local overrides are not suppressed by global defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
