### PR TITLE
fix: validate threadType input before persisting new conversation

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -437,6 +437,52 @@ describe('DaemonServer initial session hydration', () => {
     });
   });
 
+  test('session_create normalizes unrecognized threadType to standard', async () => {
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket, writes } = createFakeSocket();
+
+    internal.dispatchMessage({
+      type: 'session_create',
+      title: 'Bad threadType',
+      threadType: 'bogus' as unknown,
+    }, socket);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should normalize to 'standard'
+    expect(lastCreateConversationArgs).toEqual({
+      title: 'Bad threadType',
+      threadType: 'standard',
+    });
+
+    const messages = decodeMessages(writes);
+    const sessionInfo = messages.find((msg) => msg.type === 'session_info');
+    expect(sessionInfo).toBeDefined();
+    expect(sessionInfo!.threadType).toBe('standard');
+  });
+
+  test('session_create defaults missing threadType to standard', async () => {
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket, writes } = createFakeSocket();
+
+    internal.dispatchMessage({
+      type: 'session_create',
+      title: 'No threadType',
+    }, socket);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastCreateConversationArgs).toEqual({
+      title: 'No threadType',
+      threadType: 'standard',
+    });
+
+    const messages = decodeMessages(writes);
+    const sessionInfo = messages.find((msg) => msg.type === 'session_info');
+    expect(sessionInfo).toBeDefined();
+    expect(sessionInfo!.threadType).toBe('standard');
+  });
+
   test('session_create with private threadType derives correct policy', async () => {
     // conversation starts as 'standard' from beforeEach — the mock
     // createConversation must derive private state from the IPC request.

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -217,9 +217,10 @@ export async function handleSessionCreate(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
+  const threadType: ThreadType = msg.threadType === 'private' ? 'private' : 'standard';
   const conversation = conversationStore.createConversation({
     title: msg.title ?? 'New Conversation',
-    threadType: msg.threadType,
+    threadType,
   });
   const session = await ctx.getOrCreateSession(conversation.id, socket, true, {
     systemPromptOverride: msg.systemPromptOverride,


### PR DESCRIPTION
Validates threadType input in handleSessionCreate to only accept 'standard' or 'private', defaulting to 'standard' for unrecognized or missing values. This addresses PR #3994 review feedback about writing untrusted msg.threadType directly to the database without runtime validation. Adds tests for unrecognized and missing threadType normalization.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
