### PR TITLE
fix: wire webview load-failure callbacks into video embed state machine

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -85,18 +85,22 @@ struct InlineVideoEmbedCard: View {
     }
 
     private var initializingView: some View {
-        // The webview loads asynchronously, so we transition straight to
-        // .playing and let the embedded player handle its own loading UI.
-        InlineVideoWebView(url: playerURL, provider: provider)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .onAppear {
-                stateManager.didStartPlaying()
-            }
+        InlineVideoWebView(
+            url: playerURL,
+            provider: provider,
+            onLoadSuccess: { stateManager.didStartPlaying() },
+            onLoadFailure: { msg in stateManager.didFail(msg) }
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
     private var playingView: some View {
-        InlineVideoWebView(url: playerURL, provider: provider)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        InlineVideoWebView(
+            url: playerURL,
+            provider: provider,
+            onLoadFailure: { msg in stateManager.didFail(msg) }
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
     private func failedView(_ message: String) -> some View {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -10,6 +10,11 @@ struct InlineVideoWebView: NSViewRepresentable {
     let url: URL
     let provider: String
 
+    /// Called when the webview finishes loading successfully.
+    var onLoadSuccess: (() -> Void)?
+    /// Called when the webview fails to load, with a human-readable error message.
+    var onLoadFailure: ((String) -> Void)?
+
     /// Host patterns allowed for programmatic navigations, keyed by provider.
     /// Exact strings match literally; entries starting with `*.` match any
     /// subdomain via `hasSuffix` (e.g. `*.googlevideo.com` matches
@@ -45,13 +50,23 @@ struct InlineVideoWebView: NSViewRepresentable {
         return webView
     }
 
-    func updateNSView(_ webView: WKWebView, context: Context) {
-        let request = URLRequest(url: url)
-        webView.load(request)
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            provider: provider,
+            onLoadSuccess: onLoadSuccess,
+            onLoadFailure: onLoadFailure
+        )
     }
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(provider: provider)
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        // Keep coordinator callbacks in sync with the latest SwiftUI closures,
+        // since SwiftUI may recreate the struct (and its closures) without
+        // recreating the coordinator.
+        context.coordinator.onLoadSuccess = onLoadSuccess
+        context.coordinator.onLoadFailure = onLoadFailure
+
+        let request = URLRequest(url: url)
+        webView.load(request)
     }
 
     /// Build a WKWebView with the privacy-hardened configuration used for embeds.
@@ -86,11 +101,19 @@ struct InlineVideoWebView: NSViewRepresentable {
 
     class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let provider: String
+        var onLoadSuccess: (() -> Void)?
+        var onLoadFailure: ((String) -> Void)?
         /// The first programmatic navigation is the embed URL we control — always allow it.
         private var hasLoadedInitial = false
 
-        init(provider: String) {
+        init(
+            provider: String,
+            onLoadSuccess: (() -> Void)? = nil,
+            onLoadFailure: ((String) -> Void)? = nil
+        ) {
             self.provider = provider
+            self.onLoadSuccess = onLoadSuccess
+            self.onLoadFailure = onLoadFailure
             super.init()
         }
 
@@ -132,6 +155,22 @@ struct InlineVideoWebView: NSViewRepresentable {
                 }
                 decisionHandler(.cancel)
             }
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            onLoadSuccess?()
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            onLoadFailure?(error.localizedDescription)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFailProvisionalNavigation navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            onLoadFailure?(error.localizedDescription)
         }
 
         // MARK: - WKUIDelegate

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+import WebKit
+@testable import VellumAssistantLib
+
+@MainActor
+final class InlineVideoWebViewFailureTests: XCTestCase {
+
+    // MARK: - Coordinator callback wiring
+
+    func testDidFinishTriggersOnLoadSuccess() {
+        var called = false
+        let coordinator = InlineVideoWebView.Coordinator(
+            provider: "youtube",
+            onLoadSuccess: { called = true }
+        )
+
+        let webView = WKWebView(frame: .zero)
+        coordinator.webView(webView, didFinish: nil)
+
+        XCTAssertTrue(called, "onLoadSuccess should be invoked when didFinish fires")
+    }
+
+    func testDidFailTriggersOnLoadFailure() {
+        var receivedMessage: String?
+        let coordinator = InlineVideoWebView.Coordinator(
+            provider: "youtube",
+            onLoadFailure: { msg in receivedMessage = msg }
+        )
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: [
+            NSLocalizedDescriptionKey: "The request timed out.",
+        ])
+        let webView = WKWebView(frame: .zero)
+        coordinator.webView(webView, didFail: nil, withError: error)
+
+        XCTAssertEqual(receivedMessage, "The request timed out.")
+    }
+
+    func testDidFailProvisionalNavigationTriggersOnLoadFailure() {
+        var receivedMessage: String?
+        let coordinator = InlineVideoWebView.Coordinator(
+            provider: "youtube",
+            onLoadFailure: { msg in receivedMessage = msg }
+        )
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotFindHost, userInfo: [
+            NSLocalizedDescriptionKey: "A server with the specified hostname could not be found.",
+        ])
+        let webView = WKWebView(frame: .zero)
+        coordinator.webView(webView, didFailProvisionalNavigation: nil, withError: error)
+
+        XCTAssertEqual(receivedMessage, "A server with the specified hostname could not be found.")
+    }
+
+    func testNoCallbacksDoesNotCrash() {
+        // Coordinator with nil callbacks should not crash when delegate methods fire
+        let coordinator = InlineVideoWebView.Coordinator(provider: "youtube")
+        let webView = WKWebView(frame: .zero)
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown)
+
+        coordinator.webView(webView, didFinish: nil)
+        coordinator.webView(webView, didFail: nil, withError: error)
+        coordinator.webView(webView, didFailProvisionalNavigation: nil, withError: error)
+        // No assertion needed — reaching here without crashing is the test.
+    }
+
+    // MARK: - Callback update (simulating SwiftUI updateNSView)
+
+    func testCallbacksCanBeUpdatedAfterInit() {
+        let coordinator = InlineVideoWebView.Coordinator(provider: "youtube")
+        var successCalled = false
+        var failureMessage: String?
+
+        coordinator.onLoadSuccess = { successCalled = true }
+        coordinator.onLoadFailure = { msg in failureMessage = msg }
+
+        let webView = WKWebView(frame: .zero)
+        coordinator.webView(webView, didFinish: nil)
+        XCTAssertTrue(successCalled)
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL, userInfo: [
+            NSLocalizedDescriptionKey: "bad URL",
+        ])
+        coordinator.webView(webView, didFail: nil, withError: error)
+        XCTAssertEqual(failureMessage, "bad URL")
+    }
+
+    // MARK: - State manager integration
+
+    func testFailureCallbackTransitionsStateManagerToFailed() {
+        let stateManager = InlineVideoEmbedStateManager()
+        stateManager.requestPlay()
+        XCTAssertEqual(stateManager.state, .initializing)
+
+        // Simulate what InlineVideoEmbedCard wires up
+        stateManager.didFail("Network error")
+        XCTAssertEqual(stateManager.state, .failed("Network error"))
+    }
+
+    func testSuccessCallbackTransitionsStateManagerToPlaying() {
+        let stateManager = InlineVideoEmbedStateManager()
+        stateManager.requestPlay()
+        XCTAssertEqual(stateManager.state, .initializing)
+
+        stateManager.didStartPlaying()
+        XCTAssertEqual(stateManager.state, .playing)
+    }
+
+    func testRetryFromFailedReturnsToInitializing() {
+        let stateManager = InlineVideoEmbedStateManager()
+        stateManager.requestPlay()
+        stateManager.didFail("Timed out")
+        XCTAssertEqual(stateManager.state, .failed("Timed out"))
+
+        // Tap-to-retry invokes requestPlay again
+        stateManager.requestPlay()
+        XCTAssertEqual(stateManager.state, .initializing)
+    }
+
+    func testFailureWhilePlayingTransitionsToFailed() {
+        let stateManager = InlineVideoEmbedStateManager()
+        stateManager.requestPlay()
+        stateManager.didStartPlaying()
+        XCTAssertEqual(stateManager.state, .playing)
+
+        // A reload failure while already playing should transition to failed
+        stateManager.didFail("Connection lost")
+        XCTAssertEqual(stateManager.state, .failed("Connection lost"))
+    }
+}


