### PR TITLE
fix: guide LLM to google-oauth-setup skill when Gmail/Calendar credentials are missing

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -7,6 +7,16 @@ metadata: {"vellum": {"emoji": "📧"}}
 
 You are a Gmail assistant with full access to the user's inbox. Use the Gmail tools to help them read, search, organize, draft, and send email.
 
+## Connection Setup
+
+Before using any Gmail tool, verify that Gmail is connected by attempting a lightweight call (e.g., `gmail_list` with `maxResults: 1`). If the call fails with a token/authorization error:
+
+1. **Do NOT call `credential_store oauth2_connect` yourself.** You do not have valid OAuth client credentials, and fabricating a client_id will cause a "401: invalid_client" error from Google.
+2. Instead, install and load the **google-oauth-setup** skill, which walks the user through creating real credentials in Google Cloud Console:
+   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
+   - Then call `vellum_skills_catalog` with `action: "load"` and `skill_id: "google-oauth-setup"`.
+3. Tell the user: *"Gmail isn't connected yet. I've loaded a setup guide that will walk you through connecting your Google account — it only takes a couple of minutes."*
+
 ## Capabilities
 
 - **Search & Read**: Find messages using Gmail search syntax, list recent messages, and read full message content.

--- a/assistant/src/config/bundled-skills/google-calendar/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-calendar/SKILL.md
@@ -7,6 +7,16 @@ metadata: {"vellum": {"emoji": "📅"}}
 
 You are a Google Calendar assistant with full access to the user's calendar. Use the Calendar tools to help them view, create, and manage events.
 
+## Connection Setup
+
+Before using any Calendar tool, verify that Google Calendar is connected by attempting a lightweight call (e.g., `calendar_list_events` with a narrow date range). If the call fails with a token/authorization error:
+
+1. **Do NOT call `credential_store oauth2_connect` yourself.** You do not have valid OAuth client credentials, and fabricating a client_id will cause a "401: invalid_client" error from Google.
+2. Instead, install and load the **google-oauth-setup** skill, which walks the user through creating real credentials in Google Cloud Console:
+   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
+   - Then call `vellum_skills_catalog` with `action: "load"` and `skill_id: "google-oauth-setup"`.
+3. Tell the user: *"Google Calendar isn't connected yet. I've loaded a setup guide that will walk you through connecting your Google account — it only takes a couple of minutes."*
+
 ## Capabilities
 
 - **List Events**: View upcoming events from any calendar within a date range.

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -108,7 +108,11 @@ export async function withValidToken<T>(
 ): Promise<T> {
   let token = getSecureKey(`credential:${service}:access_token`);
   if (!token) {
-    throw new TokenExpiredError(service, `No access token found for "${service}". Authorization required.`);
+    const isGoogle = service === 'integration:gmail' || service === 'integration:google-calendar';
+    const googleHint = isGoogle
+      ? ' Do NOT fabricate credentials. Install and load the "google-oauth-setup" skill to set up OAuth credentials properly.'
+      : '';
+    throw new TokenExpiredError(service, `No access token found for "${service}". Authorization required.${googleHint}`);
   }
 
   // Proactively refresh if expired or about to expire.

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -7,6 +7,7 @@ import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } f
 import { addRule } from '../permissions/trust-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { ToolError, PermissionDeniedError } from '../util/errors.js';
+import { TokenExpiredError } from '../security/token-manager.js';
 import { getLogger } from '../util/logger.js';
 import { sandboxPolicy } from './shared/filesystem/path-policy.js';
 import { MAX_FILE_SIZE_BYTES } from './shared/filesystem/size-guard.js';
@@ -479,7 +480,7 @@ export class ToolExecutor {
     } catch (err) {
       const durationMs = Date.now() - startTime;
       const msg = err instanceof Error ? err.message : String(err);
-      const isExpected = err instanceof PermissionDeniedError || err instanceof ToolError;
+      const isExpected = err instanceof PermissionDeniedError || err instanceof ToolError || err instanceof TokenExpiredError;
 
       emitLifecycleEvent(context, {
         type: 'error',


### PR DESCRIPTION
## Summary

- Add "Connection Setup" section to Gmail and Google Calendar SKILL.md files that explicitly prohibit fabricating `oauth2_connect` credentials and direct the LLM to install/load the `google-oauth-setup` skill instead
- Mark `TokenExpiredError` as an expected error in `executor.ts` so error messages are clean (no "unexpected error" prefix that triggers creative "fixing")
- Add Google-specific hint to `token-manager.ts` error message reinforcing the correct setup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
