### PR TITLE
fix: move bundled skill auto-allow after strict mode check in permissions

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -78,6 +78,24 @@ const mockSkillTool: Tool = {
 };
 registerTool(mockSkillTool);
 
+// Register a mock bundled skill-origin tool for testing strict mode + bundled policy.
+const mockBundledSkillTool: Tool = {
+  name: 'skill_bundled_test_tool',
+  description: 'A test bundled skill tool',
+  category: 'skill',
+  defaultRiskLevel: RiskLevel.Low,
+  origin: 'skill',
+  ownerSkillId: 'gmail',
+  ownerSkillBundled: true,
+  getDefinition: () => ({
+    name: 'skill_bundled_test_tool',
+    description: 'A test bundled skill tool',
+    input_schema: { type: 'object' as const, properties: {} },
+  }),
+  execute: async () => ({ content: 'ok', isError: false }),
+};
+registerTool(mockBundledSkillTool);
+
 function writeSkill(skillId: string, name: string, description = 'Test skill'): void {
   const skillDir = join(checkerTestDir, 'skills', skillId);
   mkdirSync(skillDir, { recursive: true });
@@ -3014,6 +3032,13 @@ describe('Permission Checker', () => {
         testConfig.permissions.mode = 'strict';
         const result = await check('skill_test_tool', {}, '/tmp');
         expect(result.decision).toBe('prompt');
+      });
+
+      test('bundled skill-origin tool with no rule prompts in strict mode', async () => {
+        testConfig.permissions.mode = 'strict';
+        const result = await check('skill_bundled_test_tool', {}, '/tmp');
+        expect(result.decision).toBe('prompt');
+        expect(result.reason).toContain('Strict mode');
       });
 
       test('explicit allow rule allows execution in strict mode', async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -380,17 +380,6 @@ export async function check(
     }
   }
 
-  // Auto-allow low-risk bundled skill tools even without explicit trust rules.
-  // These are first-party tools with a vetted risk declaration — applying the
-  // same policy as the per-tool default allow rules for browser tools, but
-  // generically so every new bundled skill benefits automatically.
-  if (!matchedRule && risk === RiskLevel.Low) {
-    const tool = getTool(toolName);
-    if (tool?.origin === 'skill' && tool.ownerSkillBundled) {
-      return { decision: 'allow', reason: 'Bundled skill tool: low risk, auto-allowed' };
-    }
-  }
-
   // In strict mode, every tool without an explicit matching rule must be
   // prompted — there is no implicit auto-allow for any risk level.
   // This explicitly covers skill_load: activating a skill can grant the
@@ -399,6 +388,19 @@ export async function check(
   const permissionsMode = getConfig().permissions.mode;
   if (permissionsMode === 'strict' && !matchedRule) {
     return { decision: 'prompt', reason: `Strict mode: no matching rule, requires approval` };
+  }
+
+  // Auto-allow low-risk bundled skill tools even without explicit trust rules.
+  // These are first-party tools with a vetted risk declaration — applying the
+  // same policy as the per-tool default allow rules for browser tools, but
+  // generically so every new bundled skill benefits automatically.
+  // This block must come AFTER the strict mode check so that strict mode
+  // still prompts for bundled skill tools without explicit rules.
+  if (!matchedRule && risk === RiskLevel.Low) {
+    const tool = getTool(toolName);
+    if (tool?.origin === 'skill' && tool.ownerSkillBundled) {
+      return { decision: 'allow', reason: 'Bundled skill tool: low risk, auto-allowed' };
+    }
   }
 
   if (risk === RiskLevel.High) {


### PR DESCRIPTION
## Summary
- Move bundled skill tool auto-allow block after strict mode check to prevent bypassing strict mode
- Add test case verifying bundled skill tools prompt in strict mode without explicit rules

Addresses feedback from #4158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
