### PR TITLE
fix: address review feedback on PR #4193 (credential_store metadata listing)

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
-import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -356,6 +356,37 @@ describe('credential_store tool', () => {
       expect(entries[0].service).toBe('keychain-test');
       expect(entries[0].field).toBe('token');
       expect(typeof entries[0].credential_id).toBe('string');
+    });
+
+    test('returns error when metadata file has unrecognized version', async () => {
+      // Write a metadata file with a future version that the current code cannot handle
+      const metadataPath = join(TEST_DIR, 'metadata.json');
+      writeFileSync(metadataPath, JSON.stringify({ version: 999, credentials: [] }), 'utf-8');
+
+      const result = await credentialStoreTool.execute({ action: 'list' }, _ctx);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('unrecognized version');
+    });
+
+    test('excludes metadata entries whose secret was deleted from secure storage', async () => {
+      // Store two credentials so both metadata and secrets exist
+      await credentialStoreTool.execute({
+        action: 'store', service: 'svc-a', field: 'key', value: 'val-a',
+      }, _ctx);
+      await credentialStoreTool.execute({
+        action: 'store', service: 'svc-b', field: 'key', value: 'val-b',
+      }, _ctx);
+
+      // Delete the secret directly without going through the tool (simulates
+      // a divergence where metadata write failed after secret deletion)
+      deleteSecureKey('credential:svc-a:key');
+
+      const result = await credentialStoreTool.execute({ action: 'list' }, _ctx);
+      expect(result.isError).toBe(false);
+      const entries = JSON.parse(result.content);
+      // svc-a's secret is gone, so it should be excluded even though metadata exists
+      expect(entries).toHaveLength(1);
+      expect(entries[0].service).toBe('svc-b');
     });
   });
 

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -3,7 +3,9 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import {
   setSecureKey,
+  getSecureKey,
   deleteSecureKey,
+  getBackendType,
 } from '../../security/secure-keys.js';
 import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata, listCredentialMetadata, assertMetadataWritable } from './metadata-store.js';
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
@@ -223,24 +225,36 @@ class CredentialStoreTool implements Tool {
       }
 
       case 'list': {
+        try {
+          assertMetadataWritable();
+        } catch {
+          return { content: 'Error: credential metadata file has an unrecognized version; cannot list credentials', isError: true };
+        }
+
         const allMetadata = listCredentialMetadata();
-        const entries = allMetadata.map((m) => {
-          const entry: Record<string, unknown> = {
-            credential_id: m.credentialId,
-            service: m.service,
-            field: m.field,
-          };
-          if (m.alias) {
-            entry.alias = m.alias;
-          }
-          if (m.injectionTemplates && m.injectionTemplates.length > 0) {
-            entry.injection_templates = {
-              count: m.injectionTemplates.length,
-              host_patterns: m.injectionTemplates.map((t) => t.hostPattern),
+        // On the encrypted backend we can cheaply verify each secret still exists,
+        // filtering out stale metadata left by divergent store/delete failures.
+        // On keychain we trust metadata since individual lookups are expensive.
+        const verifySecrets = getBackendType() === 'encrypted';
+        const entries = allMetadata
+          .filter((m) => !verifySecrets || getSecureKey(`credential:${m.service}:${m.field}`) !== undefined)
+          .map((m) => {
+            const entry: Record<string, unknown> = {
+              credential_id: m.credentialId,
+              service: m.service,
+              field: m.field,
             };
-          }
-          return entry;
-        });
+            if (m.alias) {
+              entry.alias = m.alias;
+            }
+            if (m.injectionTemplates && m.injectionTemplates.length > 0) {
+              entry.injection_templates = {
+                count: m.injectionTemplates.length,
+                host_patterns: m.injectionTemplates.map((t) => t.hostPattern),
+              };
+            }
+            return entry;
+          });
         return { content: JSON.stringify(entries, null, 2), isError: false };
       }
 


### PR DESCRIPTION
Addresses review feedback on #4193.

## Changes
- Surface metadata version errors in list output: list now calls assertMetadataWritable() and returns an error when the metadata file has an unrecognized version, instead of silently returning an empty array.
- Verify secret existence before listing metadata entries: on the encrypted backend, list now filters out metadata entries whose corresponding secret no longer exists in secure storage, preventing stale entries from appearing after divergent store/delete failures. On keychain backend, metadata is trusted since individual lookups are expensive.
- Added tests for both behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
