### PR TITLE
feat: IPC contract adds persistentDecisionsAllowed + Swift regeneration

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -839,6 +839,8 @@ export interface ConfirmationRequest {
   principalId?: string;
   /** Content-hash of the skill source for version tracking. */
   principalVersion?: string;
+  /** When false, the client should hide "always allow" / trust-rule persistence affordances. */
+  persistentDecisionsAllowed?: boolean;
 }
 
 export interface SecretRequest {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -218,6 +218,8 @@ public struct IPCConfirmationRequest: Codable, Sendable {
     public let principalId: String?
     /// Content-hash of the skill source for version tracking.
     public let principalVersion: String?
+    /// When false, the client should hide "always allow" / trust-rule persistence affordances.
+    public let persistentDecisionsAllowed: Bool?
 }
 
 public struct IPCConfirmationRequestAllowlistOption: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Add optional `persistentDecisionsAllowed` field to `ConfirmationRequest` in IPC contract
- Regenerate Swift IPC code and update inventory snapshot
- Combines plan PRs 16 (IPC field) and 17 (Swift regeneration) since they're tightly coupled

## Behavior Delta
New optional IPC field; no behavior change. Client can now distinguish persistent vs non-persistent prompts.

## Tests Run
- `bun test src/__tests__/ipc-snapshot.test.ts` — 170/170 pass (snapshots updated)

## Rollback
Revert IPC field addition and regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
