### PR TITLE
fix: use opacity-only transition for Control Center drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1258,7 +1258,7 @@ private struct ControlCenterMenuButton: View {
                     onDoctor: { showDrawer = false; onDoctor() }
                 )
                 .offset(y: -68)
-                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .transition(.opacity)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace `.transition(.opacity.combined(with: .move(edge: .bottom)))` with `.transition(.opacity)` for the Control Center drawer
- The combined transition caused the drawer to visually jump from the bottom edge before settling, producing a jarring animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
