### PR TITLE
fix(ios): make attachment button tap open photo library directly

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -36,8 +36,8 @@ struct InputBarView: View {
             AttachmentStripView(viewModel: viewModel)
 
             HStack(spacing: VSpacing.md) {
-                // Attachment button
-                Button(action: {}) {
+                // Attachment button — tap opens photo library (most common), long-press shows both options
+                Button(action: { showPhotosPicker = true }) {
                     Image(systemName: "paperclip")
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)


### PR DESCRIPTION
## Summary
- The paperclip attachment button had an empty tap action `{}`, making it appear non-functional on standard tap — users could only reach the pickers via the hidden long-press context menu
- Fix: tap now opens the photo library directly (most common attachment type on iOS), matching user expectations from apps like iMessage
- Long-press context menu still shows both "Photo Library" and "Files" options for users who need file attachments

Also note: the other two comments on #3888 are already fixed:
- Regenerate showing on all assistant bubbles → fixed in #4145
- TLS/auth token not re-read on reconnect → fixed in #4149

Closes feedback on https://github.com/vellum-ai/vellum-assistant/pull/3888

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
