### PR TITLE
fix: add credential_store to side-effect set for private thread prompting

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -935,6 +935,7 @@ describe('isSideEffectTool', () => {
       'schedule_create',
       'schedule_update',
       'schedule_delete',
+      'credential_store',
     ];
 
     for (const toolName of sideEffectTools) {
@@ -1230,6 +1231,7 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
       { name: 'document_update', input: { id: 'doc-1', content: 'updated' } },
       { name: 'account_manage', input: { action: 'create', name: 'acct' } },
       { name: 'reminder', input: { action: 'create', message: 'remind me' } },
+      { name: 'credential_store', input: { name: 'api-key', value: 'secret' } },
     ];
 
     for (const { name, input } of sideEffectTools) {
@@ -1419,6 +1421,22 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
     const result = await executor.execute(
       'schedule_delete',
       { id: 'sched-1' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  // ── Credential store (PR fix8) ──────────
+
+  test('credential_store forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'credential_store',
+      { name: 'api-key', value: 'sk-secret-123' },
       makeContext({ forcePromptSideEffects: true }),
     );
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -541,6 +541,7 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   'schedule_create',
   'schedule_update',
   'schedule_delete',
+  'credential_store',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Add `credential_store` to `SIDE_EFFECT_TOOLS` in `executor.ts` so private threads force prompting before storing credentials in the vault
- Add regression test: `credential_store forces prompt in private thread` (forcePromptSideEffects: true, checker returns allow, verify prompter called)
- Update exhaustive isSideEffectTool classifier test list and all-side-effect-tools-forced-to-prompt integration list to include `credential_store`

## Test plan
- [x] `bun test assistant/src/__tests__/tool-executor.test.ts` — 91 tests pass
- [x] `bun test assistant/src/__tests__/tool-executor-lifecycle-events.test.ts` — 17 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
