### PR TITLE
fix: add default-scope fallback for memory_search in private threads

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -101,6 +101,7 @@ import {
   formatRelativeTime,
   injectMemoryRecallIntoUserMessage,
   injectMemoryRecallAsSeparateMessage,
+  searchMemoryItems,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 import { addMessage, createConversation, getConversationMemoryScopeId } from '../memory/conversation-store.js';
@@ -4066,5 +4067,122 @@ describe('Memory regressions', () => {
     expect(summaryText).toContain('publicframework');
     // Private-scope conversation summary content must NOT leak
     expect(summaryText).not.toContain('confidentialproject');
+  });
+
+  // ── searchMemoryItems scopePolicyOverride tests ────────────────────
+
+  test('memory_search in private thread includes default-scope items via fallback', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = 'conv-search-fb';
+
+    db.insert(conversations).values({
+      id: convId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-search-fb-1',
+      conversationId: convId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'search fallback test' }]),
+      createdAt: now,
+    }).run();
+
+    // Insert a default-scope segment with FTS so lexical search can find it
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-search-fb-default', 'msg-search-fb-1', '${convId}', 'user', 0, 'The team uses Erlang for distributed message processing systems', 10, 'default', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-search-fb-default', 'The team uses Erlang for distributed message processing systems')`);
+
+    const strictConfig = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        embeddings: { ...TEST_CONFIG.memory.embeddings, required: false },
+        retrieval: {
+          ...TEST_CONFIG.memory.retrieval,
+          scopePolicy: 'strict' as const,
+        },
+      },
+    };
+
+    // With the scopePolicyOverride, default-scope items should be included
+    // even though the global policy is strict.
+    const results = await searchMemoryItems(
+      'Erlang distributed message processing',
+      10,
+      strictConfig,
+      'private:thread-search-test',
+      { scopeId: 'private:thread-search-test', fallbackToDefault: true },
+    );
+
+    const ids = results.map((r) => r.id);
+    expect(ids).toContain('seg-search-fb-default');
+  });
+
+  test('memory_search in private thread still returns private-scope items', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = 'conv-search-priv';
+    const privateScopeId = 'private:thread-search-priv';
+
+    db.insert(conversations).values({
+      id: convId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-search-priv-1',
+      conversationId: convId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'search private scope test' }]),
+      createdAt: now,
+    }).run();
+
+    // Insert a private-scope segment with FTS
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-search-priv-scope', 'msg-search-priv-1', '${convId}', 'user', 0, 'User prefers Haskell for type-safe functional programming', 10, '${privateScopeId}', ${now}, ${now})
+    `);
+    db.run(`INSERT INTO memory_segment_fts(segment_id, text) VALUES ('seg-search-priv-scope', 'User prefers Haskell for type-safe functional programming')`);
+
+    const strictConfig = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        embeddings: { ...TEST_CONFIG.memory.embeddings, required: false },
+        retrieval: {
+          ...TEST_CONFIG.memory.retrieval,
+          scopePolicy: 'strict' as const,
+        },
+      },
+    };
+
+    const results = await searchMemoryItems(
+      'Haskell functional programming',
+      10,
+      strictConfig,
+      privateScopeId,
+      { scopeId: privateScopeId, fallbackToDefault: true },
+    );
+
+    const ids = results.map((r) => r.id);
+    expect(ids).toContain('seg-search-priv-scope');
   });
 });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -567,6 +567,7 @@ export async function searchMemoryItems(
   limit: number,
   config: AssistantConfig,
   scopeId?: string,
+  scopePolicyOverride?: ScopePolicyOverride,
 ): Promise<MemorySearchResult[]> {
   const trimmed = query.trim();
   if (trimmed.length === 0 || limit <= 0) return [];
@@ -592,6 +593,7 @@ export async function searchMemoryItems(
     provider,
     model,
     scopeId,
+    scopePolicyOverride,
   });
   const merged = result.merged;
 

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -7,6 +7,7 @@ import { getDb } from '../../memory/db.js';
 import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import { searchMemoryItems, formatRelativeTime } from '../../memory/retriever.js';
+import type { ScopePolicyOverride } from '../../memory/search/types.js';
 import type { ToolExecutionResult } from '../types.js';
 
 const log = getLogger('memory-tools');
@@ -27,8 +28,14 @@ export async function handleMemorySearch(
     ? Math.min(args.limit, 20)
     : 5;
 
+  // Private threads should always fall back to default scope for search
+  const scopePolicyOverride: ScopePolicyOverride | undefined =
+    scopeId && scopeId.startsWith('private:')
+      ? { scopeId, fallbackToDefault: true }
+      : undefined;
+
   try {
-    const results = await searchMemoryItems(query, limit, config, scopeId);
+    const results = await searchMemoryItems(query, limit, config, scopeId, scopePolicyOverride);
 
     if (results.length === 0) {
       return { content: 'No matching memories found.', isError: false };


### PR DESCRIPTION
## Summary

- Add `scopePolicyOverride` parameter to `searchMemoryItems()` in `retriever.ts` and pass it through to `collectAndMergeCandidates()`, matching the pattern already used by `buildMemoryRecall()` (auto recall)
- In `handleMemorySearch()` (`handlers.ts`), automatically compute a `scopePolicyOverride` with `fallbackToDefault: true` when the scope is a private thread (`private:*`), so the `memory_search` tool includes default-scope items even under strict scope policy
- Add two regression tests verifying that `searchMemoryItems` with a private scope override returns both default-scope and private-scope items

## Test plan

- [x] `bun test assistant/src/__tests__/memory-regressions.test.ts` — all 86 tests pass (including 2 new)
- [ ] Verify that memory_search in a private thread returns default-scope items when global `scopePolicy` is `strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
