### PR TITLE
test: e2e proxied bash + approval persistence rules

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -381,4 +381,107 @@ describe('createProxyApprovalCallback', () => {
     const callback = createProxyApprovalCallback(prompter, ctx);
     await callback(makeAskUnauthenticatedRequest());
   });
+
+  // ── E2E persistence invariants (PR 32) ──────────────────────────────
+  // These tests verify the proxy approval path CAN save persistent rules,
+  // in contrast to the proxied bash activation path which CANNOT (tested
+  // in tool-executor.test.ts).
+
+  test('always_allow_high_risk persists rule with allowHighRisk flag', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'always_allow_high_risk', 'proxy:api.fal.ai', '/tmp/test-project');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskMissingCredentialRequest());
+
+    expect(result).toBe(true);
+    expect(addRuleMock).toHaveBeenCalledWith(
+      'proxy:missing_credential',
+      'proxy:api.fal.ai',
+      '/tmp/test-project',
+      'allow',
+      100,
+      { allowHighRisk: true },
+    );
+  });
+
+  test('one-time allow does NOT persist any rule', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'allow');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskMissingCredentialRequest());
+
+    expect(result).toBe(true);
+    // One-time allow should NOT save any persistent rule
+    expect(addRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('one-time deny does NOT persist any rule', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, 'deny');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskUnauthenticatedRequest());
+
+    expect(result).toBe(false);
+    expect(addRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('always_allow without selectedPattern does not persist a rule', async () => {
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = prompterSendToClient.mock.calls[0];
+      const msg = call[0] as { requestId: string };
+      // Resolve with always_allow but NO pattern/scope
+      prompter.resolveConfirmation(msg.requestId, 'always_allow');
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskMissingCredentialRequest());
+
+    expect(result).toBe(true);
+    // No pattern/scope -> cannot save a rule
+    expect(addRuleMock).not.toHaveBeenCalled();
+  });
 });

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1734,6 +1734,161 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
 });
 
 // ---------------------------------------------------------------------------
+// E2E: Proxied bash vs. proxy approval persistence invariants (PR 32)
+//
+// Design invariant: the proxied-run activation prompt (when the agent wants
+// to run `bash` with `network_mode=proxied`) must NOT allow saving persistent
+// trust rules — each invocation must be explicitly approved. In contrast,
+// the proxy-request approval path (when the proxy service asks the user
+// about a specific outbound request) CAN save persistent trust rules so the
+// user doesn't get re-prompted for the same host/pattern.
+// ---------------------------------------------------------------------------
+
+describe('E2E: proxied bash activation vs proxy approval persistence', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+    lastCheckArgs = undefined;
+    getToolOverride = undefined;
+    checkResultOverride = { decision: 'prompt', reason: 'Requires explicit approval' };
+    checkFnOverride = undefined;
+    if (addRuleSpy) { addRuleSpy.mockRestore(); addRuleSpy = undefined; }
+  });
+
+  function setupAddRuleSpy() {
+    addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      },
+    );
+    return addRuleSpy;
+  }
+
+  test('proxied bash: always_allow skips rule, always_deny skips rule, non-proxied bash saves both', async () => {
+    const spy = setupAddRuleSpy();
+
+    // 1. Proxied bash always_allow -> NO rule saved
+    const p1 = makePrompterWithDecision('always_allow', 'bash:curl*', '/tmp/project');
+    const e1 = new ToolExecutor(p1);
+    const r1 = await e1.execute('bash', { command: 'curl https://api.example.com', network_mode: 'proxied' }, makeContext());
+    expect(r1.isError).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+
+    // 2. Proxied bash always_deny -> NO rule saved
+    const p2 = makePrompterWithDecision('always_deny', 'bash:curl*', '/tmp/project');
+    const e2 = new ToolExecutor(p2);
+    const r2 = await e2.execute('bash', { command: 'curl https://evil.com', network_mode: 'proxied' }, makeContext());
+    expect(r2.isError).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+
+    // 3. Non-proxied bash always_allow -> rule IS saved
+    const p3 = makePrompterWithDecision('always_allow', 'bash:git*', '/tmp/project');
+    const e3 = new ToolExecutor(p3);
+    const r3 = await e3.execute('bash', { command: 'git push' }, makeContext());
+    expect(r3.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toBe('bash');
+    expect(spy.mock.calls[0][1]).toBe('bash:git*');
+    expect(spy.mock.calls[0][3]).toBe('allow');
+  });
+
+  test('proxied bash always_allow_high_risk also skips rule saving', async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow_high_risk', 'bash:*', 'everywhere');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl -X POST https://api.example.com/deploy', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('non-proxied bash always_deny DOES save a deny rule', async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_deny', 'bash:rm*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'rm -rf /' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toBe('bash');
+    expect(spy.mock.calls[0][1]).toBe('bash:rm*');
+    expect(spy.mock.calls[0][3]).toBe('deny');
+  });
+
+  test('file_write with proxied network_mode is NOT affected (persistence still allowed)', async () => {
+    // Only bash/host_bash with proxied mode disable persistence
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow', 'file_write:*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'file_write',
+      { path: '/tmp/test.txt', content: 'data', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('host_bash proxied always_allow_high_risk skips rule saving', async () => {
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow_high_risk', 'host_bash:*', 'everywhere');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'host_bash',
+      { command: 'wget https://example.com/data.tar.gz', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('proxied bash denied result message omits "rule saved" suffix', async () => {
+    setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_deny', 'bash:*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl https://malicious.com', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    // Since no rule was saved, the message should NOT include "(rule saved)"
+    expect(result.content).toBe('Permission denied by user');
+    expect(result.content).not.toContain('rule saved');
+  });
+
+  test('non-proxied bash denied result message includes "rule saved" suffix', async () => {
+    setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_deny', 'bash:rm*', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute(
+      'bash',
+      { command: 'rm -rf /' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe('Permission denied by user (rule saved)');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Baseline: sanitized env excludes credential-like variables
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- PR 32 of MEDIA_REUSE plan
- Adds end-to-end tests verifying the dual-persistence design invariant for proxied bash and proxy approval paths
- Proxied bash activation prompts (`always_allow`, `always_deny`, `always_allow_high_risk`) cannot save persistent trust rules — each invocation requires explicit approval
- Proxy request approval callbacks CAN save persistent trust rules so users aren't re-prompted for the same host/pattern
- Tests also verify one-time allow/deny decisions never persist, non-proxied bash preserves normal persistence, and edge cases (missing pattern/scope, `always_allow_high_risk` flags)

## Test plan
- [x] `bun test assistant/src/__tests__/tool-executor.test.ts` — 116 tests pass (7 new)
- [x] `bun test assistant/src/__tests__/proxy-approval-callback.test.ts` — 16 tests pass (4 new)
- [x] `bun test assistant/src/__tests__/shell-tool-proxy-mode.test.ts` — 6 tests pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
