### PR TITLE
Fix composer cursor vertical alignment with placeholder text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -855,7 +855,7 @@ private final class CenteringClipView: NSClipView {
             let insetHeight = textView.textContainerInset.height * 2
             let contentHeight = usedHeight + insetHeight
             if contentHeight < bounds.height {
-                rect.origin.y = ceil((contentHeight - bounds.height) / 2)
+                rect.origin.y = (contentHeight - bounds.height) / 2
             }
         }
         return rect


### PR DESCRIPTION
## Summary
- Remove `ceil()` rounding from `CenteringClipView.constrainBoundsRect` that was preventing sub-pixel vertical centering
- The cursor now properly aligns with placeholder and ghost suffix text in the composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
