### PR TITLE
fix: restrict webview navigation to provider-approved hosts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -87,7 +87,7 @@ struct InlineVideoEmbedCard: View {
     private var initializingView: some View {
         // The webview loads asynchronously, so we transition straight to
         // .playing and let the embedded player handle its own loading UI.
-        InlineVideoWebView(url: playerURL)
+        InlineVideoWebView(url: playerURL, provider: provider)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .onAppear {
                 stateManager.didStartPlaying()
@@ -95,7 +95,7 @@ struct InlineVideoEmbedCard: View {
     }
 
     private var playingView: some View {
-        InlineVideoWebView(url: playerURL)
+        InlineVideoWebView(url: playerURL, provider: provider)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -8,6 +8,35 @@ import WebKit
 /// third-party video players.
 struct InlineVideoWebView: NSViewRepresentable {
     let url: URL
+    let provider: String
+
+    /// Host patterns allowed for programmatic navigations, keyed by provider.
+    /// Exact strings match literally; entries starting with `*.` match any
+    /// subdomain via `hasSuffix` (e.g. `*.googlevideo.com` matches
+    /// `r4---sn.googlevideo.com`).
+    static let allowedHostsByProvider: [String: [String]] = [
+        "youtube": [
+            "youtube.com",
+            "www.youtube.com",
+            "*.googlevideo.com",
+            "*.youtube.com",
+            "*.ytimg.com",
+            "*.google.com",
+            "*.gstatic.com",
+            "accounts.google.com",
+        ],
+        "vimeo": [
+            "*.vimeo.com",
+            "*.vimeocdn.com",
+            "player.vimeo.com",
+            "*.akamaized.net",
+        ],
+        "loom": [
+            "*.loom.com",
+            "*.loomcdn.com",
+            "cdn.loom.com",
+        ],
+    ]
 
     func makeNSView(context: Context) -> WKWebView {
         let webView = Self.makeConfiguredWebView()
@@ -22,7 +51,7 @@ struct InlineVideoWebView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(provider: provider)
     }
 
     /// Build a WKWebView with the privacy-hardened configuration used for embeds.
@@ -37,12 +66,39 @@ struct InlineVideoWebView: NSViewRepresentable {
         return webView
     }
 
+    /// Check whether `host` matches any of the allowed patterns for `provider`.
+    static func isAllowedHost(_ host: String, forProvider provider: String) -> Bool {
+        guard let patterns = allowedHostsByProvider[provider] else {
+            return false
+        }
+        for pattern in patterns {
+            if pattern.hasPrefix("*.") {
+                let suffix = String(pattern.dropFirst(1)) // e.g. ".googlevideo.com"
+                if host == String(pattern.dropFirst(2)) || host.hasSuffix(suffix) {
+                    return true
+                }
+            } else if host == pattern {
+                return true
+            }
+        }
+        return false
+    }
+
     class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+        let provider: String
+        /// The first programmatic navigation is the embed URL we control — always allow it.
+        private var hasLoadedInitial = false
+
+        init(provider: String) {
+            self.provider = provider
+            super.init()
+        }
 
         // MARK: - WKNavigationDelegate
 
-        /// Only allow programmatic/iframe loads (navigationType == .other) which cover the
-        /// initial embed load and any in-player iframe navigations. All user-initiated
+        /// Only allow programmatic/iframe loads (navigationType == .other) whose host
+        /// belongs to the active provider's allowlist. The initial embed load is always
+        /// permitted since we construct that URL ourselves. All user-initiated
         /// navigations (link clicks, form submissions, etc.) are blocked and opened
         /// externally so the webview stays locked to the video player.
         func webView(
@@ -52,8 +108,23 @@ struct InlineVideoWebView: NSViewRepresentable {
         ) {
             switch navigationAction.navigationType {
             case .other:
-                // Programmatic loads — initial embed request + iframe navigations
-                decisionHandler(.allow)
+                if !hasLoadedInitial {
+                    hasLoadedInitial = true
+                    decisionHandler(.allow)
+                    return
+                }
+
+                if let host = navigationAction.request.url?.host,
+                   InlineVideoWebView.isAllowedHost(host, forProvider: provider) {
+                    decisionHandler(.allow)
+                } else {
+                    // Subresource from an unknown domain — block it and open externally
+                    // so the user can still reach it if they need to.
+                    if let url = navigationAction.request.url {
+                        NSWorkspace.shared.open(url)
+                    }
+                    decisionHandler(.cancel)
+                }
             default:
                 // User-initiated navigation — open in the default browser instead
                 if let url = navigationAction.request.url {

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewNavigationTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewNavigationTests.swift
@@ -8,19 +8,19 @@ final class InlineVideoWebViewNavigationTests: XCTestCase {
     // MARK: - Delegate conformance
 
     func testCoordinatorConformsToWKNavigationDelegate() {
-        let coordinator = InlineVideoWebView.Coordinator()
+        let coordinator = InlineVideoWebView.Coordinator(provider: "youtube")
         XCTAssertTrue(coordinator is WKNavigationDelegate)
     }
 
     func testCoordinatorConformsToWKUIDelegate() {
-        let coordinator = InlineVideoWebView.Coordinator()
+        let coordinator = InlineVideoWebView.Coordinator(provider: "youtube")
         XCTAssertTrue(coordinator is WKUIDelegate)
     }
 
     // MARK: - Popup blocking
 
     func testCreateWebViewReturnsNil() {
-        let coordinator = InlineVideoWebView.Coordinator()
+        let coordinator = InlineVideoWebView.Coordinator(provider: "youtube")
         let config = WKWebViewConfiguration()
         let webView = WKWebView(frame: .zero, configuration: config)
 
@@ -35,5 +35,136 @@ final class InlineVideoWebViewNavigationTests: XCTestCase {
         )
 
         XCTAssertNil(result, "Popup windows should be blocked by returning nil")
+    }
+
+    // MARK: - Host allowlist (static helper)
+
+    func testYouTubeEmbedHostAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("www.youtube.com", forProvider: "youtube"),
+            "www.youtube.com should be allowed for youtube provider"
+        )
+    }
+
+    func testYouTubeExactHostAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("youtube.com", forProvider: "youtube"),
+            "youtube.com should be allowed for youtube provider"
+        )
+    }
+
+    func testYouTubeCDNSubresourceAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("r4---sn-abc.googlevideo.com", forProvider: "youtube"),
+            "googlevideo.com subdomains should be allowed for youtube provider"
+        )
+    }
+
+    func testYouTubeWildcardRootMatchAllowed() {
+        // *.googlevideo.com should also match "googlevideo.com" itself
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("googlevideo.com", forProvider: "youtube"),
+            "googlevideo.com root should match *.googlevideo.com wildcard"
+        )
+    }
+
+    func testYouTubeYtimgAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("i.ytimg.com", forProvider: "youtube"),
+            "ytimg.com subdomains should be allowed for youtube provider"
+        )
+    }
+
+    func testYouTubeGstaticAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("fonts.gstatic.com", forProvider: "youtube"),
+            "gstatic.com subdomains should be allowed for youtube provider"
+        )
+    }
+
+    func testArbitraryDomainBlockedForYouTube() {
+        XCTAssertFalse(
+            InlineVideoWebView.isAllowedHost("evil.com", forProvider: "youtube"),
+            "evil.com should not be allowed for youtube provider"
+        )
+    }
+
+    func testVimeoEmbedHostAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("player.vimeo.com", forProvider: "vimeo"),
+            "player.vimeo.com should be allowed for vimeo provider"
+        )
+    }
+
+    func testVimeoCDNAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("f.vimeocdn.com", forProvider: "vimeo"),
+            "vimeocdn.com subdomains should be allowed for vimeo provider"
+        )
+    }
+
+    func testVimeoAkamaizedAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("skyfire.vimeocdn.akamaized.net", forProvider: "vimeo"),
+            "akamaized.net subdomains should be allowed for vimeo provider"
+        )
+    }
+
+    func testArbitraryDomainBlockedForVimeo() {
+        XCTAssertFalse(
+            InlineVideoWebView.isAllowedHost("evil.com", forProvider: "vimeo"),
+            "evil.com should not be allowed for vimeo provider"
+        )
+    }
+
+    func testLoomEmbedHostAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("www.loom.com", forProvider: "loom"),
+            "www.loom.com should be allowed for loom provider"
+        )
+    }
+
+    func testLoomCDNAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("cdn.loom.com", forProvider: "loom"),
+            "cdn.loom.com should be allowed for loom provider"
+        )
+    }
+
+    func testLoomCDNSubdomainAllowed() {
+        XCTAssertTrue(
+            InlineVideoWebView.isAllowedHost("assets.loomcdn.com", forProvider: "loom"),
+            "loomcdn.com subdomains should be allowed for loom provider"
+        )
+    }
+
+    func testArbitraryDomainBlockedForLoom() {
+        XCTAssertFalse(
+            InlineVideoWebView.isAllowedHost("evil.com", forProvider: "loom"),
+            "evil.com should not be allowed for loom provider"
+        )
+    }
+
+    func testUnknownProviderBlocksEverything() {
+        XCTAssertFalse(
+            InlineVideoWebView.isAllowedHost("youtube.com", forProvider: "unknown"),
+            "Unknown provider should block all hosts"
+        )
+    }
+
+    // MARK: - Cross-provider isolation
+
+    func testYouTubeHostBlockedForVimeoProvider() {
+        XCTAssertFalse(
+            InlineVideoWebView.isAllowedHost("www.youtube.com", forProvider: "vimeo"),
+            "YouTube host should not be allowed for vimeo provider"
+        )
+    }
+
+    func testVimeoHostBlockedForYouTubeProvider() {
+        XCTAssertFalse(
+            InlineVideoWebView.isAllowedHost("player.vimeo.com", forProvider: "youtube"),
+            "Vimeo host should not be allowed for youtube provider"
+        )
     }
 }

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewPolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewPolicyTests.swift
@@ -31,14 +31,14 @@ final class InlineVideoWebViewPolicyTests: XCTestCase {
 
     func testURLIsStoredCorrectly() {
         let url = URL(string: "https://player.vimeo.com/video/76979871")!
-        let view = InlineVideoWebView(url: url)
+        let view = InlineVideoWebView(url: url, provider: "vimeo")
 
         XCTAssertEqual(view.url, url)
     }
 
     func testURLPreservesQueryParameters() {
         let url = URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=0&mute=1")!
-        let view = InlineVideoWebView(url: url)
+        let view = InlineVideoWebView(url: url, provider: "youtube")
 
         XCTAssertEqual(view.url.absoluteString, url.absoluteString)
     }
@@ -46,7 +46,7 @@ final class InlineVideoWebViewPolicyTests: XCTestCase {
     // MARK: - Coordinator
 
     func testCoordinatorConformsToWKNavigationDelegate() {
-        let view = InlineVideoWebView(url: URL(string: "https://example.com")!)
+        let view = InlineVideoWebView(url: URL(string: "https://example.com")!, provider: "youtube")
         let coordinator = view.makeCoordinator()
 
         // Verify the coordinator can be used as a WKNavigationDelegate


### PR DESCRIPTION
## Summary
- **Security fix**: The `InlineVideoWebView` previously allowed all programmatic (`.other`) navigations regardless of host, meaning the webview could load arbitrary content from any domain.
- Adds a per-provider host allowlist (YouTube, Vimeo, Loom) so only known subresource domains are permitted after the initial embed load.
- The first navigation is always allowed since we control the embed URL ourselves; subsequent `.other` navigations are checked against the provider's allowed hosts.
- Unrecognized hosts are blocked and opened in the default browser as a fallback.

## Changes
- `InlineVideoWebView.swift`: Added `provider` property, static `allowedHostsByProvider` dictionary, `isAllowedHost(_:forProvider:)` method, and `hasLoadedInitial` tracking in the Coordinator.
- `InlineVideoEmbedCard.swift`: Passes `provider` through to `InlineVideoWebView` in both `initializingView` and `playingView`.
- `InlineVideoWebViewNavigationTests.swift`: 18 new tests covering YouTube/Vimeo/Loom allowlisting, arbitrary domain blocking, cross-provider isolation, and unknown provider handling.
- `InlineVideoWebViewPolicyTests.swift`: Updated existing tests to pass the new `provider` parameter.

## Test plan
- [x] All 21 `InlineVideoWebViewNavigationTests` pass (0 failures)
- [x] All 6 `InlineVideoWebViewPolicyTests` pass (0 failures)
- [ ] Manual: Play a YouTube embed — video loads and plays normally
- [ ] Manual: Play a Vimeo embed — video loads and plays normally
- [ ] Manual: Play a Loom embed — video loads and plays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
