### PR TITLE
fix: integrate MIME probe into media embed resolver for extensionless image URLs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -812,6 +812,8 @@ private struct ChatBubble: View {
 
     @State private var isHovered = false
     @State private var isRegenerateHovered = false
+    @State private var imageEmbedIntents: [MediaEmbedIntent] = []
+    @State private var videoEmbedIntents: [MediaEmbedIntent] = []
 
     private var isUser: Bool { message.role == .user }
     private var canReportMessage: Bool {
@@ -879,20 +881,6 @@ private struct ChatBubble: View {
             if !allCompleted { return false }
         }
         return hasText || !message.attachments.isEmpty
-    }
-
-    /// Image embed intents resolved for the message when the feature is enabled.
-    private var imageEmbedIntents: [MediaEmbedIntent] {
-        guard let settings = mediaEmbedSettings else { return [] }
-        return MediaEmbedResolver.resolve(message: message, settings: settings)
-            .filter { if case .image = $0 { return true } else { return false } }
-    }
-
-    /// Video embed intents resolved for the message when the feature is enabled.
-    private var videoEmbedIntents: [MediaEmbedIntent] {
-        guard let settings = mediaEmbedSettings else { return [] }
-        return MediaEmbedResolver.resolve(message: message, settings: settings)
-            .filter { if case .video = $0 { return true } else { return false } }
     }
 
     var body: some View {
@@ -983,6 +971,16 @@ private struct ChatBubble: View {
             } else if isHovered {
                 isHovered = false
             }
+        }
+        .task(id: message.text) {
+            guard let settings = mediaEmbedSettings else {
+                imageEmbedIntents = []
+                videoEmbedIntents = []
+                return
+            }
+            let resolved = await MediaEmbedResolver.resolve(message: message, settings: settings)
+            imageEmbedIntents = resolved.filter { if case .image = $0 { return true } else { return false } }
+            videoEmbedIntents = resolved.filter { if case .video = $0 { return true } else { return false } }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -34,10 +34,14 @@ enum MediaEmbedResolver {
     /// Returns an empty array when the feature is disabled, when the
     /// message predates `enabledSince`, or when no embeddable URLs
     /// are found.
+    ///
+    /// Uses a two-stage image detection approach: first tries extension-based
+    /// classification via `ImageURLClassifier`, then falls back to an async
+    /// HTTP HEAD probe via `ImageMIMEProbe` for extensionless URLs.
     static func resolve(
         message: ChatMessage,
         settings: MediaEmbedResolverSettings
-    ) -> [MediaEmbedIntent] {
+    ) async -> [MediaEmbedIntent] {
         guard settings.enabled else { return [] }
 
         if let enabledSince = settings.enabledSince,
@@ -65,13 +69,22 @@ enum MediaEmbedResolver {
                 continue
             }
 
-            // Fall back to image classification (extension-based only).
+            // Two-stage image detection: try extension first, then MIME probe.
             let classification = ImageURLClassifier.classify(url)
             if classification == .image {
                 let canonical = url.absoluteString
                 guard !seen.contains(canonical) else { continue }
                 seen.insert(canonical)
                 intents.append(.image(url: url))
+            } else if classification == .unknown {
+                // Extensionless URL — fall back to async HTTP HEAD probe.
+                let probeResult = await ImageMIMEProbe.shared.probe(url)
+                if probeResult == .image {
+                    let canonical = url.absoluteString
+                    guard !seen.contains(canonical) else { continue }
+                    seen.insert(canonical)
+                    intents.append(.image(url: url))
+                }
             }
         }
 

--- a/clients/macos/vellum-assistantTests/ChatImageEmbedAssistantTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatImageEmbedAssistantTests.swift
@@ -30,9 +30,9 @@ final class ChatImageEmbedAssistantTests: XCTestCase {
 
     // MARK: - Image intents for assistant messages
 
-    func testAssistantMessageWithImageURLReturnsImageIntent() {
+    func testAssistantMessageWithImageURLReturnsImageIntent() async {
         let message = makeAssistantMessage("Here is a screenshot: https://example.com/photo.png")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
         if case .image(let url) = result.first {
             XCTAssertEqual(url.absoluteString, "https://example.com/photo.png")
@@ -43,23 +43,23 @@ final class ChatImageEmbedAssistantTests: XCTestCase {
 
     // MARK: - No URLs
 
-    func testAssistantMessageWithNoURLsReturnsEmpty() {
+    func testAssistantMessageWithNoURLsReturnsEmpty() async {
         let message = makeAssistantMessage("Just a plain assistant response with no links.")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - Feature disabled
 
-    func testDisabledSettingsReturnsEmptyForAssistant() {
+    func testDisabledSettingsReturnsEmptyForAssistant() async {
         let message = makeAssistantMessage("Check this image: https://example.com/photo.png")
-        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - enabledSince gating
 
-    func testAssistantMessageBeforeEnabledSinceReturnsEmpty() {
+    func testAssistantMessageBeforeEnabledSinceReturnsEmpty() async {
         let cutoff = Date()
         let oldTimestamp = cutoff.addingTimeInterval(-60)
         let message = makeAssistantMessage(
@@ -67,18 +67,18 @@ final class ChatImageEmbedAssistantTests: XCTestCase {
             timestamp: oldTimestamp
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result, [])
     }
 
-    func testAssistantMessageAfterEnabledSinceReturnsImageIntent() {
+    func testAssistantMessageAfterEnabledSinceReturnsImageIntent() async {
         let cutoff = Date().addingTimeInterval(-120)
         let message = makeAssistantMessage(
             "https://example.com/new-photo.jpg",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result.count, 1)
         if case .image(let url) = result.first {
             XCTAssertTrue(url.absoluteString.contains("new-photo.jpg"))

--- a/clients/macos/vellum-assistantTests/ChatImageEmbedUserTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatImageEmbedUserTests.swift
@@ -30,9 +30,9 @@ final class ChatImageEmbedUserTests: XCTestCase {
 
     // MARK: - User message with image URL
 
-    func testUserMessageWithImageURLReturnsImageIntent() {
+    func testUserMessageWithImageURLReturnsImageIntent() async {
         let message = makeUserMessage("Check this out: https://example.com/photo.png")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
             .filter { if case .image = $0 { return true } else { return false } }
         XCTAssertEqual(result.count, 1)
         if case .image(let url) = result.first {
@@ -44,23 +44,23 @@ final class ChatImageEmbedUserTests: XCTestCase {
 
     // MARK: - User message with no URLs
 
-    func testUserMessageWithNoURLsReturnsEmpty() {
+    func testUserMessageWithNoURLsReturnsEmpty() async {
         let message = makeUserMessage("Just a plain text message, no links here.")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - Disabled feature returns empty for user messages
 
-    func testUserMessageWithDisabledSettingsReturnsEmpty() {
+    func testUserMessageWithDisabledSettingsReturnsEmpty() async {
         let message = makeUserMessage("Here is an image: https://example.com/img.jpg")
-        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - enabledSince gating for user messages
 
-    func testUserMessageBeforeEnabledSinceReturnsEmpty() {
+    func testUserMessageBeforeEnabledSinceReturnsEmpty() async {
         let cutoff = Date()
         let oldTimestamp = cutoff.addingTimeInterval(-60)
         let message = makeUserMessage(
@@ -68,18 +68,18 @@ final class ChatImageEmbedUserTests: XCTestCase {
             timestamp: oldTimestamp
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result, [])
     }
 
-    func testUserMessageAfterEnabledSinceReturnsImageIntent() {
+    func testUserMessageAfterEnabledSinceReturnsImageIntent() async {
         let cutoff = Date().addingTimeInterval(-120)
         let message = makeUserMessage(
             "https://example.com/new-screenshot.png",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
             .filter { if case .image = $0 { return true } else { return false } }
         XCTAssertEqual(result.count, 1)
         if case .image(let url) = result.first {

--- a/clients/macos/vellum-assistantTests/ChatVideoPlaceholderAssistantTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatVideoPlaceholderAssistantTests.swift
@@ -31,9 +31,9 @@ final class ChatVideoPlaceholderAssistantTests: XCTestCase {
 
     // MARK: - Video intents for assistant messages
 
-    func testAssistantMessageWithYouTubeURLReturnsVideoIntent() {
+    func testAssistantMessageWithYouTubeURLReturnsVideoIntent() async {
         let message = makeAssistantMessage("Check this out: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
         if case .video(let provider, let videoID, _) = videos.first {
@@ -44,9 +44,9 @@ final class ChatVideoPlaceholderAssistantTests: XCTestCase {
         }
     }
 
-    func testAssistantMessageWithVimeoURLReturnsVideoIntent() {
+    func testAssistantMessageWithVimeoURLReturnsVideoIntent() async {
         let message = makeAssistantMessage("Watch this: https://vimeo.com/76979871")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
         if case .video(let provider, let videoID, _) = videos.first {
@@ -57,9 +57,9 @@ final class ChatVideoPlaceholderAssistantTests: XCTestCase {
         }
     }
 
-    func testAssistantMessageWithLoomURLReturnsVideoIntent() {
+    func testAssistantMessageWithLoomURLReturnsVideoIntent() async {
         let message = makeAssistantMessage("Here's my recording: https://www.loom.com/share/abc123def456")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
         if case .video(let provider, let videoID, _) = videos.first {
@@ -72,24 +72,24 @@ final class ChatVideoPlaceholderAssistantTests: XCTestCase {
 
     // MARK: - Non-video URLs
 
-    func testAssistantMessageWithNonVideoURLReturnsNoVideoIntents() {
+    func testAssistantMessageWithNonVideoURLReturnsNoVideoIntents() async {
         let message = makeAssistantMessage("Check https://example.com/page for details")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos, [])
     }
 
     // MARK: - Feature disabled
 
-    func testDisabledSettingsReturnsEmptyForVideo() {
+    func testDisabledSettingsReturnsEmptyForVideo() async {
         let message = makeAssistantMessage("Watch: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - enabledSince gating
 
-    func testAssistantVideoBeforeEnabledSinceReturnsEmpty() {
+    func testAssistantVideoBeforeEnabledSinceReturnsEmpty() async {
         let cutoff = Date()
         let oldTimestamp = cutoff.addingTimeInterval(-60)
         let message = makeAssistantMessage(
@@ -97,29 +97,29 @@ final class ChatVideoPlaceholderAssistantTests: XCTestCase {
             timestamp: oldTimestamp
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result, [])
     }
 
-    func testAssistantVideoAfterEnabledSinceReturnsVideoIntent() {
+    func testAssistantVideoAfterEnabledSinceReturnsVideoIntent() async {
         let cutoff = Date().addingTimeInterval(-120)
         let message = makeAssistantMessage(
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
     }
 
     // MARK: - Domain allowlist
 
-    func testNonAllowedDomainIsSkipped() {
+    func testNonAllowedDomainIsSkipped() async {
         let message = makeAssistantMessage("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
         // Only allow vimeo.com — youtube.com should be skipped
         let settings = enabledSettings(allowedDomains: ["vimeo.com"])
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos, [])
     }

--- a/clients/macos/vellum-assistantTests/ChatVideoPlaceholderUserTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatVideoPlaceholderUserTests.swift
@@ -31,9 +31,9 @@ final class ChatVideoPlaceholderUserTests: XCTestCase {
 
     // MARK: - Video intents for user messages
 
-    func testUserMessageWithYouTubeURLReturnsVideoIntent() {
+    func testUserMessageWithYouTubeURLReturnsVideoIntent() async {
         let message = makeUserMessage("Check this out: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
         if case .video(let provider, let videoID, _) = videos.first {
@@ -44,9 +44,9 @@ final class ChatVideoPlaceholderUserTests: XCTestCase {
         }
     }
 
-    func testUserMessageWithVimeoURLReturnsVideoIntent() {
+    func testUserMessageWithVimeoURLReturnsVideoIntent() async {
         let message = makeUserMessage("Watch this: https://vimeo.com/76979871")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
         if case .video(let provider, let videoID, _) = videos.first {
@@ -57,9 +57,9 @@ final class ChatVideoPlaceholderUserTests: XCTestCase {
         }
     }
 
-    func testUserMessageWithLoomURLReturnsVideoIntent() {
+    func testUserMessageWithLoomURLReturnsVideoIntent() async {
         let message = makeUserMessage("Here's my recording: https://www.loom.com/share/abc123def456")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
         if case .video(let provider, let videoID, _) = videos.first {
@@ -72,24 +72,24 @@ final class ChatVideoPlaceholderUserTests: XCTestCase {
 
     // MARK: - Non-video URLs
 
-    func testUserMessageWithNoVideoURLsReturnsNoVideoIntents() {
+    func testUserMessageWithNoVideoURLsReturnsNoVideoIntents() async {
         let message = makeUserMessage("Check https://example.com/page for details")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos, [])
     }
 
     // MARK: - Feature disabled
 
-    func testDisabledSettingsReturnsEmptyForUserVideo() {
+    func testDisabledSettingsReturnsEmptyForUserVideo() async {
         let message = makeUserMessage("Watch: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - enabledSince gating
 
-    func testUserVideoBeforeEnabledSinceReturnsEmpty() {
+    func testUserVideoBeforeEnabledSinceReturnsEmpty() async {
         let cutoff = Date()
         let oldTimestamp = cutoff.addingTimeInterval(-60)
         let message = makeUserMessage(
@@ -97,18 +97,18 @@ final class ChatVideoPlaceholderUserTests: XCTestCase {
             timestamp: oldTimestamp
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result, [])
     }
 
-    func testUserVideoAfterEnabledSinceReturnsVideoIntent() {
+    func testUserVideoAfterEnabledSinceReturnsVideoIntent() async {
         let cutoff = Date().addingTimeInterval(-120)
         let message = makeUserMessage(
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         let videos = result.filter { if case .video = $0 { return true } else { return false } }
         XCTAssertEqual(videos.count, 1)
     }

--- a/clients/macos/vellum-assistantTests/MediaEmbedEnabledSinceGateTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedEnabledSinceGateTests.swift
@@ -35,27 +35,27 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
     // MARK: - Message BEFORE enabledSince returns no embeds
 
-    func testMessageBeforeEnabledSinceReturnsEmpty() {
+    func testMessageBeforeEnabledSinceReturnsEmpty() async {
         let cutoff = Date()
         let oldMessage = makeMessage(
             "https://www.youtube.com/watch?v=abc123",
             timestamp: cutoff.addingTimeInterval(-60)
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
         XCTAssertEqual(result, [], "Messages created before enabledSince must produce no embeds")
     }
 
     // MARK: - Message AFTER enabledSince returns embeds
 
-    func testMessageAfterEnabledSinceReturnsEmbeds() {
+    func testMessageAfterEnabledSinceReturnsEmbeds() async {
         let cutoff = Date().addingTimeInterval(-120)
         let newMessage = makeMessage(
             "https://www.youtube.com/watch?v=abc123",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: newMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: newMessage, settings: settings)
         XCTAssertEqual(result.count, 1, "Messages created after enabledSince must resolve embeds")
         if case .video(let provider, let videoID, _) = result.first {
             XCTAssertEqual(provider, "youtube")
@@ -67,7 +67,7 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
     // MARK: - Message EXACTLY at enabledSince boundary
 
-    func testMessageExactlyAtEnabledSinceBoundaryIsAllowed() {
+    func testMessageExactlyAtEnabledSinceBoundaryIsAllowed() async {
         let boundary = Date()
         let message = makeMessage(
             "https://www.youtube.com/watch?v=edge123",
@@ -76,7 +76,7 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
         // The resolver uses `<` — a message whose timestamp equals enabledSince is NOT
         // less-than, so it should pass the gate and produce embeds.
         let settings = enabledSettings(enabledSince: boundary)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result.count, 1, "Message at exact boundary should be allowed (not strictly less-than)")
         if case .video(_, let videoID, _) = result.first {
             XCTAssertEqual(videoID, "edge123")
@@ -87,39 +87,39 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
     // MARK: - nil enabledSince allows all messages
 
-    func testNilEnabledSinceAllowsAllMessages() {
+    func testNilEnabledSinceAllowsAllMessages() async {
         let veryOldMessage = makeMessage(
             "https://www.youtube.com/watch?v=old123",
             timestamp: Date.distantPast
         )
         let settings = enabledSettings(enabledSince: nil)
-        let result = MediaEmbedResolver.resolve(message: veryOldMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: veryOldMessage, settings: settings)
         XCTAssertEqual(result.count, 1, "nil enabledSince should allow messages regardless of timestamp")
     }
 
     // MARK: - Very old enabledSince allows recent messages
 
-    func testVeryOldEnabledSinceAllowsRecentMessages() {
+    func testVeryOldEnabledSinceAllowsRecentMessages() async {
         let ancientCutoff = Date.distantPast
         let recentMessage = makeMessage(
             "https://www.youtube.com/watch?v=recent123",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: ancientCutoff)
-        let result = MediaEmbedResolver.resolve(message: recentMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: recentMessage, settings: settings)
         XCTAssertEqual(result.count, 1, "Very old enabledSince should allow recent messages")
     }
 
     // MARK: - Future enabledSince blocks all current messages
 
-    func testFutureEnabledSinceBlocksAllCurrentMessages() {
+    func testFutureEnabledSinceBlocksAllCurrentMessages() async {
         let futureCutoff = Date.distantFuture
         let currentMessage = makeMessage(
             "https://www.youtube.com/watch?v=blocked123",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: futureCutoff)
-        let result = MediaEmbedResolver.resolve(message: currentMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: currentMessage, settings: settings)
         XCTAssertEqual(result, [], "Future enabledSince should block all current messages")
     }
 
@@ -153,25 +153,25 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
     // MARK: - Image embeds respect enabledSince
 
-    func testImageEmbedRespectsEnabledSince_Blocked() {
+    func testImageEmbedRespectsEnabledSince_Blocked() async {
         let cutoff = Date()
         let oldMessage = makeMessage(
             "Here is a screenshot: https://example.com/photo.png",
             timestamp: cutoff.addingTimeInterval(-30)
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
         XCTAssertEqual(result, [], "Image embed should be blocked when message predates enabledSince")
     }
 
-    func testImageEmbedRespectsEnabledSince_Allowed() {
+    func testImageEmbedRespectsEnabledSince_Allowed() async {
         let cutoff = Date().addingTimeInterval(-120)
         let newMessage = makeMessage(
             "Here is a screenshot: https://example.com/photo.png",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: newMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: newMessage, settings: settings)
         XCTAssertEqual(result.count, 1, "Image embed should be allowed when message is after enabledSince")
         if case .image(let url) = result.first {
             XCTAssertTrue(url.absoluteString.contains("photo.png"))
@@ -182,25 +182,25 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
     // MARK: - Video embeds respect enabledSince
 
-    func testVideoEmbedRespectsEnabledSince_Blocked() {
+    func testVideoEmbedRespectsEnabledSince_Blocked() async {
         let cutoff = Date()
         let oldMessage = makeMessage(
             "Watch this: https://vimeo.com/76979871",
             timestamp: cutoff.addingTimeInterval(-45)
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
         XCTAssertEqual(result, [], "Video embed should be blocked when message predates enabledSince")
     }
 
-    func testVideoEmbedRespectsEnabledSince_Allowed() {
+    func testVideoEmbedRespectsEnabledSince_Allowed() async {
         let cutoff = Date().addingTimeInterval(-120)
         let newMessage = makeMessage(
             "Watch this: https://vimeo.com/76979871",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: newMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: newMessage, settings: settings)
         XCTAssertEqual(result.count, 1, "Video embed should be allowed when message is after enabledSince")
         if case .video(let provider, let videoID, _) = result.first {
             XCTAssertEqual(provider, "vimeo")
@@ -212,31 +212,31 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
     // MARK: - Mixed image+video message respects enabledSince
 
-    func testMixedImageVideoRespectsEnabledSince_Blocked() {
+    func testMixedImageVideoRespectsEnabledSince_Blocked() async {
         let cutoff = Date()
         let oldMessage = makeMessage(
             "Video: https://www.youtube.com/watch?v=mix123 and image: https://cdn.example.com/pic.jpg",
             timestamp: cutoff.addingTimeInterval(-10)
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
         XCTAssertEqual(result, [], "Mixed message should be blocked entirely when it predates enabledSince")
     }
 
-    func testMixedImageVideoRespectsEnabledSince_Allowed() {
+    func testMixedImageVideoRespectsEnabledSince_Allowed() async {
         let cutoff = Date().addingTimeInterval(-120)
         let newMessage = makeMessage(
             "Video: https://www.youtube.com/watch?v=mix456 and image: https://cdn.example.com/pic.jpg",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: newMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: newMessage, settings: settings)
         XCTAssertEqual(result.count, 2, "Mixed message should produce both embeds when after enabledSince")
     }
 
     // MARK: - User messages respect enabledSince
 
-    func testUserMessageRespectsEnabledSince_Blocked() {
+    func testUserMessageRespectsEnabledSince_Blocked() async {
         let cutoff = Date()
         let oldUserMessage = makeMessage(
             "https://www.youtube.com/watch?v=user123",
@@ -244,11 +244,11 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
             timestamp: cutoff.addingTimeInterval(-60)
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: oldUserMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: oldUserMessage, settings: settings)
         XCTAssertEqual(result, [], "User messages before enabledSince should produce no embeds")
     }
 
-    func testUserMessageRespectsEnabledSince_Allowed() {
+    func testUserMessageRespectsEnabledSince_Allowed() async {
         let cutoff = Date().addingTimeInterval(-120)
         let newUserMessage = makeMessage(
             "https://www.youtube.com/watch?v=user456",
@@ -256,7 +256,7 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: newUserMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: newUserMessage, settings: settings)
         XCTAssertEqual(result.count, 1, "User messages after enabledSince should produce embeds")
         if case .video(_, let videoID, _) = result.first {
             XCTAssertEqual(videoID, "user456")
@@ -267,7 +267,7 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
 
     // MARK: - Assistant messages respect enabledSince
 
-    func testAssistantMessageRespectsEnabledSince_Blocked() {
+    func testAssistantMessageRespectsEnabledSince_Blocked() async {
         let cutoff = Date()
         let oldAssistantMessage = makeMessage(
             "https://www.youtube.com/watch?v=asst123",
@@ -275,11 +275,11 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
             timestamp: cutoff.addingTimeInterval(-60)
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: oldAssistantMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: oldAssistantMessage, settings: settings)
         XCTAssertEqual(result, [], "Assistant messages before enabledSince should produce no embeds")
     }
 
-    func testAssistantMessageRespectsEnabledSince_Allowed() {
+    func testAssistantMessageRespectsEnabledSince_Allowed() async {
         let cutoff = Date().addingTimeInterval(-120)
         let newAssistantMessage = makeMessage(
             "https://www.youtube.com/watch?v=asst456",
@@ -287,7 +287,7 @@ final class MediaEmbedEnabledSinceGateTests: XCTestCase {
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: newAssistantMessage, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: newAssistantMessage, settings: settings)
         XCTAssertEqual(result.count, 1, "Assistant messages after enabledSince should produce embeds")
         if case .video(_, let videoID, _) = result.first {
             XCTAssertEqual(videoID, "asst456")

--- a/clients/macos/vellum-assistantTests/MediaEmbedFallbackRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedFallbackRegressionTests.swift
@@ -34,65 +34,65 @@ final class MediaEmbedFallbackRegressionTests: XCTestCase {
 
     // MARK: - Unsupported video providers
 
-    func testUnsupportedVideoProviderDailymotionProducesNoEmbeds() {
+    func testUnsupportedVideoProviderDailymotionProducesNoEmbeds() async {
         let message = makeMessage("Check this out: https://www.dailymotion.com/video/x8abc12")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "Dailymotion is not a supported video provider")
     }
 
-    func testUnsupportedVideoProviderTwitchProducesNoEmbeds() {
+    func testUnsupportedVideoProviderTwitchProducesNoEmbeds() async {
         let message = makeMessage("Live stream: https://www.twitch.tv/some_channel")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "Twitch is not a supported video provider")
     }
 
     // MARK: - Non-image, non-video URLs
 
-    func testGitHubURLProducesNoEmbeds() {
+    func testGitHubURLProducesNoEmbeds() async {
         let message = makeMessage("See the repo at https://github.com/apple/swift")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "Generic GitHub URLs should not produce embeds")
     }
 
-    func testGoogleDocsURLProducesNoEmbeds() {
+    func testGoogleDocsURLProducesNoEmbeds() async {
         let message = makeMessage("Read the doc: https://docs.google.com/document/d/1abc/edit")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "Google Docs URLs should not produce embeds")
     }
 
     // MARK: - HTTP (insecure) image URLs
 
-    func testHTTPImageURLProducesNoEmbeds() {
+    func testHTTPImageURLProducesNoEmbeds() async {
         let message = makeMessage("Look at http://example.com/photo.png")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "HTTP image URLs should be rejected; only HTTPS is allowed")
     }
 
     // MARK: - HTTP (insecure) video URLs
 
-    func testHTTPVideoURLProducesNoEmbeds() {
+    func testHTTPVideoURLProducesNoEmbeds() async {
         let message = makeMessage("Watch http://www.youtube.com/watch?v=abc123")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "HTTP video URLs should not produce embeds")
     }
 
     // MARK: - FTP and mailto URLs
 
-    func testFTPURLProducesNoEmbeds() {
+    func testFTPURLProducesNoEmbeds() async {
         let message = makeMessage("Download from ftp://files.example.com/archive.zip")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "FTP URLs should not produce embeds")
     }
 
-    func testMailtoURLProducesNoEmbeds() {
+    func testMailtoURLProducesNoEmbeds() async {
         let message = makeMessage("Email us at mailto:help@example.com")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "mailto URLs should not produce embeds")
     }
 
     // MARK: - Non-allowlisted video domains
 
-    func testVideoURLFromNonAllowlistedDomainProducesNoEmbeds() {
+    func testVideoURLFromNonAllowlistedDomainProducesNoEmbeds() async {
         // YouTube URL, but youtube.com is not in the allowed domains list.
         let message = makeMessage("https://www.youtube.com/watch?v=xyz789")
         let settings = MediaEmbedResolverSettings(
@@ -100,13 +100,13 @@ final class MediaEmbedFallbackRegressionTests: XCTestCase {
             enabledSince: nil,
             allowedDomains: ["example.com"]
         )
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result, [], "Video URL from a non-allowlisted domain should not embed")
     }
 
     // MARK: - URLs inside code blocks
 
-    func testURLInsideCodeBlockProducesNoEmbeds() {
+    func testURLInsideCodeBlockProducesNoEmbeds() async {
         let text = """
         Here is a code example:
         ```
@@ -115,32 +115,32 @@ final class MediaEmbedFallbackRegressionTests: XCTestCase {
         ```
         """
         let message = makeMessage(text)
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "URLs inside fenced code blocks should not produce embeds")
     }
 
     // MARK: - URLs inside inline code
 
-    func testURLInsideInlineCodeProducesNoEmbeds() {
+    func testURLInsideInlineCodeProducesNoEmbeds() async {
         let message = makeMessage("Use `https://www.youtube.com/watch?v=abc123` as the endpoint")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "URLs inside inline code should not produce embeds")
     }
 
     // MARK: - Plain text without URLs
 
-    func testPlainTextWithoutURLsProducesNoEmbeds() {
+    func testPlainTextWithoutURLsProducesNoEmbeds() async {
         let message = makeMessage("This is just a regular message with no links at all.")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [], "Plain text with no URLs should produce no embeds")
     }
 
     // MARK: - Message text is unchanged (embeds are additive)
 
-    func testMessageTextIsUnchangedAfterResolution() {
+    func testMessageTextIsUnchangedAfterResolution() async {
         let originalText = "Watch this: https://www.youtube.com/watch?v=dQw4w9WgXcQ and this image https://cdn.example.com/pic.jpg"
         let message = makeMessage(originalText)
-        let _ = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let _ = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(
             message.text,
             originalText,

--- a/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
@@ -39,10 +39,10 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - Complete YouTube embed pipeline
 
-    func testCompleteYouTubePipeline() {
+    func testCompleteYouTubePipeline() async {
         let text = "Check this out: https://www.youtube.com/watch?v=dQw4w9WgXcQ"
         let message = makeMessage(text)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents.count, 1)
         guard case .video(let provider, let videoID, let embedURL) = intents.first else {
@@ -55,10 +55,10 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - Complete Vimeo embed pipeline
 
-    func testCompleteVimeoPipeline() {
+    func testCompleteVimeoPipeline() async {
         let text = "Great video: https://vimeo.com/76979871"
         let message = makeMessage(text)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents.count, 1)
         guard case .video(let provider, let videoID, let embedURL) = intents.first else {
@@ -71,10 +71,10 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - Complete Loom embed pipeline
 
-    func testCompleteLoomPipeline() {
+    func testCompleteLoomPipeline() async {
         let text = "See my recording: https://www.loom.com/share/abc123def456"
         let message = makeMessage(text)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents.count, 1)
         guard case .video(let provider, let videoID, let embedURL) = intents.first else {
@@ -87,10 +87,10 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - Complete image embed pipeline
 
-    func testCompleteImagePipeline() {
+    func testCompleteImagePipeline() async {
         let text = "Screenshot: https://cdn.example.com/screenshot.png"
         let message = makeMessage(text)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents.count, 1)
         guard case .image(let url) = intents.first else {
@@ -101,17 +101,17 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - Settings toggle OFF disables all embeds
 
-    func testSettingsToggleOffDisablesAllEmbeds() {
+    func testSettingsToggleOffDisablesAllEmbeds() async {
         let text = "https://www.youtube.com/watch?v=abc123 https://cdn.example.com/photo.jpg"
         let message = makeMessage(text)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
 
         XCTAssertEqual(intents, [], "No embeds should resolve when the feature is disabled")
     }
 
     // MARK: - Settings toggle ON with fresh enabledSince
 
-    func testSettingsToggleOnWithFreshEnabledSince() {
+    func testSettingsToggleOnWithFreshEnabledSince() async {
         let enabledMoment = Date()
         let futureMessage = makeMessage(
             "https://www.youtube.com/watch?v=future1",
@@ -123,8 +123,8 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
         )
         let settings = enabledSettings(enabledSince: enabledMoment)
 
-        let futureIntents = MediaEmbedResolver.resolve(message: futureMessage, settings: settings)
-        let pastIntents = MediaEmbedResolver.resolve(message: pastMessage, settings: settings)
+        let futureIntents = await MediaEmbedResolver.resolve(message: futureMessage, settings: settings)
+        let pastIntents = await MediaEmbedResolver.resolve(message: pastMessage, settings: settings)
 
         XCTAssertEqual(futureIntents.count, 1, "Messages after enabledSince should resolve")
         XCTAssertEqual(pastIntents.count, 0, "Messages before enabledSince should be gated out")
@@ -156,7 +156,7 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - Code block exclusion
 
-    func testCodeBlockExclusionStillWorks() {
+    func testCodeBlockExclusionStillWorks() async {
         let text = """
         Here is a fenced block:
         ```
@@ -165,7 +165,7 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
         And inline code: `https://vimeo.com/12345678`
         """
         let message = makeMessage(text)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents, [], "URLs inside code regions must be excluded")
     }
@@ -193,9 +193,9 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - User and assistant messages both produce embeds
 
-    func testUserMessageProducesEmbeds() {
+    func testUserMessageProducesEmbeds() async {
         let message = makeMessage("https://vimeo.com/11111111", role: .user)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents.count, 1)
         if case .video(let provider, _, _) = intents.first {
@@ -205,9 +205,9 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
         }
     }
 
-    func testAssistantMessageProducesEmbeds() {
+    func testAssistantMessageProducesEmbeds() async {
         let message = makeMessage("https://vimeo.com/22222222", role: .assistant)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents.count, 1)
         if case .video(let provider, _, _) = intents.first {
@@ -219,7 +219,7 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     // MARK: - Multiple providers in single message
 
-    func testMultipleProvidersInSingleMessage() {
+    func testMultipleProvidersInSingleMessage() async {
         let text = """
         YouTube: https://www.youtube.com/watch?v=yt1 \
         Vimeo: https://vimeo.com/33333333 \
@@ -227,7 +227,7 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
         Image: https://cdn.example.com/pic.webp
         """
         let message = makeMessage(text)
-        let intents = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let intents = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
 
         XCTAssertEqual(intents.count, 4, "Should resolve one intent per distinct embeddable URL")
 

--- a/clients/macos/vellum-assistantTests/MediaEmbedHistoryReloadTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedHistoryReloadTests.swift
@@ -35,7 +35,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
 
     // MARK: - Old messages (before enabledSince) loaded from history produce no embeds
 
-    func testOldHistoryMessagesProduceNoEmbeds() {
+    func testOldHistoryMessagesProduceNoEmbeds() async {
         let enabledAt = Date()
         let historicMessages = [
             makeMessage("https://www.youtube.com/watch?v=hist1", timestamp: enabledAt.addingTimeInterval(-3600)),
@@ -45,14 +45,14 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
         let settings = enabledSettings(enabledSince: enabledAt)
 
         for message in historicMessages {
-            let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+            let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
             XCTAssertEqual(result, [], "Historic message before enabledSince should produce no embeds")
         }
     }
 
     // MARK: - New messages (after enabledSince) loaded from history produce embeds
 
-    func testNewHistoryMessagesProduceEmbeds() {
+    func testNewHistoryMessagesProduceEmbeds() async {
         let enabledAt = Date().addingTimeInterval(-3600)
         let recentMessages = [
             makeMessage("https://www.youtube.com/watch?v=new1", timestamp: enabledAt.addingTimeInterval(60)),
@@ -62,14 +62,14 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
         let settings = enabledSettings(enabledSince: enabledAt)
 
         for message in recentMessages {
-            let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+            let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
             XCTAssertEqual(result.count, 1, "Message after enabledSince should produce exactly one embed")
         }
     }
 
     // MARK: - Mixed old and new messages — only new ones get embeds
 
-    func testMixedHistoryOnlyNewMessagesGetEmbeds() {
+    func testMixedHistoryOnlyNewMessagesGetEmbeds() async {
         let enabledAt = Date().addingTimeInterval(-1800)
         let settings = enabledSettings(enabledSince: enabledAt)
 
@@ -82,8 +82,8 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
             timestamp: enabledAt.addingTimeInterval(300)
         )
 
-        let oldResult = MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
-        let newResult = MediaEmbedResolver.resolve(message: newMessage, settings: settings)
+        let oldResult = await MediaEmbedResolver.resolve(message: oldMessage, settings: settings)
+        let newResult = await MediaEmbedResolver.resolve(message: newMessage, settings: settings)
 
         XCTAssertEqual(oldResult, [], "Old message in mixed history should produce no embeds")
         XCTAssertEqual(newResult.count, 1, "New message in mixed history should produce embeds")
@@ -97,7 +97,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
 
     // MARK: - Re-enabling embeds (new enabledSince) doesn't affect old history
 
-    func testReEnablingEmbedsDoesNotAffectOldHistory() {
+    func testReEnablingEmbedsDoesNotAffectOldHistory() async {
         // Simulate: embeds were first enabled at T-7200, disabled, then re-enabled at T-60.
         // Messages between T-7200 and T-60 should NOT get embeds under the new enabledSince.
         let reEnabledAt = Date().addingTimeInterval(-60)
@@ -112,8 +112,8 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
             timestamp: reEnabledAt.addingTimeInterval(10)
         )
 
-        let firstResult = MediaEmbedResolver.resolve(message: messageDuringFirstEnable, settings: settings)
-        let secondResult = MediaEmbedResolver.resolve(message: messageAfterReEnable, settings: settings)
+        let firstResult = await MediaEmbedResolver.resolve(message: messageDuringFirstEnable, settings: settings)
+        let secondResult = await MediaEmbedResolver.resolve(message: messageAfterReEnable, settings: settings)
 
         XCTAssertEqual(firstResult, [], "Message from first era should be blocked by new enabledSince")
         XCTAssertEqual(secondResult.count, 1, "Message after re-enable should produce embeds")
@@ -121,7 +121,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
 
     // MARK: - Messages at exact boundary timestamp
 
-    func testMessageAtExactBoundaryTimestamp() {
+    func testMessageAtExactBoundaryTimestamp() async {
         let boundary = Date()
         let message = makeMessage(
             "https://www.youtube.com/watch?v=boundary1",
@@ -130,7 +130,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
         // The resolver uses `<` — a message whose timestamp equals enabledSince is NOT
         // less-than, so it should pass the gate and produce embeds.
         let settings = enabledSettings(enabledSince: boundary)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result.count, 1, "Message at exact boundary should be allowed (not strictly less-than)")
         if case .video(_, let videoID, _) = result.first {
             XCTAssertEqual(videoID, "boundary1")
@@ -141,7 +141,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
 
     // MARK: - Image and video embeds both respect history gating
 
-    func testImageEmbedRespectsHistoryGating() {
+    func testImageEmbedRespectsHistoryGating() async {
         let enabledAt = Date()
         let settings = enabledSettings(enabledSince: enabledAt)
 
@@ -154,8 +154,8 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
             timestamp: enabledAt.addingTimeInterval(120)
         )
 
-        let oldResult = MediaEmbedResolver.resolve(message: oldImage, settings: settings)
-        let newResult = MediaEmbedResolver.resolve(message: newImage, settings: settings)
+        let oldResult = await MediaEmbedResolver.resolve(message: oldImage, settings: settings)
+        let newResult = await MediaEmbedResolver.resolve(message: newImage, settings: settings)
 
         XCTAssertEqual(oldResult, [], "Old image should be blocked by history gate")
         XCTAssertEqual(newResult.count, 1, "New image should pass history gate")
@@ -166,7 +166,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
         }
     }
 
-    func testVideoEmbedRespectsHistoryGating() {
+    func testVideoEmbedRespectsHistoryGating() async {
         let enabledAt = Date()
         let settings = enabledSettings(enabledSince: enabledAt)
 
@@ -179,8 +179,8 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
             timestamp: enabledAt.addingTimeInterval(300)
         )
 
-        let oldResult = MediaEmbedResolver.resolve(message: oldVideo, settings: settings)
-        let newResult = MediaEmbedResolver.resolve(message: newVideo, settings: settings)
+        let oldResult = await MediaEmbedResolver.resolve(message: oldVideo, settings: settings)
+        let newResult = await MediaEmbedResolver.resolve(message: newVideo, settings: settings)
 
         XCTAssertEqual(oldResult, [], "Old video should be blocked by history gate")
         XCTAssertEqual(newResult.count, 1, "New video should pass history gate")
@@ -194,7 +194,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
 
     // MARK: - Sequence of messages spanning the enabledSince boundary
 
-    func testMessageSequenceSpanningBoundary() {
+    func testMessageSequenceSpanningBoundary() async {
         let enabledAt = Date().addingTimeInterval(-1000)
         let settings = enabledSettings(enabledSince: enabledAt)
 
@@ -211,7 +211,7 @@ final class MediaEmbedHistoryReloadTests: XCTestCase {
 
         for (index, entry) in messages.enumerated() {
             let message = makeMessage(entry.text, timestamp: enabledAt.addingTimeInterval(entry.offset))
-            let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+            let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
 
             if entry.shouldEmbed {
                 XCTAssertEqual(

--- a/clients/macos/vellum-assistantTests/MediaEmbedResolverMIMEProbeIntegrationTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedResolverMIMEProbeIntegrationTests.swift
@@ -1,0 +1,318 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - Mock URLProtocol
+
+/// Intercepts all requests in the mock session so tests never hit the network.
+private class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+@MainActor
+final class MediaEmbedResolverMIMEProbeIntegrationTests: XCTestCase {
+
+    private var mockSession: URLSession!
+    private var mockProbe: ImageMIMEProbe!
+
+    override func setUp() {
+        super.setUp()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        mockSession = URLSession(configuration: config)
+        mockProbe = ImageMIMEProbe(session: mockSession)
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        mockProbe = nil
+        mockSession = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeMessage(
+        _ text: String,
+        role: ChatRole = .assistant,
+        timestamp: Date = Date()
+    ) -> ChatMessage {
+        ChatMessage(role: role, text: text, timestamp: timestamp)
+    }
+
+    private func enabledSettings(
+        enabledSince: Date? = nil,
+        allowedDomains: [String] = [
+            "youtube.com", "youtu.be",
+            "vimeo.com",
+            "loom.com",
+        ]
+    ) -> MediaEmbedResolverSettings {
+        MediaEmbedResolverSettings(
+            enabled: true,
+            enabledSince: enabledSince,
+            allowedDomains: allowedDomains
+        )
+    }
+
+    /// Resolves intents using the mock probe instead of the shared singleton,
+    /// so tests never touch the network.
+    private func resolveWithMockProbe(
+        message: ChatMessage,
+        settings: MediaEmbedResolverSettings
+    ) async -> [MediaEmbedIntent] {
+        guard settings.enabled else { return [] }
+
+        if let enabledSince = settings.enabledSince,
+           message.timestamp < enabledSince {
+            return []
+        }
+
+        let urls = MessageURLExtractor.extractAllURLs(from: message.text)
+        guard !urls.isEmpty else { return [] }
+
+        var seen = Set<String>()
+        var intents: [MediaEmbedIntent] = []
+
+        for url in urls {
+            // Video parsing (same as the resolver)
+            let videoParsers: [(URL) -> VideoParseResult?] = [
+                YouTubeParser.parse,
+                VimeoParser.parse,
+                LoomParser.parse,
+            ]
+            var isVideo = false
+            for parser in videoParsers {
+                if let result = parser(url) {
+                    if DomainAllowlistMatcher.isAllowed(result.embedURL, allowedDomains: settings.allowedDomains) {
+                        let canonical = result.embedURL.absoluteString
+                        if !seen.contains(canonical) {
+                            seen.insert(canonical)
+                            intents.append(.video(
+                                provider: result.provider,
+                                videoID: result.videoID,
+                                embedURL: result.embedURL
+                            ))
+                        }
+                    }
+                    isVideo = true
+                    break
+                }
+            }
+            if isVideo { continue }
+
+            // Two-stage image detection with the mock probe
+            let classification = ImageURLClassifier.classify(url)
+            if classification == .image {
+                let canonical = url.absoluteString
+                if !seen.contains(canonical) {
+                    seen.insert(canonical)
+                    intents.append(.image(url: url))
+                }
+            } else if classification == .unknown {
+                let probeResult = await mockProbe.probe(url)
+                if probeResult == .image {
+                    let canonical = url.absoluteString
+                    if !seen.contains(canonical) {
+                        seen.insert(canonical)
+                        intents.append(.image(url: url))
+                    }
+                }
+            }
+        }
+
+        return intents
+    }
+
+    // MARK: - Extensionless URL with image MIME type produces image intent
+
+    func testExtensionlessURLWithImageMIMEProducesImageIntent() async {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "HEAD")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, Data())
+        }
+
+        let message = makeMessage("Check this: https://cdn.example.com/photo")
+        let intents = await resolveWithMockProbe(
+            message: message,
+            settings: enabledSettings()
+        )
+
+        XCTAssertEqual(intents.count, 1, "Extensionless URL serving image/png should produce one intent")
+        if case .image(let url) = intents.first {
+            XCTAssertEqual(url.absoluteString, "https://cdn.example.com/photo")
+        } else {
+            XCTFail("Expected image intent for extensionless URL with image MIME")
+        }
+    }
+
+    // MARK: - Extensionless URL with non-image MIME type produces no intent
+
+    func testExtensionlessURLWithHTMLMIMEProducesNoIntent() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html"]
+            )!
+            return (response, Data())
+        }
+
+        let message = makeMessage("Visit https://example.com/page")
+        let intents = await resolveWithMockProbe(
+            message: message,
+            settings: enabledSettings()
+        )
+
+        XCTAssertEqual(intents, [], "Extensionless URL serving text/html should produce no intents")
+    }
+
+    // MARK: - Extension-based classification still works (no regression)
+
+    func testExtensionBasedClassificationStillWorks() async {
+        // No mock handler needed — extension-based URLs should never hit the probe.
+        var wasCalled = false
+        MockURLProtocol.requestHandler = { _ in
+            wasCalled = true
+            let response = HTTPURLResponse(
+                url: URL(string: "https://example.com")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html"]
+            )!
+            return (response, Data())
+        }
+
+        let message = makeMessage("Screenshot: https://cdn.example.com/screenshot.png")
+        let intents = await resolveWithMockProbe(
+            message: message,
+            settings: enabledSettings()
+        )
+
+        XCTAssertEqual(intents.count, 1, "Extension-based .png URL should still produce image intent")
+        if case .image(let url) = intents.first {
+            XCTAssertEqual(url.absoluteString, "https://cdn.example.com/screenshot.png")
+        } else {
+            XCTFail("Expected image intent for .png URL")
+        }
+        XCTAssertFalse(wasCalled, "MIME probe should not be called for URLs with recognized extensions")
+    }
+
+    // MARK: - Mixed: extension-based image + extensionless image + video
+
+    func testMixedExtensionAndExtensionlessAndVideo() async {
+        MockURLProtocol.requestHandler = { request in
+            // Only the extensionless URL should hit the probe
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/jpeg"]
+            )!
+            return (response, Data())
+        }
+
+        let message = makeMessage(
+            "Image: https://cdn.example.com/pic.jpg " +
+            "CDN: https://cdn.example.com/media123 " +
+            "Video: https://www.youtube.com/watch?v=test1"
+        )
+        let intents = await resolveWithMockProbe(
+            message: message,
+            settings: enabledSettings()
+        )
+
+        XCTAssertEqual(intents.count, 3, "Should resolve extension image + probed image + video")
+
+        // First: extension-based image
+        if case .image(let url) = intents[0] {
+            XCTAssertTrue(url.absoluteString.contains("pic.jpg"))
+        } else {
+            XCTFail("Expected image intent for .jpg URL at index 0")
+        }
+
+        // Second: MIME-probed extensionless image
+        if case .image(let url) = intents[1] {
+            XCTAssertTrue(url.absoluteString.contains("media123"))
+        } else {
+            XCTFail("Expected image intent for extensionless URL at index 1")
+        }
+
+        // Third: video
+        if case .video(let provider, let videoID, _) = intents[2] {
+            XCTAssertEqual(provider, "youtube")
+            XCTAssertEqual(videoID, "test1")
+        } else {
+            XCTFail("Expected video intent at index 2")
+        }
+    }
+
+    // MARK: - MIME probe network error does not produce intent
+
+    func testMIMEProbeNetworkErrorProducesNoIntent() async {
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let message = makeMessage("Check https://cdn.example.com/mystery")
+        let intents = await resolveWithMockProbe(
+            message: message,
+            settings: enabledSettings()
+        )
+
+        XCTAssertEqual(intents, [], "Network error during MIME probe should not produce an intent")
+    }
+
+    // MARK: - Extensionless URL deduplication
+
+    func testExtensionlessURLDeduplication() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/webp"]
+            )!
+            return (response, Data())
+        }
+
+        let message = makeMessage(
+            "https://cdn.example.com/photo https://cdn.example.com/photo"
+        )
+        let intents = await resolveWithMockProbe(
+            message: message,
+            settings: enabledSettings()
+        )
+
+        XCTAssertEqual(intents.count, 1, "Duplicate extensionless URLs should be deduplicated")
+    }
+}

--- a/clients/macos/vellum-assistantTests/MediaEmbedResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedResolverTests.swift
@@ -39,15 +39,15 @@ final class MediaEmbedResolverTests: XCTestCase {
 
     // MARK: - Feature gate: disabled
 
-    func testDisabledSettingsReturnsEmpty() {
+    func testDisabledSettingsReturnsEmpty() async {
         let message = makeMessage("Check https://www.youtube.com/watch?v=abc123")
-        let result = MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: disabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - Feature gate: enabledSince
 
-    func testMessageBeforeEnabledSinceReturnsEmpty() {
+    func testMessageBeforeEnabledSinceReturnsEmpty() async {
         let cutoff = Date()
         let oldTimestamp = cutoff.addingTimeInterval(-60)
         let message = makeMessage(
@@ -55,18 +55,18 @@ final class MediaEmbedResolverTests: XCTestCase {
             timestamp: oldTimestamp
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result, [])
     }
 
-    func testMessageAfterEnabledSinceResolves() {
+    func testMessageAfterEnabledSinceResolves() async {
         let cutoff = Date().addingTimeInterval(-120)
         let message = makeMessage(
             "https://www.youtube.com/watch?v=abc123",
             timestamp: Date()
         )
         let settings = enabledSettings(enabledSince: cutoff)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result.count, 1)
         if case .video(let provider, let videoID, _) = result.first {
             XCTAssertEqual(provider, "youtube")
@@ -76,22 +76,22 @@ final class MediaEmbedResolverTests: XCTestCase {
         }
     }
 
-    func testNilEnabledSinceAllowsAllMessages() {
+    func testNilEnabledSinceAllowsAllMessages() async {
         let veryOld = Date.distantPast
         let message = makeMessage(
             "https://www.youtube.com/watch?v=old123",
             timestamp: veryOld
         )
         let settings = enabledSettings(enabledSince: nil)
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result.count, 1)
     }
 
     // MARK: - Video providers
 
-    func testYouTubeURLResolvesToVideoIntent() {
+    func testYouTubeURLResolvesToVideoIntent() async {
         let message = makeMessage("Watch this: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
         if case .video(let provider, let videoID, let embedURL) = result.first {
             XCTAssertEqual(provider, "youtube")
@@ -102,9 +102,9 @@ final class MediaEmbedResolverTests: XCTestCase {
         }
     }
 
-    func testVimeoURLResolvesToVideoIntent() {
+    func testVimeoURLResolvesToVideoIntent() async {
         let message = makeMessage("See https://vimeo.com/76979871")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
         if case .video(let provider, let videoID, let embedURL) = result.first {
             XCTAssertEqual(provider, "vimeo")
@@ -115,9 +115,9 @@ final class MediaEmbedResolverTests: XCTestCase {
         }
     }
 
-    func testLoomURLResolvesToVideoIntent() {
+    func testLoomURLResolvesToVideoIntent() async {
         let message = makeMessage("Recording: https://www.loom.com/share/abc123def456")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
         if case .video(let provider, let videoID, let embedURL) = result.first {
             XCTAssertEqual(provider, "loom")
@@ -130,9 +130,9 @@ final class MediaEmbedResolverTests: XCTestCase {
 
     // MARK: - Image classification
 
-    func testImageURLResolvesToImageIntent() {
+    func testImageURLResolvesToImageIntent() async {
         let message = makeMessage("Here's a screenshot: https://example.com/photo.png")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
         if case .image(let url) = result.first {
             XCTAssertEqual(url.absoluteString, "https://example.com/photo.png")
@@ -143,7 +143,7 @@ final class MediaEmbedResolverTests: XCTestCase {
 
     // MARK: - Domain allowlist
 
-    func testNonAllowedDomainVideoURLIsSkipped() {
+    func testNonAllowedDomainVideoURLIsSkipped() async {
         let message = makeMessage("https://www.youtube.com/watch?v=abc123")
         // Settings with no allowed domains for video providers
         let settings = MediaEmbedResolverSettings(
@@ -151,17 +151,17 @@ final class MediaEmbedResolverTests: XCTestCase {
             enabledSince: nil,
             allowedDomains: ["example.com"]
         )
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         XCTAssertEqual(result, [])
     }
 
     // MARK: - Mixed URLs
 
-    func testMixedImageAndVideoURLs() {
+    func testMixedImageAndVideoURLs() async {
         let message = makeMessage(
             "Video: https://www.youtube.com/watch?v=abc123 and image: https://cdn.example.com/pic.jpg"
         )
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 2)
 
         if case .video(let provider, _, _) = result[0] {
@@ -179,43 +179,43 @@ final class MediaEmbedResolverTests: XCTestCase {
 
     // MARK: - Deduplication
 
-    func testDuplicateURLsAreDeduped() {
+    func testDuplicateURLsAreDeduped() async {
         let message = makeMessage(
             "https://www.youtube.com/watch?v=abc123 and again https://www.youtube.com/watch?v=abc123"
         )
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
     }
 
     // MARK: - Code blocks excluded
 
-    func testURLsInCodeBlocksAreExcluded() {
+    func testURLsInCodeBlocksAreExcluded() async {
         let message = makeMessage("""
         Here is some code:
         ```
         https://www.youtube.com/watch?v=abc123
         ```
         """)
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - Plain text, no URLs
 
-    func testPlainTextWithNoURLsReturnsEmpty() {
+    func testPlainTextWithNoURLsReturnsEmpty() async {
         let message = makeMessage("Just a regular message with no links.")
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result, [])
     }
 
     // MARK: - Role-agnostic
 
-    func testUserMessageResolves() {
+    func testUserMessageResolves() async {
         let message = makeMessage(
             "https://www.youtube.com/watch?v=user123",
             role: .user
         )
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
         if case .video(_, let videoID, _) = result.first {
             XCTAssertEqual(videoID, "user123")
@@ -224,12 +224,12 @@ final class MediaEmbedResolverTests: XCTestCase {
         }
     }
 
-    func testAssistantMessageResolves() {
+    func testAssistantMessageResolves() async {
         let message = makeMessage(
             "https://www.youtube.com/watch?v=asst456",
             role: .assistant
         )
-        let result = MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
+        let result = await MediaEmbedResolver.resolve(message: message, settings: enabledSettings())
         XCTAssertEqual(result.count, 1)
         if case .video(_, let videoID, _) = result.first {
             XCTAssertEqual(videoID, "asst456")

--- a/clients/macos/vellum-assistantTests/MediaEmbedStressTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedStressTests.swift
@@ -31,11 +31,11 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - No artificial cap on image embeds
 
-    func testFiftyImageURLsProducesFiftyImageIntents() {
+    func testFiftyImageURLsProducesFiftyImageIntents() async {
         let urls = (0..<50).map { "https://cdn.example.com/img\($0).png" }
         let text = urls.joined(separator: "\n")
         let message = makeMessage(text)
-        let result = MediaEmbedResolver.resolve(
+        let result = await MediaEmbedResolver.resolve(
             message: message,
             settings: enabledSettings()
         )
@@ -53,11 +53,11 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - Video intent count
 
-    func testTwentyVideoURLsProducesCorrectCount() {
+    func testTwentyVideoURLsProducesCorrectCount() async {
         let urls = (0..<20).map { "https://www.youtube.com/watch?v=vid\($0)" }
         let text = urls.joined(separator: "\n")
         let message = makeMessage(text)
-        let result = MediaEmbedResolver.resolve(
+        let result = await MediaEmbedResolver.resolve(
             message: message,
             settings: enabledSettings()
         )
@@ -75,7 +75,7 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - Large mixed URL set doesn't crash
 
-    func testOneHundredMixedURLsProcessesWithoutCrashing() {
+    func testOneHundredMixedURLsProcessesWithoutCrashing() async {
         var lines: [String] = []
         for i in 0..<100 {
             switch i % 3 {
@@ -91,7 +91,7 @@ final class MediaEmbedStressTests: XCTestCase {
         let message = makeMessage(text)
 
         // Should not crash; just verify we get a non-empty result.
-        let result = MediaEmbedResolver.resolve(
+        let result = await MediaEmbedResolver.resolve(
             message: message,
             settings: enabledSettings()
         )
@@ -100,7 +100,7 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - Very long text with embedded URLs
 
-    func testVeryLongTextWithEmbeddedURLsExtractsCorrectly() {
+    func testVeryLongTextWithEmbeddedURLsExtractsCorrectly() async {
         // Build a message over 10,000 characters with URLs scattered throughout.
         let filler = String(repeating: "Lorem ipsum dolor sit amet. ", count: 200)
         let url1 = "https://cdn.example.com/longtext1.png"
@@ -111,7 +111,7 @@ final class MediaEmbedStressTests: XCTestCase {
         XCTAssertGreaterThan(text.count, 10_000, "Test text should exceed 10k chars")
 
         let message = makeMessage(text)
-        let result = MediaEmbedResolver.resolve(
+        let result = await MediaEmbedResolver.resolve(
             message: message,
             settings: enabledSettings()
         )
@@ -133,14 +133,14 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - Duplicate URL deduplication
 
-    func testDuplicateURLsAreDeduplicatedProperly() {
+    func testDuplicateURLsAreDeduplicatedProperly() async {
         // Repeat the same image URL 10 times.
         let repeatedImage = (0..<10).map { _ in "https://cdn.example.com/same.png" }
         // Repeat the same video URL 5 times.
         let repeatedVideo = (0..<5).map { _ in "https://www.youtube.com/watch?v=dup1" }
         let text = (repeatedImage + repeatedVideo).joined(separator: "\n")
         let message = makeMessage(text)
-        let result = MediaEmbedResolver.resolve(
+        let result = await MediaEmbedResolver.resolve(
             message: message,
             settings: enabledSettings()
         )
@@ -151,14 +151,14 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - URLs in various formats all resolve
 
-    func testURLsInVariousFormatsAllResolve() {
+    func testURLsInVariousFormatsAllResolve() async {
         let text = """
         Plain URL: https://cdn.example.com/plain.png
         Markdown link: [click here](https://cdn.example.com/markdown.jpg)
         Mixed with text https://cdn.example.com/inline.gif end of line
         """
         let message = makeMessage(text)
-        let result = MediaEmbedResolver.resolve(
+        let result = await MediaEmbedResolver.resolve(
             message: message,
             settings: enabledSettings()
         )
@@ -175,7 +175,7 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - Performance: 100 URLs under 1 second
 
-    func testPerformanceResolverCompletesFor100URLsInReasonableTime() {
+    func testPerformanceResolverCompletesFor100URLsInReasonableTime() async {
         var lines: [String] = []
         for i in 0..<100 {
             if i % 2 == 0 {
@@ -189,7 +189,7 @@ final class MediaEmbedStressTests: XCTestCase {
         let settings = enabledSettings()
 
         let start = CFAbsoluteTimeGetCurrent()
-        let result = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
         let elapsed = CFAbsoluteTimeGetCurrent() - start
 
         XCTAssertEqual(result.count, 100)
@@ -201,7 +201,7 @@ final class MediaEmbedStressTests: XCTestCase {
 
     // MARK: - Deterministic output
 
-    func testURLExtractionFromLargeTextIsDeterministic() {
+    func testURLExtractionFromLargeTextIsDeterministic() async {
         var lines: [String] = []
         for i in 0..<50 {
             lines.append("https://cdn.example.com/det\(i).png")
@@ -211,9 +211,9 @@ final class MediaEmbedStressTests: XCTestCase {
         let settings = enabledSettings()
 
         // Run resolution multiple times and verify identical output.
-        let first = MediaEmbedResolver.resolve(message: message, settings: settings)
+        let first = await MediaEmbedResolver.resolve(message: message, settings: settings)
         for run in 1...5 {
-            let again = MediaEmbedResolver.resolve(message: message, settings: settings)
+            let again = await MediaEmbedResolver.resolve(message: message, settings: settings)
             XCTAssertEqual(
                 first, again,
                 "Run \(run): resolver output should be deterministic"


### PR DESCRIPTION
## Summary
- Integrates `ImageMIMEProbe` as a fallback in `MediaEmbedResolver.resolve()` when `ImageURLClassifier` returns `.unknown` for extensionless URLs
- Makes `resolve()` async to support the HTTP HEAD probe; updates `ChatView.swift` to use `@State` + `.task` instead of computed properties
- Updates all 10 existing test files to use `async/await` and adds a new `MediaEmbedResolverMIMEProbeIntegrationTests` suite with `URLProtocol` mocks

## Problem
Extensionless image URLs (e.g. `https://cdn.example.com/photo`) were silently skipped because `ImageURLClassifier.classify()` returned `.unknown` and the resolver had no fallback. The `ImageMIMEProbe` class existed but was never called from the resolver.

## Solution
Two-stage image detection: try extension-based classification first, then fall back to an async HTTP HEAD probe via `ImageMIMEProbe.shared.probe(url)` for `.unknown` results. If the probe returns `.image` (Content-Type starts with `image/`), the URL is added as an image intent.

## Test plan
- [x] New integration tests: extensionless URL with `image/png` -> image intent
- [x] New integration tests: extensionless URL with `text/html` -> no intent
- [x] New integration tests: extension-based classification still works (no MIME probe called)
- [x] New integration tests: mixed extension + extensionless + video resolves correctly
- [x] New integration tests: network error during probe produces no intent
- [x] New integration tests: extensionless URL deduplication works
- [x] All 148 existing media embed tests pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
