### PR TITLE
feat: enforce visibility policy in asset_search and asset_materialize

### DIFF
--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -36,7 +36,8 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import { initializeDb, getDb } from '../memory/db.js';
-import { uploadAttachment } from '../memory/attachments-store.js';
+import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
+import { createConversation, addMessage } from '../memory/conversation-store.js';
 import { assetMaterializeTool } from '../tools/assets/materialize.js';
 import type { ToolContext } from '../tools/types.js';
 
@@ -292,5 +293,158 @@ describe('AssetMaterializeTool metadata', () => {
 
   test('tool name is asset_materialize', () => {
     expect(assetMaterializeTool.name).toBe('asset_materialize');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Visibility policy enforcement
+// ---------------------------------------------------------------------------
+
+describe('AssetMaterializeTool visibility policy', () => {
+  beforeEach(resetTables);
+
+  test('materializing from a standard thread works from any context', async () => {
+    const standardConv = createConversation({ title: 'standard-conv' });
+    const base64Content = Buffer.from('standard content').toString('base64');
+    const attachment = uploadAttachment('ast-1', 'public.txt', 'text/plain', base64Content);
+    const msg = addMessage(standardConv.id, 'user', 'standard message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Materialize from a different standard conversation
+    const otherConv = createConversation({ title: 'other-conv' });
+    const context: ToolContext = {
+      workingDir: sandboxDir,
+      sessionId: 'sess-test',
+      conversationId: otherConv.id,
+    };
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: attachment.id, destination_path: 'public-output.txt' },
+      context,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Materialized');
+  });
+
+  test('materializing from a private thread works within the same private thread', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const base64Content = Buffer.from('private content').toString('base64');
+    const attachment = uploadAttachment('ast-1', 'secret.txt', 'text/plain', base64Content);
+    const msg = addMessage(privateConv.id, 'user', 'private message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Materialize from the same private conversation
+    const context: ToolContext = {
+      workingDir: sandboxDir,
+      sessionId: 'sess-test',
+      conversationId: privateConv.id,
+    };
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: attachment.id, destination_path: 'private-output.txt' },
+      context,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Materialized');
+  });
+
+  test('materializing from a private thread is REJECTED from a different conversation', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const base64Content = Buffer.from('private content').toString('base64');
+    const attachment = uploadAttachment('ast-1', 'secret.txt', 'text/plain', base64Content);
+    const msg = addMessage(privateConv.id, 'user', 'private message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Attempt to materialize from a different conversation
+    const otherConv = createConversation({ title: 'other-conv' });
+    const context: ToolContext = {
+      workingDir: sandboxDir,
+      sessionId: 'sess-test',
+      conversationId: otherConv.id,
+    };
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: attachment.id, destination_path: 'stolen.txt' },
+      context,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('private thread');
+    expect(result.content).toContain('cannot be accessed');
+  });
+
+  test('error message is user-actionable', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const base64Content = Buffer.from('private content').toString('base64');
+    const attachment = uploadAttachment('ast-1', 'confidential.pdf', 'application/pdf', base64Content);
+    const msg = addMessage(privateConv.id, 'user', 'private message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // From a standard conversation
+    const standardConv = createConversation({ title: 'standard-conv' });
+    const context: ToolContext = {
+      workingDir: sandboxDir,
+      sessionId: 'sess-test',
+      conversationId: standardConv.id,
+    };
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: attachment.id, destination_path: 'stolen.pdf' },
+      context,
+    );
+    expect(result.isError).toBe(true);
+    // Should mention the filename so the user knows which file
+    expect(result.content).toContain('confidential.pdf');
+    // Should explain how to access it
+    expect(result.content).toContain('from within the private thread');
+  });
+
+  test('materializing from a different private thread is REJECTED', async () => {
+    const privateConv1 = createConversation({ title: 'private-conv-1', threadType: 'private' });
+    const base64Content = Buffer.from('private content').toString('base64');
+    const attachment = uploadAttachment('ast-1', 'secret.txt', 'text/plain', base64Content);
+    const msg = addMessage(privateConv1.id, 'user', 'private message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Attempt from a different private conversation
+    const privateConv2 = createConversation({ title: 'private-conv-2', threadType: 'private' });
+    const context: ToolContext = {
+      workingDir: sandboxDir,
+      sessionId: 'sess-test',
+      conversationId: privateConv2.id,
+    };
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: attachment.id, destination_path: 'cross-thread.txt' },
+      context,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('private thread');
+  });
+
+  test('attachment linked to both private and standard threads can be materialized from anywhere', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const standardConv = createConversation({ title: 'standard-conv' });
+    const base64Content = Buffer.from('shared content').toString('base64');
+    const attachment = uploadAttachment('ast-1', 'shared.txt', 'text/plain', base64Content);
+
+    const msg1 = addMessage(privateConv.id, 'user', 'private message');
+    const msg2 = addMessage(standardConv.id, 'user', 'standard message');
+    linkAttachmentToMessage(msg1.id, attachment.id, 0);
+    linkAttachmentToMessage(msg2.id, attachment.id, 0);
+
+    // Should be materializable from a third, unrelated standard conversation
+    const otherConv = createConversation({ title: 'other-conv' });
+    const context: ToolContext = {
+      workingDir: sandboxDir,
+      sessionId: 'sess-test',
+      conversationId: otherConv.id,
+    };
+
+    const result = await assetMaterializeTool.execute(
+      { attachment_id: attachment.id, destination_path: 'shared-output.txt' },
+      context,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Materialized');
   });
 });

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -38,6 +38,7 @@ import { initializeDb, getDb } from '../memory/db.js';
 import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
 import { createConversation, addMessage } from '../memory/conversation-store.js';
 import { searchAttachments } from '../tools/assets/search.js';
