### PR TITLE
PR 14: Final Regression Sweep + Rollback Checklist

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -1,0 +1,153 @@
+/**
+ * End-state verification test for the browser skill migration.
+ *
+ * Locks the final invariants from the BROWSER_SKILL plan so that future
+ * changes cannot silently regress any of the migration guarantees.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+
+import { eagerModules, eagerModuleToolNames } from '../tools/tool-manifest.js';
+import {
+  initializeTools,
+  getAllTools,
+  getAllToolDefinitions,
+  __resetRegistryForTesting,
+} from '../tools/registry.js';
+import { getDefaultRuleTemplates } from '../permissions/defaults.js';
+
+afterAll(() => { __resetRegistryForTesting(); });
+
+describe('browser skill migration end-state', () => {
+  beforeAll(async () => {
+    __resetRegistryForTesting();
+    await initializeTools();
+  });
+
+  const BROWSER_TOOLS = [
+    'browser_navigate',
+    'browser_snapshot',
+    'browser_screenshot',
+    'browser_close',
+    'browser_click',
+    'browser_type',
+    'browser_press_key',
+    'browser_wait_for',
+    'browser_extract',
+    'browser_fill_credential',
+  ] as const;
+
+  // ── 1. Startup payload excludes browser tools ──────────────────────
+
+  test('browser tools are NOT in startup core registry', () => {
+    const toolNames = getAllTools().map((t) => t.name);
+    for (const name of BROWSER_TOOLS) {
+      expect(toolNames).not.toContain(name);
+    }
+  });
+
+  test('browser module is NOT in eagerModules', () => {
+    expect(eagerModules).not.toContain('./browser/headless-browser.js');
+  });
+
+  test('browser tool names are NOT in eagerModuleToolNames', () => {
+    for (const name of BROWSER_TOOLS) {
+      expect(eagerModuleToolNames).not.toContain(name);
+    }
+  });
+
+  test('startup tool definition count is reduced (no browser tools)', () => {
+    const definitions = getAllToolDefinitions();
+    // Previous baseline was ~41 definitions.  With 10 browser tools removed,
+    // expect ~31.  Use a range to tolerate minor additions/removals.
+    expect(definitions.length).toBeGreaterThanOrEqual(25);
+    expect(definitions.length).toBeLessThanOrEqual(40);
+
+    const defNames = definitions.map((d) => d.name);
+    for (const name of BROWSER_TOOLS) {
+      expect(defNames).not.toContain(name);
+    }
+  });
+
+  // ── 2. Browser skill exists and is active ──────────────────────────
+
+  test('bundled browser skill directory exists with SKILL.md and TOOLS.json', async () => {
+    const path = await import('node:path');
+    const fs = await import('node:fs');
+    const skillDir = path.resolve(import.meta.dirname, '../config/bundled-skills/browser');
+    expect(fs.existsSync(path.join(skillDir, 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, 'TOOLS.json'))).toBe(true);
+  });
+
+  test('browser TOOLS.json contains all 10 tools', async () => {
+    const path = await import('node:path');
+    const fs = await import('node:fs');
+    const toolsPath = path.resolve(import.meta.dirname, '../config/bundled-skills/browser/TOOLS.json');
+    const manifest = JSON.parse(fs.readFileSync(toolsPath, 'utf-8'));
+    expect(manifest.version).toBe(1);
+    expect(manifest.tools).toHaveLength(10);
+    const toolNames = manifest.tools.map((t: { name: string }) => t.name);
+    for (const name of BROWSER_TOOLS) {
+      expect(toolNames).toContain(name);
+    }
+  });
+
+  // ── 3. Permission defaults align with PR 08/09 ────────────────────
+
+  test('skill_load has default allow rule', () => {
+    const templates = getDefaultRuleTemplates();
+    const rule = templates.find((t) => t.id === 'default:allow-skill_load-global');
+    expect(rule).toBeDefined();
+    expect(rule!.decision).toBe('allow');
+  });
+
+  test('all browser tools have default allow rules', () => {
+    const templates = getDefaultRuleTemplates();
+    for (const tool of BROWSER_TOOLS) {
+      const rule = templates.find((t) => t.id === `default:allow-${tool}-global`);
+      expect(rule).toBeDefined();
+      expect(rule!.decision).toBe('allow');
+      expect(rule!.pattern).toBe(`${tool}:*`);
+    }
+  });
+
+  // ── 4. Tool wrapper scripts exist ──────────────────────────────────
+
+  test('all 10 browser tool wrapper scripts exist', async () => {
+    const path = await import('node:path');
+    const fs = await import('node:fs');
+    const toolsDir = path.resolve(import.meta.dirname, '../config/bundled-skills/browser/tools');
+    const wrapperFiles = [
+      'browser-navigate.ts',
+      'browser-snapshot.ts',
+      'browser-screenshot.ts',
+      'browser-close.ts',
+      'browser-click.ts',
+      'browser-type.ts',
+      'browser-press-key.ts',
+      'browser-wait-for.ts',
+      'browser-extract.ts',
+      'browser-fill-credential.ts',
+    ];
+    for (const file of wrapperFiles) {
+      expect(fs.existsSync(path.join(toolsDir, file))).toBe(true);
+    }
+  });
+
+  // ── 5. Execution extraction is in place ────────────────────────────
+
+  test('browser-execution.ts exists with exported execute functions', async () => {
+    const path = await import('node:path');
+    const fs = await import('node:fs');
+    const execPath = path.resolve(import.meta.dirname, '../tools/browser/browser-execution.ts');
+    expect(fs.existsSync(execPath)).toBe(true);
+    const content = fs.readFileSync(execPath, 'utf-8');
+    for (const name of BROWSER_TOOLS) {
+      // Derive expected function name: browser_navigate -> executeBrowserNavigate
+      const fnName = 'execute' + name
+        .split('_')
+        .map((s, i) => (i === 0 ? 'Browser' : s.charAt(0).toUpperCase() + s.slice(1)))
+        .join('');
+      expect(content).toContain(fnName);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused end-state test verifying all browser skill migration invariants
- 10 tests / 100 expect() calls covering: startup payload exclusion, skill directory structure, TOOLS.json manifest, permission defaults, tool wrapper scripts, and execution function exports
- Updates plan with completion notes and rollback checklist (gitignored .private/ file)

Part of browser skill migration plan (BROWSER_SKILL.md) -- **FINAL PR**

## Test plan
- [x] browser-skill-endstate tests pass (10/10, 100 expect() calls)
- [x] browser-skill-baseline-tool-payload tests pass (5/5)
- [x] No pre-existing test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
