### PR TITLE
Prevent SecretPromptManagerTests from showing macOS popup panels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -15,6 +15,11 @@ final class SecretPromptManager {
 
     private var panels: [String: NSPanel] = [:]
     private let panelWidth: CGFloat = 400
+    /// Injected presenter so tests can suppress visible panel popups.
+    /// Default behavior remains `orderFront(nil)` in app runtime.
+    var panelPresenter: (NSPanel) -> Void = { panel in
+        panel.orderFront(nil)
+    }
 
     /// Called when the user responds to a secret prompt.
     /// Parameters: (requestId, value?, delivery?) — value is nil if user cancelled.
@@ -84,7 +89,7 @@ final class SecretPromptManager {
         }
 
         panels[message.requestId] = panel
-        panel.orderFront(nil)
+        panelPresenter(panel)
 
         log.info("Showing secret prompt: requestId=\(message.requestId), service=\(message.service), field=\(message.field)")
     }

--- a/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
@@ -11,6 +11,7 @@ final class SecretPromptManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         manager = SecretPromptManager()
+        manager.panelPresenter = { _ in /* suppress UI popups during tests */ }
         responses = []
         manager.onResponse = { [unowned self] requestId, value, delivery in
             self.responses.append((requestId: requestId, value: value, delivery: delivery))


### PR DESCRIPTION
## Summary
- add a  injection point in  with runtime default behavior unchanged
- configure  to use a no-op presenter so tests do not open floating UI windows
- keep existing assertions intact while preventing disruptive top-right popup windows during background test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
