### PR TITLE
feat: bash tool schema: network_mode + credential_ids

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1,0 +1,1606 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`IPC message snapshots ClientMessage types auth serializes to expected JSON 1`] = `
+{
+  "token": "abc123def456",
+  "type": "auth",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
+{
+  "content": "Hello, assistant!",
+  "sessionId": "sess-001",
+  "type": "user_message",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types confirmation_response serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "requestId": "req-001",
+  "selectedPattern": "bash:npm *",
+  "selectedScope": "/projects/my-app",
+  "type": "confirmation_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_list serializes to expected JSON 1`] = `
+{
+  "type": "session_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_create serializes to expected JSON 1`] = `
+{
+  "correlationId": "corr-001",
+  "threadType": "standard",
+  "title": "New session",
+  "transport": {
+    "channelId": "desktop",
+    "hints": [
+      "dashboard-capable",
+    ],
+    "uxBrief": "Prefer dashboard-first onboarding.",
+  },
+  "type": "session_create",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_switch serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-002",
+  "type": "session_switch",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types ping serializes to expected JSON 1`] = `
+{
+  "type": "ping",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types cancel serializes to expected JSON 1`] = `
+{
+  "type": "cancel",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types model_get serializes to expected JSON 1`] = `
+{
+  "type": "model_get",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types model_set serializes to expected JSON 1`] = `
+{
+  "model": "claude-opus-4-6",
+  "type": "model_set",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types history_request serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "history_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types undo serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "undo",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types regenerate serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "regenerate",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types usage_request serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "usage_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types sandbox_set serializes to expected JSON 1`] = `
+{
+  "enabled": true,
+  "type": "sandbox_set",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types cu_session_create serializes to expected JSON 1`] = `
+{
+  "screenHeight": 1080,
+  "screenWidth": 1920,
+  "sessionId": "cu-sess-001",
+  "task": "Open Safari and search for weather",
+  "type": "cu_session_create",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types cu_session_abort serializes to expected JSON 1`] = `
+{
+  "sessionId": "cu-sess-001",
+  "type": "cu_session_abort",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types cu_observation serializes to expected JSON 1`] = `
+{
+  "axDiff": "+ new element",
+  "axTree": "<ax-tree>...</ax-tree>",
+  "captureDisplayId": 69734112,
+  "coordinateOrigin": "top_left",
+  "executionResult": "click completed",
+  "screenHeightPt": 1080,
+  "screenWidthPt": 1920,
+  "screenshot": "base64-screenshot-data",
+  "screenshotHeightPx": 720,
+  "screenshotWidthPx": 1280,
+  "secondaryWindows": "Finder, Terminal",
+  "sessionId": "cu-sess-001",
+  "type": "cu_observation",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types ride_shotgun_start serializes to expected JSON 1`] = `
+{
+  "durationSeconds": 300,
+  "intervalSeconds": 10,
+  "type": "ride_shotgun_start",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types watch_observation serializes to expected JSON 1`] = `
+{
+  "appName": "Xcode",
+  "bundleIdentifier": "com.apple.dt.Xcode",
+  "captureIndex": 0,
+  "ocrText": "Screen text captured during watch",
+  "sessionId": "sess-001",
+  "timestamp": 1700000000,
+  "totalExpected": 10,
+  "type": "watch_observation",
+  "watchId": "watch-001",
+  "windowTitle": "Project.swift",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types task_submit serializes to expected JSON 1`] = `
+{
+  "screenHeight": 1080,
+  "screenWidth": 1920,
+  "task": "Open Safari and search for weather",
+  "type": "task_submit",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types ui_surface_action serializes to expected JSON 1`] = `
+{
+  "actionId": "btn-ok",
+  "data": {
+    "selectedItem": "item-1",
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_action",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_data_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "callId": "call-001",
+  "method": "query",
+  "surfaceId": "surface-001",
+  "type": "app_data_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_list serializes to expected JSON 1`] = `
+{
+  "type": "skills_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skill_detail serializes to expected JSON 1`] = `
+{
+  "skillId": "my-skill",
+  "type": "skill_detail",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_enable serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_enable",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_disable serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_disable",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_configure serializes to expected JSON 1`] = `
+{
+  "apiKey": "sk-test",
+  "config": {
+    "verbose": true,
+  },
+  "env": {
+    "API_KEY": "test-key",
+  },
+  "name": "my-skill",
+  "type": "skills_configure",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_install serializes to expected JSON 1`] = `
+{
+  "slug": "clawhub/my-skill",
+  "type": "skills_install",
+  "version": "1.0.0",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_uninstall serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_uninstall",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_update serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_update",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_check_updates serializes to expected JSON 1`] = `
+{
+  "type": "skills_check_updates",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_search serializes to expected JSON 1`] = `
+{
+  "query": "weather",
+  "type": "skills_search",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_inspect serializes to expected JSON 1`] = `
+{
+  "slug": "clawhub/my-skill",
+  "type": "skills_inspect",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types suggestion_request serializes to expected JSON 1`] = `
+{
+  "requestId": "req-suggest-001",
+  "sessionId": "sess-001",
+  "type": "suggestion_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types add_trust_rule serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "pattern": "git *",
+  "scope": "/projects/my-app",
+  "toolName": "bash",
+  "type": "add_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types trust_rules_list serializes to expected JSON 1`] = `
+{
+  "type": "trust_rules_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types remove_trust_rule serializes to expected JSON 1`] = `
+{
+  "id": "rule-001",
+  "type": "remove_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types update_trust_rule serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "id": "rule-001",
+  "pattern": "git push *",
+  "priority": 50,
+  "scope": "/projects/my-app",
+  "tool": "bash",
+  "type": "update_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types schedules_list serializes to expected JSON 1`] = `
+{
+  "type": "schedules_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types schedule_toggle serializes to expected JSON 1`] = `
+{
+  "enabled": false,
+  "id": "sched-001",
+  "type": "schedule_toggle",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types schedule_remove serializes to expected JSON 1`] = `
+{
+  "id": "sched-001",
+  "type": "schedule_remove",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types reminders_list serializes to expected JSON 1`] = `
+{
+  "type": "reminders_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types reminder_cancel serializes to expected JSON 1`] = `
+{
+  "id": "rem-001",
+  "type": "reminder_cancel",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types bundle_app serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "bundle_app",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_open_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "app_open_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types apps_list serializes to expected JSON 1`] = `
+{
+  "type": "apps_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types home_base_get serializes to expected JSON 1`] = `
+{
+  "ensureLinked": true,
+  "type": "home_base_get",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types shared_apps_list serializes to expected JSON 1`] = `
+{
+  "type": "shared_apps_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types shared_app_delete serializes to expected JSON 1`] = `
+{
+  "type": "shared_app_delete",
+  "uuid": "abc-123-def",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types fork_shared_app serializes to expected JSON 1`] = `
+{
+  "type": "fork_shared_app",
+  "uuid": "abc-123-def",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types open_bundle serializes to expected JSON 1`] = `
+{
+  "filePath": "/tmp/My_App.vellumapp",
+  "type": "open_bundle",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types sign_bundle_payload_response serializes to expected JSON 1`] = `
+{
+  "keyId": "abc123",
+  "publicKey": "dGVzdA==",
+  "requestId": "req-sign-001",
+  "signature": "dGVzdC1zaWduYXR1cmU=",
+  "type": "sign_bundle_payload_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types get_signing_identity_response serializes to expected JSON 1`] = `
+{
+  "keyId": "abc123",
+  "publicKey": "dGVzdA==",
+  "requestId": "req-identity-001",
+  "type": "get_signing_identity_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types secret_response serializes to expected JSON 1`] = `
+{
+  "delivery": "store",
+  "requestId": "req-secret-001",
+  "type": "secret_response",
+  "value": "ghp_test_token_value",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types sessions_clear serializes to expected JSON 1`] = `
+{
+  "type": "sessions_clear",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types ipc_blob_probe serializes to expected JSON 1`] = `
+{
+  "nonceSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "probeId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "type": "ipc_blob_probe",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types gallery_list serializes to expected JSON 1`] = `
+{
+  "type": "gallery_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types gallery_install serializes to expected JSON 1`] = `
+{
+  "galleryAppId": "gallery-focus-timer",
+  "type": "gallery_install",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_update_preview serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "preview": "base64-png-data",
+  "type": "app_update_preview",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types share_app_cloud serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "share_app_cloud",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types share_to_slack serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "share_to_slack",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types slack_webhook_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "slack_webhook_config",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types vercel_api_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "vercel_api_config",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types link_open_request serializes to expected JSON 1`] = `
+{
+  "type": "link_open_request",
+  "url": "https://example.com",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types ui_surface_undo serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_undo",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types publish_page serializes to expected JSON 1`] = `
+{
+  "html": "<html><body>Hello</body></html>",
+  "type": "publish_page",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types unpublish_page serializes to expected JSON 1`] = `
+{
+  "deploymentId": "dpl-001",
+  "type": "unpublish_page",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types diagnostics_export_request serializes to expected JSON 1`] = `
+{
+  "anchorMessageId": "msg-042",
+  "conversationId": "conv-001",
+  "type": "diagnostics_export_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types accept_starter_bundle serializes to expected JSON 1`] = `
+{
+  "type": "accept_starter_bundle",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "auth_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types user_message_echo serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "text": "Check the weather for me",
+  "type": "user_message_echo",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "text": "Here is some output",
+  "type": "assistant_text_delta",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types assistant_thinking_delta serializes to expected JSON 1`] = `
+{
+  "thinking": "Let me consider this...",
+  "type": "assistant_thinking_delta",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_use_start serializes to expected JSON 1`] = `
+{
+  "input": {
+    "command": "ls -la",
+  },
+  "toolName": "bash",
+  "type": "tool_use_start",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_output_chunk serializes to expected JSON 1`] = `
+{
+  "chunk": 
+"file1.ts
+file2.ts
+"
+,
+  "type": "tool_output_chunk",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_input_delta serializes to expected JSON 1`] = `
+{
+  "content": "{"html": "<div>Hello</div>"}",
+  "sessionId": "sess-001",
+  "toolName": "app_create",
+  "type": "tool_input_delta",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_result serializes to expected JSON 1`] = `
+{
+  "diff": {
+    "filePath": "/tmp/test.ts",
+    "isNewFile": false,
+    "newContent": "const x = 2;",
+    "oldContent": "const x = 1;",
+  },
+  "isError": false,
+  "result": "Command completed successfully",
+  "status": "success",
+  "toolName": "bash",
+  "type": "tool_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types secret_request serializes to expected JSON 1`] = `
+{
+  "allowOneTimeSend": false,
+  "allowedDomains": [
+    "github.com",
+  ],
+  "allowedTools": [
+    "browser_fill_credential",
+  ],
+  "description": "Needed to push changes",
+  "field": "token",
+  "label": "GitHub Personal Access Token",
+  "placeholder": "ghp_xxxxxxxxxxxx",
+  "purpose": "Push code changes to GitHub",
+  "requestId": "req-secret-001",
+  "service": "github",
+  "sessionId": "sess-001",
+  "type": "secret_request",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types confirmation_request serializes to expected JSON 1`] = `
+{
+  "allowlistOptions": [
+    {
+      "description": "Allow rm commands",
+      "label": "Allow rm commands",
+      "pattern": "bash:rm *",
+    },
+  ],
+  "diff": {
+    "filePath": "/tmp/test.ts",
+    "isNewFile": false,
+    "newContent": "new",
+    "oldContent": "old",
+  },
+  "executionTarget": "sandbox",
+  "input": {
+    "command": "rm -rf /tmp/test",
+  },
+  "principalId": "my-skill",
+  "principalKind": "skill",
+  "principalVersion": "sha256:abcdef1234567890",
+  "requestId": "req-002",
+  "riskLevel": "high",
+  "sandboxed": false,
+  "scopeOptions": [
+    {
+      "label": "In /tmp",
+      "scope": "/tmp",
+    },
+  ],
+  "sessionId": "sess-001",
+  "toolName": "bash",
+  "type": "confirmation_request",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types message_complete serializes to expected JSON 1`] = `
+{
+  "attachments": [
+    {
+      "data": "iVBORw0K",
+      "filename": "chart.png",
+      "mimeType": "image/png",
+    },
+  ],
+  "sessionId": "sess-001",
+  "type": "message_complete",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types session_info serializes to expected JSON 1`] = `
+{
+  "correlationId": "corr-001",
+  "sessionId": "sess-001",
+  "threadType": "standard",
+  "title": "My session",
+  "type": "session_info",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types session_list_response serializes to expected JSON 1`] = `
+{
+  "sessions": [
+    {
+      "id": "sess-001",
+      "threadType": "standard",
+      "title": "First session",
+      "updatedAt": 1700000000,
+    },
+    {
+      "id": "sess-002",
+      "threadType": "standard",
+      "title": "Second session",
+      "updatedAt": 1700001000,
+    },
+  ],
+  "type": "session_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types sessions_clear_response serializes to expected JSON 1`] = `
+{
+  "cleared": 3,
+  "type": "sessions_clear_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types error serializes to expected JSON 1`] = `
+{
+  "message": "Something went wrong",
+  "type": "error",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types pong serializes to expected JSON 1`] = `
+{
+  "type": "pong",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types daemon_status serializes to expected JSON 1`] = `
+{
+  "httpPort": 7821,
+  "type": "daemon_status",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types generation_cancelled serializes to expected JSON 1`] = `
+{
+  "type": "generation_cancelled",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types generation_handoff serializes to expected JSON 1`] = `
+{
+  "attachments": [
+    {
+      "data": "JVBER",
+      "filename": "report.pdf",
+      "mimeType": "application/pdf",
+    },
+  ],
+  "queuedCount": 2,
+  "requestId": "req-handoff-001",
+  "sessionId": "sess-001",
+  "type": "generation_handoff",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types model_info serializes to expected JSON 1`] = `
+{
+  "model": "claude-opus-4-6",
+  "provider": "anthropic",
+  "type": "model_info",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types history_response serializes to expected JSON 1`] = `
+{
+  "messages": [
+    {
+      "role": "user",
+      "text": "Hello",
+      "timestamp": 1700000000,
+    },
+    {
+      "attachments": [
+        {
+          "data": "iVBORw0K",
+          "filename": "result.png",
+          "mimeType": "image/png",
+        },
+      ],
+      "role": "assistant",
+      "text": "Hi there!",
+      "timestamp": 1700000001,
+    },
+  ],
+  "sessionId": "sess-history-001",
+  "type": "history_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types undo_complete serializes to expected JSON 1`] = `
+{
+  "removedCount": 2,
+  "sessionId": "session-abc",
+  "type": "undo_complete",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types usage_update serializes to expected JSON 1`] = `
+{
+  "estimatedCost": 0.025,
+  "inputTokens": 150,
+  "model": "claude-opus-4-6",
+  "outputTokens": 50,
+  "totalInputTokens": 1500,
+  "totalOutputTokens": 500,
+  "type": "usage_update",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types usage_response serializes to expected JSON 1`] = `
+{
+  "estimatedCost": 0.025,
+  "model": "claude-opus-4-6",
+  "totalInputTokens": 1500,
+  "totalOutputTokens": 500,
+  "type": "usage_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types context_compacted serializes to expected JSON 1`] = `
+{
+  "compactedMessages": 56,
+  "estimatedInputTokens": 108000,
+  "maxInputTokens": 180000,
+  "previousEstimatedInputTokens": 220000,
+  "summaryCalls": 3,
+  "summaryInputTokens": 4200,
+  "summaryModel": "claude-opus-4-6",
+  "summaryOutputTokens": 900,
+  "thresholdTokens": 144000,
+  "type": "context_compacted",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types secret_detected serializes to expected JSON 1`] = `
+{
+  "action": "redact",
+  "matches": [
+    {
+      "redactedValue": "sk-****abcd",
+      "type": "api_key",
+    },
+  ],
+  "toolName": "bash",
+  "type": "secret_detected",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types memory_recalled serializes to expected JSON 1`] = `
+{
+  "earlyTerminated": false,
+  "entityHits": 3,
+  "injectedTokens": 480,
+  "latencyMs": 55,
+  "lexicalHits": 12,
+  "mergedCount": 18,
+  "model": "text-embedding-3-small",
+  "provider": "openai",
+  "recencyHits": 6,
+  "relationExpandedItemCount": 4,
+  "relationNeighborEntityCount": 3,
+  "relationSeedEntityCount": 2,
+  "relationTraversedEdgeCount": 5,
+  "rerankApplied": false,
+  "selectedCount": 10,
+  "semanticHits": 8,
+  "topCandidates": [
+    {
+      "finalScore": 0.85,
+      "key": "segment:seg-1",
+      "kind": "fact",
+      "lexical": 0.9,
+      "recency": 0.3,
+      "semantic": 0.7,
+      "type": "segment",
+    },
+    {
+      "finalScore": 0.72,
+      "key": "item:item-1",
+      "kind": "preference",
+      "lexical": 0.6,
+      "recency": 0.1,
+      "semantic": 0.8,
+      "type": "item",
+    },
+  ],
+  "type": "memory_recalled",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types memory_status serializes to expected JSON 1`] = `
+{
+  "cleanupResolvedJobsCompleted24h": 12,
+  "cleanupResolvedJobsPending": 1,
+  "cleanupSupersededJobsCompleted24h": 8,
+  "cleanupSupersededJobsPending": 0,
+  "conflictsPending": 2,
+  "conflictsResolved": 7,
+  "degraded": false,
+  "enabled": true,
+  "model": "text-embedding-3-small",
+  "oldestPendingConflictAgeMs": 90000,
+  "provider": "openai",
+  "type": "memory_status",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types cu_action serializes to expected JSON 1`] = `
+{
+  "input": {
+    "x": 100,
+    "y": 200,
+  },
+  "reasoning": "Clicking the search button",
+  "sessionId": "cu-sess-001",
+  "stepNumber": 1,
+  "toolName": "click",
+  "type": "cu_action",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types cu_complete serializes to expected JSON 1`] = `
+{
+  "sessionId": "cu-sess-001",
+  "stepCount": 5,
+  "summary": "Successfully opened Safari and searched for weather",
+  "type": "cu_complete",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types cu_error serializes to expected JSON 1`] = `
+{
+  "message": "Session timed out after 30 steps",
+  "sessionId": "cu-sess-001",
+  "type": "cu_error",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types task_routed serializes to expected JSON 1`] = `
+{
+  "interactionType": "computer_use",
+  "sessionId": "sess-routed-001",
+  "type": "task_routed",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ride_shotgun_result serializes to expected JSON 1`] = `
+{
+  "observationCount": 5,
+  "sessionId": "sess-shotgun-001",
+  "summary": "User was debugging a test failure",
+  "type": "ride_shotgun_result",
+  "watchId": "watch-shotgun-001",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_show serializes to expected JSON 1`] = `
+{
+  "actions": [
+    {
+      "id": "dismiss",
+      "label": "OK",
+      "style": "primary",
+    },
+  ],
+  "data": {
+    "body": "All tests passed.",
+    "title": "Build Complete",
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "surfaceType": "card",
+  "title": "Status Update",
+  "type": "ui_surface_show",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_update serializes to expected JSON 1`] = `
+{
+  "data": {
+    "body": "Updated body text.",
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_update",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_dismiss serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_dismiss",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_complete serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "summary": "Confirmed",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_complete",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_data_response serializes to expected JSON 1`] = `
+{
+  "callId": "call-001",
+  "result": [
+    {
+      "appId": "app-001",
+      "createdAt": 1700000000,
+      "data": {
+        "name": "Test",
+      },
+      "id": "rec-001",
+      "updatedAt": 1700000000,
+    },
+  ],
+  "success": true,
+  "surfaceId": "surface-001",
+  "type": "app_data_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_list_response serializes to expected JSON 1`] = `
+{
+  "skills": [
+    {
+      "degraded": false,
+      "description": "A test skill",
+      "emoji": "🔧",
+      "id": "my-skill",
+      "name": "My Skill",
+      "source": "bundled",
+      "state": "enabled",
+      "updateAvailable": false,
+      "userInvocable": true,
+    },
+  ],
+  "type": "skills_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_state_changed serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "state": "enabled",
+  "type": "skills_state_changed",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_operation_response serializes to expected JSON 1`] = `
+{
+  "operation": "enable",
+  "success": true,
+  "type": "skills_operation_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skill_detail_response serializes to expected JSON 1`] = `
+{
+  "body": 
+"# Skill content
+
+Do the thing."
+,
+  "skillId": "my-skill",
+  "type": "skill_detail_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_inspect_response serializes to expected JSON 1`] = `
+{
+  "data": {
+    "createdAt": 1700000000,
+    "files": [
+      {
+        "path": "SKILL.md",
+        "size": 1024,
+      },
+    ],
+    "latestVersion": {
+      "changelog": "Bug fixes",
+      "version": "1.2.0",
+    },
+    "owner": {
+      "displayName": "ClaWHub",
+      "handle": "clawhub",
+    },
+    "skill": {
+      "displayName": "My Skill",
+      "slug": "clawhub/my-skill",
+      "summary": "A test skill",
+    },
+    "skillMdContent": 
+"# My Skill
+
+Does things."
+,
+    "stats": {
+      "downloads": 5000,
+      "installs": 1000,
+      "stars": 42,
+      "versions": 3,
+    },
+    "updatedAt": 1700001000,
+  },
+  "slug": "clawhub/my-skill",
+  "type": "skills_inspect_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types suggestion_response serializes to expected JSON 1`] = `
+{
+  "requestId": "req-suggest-001",
+  "source": "llm",
+  "suggestion": "Tell me more about that",
+  "type": "suggestion_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types message_queued serializes to expected JSON 1`] = `
+{
+  "position": 1,
+  "requestId": "req-queue-001",
+  "sessionId": "sess-001",
+  "type": "message_queued",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types message_dequeued serializes to expected JSON 1`] = `
+{
+  "requestId": "req-queue-001",
+  "sessionId": "sess-001",
+  "type": "message_dequeued",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types reminder_fired serializes to expected JSON 1`] = `
+{
+  "label": "Call Sidd",
+  "message": "Remember to call Sidd about the project",
+  "reminderId": "rem-001",
+  "type": "reminder_fired",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types schedule_complete serializes to expected JSON 1`] = `
+{
+  "name": "Daily backup",
+  "scheduleId": "sched-001",
+  "type": "schedule_complete",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types watcher_notification serializes to expected JSON 1`] = `
+{
+  "body": "Disabled after 5 consecutive errors.",
+  "title": "Watcher disabled: My Gmail",
+  "type": "watcher_notification",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types watcher_escalation serializes to expected JSON 1`] = `
+{
+  "body": "Meeting rescheduled to 3pm today.",
+  "title": "Urgent email from Alice",
+  "type": "watcher_escalation",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types watch_started serializes to expected JSON 1`] = `
+{
+  "durationSeconds": 300,
+  "intervalSeconds": 5,
+  "sessionId": "sess-001",
+  "type": "watch_started",
+  "watchId": "watch-001",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types watch_complete_request serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "watch_complete_request",
+  "watchId": "watch-001",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types trust_rules_list_response serializes to expected JSON 1`] = `
+{
+  "rules": [
+    {
+      "createdAt": 1700000000,
+      "decision": "allow",
+      "id": "rule-001",
+      "pattern": "git *",
+      "priority": 100,
+      "scope": "/projects/my-app",
+      "tool": "bash",
+    },
+  ],
+  "type": "trust_rules_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types schedules_list_response serializes to expected JSON 1`] = `
+{
+  "schedules": [
+    {
+      "cronExpression": "0 9 * * 1-5",
+      "description": "Every weekday at 9:00 AM",
+      "enabled": true,
+      "id": "sched-001",
+      "lastRunAt": 1700000000000,
+      "lastStatus": "ok",
+      "message": "Remind me about the standup",
+      "name": "Daily standup reminder",
+      "nextRunAt": 1700100000000,
+      "timezone": "America/Los_Angeles",
+    },
+  ],
+  "type": "schedules_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types reminders_list_response serializes to expected JSON 1`] = `
+{
+  "reminders": [
+    {
+      "createdAt": 1700000000000,
+      "fireAt": 1700100000000,
+      "firedAt": null,
+      "id": "rem-001",
+      "label": "Call Sidd",
+      "message": "Remember to call Sidd about the project",
+      "mode": "notify",
+      "status": "pending",
+    },
+  ],
+  "type": "reminders_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types bundle_app_response serializes to expected JSON 1`] = `
+{
+  "bundlePath": "/tmp/My_App-abc12345.vellumapp",
+  "manifest": {
+    "capabilities": [],
+    "content_id": "a1b2c3d4e5f6a7b8",
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "created_by": "vellum-assistant/0.1.6",
+    "description": "A test app",
+    "entry": "index.html",
+    "format_version": 1,
+    "name": "My App",
+    "version": "1.0.0",
+  },
+  "type": "bundle_app_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types apps_list_response serializes to expected JSON 1`] = `
+{
+  "apps": [
+    {
+      "contentId": "a1b2c3d4e5f6a7b8",
+      "createdAt": 1700000000,
+      "description": "A test app",
+      "icon": "📱",
+      "id": "app-001",
+      "name": "My App",
+      "preview": "iVBORw0KGgoAAAANSUhEUg==",
+      "version": "1.0.0",
+    },
+  ],
+  "type": "apps_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types home_base_get_response serializes to expected JSON 1`] = `
+{
+  "homeBase": {
+    "appId": "home-base-001",
+    "onboardingTasks": [
+      "Make it mine",
+      "Enable voice mode",
+      "Enable computer control",
+      "Try ambient mode",
+    ],
+    "preview": {
+      "description": "Prebuilt onboarding + starter task canvas",
+      "icon": "🏠",
+      "metrics": [
+        {
+          "label": "Starter tasks",
+          "value": "3",
+        },
+        {
+          "label": "Onboarding tasks",
+          "value": "4",
+        },
+      ],
+      "subtitle": "Dashboard",
+      "title": "Home Base",
+    },
+    "source": "prebuilt_seed",
+    "starterTasks": [
+      "Change the look and feel",
+      "Research something for me about X",
+      "Turn it into a webpage or interactive UI",
+    ],
+  },
+  "type": "home_base_get_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types shared_apps_list_response serializes to expected JSON 1`] = `
+{
+  "apps": [
+    {
+      "bundleSizeBytes": 4096,
+      "contentId": "abcdef0123456789",
+      "description": "A shared app",
+      "entry": "index.html",
+      "icon": "📱",
+      "installedAt": "2026-01-15T00:00:00Z",
+      "name": "Shared App",
+      "preview": "iVBORw0KGgoAAAANSUhEUg==",
+      "signerDisplayName": "Test User",
+      "trustTier": "signed",
+      "updateAvailable": true,
+      "uuid": "abc-123-def",
+      "version": "1.2.0",
+    },
+  ],
+  "type": "shared_apps_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types shared_app_delete_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "shared_app_delete_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types fork_shared_app_response serializes to expected JSON 1`] = `
+{
+  "appId": "new-app-id",
+  "name": "My App (Fork)",
+  "success": true,
+  "type": "fork_shared_app_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types open_bundle_response serializes to expected JSON 1`] = `
+{
+  "bundleSizeBytes": 4096,
+  "manifest": {
+    "capabilities": [],
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "created_by": "vellum-assistant/0.1.6",
+    "description": "A test app",
+    "entry": "index.html",
+    "format_version": 1,
+    "name": "My App",
+  },
+  "scanResult": {
+    "blocked": [],
+    "passed": true,
+    "warnings": [
+      "Use of fetch() detected",
+    ],
+  },
+  "signatureResult": {
+    "signerAccount": "test@example.com",
+    "signerDisplayName": "Test Signer",
+    "signerKeyId": "key-001",
+    "trustTier": "signed",
+  },
+  "type": "open_bundle_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types sign_bundle_payload serializes to expected JSON 1`] = `
+{
+  "payload": "{"content_hashes":{},"manifest":{}}",
+  "requestId": "req-sign-001",
+  "type": "sign_bundle_payload",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types get_signing_identity serializes to expected JSON 1`] = `
+{
+  "requestId": "req-identity-001",
+  "type": "get_signing_identity",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types session_error serializes to expected JSON 1`] = `
+{
+  "code": "PROVIDER_NETWORK",
+  "debugDetails": "ETIMEDOUT after 30000ms",
+  "retryable": true,
+  "sessionId": "sess-001",
+  "type": "session_error",
+  "userMessage": "Unable to reach the AI provider. Please try again.",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types trace_event serializes to expected JSON 1`] = `
+{
+  "attributes": {
+    "command": "ls -la",
+    "riskLevel": "low",
+    "sandboxed": true,
+    "toolName": "bash",
+  },
+  "eventId": "evt-001",
+  "kind": "tool_started",
+  "requestId": "req-001",
+  "sequence": 1,
+  "sessionId": "sess-001",
+  "status": "info",
+  "summary": "Running bash: ls -la",
+  "timestampMs": 1700000000000,
+  "type": "trace_event",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ipc_blob_probe_result serializes to expected JSON 1`] = `
+{
+  "observedNonceSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "ok": true,
+  "probeId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "type": "ipc_blob_probe_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types gallery_list_response serializes to expected JSON 1`] = `
+{
+  "gallery": {
+    "apps": [],
+    "categories": [
+      {
+        "icon": "📋",
+        "id": "productivity",
+        "name": "Productivity",
+      },
+    ],
+    "updatedAt": "2026-02-15T00:00:00Z",
+    "version": 1,
+  },
+  "type": "gallery_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types gallery_install_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-new-001",
+  "name": "Focus Timer",
+  "success": true,
+  "type": "gallery_install_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types share_app_cloud_response serializes to expected JSON 1`] = `
+{
+  "shareToken": "abc123def456",
+  "shareUrl": "http://localhost:7821/v1/apps/shared/abc123def456",
+  "success": true,
+  "type": "share_app_cloud_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types share_to_slack_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "share_to_slack_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types slack_webhook_config_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "slack_webhook_config_response",
+  "webhookUrl": "https://hooks.slack.com/services/T00/B00/xxx",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types vercel_api_config_response serializes to expected JSON 1`] = `
+{
+  "hasToken": true,
+  "success": true,
+  "type": "vercel_api_config_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types open_url serializes to expected JSON 1`] = `
+{
+  "title": "Example",
+  "type": "open_url",
+  "url": "https://example.com",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_update_preview_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "success": true,
+  "type": "app_update_preview_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_undo_result serializes to expected JSON 1`] = `
+{
+  "remainingUndos": 3,
+  "sessionId": "sess-001",
+  "success": true,
+  "surfaceId": "surface-001",
+  "type": "ui_surface_undo_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types publish_page_response serializes to expected JSON 1`] = `
+{
+  "deploymentId": "dpl-001",
+  "publicUrl": "https://example.vercel.app",
+  "success": true,
+  "type": "publish_page_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types unpublish_page_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "unpublish_page_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_files_changed serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "app_files_changed",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types browser_frame serializes to expected JSON 1`] = `
+{
+  "frame": "base64-jpeg-data",
+  "metadata": {
+    "offsetTop": 0,
+    "pageScaleFactor": 1,
+    "scrollOffsetX": 0,
+    "scrollOffsetY": 0,
+    "timestamp": 1700000000,
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "browser_frame",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types diagnostics_export_response serializes to expected JSON 1`] = `
+{
+  "filePath": "/tmp/diagnostics-conv-001.zip",
+  "success": true,
+  "type": "diagnostics_export_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types accept_starter_bundle_response serializes to expected JSON 1`] = `
+{
+  "accepted": true,
+  "alreadyAccepted": false,
+  "rulesAdded": 5,
+  "type": "accept_starter_bundle_response",
+}
+`;

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -33,6 +33,16 @@ class ShellTool implements Tool {
             type: 'number',
             description: 'Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.',
           },
