### PR TITLE
feat: proxy policy engine: template match + credential binding

### DIFF
--- a/assistant/src/__tests__/script-proxy-policy.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test';
+import { evaluateRequest } from '../tools/network/script-proxy/policy.js';
+import type { CredentialInjectionTemplate } from '../tools/credentials/policy-types.js';
+
+function headerTemplate(
+  hostPattern: string,
+  headerName = 'Authorization',
+  valuePrefix = 'Key ',
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'header', headerName, valuePrefix };
+}
+
+function queryTemplate(
+  hostPattern: string,
+  queryParamName: string,
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'query', queryParamName };
+}
+
+describe('evaluateRequest', () => {
+  test('returns unauthenticated when no credential_ids are provided', () => {
+    const result = evaluateRequest('api.fal.ai', '/v1/run', [], new Map());
+    expect(result).toEqual({ kind: 'unauthenticated' });
+  });
+
+  test('returns missing when credential_ids exist but no templates match', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.openai.com')]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-1'], templates);
+    expect(result).toEqual({ kind: 'missing' });
+  });
+
+  test('returns missing when credential_id has no templates at all', () => {
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-unknown'], new Map());
+    expect(result).toEqual({ kind: 'missing' });
+  });
+
+  test('returns matched for a single matching credential', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/v1/run', ['cred-fal'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-fal', template: tpl });
+  });
+
+  test('returns matched with exact hostname pattern', () => {
+    const tpl = headerTemplate('api.replicate.com', 'Authorization', 'Token ');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-rep', [tpl]],
+    ]);
+    const result = evaluateRequest('api.replicate.com', '/v1/predictions', ['cred-rep'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-rep', template: tpl });
+  });
+
+  test('returns ambiguous when multiple credentials match', () => {
+    const tpl1 = headerTemplate('*.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('*.fal.ai', 'X-Api-Key');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [tpl1]],
+      ['cred-b', [tpl2]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-a', 'cred-b'], templates);
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toHaveLength(2);
+      expect(result.candidates[0]).toEqual({ credentialId: 'cred-a', template: tpl1 });
+      expect(result.candidates[1]).toEqual({ credentialId: 'cred-b', template: tpl2 });
+    }
+  });
+
+  test('only considers credentials in the credentialIds list', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [tpl]],
+      ['cred-b', [headerTemplate('*.fal.ai', 'X-Key')]],
+    ]);
+    // Only cred-a is in the allowed list
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-a'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-a', template: tpl });
+  });
+
+  test('handles multiple templates per credential — returns first match', () => {
+    const tpl1 = headerTemplate('*.openai.com');
+    const tpl2 = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-multi', [tpl1, tpl2]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-multi'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-multi', template: tpl2 });
+  });
+
+  test('returns ambiguous when one credential matches multiple templates', () => {
+    const tpl1 = headerTemplate('*.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('api.fal.ai', 'Authorization', 'Bearer ');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-dual', [tpl1, tpl2]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-dual'], templates);
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+
+  test('works with query injection templates', () => {
+    const tpl = queryTemplate('maps.googleapis.com', 'key');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-gcp', [tpl]],
+    ]);
+    const result = evaluateRequest('maps.googleapis.com', '/api/geocode', ['cred-gcp'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-gcp', template: tpl });
+  });
+
+  test('non-matching hostname with glob returns missing', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = evaluateRequest('fal.ai', '/', ['cred-1'], templates);
+    // "*.fal.ai" does not match bare "fal.ai" with minimatch
+    expect(result).toEqual({ kind: 'missing' });
+  });
+});

--- a/assistant/src/tools/network/script-proxy/policy.ts
+++ b/assistant/src/tools/network/script-proxy/policy.ts
@@ -1,0 +1,59 @@
+/**
+ * Proxy policy engine — matches outbound request targets to credential
+ * injection templates and emits deterministic policy decisions.
+ */
+
+import { minimatch } from 'minimatch';
+import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
+import type { PolicyDecision } from './types.js';
+
+interface MatchCandidate {
+  credentialId: string;
+  template: CredentialInjectionTemplate;
+}
+
+/**
+ * Evaluate an outbound request against credential injection templates.
+ *
+ * @param hostname  Target hostname (e.g. "api.fal.ai")
+ * @param _path     Request path — reserved for future path-level matching
+ * @param credentialIds  Credential IDs the session is authorized to use
+ * @param templates  Map from credentialId → injection templates
+ */
+export function evaluateRequest(
+  hostname: string,
+  _path: string,
+  credentialIds: string[],
+  templates: Map<string, CredentialInjectionTemplate[]>,
+): PolicyDecision {
+  if (credentialIds.length === 0) {
+    return { kind: 'unauthenticated' };
+  }
+
+  const candidates: MatchCandidate[] = [];
+
+  for (const id of credentialIds) {
+    const tpls = templates.get(id);
+    if (!tpls) continue;
+
+    for (const tpl of tpls) {
+      if (minimatch(hostname, tpl.hostPattern)) {
+        candidates.push({ credentialId: id, template: tpl });
+      }
+    }
+  }
+
+  if (candidates.length === 0) {
+    return { kind: 'missing' };
+  }
+
+  if (candidates.length === 1) {
+    return {
+      kind: 'matched',
+      credentialId: candidates[0].credentialId,
+      template: candidates[0].template,
+    };
+  }
+
+  return { kind: 'ambiguous', candidates };
+}

--- a/assistant/src/tools/network/script-proxy/types.ts
+++ b/assistant/src/tools/network/script-proxy/types.ts
@@ -26,3 +26,38 @@ export interface ProxyEnvVars {
   NO_PROXY: string;
   SSL_CERT_FILE?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Policy engine types
+// ---------------------------------------------------------------------------
+
+import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
+
+/** A single credential matched — inject it. */
+export interface PolicyDecisionMatched {
+  kind: 'matched';
+  credentialId: string;
+  template: CredentialInjectionTemplate;
+}
+
+/** Multiple credentials match — caller must disambiguate. */
+export interface PolicyDecisionAmbiguous {
+  kind: 'ambiguous';
+  candidates: Array<{ credentialId: string; template: CredentialInjectionTemplate }>;
+}
+
+/** No credential matches the target host/path. */
+export interface PolicyDecisionMissing {
+  kind: 'missing';
+}
+
+/** No credential_ids were requested — pass-through. */
+export interface PolicyDecisionUnauthenticated {
+  kind: 'unauthenticated';
+}
+
+export type PolicyDecision =
+  | PolicyDecisionMatched
+  | PolicyDecisionAmbiguous
+  | PolicyDecisionMissing
+  | PolicyDecisionUnauthenticated;


### PR DESCRIPTION
## Summary
- Implement host/path template matcher for outbound requests
- Restrict eligible credentials to requested credential_ids
- Emit deterministic decisions: matched, ambiguous, missing, unauthenticated

## Behavior Delta
New policy module — no integration with proxy server yet.

## Tests Run
- `bun test src/__tests__/script-proxy-policy.test.ts`

## Rollback
Revert policy module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
