### PR TITLE
fix: reset slash menu selection on filter change

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -489,8 +489,10 @@ struct ComposerView: View {
             let filtered = filteredSlashCommands(filter)
             if !filtered.isEmpty {
                 withAnimation(VAnimation.fast) { showSlashMenu = true }
+                if slashFilter != filter {
+                    slashSelectedIndex = 0
+                }
                 slashFilter = filter
-                slashSelectedIndex = min(slashSelectedIndex, max(filtered.count - 1, 0))
             } else {
                 withAnimation(VAnimation.fast) { showSlashMenu = false }
             }


### PR DESCRIPTION
## Summary
- Reset `slashSelectedIndex` to 0 when the slash filter text changes, preventing a stale arrow-key selection from dispatching the wrong command (e.g. selecting `/models` when the user intended `/model`)

## Test plan
- [ ] Type `/` — menu shows, arrow down to second item, then type `model` — selection resets to first item (`/model`)
- [ ] Press Enter with `/model` typed — dispatches `/model`, not `/models`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
