### PR TITLE
fix: add close button to dynamic workspace toolbar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1684,6 +1684,23 @@ private struct DynamicWorkspaceWrapper: View {
                             .frame(width: 1, height: 1)
                         )
                     }
+
+                    Button(action: {
+                        showSharePicker = false
+                        windowState.closeDynamicPanel()
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(VColor.textPrimary)
+                            .frame(width: 32, height: 32)
+                            .background(
+                                Circle()
+                                    .fill(VColor.surface.opacity(0.85))
+                                    .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Close workspace")
                 }
                 .padding(.leading, trafficLightPadding)
                 .padding(.trailing, VSpacing.xl)


### PR DESCRIPTION
## Summary
- The dynamic workspace (opened via the arrow icon on inline card previews) had no way to close and return to chat
- Adds an X button on the right side of the floating toolbar that calls `closeDynamicPanel()`

## Test plan
- [ ] Open a dynamic page preview (e.g. weather card) by clicking the arrow icon
- [ ] Verify the X button appears on the right side of the workspace toolbar
- [ ] Click the X button and verify it closes the workspace and returns to chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
