### PR TITLE
feat: proxy local CA and certificate issuance utilities

### DIFF
--- a/assistant/src/__tests__/script-proxy-certs.test.ts
+++ b/assistant/src/__tests__/script-proxy-certs.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtemp, rm, stat, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureLocalCA, issueLeafCert, getCAPath } from '../tools/network/script-proxy/certs.js';
+
+let dataDir: string;
+
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'vellum-certs-test-'));
+});
+
+afterAll(async () => {
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+describe('ensureLocalCA', () => {
+  test('creates CA cert and key with correct permissions', async () => {
+    await ensureLocalCA(dataDir);
+
+    const caDir = join(dataDir, 'proxy-ca');
+    const certStat = await stat(join(caDir, 'ca.pem'));
+    const keyStat = await stat(join(caDir, 'ca-key.pem'));
+
+    expect(certStat.isFile()).toBe(true);
+    expect(keyStat.isFile()).toBe(true);
+
+    // Check permissions (mask with 0o777 to get just the permission bits)
+    expect(keyStat.mode & 0o777).toBe(0o600);
+    expect(certStat.mode & 0o777).toBe(0o644);
+  });
+
+  test('is idempotent — repeated calls do not regenerate', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const certBefore = await readFile(join(caDir, 'ca.pem'), 'utf-8');
+    const keyBefore = await readFile(join(caDir, 'ca-key.pem'), 'utf-8');
+
+    await ensureLocalCA(dataDir);
+
+    const certAfter = await readFile(join(caDir, 'ca.pem'), 'utf-8');
+    const keyAfter = await readFile(join(caDir, 'ca-key.pem'), 'utf-8');
+
+    expect(certAfter).toBe(certBefore);
+    expect(keyAfter).toBe(keyBefore);
+  });
+});
+
+describe('issueLeafCert', () => {
+  const HOSTNAME = 'example.com';
+
+  test('generates a leaf cert for a hostname', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const result = await issueLeafCert(caDir, HOSTNAME);
+
+    expect(result.cert).toContain('BEGIN CERTIFICATE');
+    expect(result.key).toContain('BEGIN');
+
+    // Verify the issued files exist on disk
+    const issuedDir = join(caDir, 'issued');
+    const certStat_ = await stat(join(issuedDir, `${HOSTNAME}.pem`));
+    const keyStat_ = await stat(join(issuedDir, `${HOSTNAME}-key.pem`));
+    expect(certStat_.isFile()).toBe(true);
+    expect(keyStat_.isFile()).toBe(true);
+  });
+
+  test('returns cached cert on repeated calls', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const first = await issueLeafCert(caDir, HOSTNAME);
+    const second = await issueLeafCert(caDir, HOSTNAME);
+
+    expect(second.cert).toBe(first.cert);
+    expect(second.key).toBe(first.key);
+  });
+
+  test('generates different certs for different hostnames', async () => {
+    const caDir = join(dataDir, 'proxy-ca');
+    const certA = await issueLeafCert(caDir, 'a.example.com');
+    const certB = await issueLeafCert(caDir, 'b.example.com');
+
+    expect(certA.cert).not.toBe(certB.cert);
+    expect(certA.key).not.toBe(certB.key);
+  });
+});
+
+describe('getCAPath', () => {
+  test('returns the correct path to the CA cert', () => {
+    const result = getCAPath('/some/data/dir');
+    expect(result).toBe('/some/data/dir/proxy-ca/ca.pem');
+  });
+});

