### PR TITLE
fix: address review feedback on PR #4022 (ThreadManager)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -80,11 +80,16 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func createThread() {
-        // If the active thread is still empty, just keep it instead of creating another
+        // If the active thread is still empty, just keep it instead of creating another.
+        // Skip this optimisation for private threads — they have different persistence
+        // semantics and should not be silently reused as standard threads.
         if let activeId = activeThreadId,
            let vm = chatViewModels[activeId],
            !vm.messages.contains(where: { $0.role == .user }) {
-            return
+            let activeThread = threads.first(where: { $0.id == activeId })
+            if activeThread?.kind != .private {
+                return
+            }
         }
 
         let thread = ThreadModel()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -206,8 +206,32 @@ public final class ChatViewModel: ObservableObject {
             callback(text)
         }
 
-        // Block rapid-fire only when bootstrapping (no session yet)
+        // Block rapid-fire only when bootstrapping with a queued message.
+        // When a message-less bootstrap is in flight (e.g. private thread
+        // pre-allocation), adopt the user's message as the pending message
+        // so it gets sent when session_info arrives instead of being dropped.
         if isSending && sessionId == nil {
+            if pendingUserMessage == nil {
+                let attachments = pendingAttachments
+                pendingAttachments = []
+                pendingUserMessage = text
+                pendingUserAttachments = attachments.isEmpty ? nil : attachments.map {
+                    IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+                }
+                isThinking = true
+                messages.append(ChatMessage(role: .user, text: text, status: .sent, skillInvocation: pendingSkillInvocation, attachments: attachments))
+                pendingSkillInvocation = nil
+                inputText = ""
+                suggestion = nil
+                pendingSuggestionRequestId = nil
+                errorText = nil
+                sessionError = nil
+                lastFailedMessageText = nil
+                lastFailedMessageAttachments = nil
+                lastFailedSendError = nil
+                currentTurnUserText = text
+                return
+            }
             pendingSkillInvocation = nil
             return
         }


### PR DESCRIPTION
Addresses review feedback on #4022.

## Changes

1. **Fix message drop during private thread bootstrap (Codex P1)**: When a private thread is being bootstrapped (message-less session create in flight), sendMessage() would silently drop the user's first message because isSending was true and sessionId was nil. Now, when a message-less bootstrap is in flight (pendingUserMessage == nil), the user's message is adopted as the pending message so it gets sent when session_info arrives.

2. **Fix createThread() reusing empty private threads (Devin bug)**: createThread()'s empty-thread reuse optimization didn't check the thread's kind, so calling createThread() while a private thread was active would silently reuse it as a standard thread. Now the reuse is skipped when the active thread is .private.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
