### PR TITLE
fix: preserve separators in code stripping and handle unterminated fences

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -101,10 +101,11 @@ enum MessageURLExtractor {
         return results
     }
 
-    // Matches fenced code blocks: ``` with optional language id, content, closing ```
-    // Uses dotMatchesLineSeparators so `.` spans newlines.
+    // Matches fenced code blocks: ``` with optional language id, content, closing ```.
+    // Also matches unterminated fences (opening ``` with no closing ```) by
+    // consuming from the opening fence to end-of-string.
     private static let fencedCodeBlockPattern: NSRegularExpression = {
-        let pattern = "```[^`\\n]*\\n[\\s\\S]*?```"
+        let pattern = "```[^`\\n]*\\n(?:[\\s\\S]*?```|[\\s\\S]*$)"
         return try! NSRegularExpression(pattern: pattern, options: [])
     }()
 
@@ -119,16 +120,20 @@ enum MessageURLExtractor {
     /// inside them are not picked up by extraction. Fenced blocks are
     /// stripped first so that backticks inside fences don't interfere
     /// with inline-code matching.
+    ///
+    /// Matches are replaced with a single space (not an empty string)
+    /// to preserve token boundaries — otherwise surrounding text could
+    /// concatenate into a spurious URL.
     static func stripCodeRegions(from text: String) -> String {
         let mutable = NSMutableString(string: text)
         let fullRange = NSRange(location: 0, length: mutable.length)
 
         // Strip fenced blocks first (they may contain backticks).
-        fencedCodeBlockPattern.replaceMatches(in: mutable, options: [], range: fullRange, withTemplate: "")
+        fencedCodeBlockPattern.replaceMatches(in: mutable, options: [], range: fullRange, withTemplate: " ")
 
         // Then strip inline code spans from what remains.
         let updatedRange = NSRange(location: 0, length: mutable.length)
-        inlineCodePattern.replaceMatches(in: mutable, options: [], range: updatedRange, withTemplate: "")
+        inlineCodePattern.replaceMatches(in: mutable, options: [], range: updatedRange, withTemplate: " ")
 
         return mutable as String
     }

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorCodeExclusionTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorCodeExclusionTests.swift
@@ -155,7 +155,7 @@ final class MessageURLExtractorCodeExclusionTests: XCTestCase {
     func testStripCodeRegionsDirectly() {
         let text = "Hello `code here` world"
         let stripped = MessageURLExtractor.stripCodeRegions(from: text)
-        XCTAssertEqual(stripped, "Hello  world")
+        XCTAssertEqual(stripped, "Hello   world")
     }
 
     func testStripFencedCodeRegionsDirectly() {
@@ -170,5 +170,72 @@ final class MessageURLExtractorCodeExclusionTests: XCTestCase {
         XCTAssertTrue(stripped.contains("Before"))
         XCTAssertTrue(stripped.contains("After"))
         XCTAssertFalse(stripped.contains("inside fence"))
+    }
+
+    // MARK: - Space placeholder prevents URL concatenation
+
+    func testInlineCodeStrippingPreservesSpaceSeparator() {
+        // Stripping code regions uses a space placeholder to prevent
+        // surrounding text from concatenating into spurious tokens.
+        let stripped = MessageURLExtractor.stripCodeRegions(from: "prefix`code`suffix")
+        XCTAssertEqual(stripped, "prefix suffix")
+        XCTAssertFalse(stripped.contains("prefixsuffix"),
+                       "Code stripping must not concatenate adjacent text")
+    }
+
+    func testSpacePlaceholderPreservesTokenBoundaries() {
+        let stripped = MessageURLExtractor.stripCodeRegions(from: "a`code`b")
+        // Should be "a b" (space between), not "ab".
+        XCTAssertEqual(stripped, "a b")
+    }
+
+    // MARK: - Unterminated fenced code blocks
+
+    func testURLInsideUnterminatedFencedBlockIsNotExtracted() {
+        let text = """
+        Here is some text
+        ```
+        curl https://api.example.com/streaming
+        more code here
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertTrue(urls.isEmpty, "URLs inside unterminated fenced blocks should be excluded")
+    }
+
+    func testURLBeforeUnterminatedFenceIsExtracted() {
+        let text = """
+        Visit https://real.example.com first.
+        ```python
+        requests.get("https://fake.example.com")
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://real.example.com")
+    }
+
+    func testUnterminatedFenceStripsToEndOfString() {
+        let text = """
+        Before
+        ```
+        inside unterminated fence
+        still inside
+        """
+        let stripped = MessageURLExtractor.stripCodeRegions(from: text)
+        XCTAssertTrue(stripped.contains("Before"))
+        XCTAssertFalse(stripped.contains("inside unterminated fence"))
+        XCTAssertFalse(stripped.contains("still inside"))
+    }
+
+    func testTerminatedFenceStillWorksNormally() {
+        // Ensure the regex change didn't break normal fenced blocks.
+        let text = """
+        ```
+        https://inside.example.com
+        ```
+        https://outside.example.com
+        """
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://outside.example.com")
     }
 }


### PR DESCRIPTION
Fixes code region stripping to use space placeholders instead of empty strings (prevents URL concatenation), and handles unterminated fenced code blocks (strips from opening fence to end of string).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
