### PR TITLE
fix: add browser action tools to side-effect set for private thread prompting

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -925,6 +925,11 @@ describe('isSideEffectTool', () => {
       'host_bash',
       'web_fetch',
       'browser_navigate',
+      'browser_click',
+      'browser_type',
+      'browser_press_key',
+      'browser_close',
+      'browser_fill_credential',
     ];
 
     for (const toolName of sideEffectTools) {
@@ -942,7 +947,8 @@ describe('isSideEffectTool', () => {
       'web_search',
       'browser_snapshot',
       'browser_screenshot',
-      'browser_close',
+      'browser_wait_for',
+      'browser_extract',
       'skill_load',
       'schedule_list',
       'evaluate_typescript_code',
@@ -1172,6 +1178,11 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
       { name: 'host_bash', input: { command: 'echo hi' } },
       { name: 'web_fetch', input: { url: 'https://example.com' } },
       { name: 'browser_navigate', input: { url: 'https://example.com' } },
+      { name: 'browser_click', input: { selector: '#btn' } },
+      { name: 'browser_type', input: { selector: '#input', text: 'hello' } },
+      { name: 'browser_press_key', input: { key: 'Enter' } },
+      { name: 'browser_close', input: {} },
+      { name: 'browser_fill_credential', input: { selector: '#pwd', credential: 'test' } },
     ];
 
     for (const { name, input } of sideEffectTools) {
@@ -1247,5 +1258,50 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
 
     expect(result.isError).toBe(false);
     expect(promptCalled).toBe(true);
+  });
+
+  // ── Browser action tools as side-effect tools (PR fix2) ──────────
+
+  test('browser_click forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'browser_click',
+      { selector: '#submit-btn' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('browser_type forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'browser_type',
+      { selector: '#search-input', text: 'query' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('browser_snapshot does NOT force prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'browser_snapshot',
+      {},
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    // browser_snapshot is read-only — must NOT trigger forced prompting
+    expect(promptCalled).toBe(false);
   });
 });

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -531,6 +531,11 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   'host_bash',
   'web_fetch',
   'browser_navigate',
+  'browser_click',
+  'browser_type',
+  'browser_press_key',
+  'browser_close',
+  'browser_fill_credential',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Add `browser_click`, `browser_type`, `browser_press_key`, `browser_close`, and `browser_fill_credential` to the `SIDE_EFFECT_TOOLS` set in `executor.ts`
- These browser action tools can mutate page state, submit forms, and fill credentials — they should trigger forced prompting in private threads
- Read-only browser tools (`browser_snapshot`, `browser_screenshot`, `browser_extract`, `browser_wait_for`) are correctly excluded

## Test plan
- [x] Added `browser_click` and `browser_type` to isSideEffectTool classifier tests
- [x] Added regression test: `browser_click` forces prompt in private thread
- [x] Added regression test: `browser_type` forces prompt in private thread
- [x] Added regression test: `browser_snapshot` does NOT force prompt in private thread (read-only)
- [x] Updated "all side-effect tool types are forced to prompt" test to include all 5 new browser action tools
- [x] All 66 tests in `tool-executor.test.ts` pass
- [x] All 17 tests in `tool-executor-lifecycle-events.test.ts` pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
