### PR TITLE
fix: move webView.load into makeNSView to prevent reload on re-render

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -47,6 +47,8 @@ struct InlineVideoWebView: NSViewRepresentable {
         let webView = Self.makeConfiguredWebView()
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
+        let request = URLRequest(url: url)
+        webView.load(request)
         return webView
     }
 
@@ -64,9 +66,6 @@ struct InlineVideoWebView: NSViewRepresentable {
         // recreating the coordinator.
         context.coordinator.onLoadSuccess = onLoadSuccess
         context.coordinator.onLoadFailure = onLoadFailure
-
-        let request = URLRequest(url: url)
-        webView.load(request)
     }
 
     /// Build a WKWebView with the privacy-hardened configuration used for embeds.


### PR DESCRIPTION
Addresses review feedback on #4031. Moves webView.load(request) from updateNSView to makeNSView since url is immutable, preventing video restart on SwiftUI re-renders.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
