### PR TITLE
feat: follow-up tracker (M6)

### DIFF
--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -1,0 +1,164 @@
+import { and, eq, lte, or } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from '../memory/db.js';
+import { followups } from '../memory/schema.js';
+import type { FollowUp, FollowUpCreateInput, FollowUpStatus } from './types.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function parseFollowUp(row: typeof followups.$inferSelect): FollowUp {
+  return {
+    id: row.id,
+    channel: row.channel,
+    threadId: row.threadId,
+    contactId: row.contactId,
+    sentAt: row.sentAt,
+    expectedResponseBy: row.expectedResponseBy,
+    status: row.status as FollowUpStatus,
+    reminderCronId: row.reminderCronId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ── CRUD ─────────────────────────────────────────────────────────────
+
+export function createFollowUp(input: FollowUpCreateInput): FollowUp {
+  const db = getDb();
+  const now = Date.now();
+  const id = uuid();
+
+  db.insert(followups).values({
+    id,
+    channel: input.channel,
+    threadId: input.threadId,
+    contactId: input.contactId ?? null,
+    sentAt: input.sentAt ?? now,
+    expectedResponseBy: input.expectedResponseBy ?? null,
+    status: 'pending',
+    reminderCronId: input.reminderCronId ?? null,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+
+  return getFollowUp(id)!;
+}
+
+export function getFollowUp(id: string): FollowUp | null {
+  const db = getDb();
+  const row = db.select().from(followups).where(eq(followups.id, id)).get();
+  if (!row) return null;
+  return parseFollowUp(row);
+}
+
+export function listFollowUps(filter?: {
+  status?: FollowUpStatus;
+  channel?: string;
+  contactId?: string;
+}): FollowUp[] {
+  const db = getDb();
+  const conditions = [];
+
+  if (filter?.status) {
+    conditions.push(eq(followups.status, filter.status));
+  }
+  if (filter?.channel) {
+    conditions.push(eq(followups.channel, filter.channel));
+  }
+  if (filter?.contactId) {
+    conditions.push(eq(followups.contactId, filter.contactId));
+  }
+
+  const whereClause = conditions.length > 0
+    ? conditions.length === 1
+      ? conditions[0]
+      : and(...conditions)
+    : undefined;
+
+  const rows = db
+    .select()
+    .from(followups)
+    .where(whereClause)
+    .all();
+
+  return rows.map(parseFollowUp);
+}
+
+export function resolveFollowUp(id: string): FollowUp {
+  const db = getDb();
+  const now = Date.now();
+
+  const existing = db.select().from(followups).where(eq(followups.id, id)).get();
+  if (!existing) throw new Error(`Follow-up "${id}" not found`);
+
+  db.update(followups)
+    .set({ status: 'resolved', updatedAt: now })
+    .where(eq(followups.id, id))
+    .run();
+
+  return getFollowUp(id)!;
+}
+
+export function resolveByThread(channel: string, threadId: string): FollowUp | null {
+  const db = getDb();
+  const now = Date.now();
+
+  // Find a pending or overdue follow-up matching this thread
+  const row = db
+    .select()
+    .from(followups)
+    .where(
+      and(
+        eq(followups.channel, channel),
+        eq(followups.threadId, threadId),
+        or(
+          eq(followups.status, 'pending'),
+          eq(followups.status, 'overdue'),
+          eq(followups.status, 'nudged'),
+        ),
+      ),
+    )
+    .get();
+
+  if (!row) return null;
+
+  db.update(followups)
+    .set({ status: 'resolved', updatedAt: now })
+    .where(eq(followups.id, row.id))
+    .run();
+
+  return getFollowUp(row.id)!;
+}
+
+export function getOverdueFollowUps(): FollowUp[] {
+  const db = getDb();
+  const now = Date.now();
+
+  const rows = db
+    .select()
+    .from(followups)
+    .where(
+      and(
+        eq(followups.status, 'pending'),
+        lte(followups.expectedResponseBy, now),
+      ),
+    )
+    .all();
+
+  return rows.map(parseFollowUp);
+}
+
+export function markNudged(id: string): FollowUp {
+  const db = getDb();
+  const now = Date.now();
+
+  const existing = db.select().from(followups).where(eq(followups.id, id)).get();
+  if (!existing) throw new Error(`Follow-up "${id}" not found`);
+
+  db.update(followups)
+    .set({ status: 'nudged', updatedAt: now })
+    .where(eq(followups.id, id))
+    .run();
+
+  return getFollowUp(id)!;
+}

--- a/assistant/src/followups/index.ts
+++ b/assistant/src/followups/index.ts
@@ -1,0 +1,10 @@
+export type { FollowUp, FollowUpCreateInput, FollowUpStatus } from './types.js';
+export {
+  createFollowUp,
+  getFollowUp,
+  listFollowUps,
+  resolveFollowUp,
+  resolveByThread,
+  getOverdueFollowUps,
+  markNudged,
+} from './followup-store.js';

--- a/assistant/src/followups/types.ts
+++ b/assistant/src/followups/types.ts
@@ -1,0 +1,23 @@
+export type FollowUpStatus = 'pending' | 'resolved' | 'overdue' | 'nudged';
+
+export interface FollowUp {
+  id: string;
+  channel: string;
+  threadId: string;
+  contactId: string | null;
+  sentAt: number;
+  expectedResponseBy: number | null;
+  status: FollowUpStatus;
+  reminderCronId: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface FollowUpCreateInput {
+  channel: string;
+  threadId: string;
+  contactId?: string | null;
+  sentAt?: number;
+  expectedResponseBy?: number | null;
+  reminderCronId?: string | null;
+}

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -672,6 +672,29 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_triage_results_sender ON triage_results(sender)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_triage_results_created_at ON triage_results(created_at DESC)`);
 
+  // ── Follow-ups ─────────────────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS followups (
+      id TEXT PRIMARY KEY,
+      channel TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      contact_id TEXT REFERENCES contacts(id) ON DELETE SET NULL,
+      sent_at INTEGER NOT NULL,
+      expected_response_by INTEGER,
+      status TEXT NOT NULL DEFAULT 'pending',
+      reminder_cron_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_followups_status ON followups(status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_followups_channel ON followups(channel)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_followups_contact_id ON followups(contact_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_followups_channel_thread ON followups(channel, thread_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_followups_status_expected ON followups(status, expected_response_by)`);
+
   migrateMemoryFtsBackfill(database);
 }
 

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -369,6 +369,22 @@ export const triageResults = sqliteTable('triage_results', {
   createdAt: integer('created_at').notNull(),
 });
 
+// ── Follow-ups ──────────────────────────────────────────────────────
+
+export const followups = sqliteTable('followups', {
+  id: text('id').primaryKey(),
+  channel: text('channel').notNull(),                     // 'email', 'slack', 'whatsapp', etc.
+  threadId: text('thread_id').notNull(),                  // external thread/conversation identifier
+  contactId: text('contact_id')
+    .references(() => contacts.id, { onDelete: 'set null' }),
+  sentAt: integer('sent_at').notNull(),                   // epoch ms — when the outbound message was sent
+  expectedResponseBy: integer('expected_response_by'),    // epoch ms — deadline for expected reply
+  status: text('status').notNull().default('pending'),    // 'pending' | 'resolved' | 'overdue' | 'nudged'
+  reminderCronId: text('reminder_cron_id'),               // optional cron job ID for reminder
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 export const homeBaseAppLinks = sqliteTable('home_base_app_links', {
   id: text('id').primaryKey(),
   appId: text('app_id').notNull(),

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -1,0 +1,118 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { createFollowUp } from '../../followups/followup-store.js';
+import { getContact } from '../../contacts/contact-store.js';
+import type { FollowUp } from '../../followups/types.js';
+
+function formatFollowUp(f: FollowUp): string {
+  const lines = [
+    `Follow-up ${f.id}`,
+    `  Channel: ${f.channel}`,
+    `  Thread: ${f.threadId}`,
+    `  Status: ${f.status}`,
+    `  Sent at: ${new Date(f.sentAt).toISOString()}`,
+  ];
+  if (f.contactId) lines.push(`  Contact ID: ${f.contactId}`);
+  if (f.expectedResponseBy) {
+    lines.push(`  Expected response by: ${new Date(f.expectedResponseBy).toISOString()}`);
+  }
+  if (f.reminderCronId) lines.push(`  Reminder cron: ${f.reminderCronId}`);
+  return lines.join('\n');
+}
+
+const definition: ToolDefinition = {
+  name: 'followup_create',
+  description: 'Create a follow-up tracker for a sent message. Tracks conversations awaiting a response across channels (email, Slack, WhatsApp, etc.).',
+  input_schema: {
+    type: 'object',
+    properties: {
+      channel: {
+        type: 'string',
+        description: 'Communication channel (e.g. email, slack, whatsapp)',
+      },
+      thread_id: {
+        type: 'string',
+        description: 'External thread or conversation identifier on that channel',
+      },
+      contact_id: {
+        type: 'string',
+        description: 'Optional contact ID from the contact graph. Used for grace period context.',
+      },
+      expected_response_hours: {
+        type: 'number',
+        description: 'Hours to wait for a response before marking as overdue. If omitted, no deadline is set.',
+      },
+      reminder_cron_id: {
+        type: 'string',
+        description: 'Optional cron job ID to fire a reminder when overdue',
+      },
+    },
+    required: ['channel', 'thread_id'],
+  },
+};
+
+class FollowUpCreateTool implements Tool {
+  name = 'followup_create';
+  description = definition.description;
+  category = 'followups';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const channel = input.channel as string | undefined;
+    if (!channel || typeof channel !== 'string' || channel.trim().length === 0) {
+      return { content: 'Error: channel is required and must be a non-empty string', isError: true };
+    }
+
+    const threadId = input.thread_id as string | undefined;
+    if (!threadId || typeof threadId !== 'string' || threadId.trim().length === 0) {
+      return { content: 'Error: thread_id is required and must be a non-empty string', isError: true };
+    }
+
+    const contactId = input.contact_id as string | undefined;
+    const expectedResponseHours = input.expected_response_hours as number | undefined;
+    const reminderCronId = input.reminder_cron_id as string | undefined;
+
+    // Validate contact exists if provided
+    if (contactId) {
+      const contact = getContact(contactId);
+      if (!contact) {
+        return { content: `Error: Contact "${contactId}" not found`, isError: true };
+      }
+    }
+
+    if (expectedResponseHours !== undefined && (typeof expectedResponseHours !== 'number' || expectedResponseHours <= 0)) {
+      return { content: 'Error: expected_response_hours must be a positive number', isError: true };
+    }
+
+    try {
+      const now = Date.now();
+      const expectedResponseBy = expectedResponseHours
+        ? now + expectedResponseHours * 60 * 60 * 1000
+        : null;
+
+      const followUp = createFollowUp({
+        channel: channel.trim(),
+        threadId: threadId.trim(),
+        contactId: contactId ?? null,
+        sentAt: now,
+        expectedResponseBy,
+        reminderCronId: reminderCronId ?? null,
+      });
+
+      return {
+        content: `Created follow-up:\n${formatFollowUp(followUp)}`,
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const followupCreateTool = new FollowUpCreateTool();

--- a/assistant/src/tools/followups/followup_list.ts
+++ b/assistant/src/tools/followups/followup_list.ts
@@ -1,0 +1,98 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { listFollowUps, getOverdueFollowUps } from '../../followups/followup-store.js';
+import type { FollowUp, FollowUpStatus } from '../../followups/types.js';
+
+const VALID_STATUSES = ['pending', 'resolved', 'overdue', 'nudged'] as const;
+
+function formatFollowUpSummary(f: FollowUp): string {
+  const parts = [`- **${f.channel}** thread:${f.threadId} (ID: ${f.id})`];
+  parts.push(`  Status: ${f.status} | Sent: ${new Date(f.sentAt).toISOString()}`);
+  if (f.contactId) parts.push(`  Contact: ${f.contactId}`);
+  if (f.expectedResponseBy) {
+    const deadline = new Date(f.expectedResponseBy);
+    const isOverdue = f.status === 'pending' && deadline.getTime() < Date.now();
+    parts.push(`  Expected by: ${deadline.toISOString()}${isOverdue ? ' (OVERDUE)' : ''}`);
+  }
+  return parts.join('\n');
+}
+
+const definition: ToolDefinition = {
+  name: 'followup_list',
+  description: 'List follow-ups with optional filters by status, channel, or contact. Can also show only overdue follow-ups.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      status: {
+        type: 'string',
+        enum: [...VALID_STATUSES],
+        description: 'Filter by status (pending, resolved, overdue, nudged)',
+      },
+      channel: {
+        type: 'string',
+        description: 'Filter by communication channel (e.g. email, slack)',
+      },
+      contact_id: {
+        type: 'string',
+        description: 'Filter by contact ID',
+      },
+      overdue_only: {
+        type: 'boolean',
+        description: 'When true, return only pending follow-ups past their expected response deadline',
+      },
+    },
+    required: [],
+  },
+};
+
+class FollowUpListTool implements Tool {
+  name = 'followup_list';
+  description = definition.description;
+  category = 'followups';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const status = input.status as FollowUpStatus | undefined;
+    const channel = input.channel as string | undefined;
+    const contactId = input.contact_id as string | undefined;
+    const overdueOnly = input.overdue_only as boolean | undefined;
+
+    if (status && !VALID_STATUSES.includes(status as typeof VALID_STATUSES[number])) {
+      return {
+        content: `Error: Invalid status "${status}". Must be one of: ${VALID_STATUSES.join(', ')}`,
+        isError: true,
+      };
+    }
+
+    try {
+      let results: FollowUp[];
+
+      if (overdueOnly) {
+        results = getOverdueFollowUps();
+      } else {
+        results = listFollowUps({ status, channel, contactId });
+      }
+
+      if (results.length === 0) {
+        return { content: 'No follow-ups found matching the criteria.', isError: false };
+      }
+
+      const lines = [`Found ${results.length} follow-up(s):\n`];
+      for (const followUp of results) {
+        lines.push(formatFollowUpSummary(followUp));
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const followupListTool = new FollowUpListTool();

--- a/assistant/src/tools/followups/followup_resolve.ts
+++ b/assistant/src/tools/followups/followup_resolve.ts
@@ -1,0 +1,89 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { resolveFollowUp, resolveByThread } from '../../followups/followup-store.js';
+import type { FollowUp } from '../../followups/types.js';
+
+function formatFollowUp(f: FollowUp): string {
+  const lines = [
+    `Follow-up ${f.id}`,
+    `  Channel: ${f.channel}`,
+    `  Thread: ${f.threadId}`,
+    `  Status: ${f.status}`,
+  ];
+  if (f.contactId) lines.push(`  Contact ID: ${f.contactId}`);
+  return lines.join('\n');
+}
+
+const definition: ToolDefinition = {
+  name: 'followup_resolve',
+  description: 'Manually resolve a follow-up by ID, or auto-resolve by channel + thread ID when a response is received.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'string',
+        description: 'Follow-up ID to resolve directly',
+      },
+      channel: {
+        type: 'string',
+        description: 'Channel to match (used with thread_id for auto-resolution)',
+      },
+      thread_id: {
+        type: 'string',
+        description: 'Thread ID to match (used with channel for auto-resolution)',
+      },
+    },
+    required: [],
+  },
+};
+
+class FollowUpResolveTool implements Tool {
+  name = 'followup_resolve';
+  description = definition.description;
+  category = 'followups';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const id = input.id as string | undefined;
+    const channel = input.channel as string | undefined;
+    const threadId = input.thread_id as string | undefined;
+
+    if (!id && !(channel && threadId)) {
+      return {
+        content: 'Error: Either id or both channel and thread_id are required',
+        isError: true,
+      };
+    }
+
+    try {
+      let followUp: FollowUp | null;
+
+      if (id) {
+        followUp = resolveFollowUp(id);
+      } else {
+        followUp = resolveByThread(channel!, threadId!);
+        if (!followUp) {
+          return {
+            content: `No pending follow-up found for channel="${channel}" thread="${threadId}"`,
+            isError: false,
+          };
+        }
+      }
+
+      return {
+        content: `Resolved follow-up:\n${formatFollowUp(followUp)}`,
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const followupResolveTool = new FollowUpResolveTool();

--- a/assistant/src/tools/followups/index.ts
+++ b/assistant/src/tools/followups/index.ts
@@ -1,0 +1,3 @@
+export { followupCreateTool } from './followup_create.js';
+export { followupListTool } from './followup_list.js';
+export { followupResolveTool } from './followup_resolve.js';

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,6 +18,7 @@ import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 import { contactUpsertTool, contactSearchTool, contactMergeTool } from './contacts/index.js';
+import { followupCreateTool, followupListTool, followupResolveTool } from './followups/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -95,6 +96,9 @@ export const explicitTools: Tool[] = [
   contactUpsertTool,
   contactSearchTool,
   contactMergeTool,
+  followupCreateTool,
+  followupListTool,
+  followupResolveTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `followups` table for tracking conversations awaiting responses
- Implement follow-up store with create, list, resolve, and overdue detection
- Add `followup_create`, `followup_list`, and `followup_resolve` tools
- Channel-agnostic: works for email, Slack, WhatsApp, any channel provider

Part of #4179

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
