### PR TITLE
fix: bind socket before initial message, use skillId and dynamic button label

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -244,6 +244,7 @@ export async function handleSessionCreate(
 
   // Auto-send the initial message if provided, kick-starting the skill.
   if (msg.initialMessage) {
+    ctx.socketToSession.set(socket, conversation.id);
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
     const requestId = uuid();
     session.processMessage(msg.initialMessage, [], sendEvent, requestId).catch((err) => {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -680,7 +680,7 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    VButton(label: "Set Up Google Cloud", style: .primary) {
+                    VButton(label: "Set Up \(integrationDisplayName(integration.id))", style: .primary) {
                         startIntegrationSetup(skillId: setup.skillId, integrationName: integrationDisplayName(integration.id))
                     }
                 }
@@ -744,10 +744,13 @@ struct SettingsPanel: View {
 
         guard let activeVM = threadManager.activeViewModel else { return }
 
+        // Pre-activate the setup skill so the daemon deterministically
+        // activates it instead of relying on model inference.
+        activeVM.preactivatedSkillIds = [skillId]
+
         // Set the input text and send via ChatViewModel so it properly
         // bootstraps (claims session_info, sets up message loop, shows the
-        // message in chat, etc.). The system prompt already instructs the
-        // agent to use the setup skill when asked about integration setup.
+        // message in chat, etc.).
         activeVM.inputText = "Please set up \(integrationName) for me."
         activeVM.sendMessage()
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -77,6 +77,9 @@ public final class ChatViewModel: ObservableObject {
     /// Set by `createSessionIfNeeded(threadType:)` and included in the IPC
     /// message so the daemon can persist the correct thread kind.
     public var threadType: String?
+    /// Skill IDs to pre-activate in the session. Included in the
+    /// `session_create` request for deterministic skill activation.
+    public var preactivatedSkillIds: [String]?
     /// Whether this view model is currently bootstrapping a new session
     /// (session_create sent, awaiting session_info). Used by ThreadManager
     /// to decide whether it's safe to release the VM on archive.
@@ -297,7 +300,7 @@ public final class ChatViewModel: ObservableObject {
 
             // Send session_create with correlation ID and thread type
             do {
-                try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId, threadType: self.threadType))
+                try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId, threadType: self.threadType, preactivatedSkillIds: self.preactivatedSkillIds))
             } catch {
                 log.error("Failed to send session_create: \(error.localizedDescription)")
                 self.isThinking = false


### PR DESCRIPTION
Address reviewer feedback on PR #3986: (1) Bind socket-to-session before processing initialMessage so escalation handlers can find the client socket. (2) Pass skillId as preactivatedSkillIds in session create request for deterministic skill activation. (3) Use dynamic integration name in setup button label instead of hardcoded 'Set Up Google Cloud'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
