### PR TITLE
fix(macos): use DaemonClientProtocol in WatchSession to avoid silent drop on non-DaemonClient

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -20,7 +20,7 @@ public final class WatchSession: ObservableObject {
     public let durationSeconds: Int
     public let intervalSeconds: Int
 
-    private var daemonClient: DaemonClient?
+    private var daemonClient: (any DaemonClientProtocol)?
     private var captureTask: Task<Void, Never>?
     private var elapsedTask: Task<Void, Never>?
     private var startedAt: Date?
@@ -35,7 +35,7 @@ public final class WatchSession: ObservableObject {
         self.intervalSeconds = intervalSeconds
     }
 
-    public func start(daemonClient: DaemonClient) {
+    public func start(daemonClient: any DaemonClientProtocol) {
         self.daemonClient = daemonClient
         state = .capturing
         totalExpected = durationSeconds / intervalSeconds

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -400,7 +400,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             self?.onInlineConfirmationResponse?(requestId, decision)
         }
         viewModel.onWatchStarted = { [weak self] msg, client in
-            guard let self, let concreteClient = client as? DaemonClient else { return }
+            guard let self else { return }
             let session = WatchSession(
                 watchId: msg.watchId,
                 sessionId: msg.sessionId,
@@ -408,7 +408,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 intervalSeconds: Int(msg.intervalSeconds)
             )
             self.ambientAgent?.activeWatchSession = session
-            session.start(daemonClient: concreteClient)
+            session.start(daemonClient: client)
         }
         viewModel.onWatchCompleteRequest = { [weak self] _ in
             self?.ambientAgent?.activeWatchSession?.stop()


### PR DESCRIPTION
## Summary
- `WatchSession.start(daemonClient:)` was typed as `DaemonClient` (concrete) instead of `any DaemonClientProtocol`
- `ThreadManager.onWatchStarted` downcast the client with `as? DaemonClient` and silently returned early on failure, meaning watch sessions would never start for non-DaemonClient implementations (e.g. `MockDaemonClient` in tests or future standalone clients)
- Fix: change `WatchSession` storage/parameter to `any DaemonClientProtocol` and remove the downcast in `ThreadManager` — only `send()` is needed, which is part of the protocol

Closes feedback on https://github.com/vellum-ai/vellum-assistant/pull/3884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
