### PR TITLE
feat: autonomy tiers / approval gates (M4)

### DIFF
--- a/assistant/src/autonomy/autonomy-resolver.ts
+++ b/assistant/src/autonomy/autonomy-resolver.ts
@@ -1,0 +1,60 @@
+/**
+ * Autonomy resolver — determines the effective autonomy tier for an
+ * inbound message based on its triage result, channel, and contact.
+ *
+ * Resolution order (first match wins):
+ *   1. Matched playbook with an explicit autonomy level
+ *   2. Contact-specific override
+ *   3. Category override for the triage result's category
+ *   4. Channel default
+ *   5. Global default tier (falls back to 'notify')
+ */
+
+import type { TriageResult } from '../messaging/types.js';
+import type { AutonomyTier } from './types.js';
+import { AUTONOMY_TIERS } from './types.js';
+import { getAutonomyConfig } from './autonomy-store.js';
+
+/**
+ * Resolve the autonomy tier for a triaged message.
+ *
+ * @param triageResult - Output from the triage engine
+ * @param channel      - The channel the message arrived on (e.g. 'email', 'slack')
+ * @param contactId    - Optional contact ID for contact-specific overrides
+ */
+export function resolveAutonomyTier(
+  triageResult: TriageResult,
+  channel: string,
+  contactId?: string,
+): AutonomyTier {
+  // 1. Playbook-specified autonomy level (first matched playbook wins)
+  for (const playbook of triageResult.matchedPlaybooks) {
+    if (isValidTier(playbook.autonomyLevel)) {
+      return playbook.autonomyLevel as AutonomyTier;
+    }
+  }
+
+  const config = getAutonomyConfig();
+
+  // 2. Contact-specific override
+  if (contactId && contactId in config.contactOverrides) {
+    return config.contactOverrides[contactId];
+  }
+
+  // 3. Category override
+  if (triageResult.category in config.categoryOverrides) {
+    return config.categoryOverrides[triageResult.category];
+  }
+
+  // 4. Channel default
+  if (channel in config.channelDefaults) {
+    return config.channelDefaults[channel];
+  }
+
+  // 5. Global default
+  return config.defaultTier;
+}
+
+function isValidTier(value: unknown): value is AutonomyTier {
+  return typeof value === 'string' && AUTONOMY_TIERS.includes(value as AutonomyTier);
+}

