### PR TITLE
fix: gmail SKILL.md tool names, skill_load usage, and dead google-calendar check (#4217)

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -9,12 +9,12 @@ You are a Gmail assistant with full access to the user's inbox. Use the Gmail to
 
 ## Connection Setup
 
-Before using any Gmail tool, verify that Gmail is connected by attempting a lightweight call (e.g., `gmail_list` with `maxResults: 1`). If the call fails with a token/authorization error:
+Before using any Gmail tool, verify that Gmail is connected by attempting a lightweight call (e.g., `gmail_list_messages` with `max_results: 1`). If the call fails with a token/authorization error:
 
 1. **Do NOT call `credential_store oauth2_connect` yourself.** You do not have valid OAuth client credentials, and fabricating a client_id will cause a "401: invalid_client" error from Google.
 2. Instead, install and load the **google-oauth-setup** skill, which walks the user through creating real credentials in Google Cloud Console:
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
-   - Then call `vellum_skills_catalog` with `action: "load"` and `skill_id: "google-oauth-setup"`.
+   - Then call `skill_load` with `skill_id: "google-oauth-setup"`.
 3. Tell the user: *"Gmail isn't connected yet. I've loaded a setup guide that will walk you through connecting your Google account — it only takes a couple of minutes."*
 
 ## Capabilities

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -108,7 +108,7 @@ export async function withValidToken<T>(
 ): Promise<T> {
   let token = getSecureKey(`credential:${service}:access_token`);
   if (!token) {
-    const isGoogle = service === 'integration:gmail' || service === 'integration:google-calendar';
+    const isGoogle = service === 'integration:gmail';
     const googleHint = isGoogle
       ? ' Do NOT fabricate credentials. Install and load the "google-oauth-setup" skill to set up OAuth credentials properly.'
       : '';


### PR DESCRIPTION
## Summary
- Fix SKILL.md to reference `gmail_list_messages` with `max_results` instead of nonexistent `gmail_list` with `maxResults`
- Use `skill_load` tool instead of `vellum_skills_catalog` with unsupported `action: "load"`
- Remove dead `integration:google-calendar` check in token-manager (Calendar always uses `integration:gmail`)

Addresses feedback from #4217
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
