### PR TITLE
fix: persist /model picker across restarts

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -46,10 +46,11 @@ export function handleModelSet(
     if (provider && provider !== 'ollama') {
       const currentConfig = getConfig();
       if (!currentConfig.apiKeys[provider]) {
-        ctx.send(socket, { type: 'error', message: `Cannot switch to ${msg.model}. No API key configured for ${provider}.` });
         // Send current model_info so the client resyncs its optimistic state
-        const cfg = getConfig();
-        ctx.send(socket, { type: 'model_info', model: cfg.model, provider: cfg.provider });
+        // (don't use generic 'error' type — it would interrupt in-flight chat)
+        const configured = Object.keys(currentConfig.apiKeys).filter((k) => !!currentConfig.apiKeys[k]);
+        if (!configured.includes('ollama')) configured.push('ollama');
+        ctx.send(socket, { type: 'model_info', model: currentConfig.model, provider: currentConfig.provider, configuredProviders: configured });
         return;
       }
     }

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -47,6 +47,9 @@ export function handleModelSet(
       const currentConfig = getConfig();
       if (!currentConfig.apiKeys[provider]) {
         ctx.send(socket, { type: 'error', message: `Cannot switch to ${msg.model}. No API key configured for ${provider}.` });
+        // Send current model_info so the client resyncs its optimistic state
+        const cfg = getConfig();
+        ctx.send(socket, { type: 'model_info', model: cfg.model, provider: cfg.provider });
         return;
       }
     }

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -41,11 +41,21 @@ export function handleModelSet(
   ctx: HandlerContext,
 ): void {
   try {
+    // Validate API key before switching
+    const provider = MODEL_TO_PROVIDER[msg.model];
+    if (provider && provider !== 'ollama') {
+      const currentConfig = getConfig();
+      if (!currentConfig.apiKeys[provider]) {
+        ctx.send(socket, { type: 'error', message: `Cannot switch to ${msg.model}. No API key configured for ${provider}.` });
+        return;
+      }
+    }
+
     // Use raw config to avoid persisting env-var API keys to disk
     const raw = loadRawConfig();
     raw.model = msg.model;
     // Infer provider from model ID to keep provider and model in sync
-    raw.provider = MODEL_TO_PROVIDER[msg.model] ?? raw.provider;
+    raw.provider = provider ?? raw.provider;
 
     // Suppress the file watcher callback — handleModelSet already does
     // the full reload sequence; a redundant watcher-triggered reload

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -21,6 +21,7 @@ import type {
   VercelApiConfigRequest,
 } from '../ipc-protocol.js';
 import { log, type HandlerContext } from './shared.js';
+import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
@@ -43,6 +44,8 @@ export function handleModelSet(
     // Use raw config to avoid persisting env-var API keys to disk
     const raw = loadRawConfig();
     raw.model = msg.model;
+    // Infer provider from model ID to keep provider and model in sync
+    raw.provider = MODEL_TO_PROVIDER[msg.model] ?? raw.provider;
 
     // Suppress the file watcher callback — handleModelSet already does
     // the full reload sequence; a redundant watcher-triggered reload

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -14,9 +14,29 @@ import type { TraceEmitter } from './trace-emitter.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { resolveSlash } from './session-slash.js';
+import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('session-process');
+
+/** Build a model_info event with fresh config data. */
+function buildModelInfoEvent(): ServerMessage {
+  const config = getConfig();
+  const configured = Object.keys(config.apiKeys).filter((k) => !!config.apiKeys[k]);
+  if (!configured.includes('ollama')) configured.push('ollama');
+  return {
+    type: 'model_info',
+    model: config.model,
+    provider: config.provider,
+    configuredProviders: configured,
+  };
+}
+
+/** True when the trimmed content is a /model or /models slash command. */
+function isModelSlashCommand(content: string): boolean {
+  const trimmed = content.trim();
+  return trimmed === '/model' || trimmed === '/models' || trimmed.startsWith('/model ');
+}
 
 // ── Context Interface ────────────────────────────────────────────────
 
@@ -96,6 +116,11 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
       );
       session.messages.push(assistantMsg);
 
+      // Emit fresh model info before the text delta so the client has
+      // up-to-date configuredProviders when rendering /model or /models UI.
+      if (isModelSlashCommand(next.content)) {
+        next.onEvent(buildModelInfoEvent());
+      }
       next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
       session.traceEmitter.emit('message_complete', 'Unknown slash command handled', {
         requestId: next.requestId,
@@ -202,6 +227,11 @@ export async function processMessage(
     );
     session.messages.push(assistantMsg);
 
+    // Emit fresh model info before the text delta so the client has
+    // up-to-date configuredProviders when rendering /model or /models UI.
+    if (isModelSlashCommand(content)) {
+      onEvent(buildModelInfoEvent());
+    }
     onEvent({ type: 'assistant_text_delta', text: slashResult.message });
     session.traceEmitter.emit('message_complete', 'Unknown slash command handled', {
       requestId,

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -50,6 +50,11 @@ const PROVIDER_MODEL_SHORTCUTS: Record<string, { provider: string; model: string
   'fireworks': { provider: 'fireworks', model: 'accounts/fireworks/models/kimi-k2p5', displayName: 'Kimi K2.5' },
 };
 
+/** Reverse lookup: model ID → provider, derived from PROVIDER_MODEL_SHORTCUTS. */
+export const MODEL_TO_PROVIDER: Record<string, string> = Object.fromEntries(
+  Object.values(PROVIDER_MODEL_SHORTCUTS).map(({ model, provider }) => [model, provider]),
+);
+
 /** Read the assistant's name from IDENTITY.md for personalized responses. */
 function getAssistantName(): string | null {
   try {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1405,13 +1405,8 @@ private struct ActiveChatViewWrapper: View {
             onPaste: { viewModel.addAttachmentFromPasteboard() },
             onMicrophoneToggle: onMicrophoneToggle,
             onModelPickerSelect: { messageId, modelId in
-                // Send "/model <id>" through the daemon silently (no user bubble)
-                // so the switch is persisted and confirmed by the daemon.
-                // Only update UI if the command was actually accepted; sendSilently
-                // returns false when a session bootstrap is already in flight.
-                if viewModel.sendSilently("/model \(modelId)") {
-                    settingsStore.selectedModel = modelId
-                }
+                settingsStore.selectedModel = modelId
+                settingsStore.setModel(modelId)
             },
             selectedModel: settingsStore.selectedModel,
             configuredProviders: settingsStore.configuredProviders,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1405,7 +1405,6 @@ private struct ActiveChatViewWrapper: View {
             onPaste: { viewModel.addAttachmentFromPasteboard() },
             onMicrophoneToggle: onMicrophoneToggle,
             onModelPickerSelect: { messageId, modelId in
-                settingsStore.selectedModel = modelId
                 settingsStore.setModel(modelId)
             },
             selectedModel: settingsStore.selectedModel,

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -259,7 +259,9 @@ extension ChatViewModel {
             } else {
                 // Create new assistant message
                 var msg = ChatMessage(role: .assistant, text: delta.text, isStreaming: true)
-                if currentTurnUserText == "/models" {
+                if currentTurnUserText == "/model" {
+                    msg.modelPicker = ModelPickerData()
+                } else if currentTurnUserText == "/models" {
                     msg.modelList = ModelListData()
                 }
                 currentAssistantMessageId = msg.id

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -199,8 +199,9 @@ public final class ChatViewModel: ObservableObject {
             try? daemonClient.send(ModelGetRequestMessage())
         }
 
-        // Fire auto-title callback on the first user message
-        if !text.isEmpty, let callback = onFirstUserMessage {
+        // Fire auto-title callback on the first user message (skip slash commands
+        // like /model so the thread title isn't set to a command string)
+        if !text.isEmpty, !text.hasPrefix("/"), let callback = onFirstUserMessage {
             onFirstUserMessage = nil
             callback(text)
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1009,15 +1009,22 @@ public final class ChatViewModel: ObservableObject {
 
         // Tag assistant messages that follow "/model" or "/models" user messages
         // so the client renders the picker/table UI instead of plain text.
+        var hasModelCommand = false
         for i in chatMessages.indices {
             guard chatMessages[i].role == .user,
                   i + 1 < chatMessages.count && chatMessages[i + 1].role == .assistant else { continue }
             let userText = chatMessages[i].text.trimmingCharacters(in: .whitespacesAndNewlines)
             if userText == "/model" {
                 chatMessages[i + 1].modelPicker = ModelPickerData()
+                hasModelCommand = true
             } else if userText == "/models" {
                 chatMessages[i + 1].modelList = ModelListData()
+                hasModelCommand = true
             }
+        }
+        // Refresh model/provider state so the picker/table has correct data on restart
+        if hasModelCommand {
+            try? daemonClient.send(ModelGetRequestMessage())
         }
 
         let hasUserSentMessages = messages.contains { $0.role == .user }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -194,21 +194,8 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
-        // Intercept bare "/model" command — show inline picker instead of sending to daemon
-        if text == "/model" && !hasSkillInvocation {
-            // Refresh model state from daemon in case it was changed via a text command
-            // (e.g. "/model opus") which doesn't notify the client.
-            try? daemonClient.send(ModelGetRequestMessage())
-            messages.append(ChatMessage(role: .user, text: "/model"))
-            var pickerMessage = ChatMessage(role: .assistant, text: "")
-            pickerMessage.modelPicker = ModelPickerData()
-            messages.append(pickerMessage)
-            inputText = ""
-            return
-        }
-
-        // When "/models" is sent, also refresh configuredProviders so the table UI has fresh data
-        if text == "/models" && !hasSkillInvocation {
+        // When "/model" or "/models" is sent, refresh model state so the picker/table has fresh data
+        if (text == "/model" || text == "/models") && !hasSkillInvocation {
             try? daemonClient.send(ModelGetRequestMessage())
         }
 
@@ -1018,11 +1005,15 @@ public final class ChatViewModel: ObservableObject {
             chatMessages.append(chatMsg)
         }
 
-        // Tag assistant messages that follow a "/models" user message so
-        // the client renders the table UI instead of plain markdown.
+        // Tag assistant messages that follow "/model" or "/models" user messages
+        // so the client renders the picker/table UI instead of plain text.
         for i in chatMessages.indices {
-            if chatMessages[i].role == .user && chatMessages[i].text.trimmingCharacters(in: .whitespacesAndNewlines) == "/models",
-               i + 1 < chatMessages.count && chatMessages[i + 1].role == .assistant {
+            guard chatMessages[i].role == .user,
+                  i + 1 < chatMessages.count && chatMessages[i + 1].role == .assistant else { continue }
+            let userText = chatMessages[i].text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if userText == "/model" {
+                chatMessages[i + 1].modelPicker = ModelPickerData()
+            } else if userText == "/models" {
                 chatMessages[i + 1].modelList = ModelListData()
             }
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -215,7 +215,8 @@ public final class ChatViewModel: ObservableObject {
         let attachments = pendingAttachments
         pendingAttachments = []
 
-        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide
+        let isModelCommand = text == "/model" || text == "/models" || text.hasPrefix("/model ")
+        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !isModelCommand
 
         let willBeQueued = isSending && sessionId != nil
         var queuedMessageId: UUID?


### PR DESCRIPTION
## Summary
- Remove client-side `/model` interception — let daemon handle it so it persists in conversation history (same pattern as `/models`)
- Tag `/model` responses with `modelPicker` in both `assistantTextDelta` (live) and `populateFromHistory` (restart) for persistent UI
- Switch picker selection from `sendSilently("/model <id>")` to `settingsStore.setModel()` via `model_set` IPC, preventing raw `/model claude-opus-4-6` commands from appearing on restart

## Test plan
- [ ] Type `/model` — inline picker appears with current model highlighted
- [ ] Select a model from picker — model switches without creating a visible command message
- [ ] Restart app — `/model` picker persists in chat history
- [ ] Type `/model opus` directly — works as before, shows confirmation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
