### PR TITLE
fix: default enabledSince to current date on fresh install

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -88,6 +88,13 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
 
+        // When enabledSince was defaulted to "now" (no value on disk),
+        // persist it immediately so subsequent loads produce the same
+        // deterministic timestamp instead of advancing each time.
+        if mediaSettings.didDefaultEnabledSince {
+            persistMediaEmbedState()
+        }
+
         // React to Keychain changes from other surfaces
         NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)
             .receive(on: RunLoop.main)
@@ -270,25 +277,37 @@ public final class SettingsStore: ObservableObject {
         let enabled: Bool
         let enabledSince: Date?
         let domains: [String]
+        /// True when `enabledSince` was not found in the config and was
+        /// defaulted to "now". The caller should persist the value so
+        /// that subsequent loads produce a deterministic timestamp.
+        let didDefaultEnabledSince: Bool
     }
 
     /// Reads `ui.mediaEmbeds` from the workspace config and falls back to
     /// `MediaEmbedSettings` defaults for any missing or invalid values.
+    ///
+    /// When no `enabledSince` is found in the config (missing file, missing
+    /// section, or missing/unparseable key), the value defaults to "now" so
+    /// that fresh installs only embed new messages going forward.
     private static func loadMediaEmbedSettings(from configPath: String? = nil) -> MediaEmbedLoadResult {
         let config = WorkspaceConfigIO.read(from: configPath)
 
         guard let ui = config["ui"] as? [String: Any],
               let mediaEmbeds = ui["mediaEmbeds"] as? [String: Any] else {
+            // No config file, empty config, or no ui.mediaEmbeds section —
+            // default enabledSince to now so old history is gated.
             return MediaEmbedLoadResult(
                 enabled: MediaEmbedSettings.defaultEnabled,
-                enabledSince: nil,
-                domains: MediaEmbedSettings.defaultDomains
+                enabledSince: MediaEmbedSettings.enabledSinceNow(),
+                domains: MediaEmbedSettings.defaultDomains,
+                didDefaultEnabledSince: true
             )
         }
 
         let enabled = mediaEmbeds["enabled"] as? Bool ?? MediaEmbedSettings.defaultEnabled
 
         var enabledSince: Date?
+        var didDefault = false
         if let isoString = mediaEmbeds["enabledSince"] as? String {
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -298,6 +317,13 @@ public final class SettingsStore: ObservableObject {
                 formatter.formatOptions = [.withInternetDateTime]
                 enabledSince = formatter.date(from: isoString)
             }
+        }
+
+        // If enabledSince is still nil (key missing, wrong type, or
+        // unparseable), default to now so old messages are gated.
+        if enabledSince == nil {
+            enabledSince = MediaEmbedSettings.enabledSinceNow()
+            didDefault = true
         }
 
         let domains: [String]
@@ -310,7 +336,8 @@ public final class SettingsStore: ObservableObject {
         return MediaEmbedLoadResult(
             enabled: enabled,
             enabledSince: enabledSince,
-            domains: domains
+            domains: domains,
+            didDefaultEnabledSince: didDefault
         )
     }
 }

--- a/clients/macos/vellum-assistantTests/MediaEmbedEnabledSinceGateTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedEnabledSinceGateTests.swift
@@ -137,7 +137,9 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
         let store = SettingsStore(configPath: configPath)
         XCTAssertFalse(store.mediaEmbedsEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        // enabledSince is defaulted to now when the key is missing from config
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince)
+        let initialSince = store.mediaEmbedsEnabledSince!
 
         let before = Date()
         store.setMediaEmbedsEnabled(true)
@@ -149,6 +151,7 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
         let since = store.mediaEmbedsEnabledSince!
         XCTAssertGreaterThanOrEqual(since, before)
         XCTAssertLessThanOrEqual(since, after)
+        XCTAssertGreaterThanOrEqual(since, initialSince, "Toggle ON should reset enabledSince to a newer date")
     }
 
     // MARK: - Image embeds respect enabledSince

