### PR TITLE
fix: correct private thread description and button label in settings panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -375,12 +375,12 @@ struct SettingsPanel: View {
                             Text("New Private Thread")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.textSecondary)
-                            Text("Private threads are excluded from memory and never appear in your thread history")
+                            Text("Private threads have isolated memory — facts learned in private threads stay private and won't appear in other conversations.")
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
                         Spacer()
-                        VButton(label: "New Thread", style: .primary) {
+                        VButton(label: "New Private Thread", style: .primary) {
                             threadManager.createPrivateThread()
                             onClose()
                         }


### PR DESCRIPTION
## Summary
- Fixed the description text for private threads in SettingsPanel — it incorrectly said private threads are "excluded from memory and never appear in your thread history." Private threads actually have isolated memory and do appear in the sidebar.
- Changed the button label from "New Thread" to "New Private Thread" for clarity.

## Test plan
- [x] `PrivateThreadPersistenceTests` pass (10 tests)
- [x] `ThreadSessionRestorerTests` pass (9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
