### PR TITLE
fix: scope global summaries to default-only to prevent private data leakage

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -49,6 +49,7 @@ mock.module('../memory/qdrant-client.js', () => ({
 
 import { and, eq } from 'drizzle-orm';
 import { DEFAULT_CONFIG } from '../config/defaults.js';
+import { currentMonthWindow } from '../memory/job-utils.js';
 
 // Disable LLM extraction in tests to avoid real API calls and ensure
 // deterministic pattern-based extraction.
@@ -103,7 +104,7 @@ import {
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 import { addMessage, createConversation, getConversationMemoryScopeId } from '../memory/conversation-store.js';
-import { buildConversationSummaryJob } from '../memory/job-handlers/summarization.js';
+import { buildConversationSummaryJob, buildGlobalSummaryJob } from '../memory/job-handlers/summarization.js';
 import {
   conversations,
   memoryEmbeddings,
@@ -3945,5 +3946,125 @@ describe('Memory regressions', () => {
     const hasObsidianInPrivate = obsidianItemKeys.some((k) => privCandidateKeys.includes(k));
     expect(hasObsidianInPrivate).toBe(true);
     expect(privRecall.injectedText.toLowerCase()).toContain('obsidian');
+  });
+
+  test('global weekly summary excludes private-scope memory items', async () => {
+    const db = getDb();
+    const now = new Date();
+    const { startMs, endMs } = currentWeekWindow(now);
+    const midMs = Math.floor((startMs + endMs) / 2);
+
+    // Insert a default-scope memory item within the current week window
+    db.insert(memoryItems).values({
+      id: 'item-global-weekly-default',
+      kind: 'preference',
+      subject: 'editor',
+      statement: 'User prefers VSCode for all editing',
+      status: 'active',
+      confidence: 0.9,
+      fingerprint: 'fp-global-weekly-default',
+      scopeId: 'default',
+      firstSeenAt: midMs,
+      lastSeenAt: midMs,
+    }).run();
+
+    // Insert a private-scope memory item within the same window
+    db.insert(memoryItems).values({
+      id: 'item-global-weekly-private',
+      kind: 'preference',
+      subject: 'secret-tool',
+      statement: 'User uses SecretTool for private work',
+      status: 'active',
+      confidence: 0.9,
+      fingerprint: 'fp-global-weekly-private',
+      scopeId: 'private:thread-weekly-test',
+      firstSeenAt: midMs,
+      lastSeenAt: midMs,
+    }).run();
+
+    const summaryConfig = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        summarization: {
+          ...TEST_CONFIG.memory.summarization,
+          useLLM: false,
+        },
+      },
+    };
+
+    await buildGlobalSummaryJob('weekly_global', summaryConfig);
+
+    const summaries = db.select().from(memorySummaries)
+      .where(eq(memorySummaries.scope, 'weekly_global'))
+      .all();
+
+    expect(summaries).toHaveLength(1);
+    const summaryText = summaries[0].summary.toLowerCase();
+    // Default-scope content should appear
+    expect(summaryText).toContain('vscode');
+    // Private-scope content must NOT leak into the global summary
+    expect(summaryText).not.toContain('secrettool');
+  });
+
+  test('global monthly summary excludes private conversation summaries', async () => {
+    const db = getDb();
+    const now = new Date();
+    const { startMs, endMs } = currentMonthWindow(now);
+    const midMs = Math.floor((startMs + endMs) / 2);
+
+    // Insert a default-scope conversation summary within the current month
+    db.insert(memorySummaries).values({
+      id: 'summary-monthly-default',
+      scope: 'conversation',
+      scopeKey: 'conv-monthly-default',
+      scopeId: 'default',
+      summary: 'User discussed PublicFramework integration patterns',
+      tokenEstimate: 10,
+      version: 1,
+      startAt: midMs - 1000,
+      endAt: midMs,
+      createdAt: midMs,
+      updatedAt: midMs,
+    }).run();
+
+    // Insert a private-scope conversation summary within the same month
+    db.insert(memorySummaries).values({
+      id: 'summary-monthly-private',
+      scope: 'conversation',
+      scopeKey: 'conv-monthly-private',
+      scopeId: 'private:thread-monthly-test',
+      summary: 'User discussed ConfidentialProject secret architecture',
+      tokenEstimate: 10,
+      version: 1,
+      startAt: midMs - 1000,
+      endAt: midMs,
+      createdAt: midMs,
+      updatedAt: midMs,
+    }).run();
+
+    const summaryConfig = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        summarization: {
+          ...TEST_CONFIG.memory.summarization,
+          useLLM: false,
+        },
+      },
+    };
+
+    await buildGlobalSummaryJob('monthly_global', summaryConfig);
+
+    const summaries = db.select().from(memorySummaries)
+      .where(eq(memorySummaries.scope, 'monthly_global'))
+      .all();
+
+    expect(summaries).toHaveLength(1);
+    const summaryText = summaries[0].summary.toLowerCase();
+    // Default-scope conversation summary content should appear
+    expect(summaryText).toContain('publicframework');
+    // Private-scope conversation summary content must NOT leak
+    expect(summaryText).not.toContain('confidentialproject');
   });
 });

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -127,6 +127,7 @@ export async function buildGlobalSummaryJob(scope: 'weekly_global' | 'monthly_gl
     .where(and(
       eq(memoryItems.status, 'active'),
       isNull(memoryItems.invalidAt),
+      eq(memoryItems.scopeId, 'default'),
       gte(memoryItems.lastSeenAt, startMs),
       lt(memoryItems.lastSeenAt, endMs),
     ))
@@ -140,6 +141,7 @@ export async function buildGlobalSummaryJob(scope: 'weekly_global' | 'monthly_gl
     .from(memorySummaries)
     .where(and(
       eq(memorySummaries.scope, 'conversation'),
+      eq(memorySummaries.scopeId, 'default'),
       gte(memorySummaries.endAt, startMs),
       lt(memorySummaries.startAt, endMs),
     ))


### PR DESCRIPTION
## Summary
- `buildGlobalSummaryJob()` in `summarization.ts` queried `memoryItems` and `memorySummaries` without scope filtering, leaking private thread content into default-scope global weekly/monthly summaries.
- Added `eq(memoryItems.scopeId, 'default')` and `eq(memorySummaries.scopeId, 'default')` WHERE clauses to restrict both queries to default-scope data only.
- Added two regression tests verifying that private-scope memory items and private conversation summaries are excluded from global weekly and monthly summaries respectively.

## Test plan
- [x] Existing 84 memory regression tests pass
- [x] New test: "global weekly summary excludes private-scope memory items" — inserts items in both default and private scopes, builds a weekly global summary, verifies only default-scope content appears
- [x] New test: "global monthly summary excludes private conversation summaries" — inserts conversation summaries in both default and private scopes, builds a monthly global summary, verifies only default-scope content appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
