### PR TITLE
fix: normalize threadType at runtime instead of type-only casts

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -5,6 +5,7 @@ import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { getAttachmentsForMessageUnscoped } from '../../memory/attachments-store.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
+import { normalizeThreadType } from '../ipc-protocol.js';
 import type {
   UserMessage,
   ConfirmationResponse,
@@ -18,7 +19,6 @@ import type {
   UsageRequest,
   SandboxSetRequest,
   ServerMessage,
-  ThreadType,
 } from '../ipc-protocol.js';
 import { getConfig } from '../../config/loader.js';
 import {
@@ -197,7 +197,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext): void
       id: c.id,
       title: c.title ?? 'Untitled',
       updatedAt: c.updatedAt,
-      threadType: c.threadType as ThreadType,
+      threadType: normalizeThreadType(c.threadType),
     })),
   });
 }
@@ -217,7 +217,7 @@ export async function handleSessionCreate(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const threadType: ThreadType = msg.threadType === 'private' ? 'private' : 'standard';
+  const threadType = normalizeThreadType(msg.threadType);
   const conversation = conversationStore.createConversation({
     title: msg.title ?? 'New Conversation',
     threadType,
@@ -240,7 +240,7 @@ export async function handleSessionCreate(
     sessionId: conversation.id,
     title: conversation.title ?? 'New Conversation',
     ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
-    threadType: conversation.threadType as ThreadType,
+    threadType: normalizeThreadType(conversation.threadType),
   });
 
   // Auto-send the initial message if provided, kick-starting the skill.
@@ -278,7 +278,7 @@ export async function handleSessionSwitch(
     type: 'session_info',
     sessionId: conversation.id,
     title: conversation.title ?? 'Untitled',
-    threadType: conversation.threadType as ThreadType,
+    threadType: normalizeThreadType(conversation.threadType),
   });
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -4,6 +4,11 @@ import type { GalleryManifest } from '../gallery/gallery-manifest.js';
 
 export type ThreadType = 'standard' | 'private';
 
+/** Runtime normalizer — collapses unknown/legacy DB values to 'standard'. */
+export function normalizeThreadType(raw: string | null | undefined): ThreadType {
+  return raw === 'private' ? 'private' : 'standard';
+}
+
 export interface IpcBlobRef {
   id: string;
   kind: 'ax_tree' | 'screenshot_jpeg';

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -25,7 +25,7 @@ import {
   MAX_LINE_SIZE,
   type ClientMessage,
   type ServerMessage,
-  type ThreadType,
+  normalizeThreadType,
 } from './ipc-protocol.js';
 import { validateClientMessage } from './ipc-validate.js';
 import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
@@ -707,7 +707,7 @@ export class DaemonServer {
       type: 'session_info',
       sessionId: conversation.id,
       title: conversation.title ?? 'New Conversation',
-      threadType: conversation.threadType as ThreadType,
+      threadType: normalizeThreadType(conversation.threadType),
     });
 
     this.send(socket, {


### PR DESCRIPTION
Addresses Codex review feedback on #4042. Replaces unsafe `as ThreadType` casts with a `normalizeThreadType()` runtime helper that collapses unknown/legacy DB values to `'standard'`, preventing malformed values from leaking through the IPC contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
