### PR TITLE
feat: proxy CONNECT tunnel support

### DIFF
--- a/assistant/src/__tests__/script-proxy-connect-tunnel.test.ts
+++ b/assistant/src/__tests__/script-proxy-connect-tunnel.test.ts
@@ -1,0 +1,177 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { createServer, type Server } from 'node:http';
+import { createServer as createTcpServer, type Server as TcpServer } from 'node:net';
+import { connect } from 'node:net';
+import { createProxyServer } from '../tools/network/script-proxy/server.js';
+
+/** Start an HTTP server and return its address + cleanup handle. */
+function listenEphemeral(server: Server): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get address'));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        close: () => new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+/** Start a raw TCP echo server. */
+function listenTcpEcho(): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = createTcpServer((socket) => {
+      socket.pipe(socket);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get address'));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        close: () => new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Send an HTTP CONNECT request to the proxy and return the raw socket
+ * once the tunnel is established (or an error status).
+ */
+function sendConnect(
+  proxyPort: number,
+  target: string,
+): Promise<{ statusCode: number; socket: import('node:net').Socket }> {
+  return new Promise((resolve, reject) => {
+    const socket = connect(proxyPort, '127.0.0.1', () => {
+      socket.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+    });
+
+    let headerBuf = '';
+    const onData = (chunk: Buffer) => {
+      headerBuf += chunk.toString();
+      const endIdx = headerBuf.indexOf('\r\n\r\n');
+      if (endIdx !== -1) {
+        socket.removeListener('data', onData);
+        const statusLine = headerBuf.slice(0, headerBuf.indexOf('\r\n'));
+        const statusCode = Number(statusLine.split(' ')[1]);
+        // Push back any data after the header
+        const remaining = headerBuf.slice(endIdx + 4);
+        if (remaining.length > 0) {
+          socket.unshift(Buffer.from(remaining));
+        }
+        resolve({ statusCode, socket });
+      }
+    };
+
+    socket.on('data', onData);
+    socket.on('error', reject);
+  });
+}
+
+describe('CONNECT tunnel', () => {
+  const cleanups: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanups.map((c) => c.close().catch(() => {})));
+    cleanups.length = 0;
+  });
+
+  test('successful CONNECT tunnel establishment', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(px.port, `127.0.0.1:${echo.port}`);
+    cleanups.push({ close: () => Promise.resolve(socket.destroy()) } as any);
+
+    expect(statusCode).toBe(200);
+    socket.destroy();
+  });
+
+  test('bidirectional data flow through tunnel', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(px.port, `127.0.0.1:${echo.port}`);
+    cleanups.push({ close: () => Promise.resolve(socket.destroy()) } as any);
+
+    expect(statusCode).toBe(200);
+
+    // Write through the tunnel and read back
+    const received = await new Promise<string>((resolve, reject) => {
+      socket.once('data', (chunk: Buffer) => resolve(chunk.toString()));
+      socket.on('error', reject);
+      socket.write('hello tunnel');
+    });
+
+    expect(received).toBe('hello tunnel');
+    socket.destroy();
+  });
+
+  test('malformed target (no port) rejected with 400', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(px.port, 'example.com');
+    expect(statusCode).toBe(400);
+    socket.destroy();
+  });
+
+  test('malformed target (empty) rejected with 400', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    // Send a CONNECT with an empty target
+    const { statusCode, socket } = await sendConnect(px.port, ':443');
+    expect(statusCode).toBe(400);
+    socket.destroy();
+  });
+
+  test('upstream connection failure returns 502', async () => {
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    // Port 1 should be unreachable
+    const { statusCode, socket } = await sendConnect(px.port, '127.0.0.1:1');
+    expect(statusCode).toBe(502);
+    socket.destroy();
+  });
+
+  test('socket cleanup on client disconnect', async () => {
+    const echo = await listenTcpEcho();
+    cleanups.push(echo);
+
+    const proxy = createProxyServer();
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px);
+
+    const { statusCode, socket } = await sendConnect(px.port, `127.0.0.1:${echo.port}`);
+    expect(statusCode).toBe(200);
+
+    // Destroy client side — upstream should clean up without crashing
+    socket.destroy();
+
+    // Give a moment for cleanup to propagate
+    await new Promise((r) => setTimeout(r, 50));
+  });
+});

