### PR TITLE
fix: preserve integration IPC compat, legacy token refresh, and SKILL.md tool refs

### DIFF
--- a/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
@@ -135,25 +135,23 @@ Use `browser_snapshot` or `browser_extract` to read the **Client ID** value from
 
 **Important:** You only need the Client ID, not the client secret (PKCE flow is used).
 
-Use the `integration_manage` tool to save the client ID:
-
-```
-action: "set_client_id"
-integration_id: "gmail"
-client_id: "<the extracted client ID>"
-```
-
-Tell the user: "Credentials created and stored! Now let's connect your Gmail account."
+Tell the user: "Credentials created! Now let's connect your Gmail account using the client ID."
 
 ## Step 7: Connect Gmail
 
 Tell the user: "Opening Google sign-in so you can authorize Vellum to access your Gmail. You'll see a Google consent page — just click 'Allow'."
 
-Use the `integration_manage` tool to trigger the OAuth flow:
+Use the `credential_store` tool to connect Gmail via OAuth2:
 
 ```
-action: "connect"
-integration_id: "gmail"
+action: "oauth2_connect"
+service: "integration:gmail"
+client_id: "<the extracted client ID>"
+auth_url: "https://accounts.google.com/o/oauth2/v2/auth"
+token_url: "https://oauth2.googleapis.com/token"
+scopes: ["https://www.googleapis.com/auth/gmail.readonly", "https://www.googleapis.com/auth/gmail.modify", "https://www.googleapis.com/auth/gmail.send", "https://www.googleapis.com/auth/userinfo.email"]
+userinfo_url: "https://www.googleapis.com/oauth2/v2/userinfo"
+extra_params: {"access_type": "offline", "prompt": "consent"}
 ```
 
 This will open the Google authorization page in the user's browser. Wait for the flow to complete.

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -226,6 +226,22 @@ const handlers: DispatchMap = {
   },
   diagnostics_export_request: handleDiagnosticsExport,
   env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
+
+  // Stub handlers: the integration registry was removed but the Swift client
+  // still sends these messages. Return safe no-op responses so the client
+  // doesn't hang waiting for a reply.
+  integration_list: (_msg, socket, ctx) => {
+    ctx.send(socket, { type: 'integration_list_response', integrations: [] });
+  },
+  integration_connect: (msg, socket, ctx) => {
+    ctx.send(socket, {
+      type: 'integration_connect_result',
+      integrationId: msg.integrationId,
+      success: false,
+      error: 'Please use chat to connect integrations.',
+    });
+  },
+  integration_disconnect: () => { /* no-op — integration registry removed */ },
 };
 
 export function handleMessage(

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -725,7 +725,51 @@ export type ClientMessage =
   | PublishPageRequest
   | UnpublishPageRequest
   | DiagnosticsExportRequest
-  | EnvVarsRequest;
+  | EnvVarsRequest
+  | IntegrationListRequest
+  | IntegrationConnectRequest
+  | IntegrationDisconnectRequest;
+
+// ── Legacy integration IPC stubs ────────────────────────────────────
+// The macOS Settings panel still sends these messages. Stub types keep
+// the dispatch map happy until the client-side migration lands.
+
+export interface IntegrationListRequest {
+  type: 'integration_list';
+}
+
+export interface IntegrationConnectRequest {
+  type: 'integration_connect';
+  integrationId: string;
+}
+
+export interface IntegrationDisconnectRequest {
+  type: 'integration_disconnect';
+  integrationId: string;
+}
+
+export interface IntegrationListResponse {
+  type: 'integration_list_response';
+  integrations: Array<{
+    id: string;
+    connected: boolean;
+    accountInfo?: string | null;
+    connectedAt?: number | null;
+    lastUsed?: number | null;
+    error?: string | null;
+  }>;
+}
+
+export interface IntegrationConnectResult {
+  type: 'integration_connect_result';
+  integrationId: string;
+  success: boolean;
+  accountInfo?: string | null;
+  error?: string | null;
+  setupRequired?: boolean;
+  setupSkillId?: string;
+  setupHint?: string;
+}
 
 // === Server → Client messages ===
 
@@ -1619,7 +1663,9 @@ export type ServerMessage =
   | DiagnosticsExportResponse
   | AppFilesChanged
   | BrowserFrame
-  | EnvVarsResponse;
+  | EnvVarsResponse
+  | IntegrationListResponse
+  | IntegrationConnectResult;
 
 // === Contract schema ===
 

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -50,21 +50,32 @@ async function doRefresh(service: string): Promise<string> {
   const tokenUrl = meta?.oauth2TokenUrl;
   const clientId = meta?.oauth2ClientId;
 
-  if (!tokenUrl || !clientId) {
+  // Legacy fallback: credentials created by the old integration flow don't
+  // store oauth2TokenUrl/oauth2ClientId in metadata. Use the known Google
+  // token URL for Gmail so existing connections survive the migration.
+  const resolvedTokenUrl = tokenUrl ?? (service === 'integration:gmail'
+    ? 'https://oauth2.googleapis.com/token'
+    : undefined);
+
+  if (!resolvedTokenUrl || !clientId) {
     throw new TokenExpiredError(
       service,
-      `Missing OAuth2 refresh config (oauth2TokenUrl/oauth2ClientId) for "${service}". Re-authorization required.`,
+      `Missing OAuth2 refresh config for "${service}". Please reconnect via chat to re-authorize.`,
     );
   }
 
   log.info({ service }, 'Refreshing OAuth2 access token');
 
-  const result = await refreshOAuth2Token(tokenUrl, clientId, refreshToken);
+  const result = await refreshOAuth2Token(resolvedTokenUrl, clientId, refreshToken);
 
-  setSecureKey(`credential:${service}:access_token`, result.accessToken);
+  if (!setSecureKey(`credential:${service}:access_token`, result.accessToken)) {
+    throw new Error(`Failed to store refreshed access token for "${service}"`);
+  }
 
   if (result.refreshToken) {
-    setSecureKey(`credential:${service}:refresh_token`, result.refreshToken);
+    if (!setSecureKey(`credential:${service}:refresh_token`, result.refreshToken)) {
+      throw new Error(`Failed to store refreshed refresh token for "${service}"`);
+    }
   }
 
   // Update metadata with new expiry.


### PR DESCRIPTION
## Summary
- Added stub IPC types (`IntegrationListRequest`, `IntegrationConnectRequest`, `IntegrationDisconnectRequest`) and response types to the contract so the Swift client doesn't hang
- Added stub handlers in `handlers/index.ts` that return empty/error responses
- Added legacy fallback to Google token URL in `token-manager.ts` for pre-migration Gmail connections
- Added `setSecureKey` return value checks with descriptive error messages
- Updated SKILL.md to use `credential_store` `oauth2_connect` instead of removed `integration_manage`

Addresses feedback from #4108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
