### PR TITLE
feat: proxy HTTP forwarder (non-CONNECT)

### DIFF
--- a/assistant/src/__tests__/script-proxy-http-forwarder.test.ts
+++ b/assistant/src/__tests__/script-proxy-http-forwarder.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { createServer, type Server, type IncomingMessage } from 'node:http';
+import { createProxyServer } from '../tools/network/script-proxy/server.js';
+
+/** Start an HTTP server and return its URL + cleanup handle. */
+function listenEphemeral(server: Server): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get address'));
+        return;
+      }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () => new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+/** Collect the full body of an IncomingMessage. */
+function readBody(msg: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    msg.on('data', (c: Buffer) => chunks.push(c));
+    msg.on('end', () => resolve(Buffer.concat(chunks).toString()));
+  });
+}
+
+describe('http-forwarder', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map((s) => s.close().catch(() => {})));
+    servers.length = 0;
+  });
+
+  async function setupPair() {
+    // Upstream echo server
+    const upstream = createServer(async (req, res) => {
+      const body = await readBody(req);
+      res.writeHead(200, { 'Content-Type': 'application/json', 'X-Echo': 'true' });
+      res.end(
+        JSON.stringify({
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body,
+        }),
+      );
+    });
+    const up = await listenEphemeral(upstream);
+    servers.push(up);
+
+    // Proxy
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    return { upstreamUrl: up.url, proxyUrl: px.url };
+  }
+
+  test('simple GET forwarded correctly', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair();
+
+    const res = await fetch(`${proxyUrl}`, {
+      method: 'GET',
+      // Absolute-URL form: the proxy sees the full URL as the request target
+      headers: { Host: '' },
+    }).then(() =>
+      // Use http module style: fetch with proxy doesn't do absolute-URL form
+      // So we'll directly request the proxy with the target as the URL
+      fetch(proxyUrl, {
+        method: 'GET',
+        headers: {},
+      }),
+    );
+
+    // fetch doesn't support proxy mode natively — use the absolute-URL approach
+    // by making a direct HTTP request to the proxy with the upstream URL as path.
+    const controller = new AbortController();
+    const response = await new Promise<Response>((resolve, reject) => {
+      const { hostname, port } = new URL(proxyUrl);
+      const http = require('node:http');
+      const req = http.request(
+        {
+          hostname,
+          port: Number(port),
+          // Absolute URL form for HTTP proxy
+          path: `${upstreamUrl}/hello?a=1`,
+          method: 'GET',
+          headers: { 'X-Custom': 'test-value' },
+        },
+        (res: IncomingMessage) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => {
+            resolve(
+              new Response(Buffer.concat(chunks), {
+                status: res.statusCode!,
+                headers: res.headers as Record<string, string>,
+              }),
+            );
+          });
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json() as any;
+    expect(data.method).toBe('GET');
+    expect(data.url).toBe('/hello?a=1');
+    expect(data.headers['x-custom']).toBe('test-value');
+  });
+
+  test('POST with body forwarded correctly', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair();
+    const { hostname, port } = new URL(proxyUrl);
+    const http = require('node:http');
+
+    const response = await new Promise<{ status: number; body: any }>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname,
+          port: Number(port),
+          path: `${upstreamUrl}/submit`,
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        },
+        (res: IncomingMessage) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => {
+            resolve({
+              status: res.statusCode!,
+              body: JSON.parse(Buffer.concat(chunks).toString()),
+            });
+          });
+        },
+      );
+      req.on('error', reject);
+      req.write(JSON.stringify({ key: 'value' }));
+      req.end();
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.method).toBe('POST');
+    expect(response.body.url).toBe('/submit');
+    expect(response.body.body).toBe('{"key":"value"}');
+  });
+
+  test('error response forwarded correctly', async () => {
+    // Upstream that returns 404
+    const upstream = createServer((_req, res) => {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    });
+    const up = await listenEphemeral(upstream);
+    servers.push(up);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    const { hostname, port } = new URL(px.url);
+    const http = require('node:http');
+
+    const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname,
+          port: Number(port),
+          path: `${up.url}/missing`,
+          method: 'GET',
+        },
+        (res: IncomingMessage) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => {
+            resolve({
+              status: res.statusCode!,
+              body: Buffer.concat(chunks).toString(),
+            });
+          });
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toBe('Not Found');
+  });
+
+  test('upstream connection failure returns 502', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    servers.push(px);
+
+    const { hostname, port } = new URL(px.url);
+    const http = require('node:http');
+
+    // Point at a port that nothing is listening on
+    const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname,
+          port: Number(port),
+          path: 'http://127.0.0.1:1/unreachable',
+          method: 'GET',
+        },
+        (res: IncomingMessage) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => {
+            resolve({
+              status: res.statusCode!,
+              body: Buffer.concat(chunks).toString(),
+            });
+          });
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(502);
+    expect(response.body).toBe('Bad Gateway');
+  });
+
+  test('hop-by-hop headers are stripped from forwarded request', async () => {
+    const { upstreamUrl, proxyUrl } = await setupPair();
+    const { hostname, port } = new URL(proxyUrl);
+    const http = require('node:http');
+
+    const response = await new Promise<{ status: number; body: any }>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname,
+          port: Number(port),
+          path: `${upstreamUrl}/headers`,
+          method: 'GET',
+          headers: {
+            'X-Custom': 'keep-me',
+            'Proxy-Authorization': 'secret',
+            Connection: 'keep-alive',
+          },
+        },
+        (res: IncomingMessage) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => {
+            resolve({
+              status: res.statusCode!,
+              body: JSON.parse(Buffer.concat(chunks).toString()),
+            });
+          });
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(200);
+    // Custom header should be forwarded
+    expect(response.body.headers['x-custom']).toBe('keep-me');
+    // Hop-by-hop headers from the client should be stripped
+    expect(response.body.headers['proxy-authorization']).toBeUndefined();
+    // Note: Node's http.request adds its own Connection header at the
+    // transport level, so we only verify our explicit hop-by-hop filter
+    // removed Proxy-Authorization above.
+  });
+});

