### PR TITLE
fix: replace flaky wall-clock gate in media embed stress test (PR #4069)

### DIFF
--- a/clients/macos/vellum-assistantTests/MediaEmbedStressTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedStressTests.swift
@@ -173,9 +173,9 @@ final class MediaEmbedStressTests: XCTestCase {
         }
     }
 
-    // MARK: - Performance: 100 URLs under 1 second
+    // MARK: - Performance: 100 URLs baseline
 
-    func testPerformanceResolverCompletesFor100URLsInReasonableTime() async {
+    func testPerformanceResolverCompletesFor100URLs() async {
         var lines: [String] = []
         for i in 0..<100 {
             if i % 2 == 0 {
@@ -188,15 +188,17 @@ final class MediaEmbedStressTests: XCTestCase {
         let message = makeMessage(text)
         let settings = enabledSettings()
 
-        let start = CFAbsoluteTimeGetCurrent()
-        let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
-        let elapsed = CFAbsoluteTimeGetCurrent() - start
-
-        XCTAssertEqual(result.count, 100)
-        XCTAssertLessThan(
-            elapsed, 1.0,
-            "Resolver should complete 100 URLs in under 1 second, took \(elapsed)s"
-        )
+        // Use XCTest's measure block to track performance over time without
+        // a hard wall-clock gate that flakes on slower or contended CI runners.
+        measure {
+            let expectation = self.expectation(description: "resolve")
+            Task { @MainActor in
+                let result = await MediaEmbedResolver.resolve(message: message, settings: settings)
+                XCTAssertEqual(result.count, 100)
+                expectation.fulfill()
+            }
+            wait(for: [expectation], timeout: 10.0)
+        }
     }
 
     // MARK: - Deterministic output


### PR DESCRIPTION
Addresses Codex P1 feedback on #4069: the hard wall-clock assertion in testPerformanceResolverCompletesFor100URLsInReasonableTime was hardware/load dependent and could cause flaky CI failures. Replaced with XCTest's measure block, which tracks performance baselines without hard-failing on specific thresholds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
