### PR TITLE
fix(ios): call completionHandler inside Task so iOS stays alive during async connect/send

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -108,8 +108,6 @@ extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        defer { completionHandler() }
-
         if response.actionIdentifier == "REPLY_ACTION",
            let textResponse = response as? UNTextInputNotificationResponse {
             let replyText = textResponse.userText
@@ -128,7 +126,14 @@ extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
                         attachments: nil
                     ))
                 }
+                // Call completionHandler inside the Task so iOS keeps the app alive
+                // until connect() and send() complete. Calling it via defer (outside
+                // the Task) would signal iOS immediately, allowing suspension before
+                // the async work finishes and silently dropping the reply.
+                completionHandler()
             }
+        } else {
+            completionHandler()
         }
     }
 


### PR DESCRIPTION
## Summary
- \`defer { completionHandler() }\` fired synchronously when \`userNotificationCenter(_:didReceive:)\` returned — before the \`Task\` even began — signaling iOS that notification processing was complete
- iOS could then suspend the app mid-connect, silently dropping the inline reply (the exact scenario the prior fix in #4157 aimed to solve)
- Fix: remove \`defer\`, call \`completionHandler()\` at the end of the \`Task\` block so iOS keeps the app alive until \`connect()\` and \`send()\` both complete; for non-REPLY_ACTION responses call it synchronously on the non-Task path

Closes feedback on https://github.com/vellum-ai/vellum-assistant/pull/4157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
