### PR TITLE
feat: proxy skeleton: session manager + lifecycle + interfaces

### DIFF
--- a/assistant/src/__tests__/script-proxy-session-manager.test.ts
+++ b/assistant/src/__tests__/script-proxy-session-manager.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import {
+  createSession,
+  startSession,
+  stopSession,
+  getSessionEnv,
+  getActiveSession,
+  getSessionsForConversation,
+  stopAllSessions,
+  type ProxySession,
+} from '../tools/network/script-proxy/index.js';
+
+afterEach(async () => {
+  await stopAllSessions();
+});
+
+describe('session-manager', () => {
+  const CONV_ID = 'conv-test-1';
+  const CRED_IDS = ['cred-a', 'cred-b'];
+
+  describe('createSession', () => {
+    test('creates a session in starting status with no port', () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      expect(session.id).toBeTruthy();
+      expect(session.conversationId).toBe(CONV_ID);
+      expect(session.credentialIds).toEqual(CRED_IDS);
+      expect(session.status).toBe('starting');
+      expect(session.port).toBeNull();
+      expect(session.createdAt).toBeInstanceOf(Date);
+    });
+
+    test('generates unique IDs', () => {
+      const a = createSession(CONV_ID, CRED_IDS);
+      const b = createSession(CONV_ID, CRED_IDS);
+      expect(a.id).not.toBe(b.id);
+    });
+
+    test('enforces maxSessionsPerConversation', () => {
+      createSession(CONV_ID, CRED_IDS, { maxSessionsPerConversation: 1 });
+      expect(() =>
+        createSession(CONV_ID, CRED_IDS, { maxSessionsPerConversation: 1 }),
+      ).toThrow(/Max sessions/);
+    });
+
+    test('does not count stopped sessions toward the limit', async () => {
+      const s = createSession(CONV_ID, CRED_IDS, { maxSessionsPerConversation: 1 });
+      await startSession(s.id);
+      await stopSession(s.id);
+      // Should succeed because the first session is now stopped
+      const s2 = createSession(CONV_ID, CRED_IDS, { maxSessionsPerConversation: 1 });
+      expect(s2.id).toBeTruthy();
+    });
+  });
+
+  describe('startSession', () => {
+    test('starts listening on an ephemeral port', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      const started = await startSession(session.id);
+      expect(started.status).toBe('active');
+      expect(started.port).toBeGreaterThan(0);
+    });
+
+    test('throws when session does not exist', async () => {
+      await expect(startSession('nonexistent')).rejects.toThrow(/not found/);
+    });
+
+    test('throws when session is not in starting status', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      await startSession(session.id);
+      await expect(startSession(session.id)).rejects.toThrow(/expected starting/);
+    });
+  });
+
+  describe('stopSession', () => {
+    test('stops an active session', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      await startSession(session.id);
+      await stopSession(session.id);
+
+      const all = getSessionsForConversation(CONV_ID);
+      const stopped = all.find((s) => s.id === session.id);
+      expect(stopped?.status).toBe('stopped');
+      expect(stopped?.port).toBeNull();
+    });
+
+    test('is idempotent for already-stopped sessions', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      await startSession(session.id);
+      await stopSession(session.id);
+      // Should not throw
+      await stopSession(session.id);
+    });
+
+    test('throws for nonexistent session', async () => {
+      await expect(stopSession('nonexistent')).rejects.toThrow(/not found/);
+    });
+  });
+
+  describe('getSessionEnv', () => {
+    test('returns proxy env vars for an active session', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      const started = await startSession(session.id);
+      const env = getSessionEnv(session.id);
+
+      expect(env.HTTP_PROXY).toBe(`http://127.0.0.1:${started.port}`);
+      expect(env.HTTPS_PROXY).toBe(`http://127.0.0.1:${started.port}`);
+      expect(env.NO_PROXY).toBe('localhost,127.0.0.1,::1');
+    });
+
+    test('throws for inactive session', () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      expect(() => getSessionEnv(session.id)).toThrow(/not active/);
+    });
+  });
+
+  describe('getActiveSession', () => {
+    test('returns an active session for the conversation', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      await startSession(session.id);
+      const active = getActiveSession(CONV_ID);
+      expect(active).toBeDefined();
+      expect(active!.id).toBe(session.id);
+      expect(active!.status).toBe('active');
+    });
+
+    test('returns undefined when no active session exists', () => {
+      expect(getActiveSession('nonexistent-conv')).toBeUndefined();
+    });
+
+    test('returns undefined after session is stopped', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      await startSession(session.id);
+      await stopSession(session.id);
+      expect(getActiveSession(CONV_ID)).toBeUndefined();
+    });
+  });
+
+  describe('getSessionsForConversation', () => {
+    test('returns all sessions for a conversation', async () => {
+      createSession(CONV_ID, CRED_IDS);
+      createSession(CONV_ID, ['cred-c']);
+      const all = getSessionsForConversation(CONV_ID);
+      expect(all).toHaveLength(2);
+    });
+
+    test('does not include sessions from other conversations', () => {
+      createSession(CONV_ID, CRED_IDS);
+      createSession('other-conv', CRED_IDS);
+      const all = getSessionsForConversation(CONV_ID);
+      expect(all).toHaveLength(1);
+    });
+  });
+
+  describe('stopAllSessions', () => {
+    test('stops all active sessions', async () => {
+      const a = createSession(CONV_ID, CRED_IDS);
+      const b = createSession('conv-2', CRED_IDS);
+      await startSession(a.id);
+      await startSession(b.id);
+
+      await stopAllSessions();
+
+      // After stopAll + clear, no sessions should exist
+      expect(getActiveSession(CONV_ID)).toBeUndefined();
+      expect(getActiveSession('conv-2')).toBeUndefined();
+    });
+  });
+
+  describe('idle timeout', () => {
+    test('auto-stops session after idle timeout', async () => {
+      const session = createSession(CONV_ID, CRED_IDS, { idleTimeoutMs: 100 });
+      await startSession(session.id);
+      expect(getActiveSession(CONV_ID)).toBeDefined();
+
+      // Wait for the idle timeout to fire
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(getActiveSession(CONV_ID)).toBeUndefined();
+      const all = getSessionsForConversation(CONV_ID);
+      const s = all.find((x) => x.id === session.id);
+      expect(s?.status).toBe('stopped');
+    });
+  });
+});

