### PR TITLE
fix: gate OAuth connect on actual client interactivity

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -43,6 +43,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   allowedToolNames?: Set<string>;
   /** Session memory policy — used to propagate scopeId and strictSideEffects into ToolContext. */
   memoryPolicy: { scopeId: string; strictSideEffects: boolean };
+  /** True when the session has no connected IPC client (HTTP-only path). */
+  hasNoClient?: boolean;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -95,6 +97,7 @@ export function createToolExecutor(
       forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => ctx.sendToClient(msg as any),
+      isInteractive: !ctx.hasNoClient,
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),
       requestSecret: async (params) => {
         return secretPrompter.prompt(

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -156,7 +156,8 @@ export class Session {
   /** @internal — exposed for session-usage.ts module functions. */
   assistantId: string | null = null;
   private conflictGate = new ConflictGate();
-  private hasNoClient = false;
+  /** @internal — exposed for session-tool-setup.ts to propagate into ToolContext. */
+  hasNoClient = false;
   /** @internal — exposed for session-process.ts module functions. */
   readonly queue = new MessageQueue();
   /** @internal — exposed for session-process.ts module functions. */

--- a/assistant/src/tools/integrations/manage.ts
+++ b/assistant/src/tools/integrations/manage.ts
@@ -133,7 +133,7 @@ class IntegrationManageTool implements Tool {
           return { content: `Error: no clientId configured for "${integrationId}". Run set_client_id first.`, isError: true };
         }
 
-        if (!context.sendToClient) {
+        if (!context.isInteractive) {
           return { content: 'Error: connect action requires an interactive client session', isError: true };
         }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -126,6 +126,8 @@ export interface ToolContext {
   }) => Promise<SecretPromptResult>;
   /** Optional callback to send a message to the connected IPC client (e.g. open_url). */
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
+  /** True when an interactive IPC client is connected (not just a no-op callback). */
+  isInteractive?: boolean;
   /** Memory scope ID from the session's memory policy, so memory tools can target the correct scope. */
   memoryScopeId?: string;
   /** When true, tools with private side-effects should always prompt for confirmation. */


### PR DESCRIPTION
## Summary
- Add `isInteractive` boolean to `ToolContext` to indicate whether a real IPC client is connected
- Expose `hasNoClient` from Session through `ToolSetupContext` and map it to `isInteractive` in the tool executor
- Use `isInteractive` in integration_manage connect guard instead of checking `sendToClient` existence
- Fixes the case where `sendToClient` is always defined (as a no-op `() => {}`) and the OAuth flow still hangs for 120s

Addresses feedback from PR #4092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
