### PR TITLE
fix: re-register skill tools on bundled status drift (PR #4038 feedback)

### DIFF
--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -17,6 +17,7 @@ import { parseToolManifestFile } from '../skills/tool-manifest.js';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
 import { createSkillToolsFromManifest } from '../tools/skills/skill-tool-factory.js';
 import {
+  getTool,
   registerSkillTools,
   unregisterSkillTools,
 } from '../tools/registry.js';
@@ -178,8 +179,17 @@ export function projectSkillTools(
         log.info({ skillId, prevHash, currentHash }, 'Skill version changed, re-registering tools');
         unregisterSkillTools(skillId);
         registerSkillTools(tools);
+      } else {
+        // Hash unchanged — check if the bundled status drifted (e.g. a
+        // managed skill override was added/removed with identical content).
+        // Re-register so the ownerSkillBundled flag stays accurate.
+        const existing = getTool(tools[0].name);
+        if (existing && existing.ownerSkillBundled !== (skill.bundled ?? undefined)) {
+          log.info({ skillId, bundled: skill.bundled }, 'Skill bundled status changed, re-registering tools');
+          unregisterSkillTools(skillId);
+          registerSkillTools(tools);
+        }
       }
-      // If hash is unchanged, skip registration to avoid inflating the refcount
 
       successfulEntries.set(skillId, currentHash);
       for (const tool of tools) {


### PR DESCRIPTION
Addresses Codex review feedback on #4038.

The ownerSkillBundled flag on registered tool objects could become stale when a managed skill override was added or removed with identical content (same hash). This caused the permission checker to trust the stale flag and incorrectly auto-allow or prompt.

Fix: when the content hash is unchanged between projection turns, check if the bundled status of the existing registered tool differs from the catalog entry. If it drifted, unregister and re-register so the ownerSkillBundled flag stays accurate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
