### PR TITLE
feat: add proxy approval hooks for missing credential and unauthenticated requests

### DIFF
--- a/assistant/src/__tests__/script-proxy-policy.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { evaluateRequest } from '../tools/network/script-proxy/policy.js';
+import { evaluateRequest, evaluateRequestWithApproval } from '../tools/network/script-proxy/policy.js';
 import type { CredentialInjectionTemplate } from '../tools/credentials/policy-types.js';
 
 function headerTemplate(
@@ -120,5 +120,146 @@ describe('evaluateRequest', () => {
     const result = evaluateRequest('fal.ai', '/', ['cred-1'], templates);
     // "*.fal.ai" does not match bare "fal.ai" with minimatch
     expect(result).toEqual({ kind: 'missing' });
+  });
+});
+
+describe('evaluateRequestWithApproval', () => {
+  test('passes through matched decisions unchanged', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai', 443, '/v1/run',
+      ['cred-fal'], sessionTemplates, [tpl],
+    );
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-fal', template: tpl });
+  });
+
+  test('passes through ambiguous decisions unchanged', () => {
+    const tpl1 = headerTemplate('*.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('*.fal.ai', 'X-Api-Key');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [tpl1]],
+      ['cred-b', [tpl2]],
+    ]);
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai', null, '/',
+      ['cred-a', 'cred-b'], sessionTemplates, [tpl1, tpl2],
+    );
+    expect(result.kind).toBe('ambiguous');
+  });
+
+  test('returns ask_missing_credential when host matches a known template but session has no matching credential', () => {
+    // Session has a credential for openai, but the request is to fal.ai.
+    // The full registry knows about fal.ai, so this is a "missing credential" case.
+    const sessionTpl = headerTemplate('*.openai.com');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-openai', [sessionTpl]],
+    ]);
+    const knownFalTpl = headerTemplate('*.fal.ai');
+    const allKnown = [sessionTpl, knownFalTpl];
+
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai', 443, '/v1/run',
+      ['cred-openai'], sessionTemplates, allKnown,
+    );
+    expect(result).toEqual({
+      kind: 'ask_missing_credential',
+      target: { hostname: 'api.fal.ai', port: 443, path: '/v1/run' },
+      matchingPatterns: ['*.fal.ai'],
+    });
+  });
+
+  test('returns ask_missing_credential with deduplicated patterns', () => {
+    // Two credentials in the full registry share the same host pattern.
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-openai', [headerTemplate('*.openai.com')]],
+    ]);
+    const allKnown = [
+      headerTemplate('*.fal.ai', 'Authorization', 'Key '),
+      headerTemplate('*.fal.ai', 'X-Api-Key'),
+    ];
+
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai', null, '/',
+      ['cred-openai'], sessionTemplates, allKnown,
+    );
+    expect(result.kind).toBe('ask_missing_credential');
+    if (result.kind === 'ask_missing_credential') {
+      // Should be deduplicated to a single pattern
+      expect(result.matchingPatterns).toEqual(['*.fal.ai']);
+    }
+  });
+
+  test('returns ask_missing_credential when session has credentials but none have templates', () => {
+    // Session references a credential ID that has no templates at all.
+    // The full registry knows about fal.ai though.
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const allKnown = [headerTemplate('*.fal.ai')];
+
+    const result = evaluateRequestWithApproval(
+      'api.fal.ai', 8080, '/generate',
+      ['cred-unknown'], sessionTemplates, allKnown,
+    );
+    expect(result).toEqual({
+      kind: 'ask_missing_credential',
+      target: { hostname: 'api.fal.ai', port: 8080, path: '/generate' },
+      matchingPatterns: ['*.fal.ai'],
+    });
+  });
+
+  test('returns ask_unauthenticated when no credentials and host is unknown', () => {
+    const result = evaluateRequestWithApproval(
+      'example.com', null, '/data',
+      [], new Map(), [],
+    );
+    expect(result).toEqual({
+      kind: 'ask_unauthenticated',
+      target: { hostname: 'example.com', port: null, path: '/data' },
+    });
+  });
+
+  test('returns ask_unauthenticated when no credentials and registry has templates for other hosts', () => {
+    // The full registry knows about fal.ai, but the request is to example.com.
+    const allKnown = [headerTemplate('*.fal.ai')];
+
+    const result = evaluateRequestWithApproval(
+      'example.com', 443, '/',
+      [], new Map(), allKnown,
+    );
+    expect(result).toEqual({
+      kind: 'ask_unauthenticated',
+      target: { hostname: 'example.com', port: 443, path: '/' },
+    });
+  });
+
+  test('returns ask_unauthenticated when session has credentials but host is completely unknown', () => {
+    // Session has openai credentials, request is to unknown host,
+    // and the full registry also has no template for this host.
+    const sessionTpl = headerTemplate('*.openai.com');
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-openai', [sessionTpl]],
+    ]);
+
+    const result = evaluateRequestWithApproval(
+      'unknown-service.internal', null, '/api',
+      ['cred-openai'], sessionTemplates, [sessionTpl],
+    );
+    expect(result).toEqual({
+      kind: 'ask_unauthenticated',
+      target: { hostname: 'unknown-service.internal', port: null, path: '/api' },
+    });
+  });
+
+  test('includes port in target context', () => {
+    const result = evaluateRequestWithApproval(
+      'localhost', 3000, '/webhook',
+      [], new Map(), [],
+    );
+    expect(result.kind).toBe('ask_unauthenticated');
+    if (result.kind === 'ask_unauthenticated') {
+      expect(result.target).toEqual({ hostname: 'localhost', port: 3000, path: '/webhook' });
+    }
   });
 });

