### PR TITLE
feat: docker backend per-invocation network override for proxied bash

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -937,3 +937,103 @@ describe('DockerBackend — baseline: network isolation defaults', () => {
     expect(networkArgs).toEqual(['--network=none']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-invocation network override (proxied bash)
+// ---------------------------------------------------------------------------
+
+describe('DockerBackend — per-invocation network override', () => {
+  test('networkMode "proxied" overrides default to --network=bridge', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('curl http://127.0.0.1:8080', sandboxRoot, {
+      networkMode: 'proxied',
+    });
+    expect(result.args).toContain('--network=bridge');
+    expect(result.args).not.toContain('--network=none');
+  });
+
+  test('networkMode "off" preserves --network=none', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot, { networkMode: 'off' });
+    expect(result.args).toContain('--network=none');
+    expect(result.args).not.toContain('--network=bridge');
+  });
+
+  test('no networkMode option preserves config default (none)', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot, {});
+    expect(result.args).toContain('--network=none');
+  });
+
+  test('undefined options preserves config default (none)', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot, undefined);
+    expect(result.args).toContain('--network=none');
+  });
+
+  test('proxied mode overrides config-level network=none', () => {
+    // Explicitly set config network to 'none', then override per-invocation
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { network: 'none' },
+      1000,
+      1000,
+    );
+    const result = backend.wrap('wget http://proxy:3128', sandboxRoot, {
+      networkMode: 'proxied',
+    });
+    expect(result.args).toContain('--network=bridge');
+  });
+
+  test('proxied mode with config network=bridge still uses bridge', () => {
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { network: 'bridge' },
+      1000,
+      1000,
+    );
+    const result = backend.wrap('ls', sandboxRoot, { networkMode: 'proxied' });
+    expect(result.args).toContain('--network=bridge');
+  });
+
+  test('off mode with config network=bridge preserves config bridge', () => {
+    // When networkMode is 'off', we defer to the config-level network value,
+    // which happens to be 'bridge' here.
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { network: 'bridge' },
+      1000,
+      1000,
+    );
+    const result = backend.wrap('ls', sandboxRoot, { networkMode: 'off' });
+    // 'off' means "no override" — config-level 'bridge' is used
+    expect(result.args).toContain('--network=bridge');
+  });
+
+  test('only one --network flag is present in proxied mode', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot, { networkMode: 'proxied' });
+    const networkArgs = result.args.filter((a: string) =>
+      a.startsWith('--network='),
+    );
+    expect(networkArgs).toEqual(['--network=bridge']);
+  });
+
+  test('all other security flags remain intact in proxied mode', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot, { networkMode: 'proxied' });
+    expect(result.args).toContain('--cap-drop=ALL');
+    expect(result.args).toContain('--security-opt=no-new-privileges');
+    expect(result.args).toContain('--read-only');
+    expect(result.args).toContain('--rm');
+    expect(result.sandboxed).toBe(true);
+  });
+
+  test('resource limits still apply in proxied mode', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot, { networkMode: 'proxied' });
+    expect(result.args).toContain('--cpus=1');
+    expect(result.args).toContain('--memory=512m');
+    expect(result.args).toContain('--pids-limit=256');
+  });
+});

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -4,7 +4,7 @@ import { resolve, relative, posix } from 'node:path';
 import { ToolError } from '../../../util/errors.js';
 import { getLogger } from '../../../util/logger.js';
 import type { DockerConfig } from '../../../config/types.js';
-import type { SandboxBackend, SandboxResult } from './types.js';
+import type { SandboxBackend, SandboxResult, WrapOptions } from './types.js';
 
 const log = getLogger('docker-sandbox');
 
@@ -237,7 +237,7 @@ export class DockerBackend implements SandboxBackend {
     return resolveShell(this.config.image, this.config.shell);
   }
 