--- a/clients/macos/vellum-assistantTests/SettingsStoreMediaLoadTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreMediaLoadTests.swift
@@ -35,34 +35,83 @@ final class SettingsStoreMediaLoadTests: XCTestCase {
     // MARK: - No config file (defaults)
 
     func testNoConfigFileUsesDefaults() {
+        let before = Date()
         let store = SettingsStore(configPath: missingConfigPath)
+        let after = Date()
 
         XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "enabledSince should default to now when no config exists")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
         XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
+    }
+
+    // MARK: - Fresh install produces enabledSince ≈ now
+
+    func testFreshInstallEnabledSinceIsApproximatelyNow() {
+        let before = Date()
+        let store = SettingsStore(configPath: missingConfigPath)
+        let after = Date()
+
+        let since = store.mediaEmbedsEnabledSince
+        XCTAssertNotNil(since, "Fresh install must produce a non-nil enabledSince")
+        let interval = since!.timeIntervalSince(before)
+        XCTAssertLessThanOrEqual(interval, 2.0, "enabledSince should be within 2 seconds of now")
+        XCTAssertGreaterThanOrEqual(since!, before)
+        XCTAssertLessThanOrEqual(since!, after)
+    }
+
+    // MARK: - Defaulted enabledSince is persisted to disk
+
+    func testDefaultedEnabledSinceIsPersistedToDisk() {
+        let configPath = tempDir.appendingPathComponent("persist-test.json").path
+        let store = SettingsStore(configPath: configPath)
+        let firstSince = store.mediaEmbedsEnabledSince
+        XCTAssertNotNil(firstSince, "enabledSince should be defaulted on first load")
+
+        // Create a second store from the same path — it should read the
+        // persisted value instead of generating a new "now".
+        let store2 = SettingsStore(configPath: configPath)
+        XCTAssertNotNil(store2.mediaEmbedsEnabledSince)
+        // Compare within 1-second tolerance because ISO8601 persistence
+        // truncates sub-second precision.
+        let diff = abs(store2.mediaEmbedsEnabledSince!.timeIntervalSince(firstSince!))
+        XCTAssertLessThan(diff, 1.0,
+                          "Second load should use the persisted enabledSince, not generate a new one")
     }
 
     // MARK: - Empty config file (defaults)
 
     func testEmptyConfigUsesDefaults() {
+        let before = Date()
         let path = writeConfig("{}")
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
         XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "enabledSince should default to now for empty config")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
         XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
     }
 
     // MARK: - enabled = false
 
     func testLoadEnabledFalse() {
+        let before = Date()
         let path = writeConfig("""
         {"ui":{"mediaEmbeds":{"enabled":false}}}
         """)
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
         XCTAssertFalse(store.mediaEmbedsEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "enabledSince should default to now when key is missing")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
         XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
     }
 
@@ -113,58 +162,83 @@ final class SettingsStoreMediaLoadTests: XCTestCase {
 
     // MARK: - Invalid enabledSince
 
-    func testLoadInvalidEnabledSinceIsNil() {
+    func testLoadInvalidEnabledSinceDefaultsToNow() {
+        let before = Date()
         let path = writeConfig("""
         {"ui":{"mediaEmbeds":{"enabledSince":"not-a-date"}}}
         """)
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "Unparseable enabledSince should default to now")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
     }
 
     // MARK: - Missing enabledSince
 
-    func testLoadMissingEnabledSinceIsNil() {
+    func testLoadMissingEnabledSinceDefaultsToNow() {
+        let before = Date()
         let path = writeConfig("""
         {"ui":{"mediaEmbeds":{"enabled":true}}}
         """)
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "Missing enabledSince key should default to now")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
     }
 
     // MARK: - Numeric enabledSince (wrong type)
 
-    func testLoadNumericEnabledSinceIsNil() {
+    func testLoadNumericEnabledSinceDefaultsToNow() {
+        let before = Date()
         let path = writeConfig("""
         {"ui":{"mediaEmbeds":{"enabledSince":12345}}}
         """)
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "Numeric enabledSince (wrong type) should default to now")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
     }
 
     // MARK: - Corrupt config (fallback to defaults)
 
     func testCorruptConfigFallsBackToDefaults() {
+        let before = Date()
         let path = writeConfig("{not valid json!!!")
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
         XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "Corrupt config should default enabledSince to now")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
         XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
     }
 
     // MARK: - Config with ui key but no mediaEmbeds
 
     func testConfigWithUiButNoMediaEmbedsUsesDefaults() {
+        let before = Date()
         let path = writeConfig("""
         {"ui":{"theme":"dark"}}
         """)
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
         XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "Missing mediaEmbeds section should default enabledSince to now")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
         XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
     }
 
