### PR TITLE
fix: add action-aware side-effect classification for private thread prompting

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -930,6 +930,8 @@ describe('isSideEffectTool', () => {
       'browser_press_key',
       'browser_close',
       'browser_fill_credential',
+      'document_create',
+      'document_update',
     ];
 
     for (const toolName of sideEffectTools) {
@@ -964,6 +966,44 @@ describe('isSideEffectTool', () => {
   test('returns false for unknown tool names', () => {
     expect(isSideEffectTool('nonexistent_tool')).toBe(false);
     expect(isSideEffectTool('')).toBe(false);
+  });
+
+  describe('action-aware classification for mixed-action tools', () => {
+    test('account_manage create is a side-effect', () => {
+      expect(isSideEffectTool('account_manage', { action: 'create' })).toBe(true);
+    });
+
+    test('account_manage update is a side-effect', () => {
+      expect(isSideEffectTool('account_manage', { action: 'update' })).toBe(true);
+    });
+
+    test('account_manage list is NOT a side-effect', () => {
+      expect(isSideEffectTool('account_manage', { action: 'list' })).toBe(false);
+    });
+
+    test('account_manage get is NOT a side-effect', () => {
+      expect(isSideEffectTool('account_manage', { action: 'get' })).toBe(false);
+    });
+
+    test('account_manage without input is NOT a side-effect', () => {
+      expect(isSideEffectTool('account_manage')).toBe(false);
+    });
+
+    test('reminder create is a side-effect', () => {
+      expect(isSideEffectTool('reminder', { action: 'create' })).toBe(true);
+    });
+
+    test('reminder cancel is a side-effect', () => {
+      expect(isSideEffectTool('reminder', { action: 'cancel' })).toBe(true);
+    });
+
+    test('reminder list is NOT a side-effect', () => {
+      expect(isSideEffectTool('reminder', { action: 'list' })).toBe(false);
+    });
+
+    test('reminder without input is NOT a side-effect', () => {
+      expect(isSideEffectTool('reminder')).toBe(false);
+    });
   });
 });
 
@@ -1183,6 +1223,10 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
       { name: 'browser_press_key', input: { key: 'Enter' } },
       { name: 'browser_close', input: {} },
       { name: 'browser_fill_credential', input: { selector: '#pwd', credential: 'test' } },
+      { name: 'document_create', input: { title: 'doc', content: 'body' } },
+      { name: 'document_update', input: { id: 'doc-1', content: 'updated' } },
+      { name: 'account_manage', input: { action: 'create', name: 'acct' } },
+      { name: 'reminder', input: { action: 'create', message: 'remind me' } },
     ];
 
     for (const { name, input } of sideEffectTools) {
@@ -1302,6 +1346,96 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
 
     expect(result.isError).toBe(false);
     // browser_snapshot is read-only — must NOT trigger forced prompting
+    expect(promptCalled).toBe(false);
+  });
+
+  // ── Always-mutating document tools (PR fix5) ──────────
+
+  test('document_create forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'document_create',
+      { title: 'New Doc', content: 'hello' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('document_update forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'document_update',
+      { id: 'doc-1', content: 'updated' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  // ── Action-aware mixed-action tools (PR fix5) ──────────
+
+  test('account_manage create forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'account_manage',
+      { action: 'create', name: 'test-account' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('account_manage list does NOT force prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'account_manage',
+      { action: 'list' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    // list is read-only — must NOT trigger forced prompting
+    expect(promptCalled).toBe(false);
+  });
+
+  test('reminder create forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'reminder',
+      { action: 'create', message: 'test reminder' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('reminder list does NOT force prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'reminder',
+      { action: 'list' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    // list is read-only — must NOT trigger forced prompting
     expect(promptCalled).toBe(false);
   });
 });

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -109,7 +109,7 @@ export class ToolExecutor {
       if (
         context.forcePromptSideEffects
         && result.decision === 'allow'
-        && isSideEffectTool(name)
+        && isSideEffectTool(name, input)
       ) {
         result.decision = 'prompt';
         result.reason = 'Private thread: side-effect tools require explicit approval';
@@ -536,15 +536,33 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   'browser_press_key',
   'browser_close',
   'browser_fill_credential',
+  'document_create',
+  'document_update',
 ]);
 
 /**
  * Returns `true` if the given tool name is classified as having side effects
  * (i.e. it can modify the filesystem, execute arbitrary commands, or trigger
  * external actions). Read-only and informational tools return `false`.
+ *
+ * For mixed-action tools (e.g. account_manage, reminder), the optional
+ * `input` parameter is inspected to distinguish mutating actions (create,
+ * update, cancel) from read-only ones (list, get).
  */
-export function isSideEffectTool(toolName: string): boolean {
-  return SIDE_EFFECT_TOOLS.has(toolName);
+export function isSideEffectTool(toolName: string, input?: Record<string, unknown>): boolean {
+  if (SIDE_EFFECT_TOOLS.has(toolName)) return true;
+
+  // Action-aware checks for mixed-action tools
+  if (toolName === 'account_manage') {
+    const action = input?.action;
+    return action === 'create' || action === 'update';
+  }
+  if (toolName === 'reminder') {
+    const action = input?.action;
+    return action === 'create' || action === 'cancel';
+  }
+
+  return false;
 }
 
 const TIMEOUT_SENTINEL = Symbol('tool-timeout');


### PR DESCRIPTION
## Summary

- Add `document_create` and `document_update` to the static `SIDE_EFFECT_TOOLS` set (always mutating).
- Make `isSideEffectTool` action-aware by accepting an optional `input` parameter for mixed-action tools (`account_manage`, `reminder`), distinguishing mutating actions (create/update/cancel) from read-only ones (list/get).
- Update the call site in `ToolExecutor.execute` to pass tool input through to the classifier.
- Add comprehensive regression tests covering all new classification paths.

## Test plan

- [x] All 83 existing + new tests in `tool-executor.test.ts` pass
- [x] All 17 tests in `tool-executor-lifecycle-events.test.ts` pass
- [x] `document_create` forces prompt in private thread
- [x] `document_update` forces prompt in private thread
- [x] `account_manage` with `action: 'create'` forces prompt; `action: 'list'` does not
- [x] `reminder` with `action: 'create'` forces prompt; `action: 'list'` does not
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
