### PR TITLE
feat: executor/prompter adds persistentDecisionsAllowed contract

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1572,6 +1572,159 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
 });
 
 // ---------------------------------------------------------------------------
+// persistentDecisionsAllowed contract (PR 15)
+// ---------------------------------------------------------------------------
+
+describe('ToolExecutor persistentDecisionsAllowed contract', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+    lastCheckArgs = undefined;
+    getToolOverride = undefined;
+    checkResultOverride = { decision: 'prompt', reason: 'Proxied network mode requires explicit approval for each invocation.' };
+    checkFnOverride = undefined;
+    if (addRuleSpy) { addRuleSpy.mockRestore(); addRuleSpy = undefined; }
+  });
+
+  function setupAddRuleSpy() {
+    addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      },
+    );
+    return addRuleSpy;
+  }
+
+  test('proxied bash always_allow does NOT save a trust rule', async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow', 'bash:*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl https://example.com', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('non-proxied bash always_allow DOES save a trust rule', async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow', 'bash:*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'git status' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('proxied bash always_deny does NOT save a trust rule', async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_deny', 'bash:*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl https://evil.com', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('persistentDecisionsAllowed: false is emitted in lifecycle event for proxied bash', async () => {
+    let capturedEvent: any;
+    const prompter = makePrompterWithDecision('allow');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl https://example.com', network_mode: 'proxied' },
+      makeContext({
+        onToolLifecycleEvent: (event: any) => {
+          if (event.type === 'permission_prompt') {
+            capturedEvent = event;
+          }
+        },
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent.persistentDecisionsAllowed).toBe(false);
+  });
+
+  test('persistentDecisionsAllowed: true is emitted in lifecycle event for non-proxied bash', async () => {
+    let capturedEvent: any;
+    const prompter = makePrompterWithDecision('allow');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'echo hello' },
+      makeContext({
+        onToolLifecycleEvent: (event: any) => {
+          if (event.type === 'permission_prompt') {
+            capturedEvent = event;
+          }
+        },
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent.persistentDecisionsAllowed).toBe(true);
+  });
+
+  test('persistentDecisionsAllowed is passed to prompter confirmation_request for proxied bash', async () => {
+    let capturedPersistent: unknown;
+    const prompter = {
+      prompt: async (
+        _toolName: string, _input: Record<string, unknown>, _riskLevel: string,
+        _allowlistOptions: any[], _scopeOptions: any[], _diff: any, _sandboxed: any,
+        _sessionId: any, _executionTarget: any, _principal: any, persistentDecisionsAllowed: any,
+      ) => {
+        capturedPersistent = persistentDecisionsAllowed;
+        return { decision: 'allow' as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl https://example.com', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedPersistent).toBe(false);
+  });
+
+  test('host_bash with proxied network_mode also disables persistence', async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow', 'host_bash:*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'host_bash',
+      { command: 'curl https://example.com', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Baseline: sanitized env excludes credential-like variables
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -38,6 +38,7 @@ export class PermissionPrompter {
     sessionId?: string,
     executionTarget?: ExecutionTarget,
     principal?: { kind?: string; id?: string; version?: string },
+    persistentDecisionsAllowed?: boolean,
   ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
     const requestId = uuid();
 
@@ -66,6 +67,7 @@ export class PermissionPrompter {
         principalKind: principal?.kind,
         principalId: principal?.id,
         principalVersion: principal?.version,
+        persistentDecisionsAllowed: persistentDecisionsAllowed ?? true,
       });
     });
   }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -154,6 +154,12 @@ export class ToolExecutor {
           sandboxed = wrapped.sandboxed;
         }
 
+        // Proxied bash prompts are non-persistent — no trust rule saving allowed
+        const persistentDecisionsAllowed = !(
+          (name === 'bash' || name === 'host_bash')
+          && input.network_mode === 'proxied'
+        );
+
         emitLifecycleEvent(context, {
           type: 'permission_prompt',
           toolName: name,
@@ -169,6 +175,7 @@ export class ToolExecutor {
           scopeOptions,
           diff: previewDiff,
           sandboxed,
+          persistentDecisionsAllowed,
         });
 
         await getHookManager().trigger('permission-request', {
@@ -193,6 +200,7 @@ export class ToolExecutor {
             id: policyContext.principal.id,
             version: policyContext.principal.version,
           } : undefined,
+          persistentDecisionsAllowed,
         );
 
         decision = response.decision;
@@ -224,7 +232,7 @@ export class ToolExecutor {
         }
 
         if (response.decision === 'always_deny') {
-          const ruleSaved = !!(response.selectedPattern && response.selectedScope);
+          const ruleSaved = !!(persistentDecisionsAllowed && response.selectedPattern && response.selectedScope);
           if (ruleSaved) {
             addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
           }
@@ -247,7 +255,8 @@ export class ToolExecutor {
         }
 
         if (
-          (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
+          persistentDecisionsAllowed
+          && (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
           && response.selectedPattern
           && response.selectedScope
         ) {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -33,6 +33,7 @@ export interface ToolPermissionPromptEvent extends ToolLifecycleEventBase {
   scopeOptions: ScopeOption[];
   diff?: DiffInfo;
   sandboxed?: boolean;
+  persistentDecisionsAllowed?: boolean;
 }
 
 export interface ToolPermissionDeniedEvent extends ToolLifecycleEventBase {


### PR DESCRIPTION
## Summary
- Add `persistentDecisionsAllowed` flag to prompter contract
- Guard trust-rule saving when persistence is disabled (proxied bash)
- Include flag in lifecycle events for downstream consumers

## Behavior Delta
Proxied bash `always_allow` decisions no longer persist as trust rules. All other behavior unchanged.

## Tests Run
- `bun test src/__tests__/tool-executor.test.ts` — 109 tests passing

## Rollback
Revert contract field and guard logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
