### PR TITLE
fix: use ASCII-only character set for YouTube video ID validation (PR #4050)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
@@ -40,9 +40,9 @@ enum YouTubeParser {
 
         guard let id = videoID, !id.isEmpty else { return nil }
 
-        // YouTube video IDs only contain alphanumerics, dashes, and underscores.
-        // Reject anything else to prevent path traversal or fragment injection.
-        let validIDCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        // YouTube video IDs are ASCII base64url: [A-Za-z0-9_-].
+        // Use an explicit set instead of .alphanumerics which includes Unicode.
+        let validIDCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
         guard id.unicodeScalars.allSatisfy({ validIDCharacters.contains($0) }) else { return nil }
 
         guard let embedURL = URL(string: "https://www.youtube.com/embed/\(id)") else {


### PR DESCRIPTION
Addresses review feedback on #4050. Both Codex and Devin flagged that CharacterSet.alphanumerics includes all Unicode letters/digits, not just ASCII. YouTube video IDs are strictly ASCII base64url characters [A-Za-z0-9_-], so we now use an explicit character set instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
