### PR TITLE
fix: reject unknown non-v1/v2 credential metadata versions

### DIFF
--- a/assistant/src/__tests__/credential-metadata-store.test.ts
+++ b/assistant/src/__tests__/credential-metadata-store.test.ts
@@ -398,6 +398,14 @@ describe('credential metadata store', () => {
       expect(() => assertMetadataWritable()).toThrow(/unrecognized version/);
     });
 
+    test.each([0, -1, 1.5, 0.5])('invalid numeric version %d is rejected as unknown', (badVersion) => {
+      writeFileSync(META_PATH, JSON.stringify({ version: badVersion, credentials: [] }, null, 2), 'utf-8');
+
+      expect(listCredentialMetadata()).toEqual([]);
+      expect(getCredentialMetadata('any', 'field')).toBeUndefined();
+      expect(() => upsertCredentialMetadata('test', 'key')).toThrow(/unrecognized version/);
+    });
+
     test('upsert on migrated v1 file saves as v2', () => {
       const v1Data = {
         version: 1,

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -117,8 +117,8 @@ function loadFile(): LoadResult {
       return { version: CURRENT_VERSION, credentials: [] };
     }
     const fileVersion = typeof data.version === 'number' ? data.version : 1;
-    if (fileVersion > CURRENT_VERSION) {
-      // Newer version we don't understand — refuse to touch it
+    if (fileVersion !== 1 && fileVersion !== 2) {
+      // Unrecognized version (future, fractional, negative, zero) — refuse to touch it
       return { unknownVersion: true };
     }
     const rawCredentials: unknown[] = Array.isArray(data.credentials) ? data.credentials : [];


### PR DESCRIPTION
Addresses review feedback on #4164. The version check in loadFile() now explicitly accepts only known versions (1 and 2) instead of accepting anything <= CURRENT_VERSION. This prevents invalid versions like 0, -1, or 1.5 from being silently treated as migratable v1 files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
