### PR TITLE
fix: future-proof session options persistence guard

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -708,7 +708,7 @@ export class DaemonServer {
     };
 
     // Persist session options so they survive eviction/recreation.
-    if (options && (options.systemPromptOverride || options.maxResponseTokens || options.transport)) {
+    if (options && Object.values(options).some(v => v !== undefined)) {
       this.sessionOptions.set(conversationId, {
         ...this.sessionOptions.get(conversationId),
         ...options,


### PR DESCRIPTION
Replaces the field-specific guard condition for persisting session options with Object.values check, so new fields like isPrivateThread and memoryScopeId are not silently dropped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
