### PR TITLE
fix: contact store escapeLike strips wildcards instead of backslash-escaping (#4199)

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -6,9 +6,10 @@ import type { Contact, ContactChannel, ContactWithChannels } from './types.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-/** Escape LIKE metacharacters so user input is matched literally. */
+/** Strip LIKE metacharacters so user input is matched literally.
+ * SQLite has no default escape character for LIKE, so we strip rather than escape. */
 function escapeLike(value: string): string {
-  return value.replace(/%/g, '\\%').replace(/_/g, '\\_');
+  return value.replace(/%/g, '').replace(/_/g, '');
 }
 
 function parseContact(row: typeof contacts.$inferSelect): Contact {


### PR DESCRIPTION
## Summary
- Fix escapeLike to strip % and _ characters instead of backslash-escaping them
- SQLite has no default escape character for LIKE, so backslash escaping was broken
- Aligns with existing pattern in lexical.ts and contradiction-checker.ts

Addresses feedback from #4199
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
