### PR TITLE
fix: use UTF-16 offsets for URL position sorting (PR #4084 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -17,7 +17,7 @@ enum MessageURLExtractor {
         extractPlainURLsWithPositions(from: text).map(\.url)
     }
 
-    /// Returns plain-text URLs paired with their character offset in
+    /// Returns plain-text URLs paired with their UTF-16 offset in
     /// `text`, used by `extractAllURLs` to merge-sort with markdown URLs.
     private static func extractPlainURLsWithPositions(from text: String) -> [(url: URL, position: Int)] {
         guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
@@ -69,7 +69,7 @@ enum MessageURLExtractor {
         extractMarkdownLinkURLsWithPositions(from: text).map(\.url)
     }
 
-    /// Returns markdown-link URLs paired with their character offset in
+    /// Returns markdown-link URLs paired with their UTF-16 offset in
     /// `text`, used by `extractAllURLs` to merge-sort with plain URLs.
     private static func extractMarkdownLinkURLsWithPositions(from text: String) -> [(url: URL, position: Int)] {
         let nsRange = NSRange(text.startIndex..., in: text)
@@ -94,7 +94,7 @@ enum MessageURLExtractor {
             guard !seen.contains(canonical) else { continue }
             seen.insert(canonical)
 
-            let position = text.distance(from: text.startIndex, to: urlRange.lowerBound)
+            let position = match.range(at: 1).location
             results.append((url: url, position: position))
         }
 

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorMarkdownTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorMarkdownTests.swift
@@ -205,4 +205,14 @@ final class MessageURLExtractorMarkdownTests: XCTestCase {
         XCTAssertEqual(urls[1].absoluteString, "https://b.com")
         XCTAssertEqual(urls[2].absoluteString, "https://c.com")
     }
+
+    func testExtractAllURLsPreservesGlobalOrder_WithEmoji() {
+        // Emoji are 1 Character but 2+ UTF-16 code units — positions must
+        // use the same coordinate space or the sort will be wrong.
+        let text = "🎉 [A](https://a.com) then https://b.com"
+        let urls = MessageURLExtractor.extractAllURLs(from: text)
+        XCTAssertEqual(urls.count, 2)
+        XCTAssertEqual(urls[0].absoluteString, "https://a.com")
+        XCTAssertEqual(urls[1].absoluteString, "https://b.com")
+    }
 }


### PR DESCRIPTION
Addresses review feedback on #4084.

Both Codex and Devin flagged that extractPlainURLsWithPositions uses UTF-16 code unit offsets (NSRange.location) while extractMarkdownLinkURLsWithPositions uses Swift Character counts (text.distance). These are incompatible coordinate spaces — with emoji or multi-byte Unicode before URLs, the merge-sort produces incorrect ordering.

Fix: use match.range(at: 1).location (UTF-16 offset) in the markdown extractor to match the plain-text extractor. Adds a regression test with emoji to prevent future breakage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
