### PR TITLE
feat: credential resolver supports credential_id lookups

### DIFF
--- a/assistant/src/__tests__/credential-resolve.test.ts
+++ b/assistant/src/__tests__/credential-resolve.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   resolveByServiceField,
   resolveById,
+  resolveForDomain,
 } from '../tools/credentials/resolve.js';
 
 const TEST_DIR = join(tmpdir(), `vellum-credresolve-test-${randomBytes(4).toString('hex')}`);
@@ -57,6 +58,36 @@ describe('credential resolver', () => {
     test('returns undefined for non-existent credential', () => {
       expect(resolveByServiceField('nonexistent', 'field')).toBeUndefined();
     });
+
+    test('includes alias when set', () => {
+      upsertCredentialMetadata('fal', 'api_key', { alias: 'fal-primary' });
+      const result = resolveByServiceField('fal', 'api_key');
+      expect(result!.alias).toBe('fal-primary');
+    });
+
+    test('alias is undefined when not set', () => {
+      upsertCredentialMetadata('fal', 'api_key');
+      const result = resolveByServiceField('fal', 'api_key');
+      expect(result!.alias).toBeUndefined();
+    });
+
+    test('includes injection templates when set', () => {
+      upsertCredentialMetadata('fal', 'api_key', {
+        injectionTemplates: [
+          { hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Key ' },
+        ],
+      });
+      const result = resolveByServiceField('fal', 'api_key');
+      expect(result!.injectionTemplates).toHaveLength(1);
+      expect(result!.injectionTemplates[0].hostPattern).toBe('*.fal.ai');
+      expect(result!.injectionTemplates[0].injectionType).toBe('header');
+    });
+
+    test('injection templates default to empty array', () => {
+      upsertCredentialMetadata('github', 'token');
+      const result = resolveByServiceField('github', 'token');
+      expect(result!.injectionTemplates).toEqual([]);
+    });
   });
 
   describe('resolveById', () => {
@@ -74,6 +105,34 @@ describe('credential resolver', () => {
     test('returns undefined for non-existent ID', () => {
       expect(resolveById('non-existent-id')).toBeUndefined();
     });
+
+    test('includes alias and injection templates', () => {
+      const created = upsertCredentialMetadata('replicate', 'api_key', {
+        alias: 'replicate-prod',
+        injectionTemplates: [
+          { hostPattern: 'api.replicate.com', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Bearer ' },
+        ],
+      });
+
+      const result = resolveById(created.credentialId);
+      expect(result!.alias).toBe('replicate-prod');
+      expect(result!.injectionTemplates).toHaveLength(1);
+      expect(result!.injectionTemplates[0].valuePrefix).toBe('Bearer ');
+    });
+
+    test('deterministic lookup among multiple credentials for same provider', () => {
+      const cred1 = upsertCredentialMetadata('openai', 'api_key_primary');
+      const cred2 = upsertCredentialMetadata('openai', 'api_key_secondary');
+
+      const result1 = resolveById(cred1.credentialId);
+      const result2 = resolveById(cred2.credentialId);
+
+      expect(result1!.credentialId).toBe(cred1.credentialId);
+      expect(result1!.field).toBe('api_key_primary');
+      expect(result2!.credentialId).toBe(cred2.credentialId);
+      expect(result2!.field).toBe('api_key_secondary');
+      expect(result1!.credentialId).not.toBe(result2!.credentialId);
+    });
   });
 
   describe('cross-resolution', () => {
@@ -88,6 +147,22 @@ describe('credential resolver', () => {
       expect(byServiceField!.credentialId).toBe(byId!.credentialId);
       expect(byServiceField!.storageKey).toBe(byId!.storageKey);
     });
+
+    test('both paths return identical injection templates', () => {
+      const templates = [
+        { hostPattern: '*.fal.ai', injectionType: 'header' as const, headerName: 'Authorization', valuePrefix: 'Key ' },
+      ];
+      const created = upsertCredentialMetadata('fal', 'api_key', {
+        injectionTemplates: templates,
+        alias: 'fal-test',
+      });
+
+      const byServiceField = resolveByServiceField('fal', 'api_key');
+      const byId = resolveById(created.credentialId);
+
+      expect(byServiceField!.injectionTemplates).toEqual(byId!.injectionTemplates);
+      expect(byServiceField!.alias).toBe(byId!.alias);
+    });
   });
 
   describe('storage key format', () => {
@@ -95,6 +170,88 @@ describe('credential resolver', () => {
       upsertCredentialMetadata('my-service', 'api-key');
       const result = resolveByServiceField('my-service', 'api-key');
       expect(result!.storageKey).toBe('credential:my-service:api-key');
+    });
+  });
+
+  describe('resolveForDomain', () => {
+    test('returns credentials matching the hostname', () => {
+      upsertCredentialMetadata('fal', 'api_key', {
+        injectionTemplates: [
+          { hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Key ' },
+        ],
+      });
+      upsertCredentialMetadata('replicate', 'api_key', {
+        injectionTemplates: [
+          { hostPattern: 'api.replicate.com', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Bearer ' },
+        ],
+      });
+
+      const results = resolveForDomain('queue.fal.ai');
+      expect(results).toHaveLength(1);
+      expect(results[0].service).toBe('fal');
+      expect(results[0].injectionTemplates).toHaveLength(1);
+      expect(results[0].injectionTemplates[0].valuePrefix).toBe('Key ');
+    });
+
+    test('returns empty array when no templates match', () => {
+      upsertCredentialMetadata('fal', 'api_key', {
+        injectionTemplates: [
+          { hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Key ' },
+        ],
+      });
+
+      const results = resolveForDomain('api.openai.com');
+      expect(results).toHaveLength(0);
+    });
+
+    test('returns empty array for credentials without injection templates', () => {
+      upsertCredentialMetadata('github', 'token');
+
+      const results = resolveForDomain('github.com');
+      expect(results).toHaveLength(0);
+    });
+
+    test('filters injection templates to only matching entries', () => {
+      upsertCredentialMetadata('multi', 'key', {
+        injectionTemplates: [
+          { hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Key ' },
+          { hostPattern: '*.replicate.com', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Bearer ' },
+        ],
+      });
+
+      const results = resolveForDomain('api.replicate.com');
+      expect(results).toHaveLength(1);
+      expect(results[0].injectionTemplates).toHaveLength(1);
+      expect(results[0].injectionTemplates[0].hostPattern).toBe('*.replicate.com');
+    });
+
+    test('returns multiple credentials when multiple match', () => {
+      upsertCredentialMetadata('provider-a', 'key1', {
+        injectionTemplates: [
+          { hostPattern: '*.example.com', injectionType: 'header', headerName: 'X-Api-Key' },
+        ],
+      });
+      upsertCredentialMetadata('provider-b', 'key2', {
+        injectionTemplates: [
+          { hostPattern: '*.example.com', injectionType: 'query', queryParamName: 'api_key' },
+        ],
+      });
+
+      const results = resolveForDomain('api.example.com');
+      expect(results).toHaveLength(2);
+      const services = results.map((r) => r.service).sort();
+      expect(services).toEqual(['provider-a', 'provider-b']);
+    });
+
+    test('exact host pattern matches', () => {
+      upsertCredentialMetadata('exact', 'key', {
+        injectionTemplates: [
+          { hostPattern: 'api.exact.com', injectionType: 'header', headerName: 'Authorization' },
+        ],
+      });
+
+      expect(resolveForDomain('api.exact.com')).toHaveLength(1);
+      expect(resolveForDomain('other.exact.com')).toHaveLength(0);
     });
   });
 });

--- a/assistant/src/tools/credentials/resolve.ts
+++ b/assistant/src/tools/credentials/resolve.ts
@@ -9,8 +9,11 @@
 import {
   getCredentialMetadata,
   getCredentialMetadataById,
+  listCredentialMetadata,
   type CredentialMetadata,
 } from './metadata-store.js';
+import type { CredentialInjectionTemplate } from './policy-types.js';
+import { minimatch } from 'minimatch';
 
 export interface ResolvedCredential {
   credentialId: string;
@@ -18,7 +21,23 @@ export interface ResolvedCredential {
   field: string;
   /** The key used in the secure key backend. */
   storageKey: string;
+  /** Human-friendly alias, if set. */
+  alias?: string;
+  /** Injection templates for proxied requests. */
+  injectionTemplates: CredentialInjectionTemplate[];
   metadata: CredentialMetadata;
+}
+
+function toResolved(metadata: CredentialMetadata): ResolvedCredential {
+  return {
+    credentialId: metadata.credentialId,
+    service: metadata.service,
+    field: metadata.field,
+    storageKey: `credential:${metadata.service}:${metadata.field}`,
+    alias: metadata.alias,
+    injectionTemplates: metadata.injectionTemplates ?? [],
+    metadata,
+  };
 }
 
 /**
@@ -31,14 +50,7 @@ export function resolveByServiceField(
 ): ResolvedCredential | undefined {
   const metadata = getCredentialMetadata(service, field);
   if (!metadata) return undefined;
-
-  return {
-    credentialId: metadata.credentialId,
-    service: metadata.service,
-    field: metadata.field,
-    storageKey: `credential:${metadata.service}:${metadata.field}`,
-    metadata,
-  };
+  return toResolved(metadata);
 }
 
 /**
@@ -50,12 +62,31 @@ export function resolveById(
 ): ResolvedCredential | undefined {
   const metadata = getCredentialMetadataById(credentialId);
   if (!metadata) return undefined;
+  return toResolved(metadata);
+}
 
-  return {
-    credentialId: metadata.credentialId,
-    service: metadata.service,
-    field: metadata.field,
-    storageKey: `credential:${metadata.service}:${metadata.field}`,
-    metadata,
-  };
+/**
+ * Find all credentials whose injection templates match a given hostname.
+ * Returns resolved credentials with their `injectionTemplates` filtered
+ * to only the matching entries.
+ */
+export function resolveForDomain(
+  hostname: string,
+): ResolvedCredential[] {
+  const all = listCredentialMetadata();
+  const results: ResolvedCredential[] = [];
+
+  for (const meta of all) {
+    const templates = meta.injectionTemplates ?? [];
+    const matching = templates.filter((t) =>
+      minimatch(hostname, t.hostPattern),
+    );
+    if (matching.length === 0) continue;
+    results.push({
+      ...toResolved(meta),
+      injectionTemplates: matching,
+    });
+  }
+
+  return results;
 }


### PR DESCRIPTION
## Summary
- Enhance `ResolvedCredential` type with top-level `alias` and `injectionTemplates` fields for convenient access
- Extract shared `toResolved()` helper to eliminate duplication between `resolveByServiceField` and `resolveById`
- Add `resolveForDomain(hostname)` to find all credentials whose injection templates match a given hostname (minimatch glob)
- Comprehensive test coverage: 19 tests covering both resolution paths, injection templates, alias, cross-resolution, and domain filtering

## Behavior Delta
- `ResolvedCredential` now exposes `alias?: string` and `injectionTemplates: CredentialInjectionTemplate[]` directly (always an array, defaults to `[]`)
- New `resolveForDomain()` function filters credentials by hostname against their injection template host patterns
- Existing `resolveByServiceField` and `resolveById` behavior unchanged

## Tests Run
- `bun test src/__tests__/credential-resolve.test.ts` — 19 pass
- All credential-related tests (94 total) pass

## Rollback
Revert resolver additions; no schema or storage changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
