### PR TITLE
fix: treat empty auth output as unauthenticated in cli-discover

### DIFF
--- a/assistant/src/tools/host-terminal/cli-discover.ts
+++ b/assistant/src/tools/host-terminal/cli-discover.ts
@@ -138,7 +138,7 @@ class CliDiscoverTool implements Tool {
       if (checkAuth && AUTH_CHECK_COMMANDS[name]) {
         const [cmd, ...args] = AUTH_CHECK_COMMANDS[name];
         const authOutput = await runQuick(cmd, args);
-        result.authenticated = authOutput !== null;
+        result.authenticated = authOutput !== null && authOutput.length > 0;
         if (authOutput) {
           // Keep auth info brief — first line, max 200 chars
           result.authInfo = authOutput.split('\n')[0].slice(0, 200);


### PR DESCRIPTION
Change the auth detection check to also treat empty strings as unauthenticated. gcloud auth list exits 0 with empty output when no account is active, causing a false positive. Fixes feedback from PR #3983.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
