### PR TITLE
Auto-compact and retry on context-too-large errors

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -50,6 +50,8 @@ export interface ContextWindowResult {
 
 export interface ContextWindowCompactOptions {
   lastCompactedAt?: number;
+  /** Bypass the threshold check and force compaction. Used for context-too-large error recovery. */
+  force?: boolean;
 }
 
 export class ContextWindowManager {
@@ -91,7 +93,7 @@ export class ContextWindowManager {
       };
     }
 
-    if (previousEstimatedInputTokens < thresholdTokens) {
+    if (!options?.force && previousEstimatedInputTokens < thresholdTokens) {
       return {
         messages,
         compacted: false,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -14,7 +14,7 @@ import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { TraceEmitter } from './trace-emitter.js';
-import { classifySessionError, isUserCancellation, buildSessionErrorMessage } from './session-error.js';
+import { classifySessionError, isUserCancellation, isContextTooLarge, buildSessionErrorMessage } from './session-error.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
 import {
@@ -802,6 +802,7 @@ export class Session {
 
       let orderingErrorDetected = false;
       let deferredOrderingError: string | null = null;
+      let contextTooLargeDetected = false;
       let preRunHistoryLength = runMessages.length;
 
       // Track whether llm_call_started has been emitted for the current provider turn.
@@ -888,6 +889,9 @@ export class Session {
               orderingErrorDetected = true;
               // Defer the error event — only forward if retry also fails
               deferredOrderingError = event.error.message;
+            } else if (isContextTooLarge(event.error.message)) {
+              contextTooLargeDetected = true;
+              // Defer — attempt compaction + retry before surfacing to user
             } else {
               const classified = classifySessionError(event.error, { phase: 'agent_loop' });
               onEvent(buildSessionErrorMessage(this.conversationId, classified));
@@ -1043,6 +1047,73 @@ export class Session {
 
         if (orderingErrorDetected) {
           rlog.error({ phase: 'retry' }, 'Deep-repair retry also failed with ordering error. Consider starting a new conversation if this persists.');
+        }
+      }
+
+      // One-shot context-too-large recovery: force compaction and retry once.
+      if (contextTooLargeDetected && updatedHistory.length === preRunHistoryLength) {
+        rlog.warn({ phase: 'retry' }, 'Context too large — attempting forced compaction and retry');
+        const emergencyCompact = await this.contextWindowManager.maybeCompact(
+          this.messages,
+          abortController.signal,
+          { lastCompactedAt: this.contextCompactedAt ?? undefined, force: true },
+        );
+        if (emergencyCompact.compacted) {
+          this.messages = emergencyCompact.messages;
+          this.contextCompactedMessageCount += emergencyCompact.compactedPersistedMessages;
+          this.contextCompactedAt = Date.now();
+          conversationStore.updateConversationContextWindow(
+            this.conversationId,
+            emergencyCompact.summaryText,
+            this.contextCompactedMessageCount,
+          );
+          onEvent({
+            type: 'context_compacted',
+            previousEstimatedInputTokens: emergencyCompact.previousEstimatedInputTokens,
+            estimatedInputTokens: emergencyCompact.estimatedInputTokens,
+            maxInputTokens: emergencyCompact.maxInputTokens,
+            thresholdTokens: emergencyCompact.thresholdTokens,
+            compactedMessages: emergencyCompact.compactedMessages,
+            summaryCalls: emergencyCompact.summaryCalls,
+            summaryInputTokens: emergencyCompact.summaryInputTokens,
+            summaryOutputTokens: emergencyCompact.summaryOutputTokens,
+            summaryModel: emergencyCompact.summaryModel,
+          });
+          this.recordUsage(
+            emergencyCompact.summaryInputTokens,
+            emergencyCompact.summaryOutputTokens,
+            emergencyCompact.summaryModel,
+            onEvent,
+            'context_compactor',
+            reqId,
+          );
+
+          // Retry with compacted context
+          runMessages = applyRuntimeInjections(this.messages, {
+            softConflictInstruction,
+            activeSurface,
+            workspaceTopLevelContext: this.workspaceTopLevelContext,
+          });
+          preRepairMessages = runMessages;
+          preRunHistoryLength = runMessages.length;
+          contextTooLargeDetected = false;
+
+          updatedHistory = await this.agentLoop.run(
+            runMessages,
+            buildEventHandler(),
+            abortController.signal,
+            reqId,
+            onCheckpoint,
+          );
+        }
+
+        // Surface the error if compaction didn't help or wasn't possible
+        if (contextTooLargeDetected) {
+          const classified = classifySessionError(
+            new Error('context_length_exceeded'),
+            { phase: 'agent_loop' },
+          );
+          onEvent(buildSessionErrorMessage(this.conversationId, classified));
         }
       }
 


### PR DESCRIPTION
## Summary
- When the agent loop encounters a context-too-large error from the provider, defers it (like ordering errors) and attempts forced context compaction + retry before surfacing to the user
- Adds `force` option to `ContextWindowCompactOptions` to bypass the threshold check during emergency compaction
- Follows the same one-shot retry pattern as the existing ordering error recovery

**Depends on:** #4211

## Test plan
- [x] All 60 session-error tests pass
- [x] TypeScript type-check passes (no new errors in modified files)
- [x] Recovery path: if forced compaction reduces context enough, the retry succeeds transparently
- [x] Fallback path: if compaction can't help (e.g. single huge message), the CONTEXT_TOO_LARGE error surfaces to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
