### PR TITLE
feat: bash runtime proxied env injection and session lifecycle

### DIFF
--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import * as realChildProcess from 'node:child_process';
+
+const originalSpawn = realChildProcess.spawn;
+
+// Track spawn calls to inspect env vars passed to child processes
+const spawnCalls: { command: string; args: string[]; env: Record<string, string> | undefined }[] = [];
+const spawnSpy = mock((...args: Parameters<typeof realChildProcess.spawn>) => {
+  const opts = args[2] as { env?: Record<string, string> } | undefined;
+  spawnCalls.push({
+    command: args[0] as string,
+    args: args[1] as string[],
+    env: opts?.env ? { ...opts.env } : undefined,
+  });
+  return (originalSpawn as (...a: unknown[]) => unknown)(...args);
+});
+
+mock.module('node:child_process', () => ({
+  ...realChildProcess,
+  spawn: spawnSpy,
+}));
+
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  sandbox: { enabled: false },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: true, action: 'warn' as const, entropyThreshold: 4.0 },
+  auditLog: { retentionDays: 0 },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../security/secret-scanner.js', () => ({
+  redactSecrets: (s: string) => s,
+}));
+
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: (cmd: string) => ({ command: '/bin/sh', args: ['-c', cmd], sandboxed: false }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => '/tmp/test-data',
+}));
+
+// --- Proxy session mocks ---
+let mockActiveSession: { id: string; conversationId: string } | undefined;
+let createSessionCalls: { conversationId: string; credentialIds: string[] }[] = [];
+let startSessionCalls: string[] = [];
+let stopSessionCalls: string[] = [];
+let getSessionEnvCalls: string[] = [];
+
+const MOCK_SESSION_ID = 'mock-proxy-session-id';
+const MOCK_PROXY_PORT = 9876;
+
+mock.module('../tools/network/script-proxy/index.js', () => ({
+  getActiveSession: (conversationId: string) => {
+    if (mockActiveSession && mockActiveSession.conversationId === conversationId) {
+      return mockActiveSession;
+    }
+    return undefined;
+  },
+  createSession: (conversationId: string, credentialIds: string[]) => {
+    createSessionCalls.push({ conversationId, credentialIds });
+    return { id: MOCK_SESSION_ID, conversationId, credentialIds, status: 'starting', createdAt: new Date(), port: null };
+  },
+  startSession: async (sessionId: string) => {
+    startSessionCalls.push(sessionId);
+    return { id: sessionId, conversationId: 'test-conv', credentialIds: [], status: 'active', createdAt: new Date(), port: MOCK_PROXY_PORT };
+  },
+  stopSession: async (sessionId: string) => {
+    stopSessionCalls.push(sessionId);
+  },
+  getSessionEnv: (sessionId: string) => {
+    getSessionEnvCalls.push(sessionId);
+    return {
+      HTTP_PROXY: `http://127.0.0.1:${MOCK_PROXY_PORT}`,
+      HTTPS_PROXY: `http://127.0.0.1:${MOCK_PROXY_PORT}`,
+      NO_PROXY: 'localhost,127.0.0.1,::1',
+      NODE_EXTRA_CA_CERTS: '/tmp/test-data/proxy-ca/ca.pem',
+    };
+  },
+  ensureLocalCA: async () => {},
+  issueLeafCert: async () => ({ cert: '', key: '' }),
+  getCAPath: () => '/tmp/test-data/proxy-ca/ca.pem',
+  getSessionsForConversation: () => [],
+  stopAllSessions: async () => {},
+}));
+
+import { shellTool } from '../tools/terminal/shell.js';
+import type { ToolContext } from '../tools/types.js';
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conv',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  spawnCalls.length = 0;
+  createSessionCalls = [];
+  startSessionCalls = [];
+  stopSessionCalls = [];
+  getSessionEnvCalls = [];
+  mockActiveSession = undefined;
+});
+
+describe('shell tool proxy mode', () => {
+  test('default mode does not inject proxy env vars', async () => {
+    const result = await shellTool.execute(
+      { command: 'echo hello' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(createSessionCalls).toHaveLength(0);
+    expect(startSessionCalls).toHaveLength(0);
+
+    const lastCall = spawnCalls[spawnCalls.length - 1];
+    expect(lastCall.env?.HTTP_PROXY).toBeUndefined();
+    expect(lastCall.env?.HTTPS_PROXY).toBeUndefined();
+  });
+
+  test('network_mode=off does not inject proxy env vars', async () => {
+    const result = await shellTool.execute(
+      { command: 'echo hello', network_mode: 'off' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(createSessionCalls).toHaveLength(0);
+
+    const lastCall = spawnCalls[spawnCalls.length - 1];
+    expect(lastCall.env?.HTTP_PROXY).toBeUndefined();
+  });
+
+  test('network_mode=proxied creates session and injects proxy env', async () => {
+    const result = await shellTool.execute(
+      { command: 'echo proxied', network_mode: 'proxied', credential_ids: ['cred-1'] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+
+    // Session lifecycle
+    expect(createSessionCalls).toHaveLength(1);
+    expect(createSessionCalls[0].conversationId).toBe('test-conv');
+    expect(createSessionCalls[0].credentialIds).toEqual(['cred-1']);
+    expect(startSessionCalls).toHaveLength(1);
+    expect(startSessionCalls[0]).toBe(MOCK_SESSION_ID);
+
+    // Env injection
+    const lastCall = spawnCalls[spawnCalls.length - 1];
+    expect(lastCall.env?.HTTP_PROXY).toBe(`http://127.0.0.1:${MOCK_PROXY_PORT}`);
+    expect(lastCall.env?.HTTPS_PROXY).toBe(`http://127.0.0.1:${MOCK_PROXY_PORT}`);
+    expect(lastCall.env?.NO_PROXY).toBe('localhost,127.0.0.1,::1');
+    expect(lastCall.env?.NODE_EXTRA_CA_CERTS).toBe('/tmp/test-data/proxy-ca/ca.pem');
+
+    // Session stopped after command
+    expect(stopSessionCalls).toHaveLength(1);
+    expect(stopSessionCalls[0]).toBe(MOCK_SESSION_ID);
+  });
+
+  test('proxied mode reuses existing active session', async () => {
+    mockActiveSession = { id: 'existing-session-id', conversationId: 'test-conv' };
+
+    const result = await shellTool.execute(
+      { command: 'echo reuse', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+
+    // Should NOT create a new session
+    expect(createSessionCalls).toHaveLength(0);
+    expect(startSessionCalls).toHaveLength(0);
+
+    // Should get env from existing session
+    expect(getSessionEnvCalls).toHaveLength(1);
+    expect(getSessionEnvCalls[0]).toBe('existing-session-id');
+
+    // Should still inject proxy env
+    const lastCall = spawnCalls[spawnCalls.length - 1];
+    expect(lastCall.env?.HTTP_PROXY).toBeDefined();
+
+    // Should stop the existing session after command
+    expect(stopSessionCalls).toHaveLength(1);
+    expect(stopSessionCalls[0]).toBe('existing-session-id');
+  });
+
+  test('safe env vars are preserved alongside proxy vars', async () => {
+    const result = await shellTool.execute(
+      { command: 'echo env-merge', network_mode: 'proxied', credential_ids: ['cred-x'] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+
+    const lastCall = spawnCalls[spawnCalls.length - 1];
+    // Safe env vars should still be present
+    expect(lastCall.env?.PATH).toBeDefined();
+    expect(lastCall.env?.HOME).toBeDefined();
+    // Proxy vars should also be present
+    expect(lastCall.env?.HTTP_PROXY).toBeDefined();
+    expect(lastCall.env?.HTTPS_PROXY).toBeDefined();
+  });
+
+  test('schema includes network_mode and credential_ids', () => {
+    const def = shellTool.getDefinition();
+    const props = (def.input_schema as { properties: Record<string, unknown> }).properties;
+    expect(props.network_mode).toBeDefined();
+    expect(props.credential_ids).toBeDefined();
+  });
+});

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -9,6 +9,14 @@ import { redactSecrets } from '../../security/secret-scanner.js';
 import { wrapCommand } from './sandbox.js';
 import { formatShellOutput } from '../shared/shell-output.js';
 import { buildSanitizedEnv } from './safe-env.js';
+import {
+  getActiveSession,
+  createSession,
+  startSession,
+  stopSession,
+  getSessionEnv,
+} from '../network/script-proxy/index.js';
+import { getDataDir } from '../../util/platform.js';
 
 const log = getLogger('shell-tool');
 
@@ -61,7 +69,6 @@ class ShellTool implements Tool {
       return { content: 'Error: command contains null bytes', isError: true };
     }
 
-    // Parse optional network/credential fields (schema-only — no execution branching yet)
     const networkMode: 'off' | 'proxied' =
       input.network_mode === 'proxied' ? 'proxied' : 'off';
 
@@ -82,7 +89,41 @@ class ShellTool implements Tool {
 
     log.info({ command: redactSecrets(command), cwd: context.workingDir, timeoutSec, networkMode, credentialIds }, 'Executing shell command');
 
-    return new Promise<ToolExecutionResult>((resolve) => {
+    // Start proxy session if proxied mode is requested
+    let proxySessionId: string | null = null;
+    let proxyEnv: Record<string, string> | null = null;
+
+    if (networkMode === 'proxied') {
+      try {
+        const existing = getActiveSession(context.conversationId);
+        if (existing) {
+          proxySessionId = existing.id;
+        } else {
+          const session = createSession(
+            context.conversationId,
+            credentialIds,
+            undefined,
+            getDataDir(),
+          );
+          const started = await startSession(session.id);
+          proxySessionId = started.id;
+        }
+        proxyEnv = getSessionEnv(proxySessionId);
+      } catch (err) {
+        log.error({ err }, 'Failed to start proxy session');
+        return {
+          content: `Error: failed to start proxy session — ${err instanceof Error ? err.message : String(err)}`,
+          isError: true,
+        };
+      }
+    }
+
+    const env = buildSanitizedEnv();
+    if (proxyEnv) {
+      Object.assign(env, proxyEnv);
+    }
+
+    const result = await new Promise<ToolExecutionResult>((resolve) => {
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
@@ -93,7 +134,7 @@ class ShellTool implements Tool {
       const wrapped = wrapCommand(command, context.workingDir, sandboxConfig);
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
-        env: buildSanitizedEnv(),
+        env,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 
@@ -117,12 +158,12 @@ class ShellTool implements Tool {
 
         const stdout = Buffer.concat(stdoutChunks).toString();
         const stderr = Buffer.concat(stderrChunks).toString();
-        const result = formatShellOutput(stdout, stderr, code, timedOut, timeoutSec);
+        const fmtResult = formatShellOutput(stdout, stderr, code, timedOut, timeoutSec);
 
         resolve({
-          content: result.content,
-          isError: result.isError,
-          status: result.status,
+          content: fmtResult.content,
+          isError: fmtResult.isError,
+          status: fmtResult.status,
         });
       });
 
@@ -134,6 +175,15 @@ class ShellTool implements Tool {
         });
       });
     });
+
+    // Stop proxy session after command completes
+    if (proxySessionId) {
+      stopSession(proxySessionId).catch((err) => {
+        log.warn({ err, sessionId: proxySessionId }, 'Failed to stop proxy session');
+      });
+    }
+
+    return result;
   }
 }
 


### PR DESCRIPTION
## Summary
- When `network_mode=proxied`, bash tool creates/reuses a proxy session and injects `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `NODE_EXTRA_CA_CERTS` into the child process environment
- Reuses existing active session for the same conversation to avoid spawning duplicate proxies
- Stops the proxy session after command completion (with graceful error handling)
- Default mode (`off`) behavior is completely unchanged

## Test plan
- [x] All 6 proxy mode tests pass (335ms)
- [x] Default mode does not inject proxy env vars
- [x] Proxied mode creates session and injects all proxy env vars
- [x] Existing active sessions are reused
- [x] Safe env vars preserved alongside proxy vars
- [x] Schema includes network_mode and credential_ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
