### PR TITLE
fix(ios): use stroke instead of strokeBorder for input bar overlays

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -82,12 +82,12 @@ struct InputBarView: View {
                     .focused(isInputFocused)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .strokeBorder(VColor.surfaceBorder, lineWidth: isInputFocused.wrappedValue ? 1.5 : 1)
+                            .stroke(VColor.surfaceBorder, lineWidth: isInputFocused.wrappedValue ? 1.5 : 1)
                     )
                     .animation(.easeInOut(duration: 0.15), value: isInputFocused.wrappedValue)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .strokeBorder(VColor.surfaceBorder.opacity(0.12), lineWidth: 3)
+                            .stroke(VColor.surfaceBorder.opacity(0.12), lineWidth: 3)
                             .opacity(isInputFocused.wrappedValue ? 1 : 0)
                             .animation(.easeInOut(duration: 0.15), value: isInputFocused.wrappedValue)
                     )


### PR DESCRIPTION
## Summary
- Change `.strokeBorder()` → `.stroke()` for both the primary border and focus glow overlays on the message text field
- `.strokeBorder()` draws entirely inside the shape boundary, so the 3px focus glow renders inward (invisible behind the fill). `.stroke()` draws centered on the path (half inside, half outside), creating the intended outer glow effect that matches macOS `ComposerView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
