### PR TITLE
feat: constrain memory_update to current scope

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -629,6 +629,80 @@ describe('Memory regressions', () => {
     expect(updated!.verificationState).toBe('user_confirmed');
   });
 
+  test('private thread cannot update default-scope item by ID', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const { handleMemoryUpdate } = await import('../tools/memory/handlers.js');
+
+    // Pre-seed an item in the default scope
+    db.insert(memoryItems).values({
+      id: 'item-default-no-cross',
+      kind: 'fact',
+      subject: 'cross-scope update',
+      statement: 'Original default-scope statement',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.6,
+      fingerprint: 'fp-default-no-cross',
+      verificationState: 'assistant_inferred',
+      scopeId: 'default',
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastUsedAt: null,
+    }).run();
+
+    // Attempt to update from a private scope — should fail with "not found"
+    const result = await handleMemoryUpdate(
+      { memory_id: 'item-default-no-cross', statement: 'Hijacked statement' },
+      DEFAULT_CONFIG,
+      'private-thread-xyz',
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+
+    // Verify the original item is unchanged
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-default-no-cross')).get();
+    expect(item).toBeDefined();
+    expect(item!.statement).toBe('Original default-scope statement');
+  });
+
+  test('standard thread cannot update private-scope item by ID', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const { handleMemoryUpdate } = await import('../tools/memory/handlers.js');
+
+    // Pre-seed an item in a private scope
+    db.insert(memoryItems).values({
+      id: 'item-private-no-cross',
+      kind: 'preference',
+      subject: 'cross-scope update reverse',
+      statement: 'Private scope secret preference',
+      status: 'active',
+      confidence: 0.9,
+      importance: 0.7,
+      fingerprint: 'fp-private-no-cross',
+      verificationState: 'user_confirmed',
+      scopeId: 'private-thread-abc',
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastUsedAt: null,
+    }).run();
+
+    // Attempt to update from the default scope — should fail with "not found"
+    const result = await handleMemoryUpdate(
+      { memory_id: 'item-private-no-cross', statement: 'Overwritten from default' },
+      DEFAULT_CONFIG,
+      'default',
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+
+    // Verify the original item is unchanged
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-private-no-cross')).get();
+    expect(item).toBeDefined();
+    expect(item!.statement).toBe('Private scope secret preference');
+  });
+
   test('extracted items from user messages get user_reported verification state', async () => {
     const db = getDb();
     const now = Date.now();

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -149,6 +149,7 @@ export async function handleMemorySave(
 export async function handleMemoryUpdate(
   args: Record<string, unknown>,
   _config: AssistantConfig,
+  scopeId: string = 'default',
 ): Promise<ToolExecutionResult> {
   const rawMemoryId = args.memory_id;
   if (typeof rawMemoryId !== 'string' || rawMemoryId.trim().length === 0) {
@@ -165,10 +166,13 @@ export async function handleMemoryUpdate(
 
   try {
     const db = getDb();
+
+    // Constrain lookup to the current scope so threads cannot mutate
+    // memory items belonging to a different scope.
     const existing = db
       .select()
       .from(memoryItems)
-      .where(eq(memoryItems.id, memoryId))
+      .where(and(eq(memoryItems.id, memoryId), eq(memoryItems.scopeId, scopeId)))
       .get();
 
     if (!existing) {
@@ -178,13 +182,16 @@ export async function handleMemoryUpdate(
     const now = Date.now();
     const trimmedStatement = statement.trim().slice(0, 500);
 
-    const normalized = `${existing.kind}|${existing.subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
+    // Salt fingerprint with scopeId so identical statements in different
+    // scopes stay distinct — mirrors the pattern in handleMemorySave.
+    const normalized = `${scopeId}|${existing.kind}|${existing.subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
     const fingerprint = createHash('sha256').update(normalized).digest('hex');
 
+    // Collision detection also constrained to the current scope.
     const collision = db
       .select({ id: memoryItems.id })
       .from(memoryItems)
-      .where(eq(memoryItems.fingerprint, fingerprint))
+      .where(and(eq(memoryItems.fingerprint, fingerprint), eq(memoryItems.scopeId, scopeId)))
       .get();
     if (collision && collision.id !== existing.id) {
       return {

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -53,9 +53,9 @@ class MemoryUpdateTool implements Tool {
     return memoryUpdateDefinition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const config = getConfig();
-    return handleMemoryUpdate(input, config);
+    return handleMemoryUpdate(input, config, context.memoryScopeId);
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `scopeId` parameter to `handleMemoryUpdate` (default `'default'`), constraining item lookup so threads can only update memory items in their own scope.
- Salts the updated fingerprint with `scopeId` and constrains collision detection to the current scope, mirroring the pattern from `handleMemorySave` (PR 24).
- Passes `context.memoryScopeId` from the tool registration layer to the handler.
- Adds two regression tests: private thread cannot update default-scope items, and standard thread cannot update private-scope items.

## Test plan
- [x] Existing `memory_update promotes verificationState` test still passes
- [x] New test: private thread cannot update default-scope item by ID
- [x] New test: standard thread cannot update private-scope item by ID
- [x] `memory_save in different scopes` test still passes (no regressions)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
