### PR TITLE
fix(ios): remove stale audio tap on engine start failure and auto-send after voice transcription

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -112,6 +112,7 @@ struct ChatTabView: View {
                 onStop: viewModel.stopGenerating,
                 onVoiceResult: { _ in
                     viewModel.pendingVoiceMessage = true
+                    viewModel.sendMessage()
                 },
                 viewModel: viewModel
             )

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -252,6 +252,9 @@ struct InputBarView: View {
             log.info("Voice recording started")
         } catch {
             log.error("Audio engine failed to start: \(error.localizedDescription)")
+            // Remove the tap installed above before cleanupRecognition — otherwise the
+            // next recording attempt fails trying to install a second tap on bus 0.
+            audioEngine.inputNode.removeTap(onBus: 0)
             cleanupRecognition()
         }
     }


### PR DESCRIPTION
## Summary

- **`InputBarView.swift`**: When `audioEngine.start()` throws, the input tap installed earlier on bus 0 was left attached — the next recording attempt would fail trying to install a second tap. Added `removeTap(onBus: 0)` in the catch path before `cleanupRecognition()`.
- **`ChatTabView.swift`**: `onVoiceResult` set `pendingVoiceMessage = true` but never called `sendMessage()`, requiring the user to manually tap Send after speaking. Also risked the flag being consumed by a later manually-typed message. Added `viewModel.sendMessage()` to match the macOS implementation.

Addresses Codex and Devin feedback on PR #3882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
