### PR TITLE
fix: clone default memory policy per session to prevent cross-session contamination

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -102,11 +102,11 @@ export interface SessionMemoryPolicy {
   strictSideEffects: boolean;
 }
 
-export const DEFAULT_MEMORY_POLICY: SessionMemoryPolicy = {
+export const DEFAULT_MEMORY_POLICY: Readonly<SessionMemoryPolicy> = Object.freeze({
   scopeId: 'default',
   includeDefaultFallback: false,
   strictSideEffects: false,
-};
+});
 
 const log = getLogger('session');
 
@@ -203,7 +203,7 @@ export class Session {
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
     this.broadcastToAllClients = broadcastToAllClients;
-    this.memoryPolicy = memoryPolicy ?? DEFAULT_MEMORY_POLICY;
+    this.memoryPolicy = memoryPolicy ? { ...memoryPolicy } : { ...DEFAULT_MEMORY_POLICY };
     this.traceEmitter = new TraceEmitter(conversationId, sendToClient);
     this.prompter = new PermissionPrompter(sendToClient);
     this.secretPrompter = new SecretPrompter(sendToClient);


### PR DESCRIPTION
Creates a shallow copy of the memory policy for each session instead of sharing a reference to DEFAULT_MEMORY_POLICY, preventing one session from mutating another's memory behavior. Also freezes DEFAULT_MEMORY_POLICY at its definition site for defense in depth.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
