### PR TITLE
chore: add 'do not wait for CI' instruction to all slash commands

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -18,6 +18,7 @@ Everything after stripping flags is the **feature description**.
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **No piping to tail/head**: `tail` and `head` may not be available in the shell. Don't pipe to them.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).

--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -7,6 +7,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a description of wha
 ## Repo-specific gotchas
 
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
 - **Project structure**: Bun + TypeScript project. Code is in `assistant/`.

--- a/.claude/commands/execute-plan.md
+++ b/.claude/commands/execute-plan.md
@@ -81,6 +81,7 @@ After all PRs are mainlined, tell the user the plan is fully executed. List all 
 ## Repo-specific gotchas
 
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
 - **Project structure**: Bun + TypeScript project. Code is in `assistant/`.

--- a/.claude/commands/mainline.md
+++ b/.claude/commands/mainline.md
@@ -2,6 +2,11 @@ Ship the current uncommitted changes to main via a squash-merged PR.
 
 If the user passed `$ARGUMENTS`, use it as the PR title. Otherwise, infer a concise title from the changes.
 
+## Repo-specific gotchas
+
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
+
 ## Steps
 
 ### 1. Check for changes

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -140,6 +140,8 @@ Then **stop**. Do NOT continue to the next PR.
 
 ## Repo-specific gotchas
 
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
 - **Project structure**: Bun + TypeScript project. Code is in `assistant/`.

--- a/.claude/commands/safe-blitz-done.md
+++ b/.claude/commands/safe-blitz-done.md
@@ -136,3 +136,4 @@ You're now on `main` with the latest changes.
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -21,6 +21,7 @@ Everything after stripping flags is the **feature description**.
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **No piping to tail/head**: `tail` and `head` may not be available in the shell. Don't pipe to them.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
@@ -186,6 +187,7 @@ You are working on a single task in an isolated git worktree.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- Do NOT wait for CI checks to pass before merging. Merge immediately.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -7,6 +7,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a description of wha
 ## Repo-specific gotchas
 
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
 - **Project structure**: Bun + TypeScript project. Code is in `assistant/`.

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -6,6 +6,8 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide the plan filename. E
 
 ## Repo-specific gotchas
 
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
 - **Project structure**: Bun + TypeScript project. Code is in `assistant/`.

--- a/.claude/commands/ship-and-merge.md
+++ b/.claude/commands/ship-and-merge.md
@@ -6,6 +6,7 @@ If the user passed `$ARGUMENTS`, use it as the PR title. Otherwise, infer a conc
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **No piping to tail/head**: `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Phase 1: Create the PR

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -13,6 +13,7 @@ If no arguments are provided, default to 12 workers with no task limit (run unti
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **No piping to tail/head**: `tail` and `head` may not be available in the shell. Avoid `cmd | tail -N`. Instead, run the command directly and let output truncate naturally, or use the Read tool on output files.
 
 ## Phase 1: Setup
@@ -54,6 +55,7 @@ You are working on a single task in an isolated git worktree.
 ## Repo-specific gotchas
 - `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
 - This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- Do NOT wait for CI checks to pass before merging. Merge immediately.
 - `tail` and `head` may not be available in the shell. Don't pipe to them.
 
 ## Your worktree

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -9,6 +9,7 @@ IMPORTANT: If the task is "Address the feedback on <PR URL>", first check if the
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **No piping to tail/head**: `tail` and `head` may not be available in the shell. Avoid `cmd | tail -N`. Instead, run the command directly and let output truncate naturally, or use the Read tool on output files.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 


### PR DESCRIPTION
## Summary
- Added `- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.` to the repo-specific gotchas section of every slash command that merges PRs
- Covers 12 files: do, safe-do, work, mainline, ship-and-merge, swarm, blitz, safe-blitz, safe-blitz-done, execute-plan, safe-execute-plan, resume-plan
- For swarm and safe-blitz, also added it to the embedded agent gotchas that get included in spawned agent prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
