### PR TITLE
fix: add schedule tools to side-effect set for private thread prompting

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -932,6 +932,9 @@ describe('isSideEffectTool', () => {
       'browser_fill_credential',
       'document_create',
       'document_update',
+      'schedule_create',
+      'schedule_update',
+      'schedule_delete',
     ];
 
     for (const toolName of sideEffectTools) {
@@ -1372,6 +1375,50 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
     const result = await executor.execute(
       'document_update',
       { id: 'doc-1', content: 'updated' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  // ── Always-mutating schedule tools (PR fix7) ──────────
+
+  test('schedule_create forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'schedule_create',
+      { name: 'Morning standup', cron: '0 9 * * 1-5' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('schedule_update forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'schedule_update',
+      { id: 'sched-1', cron: '0 10 * * 1-5' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('schedule_delete forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'schedule_delete',
+      { id: 'sched-1' },
       makeContext({ forcePromptSideEffects: true }),
     );
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -538,6 +538,9 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   'browser_fill_credential',
   'document_create',
   'document_update',
+  'schedule_create',
+  'schedule_update',
+  'schedule_delete',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Add `schedule_create`, `schedule_update`, and `schedule_delete` to the `SIDE_EFFECT_TOOLS` set in `executor.ts`
- These mutating tools were missing from the classifier, allowing them to bypass forced prompting in private threads
- Add regression tests verifying each schedule tool forces a prompt when `forcePromptSideEffects: true`
- Update the exhaustive `isSideEffectTool` classifier test list to include the 3 new tools

## Test plan
- [x] `bun test assistant/src/__tests__/tool-executor.test.ts` — 89 tests pass
- [x] `bun test assistant/src/__tests__/tool-executor-lifecycle-events.test.ts` — 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
