### PR TITLE
fix: make credential_store action-aware in side-effect classifier

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -935,7 +935,6 @@ describe('isSideEffectTool', () => {
       'schedule_create',
       'schedule_update',
       'schedule_delete',
-      'credential_store',
     ];
 
     for (const toolName of sideEffectTools) {
@@ -1007,6 +1006,30 @@ describe('isSideEffectTool', () => {
 
     test('reminder without input is NOT a side-effect', () => {
       expect(isSideEffectTool('reminder')).toBe(false);
+    });
+
+    test('credential_store store is a side-effect', () => {
+      expect(isSideEffectTool('credential_store', { action: 'store' })).toBe(true);
+    });
+
+    test('credential_store delete is a side-effect', () => {
+      expect(isSideEffectTool('credential_store', { action: 'delete' })).toBe(true);
+    });
+
+    test('credential_store prompt is a side-effect', () => {
+      expect(isSideEffectTool('credential_store', { action: 'prompt' })).toBe(true);
+    });
+
+    test('credential_store oauth2_connect is a side-effect', () => {
+      expect(isSideEffectTool('credential_store', { action: 'oauth2_connect' })).toBe(true);
+    });
+
+    test('credential_store list is NOT a side-effect', () => {
+      expect(isSideEffectTool('credential_store', { action: 'list' })).toBe(false);
+    });
+
+    test('credential_store without input is NOT a side-effect', () => {
+      expect(isSideEffectTool('credential_store')).toBe(false);
     });
   });
 });
@@ -1231,7 +1254,7 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
       { name: 'document_update', input: { id: 'doc-1', content: 'updated' } },
       { name: 'account_manage', input: { action: 'create', name: 'acct' } },
       { name: 'reminder', input: { action: 'create', message: 'remind me' } },
-      { name: 'credential_store', input: { name: 'api-key', value: 'secret' } },
+      { name: 'credential_store', input: { action: 'store', name: 'api-key', value: 'secret' } },
     ];
 
     for (const { name, input } of sideEffectTools) {
@@ -1428,20 +1451,63 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
     expect(promptCalled).toBe(true);
   });
 
-  // ── Credential store (PR fix8) ──────────
+  // ── Credential store action-aware (PR fix9) ──────────
 
-  test('credential_store forces prompt in private thread', async () => {
+  test('credential_store store forces prompt in private thread', async () => {
     checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
     const result = await executor.execute(
       'credential_store',
-      { name: 'api-key', value: 'sk-secret-123' },
+      { action: 'store', name: 'api-key', value: 'sk-secret-123' },
       makeContext({ forcePromptSideEffects: true }),
     );
 
     expect(result.isError).toBe(false);
     expect(promptCalled).toBe(true);
+  });
+
+  test('credential_store delete forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'credential_store',
+      { action: 'delete', name: 'api-key' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('credential_store oauth2_connect forces prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'credential_store',
+      { action: 'oauth2_connect', provider: 'google' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
+  });
+
+  test('credential_store list does NOT force prompt in private thread', async () => {
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
+
+    const executor = new ToolExecutor(makeTrackingPrompter());
+    const result = await executor.execute(
+      'credential_store',
+      { action: 'list' },
+      makeContext({ forcePromptSideEffects: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    // list is read-only — must NOT trigger forced prompting
+    expect(promptCalled).toBe(false);
   });
 
   // ── Action-aware mixed-action tools (PR fix5) ──────────

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -541,7 +541,6 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   'schedule_create',
   'schedule_update',
   'schedule_delete',
-  'credential_store',
 ]);
 
 /**
@@ -564,6 +563,10 @@ export function isSideEffectTool(toolName: string, input?: Record<string, unknow
   if (toolName === 'reminder') {
     const action = input?.action;
     return action === 'create' || action === 'cancel';
+  }
+  if (toolName === 'credential_store') {
+    const action = input?.action;
+    return action === 'store' || action === 'delete' || action === 'prompt' || action === 'oauth2_connect';
   }
 
   return false;


### PR DESCRIPTION
## Summary
- Moves `credential_store` from the static `SIDE_EFFECT_TOOLS` set to action-aware logic in `isSideEffectTool`
- Mutating actions (`store`, `delete`, `prompt`, `oauth2_connect`) are classified as side-effects; `list` is read-only
- Follows the same pattern already used by `account_manage` and `reminder`

## Test plan
- [x] Updated `isSideEffectTool` unit tests: added action-aware cases for all credential_store actions
- [x] Updated forcePromptSideEffects integration tests: `store`/`delete`/`oauth2_connect` force prompt, `list` does not
- [x] Updated exhaustive "all side-effect tool types" test to pass `{ action: 'store' }` for credential_store
- [x] All 99 tool-executor tests pass
- [x] All 17 tool-executor-lifecycle-events tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
