### PR TITLE
PR 03: Add Browser Migration Test Harness (No Runtime Change)

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -4,6 +4,12 @@ import type { Message, ToolDefinition } from '../providers/types.js';
 import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
 import type { Tool } from '../tools/types.js';
 import { RiskLevel } from '../permissions/types.js';
+import {
+  BROWSER_TOOL_NAMES,
+  buildSkillLoadHistory,
+  assertBrowserToolsPresent,
+  assertBrowserToolsAbsent,
+} from './test-support/browser-skill-harness.js';
 
 // ---------------------------------------------------------------------------
 // Mock state — controlled by tests
@@ -2286,5 +2292,48 @@ describe('includes metadata does not auto-activate child skill tools', () => {
     expect(result.toolDefinitions[0].name).toBe('gp_action');
     expect(result.allowedToolNames.has('parent_action')).toBe(false);
     expect(result.allowedToolNames.has('child_action')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Browser skill migration harness — validates shared test helpers
+// ---------------------------------------------------------------------------
+
+describe('browser skill migration harness', () => {
+  test('buildSkillLoadHistory creates valid skill_load history', () => {
+    const history = buildSkillLoadHistory('browser', 'v1:abc123');
+    expect(history).toHaveLength(2);
+    expect(history[0].role).toBe('assistant');
+    expect(history[1].role).toBe('user');
+    // Verify tool_use block
+    const toolUse = history[0].content[0];
+    expect(toolUse.type).toBe('tool_use');
+    expect(toolUse.name).toBe('skill_load');
+    // Verify tool_result has marker
+    const toolResult = history[1].content[0];
+    expect(toolResult.type).toBe('tool_result');
+    expect(toolResult.content).toContain('<loaded_skill id="browser" version="v1:abc123" />');
+  });
+
+  test('BROWSER_TOOL_NAMES contains all 10 browser tools', () => {
+    expect(BROWSER_TOOL_NAMES).toHaveLength(10);
+    expect(BROWSER_TOOL_NAMES).toContain('browser_navigate');
+    expect(BROWSER_TOOL_NAMES).toContain('browser_fill_credential');
+  });
+
+  test('assertBrowserToolsPresent passes when all tools present', () => {
+    expect(() => assertBrowserToolsPresent([...BROWSER_TOOL_NAMES, 'extra_tool'])).not.toThrow();
+  });
+
+  test('assertBrowserToolsPresent fails when tool missing', () => {
+    expect(() => assertBrowserToolsPresent(['browser_navigate'])).toThrow();
+  });
+
+  test('assertBrowserToolsAbsent passes when no browser tools present', () => {
+    expect(() => assertBrowserToolsAbsent(['file_read', 'web_search'])).not.toThrow();
+  });
+
+  test('assertBrowserToolsAbsent fails when browser tool present', () => {
+    expect(() => assertBrowserToolsAbsent(['browser_navigate'])).toThrow();
   });
 });

--- a/assistant/src/__tests__/test-support/browser-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/browser-skill-harness.ts
@@ -1,0 +1,88 @@
+import type { Message } from '../../providers/types.js';
+
+/** The 10 browser tool names that are being migrated from core to skill. */
+export const BROWSER_TOOL_NAMES = [
+  'browser_navigate',
+  'browser_snapshot',
+  'browser_screenshot',
+  'browser_close',
+  'browser_click',
+  'browser_type',
+  'browser_press_key',
+  'browser_wait_for',
+  'browser_extract',
+  'browser_fill_credential',
+] as const;
+
+/** Number of browser tools being migrated. */
+export const BROWSER_TOOL_COUNT = BROWSER_TOOL_NAMES.length;
+
+/** Skill ID for the bundled browser skill. */
+export const BROWSER_SKILL_ID = 'browser';
+
+/**
+ * Build a synthetic conversation history containing a skill_load tool_use
+ * and matching tool_result with a <loaded_skill /> marker.
+ */
+export function buildSkillLoadHistory(skillId: string, versionHash?: string): Message[] {
+  const toolUseId = `test-tool-use-${skillId}`;
+  const versionAttr = versionHash ? ` version="${versionHash}"` : '';
+  return [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id: toolUseId,
+          name: 'skill_load',
+          input: { skill: skillId },
+        },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content: `Skill loaded successfully.\n<loaded_skill id="${skillId}"${versionAttr} />`,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Assert that a set of tool names is exactly the expected set (order-independent).
+ */
+export function expectToolNamesEqual(actual: string[], expected: readonly string[]): void {
+  const sorted = [...actual].sort();
+  const expectedSorted = [...expected].sort();
+  if (JSON.stringify(sorted) !== JSON.stringify(expectedSorted)) {
+    throw new Error(
+      `Tool names mismatch.\nExpected: ${JSON.stringify(expectedSorted)}\nActual: ${JSON.stringify(sorted)}`
+    );
+  }
+}
+
+/**
+ * Assert that all browser tool names are present in a given set.
+ */
+export function assertBrowserToolsPresent(toolNames: string[]): void {
+  for (const name of BROWSER_TOOL_NAMES) {
+    if (!toolNames.includes(name)) {
+      throw new Error(`Expected browser tool "${name}" to be present in tool names`);
+    }
+  }
+}
+
+/**
+ * Assert that no browser tool names are present in a given set.
+ */
+export function assertBrowserToolsAbsent(toolNames: string[]): void {
+  for (const name of BROWSER_TOOL_NAMES) {
+    if (toolNames.includes(name)) {
+      throw new Error(`Expected browser tool "${name}" to be absent from tool names`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Creates reusable `browser-skill-harness.ts` with helpers for skill load history construction and tool name assertions
- Adds harness validation tests in `session-skill-tools.test.ts`

Part of browser skill migration plan (BROWSER_SKILL.md)

## Test plan
- [x] session-skill-tools tests pass (75 tests, 345 assertions)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
