### PR TITLE
test: add unit tests for multi-key same-service selection

### DIFF
--- a/assistant/src/__tests__/credential-selection.test.ts
+++ b/assistant/src/__tests__/credential-selection.test.ts
@@ -222,3 +222,105 @@ describe('rankCredentialsForEndpoint', () => {
     expect(result.topChoice?.confidence).toBe('high');
   });
 });
+
+describe('multi-key same-service selection', () => {
+  test('two OpenAI credentials targeting the same endpoint — deterministic chosen credential_id', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'openai-key-1',
+        service: 'openai',
+        injectionTemplates: [{ hostPattern: 'api.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 1000000,
+      }),
+      makeCred({
+        credentialId: 'openai-key-2',
+        service: 'openai',
+        injectionTemplates: [{ hostPattern: 'api.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 2000000,
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.openai.com');
+    // Both have exact host match (score 100), differ only by recency.
+    // Recency difference is small (< SCORE_ALIAS_SET=10), so this is ambiguous.
+    expect(result.ambiguous).toBe(true);
+    expect(result.topChoice?.confidence).toBe('low');
+    // Despite ambiguity, topChoice is deterministic: the more recent key wins.
+    expect(result.topChoice?.credentialId).toBe('openai-key-2');
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  test('ambiguity fallback path when two credentials have identical scores', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'key-a',
+        service: 'openai',
+        injectionTemplates: [{ hostPattern: '*.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 1000000,
+      }),
+      makeCred({
+        credentialId: 'key-b',
+        service: 'openai',
+        injectionTemplates: [{ hostPattern: '*.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 1000000,
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.openai.com');
+    expect(result.ambiguous).toBe(true);
+    expect(result.topChoice?.confidence).toBe('low');
+    // Both candidates are present
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  test('one credential with specific host template wins over one with generic template', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'generic-key',
+        service: 'openai',
+        injectionTemplates: [{ hostPattern: '*.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 2000000,
+      }),
+      makeCred({
+        credentialId: 'specific-key',
+        service: 'openai',
+        injectionTemplates: [{ hostPattern: 'api.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 1000000,
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.openai.com');
+    // exact host (100) vs wildcard (50) — not ambiguous, specific key wins
+    expect(result.topChoice?.credentialId).toBe('specific-key');
+    expect(result.topChoice?.confidence).toBe('high');
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test('both credentials have aliases — alias alone does not break ties', () => {
+    const creds = [
+      makeCred({
+        credentialId: 'aliased-1',
+        service: 'openai',
+        alias: 'production-key',
+        injectionTemplates: [{ hostPattern: 'api.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 1000000,
+      }),
+      makeCred({
+        credentialId: 'aliased-2',
+        service: 'openai',
+        alias: 'staging-key',
+        injectionTemplates: [{ hostPattern: 'api.openai.com', injectionType: 'header', headerName: 'Authorization' }],
+        updatedAt: 1000000,
+      }),
+    ];
+
+    const result = rankCredentialsForEndpoint(creds, 'api.openai.com');
+    // Both have exact host (100) + alias (10) = 110 each + identical recency
+    // Score difference is 0, which is < SCORE_ALIAS_SET, so ambiguous
+    expect(result.ambiguous).toBe(true);
+    expect(result.topChoice?.confidence).toBe('low');
+    expect(result.candidates).toHaveLength(2);
+    // Both candidates score 110 + same recency
+    expect(result.candidates[0].score).toBeCloseTo(result.candidates[1].score, 5);
+  });
+});

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -683,6 +683,92 @@ describe('credential_store tool', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Multi-key same-service vault storage
+  // -----------------------------------------------------------------------
+  describe('multi-key same-service storage', () => {
+    test('stores two credentials with same service but different aliases', async () => {
+      const result1 = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'openai',
+        field: 'api_key_prod',
+        value: 'sk-prod-abc',
+        alias: 'production',
+      }, _ctx);
+      expect(result1.isError).toBe(false);
+
+      const result2 = await credentialStoreTool.execute({
+        action: 'store',
+        service: 'openai',
+        field: 'api_key_staging',
+        value: 'sk-staging-xyz',
+        alias: 'staging',
+      }, _ctx);
+      expect(result2.isError).toBe(false);
+
+      // Verify both stored independently in metadata
+      const meta1 = getCredentialMetadata('openai', 'api_key_prod');
+      const meta2 = getCredentialMetadata('openai', 'api_key_staging');
+      expect(meta1).toBeDefined();
+      expect(meta2).toBeDefined();
+      expect(meta1!.alias).toBe('production');
+      expect(meta2!.alias).toBe('staging');
+    });
+
+    test('listing shows both same-service credentials independently', async () => {
+      await credentialStoreTool.execute({
+        action: 'store',
+        service: 'openai',
+        field: 'api_key_prod',
+        value: 'sk-prod-abc',
+        alias: 'production',
+      }, _ctx);
+      await credentialStoreTool.execute({
+        action: 'store',
+        service: 'openai',
+        field: 'api_key_staging',
+        value: 'sk-staging-xyz',
+        alias: 'staging',
+      }, _ctx);
+
+      const result = await credentialStoreTool.execute({ action: 'list' }, _ctx);
+      expect(result.isError).toBe(false);
+
+      const entries = JSON.parse(result.content);
+      const openaiEntries = entries.filter((e: { service: string }) => e.service === 'openai');
+      expect(openaiEntries).toHaveLength(2);
+
+      const aliases = openaiEntries.map((e: { alias?: string }) => e.alias).sort();
+      expect(aliases).toEqual(['production', 'staging']);
+    });
+
+    test('each same-service credential has its own credential_id', async () => {
+      await credentialStoreTool.execute({
+        action: 'store',
+        service: 'openai',
+        field: 'api_key_prod',
+        value: 'sk-prod-abc',
+        alias: 'production',
+      }, _ctx);
+      await credentialStoreTool.execute({
+        action: 'store',
+        service: 'openai',
+        field: 'api_key_staging',
+        value: 'sk-staging-xyz',
+        alias: 'staging',
+      }, _ctx);
+
+      const meta1 = getCredentialMetadata('openai', 'api_key_prod');
+      const meta2 = getCredentialMetadata('openai', 'api_key_staging');
+      expect(meta1).toBeDefined();
+      expect(meta2).toBeDefined();
+      expect(meta1!.credentialId).not.toBe(meta2!.credentialId);
+      // Both should be valid UUIDs (non-empty strings)
+      expect(meta1!.credentialId.length).toBeGreaterThan(0);
+      expect(meta2!.credentialId.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Namespace isolation
   // -----------------------------------------------------------------------
   describe('namespace isolation', () => {


### PR DESCRIPTION
## Summary
- Lock multi-key same-service credential selection behavior
- Test deterministic credential_id choice and ambiguity fallback
- Test vault storage of multiple same-service credentials with different aliases

## Behavior Delta
Tests-only — no runtime changes.

## Tests Run
- `bun test src/__tests__/credential-selection.test.ts` — 19 pass
- `bun test src/__tests__/credential-vault.test.ts` — 36 pass

## Rollback
Revert added tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
