### PR TITLE
feat: Action Playbooks (M2)

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -24,7 +24,8 @@ export type MemoryItemKind =
   | 'event'
   | 'opinion'
   | 'instruction'
-  | 'style';
+  | 'style'
+  | 'playbook';
 
 interface ExtractedItem {
   kind: MemoryItemKind;
@@ -38,6 +39,7 @@ interface ExtractedItem {
 const VALID_KINDS = new Set<string>([
   'preference', 'profile', 'project', 'decision', 'todo',
   'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style',
+  'playbook',
 ]);
 
 const SUPERSEDE_KINDS = new Set<MemoryItemKind>(['decision', 'preference', 'constraint']);
@@ -82,6 +84,7 @@ Extract items in these categories:
 - opinion: Viewpoints, assessments, evaluations of tools/approaches
 - instruction: Explicit directives on how the assistant should behave
 - style: Communication style patterns — writing tone, formatting habits, vocabulary choices, greeting/sign-off conventions
+- playbook: Trigger→action rules for handling messages — e.g. "when I get a meeting request, check my calendar and propose 3 times", "archive newsletters automatically", "if an email is from my CEO, respond within 1 hour"
 
 For each item, provide:
 - kind: One of the categories above
@@ -401,6 +404,9 @@ function classifySentence(lower: string): { kind: MemoryItemKind; confidence: nu
   }
   if (includesAny(lower, ['remember', 'important', 'fact', 'noted'])) {
     return { kind: 'fact', confidence: 0.62, importance: 0.5 };
+  }
+  if (includesAny(lower, ['when i get', 'whenever', 'if i receive', 'archive', 'auto-reply', 'auto reply', 'respond within', 'when someone'])) {
+    return { kind: 'playbook', confidence: 0.72, importance: 0.8 };
   }
   return null;
 }

--- a/assistant/src/playbooks/index.ts
+++ b/assistant/src/playbooks/index.ts
@@ -1,0 +1,2 @@
+export { type Playbook, type PlaybookAutonomyLevel, parsePlaybookStatement } from './types.js';
+export { compilePlaybooks, type CompiledPlaybooks, type CompilePlaybooksOptions } from './playbook-compiler.js';

--- a/assistant/src/playbooks/playbook-compiler.ts
+++ b/assistant/src/playbooks/playbook-compiler.ts
@@ -1,0 +1,90 @@
+/**
+ * Compile all active playbook memory items into a triage context block
+ * that can be injected into the system prompt alongside the contact
+ * graph and dynamic profile.
+ */
+
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { getDb } from '../memory/db.js';
+import { memoryItems } from '../memory/schema.js';
+import { parsePlaybookStatement } from './types.js';
+import type { Playbook } from './types.js';
+
+export interface CompiledPlaybooks {
+  /** Formatted text block ready for system prompt injection. */
+  text: string;
+  /** Total number of active playbook items found. */
+  totalCount: number;
+  /** Number of playbooks successfully parsed and included. */
+  includedCount: number;
+}
+
+export interface CompilePlaybooksOptions {
+  scopeId?: string;
+}
+
+interface PlaybookRow {
+  id: string;
+  subject: string;
+  statement: string;
+}
+
+export function compilePlaybooks(options?: CompilePlaybooksOptions): CompiledPlaybooks {
+  const scopeId = options?.scopeId ?? 'default';
+  const db = getDb();
+
+  const rows: PlaybookRow[] = db
+    .select({
+      id: memoryItems.id,
+      subject: memoryItems.subject,
+      statement: memoryItems.statement,
+    })
+    .from(memoryItems)
+    .where(and(
+      eq(memoryItems.kind, 'playbook'),
+      eq(memoryItems.status, 'active'),
+      eq(memoryItems.scopeId, scopeId),
+      isNull(memoryItems.invalidAt),
+    ))
+    .orderBy(desc(memoryItems.importance))
+    .all();
+
+  if (rows.length === 0) {
+    return { text: '', totalCount: 0, includedCount: 0 };
+  }
+
+  const parsed: Array<{ id: string; subject: string; playbook: Playbook }> = [];
+  for (const row of rows) {
+    const playbook = parsePlaybookStatement(row.statement);
+    if (playbook) {
+      parsed.push({ id: row.id, subject: row.subject, playbook });
+    }
+  }
+
+  if (parsed.length === 0) {
+    return { text: '', totalCount: rows.length, includedCount: 0 };
+  }
+
+  // Sort by priority descending so higher-priority rules appear first
+  parsed.sort((a, b) => b.playbook.priority - a.playbook.priority);
+
+  const lines: string[] = ['<action-playbooks>'];
+  for (const { playbook } of parsed) {
+    const channelLabel = playbook.channel === '*' ? 'all channels' : playbook.channel;
+    const autonomyLabel = playbook.autonomyLevel === 'auto'
+      ? 'execute automatically'
+      : playbook.autonomyLevel === 'draft'
+        ? 'draft for review'
+        : 'notify only';
+    lines.push(
+      `- WHEN "${playbook.trigger}" on ${channelLabel} → ${playbook.action} [${autonomyLabel}, priority=${playbook.priority}]`,
+    );
+  }
+  lines.push('</action-playbooks>');
+
+  return {
+    text: lines.join('\n'),
+    totalCount: rows.length,
+    includedCount: parsed.length,
+  };
+}

--- a/assistant/src/playbooks/types.ts
+++ b/assistant/src/playbooks/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Action Playbook — a structured trigger→action rule that tells the
+ * triage engine how to handle incoming messages matching a pattern.
+ *
+ * Playbooks are stored as memory items with kind='playbook'. The
+ * structured fields below are serialized into the statement column as
+ * JSON, while the subject column holds a human-readable label.
+ */
+
+export interface Playbook {
+  /** Pattern or description that triggers this playbook (e.g. "meeting request", "from:ceo@*"). */
+  trigger: string;
+  /** Channel this rule applies to, or '*' for all channels. */
+  channel: string;
+  /** Free-form category for grouping (e.g. "scheduling", "triage", "notifications"). */
+  category: string;
+  /** What to do when the trigger matches — natural language action description. */
+  action: string;
+  /** How much autonomy the assistant has when executing this playbook. */
+  autonomyLevel: PlaybookAutonomyLevel;
+  /** Relative priority — higher numbers take precedence when multiple playbooks match. */
+  priority: number;
+}
+
+export type PlaybookAutonomyLevel = 'auto' | 'draft' | 'notify';
+
+/**
+ * Parse a playbook from its JSON-serialized statement column.
+ * Returns null if the statement is not valid playbook JSON.
+ */
+export function parsePlaybookStatement(statement: string): Playbook | null {
+  try {
+    const parsed = JSON.parse(statement);
+    if (
+      typeof parsed.trigger !== 'string' ||
+      typeof parsed.action !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      trigger: parsed.trigger,
+      channel: typeof parsed.channel === 'string' ? parsed.channel : '*',
+      category: typeof parsed.category === 'string' ? parsed.category : 'general',
+      action: parsed.action,
+      autonomyLevel: isValidAutonomyLevel(parsed.autonomyLevel) ? parsed.autonomyLevel : 'draft',
+      priority: typeof parsed.priority === 'number' ? parsed.priority : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isValidAutonomyLevel(value: unknown): value is PlaybookAutonomyLevel {
+  return value === 'auto' || value === 'draft' || value === 'notify';
+}

--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -31,7 +31,7 @@ export const memorySaveDefinition: ToolDefinition = {
       },
       kind: {
         type: 'string',
-        enum: ['preference', 'fact', 'decision', 'profile', 'relationship', 'event', 'opinion', 'instruction', 'style'],
+        enum: ['preference', 'fact', 'decision', 'profile', 'relationship', 'event', 'opinion', 'instruction', 'style', 'playbook'],
         description: 'Category of the memory item',
       },
       subject: {

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -74,6 +74,7 @@ export async function handleMemorySave(
   const validKinds = new Set([
     'preference', 'fact', 'decision', 'profile',
     'relationship', 'event', 'opinion', 'instruction', 'style',
+    'playbook',
   ]);
   if (typeof kind !== 'string' || !validKinds.has(kind)) {
     return {

--- a/assistant/src/tools/playbooks/index.ts
+++ b/assistant/src/tools/playbooks/index.ts
@@ -1,0 +1,5 @@
+// Barrel export — importing this module triggers registration of all playbook tools.
+import './playbook-create.js';
+import './playbook-list.js';
+import './playbook-update.js';
+import './playbook-delete.js';

--- a/assistant/src/tools/playbooks/playbook-create.ts
+++ b/assistant/src/tools/playbooks/playbook-create.ts
@@ -1,0 +1,146 @@
+import { createHash } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getDb } from '../../memory/db.js';
+import { memoryItems } from '../../memory/schema.js';
+import { enqueueMemoryJob } from '../../memory/jobs-store.js';
+import type { Playbook, PlaybookAutonomyLevel } from '../../playbooks/types.js';
+
+const VALID_AUTONOMY_LEVELS = new Set<string>(['auto', 'draft', 'notify']);
+
+class PlaybookCreateTool implements Tool {
+  name = 'playbook_create';
+  description = 'Create an action playbook — a trigger→action rule that tells the assistant how to handle incoming messages matching a pattern';
+  category = 'playbook';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          trigger: {
+            type: 'string',
+            description: 'Pattern or description that triggers this playbook (e.g. "meeting request", "from:ceo@*", "newsletter")',
+          },
+          action: {
+            type: 'string',
+            description: 'What to do when the trigger matches — natural language action description (e.g. "check calendar, propose 3 times")',
+          },
+          channel: {
+            type: 'string',
+            description: 'Channel this rule applies to (e.g. "email", "slack"), or "*" for all channels. Defaults to "*".',
+          },
+          category: {
+            type: 'string',
+            description: 'Free-form category for grouping (e.g. "scheduling", "triage"). Defaults to "general".',
+          },
+          autonomy_level: {
+            type: 'string',
+            enum: ['auto', 'draft', 'notify'],
+            description: 'How much autonomy: "auto" = execute automatically, "draft" = draft for review, "notify" = notify only. Defaults to "draft".',
+          },
+          priority: {
+            type: 'number',
+            description: 'Relative priority — higher numbers take precedence. Defaults to 0.',
+          },
+        },
+        required: ['trigger', 'action'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const trigger = input.trigger as string;
+    const action = input.action as string;
+
+    if (!trigger || typeof trigger !== 'string') {
+      return { content: 'Error: trigger is required and must be a string', isError: true };
+    }
+    if (!action || typeof action !== 'string') {
+      return { content: 'Error: action is required and must be a string', isError: true };
+    }
+
+    const channel = typeof input.channel === 'string' ? input.channel : '*';
+    const category = typeof input.category === 'string' ? input.category : 'general';
+    const autonomyLevel: PlaybookAutonomyLevel =
+      typeof input.autonomy_level === 'string' && VALID_AUTONOMY_LEVELS.has(input.autonomy_level)
+        ? (input.autonomy_level as PlaybookAutonomyLevel)
+        : 'draft';
+    const priority = typeof input.priority === 'number' ? input.priority : 0;
+
+    const playbook: Playbook = { trigger, channel, category, action, autonomyLevel, priority };
+    const statement = JSON.stringify(playbook);
+    const subject = `Playbook: ${trigger}`.slice(0, 80);
+    const scopeId = context.memoryScopeId ?? 'default';
+
+    const normalized = `${scopeId}|playbook|${subject.toLowerCase()}|${statement.toLowerCase()}`;
+    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+
+    try {
+      const db = getDb();
+
+      const existing = db
+        .select()
+        .from(memoryItems)
+        .where(and(eq(memoryItems.fingerprint, fingerprint), eq(memoryItems.scopeId, scopeId)))
+        .get();
+
+      if (existing) {
+        return {
+          content: `A playbook with this exact configuration already exists (ID: ${existing.id}).`,
+          isError: false,
+        };
+      }
+
+      const id = uuid();
+      const now = Date.now();
+
+      db.insert(memoryItems).values({
+        id,
+        kind: 'playbook',
+        subject,
+        statement,
+        status: 'active',
+        confidence: 0.95,
+        importance: 0.8,
+        fingerprint,
+        verificationState: 'user_confirmed',
+        scopeId,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        lastUsedAt: null,
+      }).run();
+
+      enqueueMemoryJob('embed_item', { itemId: id });
+
+      const autonomyLabel = autonomyLevel === 'auto' ? 'execute automatically'
+        : autonomyLevel === 'draft' ? 'draft for review' : 'notify only';
+
+      return {
+        content: [
+          'Playbook created successfully.',
+          `  ID: ${id}`,
+          `  Trigger: ${trigger}`,
+          `  Channel: ${channel}`,
+          `  Category: ${category}`,
+          `  Action: ${action}`,
+          `  Autonomy: ${autonomyLabel}`,
+          `  Priority: ${priority}`,
+        ].join('\n'),
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error creating playbook: ${msg}`, isError: true };
+    }
+  }
+}
+
+registerTool(new PlaybookCreateTool());

--- a/assistant/src/tools/playbooks/playbook-delete.ts
+++ b/assistant/src/tools/playbooks/playbook-delete.ts
@@ -1,0 +1,79 @@
+import { and, eq } from 'drizzle-orm';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getDb } from '../../memory/db.js';
+import { memoryItems } from '../../memory/schema.js';
+import { parsePlaybookStatement } from '../../playbooks/types.js';
+
+class PlaybookDeleteTool implements Tool {
+  name = 'playbook_delete';
+  description = 'Delete an action playbook rule';
+  category = 'playbook';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          playbook_id: {
+            type: 'string',
+            description: 'ID of the playbook to delete (from playbook_list results)',
+          },
+        },
+        required: ['playbook_id'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const playbookId = input.playbook_id as string;
+    if (!playbookId || typeof playbookId !== 'string') {
+      return { content: 'Error: playbook_id is required and must be a string', isError: true };
+    }
+
+    const scopeId = context.memoryScopeId ?? 'default';
+
+    try {
+      const db = getDb();
+
+      const existing = db
+        .select()
+        .from(memoryItems)
+        .where(and(
+          eq(memoryItems.id, playbookId),
+          eq(memoryItems.kind, 'playbook'),
+          eq(memoryItems.scopeId, scopeId),
+        ))
+        .get();
+
+      if (!existing) {
+        return { content: `Error: Playbook with ID "${playbookId}" not found`, isError: true };
+      }
+
+      const playbook = parsePlaybookStatement(existing.statement);
+      const triggerLabel = playbook?.trigger ?? existing.subject;
+
+      // Soft-delete by marking as superseded rather than hard-deleting,
+      // consistent with how other memory items are retired.
+      db.update(memoryItems)
+        .set({ status: 'superseded' })
+        .where(eq(memoryItems.id, existing.id))
+        .run();
+
+      return {
+        content: `Playbook deleted (ID: ${existing.id}, trigger: "${triggerLabel}").`,
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error deleting playbook: ${msg}`, isError: true };
+    }
+  }
+}
+
+registerTool(new PlaybookDeleteTool());

--- a/assistant/src/tools/playbooks/playbook-list.ts
+++ b/assistant/src/tools/playbooks/playbook-list.ts
@@ -1,0 +1,106 @@
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getDb } from '../../memory/db.js';
+import { memoryItems } from '../../memory/schema.js';
+import { parsePlaybookStatement } from '../../playbooks/types.js';
+
+class PlaybookListTool implements Tool {
+  name = 'playbook_list';
+  description = 'List action playbooks, optionally filtered by channel or category';
+  category = 'playbook';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          channel: {
+            type: 'string',
+            description: 'Filter by channel (e.g. "email", "slack"). Omit to show all.',
+          },
+          category: {
+            type: 'string',
+            description: 'Filter by category (e.g. "scheduling", "triage"). Omit to show all.',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const scopeId = context.memoryScopeId ?? 'default';
+    const channelFilter = typeof input.channel === 'string' ? input.channel : null;
+    const categoryFilter = typeof input.category === 'string' ? input.category : null;
+
+    try {
+      const db = getDb();
+
+      const rows = db
+        .select({
+          id: memoryItems.id,
+          subject: memoryItems.subject,
+          statement: memoryItems.statement,
+          importance: memoryItems.importance,
+          lastSeenAt: memoryItems.lastSeenAt,
+        })
+        .from(memoryItems)
+        .where(and(
+          eq(memoryItems.kind, 'playbook'),
+          eq(memoryItems.status, 'active'),
+          eq(memoryItems.scopeId, scopeId),
+          isNull(memoryItems.invalidAt),
+        ))
+        .orderBy(desc(memoryItems.importance))
+        .all();
+
+      if (rows.length === 0) {
+        return { content: 'No playbooks found.', isError: false };
+      }
+
+      const entries: Array<{ id: string; subject: string; statement: string; playbook: NonNullable<ReturnType<typeof parsePlaybookStatement>> }> = [];
+      for (const row of rows) {
+        const playbook = parsePlaybookStatement(row.statement);
+        if (!playbook) continue;
+
+        // Apply filters
+        if (channelFilter && playbook.channel !== channelFilter && playbook.channel !== '*') continue;
+        if (categoryFilter && playbook.category !== categoryFilter) continue;
+
+        entries.push({ id: row.id, subject: row.subject, statement: row.statement, playbook });
+      }
+
+      if (entries.length === 0) {
+        const filters = [
+          channelFilter ? `channel="${channelFilter}"` : null,
+          categoryFilter ? `category="${categoryFilter}"` : null,
+        ].filter(Boolean).join(', ');
+        return { content: `No playbooks found matching ${filters}.`, isError: false };
+      }
+
+      // Sort by priority descending
+      entries.sort((a, b) => b.playbook.priority - a.playbook.priority);
+
+      const lines: string[] = [`Found ${entries.length} playbook(s):\n`];
+      for (const { id, playbook } of entries) {
+        const channelLabel = playbook.channel === '*' ? 'all channels' : playbook.channel;
+        const autonomyLabel = playbook.autonomyLevel === 'auto' ? 'auto'
+          : playbook.autonomyLevel === 'draft' ? 'draft' : 'notify';
+        lines.push(`- **${playbook.trigger}** (${channelLabel}) → ${playbook.action}`);
+        lines.push(`  _ID: ${id} | category: ${playbook.category} | autonomy: ${autonomyLabel} | priority: ${playbook.priority}_`);
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error listing playbooks: ${msg}`, isError: true };
+    }
+  }
+}
+
+registerTool(new PlaybookListTool());

--- a/assistant/src/tools/playbooks/playbook-update.ts
+++ b/assistant/src/tools/playbooks/playbook-update.ts
@@ -1,0 +1,149 @@
+import { createHash } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getDb } from '../../memory/db.js';
+import { memoryItems } from '../../memory/schema.js';
+import { enqueueMemoryJob } from '../../memory/jobs-store.js';
+import { parsePlaybookStatement } from '../../playbooks/types.js';
+import type { Playbook, PlaybookAutonomyLevel } from '../../playbooks/types.js';
+
+const VALID_AUTONOMY_LEVELS = new Set<string>(['auto', 'draft', 'notify']);
+
+class PlaybookUpdateTool implements Tool {
+  name = 'playbook_update';
+  description = 'Update an existing action playbook rule';
+  category = 'playbook';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          playbook_id: {
+            type: 'string',
+            description: 'ID of the playbook to update (from playbook_list results)',
+          },
+          trigger: {
+            type: 'string',
+            description: 'Updated trigger pattern',
+          },
+          action: {
+            type: 'string',
+            description: 'Updated action description',
+          },
+          channel: {
+            type: 'string',
+            description: 'Updated channel ("*" for all)',
+          },
+          category: {
+            type: 'string',
+            description: 'Updated category',
+          },
+          autonomy_level: {
+            type: 'string',
+            enum: ['auto', 'draft', 'notify'],
+            description: 'Updated autonomy level',
+          },
+          priority: {
+            type: 'number',
+            description: 'Updated priority',
+          },
+        },
+        required: ['playbook_id'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const playbookId = input.playbook_id as string;
+    if (!playbookId || typeof playbookId !== 'string') {
+      return { content: 'Error: playbook_id is required and must be a string', isError: true };
+    }
+
+    const scopeId = context.memoryScopeId ?? 'default';
+
+    try {
+      const db = getDb();
+
+      const existing = db
+        .select()
+        .from(memoryItems)
+        .where(and(
+          eq(memoryItems.id, playbookId),
+          eq(memoryItems.kind, 'playbook'),
+          eq(memoryItems.scopeId, scopeId),
+        ))
+        .get();
+
+      if (!existing) {
+        return { content: `Error: Playbook with ID "${playbookId}" not found`, isError: true };
+      }
+
+      const currentPlaybook = parsePlaybookStatement(existing.statement);
+      if (!currentPlaybook) {
+        return { content: `Error: Playbook data is corrupted for ID "${playbookId}"`, isError: true };
+      }
+
+      // Merge updates onto existing playbook
+      const updated: Playbook = {
+        trigger: typeof input.trigger === 'string' ? input.trigger : currentPlaybook.trigger,
+        channel: typeof input.channel === 'string' ? input.channel : currentPlaybook.channel,
+        category: typeof input.category === 'string' ? input.category : currentPlaybook.category,
+        action: typeof input.action === 'string' ? input.action : currentPlaybook.action,
+        autonomyLevel:
+          typeof input.autonomy_level === 'string' && VALID_AUTONOMY_LEVELS.has(input.autonomy_level)
+            ? (input.autonomy_level as PlaybookAutonomyLevel)
+            : currentPlaybook.autonomyLevel,
+        priority: typeof input.priority === 'number' ? input.priority : currentPlaybook.priority,
+      };
+
+      const statement = JSON.stringify(updated);
+      const subject = `Playbook: ${updated.trigger}`.slice(0, 80);
+      const now = Date.now();
+
+      const normalized = `${scopeId}|playbook|${subject.toLowerCase()}|${statement.toLowerCase()}`;
+      const fingerprint = createHash('sha256').update(normalized).digest('hex');
+
+      db.update(memoryItems)
+        .set({
+          subject,
+          statement,
+          fingerprint,
+          lastSeenAt: now,
+          verificationState: 'user_confirmed',
+        })
+        .where(eq(memoryItems.id, existing.id))
+        .run();
+
+      enqueueMemoryJob('embed_item', { itemId: existing.id });
+
+      const autonomyLabel = updated.autonomyLevel === 'auto' ? 'execute automatically'
+        : updated.autonomyLevel === 'draft' ? 'draft for review' : 'notify only';
+
+      return {
+        content: [
+          'Playbook updated successfully.',
+          `  ID: ${existing.id}`,
+          `  Trigger: ${updated.trigger}`,
+          `  Channel: ${updated.channel}`,
+          `  Category: ${updated.category}`,
+          `  Action: ${updated.action}`,
+          `  Autonomy: ${autonomyLabel}`,
+          `  Priority: ${updated.priority}`,
+        ].join('\n'),
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error updating playbook: ${msg}`, isError: true };
+    }
+  }
+}
+
+registerTool(new PlaybookUpdateTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -40,6 +40,10 @@ export const eagerModules: string[] = [
   './watcher/update.js',
   './watcher/delete.js',
   './watcher/digest.js',
+  './playbooks/playbook-create.js',
+  './playbooks/playbook-list.js',
+  './playbooks/playbook-update.js',
+  './playbooks/playbook-delete.js',
 ];
 
 // Tool names registered by the eager modules above.  Listed explicitly so
@@ -65,6 +69,10 @@ export const eagerModuleToolNames: string[] = [
   'watcher_update',
   'watcher_delete',
   'watcher_digest',
+  'playbook_create',
+  'playbook_list',
+  'playbook_update',
+  'playbook_delete',
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add playbook memory kind to extraction pipeline
- Implement playbook_create, playbook_list, playbook_update, playbook_delete tools
- Add playbook compiler for triage context injection

Part of #4171: Channel-agnostic messaging primitives

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