-  wrap(command: string, workingDir: string): SandboxResult {
+  wrap(command: string, workingDir: string, options?: WrapOptions): SandboxResult {
     // Preflight: fail closed if Docker is not usable.
     const shell = this.preflight();
 
@@ -267,11 +267,17 @@ export class DockerBackend implements SandboxBackend {
 
     const { image, cpus, memoryMb, pidsLimit, network } = this.config;
 
+    // Per-invocation network override: proxied mode needs bridge networking
+    // so the container can reach the proxy on the host. Default ('off' or
+    // undefined) preserves the config-level network setting.
+    const effectiveNetwork =
+      options?.networkMode === 'proxied' ? 'bridge' : network;
+
     // Every flag is a separate argv segment — no shell interpolation occurs.
     const args: string[] = [
       'run',
       '--rm',
-      `--network=${network}`,
+      `--network=${effectiveNetwork}`,
       `--cpus=${cpus}`,
       `--memory=${memoryMb}m`,
       `--pids-limit=${pidsLimit}`,

--- a/assistant/src/tools/terminal/backends/types.ts
+++ b/assistant/src/tools/terminal/backends/types.ts
@@ -6,11 +6,21 @@ export interface SandboxResult {
   sandboxed: boolean;
 }
 
+/** Per-invocation options that override backend defaults. */
+export interface WrapOptions {
+  /**
+   * Network mode for this invocation.
+   * - 'off': no container network (--network=none). This is the default.
+   * - 'proxied': bridge network so the container can reach a host proxy (--network=bridge).
+   */
+  networkMode?: 'off' | 'proxied';
+}
+
 /**
  * A sandbox backend knows how to wrap a shell command so it runs
  * inside an OS-level sandbox (macOS sandbox-exec, Linux bwrap, Docker, etc.).
  */
 export interface SandboxBackend {
   /** Wrap a command for sandboxed execution in the given working directory. */
-  wrap(command: string, workingDir: string): SandboxResult;
+  wrap(command: string, workingDir: string, options?: WrapOptions): SandboxResult;
 }

--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -1,10 +1,10 @@
 import { NativeBackend } from './backends/native.js';
 import { DockerBackend } from './backends/docker.js';
-import type { SandboxResult } from './backends/types.js';
+import type { SandboxResult, WrapOptions } from './backends/types.js';
 import type { SandboxConfig } from '../../config/schema.js';
 import { getSandboxWorkingDir } from '../../util/platform.js';
 
-export type { SandboxResult, SandboxBackend } from './backends/types.js';
+export type { SandboxResult, SandboxBackend, WrapOptions } from './backends/types.js';
 
 const nativeBackend = new NativeBackend();
 
@@ -14,11 +14,14 @@ const nativeBackend = new NativeBackend();
  * When sandboxing is disabled, returns a plain bash invocation.
  * When enabled, delegates to the configured backend (native or docker).
  * Fails closed if the backend cannot be applied.
+ *
+ * @param options  Per-invocation overrides (e.g. networkMode for proxied bash).
  */
 export function wrapCommand(
   command: string,
   workingDir: string,
   config: SandboxConfig,
+  options?: WrapOptions,
 ): SandboxResult {
   if (!config.enabled) {
     return {
@@ -34,8 +37,8 @@ export function wrapCommand(
     // must be the fixed root so the entire sandbox filesystem is available.
     const sandboxRoot = getSandboxWorkingDir();
     const backend = new DockerBackend(sandboxRoot, config.docker);
-    return backend.wrap(command, workingDir);
+    return backend.wrap(command, workingDir, options);
   }
 
-  return nativeBackend.wrap(command, workingDir);
+  return nativeBackend.wrap(command, workingDir, options);
 }


### PR DESCRIPTION
## Summary
- Add `WrapOptions` interface with `networkMode` field (`'off' | 'proxied'`) to `backends/types.ts`
- Thread `options` through `sandbox.ts` `wrapCommand` and into Docker/native backend `wrap` methods
- In `docker.ts`, when `networkMode === 'proxied'`, override `--network` to `bridge` (instead of config-level default `none`) so the container can reach a host proxy
- Add 10 new tests covering all combinations: proxied override, off passthrough, undefined passthrough, config-level interactions, single-flag invariant, and security/resource-limit preservation

## Test plan
- [x] `bun test terminal-sandbox-docker.test.ts` passes (73 tests, 0 failures)
- [x] `bun test terminal-sandbox.test.ts` passes (13 tests, 0 failures)
- [x] `bun test sandbox-host-parity.test.ts` passes (49 tests, 0 failures)
- [x] Verified proxied mode produces `--network=bridge`
- [x] Verified default/off mode preserves `--network=none`
- [x] Verified all security flags (cap-drop, no-new-privileges, read-only) remain intact in proxied mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
