### PR TITLE
fix: exclude skill-origin tools from base tool definitions to prevent duplicate tool names

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -188,8 +188,13 @@ export function getSkillRefCount(skillId: string): number {
 export function getAllToolDefinitions(): ToolDefinition[] {
   // Exclude proxy tools (e.g. computer_use_* tools) — they are only used
   // by ComputerUseSession which builds its own tool definitions list.
+  // Exclude skill-origin tools — they are managed by the session-level
+  // skill projection system (projectSkillTools) and must not leak into
+  // the base tool list, which is shared across sessions via the global
+  // registry.  Including them here causes "Tool names must be unique"
+  // errors when the projection appends the same tools a second time.
   return getAllTools()
-    .filter((t) => t.executionMode !== 'proxy')
+    .filter((t) => t.executionMode !== 'proxy' && t.origin !== 'skill')
     .map((t) => t.getDefinition());
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: The global tool registry is shared across sessions. When one session loads a skill (e.g. Gmail), those tools persist in the registry. A second session's `buildToolDefinitions()` then picks them up via `getAllToolDefinitions()`, and when the same skill is activated in that session, `projectSkillTools()` appends the tools again — producing duplicate names that Anthropic rejects with `"tools: Tool names must be unique."`.
- **Fix**: Filter out `origin: 'skill'` tools in `getAllToolDefinitions()`. Skill tools are exclusively managed by the session-level projection system and should never leak into the base tool list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