--- a/assistant/src/tools/network/script-proxy/http-forwarder.ts
+++ b/assistant/src/tools/network/script-proxy/http-forwarder.ts
@@ -1,0 +1,131 @@
+/**
+ * HTTP proxy forwarder — parses absolute-URL proxy requests and forwards
+ * them to the upstream server with full body streaming.
+ */
+
+import { request as httpRequest, type IncomingMessage, type ServerResponse } from 'node:http';
+import { URL } from 'node:url';
+
+/** Hop-by-hop headers that MUST NOT be forwarded between proxy hops. */
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+/**
+ * Optional callback for credential injection or policy gating.
+ * Called before the upstream request is sent. Returns extra headers
+ * to merge, or null to reject the request.
+ */
+export type PolicyCallback = (
+  hostname: string,
+  path: string,
+) => Promise<Record<string, string> | null>;
+
+/**
+ * Strip hop-by-hop headers from an incoming header set.
+ */
+function filterHeaders(raw: IncomingMessage['headers']): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (HOP_BY_HOP.has(key.toLowerCase())) continue;
+    if (value === undefined) continue;
+    out[key] = Array.isArray(value) ? value.join(', ') : value;
+  }
+  return out;
+}
+
+/**
+ * Forward a plain HTTP proxy request (absolute-URL form) to the upstream
+ * server and stream the response back to the client.
+ */
+export function forwardHttpRequest(
+  clientReq: IncomingMessage,
+  clientRes: ServerResponse,
+  policyCallback?: PolicyCallback,
+): void {
+  const urlStr = clientReq.url;
+  if (!urlStr) {
+    clientRes.writeHead(400, { 'Content-Type': 'text/plain' });
+    clientRes.end('Bad Request');
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    clientRes.writeHead(400, { 'Content-Type': 'text/plain' });
+    clientRes.end('Bad Request');
+    return;
+  }
+
+  if (parsed.protocol !== 'http:') {
+    clientRes.writeHead(400, { 'Content-Type': 'text/plain' });
+    clientRes.end('Only HTTP is supported for non-CONNECT proxy requests');
+    return;
+  }
+
+  const hostname = parsed.hostname;
+  const port = parsed.port ? Number(parsed.port) : 80;
+  const path = parsed.pathname + parsed.search;
+
+  const doForward = (extraHeaders: Record<string, string> = {}) => {
+    const headers = { ...filterHeaders(clientReq.headers), ...extraHeaders };
+    // Ensure Host header matches the upstream target
+    headers['host'] = parsed.host;
+
+    const upstreamReq = httpRequest(
+      {
+        hostname,
+        port,
+        path,
+        method: clientReq.method,
+        headers,
+      },
+      (upstreamRes: IncomingMessage) => {
+        const responseHeaders = filterHeaders(upstreamRes.headers);
+        clientRes.writeHead(upstreamRes.statusCode ?? 502, responseHeaders);
+        upstreamRes.pipe(clientRes);
+      },
+    );
+
+    upstreamReq.on('error', () => {
+      // Don't leak internal error details — generic 502
+      if (!clientRes.headersSent) {
+        clientRes.writeHead(502, { 'Content-Type': 'text/plain' });
+      }
+      clientRes.end('Bad Gateway');
+    });
+
+    // Stream client body to upstream
+    clientReq.pipe(upstreamReq);
+  };
+
+  if (policyCallback) {
+    policyCallback(hostname, path)
+      .then((extraHeaders) => {
+        if (extraHeaders === null) {
+          clientRes.writeHead(403, { 'Content-Type': 'text/plain' });
+          clientRes.end('Forbidden');
+          return;
+        }
+        doForward(extraHeaders);
+      })
+      .catch(() => {
+        if (!clientRes.headersSent) {
+          clientRes.writeHead(502, { 'Content-Type': 'text/plain' });
+        }
+        clientRes.end('Bad Gateway');
+      });
+  } else {
+    doForward();
+  }
+}

