### PR TITLE
feat: add MITM handler for proxy TLS interception

### DIFF
--- a/assistant/src/__tests__/script-proxy-mitm-handler.test.ts
+++ b/assistant/src/__tests__/script-proxy-mitm-handler.test.ts
@@ -1,0 +1,406 @@
+import { describe, test, expect, beforeAll, afterEach } from 'bun:test';
+import { createServer as createHttpsServer } from 'node:https';
+import type { Server } from 'node:http';
+import { connect } from 'node:net';
+import { connect as tlsConnect } from 'node:tls';
+import { readFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureLocalCA, issueLeafCert, getCAPath } from '../tools/network/script-proxy/certs.js';
+import { createProxyServer } from '../tools/network/script-proxy/server.js';
+import type { RewriteCallback } from '../tools/network/script-proxy/mitm-handler.js';
+
+let dataDir: string;
+let caDir: string;
+let caCert: string;
+
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'mitm-test-'));
+  await ensureLocalCA(dataDir);
+  caDir = join(dataDir, 'proxy-ca');
+  caCert = await readFile(getCAPath(dataDir), 'utf-8');
+});
+
+/**
+ * Create a local HTTPS server using a leaf cert issued by our test CA.
+ * Echoes request info as JSON.
+ */
+async function createUpstreamHttpsServer(): Promise<{
+  port: number;
+  close: () => void;
+  lastRequest: () => { method: string; url: string; headers: Record<string, string> } | null;
+}> {
+  const { cert, key } = await issueLeafCert(caDir, 'localhost');
+  let lastReq: { method: string; url: string; headers: Record<string, string> } | null = null;
+
+  const server = createHttpsServer({ cert, key }, (req, res) => {
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (v !== undefined) {
+        headers[k] = Array.isArray(v) ? v.join(', ') : v;
+      }
+    }
+    lastReq = { method: req.method ?? 'GET', url: req.url ?? '/', headers };
+    const body = JSON.stringify(lastReq);
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Content-Length': String(Buffer.byteLength(body)),
+    });
+    res.end(body);
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') { reject(new Error('no addr')); return; }
+      resolve({
+        port: addr.port,
+        close: () => server.close(),
+        lastRequest: () => lastReq,
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+function listenEphemeral(server: Server): Promise<{ port: number; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') { reject(new Error('no addr')); return; }
+      resolve({ port: addr.port, close: () => server.close() });
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Send CONNECT -> TLS handshake -> HTTP request through the proxy.
+ * Returns the response. Destroys all sockets when done.
+ */
+function connectAndRequest(
+  proxyPort: number,
+  targetHost: string,
+  targetPort: number,
+  method: string,
+  path: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ statusCode: number; body: string; headers: Record<string, string> }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('connectAndRequest timed out'));
+    }, 8000);
+
+    const socket = connect(proxyPort, '127.0.0.1', () => {
+      socket.write(
+        `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n\r\n`,
+      );
+    });
+
+    let headerBuf = '';
+    const onData = (chunk: Buffer) => {
+      headerBuf += chunk.toString();
+      const endIdx = headerBuf.indexOf('\r\n\r\n');
+      if (endIdx === -1) return;
+
+      socket.removeListener('data', onData);
+      const statusLine = headerBuf.slice(0, headerBuf.indexOf('\r\n'));
+      const connectStatus = Number(statusLine.split(' ')[1]);
+
+      if (connectStatus !== 200) {
+        clearTimeout(timeout);
+        socket.destroy();
+        reject(new Error(`CONNECT failed with ${connectStatus}`));
+        return;
+      }
+
+      const tlsSocket = tlsConnect(
+        { socket, servername: targetHost, ca: caCert },
+        () => {
+          const headerLines = [`${method} ${path} HTTP/1.1`, `Host: ${targetHost}:${targetPort}`, 'Connection: close'];
+          for (const [k, v] of Object.entries(extraHeaders)) {
+            headerLines.push(`${k}: ${v}`);
+          }
+          tlsSocket.write(headerLines.join('\r\n') + '\r\n\r\n');
+        },
+      );
+
+      let responseBuf = '';
+      let resolved = false;
+
+      const tryResolve = () => {
+        if (resolved) return;
+        const headerEndIdx = responseBuf.indexOf('\r\n\r\n');
+        if (headerEndIdx === -1) return;
+
+        const responseHeaderBlock = responseBuf.slice(0, headerEndIdx);
+        const bodyPart = responseBuf.slice(headerEndIdx + 4);
+        const responseLines = responseHeaderBlock.split('\r\n');
+        const statusCode = Number(responseLines[0].split(' ')[1]);
+        const responseHeaders: Record<string, string> = {};
+        for (let i = 1; i < responseLines.length; i++) {
+          const ci = responseLines[i].indexOf(':');
+          if (ci > 0) {
+            responseHeaders[responseLines[i].slice(0, ci).trim().toLowerCase()] =
+              responseLines[i].slice(ci + 1).trim();
+          }
+        }
+
+        const cl = responseHeaders['content-length'];
+        if (cl !== undefined && bodyPart.length >= Number(cl)) {
+          resolved = true;
+          clearTimeout(timeout);
+          tlsSocket.destroy();
+          resolve({ statusCode, body: bodyPart.slice(0, Number(cl)), headers: responseHeaders });
+        }
+      };
+
+      tlsSocket.on('data', (chunk: Buffer) => {
+        responseBuf += chunk.toString('utf-8');
+        tryResolve();
+      });
+
+      tlsSocket.on('end', () => {
+        if (!resolved) {
+          clearTimeout(timeout);
+          const headerEndIdx = responseBuf.indexOf('\r\n\r\n');
+          if (headerEndIdx === -1) {
+            reject(new Error('No complete HTTP response'));
+            return;
+          }
+          const responseHeaderBlock = responseBuf.slice(0, headerEndIdx);
+          const body = responseBuf.slice(headerEndIdx + 4);
+          const responseLines = responseHeaderBlock.split('\r\n');
+          const statusCode = Number(responseLines[0].split(' ')[1]);
+          const responseHeaders: Record<string, string> = {};
+          for (let i = 1; i < responseLines.length; i++) {
+            const ci = responseLines[i].indexOf(':');
+            if (ci > 0) {
+              responseHeaders[responseLines[i].slice(0, ci).trim().toLowerCase()] =
+                responseLines[i].slice(ci + 1).trim();
+            }
+          }
+          resolve({ statusCode, body, headers: responseHeaders });
+        }
+      });
+
+      tlsSocket.on('error', (e) => {
+        if (!resolved) {
+          clearTimeout(timeout);
+          reject(e);
+        }
+      });
+    };
+
+    socket.on('data', onData);
+    socket.on('error', (e) => {
+      clearTimeout(timeout);
+      reject(e);
+    });
+  });
+}
+
+describe('MITM handler', () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanups) {
+      try { fn(); } catch {}
+    }
+    cleanups.length = 0;
+  });
+
+  test('MITM intercepts and can read/rewrite headers', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const rewriteCallback: RewriteCallback = async (req) => {
+      return { 'x-injected-token': 'secret-123', 'x-original-host': req.hostname };
+    };
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: () => true,
+        rewriteCallback,
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body } = await connectAndRequest(
+      px.port, 'localhost', upstream.port, 'GET', '/test',
+    );
+
+    expect(statusCode).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.headers['x-injected-token']).toBe('secret-123');
+    expect(parsed.headers['x-original-host']).toBe('localhost');
+    expect(parsed.url).toBe('/test');
+  });
+
+  test('response streaming works through MITM', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: () => true,
+        rewriteCallback: async () => ({}),
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body, headers } = await connectAndRequest(
+      px.port, 'localhost', upstream.port, 'GET', '/stream-test',
+      { 'accept': 'application/json' },
+    );
+
+    expect(statusCode).toBe(200);
+    expect(headers['content-type']).toBe('application/json');
+    const parsed = JSON.parse(body);
+    expect(parsed.url).toBe('/stream-test');
+    expect(parsed.method).toBe('GET');
+  });
+
+  test('original request reaches upstream with modifications', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const rewriteCallback: RewriteCallback = async () => {
+      return { 'authorization': 'Bearer my-secret-token' };
+    };
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: () => true,
+        rewriteCallback,
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body } = await connectAndRequest(
+      px.port, 'localhost', upstream.port, 'GET', '/api/data',
+      { 'x-custom': 'original-value' },
+    );
+
+    expect(statusCode).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.headers['authorization']).toBe('Bearer my-secret-token');
+    expect(parsed.headers['x-custom']).toBe('original-value');
+
+    const last = upstream.lastRequest();
+    expect(last).not.toBeNull();
+    expect(last!.headers['authorization']).toBe('Bearer my-secret-token');
+    expect(last!.headers['x-custom']).toBe('original-value');
+  });
+
+  test('non-intercepted requests pass through unchanged via tunnel', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const interceptedHosts: string[] = [];
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: (hostname) => {
+          interceptedHosts.push(hostname);
+          return false;
+        },
+        rewriteCallback: async () => ({ 'x-should-not-appear': 'true' }),
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    // With shouldIntercept=false, the tunnel passes through without MITM.
+    // The client's TLS handshake happens directly with the upstream server.
+    const result = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('tunnel test timed out')), 8000);
+
+      const socket = connect(px.port, '127.0.0.1', () => {
+        socket.write(
+          `CONNECT localhost:${upstream.port} HTTP/1.1\r\nHost: localhost:${upstream.port}\r\n\r\n`,
+        );
+      });
+
+      let headerBuf = '';
+      const onData = (chunk: Buffer) => {
+        headerBuf += chunk.toString();
+        const endIdx = headerBuf.indexOf('\r\n\r\n');
+        if (endIdx === -1) return;
+        socket.removeListener('data', onData);
+        const connectStatus = Number(headerBuf.slice(0, headerBuf.indexOf('\r\n')).split(' ')[1]);
+
+        if (connectStatus !== 200) {
+          clearTimeout(timeout);
+          socket.destroy();
+          reject(new Error(`CONNECT failed: ${connectStatus}`));
+          return;
+        }
+
+        const tlsSocket = tlsConnect(
+          { socket, servername: 'localhost', ca: caCert },
+          () => {
+            tlsSocket.write(
+              `GET /tunnel-check HTTP/1.1\r\nHost: localhost:${upstream.port}\r\nConnection: close\r\n\r\n`,
+            );
+          },
+        );
+
+        const chunks: Buffer[] = [];
+        tlsSocket.on('data', (c: Buffer) => chunks.push(c));
+        tlsSocket.on('end', () => {
+          clearTimeout(timeout);
+          const raw = Buffer.concat(chunks).toString('utf-8');
+          const hEnd = raw.indexOf('\r\n\r\n');
+          if (hEnd === -1) { reject(new Error('Incomplete response')); return; }
+          resolve({
+            statusCode: Number(raw.slice(0, hEnd).split('\r\n')[0].split(' ')[1]),
+            body: raw.slice(hEnd + 4),
+          });
+        });
+        tlsSocket.on('error', (e) => { clearTimeout(timeout); reject(e); });
+      };
+
+      socket.on('data', onData);
+      socket.on('error', (e) => { clearTimeout(timeout); reject(e); });
+    });
+
+    expect(result.statusCode).toBe(200);
+    const parsed = JSON.parse(result.body);
+    expect(parsed.headers['x-should-not-appear']).toBeUndefined();
+    expect(parsed.url).toBe('/tunnel-check');
+    expect(interceptedHosts).toContain('localhost');
+  });
+
+  test('rewriteCallback returning null rejects with 403', async () => {
+    const upstream = await createUpstreamHttpsServer();
+    cleanups.push(upstream.close);
+
+    const proxy = createProxyServer({
+      mitmHandler: {
+        caDir,
+        shouldIntercept: () => true,
+        rewriteCallback: async () => null,
+        upstreamTlsOptions: { ca: caCert },
+      },
+    });
+    const px = await listenEphemeral(proxy);
+    cleanups.push(px.close);
+
+    const { statusCode, body } = await connectAndRequest(
+      px.port, 'localhost', upstream.port, 'GET', '/forbidden',
+    );
+
+    expect(statusCode).toBe(403);
+    expect(body).toContain('Forbidden');
+  });
+});