--- a/assistant/src/tools/network/script-proxy/connect-tunnel.ts
+++ b/assistant/src/tools/network/script-proxy/connect-tunnel.ts
@@ -1,0 +1,70 @@
+/**
+ * CONNECT tunnel handler — establishes a raw TCP tunnel between the
+ * client and a remote host for HTTPS pass-through (no MITM).
+ */
+
+import { connect, type Socket } from 'node:net';
+import type { IncomingMessage } from 'node:http';
+
+/**
+ * Parse and validate a CONNECT target of the form `host:port`.
+ * Returns null if the target is malformed.
+ */
+function parseTarget(url: string | undefined): { host: string; port: number } | null {
+  if (!url) return null;
+
+  const colonIdx = url.lastIndexOf(':');
+  if (colonIdx <= 0) return null; // no port separator, or leading colon only
+
+  const host = url.slice(0, colonIdx);
+  const portStr = url.slice(colonIdx + 1);
+
+  if (!host || !portStr) return null;
+
+  const port = Number(portStr);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+
+  return { host, port };
+}
+
+/**
+ * Handle an HTTP CONNECT request by establishing a bidirectional TCP
+ * tunnel to the requested target.
+ */
+export function handleConnect(
+  req: IncomingMessage,
+  clientSocket: Socket,
+  head: Buffer,
+): void {
+  const target = parseTarget(req.url);
+
+  if (!target) {
+    clientSocket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+    clientSocket.destroy();
+    return;
+  }
+
+  const upstream = connect(target.port, target.host, () => {
+    clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+
+    // Forward any data already buffered by the HTTP parser
+    if (head.length > 0) {
+      upstream.write(head);
+    }
+
+    // Bidirectional piping
+    upstream.pipe(clientSocket);
+    clientSocket.pipe(upstream);
+  });
+
+  upstream.on('error', () => {
+    if (clientSocket.writable) {
+      clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+    }
+    clientSocket.destroy();
+  });
+
+  clientSocket.on('error', () => {
+    upstream.destroy();
+  });
+}

--- a/assistant/src/tools/network/script-proxy/server.ts
+++ b/assistant/src/tools/network/script-proxy/server.ts
@@ -5,6 +5,7 @@
 
 import { createServer, type Server } from 'node:http';
 import { forwardHttpRequest, type PolicyCallback } from './http-forwarder.js';
+import { handleConnect } from './connect-tunnel.js';
 
 export interface ProxyServerConfig {
   /** Optional policy callback for credential injection / access control. */
@@ -15,7 +16,7 @@ export interface ProxyServerConfig {
 
 /**
  * Create an HTTP server that acts as a forward proxy for plain HTTP
- * requests (absolute-URL form). CONNECT tunnelling is not handled here.
+ * requests (absolute-URL form) and CONNECT tunnelling for HTTPS pass-through.
  */
 export function createProxyServer(config: ProxyServerConfig = {}): Server {
   const server = createServer((req, res) => {
@@ -24,6 +25,10 @@ export function createProxyServer(config: ProxyServerConfig = {}): Server {
     }
 
     forwardHttpRequest(req, res, config.policyCallback);
+  });
+
+  server.on('connect', (req, clientSocket, head) => {
+    handleConnect(req, clientSocket, head);
   });
 
   return server;


### PR DESCRIPTION
## Summary
- Handle CONNECT method for HTTPS tunneling
- Validate target host:port and reject malformed requests
- Bidirectional socket piping with error cleanup
- Wire into proxy server's connect event

## Behavior Delta
Proxy can now tunnel HTTPS for non-rewrite path.

## Tests Run
- `bun test src/__tests__/script-proxy-connect-tunnel.test.ts`

## Rollback
Remove CONNECT handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
