### PR TITLE
feat: credential broker adds serverUseById and template accessors

### DIFF
--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -340,6 +340,24 @@ describe('CredentialBroker.serverUse', () => {
       expect(r2.result).toBe('triggered');
     });
 
+    test('different services with same field name are independent (serverUseById)', () => {
+      const meta1 = upsertCredentialMetadata('github', 'api_token', {
+        allowedTools: ['github_api'],
+      });
+      upsertCredentialMetadata('gitlab', 'api_token', {
+        allowedTools: ['gitlab_api'],
+      });
+      setSecureKey('credential:github:api_token', 'gh_tok');
+      setSecureKey('credential:gitlab:api_token', 'gl_tok');
+
+      // github credential should not serve gitlab tool
+      const r1 = broker.serverUseById({
+        credentialId: meta1.credentialId,
+        requestingTool: 'gitlab_api',
+      });
+      expect(r1.success).toBe(false);
+    });
+
     test('different services with same field name are independent', async () => {
       upsertCredentialMetadata('github', 'api_token', {
         allowedTools: ['github_api'],
@@ -371,5 +389,142 @@ describe('CredentialBroker.serverUse', () => {
       });
       expect(r2.success).toBe(true);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — serverUseById (proxy credential consumption by ID)
+// ---------------------------------------------------------------------------
+
+describe('CredentialBroker.serverUseById', () => {
+  let broker: CredentialBroker;
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+    _resetBackend();
+    _setMetadataPath(join(TEST_DIR, 'metadata.json'));
+    broker = new CredentialBroker();
+  });
+
+  afterEach(() => {
+    _setMetadataPath(null);
+    _setStorePath(null);
+    _resetBackend();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  test('returns metadata and injection templates for valid credential', () => {
+    const meta = upsertCredentialMetadata('fal', 'api_key', {
+      allowedTools: ['media_proxy'],
+      injectionTemplates: [
+        {
+          hostPattern: '*.fal.ai',
+          injectionType: 'header',
+          headerName: 'Authorization',
+          valuePrefix: 'Key ',
+        },
+      ],
+    });
+    setSecureKey('credential:fal:api_key', 'fal-secret-key');
+
+    const result = broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: 'media_proxy',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    expect(result.credentialId).toBe(meta.credentialId);
+    expect(result.service).toBe('fal');
+    expect(result.field).toBe('api_key');
+    expect(result.injectionTemplates).toHaveLength(1);
+    expect(result.injectionTemplates[0].hostPattern).toBe('*.fal.ai');
+    expect(result.injectionTemplates[0].headerName).toBe('Authorization');
+    expect(result.injectionTemplates[0].valuePrefix).toBe('Key ');
+    // Secret value must NEVER appear in the result
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('fal-secret-key');
+  });
+
+  test('denies when requesting tool is not in allowed list', () => {
+    const meta = upsertCredentialMetadata('fal', 'api_key', {
+      allowedTools: ['media_proxy'],
+    });
+    setSecureKey('credential:fal:api_key', 'fal-secret-key');
+
+    const result = broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: 'unauthorized_tool',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected denial');
+    expect(result.reason).toContain('not allowed');
+    expect(result.reason).toContain('unauthorized_tool');
+    expect(result.reason).toContain('media_proxy');
+  });
+
+  test('returns not found for unknown credential ID', () => {
+    const result = broker.serverUseById({
+      credentialId: 'nonexistent-id',
+      requestingTool: 'media_proxy',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected denial');
+    expect(result.reason).toContain('No credential found');
+    expect(result.reason).toContain('nonexistent-id');
+  });
+
+  test('denies when credential has domain restrictions', () => {
+    const meta = upsertCredentialMetadata('github', 'oauth_token', {
+      allowedTools: ['media_proxy'],
+      allowedDomains: ['github.com'],
+    });
+    setSecureKey('credential:github:oauth_token', 'gho_test');
+
+    const result = broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: 'media_proxy',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected denial');
+    expect(result.reason).toContain('domain restrictions');
+    expect(result.reason).toContain('cannot be used server-side');
+  });
+
+  test('returns empty injection templates when credential has none', () => {
+    const meta = upsertCredentialMetadata('vercel', 'api_token', {
+      allowedTools: ['media_proxy'],
+    });
+    setSecureKey('credential:vercel:api_token', 'test-vercel-token');
+
+    const result = broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: 'media_proxy',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('expected success');
+    expect(result.injectionTemplates).toEqual([]);
+  });
+
+  test('denies with empty allowedTools and suggests updating credential', () => {
+    const meta = upsertCredentialMetadata('stripe', 'secret_key', {
+      allowedTools: [],
+    });
+    setSecureKey('credential:stripe:secret_key', 'sk_test_xyz');
+
+    const result = broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: 'media_proxy',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected denial');
+    expect(result.reason).toContain('No tools are currently allowed');
+    expect(result.reason).toContain('credential_store');
   });
 });

--- a/assistant/src/tools/credentials/broker-types.ts
+++ b/assistant/src/tools/credentials/broker-types.ts
@@ -82,3 +82,26 @@ export interface ServerUseResult<T> {
   result?: T;
   reason?: string;
 }
+
+/** Request to look up a credential by ID for proxy injection (no secret exposed). */
+export interface ServerUseByIdRequest {
+  credentialId: string;
+  requestingTool: string;
+}
+
+/** Successful by-id lookup result — metadata + injection templates, never plaintext. */
+export interface ServerUseByIdSuccess {
+  success: true;
+  credentialId: string;
+  service: string;
+  field: string;
+  injectionTemplates: import('./policy-types.js').CredentialInjectionTemplate[];
+}
+
+/** Denied or not-found by-id lookup result. */
+export interface ServerUseByIdDenied {
+  success: false;
+  reason: string;
+}
+
+export type ServerUseByIdResult = ServerUseByIdSuccess | ServerUseByIdDenied;

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -5,11 +5,14 @@ import type {
   BrowserFillRequest,
   BrowserFillResult,
   ConsumeResult,
+  ServerUseByIdRequest,
+  ServerUseByIdResult,
   ServerUseRequest,
   ServerUseResult,
   UsageToken,
 } from './broker-types.js';
 import { getCredentialMetadata } from './metadata-store.js';
+import { resolveById } from './resolve.js';
 import { isToolAllowed } from './tool-policy.js';
 import { isDomainAllowed } from './domain-policy.js';
 import { getSecureKey } from '../../security/secure-keys.js';
@@ -286,6 +289,63 @@ export class CredentialBroker {
       );
       return { success: false, reason: 'Credential use failed' };
     }
+  }
+
+  /**
+   * Look up a credential by its opaque ID for proxy injection.
+   *
+   * Returns metadata and injection templates so the proxy knows how to
+   * inject the credential into outbound requests. The secret value is
+   * never included in the result — the proxy reads it separately via
+   * the secure key backend at injection time.
+   */
+  serverUseById(request: ServerUseByIdRequest): ServerUseByIdResult {
+    const resolved = resolveById(request.credentialId);
+    if (!resolved) {
+      return {
+        success: false,
+        reason: `No credential found for id "${request.credentialId}"`,
+      };
+    }
+
+    const { metadata } = resolved;
+
+    // Tool policy enforcement
+    if (!isToolAllowed(request.requestingTool, metadata.allowedTools)) {
+      const tools = metadata.allowedTools ?? [];
+      return {
+        success: false,
+        reason: `Tool "${request.requestingTool}" is not allowed to use credential ${metadata.service}/${metadata.field}. ` +
+          (tools.length === 0
+            ? 'No tools are currently allowed — update the credential with allowed_tools via credential_store.'
+            : `Allowed tools: ${tools.join(', ')}.`),
+      };
+    }
+
+    // Domain policy enforcement — credentials with domain restrictions are
+    // scoped to browser use on those domains and cannot be used server-side.
+    const domains = metadata.allowedDomains ?? [];
+    if (domains.length > 0) {
+      return {
+        success: false,
+        reason: `Credential ${metadata.service}/${metadata.field} has domain restrictions ` +
+          `(${domains.join(', ')}) and cannot be used server-side. ` +
+          'Remove domain restrictions or use a separate credential without domain policy.',
+      };
+    }
+
+    log.info(
+      { credentialId: request.credentialId, service: metadata.service, field: metadata.field, tool: request.requestingTool },
+      'Server-side credential lookup by ID completed',
+    );
+
+    return {
+      success: true,
+      credentialId: resolved.credentialId,
+      service: resolved.service,
+      field: resolved.field,
+      injectionTemplates: resolved.injectionTemplates,
+    };
   }
 
   /** Return the number of active (non-consumed, non-revoked) tokens. */


### PR DESCRIPTION
## Summary
- Add `serverUseById` entry point for proxy credential consumption by opaque ID
- Return metadata + injection templates without exposing secret values
- Preserve existing policy checks (allowed tools/domains enforced)

## Behavior Delta
New broker method added; existing methods unchanged.

## Tests Run
- `bun test src/__tests__/credential-broker-server-use.test.ts` — 21 pass
- Full test suite: pre-existing failures in `credential-security-invariants.test.ts` unrelated to this PR

## Rollback
Revert new broker method and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
