### PR TITLE
fix: autonomy resolver hasOwn checks, deep copy defaults, and dir creation (#4191)

### DIFF
--- a/assistant/src/autonomy/autonomy-resolver.ts
+++ b/assistant/src/autonomy/autonomy-resolver.ts
@@ -37,17 +37,17 @@ export function resolveAutonomyTier(
   const config = getAutonomyConfig();
 
   // 2. Contact-specific override
-  if (contactId && contactId in config.contactOverrides) {
+  if (contactId && Object.hasOwn(config.contactOverrides, contactId)) {
     return config.contactOverrides[contactId];
   }
 
   // 3. Category override
-  if (triageResult.category in config.categoryOverrides) {
+  if (Object.hasOwn(config.categoryOverrides, triageResult.category)) {
     return config.categoryOverrides[triageResult.category];
   }
 
   // 4. Channel default
-  if (channel in config.channelDefaults) {
+  if (Object.hasOwn(config.channelDefaults, channel)) {
     return config.channelDefaults[channel];
   }
 

--- a/assistant/src/autonomy/autonomy-store.ts
+++ b/assistant/src/autonomy/autonomy-store.ts
@@ -7,8 +7,8 @@
  * preferences), so it belongs on disk rather than in the SQLite database.
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { getWorkspaceDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import type { AutonomyConfig, AutonomyTier } from './types.js';
@@ -27,7 +27,7 @@ function getAutonomyConfigPath(): string {
 export function getAutonomyConfig(): AutonomyConfig {
   const configPath = getAutonomyConfigPath();
   if (!existsSync(configPath)) {
-    return { ...DEFAULT_AUTONOMY_CONFIG };
+    return structuredClone(DEFAULT_AUTONOMY_CONFIG);
   }
 
   try {
@@ -35,7 +35,7 @@ export function getAutonomyConfig(): AutonomyConfig {
     return validateAutonomyConfig(raw);
   } catch (err) {
     log.warn({ err }, 'Failed to parse autonomy config; using defaults');
-    return { ...DEFAULT_AUTONOMY_CONFIG };
+    return structuredClone(DEFAULT_AUTONOMY_CONFIG);
   }
 }
 
@@ -87,6 +87,7 @@ export function setChannelDefault(channel: string, tier: AutonomyTier): void {
 
 function persistConfig(config: AutonomyConfig): void {
   const configPath = getAutonomyConfigPath();
+  mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
 }
 
@@ -107,7 +108,7 @@ function validateTierRecord(raw: unknown): Record<string, AutonomyTier> {
 
 function validateAutonomyConfig(raw: unknown): AutonomyConfig {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return { ...DEFAULT_AUTONOMY_CONFIG };
+    return structuredClone(DEFAULT_AUTONOMY_CONFIG);
   }
 
   const obj = raw as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Replace `in` operator with `Object.hasOwn()` in autonomy-resolver.ts for contact/category/channel override lookups to prevent prototype pollution
- Deep copy DEFAULT_AUTONOMY_CONFIG using structuredClone to prevent mutation of module-level constant
- Ensure ~/.vellum/workspace directory exists before writing autonomy.json

Addresses feedback from #4191
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
