### PR TITLE
fix: address review feedback on PR #4081 (domain normalization)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/MediaEmbedSettings.swift
@@ -49,6 +49,9 @@ public enum MediaEmbedSettings {
             if let components = URLComponents(string: value), let host = components.host, !host.isEmpty {
                 return host
             }
+            // Scheme was present but URLComponents couldn't extract a host;
+            // return the original value rather than slicing at the scheme's slashes.
+            return value
         }
 
         // No scheme — strip anything after the first `/` (path, query, fragment).

--- a/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
@@ -131,4 +131,15 @@ final class MediaEmbedSettingsDefaultsTests: XCTestCase {
         ])
         XCTAssertEqual(result, ["youtube.com"])
     }
+
+    func testNormalizeDomainsSchemeOnlyURLDoesNotProduceSchemePrefix() {
+        // Malformed URLs with scheme but no valid host should not produce "http:" or "https:"
+        let result = MediaEmbedSettings.normalizeDomains(["http://", "https://"])
+        // URLComponents parses these with empty host, so they pass through unchanged
+        // rather than being sliced at the scheme's slashes to produce "http:" / "https:"
+        for domain in result {
+            XCTAssertFalse(domain == "http:" || domain == "https:",
+                           "Should not produce scheme-only string, got: \(domain)")
+        }
+    }
 }


### PR DESCRIPTION
Addresses review feedback on #4081.

When extractHost receives a URL with an http/https scheme but URLComponents fails to extract a valid host (e.g. "http://" or "https://[invalid"), the function previously fell through to the slash-stripping branch, which would slice at the scheme's slashes and produce nonsensical values like "http:" or "https:". Now returns the original value instead of falling through.

Adds a test case for malformed scheme-only URLs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
