### PR TITLE
fix: case-insensitive HTTPS scheme check in DomainAllowlistMatcher

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/DomainAllowlistMatcher.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/DomainAllowlistMatcher.swift
@@ -4,7 +4,7 @@ enum DomainAllowlistMatcher {
     /// Returns true if the URL's host matches any domain in the allowlist.
     /// Supports exact and subdomain matching (e.g., "youtube.com" matches "www.youtube.com").
     static func isAllowed(_ url: URL, allowedDomains: [String]) -> Bool {
-        guard url.scheme == "https",
+        guard url.scheme?.lowercased() == "https",
               let host = url.host?.lowercased() else { return false }
 
         for domain in allowedDomains {

--- a/clients/macos/vellum-assistantTests/DomainAllowlistMatcherTests.swift
+++ b/clients/macos/vellum-assistantTests/DomainAllowlistMatcherTests.swift
@@ -56,6 +56,13 @@ final class DomainAllowlistMatcherTests: XCTestCase {
         XCTAssertFalse(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
     }
 
+    // MARK: - Mixed-case scheme
+
+    func testMixedCaseSchemeIsAccepted() {
+        let url = URL(string: "HTTPS://www.youtube.com/watch?v=abc")!
+        XCTAssertTrue(DomainAllowlistMatcher.isAllowed(url, allowedDomains: ["youtube.com"]))
+    }
+
     // MARK: - URL with no host
 
     func testNoHostReturnsFalse() {


### PR DESCRIPTION
Normalizes URL scheme comparison to be case-insensitive so uppercase HTTPS URLs are not rejected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
