### PR TITLE
fix: backfill handler preserves private conversation scope (PR #4027 feedback)

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -105,6 +105,7 @@ import {
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 import { addMessage, createConversation, getConversationMemoryScopeId } from '../memory/conversation-store.js';
+import { backfillJob } from '../memory/job-handlers/backfill.js';
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from '../memory/job-handlers/summarization.js';
 import {
   conversations,
@@ -4184,5 +4185,51 @@ describe('Memory regressions', () => {
 
     const ids = results.map((r) => r.id);
     expect(ids).toContain('seg-search-priv-scope');
+  });
+
+  // Backfill preserves private conversation scope on memory segments
+  test('backfillJob preserves private conversation scope during reindex', () => {
+    const db = getDb();
+
+    // Create a private conversation with a message
+    const conv = createConversation({ title: 'Backfill scope test', threadType: 'private' });
+    expect(conv.memoryScopeId).toMatch(/^private:/);
+
+    // Insert a message directly (bypassing addMessage to avoid pre-indexing)
+    const msgId = 'msg-backfill-scope-test';
+    db.insert(messages).values({
+      id: msgId,
+      conversationId: conv.id,
+      role: 'user',
+      content: 'My confidential backfill test content for private thread preservation.',
+      createdAt: conv.createdAt + 1,
+    }).run();
+
+    // Run the backfill job — it should look up the conversation scope
+    const fakeJob = {
+      id: 'job-backfill-scope',
+      type: 'backfill' as const,
+      payload: { force: true },
+      status: 'running' as const,
+      attempts: 0,
+      deferrals: 0,
+      runAfter: 0,
+      lastError: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    backfillJob(fakeJob, TEST_CONFIG);
+
+    // Verify the segments were indexed with the private scope
+    const segments = db
+      .select()
+      .from(memorySegments)
+      .where(eq(memorySegments.messageId, msgId))
+      .all();
+
+    expect(segments.length).toBeGreaterThan(0);
+    for (const seg of segments) {
+      expect(seg.scopeId).toBe(conv.memoryScopeId);
+    }
   });
 });

--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -7,6 +7,7 @@ import {
   resetMessageCursorCheckpoint,
   writeMessageCursorCheckpoint,
 } from '../checkpoints.js';
+import { getConversationMemoryScopeId } from '../conversation-store.js';
 import { indexMessageNow } from '../indexer.js';
 import {
   enqueueBackfillEntityRelationsJob,
@@ -42,13 +43,20 @@ export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
     .all();
 
   if (batch.length > 0) {
+    const scopeCache = new Map<string, string>();
     for (const message of batch) {
+      let scopeId = scopeCache.get(message.conversationId);
+      if (scopeId === undefined) {
+        scopeId = getConversationMemoryScopeId(message.conversationId);
+        scopeCache.set(message.conversationId, scopeId);
+      }
       indexMessageNow({
         messageId: message.id,
         conversationId: message.conversationId,
         role: message.role,
         content: message.content,
         createdAt: message.createdAt,
+        scopeId,
       }, config.memory);
     }
     const lastMessage = batch[batch.length - 1];


### PR DESCRIPTION
Addresses review feedback on #4027 from both Codex and Devin.

The backfill handler was calling indexMessageNow() without passing scopeId, causing private conversation segments to be rewritten with scope_id='default' during reindex. This fix looks up each conversation's memoryScopeId in the backfill loop (with per-batch caching) and passes it through to the indexer.

Added a regression test verifying that backfillJob preserves private scope on memory segments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
