### PR TITLE
fix(ios): cache background.png UIImage to avoid per-render disk I/O

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -2,6 +2,12 @@
 import SwiftUI
 import VellumAssistantShared
 
+// Loaded once at startup; avoids decoding the 2.3MB PNG on every re-render.
+private let chatBackgroundImage: UIImage? = {
+    guard let url = Bundle.main.url(forResource: "background", withExtension: "png") else { return nil }
+    return UIImage(contentsOfFile: url.path)
+}()
+
 struct ChatTabView: View {
     @StateObject private var viewModel: ChatViewModel
     @FocusState private var isInputFocused: Bool
@@ -292,9 +298,7 @@ struct ChatTabView: View {
 
     @ViewBuilder
     private var chatBackground: some View {
-        if colorScheme == .dark,
-           let url = Bundle.main.url(forResource: "background", withExtension: "png"),
-           let uiImage = UIImage(contentsOfFile: url.path) {
+        if colorScheme == .dark, let uiImage = chatBackgroundImage {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFit()

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -494,9 +494,7 @@ struct ThreadChatView: View {
 
     @ViewBuilder
     private var chatBackground: some View {
-        if colorScheme == .dark,
-           let url = Bundle.main.url(forResource: "background", withExtension: "png"),
-           let uiImage = UIImage(contentsOfFile: url.path) {
+        if colorScheme == .dark, let uiImage = chatBackgroundImage {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFit()


### PR DESCRIPTION
## Summary
- Add a file-level `chatBackgroundImage: UIImage?` constant (lazy closure) that decodes `background.png` once at startup
- Remove the per-render `Bundle.main.url` + `UIImage(contentsOfFile:)` calls from `ChatTabView.chatBackground` and `ThreadChatView.chatBackground`
- Eliminates repeated 2.3MB PNG decodes on every SwiftUI re-render (e.g. each keystroke in the input bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