+          network_mode: {
+            type: 'string',
+            enum: ['off', 'proxied'],
+            description: 'Network access mode for the command. "off" (default) blocks network access; "proxied" routes traffic through the credential proxy.',
+          },
+          credential_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
+          },
         },
         required: ['command'],
       },
@@ -51,13 +61,26 @@ class ShellTool implements Tool {
       return { content: 'Error: command contains null bytes', isError: true };
     }
 
+    // Parse optional network/credential fields (schema-only — no execution branching yet)
+    const networkMode: 'off' | 'proxied' =
+      input.network_mode === 'proxied' ? 'proxied' : 'off';
+
+    const credentialIds: string[] = [];
+    if (Array.isArray(input.credential_ids)) {
+      for (const id of input.credential_ids) {
+        if (typeof id === 'string' && id.length > 0) {
+          credentialIds.push(id);
+        }
+      }
+    }
+
     const config = getConfig();
     const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = config.timeouts;
     const requestedSec = typeof input.timeout_seconds === 'number' ? input.timeout_seconds : shellDefaultTimeoutSec;
     const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
     const timeoutMs = timeoutSec * 1000;
 
-    log.info({ command: redactSecrets(command), cwd: context.workingDir, timeoutSec }, 'Executing shell command');
+    log.info({ command: redactSecrets(command), cwd: context.workingDir, timeoutSec, networkMode, credentialIds }, 'Executing shell command');
 
     return new Promise<ToolExecutionResult>((resolve) => {
       const stdoutChunks: Buffer[] = [];

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -171,6 +171,16 @@ export const lazyTools: LazyToolDescriptor[] = [
             type: 'number',
             description: 'Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.',
           },
+          network_mode: {
+            type: 'string',
+            enum: ['off', 'proxied'],
+            description: 'Network access mode for the command. "off" (default) blocks network access; "proxied" routes traffic through the credential proxy.',
+          },
+          credential_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
+          },
         },
         required: ['command'],
       },


### PR DESCRIPTION
## Summary
- Add `network_mode` (off|proxied, default off) and `credential_ids` (string[]) to bash tool schema
- Parse and validate fields but no execution branching yet
- Update IPC snapshot tests

## Behavior Delta
Schema extension only — no runtime behavior changes.

## Tests Run
- `bun test src/__tests__/ipc-snapshot.test.ts` — 170 pass, 0 fail
- Full test suite: pre-existing failures only (missing packages in worktree), no regressions from this PR

## Rollback
Revert schema additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
