### PR TITLE
fix: use case-insensitive hostname matching in proxy policy engine (#4210)

### DIFF
--- a/assistant/src/__tests__/script-proxy-policy.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy.test.ts
@@ -113,6 +113,15 @@ describe('evaluateRequest', () => {
     expect(result).toEqual({ kind: 'matched', credentialId: 'cred-gcp', template: tpl });
   });
 
+  test('matches hostnames case-insensitively', () => {
+    const tpl = headerTemplate('*.fal.ai');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequest('API.FAL.AI', '/v1/run', ['cred-fal'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-fal', template: tpl });
+  });
+
   test('non-matching hostname with glob returns missing', () => {
     const templates = new Map<string, CredentialInjectionTemplate[]>([
       ['cred-1', [headerTemplate('*.fal.ai')]],

--- a/assistant/src/tools/network/script-proxy/policy.ts
+++ b/assistant/src/tools/network/script-proxy/policy.ts
@@ -37,7 +37,7 @@ export function evaluateRequest(
     if (!tpls) continue;
 
     for (const tpl of tpls) {
-      if (minimatch(hostname, tpl.hostPattern)) {
+      if (minimatch(hostname, tpl.hostPattern, { nocase: true })) {
         candidates.push({ credentialId: id, template: tpl });
       }
     }
@@ -102,7 +102,7 @@ export function evaluateRequestWithApproval(
   // Check whether any template in the full registry covers this host.
   const matchingPatterns: string[] = [];
   for (const tpl of allKnownTemplates) {
-    if (minimatch(hostname, tpl.hostPattern)) {
+    if (minimatch(hostname, tpl.hostPattern, { nocase: true })) {
       matchingPatterns.push(tpl.hostPattern);
     }
   }


### PR DESCRIPTION
Addresses review feedback on #4210.

Both Codex and Devin flagged that minimatch performs case-sensitive matching by default, but DNS hostnames are case-insensitive (RFC 4343). This adds `{ nocase: true }` to both minimatch calls in the policy engine and adds a test for mixed-case hostnames.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
