### PR TITLE
test: baseline CU runtime behavior and permission defaults

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -96,6 +96,11 @@ const mockBundledSkillTool: Tool = {
 };
 registerTool(mockBundledSkillTool);
 
+// Register CU tools so classifyRisk returns their declared Low risk level
+// instead of falling through to Medium (unknown tool).
+import { registerComputerUseTools } from '../tools/computer-use/registry.js';
+registerComputerUseTools();
+
 function writeSkill(skillId: string, name: string, description = 'Test skill'): void {
   const skillDir = join(checkerTestDir, 'skills', skillId);
   mkdirSync(skillDir, { recursive: true });
@@ -3637,5 +3642,36 @@ describe('Permission Checker', () => {
       const result = await check('skill_test_tool', {}, '/tmp');
       expect(result.decision).not.toBe('allow');
     });
+  });
+});
+
+describe('computer-use tool permission defaults', () => {
+  test('computer_use_* tools classify as Low risk (proxy tools)', async () => {
+    const cuToolNames = [
+      'computer_use_click',
+      'computer_use_double_click',
+      'computer_use_right_click',
+      'computer_use_type_text',
+      'computer_use_key',
+      'computer_use_scroll',
+      'computer_use_drag',
+      'computer_use_wait',
+      'computer_use_open_app',
+      'computer_use_run_applescript',
+      'computer_use_done',
+      'computer_use_respond',
+    ];
+
+    for (const name of cuToolNames) {
+      const risk = await classifyRisk(name, {});
+      // CU tools are proxy tools with RiskLevel.Low, but classifyRisk looks them up
+      // in the registry. In legacy mode, Low risk tools are auto-allowed.
+      expect(risk).toBe(RiskLevel.Low);
+    }
+  });
+
+  test('request_computer_control classifies as Low risk', async () => {
+    const risk = await classifyRisk('request_computer_control', {});
+    expect(risk).toBe(RiskLevel.Low);
   });
 });

--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -12,6 +12,15 @@ mock.module('../config/loader.js', () => ({
     timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },
     skills: { load: { extraDirs: [] } },
     secretDetection: { enabled: false },
+    contextWindow: {
+      enabled: true,
+      maxInputTokens: 180000,
+      targetInputTokens: 110000,
+      compactThreshold: 0.8,
+      preserveRecentUserTurns: 8,
+      summaryMaxTokens: 1200,
+      chunkTokens: 12000,
+    },
   }),
   invalidateConfigCache: () => {},
 }));
@@ -119,5 +128,105 @@ describe('ComputerUseSession lifecycle', () => {
 
     expect(terminalCalls).toBe(1);
     expect(session.getState()).toBe('error');
+  });
+
+  test('CU session passes exactly 12 computer_use_* tools to the agent loop', async () => {
+    let capturedTools: string[] = [];
+    const provider: Provider = {
+      name: 'mock',
+      async sendMessage(_msgs, tools) {
+        capturedTools = (tools ?? []).map((t) => t.name);
+        return {
+          content: [{
+            type: 'tool_use',
+            id: 'tu-capture',
+            name: 'computer_use_done',
+            input: { summary: 'Done' },
+          }],
+          model: 'mock-model',
+          usage: { inputTokens: 10, outputTokens: 5 },
+          stopReason: 'tool_use',
+        };
+      },
+    };
+
+    const session = new ComputerUseSession(
+      'cu-tool-capture',
+      'capture tools',
+      1440,
+      900,
+      provider,
+      () => {},
+      'computer_use',
+    );
+
+    await session.handleObservation({
+      type: 'cu_observation',
+      sessionId: 'cu-tool-capture',
+      axTree: 'Window "Test" [1]',
+    });
+
+    const cuTools = capturedTools.filter((n) => n.startsWith('computer_use_'));
+    expect(cuTools).toHaveLength(12);
+
+    // Assert exact set of expected CU tool names
+    const expectedCuTools = [
+      'computer_use_click',
+      'computer_use_double_click',
+      'computer_use_right_click',
+      'computer_use_type_text',
+      'computer_use_key',
+      'computer_use_scroll',
+      'computer_use_drag',
+      'computer_use_wait',
+      'computer_use_open_app',
+      'computer_use_run_applescript',
+      'computer_use_done',
+      'computer_use_respond',
+    ];
+    for (const name of expectedCuTools) {
+      expect(cuTools).toContain(name);
+    }
+  });
+
+  test('computer_use_respond is a terminal tool that completes the session', async () => {
+    const { provider } = createProvider([
+      {
+        content: [{
+          type: 'tool_use',
+          id: 'tu-respond',
+          name: 'computer_use_respond',
+          input: { answer: 'The meeting is at 3pm', reasoning: 'Found in calendar' },
+        }],
+        model: 'mock-model',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: 'tool_use',
+      },
+    ]);
+
+    const sentMessages: ServerMessage[] = [];
+    const session = new ComputerUseSession(
+      'cu-respond-test',
+      'check my schedule',
+      1440,
+      900,
+      provider,
+      (msg) => { sentMessages.push(msg); },
+      'computer_use',
+    );
+
+    await session.handleObservation({
+      type: 'cu_observation',
+      sessionId: 'cu-respond-test',
+      axTree: 'Window "Calendar" [1]',
+    });
+
+    expect(session.getState()).toBe('complete');
+    const completes = sentMessages.filter(
+      (msg): msg is Extract<ServerMessage, { type: 'cu_complete' }> => msg.type === 'cu_complete',
+    );
+    expect(completes).toHaveLength(1);
+    expect(completes[0].summary).toBe('The meeting is at 3pm');
+    expect(completes[0].isResponse).toBe(true);
   });
 });

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1915,3 +1915,33 @@ describe('Trust Store', () => {
     });
   });
 });
+
+describe('computer-use tool trust rule matching', () => {
+  test('actionable CU tools have default ask trust rules', () => {
+    // Actionable CU tools (those that perform screen interactions) should
+    // have default "ask" rules so strict mode prompts before use.
+    const actionableCuTools = [
+      'computer_use_click',
+      'computer_use_type_text',
+      'request_computer_control',
+    ];
+
+    for (const name of actionableCuTools) {
+      const rule = findHighestPriorityRule(name, [name], '/tmp/test');
+      expect(rule).not.toBeNull();
+      expect(rule!.decision).toBe('ask');
+    }
+  });
+
+  test('terminal CU tools (done/respond) have no default trust rules', () => {
+    // computer_use_done and computer_use_respond are terminal signal tools
+    // with RiskLevel.Low — they should not have ask rules since they don't
+    // perform any screen action.
+    const terminalCuTools = ['computer_use_done', 'computer_use_respond'];
+
+    for (const name of terminalCuTools) {
+      const defaultRule = DEFAULT_TEMPLATES.find((t) => t.tool === name);
+      expect(defaultRule).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Extend CU lifecycle tests to capture and assert tool names passed to agent loop (12 CU tools)
- Add terminal behavior test for `computer_use_respond`
- Add permission baseline tests in checker.test.ts for CU tool risk classification
- Add trust-store baseline confirming actionable CU tools have default ask rules and terminal tools have none

## Test plan
- [x] `bun test src/__tests__/computer-use-session-lifecycle.test.ts` passes (4 tests)
- [x] `bun test src/__tests__/checker.test.ts` passes (302 tests)
- [x] `bun test src/__tests__/trust-store.test.ts` passes (140 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 02/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
