### PR TITLE
test: add end-state tests for computer-use skill migration

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-endstate.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-endstate.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect, beforeAll } from 'bun:test';
+import {
+  initializeTools,
+  getAllTools,
+  getTool,
+  getAllToolDefinitions,
+  __resetRegistryForTesting,
+} from '../tools/registry.js';
+import { buildToolDefinitions } from '../daemon/session-tool-setup.js';
+import {
+  COMPUTER_USE_TOOL_NAMES,
+  COMPUTER_USE_TOOL_COUNT,
+} from './test-support/computer-use-skill-harness.js';
+
+beforeAll(async () => {
+  __resetRegistryForTesting();
+  await initializeTools();
+});
+
+describe('computer-use skill end-state', () => {
+  // ── Core Registry ──────────────────────────────────────────────────
+
+  test('core registry contains 0 computer_use_* tools', () => {
+    const allTools = getAllTools();
+    const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
+    expect(cuTools).toHaveLength(0);
+  });
+
+  test('no individual computer_use_* tool is resolvable from core registry', () => {
+    for (const name of COMPUTER_USE_TOOL_NAMES) {
+      expect(getTool(name)).toBeUndefined();
+    }
+  });
+
+  test('request_computer_control is still present in core registry', () => {
+    const tool = getTool('request_computer_control');
+    expect(tool).toBeDefined();
+    expect(tool!.name).toBe('request_computer_control');
+  });
+
+  // ── getAllToolDefinitions (excludes proxy & skill tools) ──────────
+
+  test('getAllToolDefinitions() excludes computer_use_* tools', () => {
+    const defs = getAllToolDefinitions();
+    const cuDefs = defs.filter((d) => d.name.startsWith('computer_use_'));
+    expect(cuDefs).toHaveLength(0);
+  });
+
+  test('getAllToolDefinitions() excludes request_computer_control (proxy exclusion)', () => {
+    const defs = getAllToolDefinitions();
+    const found = defs.find((d) => d.name === 'request_computer_control');
+    expect(found).toBeUndefined();
+  });
+
+  // ── buildToolDefinitions (text session tool set) ─────────────────
+
+  test('buildToolDefinitions() includes request_computer_control', () => {
+    const defs = buildToolDefinitions();
+    const found = defs.find((d) => d.name === 'request_computer_control');
+    expect(found).toBeDefined();
+  });
+
+  test('buildToolDefinitions() excludes computer_use_* action tools', () => {
+    const defs = buildToolDefinitions();
+    const cuDefs = defs.filter((d) => d.name.startsWith('computer_use_'));
+    expect(cuDefs).toHaveLength(0);
+  });
+
+  // ── Bundled Skill Catalog ────────────────────────────────────────
+
+  test('computer-use skill has exactly ' + COMPUTER_USE_TOOL_COUNT + ' tools in TOOLS.json', () => {
+    const { loadSkillCatalog } = require('../config/skills.js');
+    const catalog = loadSkillCatalog();
+    const cuSkill = catalog.find((s: any) => s.id === 'computer-use');
+    expect(cuSkill).toBeDefined();
+    expect(cuSkill!.toolManifest).toBeDefined();
+    expect(cuSkill!.toolManifest!.toolCount).toBe(COMPUTER_USE_TOOL_COUNT);
+  });
+
+  test('bundled skill tool names match expected computer_use_* names', () => {
+    const { loadSkillCatalog } = require('../config/skills.js');
+    const catalog = loadSkillCatalog();
+    const cuSkill = catalog.find((s: any) => s.id === 'computer-use');
+    expect(cuSkill).toBeDefined();
+    expect(cuSkill!.toolManifest).toBeDefined();
+    const toolNames = new Set(cuSkill!.toolManifest!.toolNames);
+    for (const name of COMPUTER_USE_TOOL_NAMES) {
+      expect(toolNames.has(name)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive end-state test suite that locks post-migration behavior
- Verifies core registry excludes `computer_use_*` tools
- Verifies `request_computer_control` remains in core registry
- Verifies `getAllToolDefinitions()` and `buildToolDefinitions()` exclude CU action tools
- Verifies bundled skill catalog has all 12 tools with correct names

## Test plan
- [x] `bun test src/__tests__/computer-use-skill-endstate.test.ts` passes (9 tests, 36 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of: Computer-Use Skill Migration (PR 11/14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
