### PR TITLE
fix: followup resolver thread matching, overdue filter, and filter passthrough (#4192)

### DIFF
--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -99,12 +99,12 @@ export function resolveFollowUp(id: string): FollowUp {
   return getFollowUp(id)!;
 }
 
-export function resolveByThread(channel: string, threadId: string): FollowUp | null {
+export function resolveByThread(channel: string, threadId: string): FollowUp[] {
   const db = getDb();
   const now = Date.now();
 
-  // Find a pending or overdue follow-up matching this thread
-  const row = db
+  // Find ALL pending/overdue/nudged follow-ups matching this thread
+  const rows = db
     .select()
     .from(followups)
     .where(
@@ -118,16 +118,18 @@ export function resolveByThread(channel: string, threadId: string): FollowUp | n
         ),
       ),
     )
-    .get();
+    .all();
 
-  if (!row) return null;
+  if (rows.length === 0) return [];
 
-  db.update(followups)
-    .set({ status: 'resolved', updatedAt: now })
-    .where(eq(followups.id, row.id))
-    .run();
+  for (const row of rows) {
+    db.update(followups)
+      .set({ status: 'resolved', updatedAt: now })
+      .where(eq(followups.id, row.id))
+      .run();
+  }
 
-  return getFollowUp(row.id)!;
+  return rows.map((row) => getFollowUp(row.id)!);
 }
 
 export function getOverdueFollowUps(): FollowUp[] {

--- a/assistant/src/tools/followups/followup_list.ts
+++ b/assistant/src/tools/followups/followup_list.ts
@@ -72,8 +72,10 @@ class FollowUpListTool implements Tool {
     try {
       let results: FollowUp[];
 
-      if (overdueOnly) {
+      if (overdueOnly || status === 'overdue') {
         results = getOverdueFollowUps();
+        if (channel) results = results.filter((f) => f.channel === channel);
+        if (contactId) results = results.filter((f) => f.contactId === contactId);
       } else {
         results = listFollowUps({ status, channel, contactId });
       }

--- a/assistant/src/tools/followups/followup_resolve.ts
+++ b/assistant/src/tools/followups/followup_resolve.ts
@@ -61,24 +61,26 @@ class FollowUpResolveTool implements Tool {
     }
 
     try {
-      let followUp: FollowUp | null;
-
       if (id) {
-        followUp = resolveFollowUp(id);
+        const followUp = resolveFollowUp(id);
+        return {
+          content: `Resolved follow-up:\n${formatFollowUp(followUp)}`,
+          isError: false,
+        };
       } else {
-        followUp = resolveByThread(channel!, threadId!);
-        if (!followUp) {
+        const resolved = resolveByThread(channel!, threadId!);
+        if (resolved.length === 0) {
           return {
             content: `No pending follow-up found for channel="${channel}" thread="${threadId}"`,
             isError: false,
           };
         }
+        const summaries = resolved.map(formatFollowUp).join('\n\n');
+        return {
+          content: `Resolved ${resolved.length} follow-up(s):\n${summaries}`,
+          isError: false,
+        };
       }
-
-      return {
-        content: `Resolved follow-up:\n${formatFollowUp(followUp)}`,
-        isError: false,
-      };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { content: `Error: ${msg}`, isError: true };


### PR DESCRIPTION
## Summary
- Fix resolveByThread to resolve ALL matching open rows instead of just the first one
- Handle status 'overdue' by querying pending items past their deadline
- Apply channel/contactId filters when using overdue_only flag
- Update followup_resolve tool to handle the new array return type

Addresses feedback from #4192
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
