### PR TITLE
fix(ios): remove double-connect on launch and clear requestIdToMessageId on reconnect

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -35,9 +35,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        Task {
-            try? await clientProvider.client.connect()
-        }
+        // Initial connect is handled by SceneDelegate.sceneWillEnterForeground, which fires
+        // during launch and on every background→foreground transition. Calling connect() here
+        // too would race with the scene's connect() since isConnected is false while in-flight.
 
         // Register for push notifications
         UNUserNotificationCenter.current().requestAuthorization(

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -181,6 +181,7 @@ public final class ChatViewModel: ObservableObject {
             Task { @MainActor [weak self] in
                 self?.pendingQueuedCount = 0
                 self?.pendingMessageIds.removeAll()
+                self?.requestIdToMessageId.removeAll()
             }
         }
     }


### PR DESCRIPTION
## Summary

- Removed duplicate `connect()` from `AppDelegate.didFinishLaunching` — `SceneDelegate.sceneWillEnterForeground` fires during launch and on every background→foreground transition, making the `AppDelegate` call redundant and racy (a superseded timeout task could fire and set `isConnected = false` after the real connection succeeded)
- Added `requestIdToMessageId.removeAll()` to `ChatViewModel`'s `daemonDidReconnect` observer — every other cancel/reset path already clears all three state variables together; this was the only gap, leaving stale daemon request ID mappings after a reconnect that could misroute queue position events

Addresses Codex and Devin feedback on PR #3877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
