### PR TITLE
feat: add bundled computer-use skill skeleton

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -537,3 +537,44 @@ describe('bundled browser skill', () => {
     ]);
   });
 });
+
+describe('bundled computer-use skill', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('computer-use skill appears in full catalog (including bundled)', () => {
+    const catalog = loadSkillCatalog();
+    const cuSkill = catalog.find((s) => s.id === 'computer-use');
+    expect(cuSkill).toBeDefined();
+    expect(cuSkill!.name).toBe('Computer Use');
+    expect(cuSkill!.bundled).toBe(true);
+  });
+
+  test('computer-use skill is not user-invocable', () => {
+    const catalog = loadSkillCatalog();
+    const cuSkill = catalog.find((s) => s.id === 'computer-use');
+    expect(cuSkill).toBeDefined();
+    expect(cuSkill!.userInvocable).toBe(false);
+  });
+
+  test('computer-use skill has model invocation disabled', () => {
+    const catalog = loadSkillCatalog();
+    const cuSkill = catalog.find((s) => s.id === 'computer-use');
+    expect(cuSkill).toBeDefined();
+    expect(cuSkill!.disableModelInvocation).toBe(true);
+  });
+
+  test('computer-use skill has no tool manifest yet (skeleton only)', () => {
+    const catalog = loadSkillCatalog();
+    const cuSkill = catalog.find((s) => s.id === 'computer-use');
+    expect(cuSkill).toBeDefined();
+    expect(cuSkill!.toolManifest).toBeUndefined();
+  });
+});

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: "Computer Use"
+description: "Computer-use action tools for controlling the macOS desktop via accessibility and screen capture."
+user-invocable: false
+disable-model-invocation: true
+---
+
+This skill provides the 12 computer_use_* action tools used by ComputerUseSession
+to control the macOS desktop. It is internally preactivated for computer-use sessions
+and is not available in text sessions.
+
+Tools in this skill are proxy tools — execution is forwarded to the connected
+macOS client, never handled locally by the daemon.


### PR DESCRIPTION
## Summary
- Add `SKILL.md` for bundled `computer-use` skill (no TOOLS.json yet)
- Configured as non-user-invocable, model-invocation disabled
- Add 4 catalog tests asserting skill exists, is bundled, and has correct settings
- Skill is cataloged but inert (no tools manifest)

## Test plan
- [x] `bun test src/__tests__/skills.test.ts` passes (all existing + 4 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 05/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
