### PR TITLE
fix: address review feedback on PR #3984 (media embed defaults)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
@@ -22,14 +22,14 @@ public enum MediaEmbedSettings {
         Date()
     }
 
-    /// Normalizes a user-provided domain list: trims whitespace, lowercases,
+    /// Normalizes a user-provided domain list: trims whitespace and newlines, lowercases,
     /// strips URL schemes/paths/query strings/fragments, removes empty strings,
     /// and deduplicates while preserving first-occurrence order.
     public static func normalizeDomains(_ domains: [String]) -> [String] {
         var seen = Set<String>()
         var result: [String] = []
         for domain in domains {
-            var normalized = domain.trimmingCharacters(in: .whitespaces).lowercased()
+            var normalized = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             guard !normalized.isEmpty else { continue }
             normalized = extractHost(from: normalized)
             guard !normalized.isEmpty, !seen.contains(normalized) else { continue }

--- a/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
@@ -71,6 +71,11 @@ final class MediaEmbedSettingsDefaultsTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    func testNormalizeDomainsTrimsNewlines() {
+        let result = MediaEmbedSettings.normalizeDomains(["youtube.com\n", "\ryoutube.com\r\n", "vimeo.com\n"])
+        XCTAssertEqual(result, ["youtube.com", "vimeo.com"])
+    }
+
     func testNormalizeDomainsDeduplicatesAcrossCaseAndWhitespace() {
         let result = MediaEmbedSettings.normalizeDomains(["  YouTube.com ", "youtube.com", " YOUTUBE.COM  "])
         XCTAssertEqual(result, ["youtube.com"])


### PR DESCRIPTION
Addresses Codex review feedback on #3984: use .whitespacesAndNewlines instead of .whitespaces in normalizeDomains to properly strip newline characters from domain input. Adds test coverage for newline trimming.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