--- a/assistant/src/tools/network/script-proxy/server.ts
+++ b/assistant/src/tools/network/script-proxy/server.ts
@@ -1,0 +1,30 @@
+/**
+ * Proxy server factory — creates an HTTP server configured to handle
+ * plain HTTP proxy requests via the forwarder.
+ */
+
+import { createServer, type Server } from 'node:http';
+import { forwardHttpRequest, type PolicyCallback } from './http-forwarder.js';
+
+export interface ProxyServerConfig {
+  /** Optional policy callback for credential injection / access control. */
+  policyCallback?: PolicyCallback;
+  /** Called on every forwarded request for logging. */
+  onRequest?: (method: string, url: string) => void;
+}
+
+/**
+ * Create an HTTP server that acts as a forward proxy for plain HTTP
+ * requests (absolute-URL form). CONNECT tunnelling is not handled here.
+ */
+export function createProxyServer(config: ProxyServerConfig = {}): Server {
+  const server = createServer((req, res) => {
+    if (config.onRequest && req.method && req.url) {
+      config.onRequest(req.method, req.url);
+    }
+
+    forwardHttpRequest(req, res, config.policyCallback);
+  });
+
+  return server;
+}


### PR DESCRIPTION
## Summary
- Implement HTTP request parsing and upstream forwarding for plain HTTP proxy
- Add body streaming pass-through (pipe client request body to upstream, pipe upstream response to client)
- Add error-path sanitization (generic 502 for connection failures, no internal details leaked)
- Create proxy server module with request routing and optional policy callback

## Behavior Delta
New modules — no integration with session manager yet.

## Tests Run
- `bun test src/__tests__/script-proxy-http-forwarder.test.ts` — 5 pass, 0 fail

## Rollback
Revert forwarder/server files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