@@ -186,13 +260,18 @@ final class SettingsStoreMediaLoadTests: XCTestCase {
     // MARK: - mediaEmbeds is wrong type (non-dict)
 
     func testMediaEmbedsAsStringFallsBackToDefaults() {
+        let before = Date()
         let path = writeConfig("""
         {"ui":{"mediaEmbeds":"invalid"}}
         """)
         let store = SettingsStore(configPath: path)
+        let after = Date()
 
         XCTAssertEqual(store.mediaEmbedsEnabled, MediaEmbedSettings.defaultEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince, "Non-dict mediaEmbeds should default enabledSince to now")
+        let since = store.mediaEmbedsEnabledSince!
+        XCTAssertGreaterThanOrEqual(since, before)
+        XCTAssertLessThanOrEqual(since, after)
         XCTAssertEqual(store.mediaEmbedVideoAllowlistDomains, MediaEmbedSettings.defaultDomains)
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreMediaToggleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreMediaToggleTests.swift
@@ -49,7 +49,8 @@ final class SettingsStoreMediaToggleTests: XCTestCase {
         let store = SettingsStore(configPath: configPath)
 
         XCTAssertFalse(store.mediaEmbedsEnabled)
-        XCTAssertNil(store.mediaEmbedsEnabledSince)
+        // enabledSince is defaulted to now when the key is missing from config
+        XCTAssertNotNil(store.mediaEmbedsEnabledSince)
 
         let before = Date()
         store.setMediaEmbedsEnabled(true)


### PR DESCRIPTION
## Summary
- When `SettingsStore.loadMediaEmbedSettings()` finds no `enabledSince` value in the workspace config (no config file, empty config, missing section, missing key, or unparseable value), it now defaults to `MediaEmbedSettings.enabledSinceNow()` instead of `nil`.
- This prevents fresh installs from retroactively showing media embeds on old history messages, since `nil` was treated by `MediaEmbedResolver` as "allow all timestamps."
- The defaulted value is persisted to disk immediately via `persistMediaEmbedState()` so subsequent loads produce a deterministic timestamp rather than advancing with each app launch.

## Changes
- **`SettingsStore.swift`**: Added `didDefaultEnabledSince` flag to `MediaEmbedLoadResult`. Updated `loadMediaEmbedSettings()` to default `enabledSince` to now when missing/invalid. Added persistence call in `init` when the value was defaulted.
- **`SettingsStoreMediaLoadTests.swift`**: Updated 9 tests that previously asserted `nil` to assert non-nil with timestamp range checks. Added `testFreshInstallEnabledSinceIsApproximatelyNow` and `testDefaultedEnabledSinceIsPersistedToDisk`.
- **`SettingsStoreMediaToggleTests.swift`**: Updated `testToggleOffToOnSetsEnabledAndTimestamp` to expect non-nil initial `enabledSince`.
- **`MediaEmbedEnabledSinceGateTests.swift`**: Updated `testToggleOffToOnResetsEnabledSince` to expect non-nil initial `enabledSince` and added assertion that toggle ON produces a newer date.

## Test plan
- [x] `swift test --filter SettingsStoreMedia` — 33 tests pass
- [x] `swift test --filter MediaEmbedEnabledSinceGateTests` — 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
