### PR TITLE
fix: address review feedback on PR #4113 (browser migration test)

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -2386,6 +2386,14 @@ describe('browser skill migration harness', () => {
     expect(toolResult.content).toContain('<loaded_skill id="browser" version="v1:abc123" />');
   });
 
+  test('buildSkillLoadHistory generates unique tool_use IDs per call', () => {
+    const h1 = buildSkillLoadHistory('browser', 'v1:abc');
+    const h2 = buildSkillLoadHistory('browser', 'v1:def');
+    const id1 = (h1[0].content[0] as { id: string }).id;
+    const id2 = (h2[0].content[0] as { id: string }).id;
+    expect(id1).not.toBe(id2);
+  });
+
   test('BROWSER_TOOL_NAMES contains all 10 browser tools', () => {
     expect(BROWSER_TOOL_NAMES).toHaveLength(10);
     expect(BROWSER_TOOL_NAMES).toContain('browser_navigate');

--- a/assistant/src/__tests__/test-support/browser-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/browser-skill-harness.ts
@@ -20,12 +20,14 @@ export const BROWSER_TOOL_COUNT = BROWSER_TOOL_NAMES.length;
 /** Skill ID for the bundled browser skill. */
 export const BROWSER_SKILL_ID = 'browser';
 
+let toolUseCounter = 0;
+
 /**
  * Build a synthetic conversation history containing a skill_load tool_use
  * and matching tool_result with a <loaded_skill /> marker.
  */
 export function buildSkillLoadHistory(skillId: string, versionHash?: string): Message[] {
-  const toolUseId = `test-tool-use-${skillId}`;
+  const toolUseId = `test-tool-use-${skillId}-${toolUseCounter++}`;
   const versionAttr = versionHash ? ` version="${versionHash}"` : '';
   return [
     {


### PR DESCRIPTION
Addresses review feedback on #4113.

- Generate unique tool_use IDs in buildSkillLoadHistory using an incrementing counter, preventing duplicate IDs when the same skill is loaded multiple times in tests
- Add test case verifying ID uniqueness across multiple calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
