### PR TITLE
feat: add credential selection ranking helper (assistant-facing)

### DIFF
--- a/assistant/src/__tests__/credential-selection.test.ts
+++ b/assistant/src/__tests__/credential-selection.test.ts
@@ -1,0 +1,224 @@
+import { describe, test, expect } from 'bun:test';
+import { rankCredentialsForEndpoint } from '../tools/credentials/selection.js';
+import type { CredentialMetadata } from '../tools/credentials/metadata-store.js';
+
+function makeCred(overrides: Partial<CredentialMetadata> & { credentialId: string }): CredentialMetadata {
+  return {
+    service: 'test',
+    field: 'api_key',
+    allowedTools: [],
+    allowedDomains: [],
+    createdAt: 1000000,
+    updatedAt: 1000000,
+    ...overrides,
+  };
+}
+
+describe('rankCredentialsForEndpoint', () => {
+  test('returns null topChoice for empty credentials list', () => {
+    const result = rankCredentialsForEndpoint([], 'api.example.com');
+    expect(result.topChoice).toBeNull();
+    expect(result.candidates).toHaveLength(0);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test('exact host match ranks higher than wildcard', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'wildcard',
+        injectionTemplates: [{ hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization' }],
+      }),
+      makeCred({
+        credentialId: 'exact',
+        injectionTemplates: [{ hostPattern: 'queue.fal.ai', injectionType: 'header', headerName: 'Authorization' }],
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'queue.fal.ai');
+    expect(result.topChoice?.credentialId).toBe('exact');
+    expect(result.topChoice?.confidence).toBe('high');
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test('wildcard match ranks higher than no template match', () => {
+    const creds = [
+      makeCred({ credentialId: 'no-template' }),
+      makeCred({
+        credentialId: 'wildcard',
+        injectionTemplates: [{ hostPattern: '*.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.openai.com');
+    expect(result.topChoice?.credentialId).toBe('wildcard');
+    expect(result.topChoice?.confidence).toBe('medium');
+  });
+
+  test('wildcard *.example.com also matches bare example.com', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'wild',
+        injectionTemplates: [{ hostPattern: '*.example.com', injectionType: 'header' }],
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'example.com');
+    expect(result.topChoice?.credentialId).toBe('wild');
+    expect(result.topChoice?.confidence).toBe('medium');
+  });
+
+  test('alias set boosts score', () => {
+    const creds = [
+      makeCred({ credentialId: 'no-alias', updatedAt: 2000000 }),
+      makeCred({ credentialId: 'with-alias', alias: 'primary-key', updatedAt: 1000000 }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.example.com');
+    expect(result.topChoice?.credentialId).toBe('with-alias');
+  });
+
+  test('recency breaks ties when host specificity and alias are equal', () => {
+    const creds = [
+      makeCred({ credentialId: 'older', updatedAt: 1000000 }),
+      makeCred({ credentialId: 'newer', updatedAt: 2000000 }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.example.com');
+    expect(result.topChoice?.credentialId).toBe('newer');
+  });
+
+  test('filters out credentials with non-matching allowedDomains', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'restricted',
+        allowedDomains: ['other.com'],
+      }),
+      makeCred({
+        credentialId: 'unrestricted',
+        // empty allowedDomains = no restriction
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.example.com');
+    expect(result.candidates).toHaveLength(1);
+    expect(result.topChoice?.credentialId).toBe('unrestricted');
+  });
+
+  test('allowedDomains with wildcard pattern allows matching hosts', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'domain-match',
+        allowedDomains: ['*.fal.ai'],
+        injectionTemplates: [{ hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization' }],
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'queue.fal.ai');
+    expect(result.candidates).toHaveLength(1);
+    expect(result.topChoice?.credentialId).toBe('domain-match');
+  });
+
+  test('ambiguous is true when top two candidates are in the same scoring tier', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'a',
+        injectionTemplates: [{ hostPattern: '*.api.com', injectionType: 'header' }],
+        updatedAt: 1000001,
+      }),
+      makeCred({
+        credentialId: 'b',
+        injectionTemplates: [{ hostPattern: '*.api.com', injectionType: 'header' }],
+        updatedAt: 1000000,
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'v1.api.com');
+    expect(result.ambiguous).toBe(true);
+    expect(result.topChoice?.confidence).toBe('low');
+  });
+
+  test('ambiguous is false when top candidate is in a strictly higher tier', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'exact',
+        injectionTemplates: [{ hostPattern: 'api.example.com', injectionType: 'header' }],
+      }),
+      makeCred({
+        credentialId: 'wildcard',
+        injectionTemplates: [{ hostPattern: '*.example.com', injectionType: 'header' }],
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.example.com');
+    expect(result.ambiguous).toBe(false);
+    expect(result.topChoice?.credentialId).toBe('exact');
+  });
+
+  test('candidates are sorted descending by score', () => {
+    const creds = [
+      makeCred({ credentialId: 'low', updatedAt: 1000000 }),
+      makeCred({
+        credentialId: 'high',
+        injectionTemplates: [{ hostPattern: 'api.test.com', injectionType: 'header' }],
+        alias: 'primary',
+        updatedAt: 2000000,
+      }),
+      makeCred({
+        credentialId: 'mid',
+        injectionTemplates: [{ hostPattern: '*.test.com', injectionType: 'header' }],
+        updatedAt: 1500000,
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.test.com');
+    expect(result.candidates.map((c) => c.credentialId)).toEqual(['high', 'mid', 'low']);
+  });
+
+  test('match reasons reflect actual matching criteria', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'full',
+        injectionTemplates: [{ hostPattern: 'api.test.com', injectionType: 'header' }],
+        alias: 'my-key',
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.test.com');
+    expect(result.candidates[0].matchReason).toContain('exact host match');
+    expect(result.candidates[0].matchReason).toContain('alias set');
+  });
+
+  test('credential with no templates and no alias gets domain allowed reason', () => {
+    const creds = [makeCred({ credentialId: 'basic' })];
+    const result = rankCredentialsForEndpoint(creds, 'api.test.com');
+    expect(result.candidates[0].matchReason).toBe('domain allowed');
+  });
+
+  test('single credential returns non-ambiguous result', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'only',
+        injectionTemplates: [{ hostPattern: '*.example.com', injectionType: 'query', queryParamName: 'key' }],
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.example.com');
+    expect(result.ambiguous).toBe(false);
+    expect(result.topChoice?.credentialId).toBe('only');
+    expect(result.topChoice?.confidence).toBe('medium');
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  test('host matching is case-insensitive', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'case',
+        injectionTemplates: [{ hostPattern: 'API.Example.COM', injectionType: 'header' }],
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.example.com');
+    expect(result.topChoice?.credentialId).toBe('case');
+    expect(result.topChoice?.confidence).toBe('high');
+  });
+});

--- a/assistant/src/tools/credentials/selection.ts
+++ b/assistant/src/tools/credentials/selection.ts
@@ -1,0 +1,173 @@
+/**
+ * Credential selection ranking helper.
+ *
+ * Pure function that ranks stored credentials for a given target endpoint,
+ * allowing the assistant to auto-pick the best credential or know when
+ * to ask the user due to ambiguity.
+ */
+
+import type { CredentialMetadata } from './metadata-store.js';
+import type { CredentialInjectionTemplate } from './policy-types.js';
+
+export interface CredentialCandidate {
+  credentialId: string;
+  score: number;
+  matchReason: string;
+}
+
+export interface CredentialSelectionResult {
+  topChoice: { credentialId: string; confidence: 'high' | 'medium' | 'low' } | null;
+  candidates: CredentialCandidate[];
+  ambiguous: boolean;
+}
+
+/**
+ * Score multipliers — higher-priority criteria use larger values so they
+ * dominate over lower-priority ones regardless of accumulation.
+ */
+const SCORE_EXACT_HOST = 100;
+const SCORE_WILDCARD_HOST = 50;
+const SCORE_ALIAS_SET = 10;
+/** Per-second bonus (scaled to keep recency as a tiebreaker, not a dominant factor). */
+const RECENCY_SCALE = 1e-9;
+
+/**
+ * Check whether `host` matches a glob-style `hostPattern`.
+ * Supports leading wildcard like "*.example.com".
+ */
+function hostMatchesPattern(host: string, pattern: string): 'exact' | 'wildcard' | 'none' {
+  const lHost = host.toLowerCase();
+  const lPattern = pattern.toLowerCase();
+
+  if (lHost === lPattern) return 'exact';
+
+  // Wildcard patterns like "*.fal.ai"
+  if (lPattern.startsWith('*.')) {
+    const suffix = lPattern.slice(1); // ".fal.ai"
+    if (lHost.endsWith(suffix) && lHost.length > suffix.length) {
+      return 'wildcard';
+    }
+    // Also match the bare domain: "*.fal.ai" should match "fal.ai"
+    if (lHost === lPattern.slice(2)) {
+      return 'wildcard';
+    }
+  }
+
+  return 'none';
+}
+
+/**
+ * Compute the best host-match level across all injection templates for a credential.
+ */
+function bestHostMatch(
+  templates: CredentialInjectionTemplate[] | undefined,
+  targetHost: string,
+): 'exact' | 'wildcard' | 'none' {
+  if (!templates || templates.length === 0) return 'none';
+
+  let best: 'exact' | 'wildcard' | 'none' = 'none';
+  for (const t of templates) {
+    const match = hostMatchesPattern(targetHost, t.hostPattern);
+    if (match === 'exact') return 'exact'; // can't do better
+    if (match === 'wildcard') best = 'wildcard';
+  }
+  return best;
+}
+
+/**
+ * Rank credentials for a given endpoint and return a selection result.
+ *
+ * Ranking criteria (in priority order):
+ * 1. Template host specificity: exact > wildcard > no match
+ * 2. Alias hints: credentials with an alias rank higher
+ * 3. Recency: more recently updated credentials rank higher (tiebreaker)
+ *
+ * Only credentials whose `allowedDomains` include the target host (or are
+ * empty, which is treated as "no domain restriction") are considered.
+ */
+export function rankCredentialsForEndpoint(
+  credentials: CredentialMetadata[],
+  targetHost: string,
+  _targetPath?: string,
+): CredentialSelectionResult {
+  if (credentials.length === 0) {
+    return { topChoice: null, candidates: [], ambiguous: false };
+  }
+
+  const scored: CredentialCandidate[] = [];
+
+  for (const cred of credentials) {
+    // Domain policy check: if allowedDomains is non-empty, the target must match
+    if (cred.allowedDomains.length > 0) {
+      const domainAllowed = cred.allowedDomains.some(
+        (d) => hostMatchesPattern(targetHost, d) !== 'none',
+      );
+      if (!domainAllowed) continue;
+    }
+
+    let score = 0;
+    const reasons: string[] = [];
+
+    // 1. Host specificity from injection templates
+    const hostMatch = bestHostMatch(cred.injectionTemplates, targetHost);
+    if (hostMatch === 'exact') {
+      score += SCORE_EXACT_HOST;
+      reasons.push('exact host match');
+    } else if (hostMatch === 'wildcard') {
+      score += SCORE_WILDCARD_HOST;
+      reasons.push('wildcard host match');
+    }
+
+    // 2. Alias hint
+    if (cred.alias) {
+      score += SCORE_ALIAS_SET;
+      reasons.push('alias set');
+    }
+
+    // 3. Recency tiebreaker (use updatedAt)
+    score += cred.updatedAt * RECENCY_SCALE;
+
+    if (reasons.length === 0) {
+      reasons.push('domain allowed');
+    }
+
+    scored.push({
+      credentialId: cred.credentialId,
+      score,
+      matchReason: reasons.join(', '),
+    });
+  }
+
+  // Sort descending by score
+  scored.sort((a, b) => b.score - a.score);
+
+  if (scored.length === 0) {
+    return { topChoice: null, candidates: scored, ambiguous: false };
+  }
+
+  const top = scored[0];
+
+  // Determine ambiguity: top two scores are within the same tier
+  // (i.e., differ by less than the smallest tier gap)
+  const ambiguous =
+    scored.length >= 2 &&
+    Math.abs(top.score - scored[1].score) < SCORE_ALIAS_SET;
+
+  // Determine confidence
+  let confidence: 'high' | 'medium' | 'low';
+  if (ambiguous) {
+    confidence = 'low';
+  } else if (top.score >= SCORE_EXACT_HOST) {
+    confidence = 'high';
+  } else if (top.score >= SCORE_WILDCARD_HOST) {
+    confidence = 'medium';
+  } else {
+    confidence = 'low';
+  }
+
+  return {
+    topChoice: { credentialId: top.credentialId, confidence },
+    candidates: scored,
+    ambiguous,
+  };
+}


### PR DESCRIPTION
## Summary
- Add deterministic ranking helper to suggest best credential_id for an endpoint
- Rank by template host specificity, alias hints, and recency
- Return ambiguity metadata when top candidates tie
- Pure helper — no side effects

## Behavior Delta
New utility file only — no runtime integration yet.

## Tests Run
- `bun test src/__tests__/credential-selection.test.ts`

## Rollback
Remove helper file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
