### PR TITLE
fix: guard empty sanitized input in contact search LIKE queries (#4204)

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -231,6 +231,7 @@ export function searchContacts(params: {
   // Search by channel address first (exact or partial match)
   if (params.channelAddress) {
     const normalizedAddress = escapeLike(params.channelAddress.toLowerCase());
+    if (!normalizedAddress) return [];
     const channelRows = db
       .select()
       .from(contactChannels)
@@ -258,7 +259,10 @@ export function searchContacts(params: {
   // Search by display name and/or relationship
   const conditions = [];
   if (params.query) {
-    conditions.push(like(contacts.displayName, `%${escapeLike(params.query)}%`));
+    const sanitized = escapeLike(params.query);
+    if (sanitized) {
+      conditions.push(like(contacts.displayName, `%${sanitized}%`));
+    }
   }
   if (params.relationship) {
     conditions.push(eq(contacts.relationship, params.relationship));


### PR DESCRIPTION
## Summary
- Short-circuit contact search when sanitized input is empty (pure wildcards like "%" or "___")
- Prevents `LIKE '%%'` from matching every row in the database
- Applies to both channel address search and display name search paths

Addresses feedback from #4204
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
