### PR TITLE
feat: add private thread media visibility policy service

### DIFF
--- a/assistant/src/__tests__/media-visibility-policy.test.ts
+++ b/assistant/src/__tests__/media-visibility-policy.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  isAttachmentVisible,
+  filterVisibleAttachments,
+  type AttachmentContext,
+} from '../daemon/media-visibility-policy.js';
+
+// ---------------------------------------------------------------------------
+// isAttachmentVisible
+// ---------------------------------------------------------------------------
+
+describe('isAttachmentVisible', () => {
+  const standardAttachment: AttachmentContext = {
+    conversationId: 'conv-standard-001',
+    isPrivate: false,
+  };
+
+  const privateAttachmentA: AttachmentContext = {
+    conversationId: 'conv-private-aaa',
+    isPrivate: true,
+  };
+
+  const privateAttachmentB: AttachmentContext = {
+    conversationId: 'conv-private-bbb',
+    isPrivate: true,
+  };
+
+  describe('standard thread attachments', () => {
+    test('visible from a standard thread', () => {
+      const ctx: AttachmentContext = { conversationId: 'conv-other', isPrivate: false };
+      expect(isAttachmentVisible(standardAttachment, ctx)).toBe(true);
+    });
+
+    test('visible from a different standard thread', () => {
+      const ctx: AttachmentContext = { conversationId: 'conv-standard-002' };
+      expect(isAttachmentVisible(standardAttachment, ctx)).toBe(true);
+    });
+
+    test('visible from a private thread', () => {
+      const ctx: AttachmentContext = { conversationId: 'conv-private-xyz', isPrivate: true };
+      expect(isAttachmentVisible(standardAttachment, ctx)).toBe(true);
+    });
+
+    test('visible when isPrivate is undefined (defaults to standard)', () => {
+      const attachment: AttachmentContext = { conversationId: 'conv-001' };
+      const ctx: AttachmentContext = { conversationId: 'conv-002' };
+      expect(isAttachmentVisible(attachment, ctx)).toBe(true);
+    });
+  });
+
+  describe('private thread attachments', () => {
+    test('visible from the same private thread', () => {
+      const ctx: AttachmentContext = {
+        conversationId: privateAttachmentA.conversationId,
+        isPrivate: true,
+      };
+      expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(true);
+    });
+
+    test('NOT visible from a different private thread', () => {
+      const ctx: AttachmentContext = {
+        conversationId: privateAttachmentB.conversationId,
+        isPrivate: true,
+      };
+      expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(false);
+    });
+
+    test('NOT visible from a standard thread', () => {
+      const ctx: AttachmentContext = { conversationId: 'conv-standard-001', isPrivate: false };
+      expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(false);
+    });
+
+    test('NOT visible when context isPrivate is undefined (standard)', () => {
+      const ctx: AttachmentContext = { conversationId: privateAttachmentA.conversationId };
+      expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(false);
+    });
+
+    test('NOT visible from standard thread even with same conversationId', () => {
+      // Edge case: same conversationId but the context is not marked as private
+      const ctx: AttachmentContext = {
+        conversationId: privateAttachmentA.conversationId,
+        isPrivate: false,
+      };
+      expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterVisibleAttachments
+// ---------------------------------------------------------------------------
+
+describe('filterVisibleAttachments', () => {
+  interface TestAttachment {
+    id: string;
+    conversationId: string;
+    isPrivate: boolean;
+  }
+
+  const getContext = (a: TestAttachment): AttachmentContext => ({
+    conversationId: a.conversationId,
+    isPrivate: a.isPrivate,
+  });
+
+  const standardAtt: TestAttachment = { id: 'att-1', conversationId: 'conv-std', isPrivate: false };
+  const privateAttA: TestAttachment = { id: 'att-2', conversationId: 'conv-priv-a', isPrivate: true };
+  const privateAttB: TestAttachment = { id: 'att-3', conversationId: 'conv-priv-b', isPrivate: true };
+
+  const allAttachments = [standardAtt, privateAttA, privateAttB];
+
+  test('returns all standard attachments regardless of context', () => {
+    const ctx: AttachmentContext = { conversationId: 'conv-unrelated', isPrivate: false };
+    const result = filterVisibleAttachments(allAttachments, ctx, getContext);
+    expect(result).toEqual([standardAtt]);
+  });
+
+  test('includes matching private attachment when in same private thread', () => {
+    const ctx: AttachmentContext = { conversationId: 'conv-priv-a', isPrivate: true };
+    const result = filterVisibleAttachments(allAttachments, ctx, getContext);
+    expect(result).toEqual([standardAtt, privateAttA]);
+  });
+
+  test('includes only the private attachment for the current thread, not others', () => {
+    const ctx: AttachmentContext = { conversationId: 'conv-priv-b', isPrivate: true };
+    const result = filterVisibleAttachments(allAttachments, ctx, getContext);
+    expect(result).toEqual([standardAtt, privateAttB]);
+  });
+
+  test('returns empty array when input is empty', () => {
+    const ctx: AttachmentContext = { conversationId: 'conv-std', isPrivate: false };
+    const result = filterVisibleAttachments([], ctx, getContext);
+    expect(result).toEqual([]);
+  });
+
+  test('preserves original attachment objects (referential identity)', () => {
+    const ctx: AttachmentContext = { conversationId: 'conv-priv-a', isPrivate: true };
+    const result = filterVisibleAttachments(allAttachments, ctx, getContext);
+    expect(result[0]).toBe(standardAtt);
+    expect(result[1]).toBe(privateAttA);
+  });
+});

--- a/assistant/src/daemon/media-visibility-policy.ts
+++ b/assistant/src/daemon/media-visibility-policy.ts
@@ -1,0 +1,56 @@
+/**
+ * Centralized policy for attachment visibility across thread types.
+ *
+ * Private-thread attachments are scoped: they are only visible when the
+ * current context is the *same* private thread. Standard (non-private)
+ * thread attachments are visible everywhere.
+ *
+ * This is a pure policy module -- no IO, no database queries, just logic.
+ * Actual enforcement in tools happens downstream (e.g., attachment-list
+ * and attachment-retrieve tools check this before returning results).
+ */
+
+export interface AttachmentContext {
+  conversationId: string;
+  isPrivate?: boolean;
+}
+
+/**
+ * Determine whether a single attachment is visible from the given context.
+ *
+ * Rules:
+ * 1. Attachments from standard (non-private) threads are always visible.
+ * 2. Attachments from private threads are only visible when the current
+ *    context matches the same private thread (same conversationId).
+ */
+export function isAttachmentVisible(
+  attachment: AttachmentContext,
+  currentContext: AttachmentContext,
+): boolean {
+  // Standard thread attachments are universally visible
+  if (!attachment.isPrivate) {
+    return true;
+  }
+
+  // Private thread attachments require the viewer to be in the same private thread
+  return (
+    currentContext.isPrivate === true &&
+    currentContext.conversationId === attachment.conversationId
+  );
+}
+
+/**
+ * Filter a list of attachments to only those visible from the current context.
+ *
+ * @param attachments - The full list of attachments to filter.
+ * @param currentContext - The thread context from which visibility is evaluated.
+ * @param getContext - Extracts the conversation context from each attachment
+ *   record (since the caller's attachment type may differ from AttachmentContext).
+ */
+export function filterVisibleAttachments<T>(
+  attachments: T[],
+  currentContext: AttachmentContext,
+  getContext: (attachment: T) => AttachmentContext,
+): T[] {
+  return attachments.filter((a) => isAttachmentVisible(getContext(a), currentContext));
+}


### PR DESCRIPTION
## Summary
- Adds `media-visibility-policy.ts` — a pure policy module that determines whether an attachment is visible from a given thread context
- Private-thread attachments are only visible from the same private thread; standard thread attachments are visible everywhere
- Includes `filterVisibleAttachments` generic helper for bulk filtering arbitrary attachment types
- Comprehensive test coverage (14 tests) covering standard/private visibility rules, edge cases, and the bulk filter helper

## Test plan
- [x] `bun test src/__tests__/media-visibility-policy.test.ts` — all 14 tests pass

Part of the media-reuse plan (PR 36). Enforcement in tools follows in PR 37.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
