### PR TITLE
fix: forward scopeId to buildMemoryRecall for default-scope filtering (#4036)

### DIFF
--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -412,8 +412,9 @@ describe('Session dynamic profile injection', () => {
     expect(profileCompilerArgs[0].scopeId).toBe('private-thread-abc');
     expect(profileCompilerArgs[0].includeDefaultFallback).toBe(true);
 
-    // Memory recall should receive a scopePolicyOverride for the private scope
+    // Memory recall should receive scopeId and a scopePolicyOverride for the private scope
     expect(recallArgs).toHaveLength(1);
+    expect(recallArgs[0].scopeId).toBe('private-thread-abc');
     expect(recallArgs[0].scopePolicyOverride).toEqual({
       scopeId: 'private-thread-abc',
       fallbackToDefault: true,
@@ -433,9 +434,11 @@ describe('Session dynamic profile injection', () => {
     expect(profileCompilerArgs[0].scopeId).toBe('default');
     expect(profileCompilerArgs[0].includeDefaultFallback).toBe(false);
 
-    // Memory recall should NOT have a scopePolicyOverride (default scope
-    // relies on the global config policy, not a per-call override)
+    // Memory recall should forward scopeId='default' so buildScopeFilter
+    // properly filters to the default scope, and should NOT have a
+    // scopePolicyOverride (default scope relies on the global config policy)
     expect(recallArgs).toHaveLength(1);
+    expect(recallArgs[0].scopeId).toBe('default');
     expect(recallArgs[0].scopePolicyOverride).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -133,6 +133,7 @@ export async function prepareMemoryContext(
     excludeMessageIds: [userMessageId],
     signal: abortSignal,
     maxInjectTokensOverride: recallBudget,
+    scopeId: ctx.scopeId,
     scopePolicyOverride,
   });
   const memoryStatus = getMemoryConflictAndCleanupStats();


### PR DESCRIPTION
Addresses review feedback on #4036.

Devin identified that `scopeId` was not being forwarded to `buildMemoryRecall`, causing default-scope sessions to bypass scope filtering in retrieval (while profile compilation correctly received it). This meant `buildScopeFilter` would get `scopeId = undefined` and return no filter, allowing default-scope sessions to query all scopes including private ones.

Fix: always pass `scopeId: ctx.scopeId` to `buildMemoryRecall`. Updated tests to verify `scopeId` is forwarded for both private and default scope sessions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