--- a/assistant/src/tools/network/script-proxy/index.ts
+++ b/assistant/src/tools/network/script-proxy/index.ts
@@ -1,0 +1,17 @@
+export type {
+  ProxySessionId,
+  ProxySession,
+  ProxySessionConfig,
+  ProxySessionStatus,
+  ProxyEnvVars,
+} from './types.js';
+
+export {
+  createSession,
+  startSession,
+  stopSession,
+  getSessionEnv,
+  getActiveSession,
+  getSessionsForConversation,
+  stopAllSessions,
+} from './session-manager.js';

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -1,0 +1,193 @@
+import { createServer, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import type {
+  ProxySession,
+  ProxySessionId,
+  ProxySessionConfig,
+  ProxyEnvVars,
+} from './types.js';
+
+const DEFAULT_CONFIG: ProxySessionConfig = {
+  idleTimeoutMs: 5 * 60 * 1000, // 5 minutes
+  maxSessionsPerConversation: 3,
+};
+
+interface ManagedSession {
+  session: ProxySession;
+  server: Server | null;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  config: ProxySessionConfig;
+}
+
+const sessions = new Map<ProxySessionId, ManagedSession>();
+
+function resetIdleTimer(managed: ManagedSession): void {
+  if (managed.idleTimer !== null) {
+    clearTimeout(managed.idleTimer);
+  }
+  managed.idleTimer = setTimeout(() => {
+    if (managed.session.status === 'active') {
+      stopSession(managed.session.id);
+    }
+  }, managed.config.idleTimeoutMs);
+}
+
+/**
+ * Create a new proxy session bound to a conversation.
+ * The session starts in 'starting' status with no port assigned yet.
+ */
+export function createSession(
+  conversationId: string,
+  credentialIds: string[],
+  config?: Partial<ProxySessionConfig>,
+): ProxySession {
+  const merged: ProxySessionConfig = { ...DEFAULT_CONFIG, ...config };
+
+  // Enforce per-conversation limit
+  const existing = getSessionsForConversation(conversationId);
+  const liveCount = existing.filter(
+    (s) => s.status !== 'stopped',
+  ).length;
+  if (liveCount >= merged.maxSessionsPerConversation) {
+    throw new Error(
+      `Max sessions (${merged.maxSessionsPerConversation}) reached for conversation ${conversationId}`,
+    );
+  }
+
+  const session: ProxySession = {
+    id: randomUUID(),
+    conversationId,
+    credentialIds: [...credentialIds],
+    status: 'starting',
+    createdAt: new Date(),
+    port: null,
+  };
+
+  sessions.set(session.id, {
+    session,
+    server: null,
+    idleTimer: null,
+    config: merged,
+  });
+
+  return { ...session };
+}
+
+/**
+ * Start the proxy session — opens an HTTP server on an ephemeral port.
+ * Resolves once the server is listening.
+ */
+export async function startSession(sessionId: ProxySessionId): Promise<ProxySession> {
+  const managed = sessions.get(sessionId);
+  if (!managed) throw new Error(`Session not found: ${sessionId}`);
+  if (managed.session.status !== 'starting') {
+    throw new Error(`Session ${sessionId} is ${managed.session.status}, expected starting`);
+  }
+
+  const server = createServer((_req, res) => {
+    // Placeholder — no traffic routing in this PR
+    res.writeHead(502, { 'Content-Type': 'text/plain' });
+    res.end('Proxy not yet implemented');
+  });
+
+  return new Promise<ProxySession>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get server address'));
+        return;
+      }
+      managed.server = server;
+      managed.session.port = addr.port;
+      managed.session.status = 'active';
+      resetIdleTimer(managed);
+      resolve({ ...managed.session });
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Gracefully stop a session — closes the HTTP server and clears the idle timer.
+ */
+export async function stopSession(sessionId: ProxySessionId): Promise<void> {
+  const managed = sessions.get(sessionId);
+  if (!managed) throw new Error(`Session not found: ${sessionId}`);
+  if (managed.session.status === 'stopped') return;
+
+  managed.session.status = 'stopping';
+
+  if (managed.idleTimer !== null) {
+    clearTimeout(managed.idleTimer);
+    managed.idleTimer = null;
+  }
+
+  if (managed.server) {
+    await new Promise<void>((resolve, reject) => {
+      managed.server!.close((err) => (err ? reject(err) : resolve()));
+    });
+    managed.server = null;
+  }
+
+  managed.session.status = 'stopped';
+  managed.session.port = null;
+}
+
+/**
+ * Build environment variables to inject into a subprocess so its HTTP
+ * traffic flows through this proxy session.
+ */
+export function getSessionEnv(sessionId: ProxySessionId): ProxyEnvVars {
+  const managed = sessions.get(sessionId);
+  if (!managed) throw new Error(`Session not found: ${sessionId}`);
+  if (managed.session.status !== 'active' || managed.session.port === null) {
+    throw new Error(`Session ${sessionId} is not active`);
+  }
+
+  // Touch the idle timer on access
+  resetIdleTimer(managed);
+
+  const proxyUrl = `http://127.0.0.1:${managed.session.port}`;
+  return {
+    HTTP_PROXY: proxyUrl,
+    HTTPS_PROXY: proxyUrl,
+    NO_PROXY: 'localhost,127.0.0.1,::1',
+  };
+}
+
+/**
+ * Find an active session for a conversation (returns the first match).
+ */
+export function getActiveSession(conversationId: string): ProxySession | undefined {
+  for (const managed of sessions.values()) {
+    if (
+      managed.session.conversationId === conversationId &&
+      managed.session.status === 'active'
+    ) {
+      return { ...managed.session };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Get all sessions for a given conversation.
+ */
+export function getSessionsForConversation(conversationId: string): ProxySession[] {
+  const result: ProxySession[] = [];
+  for (const managed of sessions.values()) {
+    if (managed.session.conversationId === conversationId) {
+      result.push({ ...managed.session });
+    }
+  }
+  return result;
+}
+
+/**
+ * Stop all sessions and clear internal state. Useful for daemon shutdown.
+ */
+export async function stopAllSessions(): Promise<void> {
+  const ids = [...sessions.keys()];
+  await Promise.all(ids.map((id) => stopSession(id).catch(() => {})));
+  sessions.clear();
+}

--- a/assistant/src/tools/network/script-proxy/types.ts
+++ b/assistant/src/tools/network/script-proxy/types.ts
@@ -1,0 +1,28 @@
+/** Unique identifier for a proxy session. */
+export type ProxySessionId = string;
+
+export type ProxySessionStatus = 'starting' | 'active' | 'stopping' | 'stopped';
+
+export interface ProxySession {
+  id: ProxySessionId;
+  conversationId: string;
+  credentialIds: string[];
+  status: ProxySessionStatus;
+  createdAt: Date;
+  /** Ephemeral port assigned once the session starts listening. */
+  port: number | null;
+}
+
+export interface ProxySessionConfig {
+  /** How long (ms) an idle session stays alive before auto-stopping. */
+  idleTimeoutMs: number;
+  /** Maximum concurrent sessions per conversation. */
+  maxSessionsPerConversation: number;
+}
+
+export interface ProxyEnvVars {
+  HTTP_PROXY: string;
+  HTTPS_PROXY: string;
+  NO_PROXY: string;
+  SSL_CERT_FILE?: string;
+}


### PR DESCRIPTION
## Summary
- Define proxy session types and lifecycle interfaces (`ProxySession`, `ProxySessionConfig`, `ProxyEnvVars`)
- Implement session manager with create/start/stop/getEnv/getActiveSession
- Add per-session ID generation (crypto.randomUUID), conversation binding, and idle-timeout auto-cleanup
- All new files — no existing code modified

## Behavior Delta
New scaffold only — no traffic routing, no integration with bash tool yet.

## Tests Run
- `bun test src/__tests__/script-proxy-session-manager.test.ts` — 19 tests, all passing

## Rollback
Remove scaffold files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
