### PR TITLE
fix: abort daemon CU session on client-side failure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -10,7 +10,11 @@ extension AppDelegate {
 
     /// Handle escalation from an active text_qa session to foreground computer use.
     func handleEscalationToComputerUse(routed: TaskRoutedMessage) {
-        guard ActionExecutor.checkAccessibilityPermission(prompt: true) else { return }
+        guard ActionExecutor.checkAccessibilityPermission(prompt: true) else {
+            log.error("Accessibility permission denied — cannot start computer use session \(routed.sessionId)")
+            try? daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+            return
+        }
 
         let storedMaxSteps = UserDefaults.standard.integer(forKey: "maxStepsPerSession")
         let maxSteps = storedMaxSteps > 0 ? storedMaxSteps : 50
@@ -130,7 +134,11 @@ extension AppDelegate {
 
             switch routed.interactionType {
             case "computer_use":
-                guard ActionExecutor.checkAccessibilityPermission(prompt: true) else { return }
+                guard ActionExecutor.checkAccessibilityPermission(prompt: true) else {
+                    log.error("Accessibility permission denied — cannot start computer use session \(routed.sessionId)")
+                    try? self.daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+                    return
+                }
                 let storedMaxSteps = UserDefaults.standard.integer(forKey: "maxStepsPerSession")
                 let maxSteps = storedMaxSteps > 0 ? storedMaxSteps : 50
                 let session = ComputerUseSession(

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -376,7 +376,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             // Only handle escalation messages (those with escalatedFrom set)
             guard routed.escalatedFrom != nil,
-                  routed.interactionType == "computer_use" else { return }
+                  routed.interactionType == "computer_use" else {
+                log.debug("Ignoring non-escalation task_routed: type=\(routed.interactionType), escalatedFrom=\(routed.escalatedFrom ?? "nil")")
+                return
+            }
             self.handleEscalationToComputerUse(routed: routed)
         }
 

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -147,6 +147,7 @@ final class ComputerUseSession: ObservableObject {
             try? daemonClient.send(obs)
         } else {
             state = .failed(reason: "No focused window and screen capture failed")
+            try? daemonClient.send(CuSessionAbortMessage(sessionId: id))
             logger.finishSession(result: "failed: no window")
             return
         }


### PR DESCRIPTION
## Summary
- When accessibility permission check fails during escalation or direct session start, send `cu_session_abort` to the daemon and log the error
- When `buildObservation()` returns nil (no focused window + screenshot failed), send `cu_session_abort` before returning
- Add debug logging to the `onTaskRouted` guard clause for non-escalation messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
