### PR TITLE
fix: isolate saveFile error during v1→v2 migration (PR #4165 feedback)

### DIFF
--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -129,7 +129,7 @@ function loadFile(): LoadResult {
       // Migrate from v1 to v2 and persist the upgrade so we don't re-migrate on every read
       const credentials = validRecords.map(migrateRecordV1toV2);
       const migrated: MetadataFile = { version: CURRENT_VERSION, credentials };
-      saveFile(migrated);
+      try { saveFile(migrated); } catch { /* persist failed — will retry on next write */ }
       return migrated;
     }
 


### PR DESCRIPTION
Addresses review feedback on #4165.

Both Codex and Devin flagged that a saveFile failure during v1→v2 migration inside loadFile() would be caught by the broad catch block and return empty credentials, risking data loss. The fix wraps saveFile in its own try-catch so the migrated data is returned in-memory even if the write fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
