### PR TITLE
fix: clear preactivatedSkillIds after session create to prevent skill leaking

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -319,6 +319,9 @@ public final class ChatViewModel: ObservableObject {
             // Send session_create with correlation ID and thread type
             do {
                 try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId, threadType: self.threadType, preactivatedSkillIds: self.preactivatedSkillIds))
+                // Clear one-shot preactivated skills so they don't leak into a
+                // later session if this bootstrap is interrupted before completion.
+                self.preactivatedSkillIds = nil
             } catch {
                 log.error("Failed to send session_create: \(error.localizedDescription)")
                 self.isThinking = false


### PR DESCRIPTION
## Summary
- Clear `preactivatedSkillIds` on `ChatViewModel` after sending the `session_create` message
- Prevents a setup skill from leaking into a later unrelated session if the original setup flow was interrupted

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
