### PR TITLE
fix: restore ? and : in URL trailing punctuation trim (PR #4046 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -9,7 +9,7 @@ enum MessageURLExtractor {
 
     // Characters that commonly trail a URL in natural prose but aren't
     // part of the URL itself.
-    private static let trailingPunctuationToTrim: CharacterSet = CharacterSet(charactersIn: ".,;!>\"')")
+    private static let trailingPunctuationToTrim: CharacterSet = CharacterSet(charactersIn: ".,;:!?)>\"'")
 
     /// Extracts all distinct `http(s)://` URLs from `text`, returned in
     /// first-occurrence order. Duplicates are suppressed (first wins).

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorPlainTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorPlainTests.swift
@@ -162,6 +162,20 @@ final class MessageURLExtractorPlainTests: XCTestCase {
         XCTAssertEqual(urls.first?.absoluteString, "https://en.wikipedia.org/wiki/Swift_(programming_language)")
     }
 
+    // MARK: - Trailing ? and : trimmed in prose
+
+    func testTrailingQuestionMarkTrimmedInProse() {
+        let urls = MessageURLExtractor.extractPlainURLs(from: "Have you seen https://example.com?")
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://example.com")
+    }
+
+    func testTrailingColonTrimmedInProse() {
+        let urls = MessageURLExtractor.extractPlainURLs(from: "Check out https://example.com: it's great")
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://example.com")
+    }
+
     // MARK: - Non-HTTP schemes are excluded
 
     func testFTPSchemeIsExcluded() {


### PR DESCRIPTION
Addresses review feedback on #4046. Codex correctly flagged that removing ? and : from trailingPunctuationToTrim causes URLs at sentence boundaries to retain prose punctuation (e.g. 'https://example.com?' in a question). Restores both characters to the trim set — mid-URL occurrences (ports, query strings) are unaffected since the trimmer only inspects trailing characters. Adds tests for the prose-trailing edge cases.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
