### PR TITLE
fix: CU escalation error feedback and main window management

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -13,6 +13,10 @@ extension AppDelegate {
         guard ActionExecutor.checkAccessibilityPermission(prompt: true) else {
             log.error("Accessibility permission denied — cannot start computer use session \(routed.sessionId)")
             try? daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+            self.mainWindow?.windowState.showToast(
+                message: "Computer control requires Accessibility permission. Grant it in System Settings → Privacy & Security → Accessibility.",
+                style: .error
+            )
             return
         }
 
@@ -41,6 +45,12 @@ extension AppDelegate {
         self.textResponseWindow?.close()
         self.textResponseWindow = nil
 
+        // Hide main window so the target app becomes frontmost for CU
+        let mainWindowWasVisible = self.mainWindow?.isVisible ?? false
+        if mainWindowWasVisible {
+            self.mainWindow?.hide()
+        }
+
         Task { @MainActor in
             await session.run()
             try? await Task.sleep(nanoseconds: 10_000_000_000)
@@ -49,6 +59,9 @@ extension AppDelegate {
             self.currentSession = nil
             self.currentTextSession = nil
             self.ambientAgent.resume()
+            if mainWindowWasVisible {
+                self.mainWindow?.show()
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -238,6 +238,11 @@ final class MainWindow {
         ))
     }
 
+    /// Hide the window without destroying it (can be restored with `show()`).
+    func hide() {
+        window?.orderOut(nil)
+    }
+
     func close() {
         if let observer = layoutObserver {
             NotificationCenter.default.removeObserver(observer)


### PR DESCRIPTION
## Summary
- Show error toast when Accessibility permission is denied during CU escalation (previously silent failure)
- Hide main window during CU session so the target app becomes frontmost
- Restore main window after CU session completes
- Add `hide()` method to `MainWindow` for non-destructive window hiding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
