### PR TITLE
fix: remove debug prints from ViewBuilder in ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -911,14 +911,7 @@ private struct ChatBubble: View {
                     }
 
                     // Document widget for document_create tool calls
-                    if !message.toolCalls.isEmpty {
-                        print("🔍 Message has \(message.toolCalls.count) tool calls:")
-                        for tc in message.toolCalls {
-                            print("  - \(tc.toolName), complete: \(tc.isComplete)")
-                        }
-                    }
                     if let documentToolCall = message.toolCalls.first(where: { $0.toolName == "document_create" && $0.isComplete }) {
-                        print("✅ Showing document widget for: \(documentToolCall.toolName)")
                         documentWidget(for: documentToolCall)
                     }
                 }


### PR DESCRIPTION
## Summary
- Remove `print` statements and `for` loop from a `@ViewBuilder` closure in `ChatView.swift` that caused a CI build error (`closure containing control flow statement cannot be used with result builder 'ViewBuilder'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
