### PR TITLE
feat: cutover — remove core computer_use_* registration, activate skill projection

### DIFF
--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -28,9 +28,6 @@ mock.module('../config/loader.js', () => ({
 import { ComputerUseSession } from '../daemon/computer-use-session.js';
 import type { Provider, ProviderResponse } from '../providers/types.js';
 import type { CuObservation, ServerMessage } from '../daemon/ipc-protocol.js';
-import { registerComputerUseTools } from '../tools/computer-use/registry.js';
-
-registerComputerUseTools();
 
 function createProvider(responses: ProviderResponse[]): { provider: Provider; getCalls: () => number } {
   let calls = 0;
@@ -230,7 +227,7 @@ describe('ComputerUseSession lifecycle', () => {
     expect(completes[0].isResponse).toBe(true);
   });
 
-  test('default construction (no preactivated skills) uses legacy CU tool definitions', async () => {
+  test('default construction preactivates computer-use skill and provides 12 CU tools', async () => {
     let capturedTools: string[] = [];
     const provider: Provider = {
       name: 'mock',

--- a/assistant/src/__tests__/computer-use-skill-baseline.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-baseline.test.ts
@@ -17,13 +17,12 @@ import {
 afterAll(() => { __resetRegistryForTesting(); });
 
 describe('computer-use skill baseline: registry tool surfaces', () => {
-  test('all 12 computer_use_* tools are registered after initializeTools()', async () => {
+  test('no computer_use_* tools are registered after initializeTools() (migrated to skill)', async () => {
     await initializeTools();
 
     for (const name of COMPUTER_USE_TOOL_NAMES) {
       const tool = getTool(name);
-      expect(tool).toBeDefined();
-      expect(tool?.executionMode).toBe('proxy');
+      expect(tool).toBeUndefined();
     }
   });
 
@@ -63,11 +62,11 @@ describe('computer-use skill baseline: registry tool surfaces', () => {
     assertComputerUseToolsAbsent(defNames);
   });
 
-  test('baseline count: 12 computer_use_* proxy tools in core registry', async () => {
+  test('post-cutover count: 0 computer_use_* tools in core registry', async () => {
     await initializeTools();
 
     const allTools = getAllTools();
     const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
-    expect(cuTools).toHaveLength(COMPUTER_USE_TOOL_COUNT);
+    expect(cuTools).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -102,7 +102,7 @@ export class ComputerUseSession {
     this.sendToClient = sendToClient;
     this.interactionType = interactionType ?? 'computer_use';
     this.onTerminal = onTerminal;
-    this.preactivatedSkillIds = preactivatedSkillIds ?? [];
+    this.preactivatedSkillIds = preactivatedSkillIds ?? ['computer-use'];
   }
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -2,7 +2,7 @@ import { RiskLevel } from '../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from './types.js';
 import type { ToolDefinition } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
-import { registerComputerUseTools } from './computer-use/registry.js';
+import { registerRequestComputerControlTool } from './computer-use/registry.js';
 import { allComputerUseTools } from './computer-use/definitions.js';
 import { requestComputerControlTool } from './computer-use/request-computer-control.js';
 import { registerUiSurfaceTools } from './ui-surface/registry.js';
@@ -223,10 +223,10 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
-  // Computer-use proxy tools — registered so ToolExecutor can look them up
-  // and forward execution to the connected macOS client.  They are excluded
-  // from getAllToolDefinitions() since regular chat sessions don't use them.
-  registerComputerUseTools();
+  // Only register the escalation tool in core. The 12 computer_use_* action
+  // tools are now provided by the bundled computer-use skill, projected into
+  // CU sessions via preactivatedSkillIds.
+  registerRequestComputerControlTool();
   registerUiSurfaceTools();
   registerAppTools();
 


### PR DESCRIPTION
## Summary
- Stop core-registering 12 `computer_use_*` action tools at startup
- Keep `request_computer_control` as a core escalation tool
- Default `ComputerUseSession` to preactivate the bundled `computer-use` skill
- CU sessions get their tools from skill projection instead of core registry
- Update baseline + lifecycle tests for post-cutover behavior

## Invariants preserved
- Text sessions still have `request_computer_control` for escalation
- CU sessions still expose all 12 `computer_use_*` tools (via skill projection)
- Terminal tools (`computer_use_done`, `computer_use_respond`) still end sessions
- Permission behavior unchanged (Low risk, default prompt)

## Test plan
- [x] `bun test src/__tests__/computer-use-skill-baseline.test.ts` passes
- [x] `bun test src/__tests__/computer-use-session-lifecycle.test.ts` passes
- [x] `bun test src/__tests__/registry.test.ts` passes (1 pre-existing failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 09/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