### PR DESCRIPTION
## Summary

- **Wire `WKNavigationDelegate` failure callbacks** (`didFail`, `didFailProvisionalNavigation`) in `InlineVideoWebView.Coordinator` to report load errors via a new `onLoadFailure` closure.
- **Wire `didFinish` success callback** via `onLoadSuccess` so the embed card only transitions to `.playing` after a confirmed successful load, instead of immediately on `.onAppear`.
- **Connect callbacks in `InlineVideoEmbedCard`**: `onLoadSuccess` triggers `stateManager.didStartPlaying()` and `onLoadFailure` triggers `stateManager.didFail(msg)` in both initializing and playing states.
- **Keep callbacks in sync** with SwiftUI's update cycle by refreshing them in `updateNSView`.

## Problem

`InlineVideoEmbedStateManager.didFail()` existed but was never called in production. When a webview failed to load (network error, invalid URL, provider error page), the card stayed in `.playing` state with a broken embed instead of transitioning to `.failed` with a retry option.

## Test plan

- [x] `testDidFinishTriggersOnLoadSuccess` -- confirms `didFinish` invokes `onLoadSuccess`
- [x] `testDidFailTriggersOnLoadFailure` -- confirms `didFail` invokes `onLoadFailure` with error message
- [x] `testDidFailProvisionalNavigationTriggersOnLoadFailure` -- confirms provisional failure invokes `onLoadFailure`
- [x] `testNoCallbacksDoesNotCrash` -- nil callbacks don't crash when delegate methods fire
- [x] `testCallbacksCanBeUpdatedAfterInit` -- callbacks can be swapped after coordinator creation
- [x] `testFailureCallbackTransitionsStateManagerToFailed` -- state manager moves to `.failed`
- [x] `testSuccessCallbackTransitionsStateManagerToPlaying` -- state manager moves to `.playing`
- [x] `testRetryFromFailedReturnsToInitializing` -- tap-to-retry cycles back to `.initializing`
- [x] `testFailureWhilePlayingTransitionsToFailed` -- reload failure during playback is caught
- [x] All 36 existing `InlineVideoWebView*` tests still pass (navigation + policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
