### PR TITLE
fix: use context memoryScopeId and guard contact.email in gmail style tool

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-analyze-style.ts
@@ -155,7 +155,7 @@ function upsertMemoryItem(opts: {
 
 // ── Main tool ──────────────────────────────────────────────────────────
 
-export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const maxEmails = Math.min(Math.max((input.max_emails as number) ?? 50, 1), 100);
   const recipientFilter = input.recipient_filter as string | undefined;
 
@@ -223,7 +223,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
     }
 
     // Persist style items to memory
-    const scopeId = 'default';
+    const scopeId = context.memoryScopeId ?? 'default';
     let savedCount = 0;
 
     for (const pattern of result.style_patterns) {
@@ -244,11 +244,12 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
     if (Array.isArray(result.contact_observations)) {
       for (const contact of result.contact_observations) {
         if (!contact.name || !contact.tone_note) continue;
+        const contactEmail = contact.email || 'unknown';
         const subject = `email relationship: ${contact.name}`;
         upsertMemoryItem({
           kind: 'relationship',
           subject,
-          statement: `${contact.name} (${contact.email}): ${contact.tone_note}`.slice(0, 500),
+          statement: `${contact.name} (${contactEmail}): ${contact.tone_note}`.slice(0, 500),
           importance: 0.6,
           scopeId,
         });


### PR DESCRIPTION
## Summary
- Use memoryScopeId from ToolContext instead of hardcoding 'default' scopeId in gmail_analyze_style
- Add contact.email guard to prevent persisting 'undefined' in memory statements

Addresses feedback from #4135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
