### PR TITLE
feat: macOS confirmation UI honors non-persistent prompt mode

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -36,6 +36,8 @@ public struct ToolConfirmationData: Equatable {
     public let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
     public let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
     public let executionTarget: String?
+    /// When false, hide "Always Allow" and trust-rule persistence controls.
+    public let persistentDecisionsAllowed: Bool
     public var state: ToolConfirmationState = .pending
 
     /// Normalized target label shown in confirmation UIs.
@@ -292,7 +294,7 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
@@ -301,6 +303,7 @@ public struct ToolConfirmationData: Equatable {
         self.allowlistOptions = allowlistOptions
         self.scopeOptions = scopeOptions
         self.executionTarget = executionTarget
+        self.persistentDecisionsAllowed = persistentDecisionsAllowed
         self.state = state
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -555,7 +555,8 @@ extension ChatViewModel {
                 diff: msg.diff,
                 allowlistOptions: msg.allowlistOptions,
                 scopeOptions: msg.scopeOptions,
-                executionTarget: msg.executionTarget
+                executionTarget: msg.executionTarget,
+                persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true
             )
             let confirmMsg = ChatMessage(
                 role: .assistant,

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -353,7 +353,7 @@ public struct ToolConfirmationBubble: View {
         HStack(spacing: VSpacing.xs) {
             confirmationButton("Don\u{2019}t Allow", isPrimary: false, isDanger: true) { onDeny() }
             confirmationButton("Allow", isPrimary: true, isDanger: false) { onAllow() }
-            if hasRuleOptions { alwaysAllowInlineButton }
+            if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
             Spacer()
         }
     }


### PR DESCRIPTION
## Summary
- Add `persistentDecisionsAllowed` property to `ToolConfirmationData` (defaults to `true` for backward compatibility)
- Pass through `persistentDecisionsAllowed` from IPC `ConfirmationRequestMessage` when constructing confirmation data
- Hide "Always Allow" button in `ToolConfirmationBubble` when `persistentDecisionsAllowed` is `false`
- Keep Allow/Deny single-use buttons always visible

## Behavior Delta
Proxied bash confirmations (where persistence is disabled) show only Allow/Deny. All other confirmations unchanged.

## Tests Run
- Visual inspection of Swift code logic (UI change, no automated test)

## Rollback
Revert UI conditionals and model field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
