### PR TITLE
fix(ios): roll back pending user message on error/cancel in DirectClaudeClient

### DIFF
--- a/clients/shared/IPC/DirectClaudeClient.swift
+++ b/clients/shared/IPC/DirectClaudeClient.swift
@@ -107,14 +107,10 @@ public final class DirectClaudeClient: ObservableObject, DaemonClientProtocol {
         let sessionId = msg.sessionId ?? ""
         activeTasks[sessionId]?.cancel()
         activeTasks.removeValue(forKey: sessionId)
-        // Roll back any trailing user message that has no assistant reply yet,
-        // in case the task was cancelled before streamCompletion could do it.
-        if var history = pendingMessages[sessionId],
-           !history.isEmpty,
-           history.last?["role"] as? String == "user" {
-            history.removeLast()
-            pendingMessages[sessionId] = history.isEmpty ? nil : history
-        }
+        // History rollback is intentionally deferred to streamCompletion, which has access
+        // to assistantText. Rolling back here would race with a mid-stream cancel: the user
+        // message would be removed while assistantText is non-empty, then streamCompletion
+        // would append the partial assistant reply producing an orphaned assistant turn.
         broadcast(.generationCancelled(GenerationCancelledMessage(sessionId: sessionId)))
     }
 

--- a/clients/shared/IPC/DirectClaudeClient.swift
+++ b/clients/shared/IPC/DirectClaudeClient.swift
@@ -159,7 +159,9 @@ public final class DirectClaudeClient: ObservableObject, DaemonClientProtocol {
                 broadcast(.messageComplete(MessageCompleteMessage(sessionId: sessionId)))
                 activeTasks.removeValue(forKey: sessionId)
                 // Roll back the user message — no assistant reply was produced
-                if var history = pendingMessages[sessionId], !history.isEmpty {
+                if var history = pendingMessages[sessionId],
+                   !history.isEmpty,
+                   history.last?["role"] as? String == "user" {
                     history.removeLast()
                     pendingMessages[sessionId] = history.isEmpty ? nil : history
                 }
@@ -204,8 +206,11 @@ public final class DirectClaudeClient: ObservableObject, DaemonClientProtocol {
 
         // Roll back the user message if no assistant text was produced (error or cancellation),
         // to preserve the alternating user/assistant invariant required by the Anthropic API.
+        // Guard on role == "user" to avoid a double-rollback if handleCancel already removed it.
         if assistantText.isEmpty {
-            if var history = pendingMessages[sessionId], !history.isEmpty {
+            if var history = pendingMessages[sessionId],
+               !history.isEmpty,
+               history.last?["role"] as? String == "user" {
                 history.removeLast()
                 pendingMessages[sessionId] = history.isEmpty ? nil : history
             }

--- a/clients/shared/IPC/DirectClaudeClient.swift
+++ b/clients/shared/IPC/DirectClaudeClient.swift
@@ -107,6 +107,14 @@ public final class DirectClaudeClient: ObservableObject, DaemonClientProtocol {
         let sessionId = msg.sessionId ?? ""
         activeTasks[sessionId]?.cancel()
         activeTasks.removeValue(forKey: sessionId)
+        // Roll back any trailing user message that has no assistant reply yet,
+        // in case the task was cancelled before streamCompletion could do it.
+        if var history = pendingMessages[sessionId],
+           !history.isEmpty,
+           history.last?["role"] as? String == "user" {
+            history.removeLast()
+            pendingMessages[sessionId] = history.isEmpty ? nil : history
+        }
         broadcast(.generationCancelled(GenerationCancelledMessage(sessionId: sessionId)))
     }
 
@@ -150,6 +158,11 @@ public final class DirectClaudeClient: ObservableObject, DaemonClientProtocol {
                 broadcast(.sessionError(SessionErrorMessage(sessionId: sessionId, code: .providerApi, userMessage: userMessage, retryable: false)))
                 broadcast(.messageComplete(MessageCompleteMessage(sessionId: sessionId)))
                 activeTasks.removeValue(forKey: sessionId)
+                // Roll back the user message — no assistant reply was produced
+                if var history = pendingMessages[sessionId], !history.isEmpty {
+                    history.removeLast()
+                    pendingMessages[sessionId] = history.isEmpty ? nil : history
+                }
                 return
             }
 
@@ -186,6 +199,15 @@ public final class DirectClaudeClient: ObservableObject, DaemonClientProtocol {
                     userMessage: error.localizedDescription,
                     retryable: true
                 )))
+            }
+        }
+
+        // Roll back the user message if no assistant text was produced (error or cancellation),
+        // to preserve the alternating user/assistant invariant required by the Anthropic API.
+        if assistantText.isEmpty {
+            if var history = pendingMessages[sessionId], !history.isEmpty {
+                history.removeLast()
+                pendingMessages[sessionId] = history.isEmpty ? nil : history
             }
         }
 


### PR DESCRIPTION
## Summary

`DirectClaudeClient` appends the user message to `pendingMessages` before calling the Anthropic API. If the call fails or is cancelled with no assistant text produced, the user message was left without a matching assistant reply. On the next send, the history contained two consecutive user messages, which the Anthropic API rejects with a 400 error.

## Fix

Roll back the trailing user message in three places:

1. **HTTP error early-return** (`streamCompletion` lines 135–154) — after broadcasting `sessionError`/`messageComplete` and before returning, remove the last entry from `pendingMessages[sessionId]`.
2. **Post-do/catch block** (`streamCompletion` after line 190) — when `assistantText` is still empty (network error, cancellation before any text), remove the trailing user message before the existing `if !assistantText.isEmpty` append block.
3. **`handleCancel`** — after cancelling the task, check if the last entry in `pendingMessages[sessionId]` has `role == "user"` and remove it. This covers the race where cancellation fires before `streamCompletion` even starts.

## Files Changed

- `clients/shared/IPC/DirectClaudeClient.swift` — +22 lines across three callsites

## Testing

1. Open standalone mode (no API key configured) → send a message → observe error → send again → should work without 400 error
2. Start a message → tap cancel mid-stream → send again → conversation continues normally
3. Configure a bad API key → send a message → get 401 → fix the key → send again → should succeed

Fixes conversation history corruption for multi-turn retry scenarios in standalone mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
