### PR TITLE
feat: credential_store adds alias + injection template fields

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -425,6 +425,189 @@ describe('credential_store tool', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Alias and injection template fields
+  // -----------------------------------------------------------------------
+  describe('alias and injection template fields', () => {
+    test('store with valid alias and templates persists metadata', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'fal',
+        field: 'api_key',
+        value: 'fal-key-123',
+        alias: 'fal-primary',
+        injection_templates: [
+          {
+            hostPattern: '*.fal.ai',
+            injectionType: 'header',
+            headerName: 'Authorization',
+            valuePrefix: 'Key ',
+          },
+        ],
+      }, _ctx);
+      expect(result.isError).toBe(false);
+      const metadata = getCredentialMetadata('fal', 'api_key');
+      expect(metadata).toBeDefined();
+      expect(metadata!.alias).toBe('fal-primary');
+      expect(metadata!.injectionTemplates).toHaveLength(1);
+      expect(metadata!.injectionTemplates![0].hostPattern).toBe('*.fal.ai');
+      expect(metadata!.injectionTemplates![0].injectionType).toBe('header');
+      expect(metadata!.injectionTemplates![0].headerName).toBe('Authorization');
+      expect(metadata!.injectionTemplates![0].valuePrefix).toBe('Key ');
+    });
+
+    test('store with alias only (no templates)', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'openai',
+        field: 'api_key',
+        value: 'sk-test',
+        alias: 'openai-main',
+      }, _ctx);
+      expect(result.isError).toBe(false);
+      const metadata = getCredentialMetadata('openai', 'api_key');
+      expect(metadata).toBeDefined();
+      expect(metadata!.alias).toBe('openai-main');
+      expect(metadata!.injectionTemplates).toBeUndefined();
+    });
+
+    test('store with templates only (no alias)', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'replicate',
+        field: 'token',
+        value: 'r8_test',
+        injection_templates: [
+          {
+            hostPattern: 'api.replicate.com',
+            injectionType: 'header',
+            headerName: 'Authorization',
+            valuePrefix: 'Bearer ',
+          },
+        ],
+      }, _ctx);
+      expect(result.isError).toBe(false);
+      const metadata = getCredentialMetadata('replicate', 'token');
+      expect(metadata).toBeDefined();
+      expect(metadata!.alias).toBeUndefined();
+      expect(metadata!.injectionTemplates).toHaveLength(1);
+      expect(metadata!.injectionTemplates![0].injectionType).toBe('header');
+    });
+
+    test('rejects template missing headerName for header type', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'fal',
+        field: 'api_key',
+        value: 'fal-key-123',
+        injection_templates: [
+          {
+            hostPattern: '*.fal.ai',
+            injectionType: 'header',
+            // missing headerName
+          },
+        ],
+      }, _ctx);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('headerName is required');
+    });
+
+    test('rejects template missing queryParamName for query type', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'mapbox',
+        field: 'token',
+        value: 'pk.test',
+        injection_templates: [
+          {
+            hostPattern: 'api.mapbox.com',
+            injectionType: 'query',
+            // missing queryParamName
+          },
+        ],
+      }, _ctx);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('queryParamName is required');
+    });
+
+    test('round-trip: store then list shows the credential', async () => {
+      await credentialStoreTool.execute({
+        action: 'store',
+        service: 'anthropic',
+        field: 'api_key',
+        value: 'sk-ant-test',
+        alias: 'claude-key',
+        injection_templates: [
+          {
+            hostPattern: 'api.anthropic.com',
+            injectionType: 'header',
+            headerName: 'x-api-key',
+          },
+        ],
+      }, _ctx);
+
+      const listResult = await credentialStoreTool.execute({ action: 'list' }, _ctx);
+      expect(listResult.isError).toBe(false);
+      const entries = JSON.parse(listResult.content);
+      const entry = entries.find((e: { service: string; field: string }) =>
+        e.service === 'anthropic' && e.field === 'api_key',
+      );
+      expect(entry).toBeDefined();
+
+      // Verify metadata persisted correctly
+      const metadata = getCredentialMetadata('anthropic', 'api_key');
+      expect(metadata).toBeDefined();
+      expect(metadata!.alias).toBe('claude-key');
+      expect(metadata!.injectionTemplates).toHaveLength(1);
+    });
+
+    test('update alias on existing credential', async () => {
+      await credentialStoreTool.execute({
+        action: 'store',
+        service: 'fal',
+        field: 'api_key',
+        value: 'fal-key-123',
+        alias: 'fal-old',
+      }, _ctx);
+
+      let metadata = getCredentialMetadata('fal', 'api_key');
+      expect(metadata!.alias).toBe('fal-old');
+
+      // Re-store same credential with updated alias
+      await credentialStoreTool.execute({
+        action: 'store',
+        service: 'fal',
+        field: 'api_key',
+        value: 'fal-key-123',
+        alias: 'fal-new',
+      }, _ctx);
+
+      metadata = getCredentialMetadata('fal', 'api_key');
+      expect(metadata!.alias).toBe('fal-new');
+    });
+
+    test('store with query injection template', async () => {
+      const result = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'mapbox',
+        field: 'token',
+        value: 'pk.test123',
+        injection_templates: [
+          {
+            hostPattern: 'api.mapbox.com',
+            injectionType: 'query',
+            queryParamName: 'access_token',
+          },
+        ],
+      }, _ctx);
+      expect(result.isError).toBe(false);
+      const metadata = getCredentialMetadata('mapbox', 'token');
+      expect(metadata!.injectionTemplates).toHaveLength(1);
+      expect(metadata!.injectionTemplates![0].injectionType).toBe('query');
+      expect(metadata!.injectionTemplates![0].queryParamName).toBe('access_token');
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Namespace isolation
   // -----------------------------------------------------------------------
   describe('namespace isolation', () => {

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -9,7 +9,7 @@ import {
 } from '../../security/secure-keys.js';
 import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata, assertMetadataWritable } from './metadata-store.js';
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
-import type { CredentialPolicyInput } from './policy-types.js';
+import type { CredentialPolicyInput, CredentialInjectionTemplate } from './policy-types.js';
 import { credentialBroker } from './broker.js';
 import { startOAuth2Flow } from '../../security/oauth2.js';
 import { getConfig } from '../../config/loader.js';
@@ -98,6 +98,25 @@ class CredentialStoreTool implements Tool {
             type: 'string',
             description: 'Endpoint to fetch account info after OAuth2 auth (only for oauth2_connect action)',
           },
+          alias: {
+            type: 'string',
+            description: 'Human-friendly name for this credential (only for store action), e.g. "fal-primary"',
+          },
+          injection_templates: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                hostPattern: { type: 'string', description: 'Glob pattern for matching request hosts, e.g. "*.fal.ai"' },
+                injectionType: { type: 'string', enum: ['header', 'query'], description: 'Where to inject the credential value' },
+                headerName: { type: 'string', description: 'Header name when injectionType is "header"' },
+                valuePrefix: { type: 'string', description: 'Prefix prepended to the secret value, e.g. "Key ", "Bearer "' },
+                queryParamName: { type: 'string', description: 'Query parameter name when injectionType is "query"' },
+              },
+              required: ['hostPattern', 'injectionType'],
+            },
+            description: 'Templates describing how to inject this credential into proxied requests (only for store action)',
+          },
         },
         required: ['action'],
       },
