### PR TITLE
fix(ios): apply ChatTabView fixes to ThreadListView (voice auto-send, regenerate last only, notification connect)

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -116,7 +116,11 @@ extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
             let sessionId = response.notification.request.content.userInfo["session_id"] as? String
 
             Task { @MainActor in
-                // If daemon is connected, send the reply via IPC
+                // If not connected (e.g. background launch via notification reply with no scene
+                // foregrounded), attempt to connect before sending the reply.
+                if !self.clientProvider.client.isConnected {
+                    try? await self.clientProvider.client.connect()
+                }
                 if self.clientProvider.client.isConnected, let sid = sessionId {
                     try? self.clientProvider.client.send(UserMessageMessage(
                         sessionId: sid,

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -226,7 +226,16 @@ struct ThreadChatView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(spacing: VSpacing.md) {
-                        ForEach(viewModel.messages) { message in
+                        let messages = viewModel.messages
+                        ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
+                            let isLastAssistant = message.role == .assistant
+                                && !message.isStreaming
+                                && (index == messages.count - 1
+                                    || (index == messages.count - 2
+                                        && messages[messages.count - 1].confirmation != nil
+                                        && messages[messages.count - 1].confirmation?.state != .pending))
+                                && !viewModel.isSending
+                                && !viewModel.isThinking
                             MessageBubbleView(
                                 message: message,
                                 onConfirmationResponse: { requestId, decision in
@@ -235,7 +244,7 @@ struct ThreadChatView: View {
                                 onSurfaceAction: { surfaceId, actionId, data in
                                     viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
                                 },
-                                onRegenerate: viewModel.isSending ? nil : { viewModel.regenerateLastMessage() }
+                                onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil
                             )
                             .id(message.id)
                         }
@@ -289,6 +298,7 @@ struct ThreadChatView: View {
                 onStop: viewModel.stopGenerating,
                 onVoiceResult: { _ in
                     viewModel.pendingVoiceMessage = true
+                    viewModel.sendMessage()
                 },
                 viewModel: viewModel
             )


### PR DESCRIPTION
## Summary

Three fixes addressing review feedback on #4140, #4141, and #4145 — the same patterns that were fixed in \`ChatTabView\` were missed in \`ThreadListView\` (the production entry point via \`ContentView\`) and \`AppDelegate\`:

### 1. Background notification reply connect (#4140)
\`AppDelegate.userNotificationCenter(_:didReceive:)\` now calls \`connect()\` if not already connected before sending the inline reply. Previously, cold launches triggered by a notification reply action (with \`options: []\`) run without foregrounding a scene, so \`sceneWillEnterForeground\` never fires and the reply was silently dropped.

### 2. Voice auto-send in ThreadListView (#4141)
\`ThreadChatView.onVoiceResult\` now calls \`viewModel.sendMessage()\` after setting \`pendingVoiceMessage = true\`, matching the fix applied to \`ChatTabView\` in #4141. Previously voice transcription completed but required a manual tap to send.

### 3. Regenerate restricted to last assistant message in ThreadListView (#4145)
\`ThreadChatView\` now uses the same \`isLastAssistant\` computation as \`ChatTabView\` (ported from macOS): iterates with \`enumerated()\` and only passes \`onRegenerate\` to the final eligible assistant message. Previously all assistant bubbles showed the context menu item.

Closes feedback on https://github.com/vellum-ai/vellum-assistant/pull/4140
Closes feedback on https://github.com/vellum-ai/vellum-assistant/pull/4141
Closes feedback on https://github.com/vellum-ai/vellum-assistant/pull/4145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
