### PR TITLE
fix: address review feedback on PR #4086 (permission chip UI)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1086,8 +1086,9 @@ private struct ChatBubble: View {
                 .frame(maxWidth: 520, alignment: .leading)
         } else if hasCompletedTools || hasPermission || showRegenerate || (hasInProgressTools && permissionWasDenied) {
             // All done (or denied) — show chips + regenerate on one line
+            let onlyPermissionTools = message.toolCalls.allSatisfy { $0.toolName.lowercased() == "request system permission" }
             HStack(spacing: VSpacing.sm) {
-                if hasCompletedTools {
+                if hasCompletedTools && !onlyPermissionTools {
                     compactToolChip
                 } else if hasInProgressTools && permissionWasDenied {
                     compactFailedToolChip

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -267,11 +267,11 @@ public struct ToolConfirmationBubble: View {
                     updateTruncation(truncatedHeight: truncatedHeight)
                 }
 
-            if isTruncated && !isPreviewExpanded {
+            if isTruncated {
                 HStack(spacing: 2) {
-                    Image(systemName: "chevron.down")
+                    Image(systemName: isPreviewExpanded ? "chevron.up" : "chevron.down")
                         .font(.system(size: 8, weight: .semibold))
-                    Text("Show more")
+                    Text(isPreviewExpanded ? "Show less" : "Show more")
                         .font(.system(size: 10))
                 }
                 .foregroundColor(VColor.textMuted)


### PR DESCRIPTION
Addresses review feedback on #4086.

- **Codex P2**: Add 'Show less' button to collapse expanded preview text in ToolConfirmationBubble. Previously, once expanded there was no way to collapse back.
- **Devin**: Skip showing compactToolChip for 'request system permission' tool calls to avoid contradictory 'granted' label when permission was denied. The compactPermissionChip already shows the correct state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