@@ -134,6 +153,52 @@ class CredentialStoreTool implements Tool {
         }
         const policy = toPolicyFromInput(policyInput);
 
+        const alias = input.alias as string | undefined;
+        const rawTemplates = input.injection_templates as unknown[] | undefined;
+
+        // Validate injection templates
+        let injectionTemplates: CredentialInjectionTemplate[] | undefined;
+        if (rawTemplates !== undefined) {
+          if (!Array.isArray(rawTemplates)) {
+            return { content: 'Error: injection_templates must be an array', isError: true };
+          }
+          const templateErrors: string[] = [];
+          injectionTemplates = [];
+          for (let i = 0; i < rawTemplates.length; i++) {
+            const t = rawTemplates[i] as Record<string, unknown>;
+            if (typeof t !== 'object' || t === null) {
+              templateErrors.push(`injection_templates[${i}] must be an object`);
+              continue;
+            }
+            if (typeof t.hostPattern !== 'string' || t.hostPattern.trim().length === 0) {
+              templateErrors.push(`injection_templates[${i}].hostPattern must be a non-empty string`);
+            }
+            if (t.injectionType !== 'header' && t.injectionType !== 'query') {
+              templateErrors.push(`injection_templates[${i}].injectionType must be 'header' or 'query'`);
+            } else if (t.injectionType === 'header') {
+              if (typeof t.headerName !== 'string' || t.headerName.trim().length === 0) {
+                templateErrors.push(`injection_templates[${i}].headerName is required when injectionType is 'header'`);
+              }
+            } else if (t.injectionType === 'query') {
+              if (typeof t.queryParamName !== 'string' || t.queryParamName.trim().length === 0) {
+                templateErrors.push(`injection_templates[${i}].queryParamName is required when injectionType is 'query'`);
+              }
+            }
+            if (templateErrors.length === 0) {
+              injectionTemplates.push({
+                hostPattern: t.hostPattern as string,
+                injectionType: t.injectionType as 'header' | 'query',
+                headerName: typeof t.headerName === 'string' ? t.headerName : undefined,
+                valuePrefix: typeof t.valuePrefix === 'string' ? t.valuePrefix : undefined,
+                queryParamName: typeof t.queryParamName === 'string' ? t.queryParamName : undefined,
+              });
+            }
+          }
+          if (templateErrors.length > 0) {
+            return { content: `Error: ${templateErrors.join('; ')}`, isError: true };
+          }
+        }
+
         try {
           assertMetadataWritable();
         } catch {
@@ -150,6 +215,8 @@ class CredentialStoreTool implements Tool {
             allowedTools: policy.allowedTools,
             allowedDomains: policy.allowedDomains,
             usageDescription: policy.usageDescription,
+            alias,
+            injectionTemplates,
           });
         } catch (err) {
           log.warn({ service, field, err }, 'metadata write failed after storing credential');


### PR DESCRIPTION
## Summary
- Extend `credential_store` tool's store action with optional `alias` and `injection_templates` parameters
- Validate injection template schema strictly (type-specific required fields: `headerName` for header type, `queryParamName` for query type)
- Persist new fields in credential metadata store via `upsertCredentialMetadata`

## Behavior Delta
Store action accepts new optional fields; existing usage unchanged.

## Tests Run
- `bun test src/__tests__/credential-vault.test.ts` — 31 tests pass
- Full test suite: pre-existing failures unrelated to this PR (SQLite disk I/O, missing exports)

## Rollback
Revert tool-schema and parser changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
