### PR TITLE
fix: form stuck on Submitting spinner when new form surface replaces old one

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -57,6 +57,7 @@ struct SurfaceContainerView: View {
                     let actionId = surface.actions.first?.id ?? "submit"
                     viewModel.onAction(actionId, values)
                 })
+                .id(surface.id)
             case .list(let data):
                 ListSurfaceView(data: data, onSelect: { selectedIds in
                     viewModel.onAction("select", ["selectedIds": selectedIds])

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -121,6 +121,7 @@ public struct InlineSurfaceRouter: View {
                 }
                 onAction(surface.id, "submit", payload)
             }
+            .id(surface.id)
         case .confirmation(let data):
             ConfirmationSurfaceView(data: data, actions: surface.actions) { actionId in
                 onAction(surface.id, actionId, nil)


### PR DESCRIPTION
## Summary
- Added `.id(surface.id)` to `FormSurfaceView` at both call sites (`SurfaceContainerView` and `InlineSurfaceRouter`) so SwiftUI resets `@State` (including `isSubmitted`) when the surface changes
- Fixes a bug where submitting one form caused subsequent form surfaces to immediately show the "Submitting…" spinner instead of the submit button, because SwiftUI preserved the stale `isSubmitted = true` across surface transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
