### PR TITLE
fix: expand domain normalization to strip scheme, path, and query

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
@@ -23,16 +23,40 @@ public enum MediaEmbedSettings {
     }
 
     /// Normalizes a user-provided domain list: trims whitespace, lowercases,
-    /// removes empty strings, and deduplicates while preserving first-occurrence order.
+    /// strips URL schemes/paths/query strings/fragments, removes empty strings,
+    /// and deduplicates while preserving first-occurrence order.
     public static func normalizeDomains(_ domains: [String]) -> [String] {
         var seen = Set<String>()
         var result: [String] = []
         for domain in domains {
-            let normalized = domain.trimmingCharacters(in: .whitespaces).lowercased()
+            var normalized = domain.trimmingCharacters(in: .whitespaces).lowercased()
+            guard !normalized.isEmpty else { continue }
+            normalized = extractHost(from: normalized)
             guard !normalized.isEmpty, !seen.contains(normalized) else { continue }
             seen.insert(normalized)
             result.append(normalized)
         }
         return result
+    }
+
+    /// Extracts just the host component from a string that may be a full URL.
+    /// If the string has an http/https scheme, the host is pulled via URLComponents.
+    /// If it contains a `/` (e.g. `youtube.com/watch`), the part before the first `/` is returned.
+    /// Otherwise the string is returned as-is.
+    private static func extractHost(from value: String) -> String {
+        // If the value has an http(s) scheme, use URLComponents to extract the host.
+        if value.hasPrefix("http://") || value.hasPrefix("https://") {
+            if let components = URLComponents(string: value), let host = components.host, !host.isEmpty {
+                return host
+            }
+        }
+
+        // No scheme — strip anything after the first `/` (path, query, fragment).
+        if let slashIndex = value.firstIndex(of: "/") {
+            let host = String(value[value.startIndex..<slashIndex])
+            return host.isEmpty ? value : host
+        }
+
+        return value
     }
 }

--- a/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
@@ -75,4 +75,55 @@ final class MediaEmbedSettingsDefaultsTests: XCTestCase {
         let result = MediaEmbedSettings.normalizeDomains(["  YouTube.com ", "youtube.com", " YOUTUBE.COM  "])
         XCTAssertEqual(result, ["youtube.com"])
     }
+
+    // MARK: - normalizeDomains — URL stripping
+
+    func testNormalizeDomainsStripsHttpsScheme() {
+        let result = MediaEmbedSettings.normalizeDomains(["https://youtube.com"])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
+
+    func testNormalizeDomainsStripsHttpScheme() {
+        let result = MediaEmbedSettings.normalizeDomains(["http://youtube.com"])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
+
+    func testNormalizeDomainsStripsSchemePathAndQuery() {
+        let result = MediaEmbedSettings.normalizeDomains(["https://www.youtube.com/watch?v=abc"])
+        XCTAssertEqual(result, ["www.youtube.com"])
+    }
+
+    func testNormalizeDomainsStripsPathWithoutScheme() {
+        let result = MediaEmbedSettings.normalizeDomains(["youtube.com/path"])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
+
+    func testNormalizeDomainsStripsFragment() {
+        let result = MediaEmbedSettings.normalizeDomains(["https://vimeo.com/video#section"])
+        XCTAssertEqual(result, ["vimeo.com"])
+    }
+
+    func testNormalizeDomainsPlainDomainUnchanged() {
+        let result = MediaEmbedSettings.normalizeDomains(["vimeo.com"])
+        XCTAssertEqual(result, ["vimeo.com"])
+    }
+
+    func testNormalizeDomainsWhitespacePlusCaseNormalization() {
+        let result = MediaEmbedSettings.normalizeDomains(["  YOUTUBE.COM  "])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
+
+    func testNormalizeDomainsDeduplicatesAfterURLStripping() {
+        let result = MediaEmbedSettings.normalizeDomains(["https://youtube.com", "youtube.com"])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
+
+    func testNormalizeDomainsDeduplicatesFullURLAndPathVariants() {
+        let result = MediaEmbedSettings.normalizeDomains([
+            "https://youtube.com/watch?v=123",
+            "youtube.com/embed",
+            "youtube.com",
+        ])
+        XCTAssertEqual(result, ["youtube.com"])
+    }
 }


### PR DESCRIPTION
## Summary
- Expands `MediaEmbedSettings.normalizeDomains()` to extract the host component from full URLs pasted into the allowlist editor
- URLs with `http(s)://` schemes are parsed via `URLComponents` to extract the host; bare domains with paths (e.g. `youtube.com/watch`) are trimmed at the first `/`
- Deduplication now works correctly across mixed input variants (e.g. `["https://youtube.com", "youtube.com"]` → `["youtube.com"]`)

## Test plan
- [x] Added 9 new test cases covering scheme stripping, path stripping, fragment stripping, combined normalization, and deduplication after URL stripping
- [x] All 20 tests in `MediaEmbedSettingsDefaultsTests` pass (8 existing + 9 new + 3 pre-existing edge cases)
- [x] Existing behavior (trim, lowercase, dedup, empty removal) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
