### PR TITLE
feat: wire proxy approval hook to existing prompter

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, mock, test, beforeEach } from 'bun:test';
+import type { ProxyApprovalRequest } from '../tools/network/script-proxy/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede the import of `createProxyApprovalCallback`.
+// ---------------------------------------------------------------------------
+
+const addRuleMock = mock(() => {});
+const findHighestPriorityRuleMock = mock(() => null as ReturnType<typeof import('../permissions/trust-store.js').findHighestPriorityRule>);
+
+mock.module('../permissions/trust-store.js', () => ({
+  addRule: addRuleMock,
+  findHighestPriorityRule: findHighestPriorityRuleMock,
+  clearCache: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    timeouts: { permissionTimeoutSec: 5 },
+    permissions: { mode: 'legacy' },
+    skills: { load: { extraDirs: [] } },
+  }),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../security/redaction.js', () => ({
+  redactSensitiveFields: (input: Record<string, unknown>) => input,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are registered.
+// ---------------------------------------------------------------------------
+
+import { createProxyApprovalCallback } from '../daemon/session-tool-setup.js';
+import type { ToolSetupContext } from '../daemon/session-tool-setup.js';
+import { PermissionPrompter } from '../permissions/prompter.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides?: Partial<ToolSetupContext>): ToolSetupContext {
+  return {
+    conversationId: 'conv-test',
+    workingDir: '/tmp/test-project',
+    abortController: null,
+    memoryPolicy: { scopeId: 'default', strictSideEffects: false },
+    sendToClient: () => {},
+    surfacesByAppId: new Map(),
+    ...overrides,
+  } as ToolSetupContext;
+}
+
+function makeAskMissingCredentialRequest(
+  overrides?: Partial<ProxyApprovalRequest>,
+): ProxyApprovalRequest {
+  return {
+    decision: {
+      kind: 'ask_missing_credential',
+      target: { hostname: 'api.fal.ai', port: 443, path: '/v1/run' },
+      matchingPatterns: ['*.fal.ai'],
+    },
+    sessionId: 'session-1',
+    ...overrides,
+  };
+}
+
+function makeAskUnauthenticatedRequest(
+  overrides?: Partial<ProxyApprovalRequest>,
+): ProxyApprovalRequest {
+  return {
+    decision: {
+      kind: 'ask_unauthenticated',
+      target: { hostname: 'example.com', port: null, path: '/data' },
+    },
+    sessionId: 'session-2',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createProxyApprovalCallback', () => {
+  beforeEach(() => {
+    addRuleMock.mockClear();
+    findHighestPriorityRuleMock.mockClear();
+    findHighestPriorityRuleMock.mockReturnValue(null);
+  });
+
+  test('returns true when user allows an ask_missing_credential request', async () => {
+    const ctx = makeContext();
+
+    let resolvePrompt: ((v: { decision: string; selectedPattern?: string; selectedScope?: string }) => void) | null = null;
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    // Intercept the prompter's prompt method to control the response
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      // Find the pending request and resolve it
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'allow');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskMissingCredentialRequest());
+
+    expect(result).toBe(true);
+  });
+
+  test('returns false when user denies an ask_unauthenticated request', async () => {
+    const ctx = makeContext();
+
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'deny');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskUnauthenticatedRequest());
+
+    expect(result).toBe(false);
+  });
+
+  test('skips prompting and returns true when trust store has an allow rule', async () => {
+    findHighestPriorityRuleMock.mockReturnValue({
+      id: 'rule-1',
+      tool: 'proxy:missing_credential',
+      pattern: 'proxy:api.fal.ai',
+      scope: '/tmp/test-project',
+      decision: 'allow' as const,
+      priority: 100,
+      createdAt: Date.now(),
+    });
+
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskMissingCredentialRequest());
+
+    expect(result).toBe(true);
+    // Prompter should not have been called
+    expect(prompterSendToClient).not.toHaveBeenCalled();
+  });
+
+  test('skips prompting and returns false when trust store has a deny rule', async () => {
+    findHighestPriorityRuleMock.mockReturnValue({
+      id: 'rule-2',
+      tool: 'proxy:unauthenticated',
+      pattern: 'proxy:example.com',
+      scope: '/tmp/test-project',
+      decision: 'deny' as const,
+      priority: 100,
+      createdAt: Date.now(),
+    });
+
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskUnauthenticatedRequest());
+
+    expect(result).toBe(false);
+    expect(prompterSendToClient).not.toHaveBeenCalled();
+  });
+
+  test('prompts when trust store has an ask rule', async () => {
+    findHighestPriorityRuleMock.mockReturnValue({
+      id: 'rule-3',
+      tool: 'proxy:unauthenticated',
+      pattern: 'proxy:example.com',
+      scope: '/tmp/test-project',
+      decision: 'ask' as const,
+      priority: 100,
+      createdAt: Date.now(),
+    });
+
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'allow');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskUnauthenticatedRequest());
+
+    expect(result).toBe(true);
+    // Prompter should have been called (ask rule forces prompt)
+    expect(prompterSendToClient).toHaveBeenCalled();
+  });
+
+  test('persists allow rule when user chooses always_allow', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'always_allow', 'proxy:api.fal.ai', '/tmp/test-project');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskMissingCredentialRequest());
+
+    expect(result).toBe(true);
+    expect(addRuleMock).toHaveBeenCalledWith(
+      'proxy:missing_credential',
+      'proxy:api.fal.ai',
+      '/tmp/test-project',
+      'allow',
+      100,
+      undefined,
+    );
+  });
+
+  test('persists deny rule when user chooses always_deny', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'always_deny', 'proxy:example.com', 'everywhere');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskUnauthenticatedRequest());
+
+    expect(result).toBe(false);
+    expect(addRuleMock).toHaveBeenCalledWith(
+      'proxy:unauthenticated',
+      'proxy:example.com',
+      'everywhere',
+      'deny',
+    );
+  });
+
+  test('sends correct tool name for ask_missing_credential decisions', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string; toolName: string; input: Record<string, unknown> };
+      // Verify the confirmation request has the right tool name
+      expect(msg.toolName).toBe('proxy:missing_credential');
+      expect(msg.input).toHaveProperty('hostname', 'api.fal.ai');
+      expect(msg.input).toHaveProperty('matching_patterns', ['*.fal.ai']);
+      prompter.resolveConfirmation(msg.requestId, 'allow');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    await callback(makeAskMissingCredentialRequest());
+  });
+
+  test('sends correct tool name for ask_unauthenticated decisions', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string; toolName: string; input: Record<string, unknown>; riskLevel: string };
+      expect(msg.toolName).toBe('proxy:unauthenticated');
+      expect(msg.input).toHaveProperty('hostname', 'example.com');
+      expect(msg.riskLevel).toBe('medium');
+      prompter.resolveConfirmation(msg.requestId, 'deny');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    await callback(makeAskUnauthenticatedRequest());
+  });
+
+  test('uses high risk level for ask_missing_credential decisions', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string; riskLevel: string };
+      // Missing credential prompts are high risk — the target wants auth
+      expect(msg.riskLevel).toBe('high');
+      prompter.resolveConfirmation(msg.requestId, 'allow');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    await callback(makeAskMissingCredentialRequest());
+  });
+
+  test('includes port in allowlist option label when port is present', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string; allowlistOptions: Array<{ label: string }> };
+      // First option should include the port
+      expect(msg.allowlistOptions[0].label).toBe('proxy:api.fal.ai:443');
+      prompter.resolveConfirmation(msg.requestId, 'allow');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    await callback(makeAskMissingCredentialRequest());
+  });
+
+  test('omits port from allowlist option label when port is null', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string; allowlistOptions: Array<{ label: string }> };
+      // Port is null — label should not include ":null"
+      expect(msg.allowlistOptions[0].label).toBe('proxy:example.com');
+      prompter.resolveConfirmation(msg.requestId, 'deny');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    await callback(makeAskUnauthenticatedRequest());
+  });
+});

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -25,6 +25,7 @@ import {
 import type { SurfaceSessionContext } from './session-surfaces.js';
 import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
 import { registerSessionSender } from '../tools/browser/browser-screencast.js';
+import type { ProxyApprovalCallback, ProxyApprovalRequest } from '../tools/network/script-proxy/index.js';
 
 // ── Context Interface ────────────────────────────────────────────────
 
@@ -171,5 +172,80 @@ export function createToolExecutor(
     }
 
     return result;
+  };
+}
+
+// ── createProxyApprovalCallback ──────────────────────────────────────
+
+/**
+ * Build a proxy approval callback that routes `ask_missing_credential` and
+ * `ask_unauthenticated` policy decisions through the existing permission
+ * prompter UI. The proxy service calls this when an outbound request needs
+ * user confirmation before proceeding.
+ */
+export function createProxyApprovalCallback(
+  prompter: PermissionPrompter,
+  ctx: ToolSetupContext,
+): ProxyApprovalCallback {
+  return async (request: ProxyApprovalRequest): Promise<boolean> => {
+    const { decision } = request;
+    const { hostname, port, path } = decision.target;
+
+    // Build a display-friendly tool name and input for the prompter
+    const toolName = decision.kind === 'ask_missing_credential'
+      ? 'proxy:missing_credential'
+      : 'proxy:unauthenticated';
+
+    const input: Record<string, unknown> = {
+      hostname,
+      port,
+      path,
+      proxy_session_id: request.sessionId,
+    };
+    if (decision.kind === 'ask_missing_credential') {
+      input.matching_patterns = decision.matchingPatterns;
+    }
+
+    // Check trust store before prompting
+    const scope = `proxy:${hostname}`;
+    const candidates = [scope, `proxy:${hostname}`, 'proxy:*'];
+    const existingRule = findHighestPriorityRule(toolName, candidates, ctx.workingDir);
+    if (existingRule && existingRule.decision !== 'ask') {
+      return existingRule.decision === 'allow';
+    }
+
+    // Build allowlist options for the prompter
+    const portSuffix = port ? `:${port}` : '';
+    const allowlistOptions = [
+      { label: `proxy:${hostname}${portSuffix}`, description: `Proxy requests to ${hostname}`, pattern: `proxy:${hostname}` },
+      { label: 'proxy:*', description: 'All proxied requests', pattern: 'proxy:*' },
+    ];
+
+    const scopeOptions = generateScopeOptions(ctx.workingDir);
+    const riskLevel = decision.kind === 'ask_missing_credential' ? 'high' : 'medium';
+
+    const response = await prompter.prompt(
+      toolName,
+      input,
+      riskLevel,
+      allowlistOptions,
+      scopeOptions,
+      undefined,
+      undefined,
+      ctx.conversationId,
+    );
+
+    // Persist trust rule if the user chose "always allow" or "always deny"
+    if ((response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') && response.selectedPattern && response.selectedScope) {
+      addRule(toolName, response.selectedPattern, response.selectedScope, 'allow', 100,
+        response.decision === 'always_allow_high_risk' ? { allowHighRisk: true } : undefined);
+    }
+    if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
+      addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
+    }
+
+    return response.decision === 'allow'
+      || response.decision === 'always_allow'
+      || response.decision === 'always_allow_high_risk';
   };
 }