+import { assetSearchTool } from '../tools/assets/search.js';
 import type { ToolContext } from '../tools/types.js';
 
 initializeDb();
@@ -349,5 +350,126 @@ describe('AssetSearchTool.execute', () => {
 
   test('tool category is assets', () => {
     expect(tool.category).toBe('assets');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Visibility policy enforcement
+// ---------------------------------------------------------------------------
+
+describe('AssetSearchTool visibility policy', () => {
+  beforeEach(resetTables);
+
+  test('attachments from standard threads are visible from any context', async () => {
+    const standardConv = createConversation({ title: 'standard-conv' });
+    const attachment = uploadAttachment('ast-1', 'public.png', 'image/png', 'AAAA');
+    const msg = addMessage(standardConv.id, 'user', 'standard message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Search from a different standard conversation
+    const otherConv = createConversation({ title: 'other-conv' });
+    const context: ToolContext = {
+      workingDir: '/tmp',
+      sessionId: 'sess-test',
+      conversationId: otherConv.id,
+    };
+
+    const result = await assetSearchTool.execute({}, context);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('public.png');
+  });
+
+  test('attachments from private threads are visible within the same private thread', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const attachment = uploadAttachment('ast-1', 'secret.png', 'image/png', 'AAAA');
+    const msg = addMessage(privateConv.id, 'user', 'private message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Search from the same private conversation
+    const context: ToolContext = {
+      workingDir: '/tmp',
+      sessionId: 'sess-test',
+      conversationId: privateConv.id,
+    };
+
+    const result = await assetSearchTool.execute({}, context);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('secret.png');
+  });
+
+  test('attachments from private threads are NOT visible from a different conversation', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const attachment = uploadAttachment('ast-1', 'secret.png', 'image/png', 'AAAA');
+    const msg = addMessage(privateConv.id, 'user', 'private message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Search from a different private conversation
+    const otherPrivateConv = createConversation({ title: 'other-private', threadType: 'private' });
+    const context: ToolContext = {
+      workingDir: '/tmp',
+      sessionId: 'sess-test',
+      conversationId: otherPrivateConv.id,
+    };
+
+    const result = await assetSearchTool.execute({}, context);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No assets found');
+  });
+
+  test('attachments from private threads are NOT visible from standard threads', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const attachment = uploadAttachment('ast-1', 'secret.png', 'image/png', 'AAAA');
+    const msg = addMessage(privateConv.id, 'user', 'private message');
+    linkAttachmentToMessage(msg.id, attachment.id, 0);
+
+    // Search from a standard conversation
+    const standardConv = createConversation({ title: 'standard-conv' });
+    const context: ToolContext = {
+      workingDir: '/tmp',
+      sessionId: 'sess-test',
+      conversationId: standardConv.id,
+    };
+
+    const result = await assetSearchTool.execute({}, context);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No assets found');
+  });
+
+  test('attachment linked to both private and standard threads is visible everywhere', async () => {
+    const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
+    const standardConv = createConversation({ title: 'standard-conv' });
+    const attachment = uploadAttachment('ast-1', 'shared.png', 'image/png', 'AAAA');
+
+    const msg1 = addMessage(privateConv.id, 'user', 'private message');
+    const msg2 = addMessage(standardConv.id, 'user', 'standard message');
+    linkAttachmentToMessage(msg1.id, attachment.id, 0);
+    linkAttachmentToMessage(msg2.id, attachment.id, 0);
+
+    // Should be visible from a third, unrelated standard conversation
+    const otherConv = createConversation({ title: 'other-conv' });
+    const context: ToolContext = {
+      workingDir: '/tmp',
+      sessionId: 'sess-test',
+      conversationId: otherConv.id,
+    };
+
+    const result = await assetSearchTool.execute({}, context);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('shared.png');
+  });
+
+  test('orphan attachments (no message linkage) remain visible', async () => {
+    uploadAttachment('ast-1', 'orphan.png', 'image/png', 'AAAA');
+
+    const conv = createConversation({ title: 'any-conv' });
+    const context: ToolContext = {
+      workingDir: '/tmp',
+      sessionId: 'sess-test',
+      conversationId: conv.id,
+    };
+
+    const result = await assetSearchTool.execute({}, context);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('orphan.png');
   });
 });

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -17,6 +17,9 @@ import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
 import { attachments } from '../../memory/schema.js';
 import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
+import { isAttachmentVisible, type AttachmentContext } from '../../daemon/media-visibility-policy.js';
+import { getConversationThreadType } from '../../memory/conversation-store.js';
+import { getAttachmentSourceConversations } from './search.js';
 
 // ---------------------------------------------------------------------------
 // Size limit — prevent materializing excessively large attachments
@@ -140,6 +143,37 @@ class AssetMaterializeTool implements Tool {
         content: `Error: Attachment "${attachmentId}" not found.`,
         isError: true,
       };
+    }
+
+    // --- Visibility check ---------------------------------------------------
+    // Reject materialization of attachments from private threads the caller
+    // does not belong to. This prevents cross-thread data leakage.
+
+    const currentThreadType = getConversationThreadType(context.conversationId);
+    const currentContext: AttachmentContext = {
+      conversationId: context.conversationId,
+      isPrivate: currentThreadType === 'private',
+    };
+
+    const sources = getAttachmentSourceConversations(attachmentId);
+    if (sources.length > 0) {
+      const hasStandard = sources.some((s) => s.threadType !== 'private');
+      if (!hasStandard) {
+        // All sources are private — check if the caller is in one of those threads
+        const attachmentContext: AttachmentContext = {
+          conversationId: sources[0].conversationId,
+          isPrivate: true,
+        };
+        if (!isAttachmentVisible(attachmentContext, currentContext)) {
+          return {
+            content:
+              `Error: Attachment "${attachment.originalFilename}" is from a private thread ` +
+              `and cannot be accessed from this context. You can only access this ` +
+              `attachment from within the private thread where it was shared.`,
+            isError: true,
+          };
+        }
+      }
     }
 
     // --- Size check ---------------------------------------------------------

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -13,8 +13,10 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
-import { attachments, messageAttachments, messages } from '../../memory/schema.js';
+import { attachments, messageAttachments, messages, conversations } from '../../memory/schema.js';
 import type { StoredAttachment } from '../../memory/attachments-store.js';
+import { filterVisibleAttachments, type AttachmentContext } from '../../daemon/media-visibility-policy.js';
+import { getConversationThreadType } from '../../memory/conversation-store.js';
 
 // ---------------------------------------------------------------------------
 // Recency presets — map human-readable labels to epoch-ms cutoff offsets
@@ -47,6 +49,55 @@ function formatAttachment(a: StoredAttachment): string {
     `  Type: ${a.mimeType} | Kind: ${a.kind} | Size: ${formatBytes(a.sizeBytes)}`,
     `  Created: ${date}`,
   ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Attachment source conversation lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up which conversations an attachment belongs to, along with each
+ * conversation's thread type. An attachment can be linked to multiple
+ * messages across multiple conversations.
+ */
+export function getAttachmentSourceConversations(
+  attachmentId: string,
+): Array<{ conversationId: string; threadType: string }> {
+  const db = getDb();
+  return db
+    .select({
+      conversationId: messages.conversationId,
+      threadType: conversations.threadType,
+    })
+    .from(messageAttachments)
+    .innerJoin(messages, eq(messages.id, messageAttachments.messageId))
+    .innerJoin(conversations, eq(conversations.id, messages.conversationId))
+    .where(eq(messageAttachments.attachmentId, attachmentId))
+    .all();
+}
+
+/**
+ * Build an AttachmentContext for a given attachment by examining its
+ * source conversations. If ALL source conversations are private, the
+ * attachment is considered private (scoped to the first private
+ * conversation found). If any source conversation is standard, the
+ * attachment is considered visible everywhere.
+ */
+function getAttachmentVisibilityContext(attachmentId: string): AttachmentContext | null {
+  const sources = getAttachmentSourceConversations(attachmentId);
+  if (sources.length === 0) {
+    // No message linkage — treat as universally visible (orphan attachment)
+    return null;
+  }
+
+  const hasStandard = sources.some((s) => s.threadType !== 'private');
+  if (hasStandard) {
+    // At least one standard-thread source — attachment is globally visible
+    return { conversationId: sources[0].conversationId, isPrivate: false };
+  }
+
+  // All sources are private — scope to the first private conversation
+  return { conversationId: sources[0].conversationId, isPrivate: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -239,7 +290,7 @@ class AssetSearchTool implements Tool {
     return definition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const mimeType = input.mime_type as string | undefined;
     const filename = input.filename as string | undefined;
     const recency = input.recency as string | undefined;
@@ -271,12 +322,26 @@ class AssetSearchTool implements Tool {
         limit,
       });
 
-      if (results.length === 0) {
+      // Enforce private-thread visibility: filter out attachments that
+      // belong exclusively to private threads the caller cannot access.
+      const currentThreadType = getConversationThreadType(context.conversationId);
+      const currentContext: AttachmentContext = {
+        conversationId: context.conversationId,
+        isPrivate: currentThreadType === 'private',
+      };
+
+      const visible = filterVisibleAttachments(results, currentContext, (attachment) => {
+        const ctx = getAttachmentVisibilityContext(attachment.id);
+        // Orphan attachments (no message linkage) are treated as globally visible
+        return ctx ?? { conversationId: '', isPrivate: false };
+      });
+
+      if (visible.length === 0) {
         return { content: 'No assets found matching the search criteria.', isError: false };
       }
 
-      const lines = [`Found ${results.length} asset(s):\n`];
-      for (const attachment of results) {
+      const lines = [`Found ${visible.length} asset(s):\n`];
+      for (const attachment of visible) {
         lines.push(formatAttachment(attachment));
       }
 


### PR DESCRIPTION
## Summary

PR 37 of MEDIA_REUSE plan. Enforces private-thread media boundaries in both asset tools:

- **asset_search**: Filters results through `filterVisibleAttachments` from `media-visibility-policy.ts`. Attachments that belong exclusively to private threads are hidden from callers in other contexts. Orphan attachments (no message linkage) remain universally visible.
- **asset_materialize**: Checks `isAttachmentVisible` before writing to disk. Rejects materialization of private-thread attachments from other contexts with an explicit, user-actionable error message explaining how to access the file.
- **Shared helper**: `getAttachmentSourceConversations` joins `messageAttachments -> messages -> conversations` to determine which conversations own an attachment and their thread types.

## Test plan

- [x] Standard-thread attachments visible from any context (search + materialize)
- [x] Private-thread attachments visible within same private thread (search + materialize)
- [x] Private-thread attachments hidden from different conversations (search + materialize)
- [x] Private-thread attachments hidden from standard threads (search + materialize)
- [x] Attachments linked to both private and standard threads are universally visible
- [x] Orphan attachments (no message linkage) remain visible
- [x] Error messages are user-actionable (include filename and guidance)
- [x] Cross-private-thread materialization is rejected
- [x] All existing tests continue to pass (36 search, 25 materialize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
