### PR TITLE
fix: address review feedback on PR #4152 (attachment reuse test)

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -482,7 +482,11 @@ describe('attachment reuse across thread lifecycles', () => {
     const convA = createConversation('Thread A');
     const convB = createConversation('Thread B');
 
+    // deleteLastExchange deletes from the last user message onward,
+    // so we need a user message before the assistant message that carries the attachment.
+    addMessage(convA.id, 'user', 'Please generate a chart');
     const msgA = addMessage(convA.id, 'assistant', 'Original');
+    addMessage(convB.id, 'user', 'Show me the chart');
     const msgB = addMessage(convB.id, 'assistant', 'Reused');
 
     const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'AAAA');


### PR DESCRIPTION
Addresses review feedback on #4152.

Codex flagged that the 'deleting conversation A does not orphan attachment reused in conversation B' test never actually exercised the deletion path: deleteLastExchange only deletes from the last user message onward, but conversation A only had an assistant message, making the call a no-op.

Fixed by adding user messages before the assistant messages in both conversations, so deleteLastExchange actually deletes the exchange and the orphan-cleanup logic is properly tested.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
