### PR TITLE
fix: permission chip labels, truncation detection, and text selection in ToolConfirmationBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1152,6 +1152,8 @@ private struct ChatBubble: View {
         case "browser navigate":       return "Opened a page"
         case "browser click":          return "Clicked on the page"
         case "browser screenshot":     return "Took a screenshot"
+        case "request system permission":
+            return "\(Self.permissionFriendlyName(from: summary)) granted"
         default:                       return "Used \(toolName)"
         }
     }
@@ -1243,7 +1245,26 @@ private struct ChatBubble: View {
         case "fetch url":                                   return "globe"
         case "browser navigate", "browser click":           return "safari"
         case "browser screenshot":                          return "camera"
+        case "request system permission":                   return "lock.shield"
         default:                                            return "gearshape"
+        }
+    }
+
+    /// Convert raw permission_type (e.g. "full_disk_access") to a user-facing label.
+    private static func permissionFriendlyName(from rawType: String) -> String {
+        switch rawType {
+        case "full_disk_access": return "Full Disk Access"
+        case "accessibility": return "Accessibility"
+        case "screen_recording": return "Screen Recording"
+        case "calendar": return "Calendar"
+        case "contacts": return "Contacts"
+        case "photos": return "Photos"
+        case "location": return "Location Services"
+        case "microphone": return "Microphone"
+        case "camera": return "Camera"
+        default:
+            if rawType.isEmpty { return "Permission" }
+            return rawType.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -13,6 +13,9 @@ public struct ToolConfirmationBubble: View {
     @State private var showAlwaysAllowMenu = false
     @State private var showTechnicalDetails = false
     @State private var isPreviewExpanded = false
+    @State private var isTruncated = false
+    @State private var fullTextHeight: CGFloat = 0
+    @State private var truncatedTextHeight: CGFloat = 0
 
     public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
         self.confirmation = confirmation
@@ -243,8 +246,28 @@ public struct ToolConfirmationBubble: View {
                 .foregroundColor(VColor.textSecondary)
                 .lineLimit(isPreviewExpanded ? nil : 3)
                 .textSelection(.enabled)
+                .background(
+                    // Hidden full-height text to detect truncation
+                    Text(preview)
+                        .font(VFont.monoSmall)
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .hidden()
+                        .background(GeometryReader { fullGeometry in
+                            Color.clear.preference(key: FullTextHeightKey.self, value: fullGeometry.size.height)
+                        })
+                )
+                .background(GeometryReader { visibleGeometry in
+                    Color.clear.preference(key: TruncatedTextHeightKey.self, value: visibleGeometry.size.height)
+                })
+                .onPreferenceChange(FullTextHeightKey.self) { fullHeight in
+                    updateTruncation(fullHeight: fullHeight)
+                }
+                .onPreferenceChange(TruncatedTextHeightKey.self) { truncatedHeight in
+                    updateTruncation(truncatedHeight: truncatedHeight)
+                }
 
-            if !isPreviewExpanded {
+            if isTruncated && !isPreviewExpanded {
                 HStack(spacing: 2) {
                     Image(systemName: "chevron.down")
                         .font(.system(size: 8, weight: .semibold))
@@ -252,6 +275,12 @@ public struct ToolConfirmationBubble: View {
                         .font(.system(size: 10))
                 }
                 .foregroundColor(VColor.textMuted)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation(VAnimation.fast) {
+                        isPreviewExpanded.toggle()
+                    }
+                }
             }
         }
         .padding(VSpacing.sm)
@@ -260,12 +289,6 @@ public struct ToolConfirmationBubble: View {
             RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(VColor.backgroundSubtle)
         )
-        .contentShape(Rectangle())
-        .onTapGesture {
-            withAnimation(VAnimation.fast) {
-                isPreviewExpanded.toggle()
-            }
-        }
     }
 
     // MARK: - Description Text
@@ -437,6 +460,31 @@ public struct ToolConfirmationBubble: View {
 
             Spacer()
         }
+    }
+
+    // MARK: - Truncation Detection
+
+    private func updateTruncation(fullHeight: CGFloat? = nil, truncatedHeight: CGFloat? = nil) {
+        if let h = fullHeight { self.fullTextHeight = h }
+        if let h = truncatedHeight { self.truncatedTextHeight = h }
+        let full = fullHeight ?? self.fullTextHeight
+        let truncated = truncatedHeight ?? self.truncatedTextHeight
+        guard full > 0, truncated > 0 else { return }
+        isTruncated = full > truncated + 1
+    }
+}
+
+private struct FullTextHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct TruncatedTextHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 


### PR DESCRIPTION
Fixes 3 issues from PR #3934 feedback: (1) compact tool chip now shows the friendly permission name (e.g. 'Screen Recording granted') instead of 'Request System Permission', (2) Show more button only appears when text is actually truncated using a hidden overlay measurement, (3) tap gesture moved to Show more indicator only so text selection works in the preview area.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
