### PR TITLE
feat(ios): add border and shadow to input bar text field

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -80,6 +80,18 @@ struct InputBarView: View {
                     .background(VColor.surface)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                     .focused(isInputFocused)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .strokeBorder(VColor.surfaceBorder, lineWidth: isInputFocused.wrappedValue ? 1.5 : 1)
+                    )
+                    .animation(.easeInOut(duration: 0.15), value: isInputFocused.wrappedValue)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .strokeBorder(VColor.surfaceBorder.opacity(0.12), lineWidth: 3)
+                            .opacity(isInputFocused.wrappedValue ? 1 : 0)
+                            .animation(.easeInOut(duration: 0.15), value: isInputFocused.wrappedValue)
+                    )
+                    .shadow(color: VColor.textPrimary.opacity(0.06), radius: 8, x: 0, y: 2)
 
                 // Stop button (shown while generating but not yet cancelling)
                 if isGenerating && !isCancelling {


### PR DESCRIPTION
## Summary
- Add 1px \`VColor.surfaceBorder\` border to the message text field, thickening to 1.5px on focus
- Add focus glow: 3px outer border at 12% opacity, fades in on focus
- Add subtle drop shadow (\`textPrimary\` at 6% opacity, radius 8)
- Both border transitions animated with 0.15s easeInOut
- Matches the macOS ComposerView border/shadow treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