--- a/assistant/src/tools/network/script-proxy/policy.ts
+++ b/assistant/src/tools/network/script-proxy/policy.ts
@@ -5,7 +5,7 @@
 
 import { minimatch } from 'minimatch';
 import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
-import type { PolicyDecision } from './types.js';
+import type { PolicyDecision, RequestTargetContext } from './types.js';
 
 interface MatchCandidate {
   credentialId: string;
@@ -56,4 +56,64 @@ export function evaluateRequest(
   }
 
   return { kind: 'ambiguous', candidates };
+}
+
+/**
+ * Evaluate an outbound request with approval-hook awareness.
+ *
+ * This wraps `evaluateRequest` and, when the base decision is `missing` or
+ * `unauthenticated`, consults the full credential template registry to
+ * determine whether an approval prompt should be surfaced:
+ *
+ * - `ask_missing_credential` — the target host matches at least one known
+ *   template pattern in the registry, but the session has no credential
+ *   bound for it.
+ * - `ask_unauthenticated` — the request doesn't match any known template
+ *   in the full registry and the session has no credentials.
+ *
+ * For `matched` and `ambiguous` decisions the result passes through unchanged.
+ *
+ * @param hostname       Target hostname
+ * @param port           Target port (null when the default for the scheme)
+ * @param path           Request path
+ * @param credentialIds  Credential IDs the session is authorized to use
+ * @param sessionTemplates  Templates for the session's credential IDs
+ * @param allKnownTemplates All credential injection templates across every
+ *                          credential in the system — used to detect whether
+ *                          the target host is "known" even if the session
+ *                          doesn't have the right credential bound.
+ */
+export function evaluateRequestWithApproval(
+  hostname: string,
+  port: number | null,
+  path: string,
+  credentialIds: string[],
+  sessionTemplates: Map<string, CredentialInjectionTemplate[]>,
+  allKnownTemplates: CredentialInjectionTemplate[],
+): PolicyDecision {
+  const base = evaluateRequest(hostname, path, credentialIds, sessionTemplates);
+
+  if (base.kind !== 'missing' && base.kind !== 'unauthenticated') {
+    return base;
+  }
+
+  const target: RequestTargetContext = { hostname, port, path };
+
+  // Check whether any template in the full registry covers this host.
+  const matchingPatterns: string[] = [];
+  for (const tpl of allKnownTemplates) {
+    if (minimatch(hostname, tpl.hostPattern)) {
+      matchingPatterns.push(tpl.hostPattern);
+    }
+  }
+  // Deduplicate — multiple credentials may share the same host pattern.
+  const uniquePatterns = [...new Set(matchingPatterns)];
+
+  if (uniquePatterns.length > 0) {
+    // A known host pattern exists but no credential is bound to this session.
+    return { kind: 'ask_missing_credential', target, matchingPatterns: uniquePatterns };
+  }
+
+  // Completely unknown host — prompt for unauthenticated access.
+  return { kind: 'ask_unauthenticated', target };
 }

--- a/assistant/src/tools/network/script-proxy/types.ts
+++ b/assistant/src/tools/network/script-proxy/types.ts
@@ -56,8 +56,44 @@ export interface PolicyDecisionUnauthenticated {
   kind: 'unauthenticated';
 }
 
+// ---------------------------------------------------------------------------
+// Approval hook outcomes — structured data for triggering permission prompts.
+// The actual prompt UI wiring happens in a later PR.
+// ---------------------------------------------------------------------------
+
+/** Context about the outbound request target, used to build permission prompts. */
+export interface RequestTargetContext {
+  hostname: string;
+  port: number | null;
+  path: string;
+}
+
+/**
+ * The target host matches a known credential template pattern, but the
+ * session has no credential bound for it. The UI should prompt the user
+ * to bind or create a credential.
+ */
+export interface PolicyDecisionAskMissingCredential {
+  kind: 'ask_missing_credential';
+  target: RequestTargetContext;
+  /** Host patterns from the known registry that matched the target. */
+  matchingPatterns: string[];
+}
+
+/**
+ * The request doesn't match any known credential template and the session
+ * has no credentials. The UI should prompt the user to allow or deny the
+ * unauthenticated request.
+ */
+export interface PolicyDecisionAskUnauthenticated {
+  kind: 'ask_unauthenticated';
+  target: RequestTargetContext;
+}
+
 export type PolicyDecision =
   | PolicyDecisionMatched
   | PolicyDecisionAmbiguous
   | PolicyDecisionMissing
-  | PolicyDecisionUnauthenticated;
+  | PolicyDecisionUnauthenticated
+  | PolicyDecisionAskMissingCredential
+  | PolicyDecisionAskUnauthenticated;


### PR DESCRIPTION
## Summary
- Adds two new `PolicyDecision` variants (`ask_missing_credential` and `ask_unauthenticated`) to the proxy policy engine types, with `RequestTargetContext` for building permission prompts
- Introduces `evaluateRequestWithApproval()` in `policy.ts` that wraps the existing `evaluateRequest()` and consults the full credential template registry to distinguish "known host, missing credential" from "completely unknown host"
- Adds 8 tests covering both approval branches, passthrough of matched/ambiguous decisions, pattern deduplication, and port context

## Test plan
- [x] `bun test src/__tests__/script-proxy-policy.test.ts` — 20 tests pass (12 existing + 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
