### PR TITLE
fix: correct README config key and default domains list

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Media embeds are controlled by settings under `ui.mediaEmbeds` in `~/.vellum/wor
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `enabled` | `true` | Global toggle for all inline media embeds |
-| `videoDomainAllowlist` | `["youtube.com", "vimeo.com", "loom.com"]` | Domains allowed to render video embeds |
+| `videoAllowlistDomains` | `["youtube.com", "youtu.be", "vimeo.com", "loom.com"]` | Domains allowed to render video embeds |
 | `enabledSince` | *(timestamp)* | Only messages created after this timestamp show embeds, so toggling the feature on does not retroactively modify older conversations |
 
 ### Security and Privacy


### PR DESCRIPTION
## Summary

- Fixes `videoDomainAllowlist` → `videoAllowlistDomains` in the README to match the actual config key in `SettingsStore.swift`
- Adds `youtu.be` to the documented default domains list to match `MediaEmbedSettings.defaultDomains`

## Test plan

- [ ] Verify README table row matches the key used in `SettingsStore.swift` line 235
- [ ] Verify default domains list matches `MediaEmbedSettings.defaultDomains`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
