### PR TITLE
fix: persist watcher conversationId and remove event-dropping slice cap

### DIFF
--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -17,6 +17,7 @@ import {
   getPendingEvents,
   updateEventDisposition,
   resetStuckWatchers,
+  setWatcherConversationId,
 } from './watcher-store.js';
 import { MAX_CONSECUTIVE_ERRORS } from './constants.js';
 
@@ -142,7 +143,7 @@ export async function runWatchersOnce(
           threadType: 'background' as 'standard' | 'private',
         });
         conversationId = conv.id;
-        // conversationId is persisted via completeWatcherPoll above
+        setWatcherConversationId(watcher.id, conversationId);
       }
 
       // Build the LLM message with action prompt + event data

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -146,7 +146,7 @@ export const gmailProvider: WatcherProvider = {
         // Fetch metadata for new messages
         const messages = await batchGetMessages(
           token,
-          Array.from(messageIds).slice(0, 50),
+          Array.from(messageIds),
           'metadata',
           ['From', 'Subject', 'Date'],
         );

--- a/assistant/src/watcher/watcher-store.ts
+++ b/assistant/src/watcher/watcher-store.ts
@@ -253,6 +253,18 @@ export function disableWatcher(id: string, reason: string): void {
 }
 
 /**
+ * Persist a background conversation ID for a watcher.
+ * Called after creating the conversation in Phase 2 of the engine tick.
+ */
+export function setWatcherConversationId(id: string, conversationId: string): void {
+  const db = getDb();
+  db.update(watchers)
+    .set({ conversationId, updatedAt: Date.now() })
+    .where(eq(watchers.id, id))
+    .run();
+}
+
+/**
  * Reset watchers stuck in 'polling' back to 'idle' (daemon restart recovery).
  */
 export function resetStuckWatchers(): number {


### PR DESCRIPTION
## Summary
- Add setWatcherConversationId to persist background conversation ID after creation in Phase 2
- Remove slice(0, 50) cap on Gmail message IDs to prevent irreversible event loss when >50 messages arrive between polls
- Remove misleading comment about completeWatcherPoll persisting the conversationId

Addresses feedback from #4142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
