### PR TITLE
fix: normalize URL scheme in MediaEmbedResolver allowlist check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -88,7 +88,7 @@ enum MediaEmbedResolver {
     ) -> VideoParseResult? {
         for parser in videoParsers {
             if let result = parser(url) {
-                guard DomainAllowlistMatcher.isAllowed(url, allowedDomains: allowedDomains) else {
+                guard DomainAllowlistMatcher.isAllowed(result.embedURL, allowedDomains: allowedDomains) else {
                     return nil
                 }
                 return result


### PR DESCRIPTION
Uses the embed URL (with normalized scheme) for allowlist checking instead of the raw URL to avoid rejecting valid uppercase HTTPS links.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
