### PR TITLE
refactor: add computer-use migration test harness

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-baseline.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-baseline.test.ts
@@ -6,28 +6,15 @@ import {
   initializeTools,
   __resetRegistryForTesting,
 } from '../tools/registry.js';
-
-// Import buildToolDefinitions which assembles the text-session tool set
 import { buildToolDefinitions } from '../daemon/session-tool-setup.js';
+import {
+  COMPUTER_USE_TOOL_NAMES,
+  COMPUTER_USE_TOOL_COUNT,
+  assertComputerUseToolsPresent,
+  assertComputerUseToolsAbsent,
+} from './test-support/computer-use-skill-harness.js';
 
-// Clean up global registry after this file completes
 afterAll(() => { __resetRegistryForTesting(); });
-
-// The 12 computer_use_* tool names that exist in the core registry today
-const COMPUTER_USE_TOOL_NAMES = [
-  'computer_use_click',
-  'computer_use_double_click',
-  'computer_use_right_click',
-  'computer_use_type_text',
-  'computer_use_key',
-  'computer_use_scroll',
-  'computer_use_drag',
-  'computer_use_wait',
-  'computer_use_open_app',
-  'computer_use_run_applescript',
-  'computer_use_done',
-  'computer_use_respond',
-] as const;
 
 describe('computer-use skill baseline: registry tool surfaces', () => {
   test('all 12 computer_use_* tools are registered after initializeTools()', async () => {
@@ -52,9 +39,7 @@ describe('computer-use skill baseline: registry tool surfaces', () => {
     await initializeTools();
 
     const defNames = getAllToolDefinitions().map((d) => d.name);
-    for (const name of COMPUTER_USE_TOOL_NAMES) {
-      expect(defNames).not.toContain(name);
-    }
+    assertComputerUseToolsAbsent(defNames);
   });
 
   test('getAllToolDefinitions() excludes request_computer_control (proxy exclusion)', async () => {
@@ -75,9 +60,7 @@ describe('computer-use skill baseline: registry tool surfaces', () => {
     await initializeTools();
 
     const defNames = buildToolDefinitions().map((d) => d.name);
-    for (const name of COMPUTER_USE_TOOL_NAMES) {
-      expect(defNames).not.toContain(name);
-    }
+    assertComputerUseToolsAbsent(defNames);
   });
 
   test('baseline count: 12 computer_use_* proxy tools in core registry', async () => {
@@ -85,7 +68,6 @@ describe('computer-use skill baseline: registry tool surfaces', () => {
 
     const allTools = getAllTools();
     const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
-    // After cutover (PR 09), this count should drop to 0 in the core registry.
-    expect(cuTools).toHaveLength(12);
+    expect(cuTools).toHaveLength(COMPUTER_USE_TOOL_COUNT);
   });
 });

--- a/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
@@ -1,0 +1,45 @@
+/**
+ * Reusable constants and helpers for the computer-use skill migration test suite.
+ */
+
+/** The 12 computer_use_* tool names in the core registry. */
+export const COMPUTER_USE_TOOL_NAMES = [
+  'computer_use_click',
+  'computer_use_double_click',
+  'computer_use_right_click',
+  'computer_use_type_text',
+  'computer_use_key',
+  'computer_use_scroll',
+  'computer_use_drag',
+  'computer_use_wait',
+  'computer_use_open_app',
+  'computer_use_run_applescript',
+  'computer_use_done',
+  'computer_use_respond',
+] as const;
+
+/** The skill ID for the bundled computer-use skill (used in later PRs). */
+export const COMPUTER_USE_SKILL_ID = 'computer-use';
+
+/** Number of computer_use_* tools. */
+export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 12
+
+import { expect } from 'bun:test';
+
+/**
+ * Assert that every COMPUTER_USE_TOOL_NAMES entry is present in `names`.
+ */
+export function assertComputerUseToolsPresent(names: string[]): void {
+  for (const name of COMPUTER_USE_TOOL_NAMES) {
+    expect(names).toContain(name);
+  }
+}
+
+/**
+ * Assert that no COMPUTER_USE_TOOL_NAMES entry is present in `names`.
+ */
+export function assertComputerUseToolsAbsent(names: string[]): void {
+  for (const name of COMPUTER_USE_TOOL_NAMES) {
+    expect(names).not.toContain(name);
+  }
+}


### PR DESCRIPTION
## Summary
- Add shared test harness with `COMPUTER_USE_TOOL_NAMES`, `COMPUTER_USE_SKILL_ID`, and assertion helpers
- Refactor baseline test (PR 01) to use harness imports
- No behavior change — pure refactoring of test infrastructure

## Test plan
- [x] `bun test src/__tests__/computer-use-skill-baseline.test.ts` passes (7 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 03/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
