### PR TITLE
fix: hostname validation, CA rotation check, and NODE_EXTRA_CA_CERTS in proxy certs

### DIFF
--- a/assistant/src/tools/network/script-proxy/certs.ts
+++ b/assistant/src/tools/network/script-proxy/certs.ts
@@ -1,9 +1,13 @@
 import { mkdir, stat, readFile, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
+import { X509Certificate } from 'node:crypto';
 
 const CA_CERT_FILENAME = 'ca.pem';
 const CA_KEY_FILENAME = 'ca-key.pem';
 const ISSUED_DIR = 'issued';
+
+// Only allow valid hostname characters: alphanumeric, hyphens, dots, and wildcards
+const HOSTNAME_RE = /^[a-zA-Z0-9.*-]+$/;
 
 /**
  * Ensure a self-signed CA cert+key exists in `{dataDir}/proxy-ca/`.
@@ -66,22 +70,37 @@ export async function issueLeafCert(
   caDir: string,
   hostname: string,
 ): Promise<{ cert: string; key: string }> {
+  if (!HOSTNAME_RE.test(hostname)) {
+    throw new Error(`Invalid hostname: ${hostname}`);
+  }
+
   const issuedDir = join(caDir, ISSUED_DIR);
   const leafCertPath = join(issuedDir, `${hostname}.pem`);
   const leafKeyPath = join(issuedDir, `${hostname}-key.pem`);
 
-  // Return cached cert if it exists
+  // Return cached cert if it exists and is signed by the current CA
   const [certExists, keyExists] = await Promise.all([
     stat(leafCertPath).then(() => true, () => false),
     stat(leafKeyPath).then(() => true, () => false),
   ]);
 
   if (certExists && keyExists) {
-    const [cert, key] = await Promise.all([
+    const [cert, key, caCert] = await Promise.all([
       readFile(leafCertPath, 'utf-8'),
       readFile(leafKeyPath, 'utf-8'),
+      readFile(join(caDir, CA_CERT_FILENAME), 'utf-8'),
     ]);
-    return { cert, key };
+
+    // Verify cached cert was signed by the current CA, not a previous one
+    try {
+      const leaf = new X509Certificate(cert);
+      const ca = new X509Certificate(caCert);
+      if (leaf.checkIssued(ca)) {
+        return { cert, key };
+      }
+    } catch {
+      // Cert parsing failed — fall through to re-issue
+    }
   }
 
   await mkdir(issuedDir, { recursive: true });
@@ -142,7 +161,7 @@ export async function issueLeafCert(
 }
 
 /**
- * Return the path to the local CA cert for use as SSL_CERT_FILE or NODE_EXTRA_CA_CERTS.
+ * Return the path to the local CA cert for use as NODE_EXTRA_CA_CERTS.
  */
 export function getCAPath(dataDir: string): string {
   return join(dataDir, 'proxy-ca', CA_CERT_FILENAME);

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -159,7 +159,7 @@ export function getSessionEnv(sessionId: ProxySessionId): ProxyEnvVars {
   };
 
   if (managed.dataDir) {
-    env.SSL_CERT_FILE = getCAPath(managed.dataDir);
+    env.NODE_EXTRA_CA_CERTS = getCAPath(managed.dataDir);
   }
 
   return env;

--- a/assistant/src/tools/network/script-proxy/types.ts
+++ b/assistant/src/tools/network/script-proxy/types.ts
@@ -24,7 +24,7 @@ export interface ProxyEnvVars {
   HTTP_PROXY: string;
   HTTPS_PROXY: string;
   NO_PROXY: string;
-  SSL_CERT_FILE?: string;
+  NODE_EXTRA_CA_CERTS?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses review feedback on #4229. Adds hostname validation to prevent path traversal, checks CA rotation before using cached leaf certs, and switches from SSL_CERT_FILE to NODE_EXTRA_CA_CERTS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
