### PR TITLE
fix: short-circuit wildcard-only display name queries in contact search (#4218)

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -260,6 +260,7 @@ export function searchContacts(params: {
   const conditions = [];
   if (params.query) {
     const sanitized = escapeLike(params.query);
+    if (!sanitized && !params.relationship) return [];
     if (sanitized) {
       conditions.push(like(contacts.displayName, `%${sanitized}%`));
     }


### PR DESCRIPTION
## Summary
- Return empty results when display name query sanitizes to empty (pure wildcards) and no relationship filter is set
- Prevents unfiltered fallthrough that would enumerate all contacts via `searchContacts({ query: '%%%' })`

Addresses feedback from #4218
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
