### PR TITLE
PR 10: System Prompt Update — Browser Skill Prerequisite Guidance

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -121,4 +121,12 @@ describe('Dynamic Skill Authoring Workflow prompt section', () => {
     const result = buildSystemPrompt();
     expect(result).toContain('skill_load');
   });
+
+  test('system prompt includes browser skill prerequisite guidance', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('Browser Skill Prerequisite');
+    expect(result).toContain('browser_*');
+    expect(result).toContain('skill_load');
+  });
 });

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -729,6 +729,9 @@ function buildDynamicSkillWorkflowSection(): string {
     '- If evaluation fails after 3 attempts, summarize the failure and ask your user for guidance instead of continuing to retry.',
     '- After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.',
     '- To remove a managed skill, use `delete_managed_skill`.',
+    '',
+    '### Browser Skill Prerequisite',
+    'If you need browser capabilities (navigating web pages, clicking elements, extracting content) and `browser_*` tools are not available, load the "browser" skill first using `skill_load`.',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Adds concise guidance in system prompt: load browser skill before using browser tools
- Prevents tool-not-active loops when agent tries to use browser without loading skill
- Adds prompt test assertion

Part of browser skill migration plan (BROWSER_SKILL.md)

## Test plan
- [x] dynamic-skill-workflow-prompt tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
