### PR TITLE
feat: add CU session skill projection plumbing (opt-in)

### DIFF
--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -229,4 +229,68 @@ describe('ComputerUseSession lifecycle', () => {
     expect(completes[0].summary).toBe('The meeting is at 3pm');
     expect(completes[0].isResponse).toBe(true);
   });
+
+  test('default construction (no preactivated skills) uses legacy CU tool definitions', async () => {
+    let capturedTools: string[] = [];
+    const provider: Provider = {
+      name: 'mock',
+      async sendMessage(_msgs, tools) {
+        capturedTools = (tools ?? []).map((t) => t.name);
+        return {
+          content: [{
+            type: 'tool_use',
+            id: 'tu-default',
+            name: 'computer_use_done',
+            input: { summary: 'Done' },
+          }],
+          model: 'mock-model',
+          usage: { inputTokens: 10, outputTokens: 5 },
+          stopReason: 'tool_use',
+        };
+      },
+    };
+
+    // No preactivatedSkillIds passed — legacy path
+    const session = new ComputerUseSession(
+      'cu-legacy-path',
+      'test legacy',
+      1440, 900,
+      provider,
+      () => {},
+      'computer_use',
+      undefined,
+    );
+
+    await session.handleObservation({
+      type: 'cu_observation',
+      sessionId: 'cu-legacy-path',
+      axTree: 'Window "Test" [1]',
+    });
+
+    const cuTools = capturedTools.filter((n) => n.startsWith('computer_use_'));
+    expect(cuTools).toHaveLength(12);
+  });
+
+  test('constructor accepts preactivatedSkillIds parameter', () => {
+    const { provider } = createProvider([{
+      content: [{ type: 'text', text: 'unused' }],
+      model: 'mock-model',
+      usage: { inputTokens: 1, outputTokens: 1 },
+      stopReason: 'end_turn',
+    }]);
+
+    // Should not throw
+    const session = new ComputerUseSession(
+      'cu-preactivated',
+      'test preactivated',
+      1440, 900,
+      provider,
+      () => {},
+      'computer_use',
+      undefined,
+      ['computer-use'],
+    );
+
+    expect(session).toBeDefined();
+  });
 });

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -20,6 +20,8 @@ import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getSandboxWorkingDir } from '../util/platform.js';
 import { getConfig } from '../config/loader.js';
+import { projectSkillTools } from './session-skill-tools.js';
+import type { SkillToolProjection } from './session-skill-tools.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('computer-use-session');
@@ -56,6 +58,8 @@ export class ComputerUseSession {
   private sendToClient: (msg: ServerMessage) => void;
   private readonly interactionType: 'computer_use' | 'text_qa';
   private readonly onTerminal?: (sessionId: string) => void;
+  private readonly preactivatedSkillIds: string[];
+  private readonly skillProjectionState = new Map<string, string>();
 
   private state: SessionState = 'idle';
   private stepCount = 0;
@@ -88,6 +92,7 @@ export class ComputerUseSession {
     sendToClient: (msg: ServerMessage) => void,
     interactionType?: 'computer_use' | 'text_qa',
     onTerminal?: (sessionId: string) => void,
+    preactivatedSkillIds?: string[],
   ) {
     this.sessionId = sessionId;
     this.task = task;
@@ -97,6 +102,7 @@ export class ComputerUseSession {
     this.sendToClient = sendToClient;
     this.interactionType = interactionType ?? 'computer_use';
     this.onTerminal = onTerminal;
+    this.preactivatedSkillIds = preactivatedSkillIds ?? [];
   }
 
   // ---------------------------------------------------------------------------
@@ -197,6 +203,28 @@ export class ComputerUseSession {
     return this.state;
   }
 
+  /**
+   * Compute CU tool definitions from the bundled computer-use skill via
+   * skill projection. Returns null if no preactivated skills are configured
+   * (i.e. the legacy path should be used).
+   */
+  private getProjectedCuToolDefinitions(): ToolDefinition[] | null {
+    if (this.preactivatedSkillIds.length === 0) {
+      return null;
+    }
+
+    const projection = projectSkillTools([], {
+      preactivatedSkillIds: this.preactivatedSkillIds,
+      previouslyActiveSkillIds: this.skillProjectionState,
+    });
+
+    if (projection.toolDefinitions.length === 0) {
+      return null;
+    }
+
+    return projection.toolDefinitions;
+  }
+
   handleSurfaceAction(surfaceId: string, actionId: string, data?: Record<string, unknown>): void {
     const pending = this.pendingSurfaceActions.get(surfaceId);
     if (!pending) {
@@ -221,8 +249,13 @@ export class ComputerUseSession {
 
   private async runAgentLoop(messages: Message[]): Promise<void> {
     const systemPrompt = buildComputerUseSystemPrompt(this.screenWidth, this.screenHeight);
+
+    // Try skill projection first; fall back to legacy direct definitions
+    const projectedCuTools = this.getProjectedCuToolDefinitions();
+    const cuToolDefs = projectedCuTools ?? allComputerUseTools.map((t) => t.getDefinition());
+
     const toolDefs: ToolDefinition[] = [
-      ...allComputerUseTools.map((t) => t.getDefinition()),
+      ...cuToolDefs,
       ...allUiSurfaceTools
         .filter((t) => t.name !== 'request_file')
         .map((t) => t.getDefinition()),


### PR DESCRIPTION
## Summary
- Add `preactivatedSkillIds` constructor option to `ComputerUseSession`
- Add `getProjectedCuToolDefinitions()` internal method using `projectSkillTools()`
- Legacy path (no preactivated skills) remains default — no behavior change
- Projection path will be activated in PR 09 (cutover)

## Test plan
- [x] `bun test src/__tests__/computer-use-session-lifecycle.test.ts` passes
- [x] Default path test confirms 12 CU tools still present
- [x] Constructor accepts preactivatedSkillIds parameter without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 07/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