--- a/assistant/src/tools/network/script-proxy/mitm-handler.ts
+++ b/assistant/src/tools/network/script-proxy/mitm-handler.ts
@@ -1,0 +1,257 @@
+/**
+ * MITM handler — intercepts HTTPS CONNECT requests by terminating TLS
+ * with a dynamically-issued leaf certificate, allowing the proxy to
+ * read and rewrite the decrypted HTTP request before forwarding it
+ * upstream over a fresh TLS connection.
+ *
+ * Uses a loopback TLS server on an ephemeral port with manual data
+ * forwarding because Bun does not support in-process TLS termination
+ * via `new TLSSocket(socket, { isServer })` or `tlsServer.emit('connection')`.
+ * Additionally, pipe() has timing issues in Bun for this use case,
+ * so we use explicit data event forwarding instead.
+ */
+
+import {
+  createServer as createTlsServer,
+  connect as tlsConnect,
+  type TLSSocket,
+  type ConnectionOptions,
+} from 'node:tls';
+import { connect as netConnect, type Socket } from 'node:net';
+import { issueLeafCert } from './certs.js';
+
+/** Hop-by-hop headers stripped during forwarding. */
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+/**
+ * Callback that receives the parsed request and returns headers to merge.
+ * Return null to reject the request with 403.
+ */
+export type RewriteCallback = (req: {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  hostname: string;
+  port: number;
+}) => Promise<Record<string, string> | null>;
+
+interface ParsedRequest {
+  method: string;
+  path: string;
+  httpVersion: string;
+  headers: Record<string, string>;
+  bodyPrefix: Buffer;
+}
+
+function parseHttpRequest(buf: Buffer): ParsedRequest | null {
+  const headerEnd = buf.indexOf('\r\n\r\n');
+  if (headerEnd === -1) return null;
+
+  const headerBlock = buf.subarray(0, headerEnd).toString('utf-8');
+  const lines = headerBlock.split('\r\n');
+  const [method, path, httpVersion] = lines[0].split(' ', 3);
+
+  const headers: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i++) {
+    const colonIdx = lines[i].indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = lines[i].slice(0, colonIdx).trim().toLowerCase();
+    const value = lines[i].slice(colonIdx + 1).trim();
+    headers[key] = value;
+  }
+
+  return { method, path, httpVersion, headers, bodyPrefix: buf.subarray(headerEnd + 4) };
+}
+
+function serializeRequestHead(
+  method: string,
+  path: string,
+  httpVersion: string,
+  headers: Record<string, string>,
+): Buffer {
+  let head = `${method} ${path} ${httpVersion}\r\n`;
+  for (const [key, value] of Object.entries(headers)) {
+    head += `${key}: ${value}\r\n`;
+  }
+  head += '\r\n';
+  return Buffer.from(head);
+}
+
+function filterHeaders(raw: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Handle a CONNECT request via MITM TLS interception.
+ */
+export async function handleMitm(
+  clientSocket: Socket,
+  head: Buffer,
+  hostname: string,
+  port: number,
+  caDir: string,
+  rewriteCallback: RewriteCallback,
+  upstreamTlsOptions?: Pick<ConnectionOptions, 'ca' | 'rejectUnauthorized'>,
+): Promise<void> {
+  const { cert, key } = await issueLeafCert(caDir, hostname);
+
+  clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+
+  const tlsServer = createTlsServer({ cert, key }, (tlsSocket: TLSSocket) => {
+    tlsServer.close();
+    handleDecryptedConnection(tlsSocket, hostname, port, rewriteCallback, upstreamTlsOptions);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    tlsServer.listen(0, '127.0.0.1', () => resolve());
+    tlsServer.on('error', reject);
+  });
+
+  const addr = tlsServer.address();
+  if (!addr || typeof addr === 'string') {
+    clientSocket.destroy();
+    tlsServer.close();
+    return;
+  }
+
+  const bridge = netConnect(addr.port, '127.0.0.1', () => {
+    if (head.length > 0) {
+      bridge.write(head);
+    }
+  });
+
+  // Manual bidirectional forwarding — pipe() has timing issues in Bun
+  clientSocket.on('data', (chunk) => bridge.write(chunk));
+  bridge.on('data', (chunk) => clientSocket.write(chunk));
+
+  bridge.on('end', () => clientSocket.end());
+  clientSocket.on('end', () => bridge.end());
+
+  bridge.on('error', () => clientSocket.destroy());
+  clientSocket.on('error', () => {
+    bridge.destroy();
+    tlsServer.close();
+  });
+}
+
+function handleDecryptedConnection(
+  tlsSocket: TLSSocket,
+  hostname: string,
+  port: number,
+  rewriteCallback: RewriteCallback,
+  upstreamTlsOptions?: Pick<ConnectionOptions, 'ca' | 'rejectUnauthorized'>,
+): void {
+  const chunks: Buffer[] = [];
+
+  const onData = (chunk: Buffer) => {
+    chunks.push(chunk);
+    const combined = Buffer.concat(chunks);
+    const parsed = parseHttpRequest(combined);
+    if (!parsed) return;
+
+    tlsSocket.removeListener('data', onData);
+    processRequest(tlsSocket, parsed, hostname, port, rewriteCallback, upstreamTlsOptions);
+  };
+
+  tlsSocket.on('data', onData);
+  tlsSocket.on('error', () => tlsSocket.destroy());
+}
+
+async function processRequest(
+  tlsSocket: TLSSocket,
+  parsed: ParsedRequest,
+  hostname: string,
+  port: number,
+  rewriteCallback: RewriteCallback,
+  upstreamTlsOptions?: Pick<ConnectionOptions, 'ca' | 'rejectUnauthorized'>,
+): Promise<void> {
+  try {
+    const filteredHeaders = filterHeaders(parsed.headers);
+    const rewriteResult = await rewriteCallback({
+      method: parsed.method,
+      path: parsed.path,
+      headers: { ...filteredHeaders },
+      hostname,
+      port,
+    });
+
+    if (rewriteResult === null) {
+      const body = 'Forbidden';
+      tlsSocket.write(
+        `HTTP/1.1 403 Forbidden\r\nContent-Length: ${body.length}\r\nContent-Type: text/plain\r\n\r\n${body}`,
+      );
+      tlsSocket.end();
+      return;
+    }
+
+    const finalHeaders = { ...filteredHeaders, ...rewriteResult };
+    if (!finalHeaders['host']) {
+      finalHeaders['host'] = port === 443 ? hostname : `${hostname}:${port}`;
+    }
+
+    const upstream = tlsConnect(
+      {
+        host: hostname,
+        port,
+        servername: hostname,
+        ...upstreamTlsOptions,
+      },
+      () => {
+        const headBuf = serializeRequestHead(
+          parsed.method,
+          parsed.path,
+          parsed.httpVersion,
+          finalHeaders,
+        );
+        upstream.write(headBuf);
+
+        if (parsed.bodyPrefix.length > 0) {
+          upstream.write(parsed.bodyPrefix);
+        }
+
+        // Manual forwarding — no pipe()
+        tlsSocket.on('data', (chunk) => upstream.write(chunk));
+        upstream.on('data', (chunk) => tlsSocket.write(chunk));
+
+        upstream.on('end', () => tlsSocket.end());
+        tlsSocket.on('end', () => upstream.end());
+      },
+    );
+
+    upstream.on('error', () => {
+      if (tlsSocket.writable) {
+        const body = 'Bad Gateway';
+        tlsSocket.write(
+          `HTTP/1.1 502 Bad Gateway\r\nContent-Length: ${body.length}\r\nContent-Type: text/plain\r\n\r\n${body}`,
+        );
+      }
+      tlsSocket.end();
+    });
+
+    tlsSocket.on('error', () => upstream.destroy());
+  } catch {
+    if (tlsSocket.writable) {
+      const body = 'Internal Server Error';
+      tlsSocket.write(
+        `HTTP/1.1 500 Internal Server Error\r\nContent-Length: ${body.length}\r\nContent-Type: text/plain\r\n\r\n${body}`,
+      );
+    }
+    tlsSocket.end();
+  }
+}

--- a/assistant/src/tools/network/script-proxy/server.ts
+++ b/assistant/src/tools/network/script-proxy/server.ts
@@ -1,22 +1,55 @@
 /**
  * Proxy server factory — creates an HTTP server configured to handle
- * plain HTTP proxy requests via the forwarder.
+ * plain HTTP proxy requests via the forwarder, plain CONNECT tunnelling,
+ * and optional MITM interception for credential-injected HTTPS requests.
  */
 
 import { createServer, type Server } from 'node:http';
+import type { ConnectionOptions } from 'node:tls';
+import type { Socket } from 'node:net';
 import { forwardHttpRequest, type PolicyCallback } from './http-forwarder.js';
 import { handleConnect } from './connect-tunnel.js';
+import { handleMitm, type RewriteCallback } from './mitm-handler.js';
+
+export interface MitmHandlerConfig {
+  /** Path to the local CA directory containing ca.pem / ca-key.pem. */
+  caDir: string;
+  /** Return true if the CONNECT target should be MITM-intercepted. */
+  shouldIntercept: (hostname: string, port: number) => boolean;
+  /** Called with the decrypted request; returns headers to merge or null to reject. */
+  rewriteCallback: RewriteCallback;
+  /** Extra TLS options for the upstream connection (e.g. custom CA for testing). */
+  upstreamTlsOptions?: Pick<ConnectionOptions, 'ca' | 'rejectUnauthorized'>;
+}
 
 export interface ProxyServerConfig {
   /** Optional policy callback for credential injection / access control. */
   policyCallback?: PolicyCallback;
   /** Called on every forwarded request for logging. */
   onRequest?: (method: string, url: string) => void;
+  /** When provided, CONNECT requests matching shouldIntercept are MITM-handled. */
+  mitmHandler?: MitmHandlerConfig;
+}
+
+/**
+ * Parse a CONNECT target of the form `host:port`.
+ */
+function parseConnectTarget(url: string | undefined): { host: string; port: number } | null {
+  if (!url) return null;
+  const colonIdx = url.lastIndexOf(':');
+  if (colonIdx <= 0) return null;
+  const host = url.slice(0, colonIdx);
+  const portStr = url.slice(colonIdx + 1);
+  if (!host || !portStr) return null;
+  const port = Number(portStr);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return { host, port };
 }
 
 /**
  * Create an HTTP server that acts as a forward proxy for plain HTTP
- * requests (absolute-URL form) and CONNECT tunnelling for HTTPS pass-through.
+ * requests (absolute-URL form), CONNECT tunnelling for HTTPS pass-through,
+ * and optional MITM interception for credential-injected HTTPS requests.
  */
 export function createProxyServer(config: ProxyServerConfig = {}): Server {
   const server = createServer((req, res) => {
@@ -27,7 +60,28 @@ export function createProxyServer(config: ProxyServerConfig = {}): Server {
     forwardHttpRequest(req, res, config.policyCallback);
   });
 
-  server.on('connect', (req, clientSocket, head) => {
+  server.on('connect', (req, clientSocket: Socket, head: Buffer) => {
+    if (config.mitmHandler) {
+      const target = parseConnectTarget(req.url);
+      if (target && config.mitmHandler.shouldIntercept(target.host, target.port)) {
+        handleMitm(
+          clientSocket,
+          head,
+          target.host,
+          target.port,
+          config.mitmHandler.caDir,
+          config.mitmHandler.rewriteCallback,
+          config.mitmHandler.upstreamTlsOptions,
+        ).catch(() => {
+          if (clientSocket.writable) {
+            clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+          }
+          clientSocket.destroy();
+        });
+        return;
+      }
+    }
+
     handleConnect(req, clientSocket, head);
   });
 


### PR DESCRIPTION
## Summary
- Adds `mitm-handler.ts` with TLS interception via loopback server + bridge socket pattern (Bun doesn't support in-process TLS termination)
- Extends `server.ts` with `MitmHandlerConfig` interface and `shouldIntercept` routing for CONNECT requests
- Decrypted HTTP requests are parsed, passed through a `RewriteCallback` for credential injection, and forwarded upstream
- Comprehensive test suite covering header rewriting, response streaming, upstream modification, tunnel passthrough, and 403 rejection

## Test plan
- [x] All 5 MITM handler tests pass (570ms)
- [x] Header rewriting injects custom headers and preserves originals
- [x] Non-intercepted requests tunnel through unchanged
- [x] Null rewrite callback returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
