### PR TITLE
fix: thread summarizer truncation prioritizes latest messages (#4196)

### DIFF
--- a/assistant/src/messaging/thread-summarizer.ts
+++ b/assistant/src/messaging/thread-summarizer.ts
@@ -108,17 +108,17 @@ function truncateMessages(
 
   // If the thread is short enough that first+last windows overlap, we can't
   // split into first/middle/last — but we still need to honor the token budget.
-  // Progressively drop the oldest messages until we fit.
+  // Progressively drop the oldest messages (from the front) to keep the
+  // newest context, which is more valuable for summarization.
   if (KEEP_FIRST + KEEP_LAST >= messages.length) {
-    const budgetChars = maxTokens * CHARS_PER_TOKEN;
     const kept = [...messages];
     while (kept.length > 1) {
       const transcript = formatTranscript(kept);
       if (transcript.length / CHARS_PER_TOKEN <= maxTokens) {
         return kept;
       }
-      // Drop the second message (preserve the first for context, trim from the front)
-      kept.splice(1, 1);
+      // Drop the first (oldest) message to prioritize keeping latest context
+      kept.shift();
     }
     return kept;
   }


### PR DESCRIPTION
## Summary
- Fix truncateMessages to prioritize keeping newest/latest messages when truncating to fit token budget
- Changed overlap path to drop from the front (oldest) instead of preserving the first message and dropping newest
- Ensures the most recent context is preserved for better summarization quality

Addresses feedback from #4196
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
