### PR TITLE
test: tighten browser skill migration delta assertions

### DIFF
--- a/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
+++ b/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
@@ -52,19 +52,20 @@ describe('browser skill cutover — startup tool payload', () => {
 
   test('total tool definition count reflects removal of 10 browser tools', () => {
     const definitions = getAllToolDefinitions();
-    // Previous baseline was ~41 definitions.  With 10 browser tools removed,
-    // expect ~31.  Use a range to tolerate minor additions.
-    expect(definitions.length).toBeGreaterThanOrEqual(28);
-    expect(definitions.length).toBeLessThanOrEqual(40);
+    // Startup has exactly 36 definitions (no browser tools).
+    // Allow ±2 for minor additions/removals in unrelated modules.
+    expect(definitions.length).toBeGreaterThanOrEqual(34);
+    expect(definitions.length).toBeLessThanOrEqual(38);
   });
 
   test('serialized tool definitions payload still exceeds a reasonable floor', () => {
     const definitions = getAllToolDefinitions();
     const serialized = JSON.stringify(definitions);
-    // With 10 browser tools removed, the payload shrinks but should still
-    // be substantial.  A floor of 15 000 catches accidental wholesale
-    // removal without being brittle.
-    expect(serialized.length).toBeGreaterThan(15_000);
+    // Startup payload is ~22 483 chars without browser tools.
+    // Floor at 20 000 catches accidental wholesale removal; ceiling ensures
+    // browser tools (~4 640 chars) haven't leaked back in.
+    expect(serialized.length).toBeGreaterThan(20_000);
+    expect(serialized.length).toBeLessThan(28_000);
   });
 
   test('no browser-categorised tools remain in startup registry', () => {

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -57,15 +57,20 @@ describe('browser skill migration end-state', () => {
 
   test('startup tool definition count is reduced (no browser tools)', () => {
     const definitions = getAllToolDefinitions();
-    // Previous baseline was ~41 definitions.  With 10 browser tools removed,
-    // expect ~31.  Use a range to tolerate minor additions/removals.
-    expect(definitions.length).toBeGreaterThanOrEqual(25);
-    expect(definitions.length).toBeLessThanOrEqual(40);
+    // Startup has exactly 36 definitions (no browser tools).
+    // Allow ±2 for minor additions/removals in unrelated modules.
+    expect(definitions.length).toBeGreaterThanOrEqual(34);
+    expect(definitions.length).toBeLessThanOrEqual(38);
 
     const defNames = definitions.map((d) => d.name);
     for (const name of BROWSER_TOOLS) {
       expect(defNames).not.toContain(name);
     }
+
+    // Payload ceiling: browser tools contribute ~4 640 chars.  If they leak
+    // back into startup definitions the payload would exceed 28 000.
+    const payloadSize = JSON.stringify(definitions).length;
+    expect(payloadSize).toBeLessThan(28_000);
   });
 
   // ── 2. Browser skill exists and is active ──────────────────────────


### PR DESCRIPTION
## Summary
- Replace broad range assertions (25-40 definitions, >15000 payload) with exact-delta semantics (36 ±2 definitions, 20k-28k payload ceiling)
- Ensures browser-skill-baseline-tool-payload.test.ts and browser-skill-endstate.test.ts catch regressions with precision rather than passing with arbitrarily loose bounds

## Test plan
- [x] Both updated test files pass with current main
- [x] Assertions would fail if browser tools leaked back into startup (payload > 28k, count > 38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
