### PR TITLE
PR 11: Slash/Skill Discoverability and Resolver Tests for /browser

### DIFF
--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -107,7 +107,7 @@ mock.module('../context/window-manager.js', () => ({
   getSummaryFromContextMessage: () => null,
 }));
 
-// Mock skill catalog — only "start-the-day" is available
+// Mock skill catalog — "start-the-day" and "browser" are available
 mock.module('../config/skills.js', () => ({
   loadSkillCatalog: () => [
     {
@@ -119,6 +119,16 @@ mock.module('../config/skills.js', () => ({
       userInvocable: true,
       disableModelInvocation: false,
       source: 'managed',
+    },
+    {
+      id: 'browser',
+      name: 'Browser',
+      description: 'Navigate and interact with web pages using a headless browser',
+      directoryPath: '/skills/browser',
+      skillFilePath: '/skills/browser/SKILL.md',
+      userInvocable: true,
+      disableModelInvocation: false,
+      source: 'bundled',
     },
   ],
   loadSkillBySelector: () => null,
@@ -236,6 +246,20 @@ describe('Session slash command — unknown', () => {
     // The assistant message content should contain the unknown-command text
     const assistantContent = addMessageCalls[1].content;
     expect(assistantContent).toContain('Unknown command');
+  });
+
+  test('unknown slash command output includes /browser in available commands', async () => {
+    const session = makeSession();
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+
+    await session.processMessage('/not-a-skill', [], onEvent);
+
+    const textDeltas = events.filter((e) => e.type === 'assistant_text_delta');
+    expect(textDeltas.length).toBe(1);
+    const delta = textDeltas[0] as { text: string };
+    expect(delta.text).toContain('/browser');
+    expect(delta.text).toContain('/start-the-day');
   });
 
   test('normal messages still go through standard path', async () => {

--- a/assistant/src/__tests__/slash-commands-resolver.test.ts
+++ b/assistant/src/__tests__/slash-commands-resolver.test.ts
@@ -110,6 +110,73 @@ describe('resolveSlashSkillCommand', () => {
   });
 });
 
+describe('browser skill slash discoverability', () => {
+  const browserSkill = makeSkill('browser', {
+    name: 'Browser',
+    userInvocable: true,
+  });
+
+  test('/browser resolves as a known slash command when browser skill is enabled', () => {
+    const catalog = buildCatalog([browserSkill]);
+    const result = resolveSlashSkillCommand('/browser', catalog);
+    expect(result).toEqual({ kind: 'known', skillId: 'browser', trailingArgs: '' });
+  });
+
+  test('/browser shows correct skill metadata', () => {
+    const catalog = buildCatalog([browserSkill]);
+    const entry = catalog.get('browser');
+    expect(entry).toBeDefined();
+    expect(entry!.canonicalId).toBe('browser');
+    expect(entry!.name).toBe('Browser');
+    expect(entry!.summary.userInvocable).toBe(true);
+    expect(entry!.summary.description).toBe('Description for browser');
+  });
+
+  test('/browser resolves with trailing args', () => {
+    const catalog = buildCatalog([browserSkill]);
+    const result = resolveSlashSkillCommand('/browser go to https://example.com', catalog);
+    expect(result).toEqual({
+      kind: 'known',
+      skillId: 'browser',
+      trailingArgs: 'go to https://example.com',
+    });
+  });
+
+  test('/browser is excluded when userInvocable is false', () => {
+    const nonInvocable = makeSkill('browser', { name: 'Browser', userInvocable: false });
+    const catalog = buildCatalog([nonInvocable]);
+    const result = resolveSlashSkillCommand('/browser', catalog);
+    expect(result.kind).toBe('unknown');
+  });
+
+  test('/browser appears in available commands when unknown command is entered', () => {
+    const catalog = buildCatalog([browserSkill, makeSkill('start-the-day')]);
+    const result = resolveSlashSkillCommand('/not-a-command', catalog);
+    expect(result.kind).toBe('unknown');
+    if (result.kind === 'unknown') {
+      expect(result.message).toContain('`/browser`');
+      expect(result.message).toContain('`/start-the-day`');
+    }
+  });
+
+  test('/browser sorts correctly among other skills in unknown listing', () => {
+    const catalog = buildCatalog([
+      makeSkill('weather'),
+      browserSkill,
+      makeSkill('agentmail'),
+    ]);
+    const result = resolveSlashSkillCommand('/nope', catalog);
+    expect(result.kind).toBe('unknown');
+    if (result.kind === 'unknown') {
+      const lines = result.message.split('\n');
+      const skillLines = lines.filter((l) => l.startsWith('- `'));
+      expect(skillLines[0]).toContain('/agentmail');
+      expect(skillLines[1]).toContain('/browser');
+      expect(skillLines[2]).toContain('/weather');
+    }
+  });
+});
+
 describe('formatUnknownSlashSkillMessage', () => {
   test('includes requested ID and available skills', () => {
     const msg = formatUnknownSlashSkillMessage('bad-cmd', ['alpha', 'beta']);


### PR DESCRIPTION
## Summary
- Adds resolver tests proving `/browser` resolves as a known slash command
- Verifies `/browser` appears in available commands listing when unknown command is entered
- Tests browser skill metadata, trailing args, non-invocable exclusion, and sort order

Part of browser skill migration plan (BROWSER_SKILL.md)

## Test plan
- [x] slash-commands-resolver tests pass (17 tests, 36 assertions)
- [x] session-slash-unknown tests pass (6 tests, 14 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
