### PR TITLE
fix: CSS.escape data-id selectors and refresh count after removeItems

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-widgets.js
+++ b/clients/macos/vellum-assistant/Resources/vellum-widgets.js
@@ -757,8 +757,10 @@
       }
     });
 
-    // Expose helper to get selected IDs from action button click handlers
+    // Expose helpers for removeItems to access action bar state
     container._getSelectedIds = getSelectedIds;
+    container._countEl = countEl;
+    container._actionBar = actionBar;
   };
 
   /**
@@ -776,7 +778,8 @@
 
     var elements = [];
     ids.forEach(function (id) {
-      var el = container.querySelector('[data-id="' + id + '"]');
+      var escapedId = CSS.escape ? CSS.escape(id) : id.replace(/(["\\])/g, '\\$1');
+      var el = container.querySelector('[data-id="' + escapedId + '"]');
       if (el) elements.push(el);
     });
 
@@ -817,12 +820,14 @@
 
       // Update action bar if groupedSelect was wired
       if (container._getSelectedIds) {
-        var actionBar = container.closest('body') ?
-          document.querySelector('.v-action-bar') : null;
+        var actionBar = container._actionBar || (container.closest('body') ?
+          document.querySelector('.v-action-bar') : null);
         if (actionBar) {
           var remaining = container._getSelectedIds();
           if (remaining.length === 0) {
             actionBar.classList.remove('visible');
+          } else if (container._countEl) {
+            container._countEl.textContent = remaining.length + ' selected';
           }
         }
       }


### PR DESCRIPTION
## Summary
- Added `CSS.escape` (with regex fallback) for `data-id` attribute selectors in `removeItems` to prevent CSS selector injection
- Stored `_countEl` and `_actionBar` references on the container element in `groupedSelect` for later access
- Updated `removeItems` to refresh the selected-count text after partial removal instead of leaving stale count

Addresses feedback from #4100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
