### PR TITLE
feat: add asset_materialize tool to copy attachment to sandbox path

### DIFF
--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -1,0 +1,296 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'asset-materialize-test-'));
+const sandboxDir = join(testDir, 'sandbox');
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { uploadAttachment } from '../memory/attachments-store.js';
+import { assetMaterializeTool } from '../tools/assets/materialize.js';
+import type { ToolContext } from '../tools/types.js';
+
+initializeDb();
+
+// Ensure the sandbox directory exists
+import { mkdirSync } from 'node:fs';
+mkdirSync(sandboxDir, { recursive: true });
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM message_attachments');
+  db.run('DELETE FROM attachments');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+}
+
+const dummyContext: ToolContext = {
+  workingDir: sandboxDir,
+  sessionId: 'sess-test',
+  conversationId: 'conv-test',
+};
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('AssetMaterializeTool input validation', () => {
+  test('returns error when attachment_id is missing', async () => {
+    const result = await assetMaterializeTool.execute(
+      { destination_path: 'output.png' },
+      dummyContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('attachment_id is required');
+  });
+
+  test('returns error when destination_path is missing', async () => {
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: 'some-id' },
+      dummyContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('destination_path is required');
+  });
+
+  test('returns error when both params are missing', async () => {
+    const result = await assetMaterializeTool.execute({}, dummyContext);
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox path enforcement
+// ---------------------------------------------------------------------------
+
+describe('AssetMaterializeTool sandbox path enforcement', () => {
+  beforeEach(resetTables);
+
+  test('rejects path that escapes sandbox via ../', async () => {
+    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: '../../etc/evil.png' },
+      dummyContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('outside');
+  });
+
+  test('rejects absolute path outside sandbox', async () => {
+    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: '/tmp/outside-sandbox/evil.png' },
+      dummyContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('outside');
+  });
+
+  test('accepts relative path inside sandbox', async () => {
+    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: 'output.png' },
+      dummyContext,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Materialized');
+  });
+
+  test('accepts nested path inside sandbox with auto-created subdirs', async () => {
+    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: 'subdir/deep/output.png' },
+      dummyContext,
+    );
+    expect(result.isError).toBe(false);
+    expect(existsSync(join(sandboxDir, 'subdir', 'deep', 'output.png'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attachment lookup
+// ---------------------------------------------------------------------------
+
+describe('AssetMaterializeTool attachment lookup', () => {
+  beforeEach(resetTables);
+
+  test('returns error for non-existent attachment ID', async () => {
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: 'nonexistent-id', destination_path: 'out.png' },
+      dummyContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful materialization
+// ---------------------------------------------------------------------------
+
+describe('AssetMaterializeTool materialization', () => {
+  beforeEach(resetTables);
+
+  test('writes correct binary content to disk', async () => {
+    // Create known content: "Hello, World!" in base64
+    const originalContent = 'Hello, World!';
+    const base64Content = Buffer.from(originalContent).toString('base64');
+
+    const stored = uploadAttachment('ast-1', 'hello.txt', 'text/plain', base64Content);
+
+    const destPath = 'materialized-hello.txt';
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: destPath },
+      dummyContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Materialized');
+    expect(result.content).toContain('hello.txt');
+    expect(result.content).toContain('text/plain');
+
+    const writtenContent = readFileSync(join(sandboxDir, destPath), 'utf-8');
+    expect(writtenContent).toBe(originalContent);
+  });
+
+  test('writes binary (image) content correctly', async () => {
+    // Small valid PNG-like bytes encoded as base64
+    const binaryBytes = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+    const base64Content = binaryBytes.toString('base64');
+
+    const stored = uploadAttachment('ast-1', 'tiny.png', 'image/png', base64Content);
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: 'images/tiny.png' },
+      dummyContext,
+    );
+
+    expect(result.isError).toBe(false);
+
+    const writtenBytes = readFileSync(join(sandboxDir, 'images', 'tiny.png'));
+    expect(Buffer.compare(writtenBytes, binaryBytes)).toBe(0);
+  });
+
+  test('result includes resolved path', async () => {
+    const base64Content = Buffer.from('test').toString('base64');
+    const stored = uploadAttachment('ast-1', 'doc.txt', 'text/plain', base64Content);
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: 'output/doc.txt' },
+      dummyContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(join(sandboxDir, 'output', 'doc.txt'));
+  });
+
+  test('result includes filename, MIME type and size info', async () => {
+    const base64Content = Buffer.from('some data here').toString('base64');
+    const stored = uploadAttachment('ast-1', 'report.pdf', 'application/pdf', base64Content);
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: stored.id, destination_path: 'report.pdf' },
+      dummyContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('report.pdf');
+    expect(result.content).toContain('application/pdf');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Size limit enforcement
+// ---------------------------------------------------------------------------
+
+describe('AssetMaterializeTool size limit', () => {
+  beforeEach(resetTables);
+
+  test('rejects attachment exceeding 50MB limit', async () => {
+    // Simulate a large attachment by inserting directly into the DB
+    // with a sizeBytes value over the limit
+    const db = getDb();
+    const fakeId = 'oversized-attachment';
+    db.run(
+      `INSERT INTO attachments (id, assistant_id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+       VALUES ('${fakeId}', 'ast-1', 'huge.bin', 'application/octet-stream', ${51 * 1024 * 1024}, 'document', 'AAAA', ${Date.now()})`,
+    );
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: fakeId, destination_path: 'huge.bin' },
+      dummyContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('exceeds');
+    expect(result.content).toContain('materialization limit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool metadata
+// ---------------------------------------------------------------------------
+
+describe('AssetMaterializeTool metadata', () => {
+  test('tool definition has correct name', () => {
+    const def = assetMaterializeTool.getDefinition();
+    expect(def.name).toBe('asset_materialize');
+  });
+
+  test('tool definition has required params', () => {
+    const def = assetMaterializeTool.getDefinition();
+    expect(def.input_schema.required).toEqual(['attachment_id', 'destination_path']);
+  });
+
+  test('tool definition has attachment_id and destination_path properties', () => {
+    const def = assetMaterializeTool.getDefinition();
+    expect(def.input_schema.properties).toHaveProperty('attachment_id');
+    expect(def.input_schema.properties).toHaveProperty('destination_path');
+  });
+
+  test('tool has LOW risk level', () => {
+    expect(assetMaterializeTool.defaultRiskLevel).toBe('low');
+  });
+
+  test('tool category is assets', () => {
+    expect(assetMaterializeTool.category).toBe('assets');
+  });
+
+  test('tool name is asset_materialize', () => {
+    expect(assetMaterializeTool.name).toBe('asset_materialize');
+  });
+});

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -1,0 +1,181 @@
+/**
+ * asset_materialize — write a stored attachment to a sandbox file path.
+ *
+ * Accepts an attachment ID (from asset_search) and a destination path
+ * within the sandbox working directory. Decodes the base64 content and
+ * writes it to disk so scripts and other tools can consume it as a
+ * regular file.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { eq } from 'drizzle-orm';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getDb } from '../../memory/db.js';
+import { attachments } from '../../memory/schema.js';
+import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
+
+// ---------------------------------------------------------------------------
+// Size limit — prevent materializing excessively large attachments
+// ---------------------------------------------------------------------------
+
+/** 50 MB ceiling for materialized files. */
+export const MAX_MATERIALIZE_BYTES = 50 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Load an attachment row (including base64 data) by its primary key.
+ * Not scoped by assistantId — the ID from asset_search is sufficient
+ * to identify the attachment unambiguously.
+ */
+function loadAttachmentById(
+  attachmentId: string,
+): { id: string; originalFilename: string; mimeType: string; sizeBytes: number; dataBase64: string } | null {
+  const db = getDb();
+  const row = db
+    .select({
+      id: attachments.id,
+      originalFilename: attachments.originalFilename,
+      mimeType: attachments.mimeType,
+      sizeBytes: attachments.sizeBytes,
+      dataBase64: attachments.dataBase64,
+    })
+    .from(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .get();
+
+  return row ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definition
+// ---------------------------------------------------------------------------
+
+const definition: ToolDefinition = {
+  name: 'asset_materialize',
+  description:
+    'Copy a stored attachment to a file on disk inside the sandbox directory. ' +
+    'Use attachment IDs from asset_search results. The file can then be used ' +
+    'as input to scripts, tools, or other processing.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      attachment_id: {
+        type: 'string',
+        description: 'The ID of the attachment to materialize (from asset_search results).',
+      },
+      destination_path: {
+        type: 'string',
+        description:
+          'Path where the file should be written, relative to (or inside) the sandbox working directory.',
+      },
+    },
+    required: ['attachment_id', 'destination_path'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tool class
+// ---------------------------------------------------------------------------
+
+class AssetMaterializeTool implements Tool {
+  name = 'asset_materialize';
+  description = definition.description;
+  category = 'assets';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const attachmentId = input.attachment_id as string | undefined;
+    const destinationPath = input.destination_path as string | undefined;
+
+    // --- Input validation ---------------------------------------------------
+
+    if (!attachmentId || typeof attachmentId !== 'string') {
+      return {
+        content: 'Error: attachment_id is required and must be a string.',
+        isError: true,
+      };
+    }
+
+    if (!destinationPath || typeof destinationPath !== 'string') {
+      return {
+        content: 'Error: destination_path is required and must be a string.',
+        isError: true,
+      };
+    }
+
+    // --- Sandbox path enforcement -------------------------------------------
+
+    const pathCheck = sandboxPolicy(destinationPath, context.workingDir, { mustExist: false });
+    if (!pathCheck.ok) {
+      return {
+        content: `Error: ${pathCheck.error}`,
+        isError: true,
+      };
+    }
+
+    const resolvedPath = pathCheck.resolved;
+
+    // --- Load attachment ----------------------------------------------------
+
+    const attachment = loadAttachmentById(attachmentId);
+    if (!attachment) {
+      return {
+        content: `Error: Attachment "${attachmentId}" not found.`,
+        isError: true,
+      };
+    }
+
+    // --- Size check ---------------------------------------------------------
+
+    if (attachment.sizeBytes > MAX_MATERIALIZE_BYTES) {
+      return {
+        content:
+          `Error: Attachment "${attachment.originalFilename}" is ${formatBytes(attachment.sizeBytes)}, ` +
+          `which exceeds the ${formatBytes(MAX_MATERIALIZE_BYTES)} materialization limit.`,
+        isError: true,
+      };
+    }
+
+    // --- Decode and write ---------------------------------------------------
+
+    try {
+      const buffer = Buffer.from(attachment.dataBase64, 'base64');
+
+      // Ensure parent directories exist
+      mkdirSync(dirname(resolvedPath), { recursive: true });
+
+      writeFileSync(resolvedPath, buffer);
+
+      return {
+        content:
+          `Materialized "${attachment.originalFilename}" (${attachment.mimeType}, ` +
+          `${formatBytes(attachment.sizeBytes)}) to ${resolvedPath}`,
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error writing file: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const assetMaterializeTool = new AssetMaterializeTool();
+
+registerTool(assetMaterializeTool);

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -49,6 +49,7 @@ export const eagerModules: string[] = [
   './contacts/contact-search.js',
   './contacts/contact-merge.js',
   './assets/search.js',
+  './assets/materialize.js',
 ];
 
 // Tool names registered by the eager modules above.  Listed explicitly so
@@ -82,6 +83,7 @@ export const eagerModuleToolNames: string[] = [
   'contact_search',
   'contact_merge',
   'asset_search',
+  'asset_materialize',
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a new `asset_materialize` tool that writes a stored attachment (by ID from `asset_search`) to a file on disk inside the sandbox directory
- Decodes base64 content, enforces sandbox path policy, and enforces a 50MB size limit
- Registers the tool in `tool-manifest.ts` as an eager module
- Includes 19 comprehensive tests covering input validation, sandbox enforcement, attachment lookup, binary content writing, size limits, and tool metadata

## Test plan
- [x] `bun test src/__tests__/asset-materialize-tool.test.ts` — all 19 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
