### PR TITLE
docs: update ARCHITECTURE.md to describe provider host allowlist navigation policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2330,7 +2330,7 @@ graph TD
 The video webview applies three hardening layers:
 
 1. **Ephemeral storage** -- `WKWebViewConfiguration.websiteDataStore = .nonPersistent()` so no cookies, local storage, or cache survive the session.
-2. **Navigation blocking** -- Only `navigationType == .other` (programmatic/iframe loads) is allowed. User-initiated link clicks are cancelled and opened in the system browser via `NSWorkspace`.
+2. **Navigation policy** -- The first programmatic load (the embed URL we control) is always allowed. Subsequent `navigationType == .other` loads are checked against a per-provider host allowlist (e.g. `*.googlevideo.com`, `*.ytimg.com` for YouTube; `*.vimeocdn.com` for Vimeo; `*.loomcdn.com` for Loom). Unrecognised hosts and all user-initiated navigations (link clicks, form submissions) are cancelled and opened in the system browser via `NSWorkspace`.
 3. **Popup blocking** -- `createWebViewWith` returns `nil`, preventing embedded players from opening new windows.
 
 ### Settings Persistence


### PR DESCRIPTION
## Summary

- Updates the navigation policy description in the Security Policies section of ARCHITECTURE.md (line 2333)
- The old text generically stated that only `navigationType == .other` is allowed, which doesn't reflect the per-provider host allowlist that was added to the implementation
- The new text accurately describes the actual behavior: first programmatic load is always allowed, subsequent `.other` navigations are checked against provider-specific CDN host allowlists (YouTube, Vimeo, Loom), and unrecognised hosts plus all user-initiated navigations are cancelled and opened in the system browser

## Test plan

- [x] Docs-only change, no functional impact
- [x] Verified the updated text accurately matches the implementation's provider host allowlist behavior

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
