### PR TITLE
feat: add asset_search tool for cross-thread attachment metadata search

### DIFF
--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -1,0 +1,353 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'asset-search-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
+import { createConversation, addMessage } from '../memory/conversation-store.js';
+import { searchAttachments } from '../tools/assets/search.js';
+import type { ToolContext } from '../tools/types.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM message_attachments');
+  db.run('DELETE FROM attachments');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+}
+
+// Seed data helpers
+function seedAttachments() {
+  const now = Date.now();
+  const oneDayAgo = now - 24 * 60 * 60 * 1000 - 1000;
+  const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
+  const sixtyDaysAgo = now - 60 * 24 * 60 * 60 * 1000;
+
+  // Force createdAt by uploading then manipulating the DB
+  const db = getDb();
+
+  const png1 = uploadAttachment('ast-1', 'selfie.png', 'image/png', 'AAAA');
+  const jpg1 = uploadAttachment('ast-1', 'photo.jpg', 'image/jpeg', 'BBBB');
+  const pdf1 = uploadAttachment('ast-1', 'report.pdf', 'application/pdf', 'CCCC');
+  const png2 = uploadAttachment('ast-1', 'screenshot.png', 'image/png', 'DDDD');
+
+  // Backdate some attachments for recency testing
+  db.run(`UPDATE attachments SET created_at = ${oneDayAgo} WHERE id = '${jpg1.id}'`);
+  db.run(`UPDATE attachments SET created_at = ${tenDaysAgo} WHERE id = '${pdf1.id}'`);
+  db.run(`UPDATE attachments SET created_at = ${sixtyDaysAgo} WHERE id = '${png2.id}'`);
+
+  return { png1, jpg1, pdf1, png2, now, oneDayAgo, tenDaysAgo, sixtyDaysAgo };
+}
+
+const dummyContext: ToolContext = {
+  workingDir: '/tmp',
+  sessionId: 'sess-test',
+  conversationId: 'conv-test',
+};
+
+// ---------------------------------------------------------------------------
+// searchAttachments (unit tests on the query function)
+// ---------------------------------------------------------------------------
+
+describe('searchAttachments', () => {
+  beforeEach(resetTables);
+
+  test('returns all attachments when no filters provided', () => {
+    seedAttachments();
+    const results = searchAttachments({});
+    expect(results.length).toBe(4);
+  });
+
+  test('filters by exact MIME type', () => {
+    seedAttachments();
+    const results = searchAttachments({ mime_type: 'application/pdf' });
+    expect(results.length).toBe(1);
+    expect(results[0].mimeType).toBe('application/pdf');
+  });
+
+  test('filters by MIME type wildcard (image/*)', () => {
+    seedAttachments();
+    const results = searchAttachments({ mime_type: 'image/*' });
+    expect(results.length).toBe(3);
+    for (const r of results) {
+      expect(r.mimeType.startsWith('image/')).toBe(true);
+    }
+  });
+
+  test('filters by filename substring', () => {
+    seedAttachments();
+    const results = searchAttachments({ filename: 'selfie' });
+    expect(results.length).toBe(1);
+    expect(results[0].originalFilename).toBe('selfie.png');
+  });
+
+  test('filename search is case-insensitive via LIKE', () => {
+    seedAttachments();
+    // SQLite LIKE is case-insensitive for ASCII by default
+    const results = searchAttachments({ filename: 'SELFIE' });
+    expect(results.length).toBe(1);
+  });
+
+  test('filters by recency: last_24_hours', () => {
+    seedAttachments();
+    const results = searchAttachments({ recency: 'last_24_hours' });
+    // Only selfie.png was uploaded "now" (not backdated past 24h)
+    expect(results.length).toBe(1);
+    expect(results[0].originalFilename).toBe('selfie.png');
+  });
+
+  test('filters by recency: last_7_days', () => {
+    seedAttachments();
+    const results = searchAttachments({ recency: 'last_7_days' });
+    // selfie.png (now) and photo.jpg (1 day ago)
+    expect(results.length).toBe(2);
+  });
+
+  test('filters by recency: last_30_days', () => {
+    seedAttachments();
+    const results = searchAttachments({ recency: 'last_30_days' });
+    // selfie.png (now), photo.jpg (1 day ago), report.pdf (10 days ago)
+    expect(results.length).toBe(3);
+  });
+
+  test('filters by recency: last_90_days', () => {
+    seedAttachments();
+    const results = searchAttachments({ recency: 'last_90_days' });
+    // All 4 attachments are within 90 days
+    expect(results.length).toBe(4);
+  });
+
+  test('combines mime_type and filename filters', () => {
+    seedAttachments();
+    const results = searchAttachments({ mime_type: 'image/*', filename: 'selfie' });
+    expect(results.length).toBe(1);
+    expect(results[0].originalFilename).toBe('selfie.png');
+  });
+
+  test('combines mime_type and recency filters', () => {
+    seedAttachments();
+    const results = searchAttachments({ mime_type: 'image/*', recency: 'last_24_hours' });
+    expect(results.length).toBe(1);
+    expect(results[0].originalFilename).toBe('selfie.png');
+  });
+
+  test('respects limit parameter', () => {
+    seedAttachments();
+    const results = searchAttachments({ limit: 2 });
+    expect(results.length).toBe(2);
+  });
+
+  test('caps limit at MAX_RESULTS (100)', () => {
+    seedAttachments();
+    const results = searchAttachments({ limit: 500 });
+    // We only have 4 attachments so we just verify it doesn't error
+    expect(results.length).toBe(4);
+  });
+
+  test('returns results ordered by createdAt desc (most recent first)', () => {
+    seedAttachments();
+    const results = searchAttachments({});
+    // selfie.png is most recent (now), then photo.jpg (1 day ago), etc.
+    expect(results[0].originalFilename).toBe('selfie.png');
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].createdAt).toBeGreaterThanOrEqual(results[i].createdAt);
+    }
+  });
+
+  test('returns empty array when no matches', () => {
+    seedAttachments();
+    const results = searchAttachments({ filename: 'nonexistent' });
+    expect(results.length).toBe(0);
+  });
+
+  test('does not return base64 data in results', () => {
+    seedAttachments();
+    const results = searchAttachments({}) as Array<Record<string, unknown>>;
+    for (const r of results) {
+      expect(r.dataBase64).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAttachments with conversation_id
+// ---------------------------------------------------------------------------
+
+describe('searchAttachments with conversation_id', () => {
+  beforeEach(resetTables);
+
+  test('returns only attachments linked to the specified conversation', () => {
+    const png1 = uploadAttachment('ast-1', 'in-conv.png', 'image/png', 'AAAA');
+    const png2 = uploadAttachment('ast-1', 'other-conv.png', 'image/png', 'BBBB');
+
+    const conv1 = createConversation();
+    const conv2 = createConversation();
+    const msg1 = addMessage(conv1.id, 'user', 'First conv');
+    const msg2 = addMessage(conv2.id, 'user', 'Second conv');
+
+    linkAttachmentToMessage(msg1.id, png1.id, 0);
+    linkAttachmentToMessage(msg2.id, png2.id, 0);
+
+    const results = searchAttachments({ conversation_id: conv1.id });
+    expect(results.length).toBe(1);
+    expect(results[0].id).toBe(png1.id);
+  });
+
+  test('returns empty when conversation has no attachments', () => {
+    uploadAttachment('ast-1', 'orphan.png', 'image/png', 'AAAA');
+    const conv = createConversation();
+    addMessage(conv.id, 'user', 'No attachments here');
+
+    const results = searchAttachments({ conversation_id: conv.id });
+    expect(results.length).toBe(0);
+  });
+
+  test('returns empty for nonexistent conversation_id', () => {
+    uploadAttachment('ast-1', 'file.png', 'image/png', 'AAAA');
+    const results = searchAttachments({ conversation_id: 'conv-nonexistent' });
+    expect(results.length).toBe(0);
+  });
+
+  test('combines conversation_id with mime_type filter', () => {
+    const png = uploadAttachment('ast-1', 'image.png', 'image/png', 'AAAA');
+    const pdf = uploadAttachment('ast-1', 'doc.pdf', 'application/pdf', 'BBBB');
+
+    const conv = createConversation();
+    const msg = addMessage(conv.id, 'user', 'Both types');
+
+    linkAttachmentToMessage(msg.id, png.id, 0);
+    linkAttachmentToMessage(msg.id, pdf.id, 1);
+
+    const results = searchAttachments({ conversation_id: conv.id, mime_type: 'image/*' });
+    expect(results.length).toBe(1);
+    expect(results[0].mimeType).toBe('image/png');
+  });
+
+  test('combines conversation_id with filename filter', () => {
+    const a = uploadAttachment('ast-1', 'target.png', 'image/png', 'AAAA');
+    const b = uploadAttachment('ast-1', 'other.png', 'image/png', 'BBBB');
+
+    const conv = createConversation();
+    const msg = addMessage(conv.id, 'user', 'Both');
+
+    linkAttachmentToMessage(msg.id, a.id, 0);
+    linkAttachmentToMessage(msg.id, b.id, 1);
+
+    const results = searchAttachments({ conversation_id: conv.id, filename: 'target' });
+    expect(results.length).toBe(1);
+    expect(results[0].originalFilename).toBe('target.png');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AssetSearchTool.execute (integration test via tool interface)
+// ---------------------------------------------------------------------------
+
+describe('AssetSearchTool.execute', () => {
+  beforeEach(resetTables);
+
+  // Import the tool instance
+  let tool: import('../tools/types.js').Tool;
+  beforeEach(async () => {
+    const mod = await import('../tools/assets/search.js');
+    tool = mod.assetSearchTool;
+  });
+
+  test('returns formatted results for matching assets', async () => {
+    uploadAttachment('ast-1', 'selfie.png', 'image/png', 'AAAA');
+    const result = await tool.execute({}, dummyContext);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('selfie.png');
+    expect(result.content).toContain('Found 1 asset(s)');
+  });
+
+  test('returns no-match message when nothing found', async () => {
+    const result = await tool.execute({ filename: 'nonexistent' }, dummyContext);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No assets found');
+  });
+
+  test('returns error for invalid recency value', async () => {
+    const result = await tool.execute({ recency: 'last_year' }, dummyContext);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid recency value');
+  });
+
+  test('returns error for invalid limit', async () => {
+    const result = await tool.execute({ limit: -1 }, dummyContext);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('limit must be a positive number');
+  });
+
+  test('includes attachment ID in output', async () => {
+    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'AAAA');
+    const result = await tool.execute({}, dummyContext);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(stored.id);
+  });
+
+  test('includes MIME type and kind in output', async () => {
+    uploadAttachment('ast-1', 'chart.png', 'image/png', 'AAAA');
+    const result = await tool.execute({}, dummyContext);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('image/png');
+    expect(result.content).toContain('image');
+  });
+
+  test('tool definition has correct name and schema', () => {
+    const def = tool.getDefinition();
+    expect(def.name).toBe('asset_search');
+    expect(def.input_schema.properties).toHaveProperty('mime_type');
+    expect(def.input_schema.properties).toHaveProperty('filename');
+    expect(def.input_schema.properties).toHaveProperty('recency');
+    expect(def.input_schema.properties).toHaveProperty('conversation_id');
+    expect(def.input_schema.properties).toHaveProperty('limit');
+    expect(def.input_schema.required).toEqual([]);
+  });
+
+  test('tool has LOW risk level', () => {
+    expect(tool.defaultRiskLevel).toBe('low');
+  });
+
+  test('tool category is assets', () => {
+    expect(tool.category).toBe('assets');
+  });
+});

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -1,0 +1,293 @@
+/**
+ * asset_search — cross-thread attachment metadata search.
+ *
+ * Queries the attachments store for matching assets by MIME type,
+ * filename, recency, or conversation scope. Returns metadata and
+ * attachment IDs only — never base64 payloads. The IDs can be
+ * passed to asset_materialize (PR 35) to retrieve actual content.
+ */
+
+import { and, eq, like, gte, desc } from 'drizzle-orm';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getDb } from '../../memory/db.js';
+import { attachments, messageAttachments, messages } from '../../memory/schema.js';
+import type { StoredAttachment } from '../../memory/attachments-store.js';
+
+// ---------------------------------------------------------------------------
+// Recency presets — map human-readable labels to epoch-ms cutoff offsets
+// ---------------------------------------------------------------------------
+
+const RECENCY_MS: Record<string, number> = {
+  last_hour: 60 * 60 * 1000,
+  last_24_hours: 24 * 60 * 60 * 1000,
+  last_7_days: 7 * 24 * 60 * 60 * 1000,
+  last_30_days: 30 * 24 * 60 * 60 * 1000,
+  last_90_days: 90 * 24 * 60 * 60 * 1000,
+};
+
+const VALID_RECENCY_VALUES = Object.keys(RECENCY_MS);
+
+// ---------------------------------------------------------------------------
+// Result formatting
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatAttachment(a: StoredAttachment): string {
+  const date = new Date(a.createdAt).toISOString();
+  return [
+    `- **${a.originalFilename}** (ID: ${a.id})`,
+    `  Type: ${a.mimeType} | Kind: ${a.kind} | Size: ${formatBytes(a.sizeBytes)}`,
+    `  Created: ${date}`,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Search logic
+// ---------------------------------------------------------------------------
+
+export interface AssetSearchParams {
+  mime_type?: string;
+  filename?: string;
+  recency?: string;
+  conversation_id?: string;
+  limit?: number;
+}
+
+const MAX_RESULTS = 100;
+const DEFAULT_LIMIT = 20;
+
+export function searchAttachments(params: AssetSearchParams): StoredAttachment[] {
+  const db = getDb();
+  const conditions = [];
+
+  // MIME type filter — supports wildcards like 'image/*' via LIKE
+  if (params.mime_type) {
+    const mimePattern = params.mime_type.replace(/\*/g, '%');
+    conditions.push(like(attachments.mimeType, mimePattern));
+  }
+
+  // Filename filter — case-insensitive substring match
+  if (params.filename) {
+    conditions.push(like(attachments.originalFilename, `%${params.filename}%`));
+  }
+
+  // Recency filter — computed cutoff timestamp
+  if (params.recency) {
+    const offsetMs = RECENCY_MS[params.recency];
+    if (offsetMs) {
+      const cutoff = Date.now() - offsetMs;
+      conditions.push(gte(attachments.createdAt, cutoff));
+    }
+  }
+
+  // Conversation scope — join through message_attachments + messages
+  if (params.conversation_id) {
+    const linkedIds = db
+      .select({ attachmentId: messageAttachments.attachmentId })
+      .from(messageAttachments)
+      .innerJoin(messages, eq(messages.id, messageAttachments.messageId))
+      .where(eq(messages.conversationId, params.conversation_id))
+      .all()
+      .map((r) => r.attachmentId)
+      .filter((id): id is string => id !== null);
+
+    if (linkedIds.length === 0) {
+      return [];
+    }
+
+    // Use raw SQL IN clause for the attachment ID set
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const placeholders = linkedIds.map(() => '?').join(', ');
+
+    // Build WHERE clauses for raw query
+    const whereParts: string[] = [`a.id IN (${placeholders})`];
+    const bindValues: (string | number)[] = [...linkedIds];
+
+    if (params.mime_type) {
+      const mimePattern = params.mime_type.replace(/\*/g, '%');
+      whereParts.push(`a.mime_type LIKE ?`);
+      bindValues.push(mimePattern);
+    }
+    if (params.filename) {
+      whereParts.push(`a.original_filename LIKE ?`);
+      bindValues.push(`%${params.filename}%`);
+    }
+    if (params.recency) {
+      const offsetMs = RECENCY_MS[params.recency];
+      if (offsetMs) {
+        whereParts.push(`a.created_at >= ?`);
+        bindValues.push(Date.now() - offsetMs);
+      }
+    }
+
+    const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_RESULTS);
+    const stmt = raw.prepare(
+      `SELECT a.id, a.assistant_id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.created_at
+       FROM attachments a
+       WHERE ${whereParts.join(' AND ')}
+       ORDER BY a.created_at DESC
+       LIMIT ?`,
+    );
+
+    const rows = stmt.all(...bindValues, limit) as Array<{
+      id: string;
+      assistant_id: string;
+      original_filename: string;
+      mime_type: string;
+      size_bytes: number;
+      kind: string;
+      created_at: number;
+    }>;
+
+    return rows.map((r) => ({
+      id: r.id,
+      assistantId: r.assistant_id,
+      originalFilename: r.original_filename,
+      mimeType: r.mime_type,
+      sizeBytes: r.size_bytes,
+      kind: r.kind,
+      createdAt: r.created_at,
+    }));
+  }
+
+  // No conversation constraint — query attachments table directly
+  const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_RESULTS);
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const query = db
+    .select({
+      id: attachments.id,
+      assistantId: attachments.assistantId,
+      originalFilename: attachments.originalFilename,
+      mimeType: attachments.mimeType,
+      sizeBytes: attachments.sizeBytes,
+      kind: attachments.kind,
+      createdAt: attachments.createdAt,
+    })
+    .from(attachments)
+    .orderBy(desc(attachments.createdAt))
+    .limit(limit);
+
+  if (where) {
+    return query.where(where).all();
+  }
+  return query.all();
+}
+
+// ---------------------------------------------------------------------------
+// Tool definition
+// ---------------------------------------------------------------------------
+
+const definition: ToolDefinition = {
+  name: 'asset_search',
+  description:
+    'Search for previously uploaded media assets (images, documents, etc.) by metadata. ' +
+    'Returns attachment IDs and metadata — not file content. Use the returned IDs with ' +
+    'asset_materialize to retrieve actual file data.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      mime_type: {
+        type: 'string',
+        description:
+          'Filter by MIME type. Supports wildcards: "image/*" matches all images, ' +
+          '"application/pdf" matches PDFs exactly.',
+      },
+      filename: {
+        type: 'string',
+        description: 'Search by original filename (case-insensitive substring match).',
+      },
+      recency: {
+        type: 'string',
+        enum: VALID_RECENCY_VALUES,
+        description:
+          'Filter by recency. One of: last_hour, last_24_hours, last_7_days, last_30_days, last_90_days.',
+      },
+      conversation_id: {
+        type: 'string',
+        description:
+          'Constrain results to attachments linked to messages in a specific conversation.',
+      },
+      limit: {
+        type: 'number',
+        description: `Maximum results to return (default ${DEFAULT_LIMIT}, max ${MAX_RESULTS}).`,
+      },
+    },
+    required: [],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tool class
+// ---------------------------------------------------------------------------
+
+class AssetSearchTool implements Tool {
+  name = 'asset_search';
+  description = definition.description;
+  category = 'assets';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const mimeType = input.mime_type as string | undefined;
+    const filename = input.filename as string | undefined;
+    const recency = input.recency as string | undefined;
+    const conversationId = input.conversation_id as string | undefined;
+    const limit = input.limit as number | undefined;
+
+    // Validate recency if provided
+    if (recency && !RECENCY_MS[recency]) {
+      return {
+        content: `Error: Invalid recency value "${recency}". Valid values: ${VALID_RECENCY_VALUES.join(', ')}`,
+        isError: true,
+      };
+    }
+
+    // Validate limit if provided
+    if (limit !== undefined && (typeof limit !== 'number' || limit < 1)) {
+      return {
+        content: 'Error: limit must be a positive number.',
+        isError: true,
+      };
+    }
+
+    try {
+      const results = searchAttachments({
+        mime_type: mimeType,
+        filename,
+        recency,
+        conversation_id: conversationId,
+        limit,
+      });
+
+      if (results.length === 0) {
+        return { content: 'No assets found matching the search criteria.', isError: false };
+      }
+
+      const lines = [`Found ${results.length} asset(s):\n`];
+      for (const attachment of results) {
+        lines.push(formatAttachment(attachment));
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const assetSearchTool = new AssetSearchTool();
+
+registerTool(assetSearchTool);

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -48,6 +48,7 @@ export const eagerModules: string[] = [
   './contacts/contact-upsert.js',
   './contacts/contact-search.js',
   './contacts/contact-merge.js',
+  './assets/search.js',
 ];
 
 // Tool names registered by the eager modules above.  Listed explicitly so
@@ -80,6 +81,7 @@ export const eagerModuleToolNames: string[] = [
   'contact_upsert',
   'contact_search',
   'contact_merge',
+  'asset_search',
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a new `asset_search` tool that queries the attachments store by MIME type (with wildcard support like `image/*`), filename (substring match), recency presets (`last_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `last_90_days`), and conversation scope
- Returns attachment metadata (ID, filename, MIME type, kind, size, creation timestamp) without base64 payloads -- IDs are intended for use with `asset_materialize` (PR 35)
- Registered as an eager tool in `tool-manifest.ts` with `RiskLevel.Low` (read-only metadata query)
- 30 comprehensive tests covering all filter combinations, conversation scoping, result ordering, edge cases, and tool interface validation

## Test plan
- [x] `bun test src/__tests__/asset-search-tool.test.ts` -- 30 tests pass
- [ ] Verify tool appears in tool definitions after daemon restart
- [ ] Test search with real attachments in a running assistant session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
