### PR TITLE
fix: use getTool() to query registry before stubbing browser tools (#4116)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -52,7 +52,7 @@ import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } f
 import { RiskLevel, type PolicyContext } from '../permissions/types.js';
 import { addRule, clearCache, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { getDefaultRuleTemplates } from '../permissions/defaults.js';
-import { registerTool } from '../tools/registry.js';
+import { registerTool, getTool } from '../tools/registry.js';
 import type { Tool } from '../tools/types.js';
 
 // Import managed skill tools so they register in the tool registry.
@@ -3548,10 +3548,8 @@ describe('Permission Checker', () => {
     // (which depends on playwright and browser-manager).
     beforeAll(() => {
       for (const name of browserToolNames) {
-        const existing = (() => {
-          try { return (registerTool as any).__registry?.get(name); } catch { return undefined; }
-        })();
-        if (existing) continue;
+        // Skip if already registered (e.g. via initializeTools)
+        if (getTool(name)) continue;
 
         registerTool({
           name,


### PR DESCRIPTION
Addresses Codex review feedback on #4116.

The beforeAll block in the browser permission baseline tests used `(registerTool as any).__registry?.get(name)` to check for existing tools — but registerTool has no `__registry` property, so the check always returned undefined. Replaced with the proper `getTool(name)` export from the registry module.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
