### PR TITLE
feat: add computer-use TOOLS.json and wrapper scripts

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { initializeTools, __resetRegistryForTesting } from '../tools/registry.js';
+import { allComputerUseTools } from '../tools/computer-use/definitions.js';
+import { COMPUTER_USE_TOOL_NAMES, COMPUTER_USE_TOOL_COUNT } from './test-support/computer-use-skill-harness.js';
+
+afterAll(() => { __resetRegistryForTesting(); });
+
+// Load the TOOLS.json manifest
+const manifestPath = resolve(import.meta.dirname, '../config/bundled-skills/computer-use/TOOLS.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+
+describe('computer-use skill manifest regression', () => {
+  test('manifest has exactly 12 tools', () => {
+    expect(manifest.tools).toHaveLength(COMPUTER_USE_TOOL_COUNT);
+  });
+
+  test('manifest version is 1', () => {
+    expect(manifest.version).toBe(1);
+  });
+
+  test('manifest tool names match harness constants', () => {
+    const manifestNames = manifest.tools.map((t: { name: string }) => t.name);
+    for (const name of COMPUTER_USE_TOOL_NAMES) {
+      expect(manifestNames).toContain(name);
+    }
+    // No extra tools
+    expect(manifestNames).toHaveLength(COMPUTER_USE_TOOL_COUNT);
+  });
+
+  test('all manifest tools have execution_target: host', () => {
+    for (const tool of manifest.tools) {
+      expect(tool.execution_target).toBe('host');
+    }
+  });
+
+  test('all manifest tools have risk: low', () => {
+    for (const tool of manifest.tools) {
+      expect(tool.risk).toBe('low');
+    }
+  });
+
+  test('all manifest tools have category: computer-use', () => {
+    for (const tool of manifest.tools) {
+      expect(tool.category).toBe('computer-use');
+    }
+  });
+
+  test('manifest descriptions match core definitions', async () => {
+    await initializeTools();
+
+    for (const cuTool of allComputerUseTools) {
+      const def = cuTool.getDefinition();
+      const manifestTool = manifest.tools.find((t: { name: string }) => t.name === def.name);
+      expect(manifestTool).toBeDefined();
+      expect(manifestTool.description).toBe(def.description);
+    }
+  });
+
+  test('manifest input_schema matches core definitions', async () => {
+    await initializeTools();
+
+    for (const cuTool of allComputerUseTools) {
+      const def = cuTool.getDefinition();
+      const manifestTool = manifest.tools.find((t: { name: string }) => t.name === def.name);
+      expect(manifestTool).toBeDefined();
+      expect(manifestTool.input_schema).toEqual(def.input_schema);
+    }
+  });
+});

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -571,10 +571,27 @@ describe('bundled computer-use skill', () => {
     expect(cuSkill!.disableModelInvocation).toBe(true);
   });
 
-  test('computer-use skill has no tool manifest yet (skeleton only)', () => {
+  test('computer-use skill has a valid tool manifest with 12 tools', () => {
     const catalog = loadSkillCatalog();
     const cuSkill = catalog.find((s) => s.id === 'computer-use');
     expect(cuSkill).toBeDefined();
-    expect(cuSkill!.toolManifest).toBeUndefined();
+    expect(cuSkill!.toolManifest).toBeDefined();
+    expect(cuSkill!.toolManifest!.present).toBe(true);
+    expect(cuSkill!.toolManifest!.valid).toBe(true);
+    expect(cuSkill!.toolManifest!.toolCount).toBe(12);
+    expect(cuSkill!.toolManifest!.toolNames).toEqual([
+      'computer_use_click',
+      'computer_use_double_click',
+      'computer_use_right_click',
+      'computer_use_type_text',
+      'computer_use_key',
+      'computer_use_scroll',
+      'computer_use_drag',
+      'computer_use_wait',
+      'computer_use_open_app',
+      'computer_use_run_applescript',
+      'computer_use_done',
+      'computer_use_respond',
+    ]);
   });
 });

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -1,0 +1,326 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "computer_use_click",
+      "description": "Click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "element_id": {
+            "type": "integer",
+            "description": "The [ID] number of the element from the accessibility tree (preferred)"
+          },
+          "x": {
+            "type": "integer",
+            "description": "X coordinate on screen (fallback when no element_id)"
+          },
+          "y": {
+            "type": "integer",
+            "description": "Y coordinate on screen (fallback when no element_id)"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what you see and why you are clicking here"
+          }
+        },
+        "required": ["reasoning"]
+      },
+      "executor": "tools/computer-use-click.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_double_click",
+      "description": "Double-click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "element_id": {
+            "type": "integer",
+            "description": "The [ID] number of the element from the accessibility tree (preferred)"
+          },
+          "x": {
+            "type": "integer",
+            "description": "X coordinate on screen (fallback when no element_id)"
+          },
+          "y": {
+            "type": "integer",
+            "description": "Y coordinate on screen (fallback when no element_id)"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what you see and why you are double-clicking here"
+          }
+        },
+        "required": ["reasoning"]
+      },
+      "executor": "tools/computer-use-double-click.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_right_click",
+      "description": "Right-click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "element_id": {
+            "type": "integer",
+            "description": "The [ID] number of the element from the accessibility tree (preferred)"
+          },
+          "x": {
+            "type": "integer",
+            "description": "X coordinate on screen (fallback when no element_id)"
+          },
+          "y": {
+            "type": "integer",
+            "description": "Y coordinate on screen (fallback when no element_id)"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what you see and why you are right-clicking here"
+          }
+        },
+        "required": ["reasoning"]
+      },
+      "executor": "tools/computer-use-right-click.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_type_text",
+      "description": "Type text at the current cursor position. The target field must already be focused (click it first).",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The text to type"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what you are typing and why"
+          }
+        },
+        "required": ["text", "reasoning"]
+      },
+      "executor": "tools/computer-use-type-text.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_key",
+      "description": "Press a key or keyboard shortcut. Supported: enter, tab, escape, backspace, delete, up, down, left, right, space, cmd+a, cmd+c, cmd+v, cmd+z, cmd+tab, cmd+w, shift+tab, option+tab",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Key or shortcut to press (e.g. enter, tab, cmd+c, cmd+v)"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of why you are pressing this key"
+          }
+        },
+        "required": ["key", "reasoning"]
+      },
+      "executor": "tools/computer-use-key.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_scroll",
+      "description": "Scroll within an element by its [ID], or at raw screen coordinates as fallback.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "element_id": {
+            "type": "integer",
+            "description": "The [ID] number of the element to scroll within (preferred)"
+          },
+          "x": {
+            "type": "integer",
+            "description": "X coordinate on screen (fallback when no element_id)"
+          },
+          "y": {
+            "type": "integer",
+            "description": "Y coordinate on screen (fallback when no element_id)"
+          },
+          "direction": {
+            "type": "string",
+            "enum": ["up", "down", "left", "right"],
+            "description": "Scroll direction"
+          },
+          "amount": {
+            "type": "integer",
+            "description": "Scroll amount (1-10)"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of why you are scrolling"
+          }
+        },
+        "required": ["direction", "amount", "reasoning"]
+      },
+      "executor": "tools/computer-use-scroll.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_drag",
+      "description": "Drag from one element or position to another. Use for moving files, resizing windows, rearranging items, or adjusting sliders.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "element_id": {
+            "type": "integer",
+            "description": "The [ID] of the source element to drag from (preferred)"
+          },
+          "x": {
+            "type": "integer",
+            "description": "Source X coordinate (fallback when no element_id)"
+          },
+          "y": {
+            "type": "integer",
+            "description": "Source Y coordinate (fallback when no element_id)"
+          },
+          "to_element_id": {
+            "type": "integer",
+            "description": "The [ID] of the destination element to drag to (preferred)"
+          },
+          "to_x": {
+            "type": "integer",
+            "description": "Destination X coordinate (fallback when no to_element_id)"
+          },
+          "to_y": {
+            "type": "integer",
+            "description": "Destination Y coordinate (fallback when no to_element_id)"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what you are dragging and why"
+          }
+        },
+        "required": ["reasoning"]
+      },
+      "executor": "tools/computer-use-drag.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_wait",
+      "description": "Wait for the UI to update",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "duration_ms": {
+            "type": "integer",
+            "description": "Milliseconds to wait"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what you are waiting for"
+          }
+        },
+        "required": ["duration_ms", "reasoning"]
+      },
+      "executor": "tools/computer-use-wait.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_open_app",
+      "description": "Open or switch to a macOS application by name. Preferred over cmd+tab for switching apps — more reliable and explicit.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_name": {
+            "type": "string",
+            "description": "The name of the application to open (e.g. \"Slack\", \"Safari\", \"Google Chrome\", \"VS Code\")"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of why you need to open or switch to this app"
+          }
+        },
+        "required": ["app_name", "reasoning"]
+      },
+      "executor": "tools/computer-use-open-app.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_run_applescript",
+      "description": "Execute an AppleScript to control applications via Apple's scripting bridge. Use this for operations that are more reliable through scripting than UI interaction: setting a browser URL directly, navigating Finder to a path, querying app state (tab count, window titles, document status), or clicking deeply nested menu items. The script's return value (if any) will be reported back. NEVER use \"do shell script\" — it is blocked for security. Keep scripts short and targeted to a single operation.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "The AppleScript source code to execute"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what this script does and why AppleScript is better than UI interaction for this step"
+          }
+        },
+        "required": ["script", "reasoning"]
+      },
+      "executor": "tools/computer-use-run-applescript.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_done",
+      "description": "Task is complete",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "Human-readable summary of what was accomplished"
+          }
+        },
+        "required": ["summary"]
+      },
+      "executor": "tools/computer-use-done.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "computer_use_respond",
+      "description": "Respond directly to the user with a text answer. Use this when the user is asking a question (about their schedule, meetings, calendar, etc.) rather than asking you to control the computer.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "The text answer to display to the user"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of how you determined the answer"
+          }
+        },
+        "required": ["answer", "reasoning"]
+      },
+      "executor": "tools/computer-use-respond.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-click.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-click.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_click', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-done.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-done.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_done', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-double-click.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-double-click.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_double_click', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-drag.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-drag.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_drag', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-key.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-key.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_key', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-open-app.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-open-app.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_open_app', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-respond.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-respond.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_respond', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-right-click.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-right-click.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_right_click', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-run-applescript.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-run-applescript.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_run_applescript', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-scroll.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-scroll.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_scroll', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-type-text.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-type-text.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_type_text', input, context);
+}

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-wait.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-wait.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_wait', input, context);
+}


### PR DESCRIPTION
## Summary
- Add TOOLS.json manifest with all 12 `computer_use_*` tool entries
- Add 12 wrapper scripts that delegate to `forwardComputerUseProxyTool()`
- Schemas and descriptions are exact copies from core `definitions.ts`
- Add manifest regression tests asserting parity with core definitions
- Update skills.test.ts to reflect manifest is now present
- Not yet active at runtime (projection wired in PR 07)

## Test plan
- [x] `bun test src/__tests__/computer-use-skill-manifest-regression.test.ts` passes
- [x] `bun test src/__tests__/skills.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 06/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