--- a/assistant/src/tools/network/script-proxy/certs.ts
+++ b/assistant/src/tools/network/script-proxy/certs.ts
@@ -1,0 +1,149 @@
+import { mkdir, stat, readFile, writeFile, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const CA_CERT_FILENAME = 'ca.pem';
+const CA_KEY_FILENAME = 'ca-key.pem';
+const ISSUED_DIR = 'issued';
+
+/**
+ * Ensure a self-signed CA cert+key exists in `{dataDir}/proxy-ca/`.
+ * Idempotent: skips generation if both files already exist.
+ */
+export async function ensureLocalCA(dataDir: string): Promise<void> {
+  const caDir = join(dataDir, 'proxy-ca');
+  const certPath = join(caDir, CA_CERT_FILENAME);
+  const keyPath = join(caDir, CA_KEY_FILENAME);
+
+  // Check if both files already exist
+  const [certExists, keyExists] = await Promise.all([
+    stat(certPath).then(() => true, () => false),
+    stat(keyPath).then(() => true, () => false),
+  ]);
+
+  if (certExists && keyExists) return;
+
+  await mkdir(caDir, { recursive: true });
+
+  // Generate CA key
+  const keyProc = Bun.spawn([
+    'openssl', 'genrsa', '-out', keyPath, '2048',
+  ], { stdout: 'pipe', stderr: 'pipe' });
+  const keyExit = await keyProc.exited;
+  if (keyExit !== 0) {
+    const stderr = await new Response(keyProc.stderr).text();
+    throw new Error(`Failed to generate CA key: ${stderr}`);
+  }
+
+  // Generate self-signed CA cert (valid 10 years)
+  const certProc = Bun.spawn([
+    'openssl', 'req', '-new', '-x509',
+    '-key', keyPath,
+    '-out', certPath,
+    '-days', '3650',
+    '-subj', '/CN=Vellum Local Proxy CA',
+    '-addext', 'basicConstraints=critical,CA:TRUE',
+    '-addext', 'keyUsage=critical,keyCertSign,cRLSign',
+  ], { stdout: 'pipe', stderr: 'pipe' });
+  const certExit = await certProc.exited;
+  if (certExit !== 0) {
+    const stderr = await new Response(certProc.stderr).text();
+    throw new Error(`Failed to generate CA cert: ${stderr}`);
+  }
+
+  // Set strict permissions
+  await Promise.all([
+    chmod(keyPath, 0o600),
+    chmod(certPath, 0o644),
+  ]);
+}
+
+/**
+ * Issue a leaf certificate signed by the local CA for the given hostname.
+ * Caches issued certs in `{caDir}/issued/{hostname}.pem`.
+ * Returns PEM strings for the cert and key.
+ */
+export async function issueLeafCert(
+  caDir: string,
+  hostname: string,
+): Promise<{ cert: string; key: string }> {
+  const issuedDir = join(caDir, ISSUED_DIR);
+  const leafCertPath = join(issuedDir, `${hostname}.pem`);
+  const leafKeyPath = join(issuedDir, `${hostname}-key.pem`);
+
+  // Return cached cert if it exists
+  const [certExists, keyExists] = await Promise.all([
+    stat(leafCertPath).then(() => true, () => false),
+    stat(leafKeyPath).then(() => true, () => false),
+  ]);
+
+  if (certExists && keyExists) {
+    const [cert, key] = await Promise.all([
+      readFile(leafCertPath, 'utf-8'),
+      readFile(leafKeyPath, 'utf-8'),
+    ]);
+    return { cert, key };
+  }
+
+  await mkdir(issuedDir, { recursive: true });
+
+  const caCertPath = join(caDir, CA_CERT_FILENAME);
+  const caKeyPath = join(caDir, CA_KEY_FILENAME);
+
+  // Generate leaf key
+  const keyProc = Bun.spawn([
+    'openssl', 'genrsa', '-out', leafKeyPath, '2048',
+  ], { stdout: 'pipe', stderr: 'pipe' });
+  const keyExit = await keyProc.exited;
+  if (keyExit !== 0) {
+    const stderr = await new Response(keyProc.stderr).text();
+    throw new Error(`Failed to generate leaf key for ${hostname}: ${stderr}`);
+  }
+
+  // Generate CSR
+  const csrPath = join(issuedDir, `${hostname}.csr`);
+  const csrProc = Bun.spawn([
+    'openssl', 'req', '-new',
+    '-key', leafKeyPath,
+    '-out', csrPath,
+    '-subj', `/CN=${hostname}`,
+  ], { stdout: 'pipe', stderr: 'pipe' });
+  const csrExit = await csrProc.exited;
+  if (csrExit !== 0) {
+    const stderr = await new Response(csrProc.stderr).text();
+    throw new Error(`Failed to generate CSR for ${hostname}: ${stderr}`);
+  }
+
+  // Write SAN extension config to a temp file
+  const extPath = join(issuedDir, `${hostname}-ext.cnf`);
+  await writeFile(extPath, `subjectAltName=DNS:${hostname}\n`);
+
+  // Sign with CA (valid 1 year)
+  const signProc = Bun.spawn([
+    'openssl', 'x509', '-req',
+    '-in', csrPath,
+    '-CA', caCertPath,
+    '-CAkey', caKeyPath,
+    '-CAcreateserial',
+    '-out', leafCertPath,
+    '-days', '365',
+    '-extfile', extPath,
+  ], { stdout: 'pipe', stderr: 'pipe' });
+  const signExit = await signProc.exited;
+  if (signExit !== 0) {
+    const stderr = await new Response(signProc.stderr).text();
+    throw new Error(`Failed to sign leaf cert for ${hostname}: ${stderr}`);
+  }
+
+  const [cert, key] = await Promise.all([
+    readFile(leafCertPath, 'utf-8'),
+    readFile(leafKeyPath, 'utf-8'),
+  ]);
+  return { cert, key };
+}
+
+/**
+ * Return the path to the local CA cert for use as SSL_CERT_FILE or NODE_EXTRA_CA_CERTS.
+ */
+export function getCAPath(dataDir: string): string {
+  return join(dataDir, 'proxy-ca', CA_CERT_FILENAME);
+}

--- a/assistant/src/tools/network/script-proxy/index.ts
+++ b/assistant/src/tools/network/script-proxy/index.ts
@@ -15,3 +15,9 @@ export {
   getSessionsForConversation,
   stopAllSessions,
 } from './session-manager.js';
+
+export {
+  ensureLocalCA,
+  issueLeafCert,
+  getCAPath,
+} from './certs.js';

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -6,6 +6,7 @@ import type {
   ProxySessionConfig,
   ProxyEnvVars,
 } from './types.js';
+import { getCAPath } from './certs.js';
 
 const DEFAULT_CONFIG: ProxySessionConfig = {
   idleTimeoutMs: 5 * 60 * 1000, // 5 minutes
@@ -17,6 +18,7 @@ interface ManagedSession {
   server: Server | null;
   idleTimer: ReturnType<typeof setTimeout> | null;
   config: ProxySessionConfig;
+  dataDir: string | null;
 }
 
 const sessions = new Map<ProxySessionId, ManagedSession>();
@@ -40,6 +42,7 @@ export function createSession(
   conversationId: string,
   credentialIds: string[],
   config?: Partial<ProxySessionConfig>,
+  dataDir?: string,
 ): ProxySession {
   const merged: ProxySessionConfig = { ...DEFAULT_CONFIG, ...config };
 
@@ -68,6 +71,7 @@ export function createSession(
     server: null,
     idleTimer: null,
     config: merged,
+    dataDir: dataDir ?? null,
   });
 
   return { ...session };
@@ -148,11 +152,17 @@ export function getSessionEnv(sessionId: ProxySessionId): ProxyEnvVars {
   resetIdleTimer(managed);
 
   const proxyUrl = `http://127.0.0.1:${managed.session.port}`;
-  return {
+  const env: ProxyEnvVars = {
     HTTP_PROXY: proxyUrl,
     HTTPS_PROXY: proxyUrl,
     NO_PROXY: 'localhost,127.0.0.1,::1',
   };
+
+  if (managed.dataDir) {
+    env.SSL_CERT_FILE = getCAPath(managed.dataDir);
+  }
+
+  return env;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Generate per-install CA cert/key with strict permissions (0o600 key, 0o644 cert)
- Issue leaf certs per-host signed by the local CA, with on-disk caching
- Expose CA path for subprocess trust via `SSL_CERT_FILE` env var in `getSessionEnv()`
- MITM prerequisites without routing changes

## Behavior Delta
New cert utilities — no routing integration yet.

## Tests Run
- `bun test src/__tests__/script-proxy-certs.test.ts` — 6 pass
- `bun test src/__tests__/script-proxy-session-manager.test.ts` — 19 pass (no regressions)

## Rollback
Remove cert utilities and references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
