### PR TITLE
fix: correct shouldShowBubble formula in preview regression test (#4057)

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -170,7 +170,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         let allCompleted = msg.inlineSurfaces.allSatisfy { $0.completionState != nil }
         XCTAssertFalse(allCompleted,
                        "Not all surfaces are completed, so shouldShowBubble should be false")
-        let shouldShowBubble = allCompleted || (msg.text.isEmpty && msg.attachments.isEmpty)
+        let shouldShowBubble = allCompleted && (!msg.text.isEmpty || !msg.attachments.isEmpty)
         XCTAssertFalse(shouldShowBubble,
                        "Bubble should be hidden when assistant message has active inline surfaces")
     }


### PR DESCRIPTION
Fixes the shouldShowBubble logic in testPreviewCardHidesTextBubble to match the production ChatView.shouldShowBubble implementation. The test previously used `allCompleted || (msg.text.isEmpty && msg.attachments.isEmpty)` which does not match the production formula. Changed to `allCompleted && (!msg.text.isEmpty || !msg.attachments.isEmpty)` which correctly mirrors the production behavior: hide bubble when surfaces are not all completed, show when completed AND there is text/attachments. Addresses review feedback on #4057.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
