### PR TITLE
test: baseline credential metadata and broker behavior snapshot

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "vellum-assistant",
@@ -8,7 +9,6 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "@google/genai": "^1.40.0",
         "@huggingface/transformers": "^3.8.1",
-        "@pydantic/logfire-node": "^0.13.0",
         "@qdrant/js-client-rest": "^1.16.2",
         "@sentry/node": "^10.38.0",
         "agentmail": "^0.1.0",
@@ -33,6 +33,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@pydantic/logfire-node": "^0.13.0",
         "@types/archiver": "^7.0.0",
         "@types/bun": "^1.2.4",
         "@types/node": "^25.2.2",

--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -317,4 +317,201 @@ describe('CredentialBroker.browserFill', () => {
     // Ensure the secret value doesn't appear in the error result
     expect(JSON.stringify(result)).not.toContain('ghp_supersecret');
   });
+
+  // ---------------------------------------------------------------------------
+  // Baseline: tool/domain policy mismatch deny behavior
+  // ---------------------------------------------------------------------------
+
+  describe('baseline — tool/domain policy mismatch deny', () => {
+    test('denies tool not in multi-tool allowlist and enumerates allowed tools', async () => {
+      upsertCredentialMetadata('aws', 'access_key', {
+        allowedTools: ['s3_upload', 'cloudfront_invalidate'],
+        allowedDomains: [],
+      });
+      setSecureKey('credential:aws:access_key', 'AKIA_test');
+
+      let fillCalled = false;
+      const result = await broker.browserFill({
+        service: 'aws',
+        field: 'access_key',
+        toolName: 'browser_fill_credential',
+        fill: async () => { fillCalled = true; },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('browser_fill_credential');
+      expect(result.reason).toContain('not allowed');
+      expect(result.reason).toContain('s3_upload');
+      expect(result.reason).toContain('cloudfront_invalidate');
+      expect(fillCalled).toBe(false);
+    });
+
+    test('denies when tool matches but domain does not', async () => {
+      upsertCredentialMetadata('github', 'pat', {
+        allowedTools: ['browser_fill_credential'],
+        allowedDomains: ['github.com'],
+      });
+      setSecureKey('credential:github:pat', 'ghp_fill_test');
+
+      let fillCalled = false;
+      const result = await broker.browserFill({
+        service: 'github',
+        field: 'pat',
+        toolName: 'browser_fill_credential',
+        domain: 'phishing-github.com',
+        fill: async () => { fillCalled = true; },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('phishing-github.com');
+      expect(result.reason).toContain('not allowed');
+      expect(fillCalled).toBe(false);
+    });
+
+    test('denies when both tool and domain mismatch — tool check runs first', async () => {
+      upsertCredentialMetadata('slack', 'bot_token', {
+        allowedTools: ['slack_post'],
+        allowedDomains: ['slack.com'],
+      });
+      setSecureKey('credential:slack:bot_token', 'xoxb-test');
+
+      const result = await broker.browserFill({
+        service: 'slack',
+        field: 'bot_token',
+        toolName: 'browser_fill_credential',
+        domain: 'evil.com',
+        fill: async () => { throw new Error('should not be called'); },
+      });
+
+      expect(result.success).toBe(false);
+      // Tool policy is evaluated before domain policy, so the denial
+      // mentions the tool name, not the domain
+      expect(result.reason).toContain('browser_fill_credential');
+      expect(result.reason).toContain('not allowed');
+    });
+
+    test('denies with empty allowedTools and suggests credential_store', async () => {
+      upsertCredentialMetadata('custom', 'key', {
+        allowedTools: [],
+      });
+      setSecureKey('credential:custom:key', 'secret');
+
+      const result = await broker.browserFill({
+        service: 'custom',
+        field: 'key',
+        toolName: 'browser_fill_credential',
+        fill: async () => { throw new Error('should not be called'); },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('No tools are currently allowed');
+      expect(result.reason).toContain('credential_store');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Baseline: service/field uniqueness assumptions
+  // ---------------------------------------------------------------------------
+
+  describe('baseline — service/field uniqueness', () => {
+    test('upsert overwrites metadata for same service+field pair', async () => {
+      upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['other_tool'],
+      });
+      // Second upsert updates the same record
+      upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['browser_fill_credential'],
+      });
+      setSecureKey('credential:github:token', 'ghp_updated');
+
+      let filledValue: string | undefined;
+      const result = await broker.browserFill({
+        service: 'github',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+        fill: async (v) => { filledValue = v; },
+      });
+
+      // The second upsert's policy should be in effect
+      expect(result.success).toBe(true);
+      expect(filledValue).toBe('ghp_updated');
+    });
+
+    test('same service with different fields are independent credentials', async () => {
+      upsertCredentialMetadata('github', 'username', {
+        allowedTools: ['browser_fill_credential'],
+      });
+      upsertCredentialMetadata('github', 'password', {
+        allowedTools: ['other_tool'],
+      });
+      setSecureKey('credential:github:username', 'octocat');
+      setSecureKey('credential:github:password', 'hunter2');
+
+      // username allows browser_fill_credential
+      const r1 = await broker.browserFill({
+        service: 'github',
+        field: 'username',
+        toolName: 'browser_fill_credential',
+        fill: async () => {},
+      });
+      expect(r1.success).toBe(true);
+
+      // password does NOT allow browser_fill_credential
+      const r2 = await broker.browserFill({
+        service: 'github',
+        field: 'password',
+        toolName: 'browser_fill_credential',
+        fill: async () => { throw new Error('should not be called'); },
+      });
+      expect(r2.success).toBe(false);
+      expect(r2.reason).toContain('not allowed');
+    });
+
+    test('different services with same field name are independent', async () => {
+      upsertCredentialMetadata('github', 'token', {
+        allowedTools: ['browser_fill_credential'],
+        allowedDomains: ['github.com'],
+      });
+      upsertCredentialMetadata('gitlab', 'token', {
+        allowedTools: ['browser_fill_credential'],
+        allowedDomains: ['gitlab.com'],
+      });
+      setSecureKey('credential:github:token', 'gh_tok');
+      setSecureKey('credential:gitlab:token', 'gl_tok');
+
+      // github credential on github.com succeeds
+      let filled1 = '';
+      const r1 = await broker.browserFill({
+        service: 'github',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+        domain: 'github.com',
+        fill: async (v) => { filled1 = v; },
+      });
+      expect(r1.success).toBe(true);
+      expect(filled1).toBe('gh_tok');
+
+      // github credential on gitlab.com fails (domain mismatch)
+      const r2 = await broker.browserFill({
+        service: 'github',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+        domain: 'gitlab.com',
+        fill: async () => { throw new Error('should not be called'); },
+      });
+      expect(r2.success).toBe(false);
+
+      // gitlab credential on gitlab.com succeeds with its own value
+      let filled3 = '';
+      const r3 = await broker.browserFill({
+        service: 'gitlab',
+        field: 'token',
+        toolName: 'browser_fill_credential',
+        domain: 'gitlab.com',
+        fill: async (v) => { filled3 = v; },
+      });
+      expect(r3.success).toBe(true);
+      expect(filled3).toBe('gl_tok');
+    });
+  });
 });

--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -215,4 +215,161 @@ describe('CredentialBroker.serverUse', () => {
     expect(result.success).toBe(true);
     expect(result.result).toEqual({ ok: true });
   });
+
+  // ---------------------------------------------------------------------------
+  // Baseline: tool/domain policy mismatch deny behavior
+  // ---------------------------------------------------------------------------
+
+  describe('baseline — tool policy mismatch deny', () => {
+    test('denies tool not in multi-tool allowlist and lists allowed tools', async () => {
+      upsertCredentialMetadata('aws', 'access_key', {
+        allowedTools: ['deploy_lambda', 's3_upload'],
+      });
+      setSecureKey('credential:aws:access_key', 'AKIA_test');
+
+      const result = await broker.serverUse({
+        service: 'aws',
+        field: 'access_key',
+        toolName: 'ec2_terminate',
+        execute: async () => { throw new Error('should not be called'); },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('ec2_terminate');
+      expect(result.reason).toContain('not allowed');
+      // The denial message should enumerate the allowed tools
+      expect(result.reason).toContain('deploy_lambda');
+      expect(result.reason).toContain('s3_upload');
+    });
+
+    test('denies with empty allowedTools and suggests updating credential', async () => {
+      upsertCredentialMetadata('stripe', 'secret_key', {
+        allowedTools: [],
+      });
+      setSecureKey('credential:stripe:secret_key', 'sk_test_xyz');
+
+      const result = await broker.serverUse({
+        service: 'stripe',
+        field: 'secret_key',
+        toolName: 'charge_card',
+        execute: async () => { throw new Error('should not be called'); },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('No tools are currently allowed');
+      expect(result.reason).toContain('credential_store');
+    });
+
+    test('denies when credential has domain restrictions even if tool matches', async () => {
+      upsertCredentialMetadata('github', 'oauth_token', {
+        allowedTools: ['git_push'],
+        allowedDomains: ['github.com'],
+      });
+      setSecureKey('credential:github:oauth_token', 'gho_test');
+
+      const result = await broker.serverUse({
+        service: 'github',
+        field: 'oauth_token',
+        toolName: 'git_push',
+        execute: async () => { throw new Error('should not be called'); },
+      });
+
+      // Domain-restricted credentials are blocked for all server-side use
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('domain restrictions');
+      expect(result.reason).toContain('cannot be used server-side');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Baseline: service/field uniqueness assumptions
+  // ---------------------------------------------------------------------------
+
+  describe('baseline — service/field uniqueness', () => {
+    test('upsert overwrites metadata for same service+field pair', async () => {
+      upsertCredentialMetadata('vercel', 'api_token', {
+        allowedTools: ['publish_page'],
+      });
+      // Second upsert with the same service+field updates the record
+      upsertCredentialMetadata('vercel', 'api_token', {
+        allowedTools: ['publish_page', 'unpublish_page'],
+      });
+      setSecureKey('credential:vercel:api_token', 'tok_updated');
+
+      const result = await broker.serverUse({
+        service: 'vercel',
+        field: 'api_token',
+        toolName: 'unpublish_page',
+        execute: async (v) => v.length,
+      });
+
+      // The second upsert's allowedTools should be in effect
+      expect(result.success).toBe(true);
+    });
+
+    test('same service with different fields are independent credentials', async () => {
+      upsertCredentialMetadata('vercel', 'api_token', {
+        allowedTools: ['publish_page'],
+      });
+      upsertCredentialMetadata('vercel', 'deploy_hook', {
+        allowedTools: ['trigger_deploy'],
+      });
+      setSecureKey('credential:vercel:api_token', 'tok_api');
+      setSecureKey('credential:vercel:deploy_hook', 'hook_secret');
+
+      // api_token should deny trigger_deploy
+      const r1 = await broker.serverUse({
+        service: 'vercel',
+        field: 'api_token',
+        toolName: 'trigger_deploy',
+        execute: async () => { throw new Error('should not be called'); },
+      });
+      expect(r1.success).toBe(false);
+
+      // deploy_hook should allow trigger_deploy
+      const r2 = await broker.serverUse({
+        service: 'vercel',
+        field: 'deploy_hook',
+        toolName: 'trigger_deploy',
+        execute: async (v) => {
+          expect(v).toBe('hook_secret');
+          return 'triggered';
+        },
+      });
+      expect(r2.success).toBe(true);
+      expect(r2.result).toBe('triggered');
+    });
+
+    test('different services with same field name are independent', async () => {
+      upsertCredentialMetadata('github', 'api_token', {
+        allowedTools: ['github_api'],
+      });
+      upsertCredentialMetadata('gitlab', 'api_token', {
+        allowedTools: ['gitlab_api'],
+      });
+      setSecureKey('credential:github:api_token', 'gh_tok');
+      setSecureKey('credential:gitlab:api_token', 'gl_tok');
+
+      // github credential should not serve gitlab tool
+      const r1 = await broker.serverUse({
+        service: 'github',
+        field: 'api_token',
+        toolName: 'gitlab_api',
+        execute: async () => { throw new Error('should not be called'); },
+      });
+      expect(r1.success).toBe(false);
+
+      // gitlab credential serves its own tool with its own value
+      const r2 = await broker.serverUse({
+        service: 'gitlab',
+        field: 'api_token',
+        toolName: 'gitlab_api',
+        execute: async (v) => {
+          expect(v).toBe('gl_tok');
+          return 'ok';
+        },
+      });
+      expect(r2.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Lock current deny behavior when tool/domain policy mismatches
- Document current service/field uniqueness assumptions in tests

## Behavior Delta
Tests-only — no runtime changes.

## Tests Run
- `bun test src/__tests__/credential-broker-server-use.test.ts`
- `bun test src/__tests__/credential-broker-browser-fill.test.ts`

## Rollback
Revert new test assertions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
