### PR TITLE
fix: clear stale panel state after onboarding so users land on chat

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -776,6 +776,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
             onboarding.close()
             self?.onboardingWindow = nil
+
+            // Clear any stale panel state so the user lands on chat, not settings
+            UserDefaults.standard.removeObject(forKey: "lastActivePanel")
+
             self?.showMainWindow()
         }
         onboarding.show()
@@ -799,6 +803,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
             onboarding.close()
             self?.onboardingWindow = nil
+
+            // Clear any stale panel state so the user lands on chat, not settings
+            UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
             // By this point the user has either entered an API key (steps 0→1→2)
             // or authenticated via Vellum Account (WorkOS). Proceed directly —


### PR DESCRIPTION
## Summary
- Clear `lastActivePanel` from UserDefaults when onboarding completes (both first-run and replay paths)
- Prevents `restoreLastActivePanel()` from navigating users to a stale settings panel instead of the chat view after onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
