### PR TITLE
fix: reuse canonical BROWSER_TOOL_NAMES in browser baseline test

### DIFF
--- a/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
+++ b/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
@@ -10,21 +10,9 @@ import {
   getAllToolDefinitions,
   __resetRegistryForTesting,
 } from '../tools/registry.js';
+import { BROWSER_TOOL_NAMES } from './test-support/browser-skill-harness.js';
 
 afterAll(() => { __resetRegistryForTesting(); });
-
-const BROWSER_TOOL_NAMES = [
-  'browser_navigate',
-  'browser_snapshot',
-  'browser_screenshot',
-  'browser_close',
-  'browser_click',
-  'browser_type',
-  'browser_press_key',
-  'browser_wait_for',
-  'browser_extract',
-  'browser_fill_credential',
-] as const;
 
 beforeAll(async () => {
   // Reset first to clear any browser tools registered via ESM side-effect


### PR DESCRIPTION
Addresses review feedback on #4114. Replaces the locally-duplicated BROWSER_TOOL_NAMES list with an import from the canonical source in browser-skill-harness.ts, eliminating dual source of truth.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
