### PR TITLE
fix: remove unsupported ui_show and secret-leaking screenshot from Google OAuth SKILL

### DIFF
--- a/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
@@ -17,8 +17,6 @@ Tell the user:
 - "I'll ask for your approval before each major step, so nothing happens without your say-so."
 - "No sensitive credentials will be shown in the conversation."
 
-Use `ui_show` with `surface_type: "browser_view"` to activate the live browser preview panel so the user can watch in real-time.
-
 ## Step 1: Navigate to Google Cloud Console
 
 Tell the user: "First, let me open Google Cloud Console."
@@ -128,8 +126,6 @@ Take a `browser_snapshot` and fill in:
 2. **Name:** "Vellum Assistant Desktop"
 
 Use `browser_click` on the "Create" button.
-
-Take a `browser_screenshot` to show the credential creation result.
 
 ## Step 6: Extract and Store the Client ID
 


### PR DESCRIPTION
## Summary
- Removed `ui_show` with `surface_type: "browser_view"` — this surface type isn't implemented yet
- Removed `browser_screenshot` after credential creation — the dialog shows client secret which shouldn't be captured

Addresses feedback from #4096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
