### PR TITLE
fix(ios): restrict Regenerate context menu to the last assistant message only

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -16,7 +16,16 @@ struct ChatTabView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(spacing: VSpacing.md) {
-                        ForEach(viewModel.messages) { message in
+                        let messages = viewModel.messages
+                        ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
+                            let isLastAssistant = message.role == .assistant
+                                && !message.isStreaming
+                                && (index == messages.count - 1
+                                    || (index == messages.count - 2
+                                        && messages[messages.count - 1].confirmation != nil
+                                        && messages[messages.count - 1].confirmation?.state != .pending))
+                                && !viewModel.isSending
+                                && !viewModel.isThinking
                             MessageBubbleView(
                                 message: message,
                                 onConfirmationResponse: { requestId, decision in
@@ -25,7 +34,7 @@ struct ChatTabView: View {
                                 onSurfaceAction: { surfaceId, actionId, data in
                                     viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
                                 },
-                                onRegenerate: viewModel.isSending ? nil : { viewModel.regenerateLastMessage() }
+                                onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil
                             )
                             .id(message.id)
                         }


### PR DESCRIPTION
## Summary
- Port macOS `isLastAssistant` logic to iOS `ChatTabView` so the Regenerate context menu action only appears on the final assistant message
- Previously `onRegenerate` was passed to every `MessageBubbleView`, showing the option on all assistant bubbles
- Uses identical logic to macOS: last assistant message, or second-to-last if the last is a non-pending confirmation

Closes feedback on https://github.com/vellum-ai/vellum-assistant/pull/3883

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
