### PR TITLE
feat(ios): add appearance mode setting (system/light/dark)

### DIFF
--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -6,6 +6,15 @@ import VellumAssistantShared
 struct VellumAssistantApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @AppStorage("onboarding_completed") private var onboardingCompleted = false
+    @AppStorage("appearance_mode") private var appearanceMode: String = "system"
+
+    var preferredScheme: ColorScheme? {
+        switch appearanceMode {
+        case "light": return .light
+        case "dark": return .dark
+        default: return nil  // system default
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -16,7 +25,7 @@ struct VellumAssistantApp: App {
                 OnboardingView(isCompleted: $onboardingCompleted)
             }
         }
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(preferredScheme)
     }
 }
 #else

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @AppStorage("connection_mode") private var connectionMode: String = ConnectionMode.standalone.rawValue
     @AppStorage("daemon_tls_enabled") private var tlsEnabled: Bool = false
+    @AppStorage("appearance_mode") private var appearanceMode: String = "system"
     @State private var apiKey: String = ""
     @State private var daemonHostname: String = ""
     @State private var daemonPort: String = ""
@@ -114,6 +115,15 @@ struct SettingsView: View {
                     } message: {
                         Text(daemonAlertMessage)
                     }
+                }
+
+                Section("Appearance") {
+                    Picker("Theme", selection: $appearanceMode) {
+                        Text("System").tag("system")
+                        Text("Light").tag("light")
+                        Text("Dark").tag("dark")
+                    }
+                    .pickerStyle(.segmented)
                 }
 
                 Section("Permissions") {


### PR DESCRIPTION
## Summary
- Remove hardcoded \`.preferredColorScheme(.dark)\` from \`VellumAssistantApp\`
- Add \`@AppStorage(\"appearance_mode\")\` with system/light/dark values, applied dynamically to the root \`WindowGroup\`
- Add Appearance section to iOS Settings with a segmented picker (System / Light / Dark)
- All color tokens already have adaptive light/dark values — no token changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
