### PR TITLE
feat: credential metadata v2 schema (alias + templates)

### DIFF
--- a/assistant/src/__tests__/credential-metadata-store.test.ts
+++ b/assistant/src/__tests__/credential-metadata-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
-import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -17,8 +17,11 @@ import {
   getCredentialMetadataById,
   listCredentialMetadata,
   deleteCredentialMetadata,
+  assertMetadataWritable,
   _setMetadataPath,
 } from '../tools/credentials/metadata-store.js';
+
+import type { CredentialInjectionTemplate } from '../tools/credentials/policy-types.js';
 
 const TEST_DIR = join(tmpdir(), `vellum-credmeta-test-${randomBytes(4).toString('hex')}`);
 const META_PATH = join(TEST_DIR, 'metadata.json');
@@ -168,6 +171,257 @@ describe('credential metadata store', () => {
       expect(keys).not.toContain('value');
       expect(keys).not.toContain('password');
       expect(JSON.stringify(record)).not.toContain('secret');
+    });
+  });
+
+  // ── v2 Schema: alias + injectionTemplates ──────────────────────────
+
+  describe('v2 schema — alias and injectionTemplates', () => {
+    const falInjection: CredentialInjectionTemplate = {
+      hostPattern: '*.fal.ai',
+      injectionType: 'header',
+      headerName: 'Authorization',
+      valuePrefix: 'Key ',
+    };
+
+    const queryInjection: CredentialInjectionTemplate = {
+      hostPattern: 'maps.example.com',
+      injectionType: 'query',
+      queryParamName: 'key',
+    };
+
+    test('creates record with alias', () => {
+      const record = upsertCredentialMetadata('fal-ai', 'api_key', {
+        alias: 'fal-primary',
+        allowedTools: ['api_request'],
+      });
+      expect(record.alias).toBe('fal-primary');
+    });
+
+    test('creates record with injectionTemplates', () => {
+      const record = upsertCredentialMetadata('fal-ai', 'api_key', {
+        injectionTemplates: [falInjection],
+      });
+      expect(record.injectionTemplates).toEqual([falInjection]);
+    });
+
+    test('creates record with multiple injection templates', () => {
+      const record = upsertCredentialMetadata('multi', 'key', {
+        injectionTemplates: [falInjection, queryInjection],
+      });
+      expect(record.injectionTemplates).toHaveLength(2);
+      expect(record.injectionTemplates![0].injectionType).toBe('header');
+      expect(record.injectionTemplates![1].injectionType).toBe('query');
+    });
+
+    test('creates record with alias and injectionTemplates together', () => {
+      const record = upsertCredentialMetadata('fal-ai', 'api_key', {
+        alias: 'fal-primary',
+        allowedDomains: ['fal.ai'],
+        injectionTemplates: [falInjection],
+      });
+      expect(record.alias).toBe('fal-primary');
+      expect(record.injectionTemplates).toEqual([falInjection]);
+      expect(record.allowedDomains).toEqual(['fal.ai']);
+    });
+
+    test('defaults alias and injectionTemplates to undefined when not provided', () => {
+      const record = upsertCredentialMetadata('basic', 'token');
+      expect(record.alias).toBeUndefined();
+      expect(record.injectionTemplates).toBeUndefined();
+    });
+
+    test('updates alias on existing record', () => {
+      upsertCredentialMetadata('fal-ai', 'api_key', { alias: 'fal-old' });
+      const updated = upsertCredentialMetadata('fal-ai', 'api_key', { alias: 'fal-new' });
+      expect(updated.alias).toBe('fal-new');
+    });
+
+    test('clears alias with null', () => {
+      upsertCredentialMetadata('fal-ai', 'api_key', { alias: 'fal-primary' });
+      const updated = upsertCredentialMetadata('fal-ai', 'api_key', { alias: null });
+      expect(updated.alias).toBeUndefined();
+    });
+
+    test('updates injectionTemplates on existing record', () => {
+      upsertCredentialMetadata('fal-ai', 'api_key', { injectionTemplates: [falInjection] });
+      const updated = upsertCredentialMetadata('fal-ai', 'api_key', { injectionTemplates: [queryInjection] });
+      expect(updated.injectionTemplates).toEqual([queryInjection]);
+    });
+
+    test('clears injectionTemplates with null', () => {
+      upsertCredentialMetadata('fal-ai', 'api_key', { injectionTemplates: [falInjection] });
+      const updated = upsertCredentialMetadata('fal-ai', 'api_key', { injectionTemplates: null });
+      expect(updated.injectionTemplates).toBeUndefined();
+    });
+
+    test('round-trip: alias and templates survive serialization', () => {
+      upsertCredentialMetadata('fal-ai', 'api_key', {
+        alias: 'fal-primary',
+        allowedTools: ['api_request'],
+        allowedDomains: ['fal.ai'],
+        injectionTemplates: [falInjection],
+      });
+
+      // Re-read from disk
+      const loaded = getCredentialMetadata('fal-ai', 'api_key');
+      expect(loaded).toBeDefined();
+      expect(loaded!.alias).toBe('fal-primary');
+      expect(loaded!.injectionTemplates).toEqual([falInjection]);
+      expect(loaded!.allowedTools).toEqual(['api_request']);
+    });
+  });
+
+  // ── Version migration ──────────────────────────────────────────────
+
+  describe('version migration', () => {
+    test('v1 file is migrated: records get undefined alias and injectionTemplates', () => {
+      // Write a v1-format file directly
+      const v1Data = {
+        version: 1,
+        credentials: [
+          {
+            credentialId: 'cred-legacy-001',
+            service: 'github',
+            field: 'token',
+            allowedTools: ['browser_fill_credential'],
+            allowedDomains: ['github.com'],
+            usageDescription: 'Legacy GitHub token',
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v1Data, null, 2), 'utf-8');
+
+      const records = listCredentialMetadata();
+      expect(records).toHaveLength(1);
+      expect(records[0].credentialId).toBe('cred-legacy-001');
+      expect(records[0].service).toBe('github');
+      expect(records[0].alias).toBeUndefined();
+      expect(records[0].injectionTemplates).toBeUndefined();
+      // Original fields preserved
+      expect(records[0].allowedTools).toEqual(['browser_fill_credential']);
+      expect(records[0].usageDescription).toBe('Legacy GitHub token');
+    });
+
+    test('v1 file with no version field is treated as v1 and migrated', () => {
+      const noVersionData = {
+        credentials: [
+          {
+            credentialId: 'cred-noversion',
+            service: 'slack',
+            field: 'token',
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(noVersionData, null, 2), 'utf-8');
+
+      const records = listCredentialMetadata();
+      expect(records).toHaveLength(1);
+      expect(records[0].alias).toBeUndefined();
+      expect(records[0].injectionTemplates).toBeUndefined();
+    });
+
+    test('v1 migration preserves credentialId as primary identifier', () => {
+      const v1Data = {
+        version: 1,
+        credentials: [
+          {
+            credentialId: 'cred-stable-id',
+            service: 'myservice',
+            field: 'key',
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v1Data, null, 2), 'utf-8');
+
+      const record = getCredentialMetadataById('cred-stable-id');
+      expect(record).toBeDefined();
+      expect(record!.credentialId).toBe('cred-stable-id');
+    });
+
+    test('v2 file is loaded without migration', () => {
+      const v2Data = {
+        version: 2,
+        credentials: [
+          {
+            credentialId: 'cred-v2-001',
+            service: 'fal-ai',
+            field: 'api_key',
+            allowedTools: ['api_request'],
+            allowedDomains: ['fal.ai'],
+            alias: 'fal-primary',
+            injectionTemplates: [
+              {
+                hostPattern: '*.fal.ai',
+                injectionType: 'header',
+                headerName: 'Authorization',
+                valuePrefix: 'Key ',
+              },
+            ],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v2Data, null, 2), 'utf-8');
+
+      const record = getCredentialMetadata('fal-ai', 'api_key');
+      expect(record).toBeDefined();
+      expect(record!.alias).toBe('fal-primary');
+      expect(record!.injectionTemplates).toHaveLength(1);
+      expect(record!.injectionTemplates![0].hostPattern).toBe('*.fal.ai');
+    });
+
+    test('future version (v3+) returns unknown version and refuses writes', () => {
+      const futureData = {
+        version: 99,
+        credentials: [],
+      };
+      writeFileSync(META_PATH, JSON.stringify(futureData, null, 2), 'utf-8');
+
+      // Reads return empty/undefined (safe degradation)
+      expect(listCredentialMetadata()).toEqual([]);
+      expect(getCredentialMetadata('any', 'field')).toBeUndefined();
+
+      // Writes throw
+      expect(() => upsertCredentialMetadata('test', 'key')).toThrow(/unrecognized version/);
+      expect(() => assertMetadataWritable()).toThrow(/unrecognized version/);
+    });
+
+    test('upsert on migrated v1 file saves as v2', () => {
+      const v1Data = {
+        version: 1,
+        credentials: [
+          {
+            credentialId: 'cred-upgrade-001',
+            service: 'github',
+            field: 'token',
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v1Data, null, 2), 'utf-8');
+
+      // Upsert triggers load (migration) + save (at current version)
+      upsertCredentialMetadata('github', 'token', { alias: 'gh-main' });
+
+      // Verify on-disk file is now v2
+      const raw = JSON.parse(require('node:fs').readFileSync(META_PATH, 'utf-8'));
+      expect(raw.version).toBe(2);
+      expect(raw.credentials[0].alias).toBe('gh-main');
     });
   });
 });

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -10,6 +10,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from '
 import { join, dirname } from 'node:path';
 import { getDataDir } from '../../util/platform.js';
 import { randomUUID } from 'node:crypto';
+import type { CredentialInjectionTemplate } from './policy-types.js';
 
 export interface CredentialMetadata {
   credentialId: string;
@@ -25,12 +26,19 @@ export interface CredentialMetadata {
   oauth2TokenUrl?: string;
   /** OAuth2 client ID — paired with oauth2TokenUrl for refresh. */
   oauth2ClientId?: string;
+  /** Human-friendly name for this credential (e.g. "fal-primary"). */
+  alias?: string;
+  /** Templates describing how to inject this credential into proxied requests. */
+  injectionTemplates?: CredentialInjectionTemplate[];
   createdAt: number;
   updatedAt: number;
 }
 
+/** Current on-disk schema version. */
+const CURRENT_VERSION = 2;
+
 interface MetadataFile {
-  version: 1;
+  version: typeof CURRENT_VERSION;
   credentials: CredentialMetadata[];
 }
 
@@ -56,27 +64,43 @@ function isUnknownVersion(r: LoadResult): r is UnknownVersionResult {
   return 'unknownVersion' in r;
 }
 
+/**
+ * Migrate a v1 record to v2 by backfilling new optional fields with defaults.
+ */
+function migrateRecordV1toV2(record: Record<string, unknown>): CredentialMetadata {
+  return {
+    ...(record as CredentialMetadata),
+    alias: (record.alias as string | undefined) ?? undefined,
+    injectionTemplates: (record.injectionTemplates as CredentialInjectionTemplate[] | undefined) ?? undefined,
+  };
+}
+
 function loadFile(): LoadResult {
   const path = getMetadataPath();
   if (!existsSync(path)) {
-    return { version: 1, credentials: [] };
+    return { version: CURRENT_VERSION, credentials: [] };
   }
   try {
     const raw = readFileSync(path, 'utf-8');
     const data = JSON.parse(raw);
     if (typeof data !== 'object' || data === null) {
-      return { version: 1, credentials: [] };
+      return { version: CURRENT_VERSION, credentials: [] };
     }
-    if (typeof data.version === 'number' && data.version !== 1) {
-      // Newer numeric version we don't understand — refuse to touch it
+    const fileVersion = typeof data.version === 'number' ? data.version : 1;
+    if (fileVersion > CURRENT_VERSION) {
+      // Newer version we don't understand — refuse to touch it
       return { unknownVersion: true };
     }
-    return {
-      version: 1,
-      credentials: Array.isArray(data.credentials) ? data.credentials : [],
-    };
+    const rawCredentials: Record<string, unknown>[] = Array.isArray(data.credentials) ? data.credentials : [];
+
+    // Migrate from v1 (no alias/injectionTemplates) to v2
+    const credentials = fileVersion < 2
+      ? rawCredentials.map(migrateRecordV1toV2)
+      : (rawCredentials as unknown as CredentialMetadata[]);
+
+    return { version: CURRENT_VERSION, credentials };
   } catch {
-    return { version: 1, credentials: [] };
+    return { version: CURRENT_VERSION, credentials: [] };
   }
 }
 
@@ -121,6 +145,10 @@ export function upsertCredentialMetadata(
     accountInfo?: string | null;
     oauth2TokenUrl?: string;
     oauth2ClientId?: string;
+    /** Pass `null` to explicitly clear a previously-set alias. */
+    alias?: string | null;
+    /** Pass `null` to explicitly clear injection templates. */
+    injectionTemplates?: CredentialInjectionTemplate[] | null;
   },
 ): CredentialMetadata {
   const result = loadFile();
@@ -155,6 +183,20 @@ export function upsertCredentialMetadata(
     }
     if (policy?.oauth2TokenUrl !== undefined) existing.oauth2TokenUrl = policy.oauth2TokenUrl;
     if (policy?.oauth2ClientId !== undefined) existing.oauth2ClientId = policy.oauth2ClientId;
+    if (policy?.alias !== undefined) {
+      if (policy.alias === null) {
+        delete existing.alias;
+      } else {
+        existing.alias = policy.alias;
+      }
+    }
+    if (policy?.injectionTemplates !== undefined) {
+      if (policy.injectionTemplates === null) {
+        delete existing.injectionTemplates;
+      } else {
+        existing.injectionTemplates = policy.injectionTemplates;
+      }
+    }
     existing.updatedAt = now;
     saveFile(data);
     return existing;
@@ -172,6 +214,8 @@ export function upsertCredentialMetadata(
     accountInfo: policy?.accountInfo ?? undefined,
     oauth2TokenUrl: policy?.oauth2TokenUrl,
     oauth2ClientId: policy?.oauth2ClientId,
+    alias: policy?.alias ?? undefined,
+    injectionTemplates: policy?.injectionTemplates ?? undefined,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/tools/credentials/policy-types.ts
+++ b/assistant/src/tools/credentials/policy-types.ts
@@ -24,6 +24,26 @@ export interface CredentialPolicy {
   createdByFlow?: CredentialCreationFlow;
 }
 
+/** How a credential value is injected into an outbound proxied request. */
+export type CredentialInjectionType = 'header' | 'query';
+
+/**
+ * Describes where and how to inject a credential into proxied requests
+ * matching a specific host pattern.
+ */
+export interface CredentialInjectionTemplate {
+  /** Glob pattern for matching request hosts (e.g. "*.fal.ai"). */
+  hostPattern: string;
+  /** Where the credential value is injected. */
+  injectionType: CredentialInjectionType;
+  /** Header name when injectionType is 'header' (e.g. "Authorization"). */
+  headerName?: string;
+  /** Prefix prepended to the secret value (e.g. "Key ", "Bearer "). */
+  valuePrefix?: string;
+  /** Query parameter name when injectionType is 'query'. */
+  queryParamName?: string;
+}
+
 /** Input fields for specifying policy when storing a credential. */
 export interface CredentialPolicyInput {
   allowed_tools?: string[];


### PR DESCRIPTION
## Summary
- Add optional `alias` field to credential metadata for human-friendly naming
- Add optional `injectionTemplates` for defining how credentials should be injected into proxied requests
- Add `CredentialInjectionTemplate` type to `policy-types.ts` with `hostPattern`, `injectionType`, `headerName`, `valuePrefix`, `queryParamName`
- Bump metadata version to v2 with backward-compatible migration from v1
- Add comprehensive tests for schema migration, round-trip serialization, and v2 fields

## Behavior Delta
Schema extension only — no runtime behavior changes. Existing credentials get empty alias/templates on load.

## Tests Run
- `bun test src/__tests__/credential-metadata-store.test.ts` — 29 pass, 0 fail
- Full test suite: pre-existing failures (missing deps) unrelated to these changes

## Rollback
Revert schema extension and migration code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
