### PR TITLE
fix: fail fast in connect action when no interactive client session

### DIFF
--- a/assistant/src/tools/integrations/manage.ts
+++ b/assistant/src/tools/integrations/manage.ts
@@ -133,13 +133,15 @@ class IntegrationManageTool implements Tool {
           return { content: `Error: no clientId configured for "${integrationId}". Run set_client_id first.`, isError: true };
         }
 
+        if (!context.sendToClient) {
+          return { content: 'Error: connect action requires an interactive client session', isError: true };
+        }
+
         try {
           const oauthConfig = { ...def.oauth2Config, clientId };
           const { tokens, grantedScopes } = await startOAuth2Flow(oauthConfig, {
             openUrl: (url) => {
-              if (context.sendToClient) {
-                context.sendToClient({ type: 'open_url', url, title: `Connect ${def.name}` });
-              }
+              context.sendToClient!({ type: 'open_url', url, title: `Connect ${def.name}` });
             },
           });
 


### PR DESCRIPTION
Add early guard in integration_manage connect action to check for sendToClient before starting OAuth2 flow. Without this, the tool silently hangs for 120 seconds when no IPC client is available to open the browser URL. Fixes feedback from PR #4013.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
