### PR TITLE
fix: exclude private threads from history (PR #4025 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -48,7 +48,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Threads that are not archived — used by the UI to populate the sidebar.
     /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by lastInteractedAt descending.
     var visibleThreads: [ThreadModel] {
-        threads.filter { !$0.isArchived }.sorted { a, b in
+        threads.filter { !$0.isArchived && $0.kind != .private }.sorted { a, b in
             if a.isPinned && b.isPinned {
                 return (a.pinnedOrder ?? 0) < (b.pinnedOrder ?? 0)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -95,6 +95,8 @@ final class ThreadSessionRestorer {
         var restoredThreads: [ThreadModel] = []
         for session in recentSessions {
             let kind: ThreadKind = session.threadType == "private" ? .private : .standard
+            // Private threads should not be restored — they are excluded from history
+            if kind == .private { continue }
             let thread = ThreadModel(
                 title: session.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),


### PR DESCRIPTION
Addresses Codex review feedback on #4025 (Private Thread button).

Private threads were appearing in the sidebar thread list and being restored on app relaunch, violating the privacy guarantee. This fix:

1. Filters private threads out of `visibleThreads` so they never appear in the sidebar history
2. Skips private sessions during session restoration so they don't reappear after relaunch

The active private thread remains fully functional while in use — it just won't persist in history.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
