### PR TITLE
fix: use correct skill_load parameter name in gmail SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -14,7 +14,7 @@ Before using any Gmail tool, verify that Gmail is connected by attempting a ligh
 1. **Do NOT call `credential_store oauth2_connect` yourself.** You do not have valid OAuth client credentials, and fabricating a client_id will cause a "401: invalid_client" error from Google.
 2. Instead, install and load the **google-oauth-setup** skill, which walks the user through creating real credentials in Google Cloud Console:
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
-   - Then call `skill_load` with `skill_id: "google-oauth-setup"`.
+   - Then call `skill_load` with `skill: "google-oauth-setup"`.
 3. Tell the user: *"Gmail isn't connected yet. I've loaded a setup guide that will walk you through connecting your Google account — it only takes a couple of minutes."*
 
 ## Capabilities


### PR DESCRIPTION
Both Codex and Devin flagged that the Gmail SKILL.md instructs the LLM to call skill_load with skill_id but the tool expects skill. This fixes the parameter name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
