### PR TITLE
fix: replace video embed retry card with link-only fallback on failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -20,12 +20,17 @@ struct InlineVideoEmbedCard: View {
         VideoEmbedURLBuilder.buildEmbedURL(provider: provider, videoID: videoID) ?? embedURL
     }
 
-    private var isExpanded: Bool {
+    /// Card height varies by state: expanded for active playback,
+    /// medium for the click-to-play placeholder, compact for the
+    /// link-only fallback shown after a load failure.
+    private var cardHeight: CGFloat {
         switch stateManager.state {
         case .playing, .initializing:
-            return true
-        case .placeholder, .failed:
-            return false
+            return 315
+        case .placeholder:
+            return 180
+        case .failed:
+            return 60
         }
     }
 
@@ -41,8 +46,8 @@ struct InlineVideoEmbedCard: View {
             stateContent
         }
         .frame(maxWidth: .infinity)
-        .frame(height: isExpanded ? 315 : 180)
-        .animation(.easeInOut(duration: 0.25), value: isExpanded)
+        .frame(height: cardHeight)
+        .animation(.easeInOut(duration: 0.25), value: cardHeight)
         .onDisappear {
             // Tear down active/loading webviews when scrolled offscreen
             // to prevent memory leaks and background audio playback.
@@ -103,24 +108,29 @@ struct InlineVideoEmbedCard: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
+    /// Link-only fallback shown when the webview fails to load.
+    /// Displays the provider name and the original embed URL as a
+    /// clickable link that opens in the default browser.
     private func failedView(_ message: String) -> some View {
-        VStack(spacing: VSpacing.sm) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 32))
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "play.rectangle.fill")
+                .font(.system(size: 16))
                 .foregroundStyle(VColor.textSecondary)
 
-            Text(message)
+            Text(provider.capitalized)
                 .font(VFont.caption)
                 .foregroundStyle(VColor.textSecondary)
-                .multilineTextAlignment(.center)
 
-            Text("Tap to retry")
+            Text(embedURL.absoluteString)
                 .font(VFont.caption)
-                .foregroundStyle(VColor.textSecondary.opacity(0.7))
+                .foregroundStyle(VColor.accent)
+                .lineLimit(1)
+                .truncationMode(.middle)
         }
+        .padding(.horizontal, VSpacing.md)
         .contentShape(Rectangle())
         .onTapGesture {
-            stateManager.requestPlay()
+            NSWorkspace.shared.open(embedURL)
         }
     }
 }

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
@@ -112,7 +112,7 @@ final class InlineVideoWebViewFailureTests: XCTestCase {
         stateManager.didFail("Timed out")
         XCTAssertEqual(stateManager.state, .failed("Timed out"))
 
-        // Tap-to-retry invokes requestPlay again
+        // requestPlay from failed transitions back to initializing
         stateManager.requestPlay()
         XCTAssertEqual(stateManager.state, .initializing)
     }


### PR DESCRIPTION
## Summary
- Replace the error icon + "Tap to retry" failed state in `InlineVideoEmbedCard` with a compact link-only fallback
- Failed state now shows a small video icon, provider name, and the original embed URL as a clickable link (opens in default browser via `NSWorkspace.shared.open()`)
- Card height for `.failed` state collapses to 60pt (from 180pt) using a new three-tier `cardHeight` computed property replacing the boolean `isExpanded`

## Test plan
- [x] All 36 `InlineVideoWebView*` tests pass
- [x] All 10 `InlineVideoEmbedState*` tests pass  
- [x] All 48 related media embed tests pass (including `InlineVideoEmbedCard`, `InlineVideoOffscreenTeardown`, `InlineVideoPlayerIntegration`, `MediaEmbedFinalRegression`)
- [ ] Manual: trigger a video load failure and verify the fallback link appears with correct styling
- [ ] Manual: click the fallback link and verify it opens in the default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