--- a/assistant/src/autonomy/autonomy-store.ts
+++ b/assistant/src/autonomy/autonomy-store.ts
@@ -1,0 +1,121 @@
+/**
+ * Autonomy config persistence — reads/writes autonomy policy from a
+ * dedicated JSON file in the workspace directory.
+ *
+ * The autonomy config lives at ~/.vellum/workspace/autonomy.json, separate
+ * from the main config.json. This is policy configuration (not learned
+ * preferences), so it belongs on disk rather than in the SQLite database.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { getWorkspaceDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+import type { AutonomyConfig, AutonomyTier } from './types.js';
+import { DEFAULT_AUTONOMY_CONFIG, AUTONOMY_TIERS } from './types.js';
+
+const log = getLogger('autonomy-store');
+
+function getAutonomyConfigPath(): string {
+  return join(getWorkspaceDir(), 'autonomy.json');
+}
+
+/**
+ * Load the current autonomy configuration from disk.
+ * Returns defaults if the file doesn't exist or is malformed.
+ */
+export function getAutonomyConfig(): AutonomyConfig {
+  const configPath = getAutonomyConfigPath();
+  if (!existsSync(configPath)) {
+    return { ...DEFAULT_AUTONOMY_CONFIG };
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+    return validateAutonomyConfig(raw);
+  } catch (err) {
+    log.warn({ err }, 'Failed to parse autonomy config; using defaults');
+    return { ...DEFAULT_AUTONOMY_CONFIG };
+  }
+}
+
+/**
+ * Merge partial updates into the existing autonomy configuration and persist.
+ * Only the provided fields are updated; omitted fields keep their current values.
+ */
+export function setAutonomyConfig(updates: Partial<AutonomyConfig>): AutonomyConfig {
+  const current = getAutonomyConfig();
+
+  if (updates.defaultTier !== undefined) {
+    current.defaultTier = updates.defaultTier;
+  }
+  if (updates.channelDefaults !== undefined) {
+    current.channelDefaults = { ...current.channelDefaults, ...updates.channelDefaults };
+  }
+  if (updates.categoryOverrides !== undefined) {
+    current.categoryOverrides = { ...current.categoryOverrides, ...updates.categoryOverrides };
+  }
+  if (updates.contactOverrides !== undefined) {
+    current.contactOverrides = { ...current.contactOverrides, ...updates.contactOverrides };
+  }
+
+  persistConfig(current);
+  return current;
+}
+
+/**
+ * Get the autonomy tier configured for a specific channel.
+ * Returns undefined if no channel-specific default is set.
+ */
+export function getChannelDefault(channel: string): AutonomyTier | undefined {
+  const config = getAutonomyConfig();
+  return config.channelDefaults[channel];
+}
+
+/**
+ * Set the autonomy tier for a specific channel.
+ */
+export function setChannelDefault(channel: string, tier: AutonomyTier): void {
+  const config = getAutonomyConfig();
+  config.channelDefaults[channel] = tier;
+  persistConfig(config);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function persistConfig(config: AutonomyConfig): void {
+  const configPath = getAutonomyConfigPath();
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+}
+
+function isValidTier(value: unknown): value is AutonomyTier {
+  return typeof value === 'string' && AUTONOMY_TIERS.includes(value as AutonomyTier);
+}
+
+function validateTierRecord(raw: unknown): Record<string, AutonomyTier> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const result: Record<string, AutonomyTier> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (isValidTier(value)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function validateAutonomyConfig(raw: unknown): AutonomyConfig {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...DEFAULT_AUTONOMY_CONFIG };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  return {
+    defaultTier: isValidTier(obj.defaultTier) ? obj.defaultTier : DEFAULT_AUTONOMY_CONFIG.defaultTier,
+    channelDefaults: validateTierRecord(obj.channelDefaults),
+    categoryOverrides: validateTierRecord(obj.categoryOverrides),
+    contactOverrides: validateTierRecord(obj.contactOverrides),
+  };
+}

--- a/assistant/src/autonomy/disposition-mapper.ts
+++ b/assistant/src/autonomy/disposition-mapper.ts
@@ -1,0 +1,31 @@
+/**
+ * Disposition mapper — bridges autonomy tiers to watcher event dispositions.
+ *
+ * The watcher engine uses three dispositions for event handling:
+ *   - `silent`   — act without notifying the user
+ *   - `notify`   — alert the user (with optional draft attached)
+ *   - `escalate` — alert the user and take no autonomous action
+ *
+ * This module maps autonomy tiers to those dispositions:
+ *   - `auto`   → `silent`   (act without notifying)
+ *   - `draft`  → `notify`   (prepare draft, alert user for approval)
+ *   - `notify` → `escalate` (alert user, take no action)
+ */
+
+import type { AutonomyTier } from './types.js';
+
+/** Watcher event disposition strings used by the watcher engine. */
+export type WatcherDisposition = 'silent' | 'notify' | 'escalate';
+
+const TIER_TO_DISPOSITION: Record<AutonomyTier, WatcherDisposition> = {
+  auto: 'silent',
+  draft: 'notify',
+  notify: 'escalate',
+};
+
+/**
+ * Map an autonomy tier to the corresponding watcher disposition.
+ */
+export function mapTierToDisposition(tier: AutonomyTier): WatcherDisposition {
+  return TIER_TO_DISPOSITION[tier];
+}

--- a/assistant/src/autonomy/index.ts
+++ b/assistant/src/autonomy/index.ts
@@ -1,0 +1,11 @@
+export type { AutonomyTier, AutonomyConfig } from './types.js';
+export { AUTONOMY_TIERS, DEFAULT_AUTONOMY_CONFIG } from './types.js';
+export {
+  getAutonomyConfig,
+  setAutonomyConfig,
+  getChannelDefault,
+  setChannelDefault,
+} from './autonomy-store.js';
+export { resolveAutonomyTier } from './autonomy-resolver.js';
+export type { WatcherDisposition } from './disposition-mapper.js';
+export { mapTierToDisposition } from './disposition-mapper.js';

--- a/assistant/src/autonomy/types.ts
+++ b/assistant/src/autonomy/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Autonomy tier types — govern what runs unsupervised per channel/category/contact.
+ *
+ * Three tiers:
+ * - `auto`   — act silently, no human in the loop
+ * - `draft`  — prepare a draft for human approval before sending
+ * - `notify` — alert the user but take no action (most conservative)
+ */
+
+export type AutonomyTier = 'auto' | 'draft' | 'notify';
+
+export const AUTONOMY_TIERS: readonly AutonomyTier[] = ['auto', 'draft', 'notify'] as const;
+
+/**
+ * Policy configuration for autonomy tiers. This is persisted as JSON config,
+ * not in the SQLite database — it represents explicit policy decisions, not
+ * learned preferences.
+ */
+export interface AutonomyConfig {
+  /** Global fallback tier when no more-specific rule matches. Defaults to 'notify'. */
+  defaultTier: AutonomyTier;
+
+  /** Per-channel defaults (e.g., { email: 'draft', slack: 'auto' }). */
+  channelDefaults: Record<string, AutonomyTier>;
+
+  /** Per-category overrides keyed by triage category (e.g., { newsletter: 'auto' }). */
+  categoryOverrides: Record<string, AutonomyTier>;
+
+  /** Per-contact overrides keyed by contact ID. */
+  contactOverrides: Record<string, AutonomyTier>;
+}
+
+/** Sensible defaults — conservative: everything starts as notify-only. */
+export const DEFAULT_AUTONOMY_CONFIG: AutonomyConfig = {
+  defaultTier: 'notify',
+  channelDefaults: {},
+  categoryOverrides: {},
+  contactOverrides: {},
+};

--- a/assistant/src/cli/autonomy.ts
+++ b/assistant/src/cli/autonomy.ts
@@ -1,0 +1,188 @@
+/**
+ * CLI command group: `vellum autonomy`
+ *
+ * View and configure autonomy tiers that govern what runs unsupervised
+ * per channel, category, or contact.
+ */
+
+import { Command } from 'commander';
+import {
+  getAutonomyConfig,
+  setAutonomyConfig,
+  AUTONOMY_TIERS,
+} from '../autonomy/index.js';
+import type { AutonomyTier } from '../autonomy/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function output(data: unknown, json: boolean): void {
+  process.stdout.write(
+    json ? JSON.stringify(data) + '\n' : JSON.stringify(data, null, 2) + '\n',
+  );
+}
+
+function exitError(message: string): void {
+  output({ ok: false, error: message }, true);
+  process.exitCode = 1;
+}
+
+function getJson(cmd: Command): boolean {
+  let c: Command | null = cmd;
+  while (c) {
+    if ((c.opts() as { json?: boolean }).json) return true;
+    c = c.parent;
+  }
+  return false;
+}
+
+function isValidTier(value: string): value is AutonomyTier {
+  return AUTONOMY_TIERS.includes(value as AutonomyTier);
+}
+
+function formatConfigForHuman(): string {
+  const config = getAutonomyConfig();
+  const lines: string[] = [
+    `  Default tier: ${config.defaultTier}`,
+  ];
+
+  const channelEntries = Object.entries(config.channelDefaults);
+  if (channelEntries.length > 0) {
+    lines.push('  Channel defaults:');
+    for (const [channel, tier] of channelEntries) {
+      lines.push(`    ${channel}: ${tier}`);
+    }
+  } else {
+    lines.push('  Channel defaults: (none)');
+  }
+
+  const categoryEntries = Object.entries(config.categoryOverrides);
+  if (categoryEntries.length > 0) {
+    lines.push('  Category overrides:');
+    for (const [category, tier] of categoryEntries) {
+      lines.push(`    ${category}: ${tier}`);
+    }
+  } else {
+    lines.push('  Category overrides: (none)');
+  }
+
+  const contactEntries = Object.entries(config.contactOverrides);
+  if (contactEntries.length > 0) {
+    lines.push('  Contact overrides:');
+    for (const [contactId, tier] of contactEntries) {
+      lines.push(`    ${contactId}: ${tier}`);
+    }
+  } else {
+    lines.push('  Contact overrides: (none)');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerAutonomyCommand(program: Command): void {
+  const autonomy = program
+    .command('autonomy')
+    .description('View and configure autonomy tiers')
+    .option('--json', 'Machine-readable JSON output');
+
+  autonomy
+    .command('get')
+    .description('Show current autonomy configuration')
+    .action((_opts: unknown, cmd: Command) => {
+      const config = getAutonomyConfig();
+      const json = getJson(cmd);
+
+      if (json) {
+        output({ ok: true, config }, true);
+      } else {
+        process.stdout.write('Autonomy configuration:\n\n');
+        process.stdout.write(formatConfigForHuman() + '\n');
+      }
+    });
+
+  autonomy
+    .command('set')
+    .description('Set autonomy tier for a channel, category, contact, or the global default')
+    .option('--default <tier>', 'Set the global default tier')
+    .option('--channel <channel>', 'Channel to configure (use with --tier)')
+    .option('--category <category>', 'Category to configure (use with --tier)')
+    .option('--contact <contactId>', 'Contact ID to configure (use with --tier)')
+    .option('--tier <tier>', 'Autonomy tier to set (auto, draft, notify)')
+    .action((opts: {
+      default?: string;
+      channel?: string;
+      category?: string;
+      contact?: string;
+      tier?: string;
+    }, cmd: Command) => {
+      const json = getJson(cmd);
+
+      // Set global default
+      if (opts.default) {
+        if (!isValidTier(opts.default)) {
+          exitError(`Invalid tier "${opts.default}". Must be one of: ${AUTONOMY_TIERS.join(', ')}`);
+          return;
+        }
+        const config = setAutonomyConfig({ defaultTier: opts.default });
+        if (json) {
+          output({ ok: true, config }, true);
+        } else {
+          process.stdout.write(`Set global default tier to "${opts.default}".\n`);
+        }
+        return;
+      }
+
+      // All other options require --tier
+      if (!opts.tier) {
+        exitError('Missing --tier. Use --tier <auto|draft|notify>.');
+        return;
+      }
+      if (!isValidTier(opts.tier)) {
+        exitError(`Invalid tier "${opts.tier}". Must be one of: ${AUTONOMY_TIERS.join(', ')}`);
+        return;
+      }
+
+      if (opts.channel) {
+        const config = setAutonomyConfig({
+          channelDefaults: { [opts.channel]: opts.tier },
+        });
+        if (json) {
+          output({ ok: true, config }, true);
+        } else {
+          process.stdout.write(`Set channel "${opts.channel}" default to "${opts.tier}".\n`);
+        }
+        return;
+      }
+
+      if (opts.category) {
+        const config = setAutonomyConfig({
+          categoryOverrides: { [opts.category]: opts.tier },
+        });
+        if (json) {
+          output({ ok: true, config }, true);
+        } else {
+          process.stdout.write(`Set category "${opts.category}" override to "${opts.tier}".\n`);
+        }
+        return;
+      }
+
+      if (opts.contact) {
+        const config = setAutonomyConfig({
+          contactOverrides: { [opts.contact]: opts.tier },
+        });
+        if (json) {
+          output({ ok: true, config }, true);
+        } else {
+          process.stdout.write(`Set contact "${opts.contact}" override to "${opts.tier}".\n`);
+        }
+        return;
+      }
+
+      exitError('Specify one of: --default <tier>, --channel <channel> --tier <tier>, --category <category> --tier <tier>, or --contact <contactId> --tier <tier>.');
+    });
+}

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -60,6 +60,7 @@ import {
 import { registerHooksCommand } from './hooks/cli.js';
 import { registerEmailCommand } from './cli/email.js';
 import { registerContactsCommand } from './cli/contacts.js';
+import { registerAutonomyCommand } from './cli/autonomy.js';
 
 function sendOneMessage(
   msg: ClientMessage,
@@ -993,6 +994,9 @@ registerEmailCommand(program);
 // --- Contacts commands ---
 registerContactsCommand(program);
 
+// --- Autonomy commands ---
+registerAutonomyCommand(program);
+
 // --- Completions command ---
 program
   .command('completions')
@@ -1008,10 +1012,11 @@ program
       memory: ['status', 'backfill', 'query', 'rebuild-index'],
       hooks: ['list', 'enable', 'disable', 'install', 'remove'],
       contacts: ['list', 'get', 'merge'],
+      autonomy: ['get', 'set'],
     };
     const topLevel = [
       'daemon', 'dev', 'sessions', 'config', 'keys', 'trust', 'memory',
-      'hooks', 'contacts', 'audit', 'doctor', 'completions', 'help',
+      'hooks', 'contacts', 'autonomy', 'audit', 'doctor', 'completions', 'help',
     ];
 
     switch (shell) {
@@ -1082,6 +1087,7 @@ _vellum() {
         'memory:Manage long-term memory'
         'hooks:Manage hooks'
         'contacts:Manage the contact graph'
+        'autonomy:View and configure autonomy tiers'
         'audit:Show recent tool invocations'
         'doctor:Run diagnostic checks'
         'completions:Generate shell completion script'
@@ -1126,6 +1132,7 @@ function generateFishCompletion(
     memory: 'Manage long-term memory',
     hooks: 'Manage hooks',
     contacts: 'Manage the contact graph',
+    autonomy: 'View and configure autonomy tiers',
     audit: 'Show recent tool invocations',
     doctor: 'Run diagnostic checks',
     completions: 'Generate shell completion script',


### PR DESCRIPTION
## Summary
- Add autonomy tier types (auto/draft/notify) and config storage
- Implement autonomy resolver with playbook → contact → category → channel → default precedence
- Add disposition mapper bridging autonomy tiers to watcher dispositions
- Add CLI commands for viewing and configuring autonomy settings

Part of #4178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
