### PR TITLE
feat: add hybrid router — MITM only when credential rewrite required

### DIFF
--- a/assistant/src/__tests__/script-proxy-mitm-handler.test.ts
+++ b/assistant/src/__tests__/script-proxy-mitm-handler.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os';
 import { ensureLocalCA, issueLeafCert, getCAPath } from '../tools/network/script-proxy/certs.js';
 import { createProxyServer } from '../tools/network/script-proxy/server.js';
 import type { RewriteCallback } from '../tools/network/script-proxy/mitm-handler.js';
+import type { RouteDecision } from '../tools/network/script-proxy/router.js';
 
 let dataDir: string;
 let caDir: string;
@@ -221,7 +222,7 @@ describe('MITM handler', () => {
     const proxy = createProxyServer({
       mitmHandler: {
         caDir,
-        shouldIntercept: () => true,
+        shouldIntercept: (): RouteDecision => ({ action: 'mitm', reason: 'mitm:credential_injection' }),
         rewriteCallback,
         upstreamTlsOptions: { ca: caCert },
       },
@@ -247,7 +248,7 @@ describe('MITM handler', () => {
     const proxy = createProxyServer({
       mitmHandler: {
         caDir,
-        shouldIntercept: () => true,
+        shouldIntercept: (): RouteDecision => ({ action: 'mitm', reason: 'mitm:credential_injection' }),
         rewriteCallback: async () => ({}),
         upstreamTlsOptions: { ca: caCert },
       },
@@ -278,7 +279,7 @@ describe('MITM handler', () => {
     const proxy = createProxyServer({
       mitmHandler: {
         caDir,
-        shouldIntercept: () => true,
+        shouldIntercept: (): RouteDecision => ({ action: 'mitm', reason: 'mitm:credential_injection' }),
         rewriteCallback,
         upstreamTlsOptions: { ca: caCert },
       },
@@ -310,9 +311,9 @@ describe('MITM handler', () => {
     const proxy = createProxyServer({
       mitmHandler: {
         caDir,
-        shouldIntercept: (hostname) => {
+        shouldIntercept: (hostname): RouteDecision => {
           interceptedHosts.push(hostname);
-          return false;
+          return { action: 'tunnel', reason: 'tunnel:no_rewrite' };
         },
         rewriteCallback: async () => ({ 'x-should-not-appear': 'true' }),
       },
@@ -388,7 +389,7 @@ describe('MITM handler', () => {
     const proxy = createProxyServer({
       mitmHandler: {
         caDir,
-        shouldIntercept: () => true,
+        shouldIntercept: (): RouteDecision => ({ action: 'mitm', reason: 'mitm:credential_injection' }),
         rewriteCallback: async () => null,
         upstreamTlsOptions: { ca: caCert },
       },

--- a/assistant/src/__tests__/script-proxy-router.test.ts
+++ b/assistant/src/__tests__/script-proxy-router.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'bun:test';
+import { routeConnection, type RouteDecision } from '../tools/network/script-proxy/router.js';
+import type { CredentialInjectionTemplate } from '../tools/credentials/policy-types.js';
+
+function headerTemplate(
+  hostPattern: string,
+  headerName = 'Authorization',
+  valuePrefix = 'Key ',
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'header', headerName, valuePrefix };
+}
+
+function queryTemplate(
+  hostPattern: string,
+  queryParamName: string,
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'query', queryParamName };
+}
+
+describe('routeConnection', () => {
+  // -- tunnel:no_credentials -------------------------------------------------
+
+  test('returns tunnel:no_credentials when credentialIds is empty', () => {
+    const result = routeConnection('api.fal.ai', 443, [], new Map());
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_credentials',
+    });
+  });
+
+  test('returns tunnel:no_credentials even when templates exist but no ids provided', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, [], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_credentials',
+    });
+  });
+
+  // -- tunnel:no_rewrite -----------------------------------------------------
+
+  test('returns tunnel:no_rewrite when no template matches the hostname', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.openai.com')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, ['cred-1'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  test('returns tunnel:no_rewrite when credential id has no templates', () => {
+    const result = routeConnection('api.fal.ai', 443, ['cred-unknown'], new Map());
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  test('returns tunnel:no_rewrite for bare domain when pattern requires subdomain', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-1', [headerTemplate('*.fal.ai')]],
+    ]);
+    // minimatch: "*.fal.ai" does not match bare "fal.ai"
+    const result = routeConnection('fal.ai', 443, ['cred-1'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  // -- mitm:credential_injection ---------------------------------------------
+
+  test('returns mitm:credential_injection when a header template matches', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, ['cred-fal'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm:credential_injection when a query template matches', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-gcp', [queryTemplate('maps.googleapis.com', 'key')]],
+    ]);
+    const result = routeConnection('maps.googleapis.com', 443, ['cred-gcp'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm:credential_injection with exact hostname match', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-rep', [headerTemplate('api.replicate.com', 'Authorization', 'Token ')]],
+    ]);
+    const result = routeConnection('api.replicate.com', 443, ['cred-rep'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm when any credential matches, even if others do not', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-openai', [headerTemplate('*.openai.com')]],
+      ['cred-fal', [headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, ['cred-openai', 'cred-fal'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  test('returns mitm when one credential has multiple templates and one matches', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-multi', [headerTemplate('*.openai.com'), headerTemplate('*.fal.ai')]],
+    ]);
+    const result = routeConnection('api.fal.ai', 443, ['cred-multi'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
+    });
+  });
+
+  // -- port is passed through but does not affect decision -------------------
+
+  test('port does not affect routing decision', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [headerTemplate('*.fal.ai')]],
+    ]);
+    const on443 = routeConnection('api.fal.ai', 443, ['cred-fal'], templates);
+    const on8443 = routeConnection('api.fal.ai', 8443, ['cred-fal'], templates);
+    expect(on443).toEqual(on8443);
+  });
+
+  // -- only authorized credential ids are considered -------------------------
+
+  test('ignores credentials not in the credentialIds list', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-a', [headerTemplate('*.fal.ai')]],
+      ['cred-b', [headerTemplate('*.openai.com')]],
+    ]);
+    // Only cred-b is authorized, but the host is fal.ai (matches cred-a only)
+    const result = routeConnection('api.fal.ai', 443, ['cred-b'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'tunnel',
+      reason: 'tunnel:no_rewrite',
+    });
+  });
+});

--- a/assistant/src/tools/network/script-proxy/router.ts
+++ b/assistant/src/tools/network/script-proxy/router.ts
@@ -1,0 +1,60 @@
+/**
+ * Hybrid proxy router — decides per-CONNECT request whether to MITM-intercept
+ * (for credential injection) or use a plain CONNECT tunnel (no rewrite needed).
+ *
+ * The router checks whether any credential injection template matches the
+ * target hostname. Only when a credential rewrite is required does the proxy
+ * pay the cost of TLS termination, cert issuance, and request rewriting.
+ */
+
+import { minimatch } from 'minimatch';
+import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
+
+// ---- Public types ----------------------------------------------------------
+
+/** Deterministic reason codes for auditing and testing. */
+export type RouteReason =
+  | 'mitm:credential_injection'
+  | 'tunnel:no_rewrite'
+  | 'tunnel:no_credentials';
+
+export interface RouteDecision {
+  action: 'mitm' | 'tunnel';
+  reason: RouteReason;
+}
+
+// ---- Router ----------------------------------------------------------------
+
+/**
+ * Decide whether a CONNECT target requires MITM interception.
+ *
+ * @param hostname       Target hostname (e.g. "api.fal.ai")
+ * @param _port          Target port — reserved for future port-level rules
+ * @param credentialIds  Credential IDs the session is authorized to use
+ * @param templates      Map from credentialId to injection templates
+ */
+export function routeConnection(
+  hostname: string,
+  _port: number,
+  credentialIds: string[],
+  templates: ReadonlyMap<string, readonly CredentialInjectionTemplate[]>,
+): RouteDecision {
+  // No credentials configured — nothing to inject, tunnel through.
+  if (credentialIds.length === 0) {
+    return { action: 'tunnel', reason: 'tunnel:no_credentials' };
+  }
+
+  for (const id of credentialIds) {
+    const tpls = templates.get(id);
+    if (!tpls) continue;
+
+    for (const tpl of tpls) {
+      if (minimatch(hostname, tpl.hostPattern)) {
+        return { action: 'mitm', reason: 'mitm:credential_injection' };
+      }
+    }
+  }
+
+  // Credentials exist but none match this host — no rewrite needed.
+  return { action: 'tunnel', reason: 'tunnel:no_rewrite' };
+}

--- a/assistant/src/tools/network/script-proxy/server.ts
+++ b/assistant/src/tools/network/script-proxy/server.ts
@@ -10,12 +10,17 @@ import type { Socket } from 'node:net';
 import { forwardHttpRequest, type PolicyCallback } from './http-forwarder.js';
 import { handleConnect } from './connect-tunnel.js';
 import { handleMitm, type RewriteCallback } from './mitm-handler.js';
+import type { RouteDecision } from './router.js';
 
 export interface MitmHandlerConfig {
   /** Path to the local CA directory containing ca.pem / ca-key.pem. */
   caDir: string;
-  /** Return true if the CONNECT target should be MITM-intercepted. */
-  shouldIntercept: (hostname: string, port: number) => boolean;
+  /**
+   * Decide whether the CONNECT target should be MITM-intercepted.
+   * Returns a RouteDecision with action ('mitm' | 'tunnel') and a
+   * deterministic reason code for auditing.
+   */
+  shouldIntercept: (hostname: string, port: number) => RouteDecision;
   /** Called with the decrypted request; returns headers to merge or null to reject. */
   rewriteCallback: RewriteCallback;
   /** Extra TLS options for the upstream connection (e.g. custom CA for testing). */
@@ -63,7 +68,11 @@ export function createProxyServer(config: ProxyServerConfig = {}): Server {
   server.on('connect', (req, clientSocket: Socket, head: Buffer) => {
     if (config.mitmHandler) {
       const target = parseConnectTarget(req.url);
-      if (target && config.mitmHandler.shouldIntercept(target.host, target.port)) {
+      const decision = target
+        ? config.mitmHandler.shouldIntercept(target.host, target.port)
+        : undefined;
+
+      if (target && decision?.action === 'mitm') {
         handleMitm(
           clientSocket,
           head,


### PR DESCRIPTION
## Summary
- Adds `router.ts` with `routeConnection()` that decides per-CONNECT request whether to MITM-intercept (for credential injection) or use a plain CONNECT tunnel (no rewrite needed)
- Exports `RouteDecision` type with deterministic reason codes (`mitm:credential_injection`, `tunnel:no_rewrite`, `tunnel:no_credentials`) for auditing/testing
- Updates `server.ts` `MitmHandlerConfig.shouldIntercept` to return a `RouteDecision` instead of a boolean, and uses `decision.action === 'mitm'` to branch
- Updates existing MITM handler tests to use the new `RouteDecision`-based interface
- Adds 12 comprehensive router tests covering all reason codes, edge cases, and authorization boundaries

## Test plan
- [x] `bun test src/__tests__/script-proxy-router.test.ts` — 12 tests pass
- [x] `bun test src/__tests__/script-proxy-mitm-handler.test.ts` — 5 tests pass (no regressions)
- [x] TypeScript type-check clean for all modified files (pre-existing errors in unrelated files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
