### PR TITLE
Add contextTooLarge to Swift client error enum and UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -789,6 +789,8 @@ struct ChatView: View {
             return "clock.badge.exclamationmark"
         case .providerApi:
             return "exclamationmark.icloud.fill"
+        case .contextTooLarge:
+            return "text.badge.xmark"
         case .queueFull:
             return "tray.full.fill"
         case .sessionAborted:
@@ -810,6 +812,8 @@ struct ChatView: View {
             return Amber._500
         case .sessionAborted:
             return VColor.textSecondary
+        case .contextTooLarge:
+            return VColor.warning
         default:
             return VColor.error
         }

--- a/clients/shared/Features/Chat/ChatSessionError.swift
+++ b/clients/shared/Features/Chat/ChatSessionError.swift
@@ -5,6 +5,7 @@ public enum SessionErrorCategory: Equatable, Sendable {
     case providerNetwork
     case rateLimit
     case providerApi
+    case contextTooLarge
     case queueFull
     case sessionAborted
     case processingFailed
@@ -19,6 +20,8 @@ public enum SessionErrorCategory: Equatable, Sendable {
             self = .rateLimit
         case .providerApi:
             self = .providerApi
+        case .contextTooLarge:
+            self = .contextTooLarge
         case .queueFull:
             self = .queueFull
         case .sessionAborted:
@@ -41,6 +44,8 @@ public enum SessionErrorCategory: Equatable, Sendable {
             return "You've hit a rate limit. Please wait a moment before retrying."
         case .providerApi:
             return "The AI provider returned an error. Try again or check your API key."
+        case .contextTooLarge:
+            return "Start a new conversation or try a shorter message."
         case .queueFull:
             return "Too many pending messages. Wait for current messages to finish processing."
         case .sessionAborted:

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1274,6 +1274,7 @@ public enum SessionErrorCode: String, CaseIterable, Codable, Sendable {
     case providerNetwork = "PROVIDER_NETWORK"
     case providerRateLimit = "PROVIDER_RATE_LIMIT"
     case providerApi = "PROVIDER_API"
+    case contextTooLarge = "CONTEXT_TOO_LARGE"
     case queueFull = "QUEUE_FULL"
     case sessionAborted = "SESSION_ABORTED"
     case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"


### PR DESCRIPTION
## Summary
- Adds `contextTooLarge` case to `SessionErrorCode` enum in `IPCMessages.swift`
- Adds `.contextTooLarge` category to `SessionErrorCategory` with recovery suggestion: "Start a new conversation or try a shorter message."
- Adds `text.badge.xmark` icon and amber warning color for the new error category in `ChatView.swift`

## Test plan
- [x] Swift build succeeds (both macOS and iOS targets)
- [x] Enum has fallback decoding — unrecognized codes fall back to `.unknown`, so this is backward-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
