### PR TITLE
refactor: remove legacy CU tool definition fallback

### DIFF
--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -247,10 +247,10 @@ describe('ComputerUseSession lifecycle', () => {
       },
     };
 
-    // No preactivatedSkillIds passed — legacy path
+    // No preactivatedSkillIds passed — defaults to ['computer-use'] via skill projection
     const session = new ComputerUseSession(
-      'cu-legacy-path',
-      'test legacy',
+      'cu-default-projection',
+      'test default projection',
       1440, 900,
       provider,
       () => {},
@@ -260,7 +260,7 @@ describe('ComputerUseSession lifecycle', () => {
 
     await session.handleObservation({
       type: 'cu_observation',
-      sessionId: 'cu-legacy-path',
+      sessionId: 'cu-default-projection',
       axTree: 'Window "Test" [1]',
     });
 

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -15,13 +15,11 @@ import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { SecretPrompter } from '../permissions/secret-prompter.js';
-import { allComputerUseTools } from '../tools/computer-use/definitions.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getSandboxWorkingDir } from '../util/platform.js';
 import { getConfig } from '../config/loader.js';
 import { projectSkillTools } from './session-skill-tools.js';
-import type { SkillToolProjection } from './session-skill-tools.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('computer-use-session');
@@ -205,12 +203,15 @@ export class ComputerUseSession {
 
   /**
    * Compute CU tool definitions from the bundled computer-use skill via
-   * skill projection. Returns null if no preactivated skills are configured
-   * (i.e. the legacy path should be used).
+   * skill projection. Throws if no preactivated skills are configured or
+   * projection produces no tool definitions.
    */
-  private getProjectedCuToolDefinitions(): ToolDefinition[] | null {
+  private getProjectedCuToolDefinitions(): ToolDefinition[] {
     if (this.preactivatedSkillIds.length === 0) {
-      return null;
+      throw new Error(
+        'ComputerUseSession requires preactivatedSkillIds to include the computer-use skill. ' +
+        'No skill IDs were provided — CU tool projection cannot proceed.',
+      );
     }
 
     const projection = projectSkillTools([], {
@@ -219,7 +220,11 @@ export class ComputerUseSession {
     });
 
     if (projection.toolDefinitions.length === 0) {
-      return null;
+      throw new Error(
+        'Skill projection for preactivatedSkillIds ' +
+        JSON.stringify(this.preactivatedSkillIds) +
+        ' produced no tool definitions. Ensure the computer-use skill is properly registered.',
+      );
     }
 
     return projection.toolDefinitions;
@@ -250,9 +255,7 @@ export class ComputerUseSession {
   private async runAgentLoop(messages: Message[]): Promise<void> {
     const systemPrompt = buildComputerUseSystemPrompt(this.screenWidth, this.screenHeight);
 
-    // Try skill projection first; fall back to legacy direct definitions
-    const projectedCuTools = this.getProjectedCuToolDefinitions();
-    const cuToolDefs = projectedCuTools ?? allComputerUseTools.map((t) => t.getDefinition());
+    const cuToolDefs = this.getProjectedCuToolDefinitions();
 
     const toolDefs: ToolDefinition[] = [
       ...cuToolDefs,


### PR DESCRIPTION
## Summary
- Remove `allComputerUseTools` import and dual-path fallback from `ComputerUseSession`
- Make `getProjectedCuToolDefinitions()` non-nullable with defensive error on empty skills
- CU sessions now exclusively use skill projection for tool definitions
- Simplify step loop to single source of truth

## Invariants preserved
- CU sessions still expose all 12 `computer_use_*` tools (via skill projection)
- Text sessions still have `request_computer_control` for escalation
- Terminal tools (`computer_use_done`, `computer_use_respond`) still end sessions

## Test plan
- [x] `bun test src/__tests__/computer-use-session-lifecycle.test.ts` passes (6/6)
- [x] `bun test src/__tests__/computer-use-skill-baseline.test.ts` passes (7/7)
- [x] `bun test src/__tests__/registry.test.ts` — 36/37 pass; 1 pre-existing failure on main (eager module count mismatch, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 10/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
