### PR TITLE
fix(ios): make chatBackgroundImage internal so ThreadListView can access it

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 import VellumAssistantShared
 
 // Loaded once at startup; avoids decoding the 2.3MB PNG on every re-render.
-private let chatBackgroundImage: UIImage? = {
+// Internal (not private) so ThreadListView in the same module can share it.
+let chatBackgroundImage: UIImage? = {
     guard let url = Bundle.main.url(forResource: "background", withExtension: "png") else { return nil }
     return UIImage(contentsOfFile: url.path)
 }()


### PR DESCRIPTION
## Summary
- Remove `private` from the file-level `chatBackgroundImage` constant in `ChatTabView.swift`
- `private` at file scope in Swift means file-private — `ThreadListView.swift` (in the same module) couldn't resolve the symbol, breaking the build
- Internal access is the right level: both files are in the same SPM target and the constant is not part of any public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
