### PR TITLE
fix: resolve IUO crash in ThreadManagerPrivateThreadTests

### DIFF
--- a/clients/macos/vellum-assistantTests/ThreadManagerPrivateThreadTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerPrivateThreadTests.swift
@@ -7,7 +7,7 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
 
     private var daemonClient: DaemonClient!
     private var threadManager: ThreadManager!
-    private var capturedMessages: [Any]!
+    private var capturedMessages: [Any] = []
 
     override func setUp() {
         super.setUp()
@@ -15,14 +15,16 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
         daemonClient.isConnected = true
         capturedMessages = []
         daemonClient.sendOverride = { [weak self] msg in
-            self?.capturedMessages.append(msg)
+            guard let self else { return }
+            capturedMessages.append(msg)
         }
         threadManager = ThreadManager(daemonClient: daemonClient)
     }
 
     override func tearDown() {
+        daemonClient?.sendOverride = nil
         threadManager = nil
-        capturedMessages = nil
+        capturedMessages = []
         daemonClient = nil
         super.tearDown()
     }


### PR DESCRIPTION
## Summary
- Change `capturedMessages` from `[Any]!` (implicitly unwrapped optional) to `[Any] = []` to eliminate the possibility of a nil IUO crash
- Clear `sendOverride` in `tearDown` before nilling `daemonClient` to prevent stale async callbacks from firing after teardown
- Guard on `weak self` in the `sendOverride` closure to safely bail out if the test instance is deallocated

## Test plan
- [x] All 8 tests in `ThreadManagerPrivateThreadTests` pass (previously crashed on `testCreatePrivateThreadSendsSessionCreate`)
- [x] All 19 tests in `PrivateThreadPersistenceTests` and `ThreadSessionRestorerTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
