### PR TITLE
PR 09: Add Default Allow Rules for browser_* Tools

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3545,21 +3545,21 @@ describe('Permission Checker', () => {
       });
     }
 
-    test('browser tools are auto-allowed in legacy mode (RiskLevel.Low)', async () => {
+    test('browser tools are auto-allowed in legacy mode', async () => {
       testConfig.permissions = { mode: 'legacy' };
       for (const toolName of browserToolNames) {
         const result = await check(toolName, {}, '/tmp');
         expect(result.decision).toBe('allow');
-        expect(result.reason).toContain('Low risk');
       }
     });
 
-    test('strict mode prompts browser tools without trust rules (no implicit auto-allow)', async () => {
+    test('browser tools are auto-allowed in strict mode via default allow rules', async () => {
       testConfig.permissions = { mode: 'strict' };
       try {
-        const result = await check('browser_navigate', { url: 'https://example.com' }, '/tmp');
-        expect(result.decision).toBe('prompt');
-        expect(result.reason).toContain('Strict mode');
+        for (const toolName of browserToolNames) {
+          const result = await check(toolName, {}, '/tmp');
+          expect(result.decision).toBe('allow');
+        }
       } finally {
         testConfig.permissions = { mode: 'legacy' };
       }
@@ -3582,6 +3582,35 @@ describe('Permission Checker', () => {
     test('skill_load with any skill name matches the default rule', async () => {
       const result = await check('skill_load', { skill: 'some-random-skill' }, '/tmp');
       expect(result.decision).toBe('allow');
+    });
+  });
+
+  // ── default allow: browser tools ──────────────────────────────
+
+  describe('default allow: browser tools', () => {
+    beforeEach(() => {
+      clearCache();
+      testConfig.permissions = { mode: 'strict' };
+    });
+
+    test('all browser tools are allowed by default rules in strict mode', async () => {
+      const browserTools = [
+        'browser_navigate', 'browser_snapshot', 'browser_screenshot', 'browser_close',
+        'browser_click', 'browser_type', 'browser_press_key', 'browser_wait_for',
+        'browser_extract', 'browser_fill_credential',
+      ];
+
+      for (const tool of browserTools) {
+        const result = await check(tool, {}, '/tmp');
+        expect(result.decision).toBe('allow');
+      }
+    });
+
+    test('non-browser skill tools are NOT auto-allowed', async () => {
+      // skill_test_tool is a registered skill-origin tool without a default
+      // allow rule — it should prompt in strict mode.
+      const result = await check('skill_test_tool', {}, '/tmp');
+      expect(result.decision).not.toBe('allow');
     });
   });
 });

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -712,6 +712,16 @@ describe('Trust Store', () => {
       )].sort();
       expect(defaultTools).toEqual([
         'bash',
+        'browser_click',
+        'browser_close',
+        'browser_extract',
+        'browser_fill_credential',
+        'browser_navigate',
+        'browser_press_key',
+        'browser_screenshot',
+        'browser_snapshot',
+        'browser_type',
+        'browser_wait_for',
         'computer_use_click',
         'computer_use_double_click',
         'computer_use_drag',
@@ -1000,6 +1010,34 @@ describe('Trust Store', () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe('default:allow-skill_load-global');
       expect(match!.decision).toBe('allow');
+    });
+
+    // ── default allow: browser tools ────────────────────────────
+
+    test('all 10 browser tools have default allow rules', () => {
+      const templates = getDefaultRuleTemplates();
+      const browserTools = [
+        'browser_navigate', 'browser_snapshot', 'browser_screenshot', 'browser_close',
+        'browser_click', 'browser_type', 'browser_press_key', 'browser_wait_for',
+        'browser_extract', 'browser_fill_credential',
+      ];
+
+      for (const tool of browserTools) {
+        const rule = templates.find(t => t.id === `default:allow-${tool}-global`);
+        expect(rule).toBeDefined();
+        expect(rule!.tool).toBe(tool);
+        expect(rule!.pattern).toBe(`${tool}:*`);
+        expect(rule!.decision).toBe('allow');
+        expect(rule!.scope).toBe('everywhere');
+      }
+    });
+
+    test('browser tool default rules match via findHighestPriorityRule', () => {
+      // Use a candidate without slashes so the `browser_snapshot:*` pattern
+      // matches (minimatch `*` does not cross `/` boundaries).
+      const result = findHighestPriorityRule('browser_snapshot', ['browser_snapshot:'], '/tmp');
+      expect(result).toBeDefined();
+      expect(result!.decision).toBe('allow');
     });
 
     test('no default ask rules exist for file_read on skill source paths', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -170,6 +170,31 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
+  // Browser tools were previously core-registered with RiskLevel.Low (auto-allowed).
+  // After migration to skill-provided tools, default allow rules preserve the
+  // same frictionless UX so they don't trigger permission prompts.
+  const BROWSER_TOOLS = [
+    'browser_navigate',
+    'browser_snapshot',
+    'browser_screenshot',
+    'browser_close',
+    'browser_click',
+    'browser_type',
+    'browser_press_key',
+    'browser_wait_for',
+    'browser_extract',
+    'browser_fill_credential',
+  ] as const;
+
+  const browserToolRules: DefaultRuleTemplate[] = BROWSER_TOOLS.map((tool) => ({
+    id: `default:allow-${tool}-global`,
+    tool,
+    pattern: `${tool}:*`,
+    scope: 'everywhere',
+    decision: 'allow' as const,
+    priority: 100,
+  }));
+
   return [
     ...protectedFileRules,
     ...hostFileRules,
@@ -180,5 +205,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     bootstrapDeleteRule,
     ...skillSourceMutationRules,
     skillLoadRule,
+    ...browserToolRules,
   ];
 }


### PR DESCRIPTION
## Summary
- Adds default allow templates for all 10 browser tools (`browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_close`, `browser_click`, `browser_type`, `browser_press_key`, `browser_wait_for`, `browser_extract`, `browser_fill_credential`)
- Pattern: `<tool>:*` with scope `everywhere` and priority 100
- Browser tools no longer trigger permission prompts after skill migration
- Non-browser skill tools remain unaffected
- Updates existing browser baseline tests to reflect the new default allow rules

Part of browser skill migration plan (BROWSER_SKILL.md)

## Test plan
- [x] trust-store tests pass (rule existence + matching)
- [x] checker tests pass (strict mode auto-allow for browser, non-browser unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
