### PR TITLE
PR 06: Add Bundled browser Skill Skeleton (No Tool Manifest Yet)

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -474,3 +474,51 @@ describe('includes frontmatter parsing', () => {
     expect(skill!.includes).toBeUndefined();
   });
 });
+
+describe('bundled browser skill', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('browser skill appears in full catalog (including bundled)', () => {
+    const catalog = loadSkillCatalog();
+    const browserSkill = catalog.find((s) => s.id === 'browser');
+    expect(browserSkill).toBeDefined();
+    expect(browserSkill!.name).toBe('Browser');
+    expect(browserSkill!.bundled).toBe(true);
+  });
+
+  test('browser skill has correct metadata', () => {
+    const catalog = loadSkillCatalog();
+    const browserSkill = catalog.find((s) => s.id === 'browser');
+    expect(browserSkill).toBeDefined();
+    expect(browserSkill!.description).toBe('Navigate and interact with web pages using a headless browser');
+  });
+
+  test('browser skill is not user-invocable in staging mode', () => {
+    const catalog = loadSkillCatalog();
+    const browserSkill = catalog.find((s) => s.id === 'browser');
+    expect(browserSkill).toBeDefined();
+    expect(browserSkill!.userInvocable).toBe(false);
+  });
+
+  test('browser skill has model invocation disabled in staging mode', () => {
+    const catalog = loadSkillCatalog();
+    const browserSkill = catalog.find((s) => s.id === 'browser');
+    expect(browserSkill).toBeDefined();
+    expect(browserSkill!.disableModelInvocation).toBe(true);
+  });
+
+  test('browser skill has no tool manifest yet (no TOOLS.json)', () => {
+    const catalog = loadSkillCatalog();
+    const browserSkill = catalog.find((s) => s.id === 'browser');
+    expect(browserSkill).toBeDefined();
+    expect(browserSkill!.toolManifest).toBeUndefined();
+  });
+});

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: "Browser"
+description: "Navigate and interact with web pages using a headless browser"
+user-invocable: false
+disable-model-invocation: true
+metadata: {"vellum": {"emoji": "🌐"}}
+---
+
+Use this skill to browse the web. After loading this skill, the following browser tools become available:
+
+- `browser_navigate` — Navigate to a URL
+- `browser_snapshot` — List interactive elements on the current page
+- `browser_screenshot` — Take a visual screenshot
+- `browser_close` — Close the browser page
+- `browser_click` — Click an element
+- `browser_type` — Type text into an input
+- `browser_press_key` — Press a keyboard key
+- `browser_wait_for` — Wait for a condition
+- `browser_extract` — Extract page text content
+- `browser_fill_credential` — Fill a stored credential into a form field
+
+## Typical Workflow
+
+1. `browser_navigate` to load a page
+2. `browser_snapshot` to discover interactive elements
+3. Use `browser_click`, `browser_type`, or `browser_press_key` to interact
+4. `browser_extract` or `browser_screenshot` to capture results
+5. `browser_close` when done


### PR DESCRIPTION
## Summary
- Adds `browser` bundled skill with SKILL.md (staging mode: not invocable, model invocation disabled)
- No TOOLS.json yet — skill exists in catalog but does not project tools
- Adds 5 catalog tests verifying skill discovery and staging properties

Part of browser skill migration plan (BROWSER_SKILL.md)

## Test plan
- [x] skills catalog tests pass (33/33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
