### PR TITLE
feat: add skill wrapper proxy bridge for computer-use tools

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-proxy-bridge.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-proxy-bridge.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'bun:test';
+import { forwardComputerUseProxyTool } from '../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../tools/types.js';
+
+describe('forwardComputerUseProxyTool', () => {
+  test('returns error when proxyToolResolver is missing', async () => {
+    const context = {} as ToolContext;
+    const result = await forwardComputerUseProxyTool('computer_use_click', { x: 100, y: 200 }, context);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('no proxy resolver available');
+    expect(result.content).toContain('computer_use_click');
+  });
+
+  test('forwards to proxyToolResolver when present', async () => {
+    const expectedResult: ToolExecutionResult = {
+      content: 'Clicked at (100, 200)',
+      isError: false,
+    };
+
+    let capturedName = '';
+    let capturedInput: Record<string, unknown> = {};
+
+    const context = {
+      proxyToolResolver: async (name: string, input: Record<string, unknown>) => {
+        capturedName = name;
+        capturedInput = input;
+        return expectedResult;
+      },
+    } as unknown as ToolContext;
+
+    const result = await forwardComputerUseProxyTool('computer_use_click', { x: 100, y: 200 }, context);
+
+    expect(result).toBe(expectedResult);
+    expect(capturedName).toBe('computer_use_click');
+    expect(capturedInput).toEqual({ x: 100, y: 200 });
+  });
+
+  test('passes through isError from resolver result', async () => {
+    const errorResult: ToolExecutionResult = {
+      content: 'Element not found',
+      isError: true,
+    };
+
+    const context = {
+      proxyToolResolver: async () => errorResult,
+    } as unknown as ToolContext;
+
+    const result = await forwardComputerUseProxyTool('computer_use_click', {}, context);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe('Element not found');
+  });
+});

--- a/assistant/src/tools/computer-use/skill-proxy-bridge.ts
+++ b/assistant/src/tools/computer-use/skill-proxy-bridge.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared helper for computer-use skill wrapper scripts.
+ *
+ * Each wrapper calls forwardComputerUseProxyTool() to delegate execution to
+ * the proxy resolver, which forwards the call to the connected macOS client.
+ */
+
+import type { ToolContext, ToolExecutionResult } from '../types.js';
+
+/**
+ * Forward a computer-use proxy tool call through the context's proxyToolResolver.
+ *
+ * Returns a clear error result if the resolver is missing (e.g. when the tool
+ * is invoked outside a session with a connected client).
+ */
+export function forwardComputerUseProxyTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (!context.proxyToolResolver) {
+    return Promise.resolve({
+      content: `Cannot execute ${toolName}: no proxy resolver available. This tool requires a connected macOS client.`,
+      isError: true,
+    });
+  }
+  return context.proxyToolResolver(toolName, input);
+}


### PR DESCRIPTION
## Summary
- Add `forwardComputerUseProxyTool()` helper in `tools/computer-use/skill-proxy-bridge.ts`
- Returns clear error when proxy resolver is missing
- Forwards tool name + input to resolver when present
- Add unit tests for missing resolver, successful forwarding, and error passthrough

## Test plan
- [x] `bun test src/__tests__/computer-use-skill-proxy-bridge.test.ts` passes (3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 04/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
