### PR TITLE
fix(ios): force dark color scheme app-wide to fix invisible text in light mode — closes #4093

### DIFF
--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -16,6 +16,7 @@ struct VellumAssistantApp: App {
                 OnboardingView(isCompleted: $onboardingCompleted)
             }
         }
+        .preferredColorScheme(.dark)
     }
 }
 #else


### PR DESCRIPTION
## Summary

- The iOS VColor design tokens are dark-mode-only; in light mode SwiftUI remaps text colors to near-black while backgrounds remain dark, making text invisible (most visible in onboarding)
- Adds `.preferredColorScheme(.dark)` to the `WindowGroup` root in `VellumAssistantApp.swift`, covering both `ContentView` and `OnboardingView` with a single modifier
- Consistent with the macOS app, which is always dark-mode-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