--- a/assistant/src/tools/network/script-proxy/index.ts
+++ b/assistant/src/tools/network/script-proxy/index.ts
@@ -4,6 +4,8 @@ export type {
   ProxySessionConfig,
   ProxySessionStatus,
   ProxyEnvVars,
+  ProxyApprovalRequest,
+  ProxyApprovalCallback,
 } from './types.js';
 
 export {

--- a/assistant/src/tools/network/script-proxy/types.ts
+++ b/assistant/src/tools/network/script-proxy/types.ts
@@ -58,7 +58,6 @@ export interface PolicyDecisionUnauthenticated {
 
 // ---------------------------------------------------------------------------
 // Approval hook outcomes — structured data for triggering permission prompts.
-// The actual prompt UI wiring happens in a later PR.
 // ---------------------------------------------------------------------------
 
 /** Context about the outbound request target, used to build permission prompts. */
@@ -97,3 +96,26 @@ export type PolicyDecision =
   | PolicyDecisionUnauthenticated
   | PolicyDecisionAskMissingCredential
   | PolicyDecisionAskUnauthenticated;
+
+// ---------------------------------------------------------------------------
+// Proxy approval callback — wires policy "ask" decisions to the UI prompter.
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload passed to the approval callback when the policy engine emits an
+ * `ask_missing_credential` or `ask_unauthenticated` decision. Contains
+ * enough context for the prompter to build a meaningful confirmation dialog.
+ */
+export interface ProxyApprovalRequest {
+  /** The policy decision that triggered the approval prompt. */
+  decision: PolicyDecisionAskMissingCredential | PolicyDecisionAskUnauthenticated;
+  /** The proxy session ID that originated the request. */
+  sessionId: ProxySessionId;
+}
+
+/**
+ * Callback signature for proxy approval prompts. The proxy service calls
+ * this when an outbound request requires user confirmation. Returns `true`
+ * if the user approves, `false` if denied.
+ */
+export type ProxyApprovalCallback = (request: ProxyApprovalRequest) => Promise<boolean>;


### PR DESCRIPTION
## Summary
- Add `ProxyApprovalRequest` and `ProxyApprovalCallback` types to the script-proxy types, defining the contract for routing proxy policy "ask" decisions to the UI
- Export the new types from the script-proxy barrel (`index.ts`)
- Add `createProxyApprovalCallback()` in `session-tool-setup.ts` that wires `ask_missing_credential` and `ask_unauthenticated` policy decisions through the existing `PermissionPrompter`, with trust store lookup, allowlist options, scope options, and persistent rule storage
- Add 12 tests covering allow/deny flows, trust store caching (allow/deny/ask rules), persistent rule creation (always_allow, always_deny), correct tool naming, risk levels, and port display in allowlist labels

## Test plan
- [x] `bun test src/__tests__/proxy-approval-callback.test.ts` — 12 tests pass
- [ ] Verify no regressions in existing proxy and session tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
