### PR TITLE
chore: stop running tests/type-checking/linting by default in slash commands

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -29,11 +29,9 @@ Remember the worktree path printed by the script. ALL work happens in the worktr
 
 ### 2. Implement the changes
 
-Working entirely inside the worktree directory, implement what was requested. Explore the codebase, make changes, add tests if appropriate, and type-check:
+Working entirely inside the worktree directory, implement what was requested. Explore the codebase and make changes.
 
-```bash
-cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
-```
+**Do NOT run tests, type-checking (`tsc`), or linting unless the task specifically requires it** (e.g., "fix the type errors", "make the tests pass"). These steps are slow and rarely catch issues for well-scoped changes.
 
 ### 3. Ship
 

--- a/.claude/commands/execute-plan.md
+++ b/.claude/commands/execute-plan.md
@@ -33,7 +33,7 @@ Read the PR section carefully. Implement all the changes described:
 
 #### 3b. Validate
 
-Run the tests and type-checks specified in the PR section. Fix any failures before proceeding.
+**Do NOT run tests, type-checking (`tsc`), or linting unless the plan's PR section explicitly specifies validation steps.** These steps are slow and rarely catch issues for well-scoped changes.
 
 #### 3c. Mainline
 

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -84,11 +84,7 @@ Read the next PR section from the plan. Implement all changes in the worktree.
 
 #### 8c. Validate
 
-```bash
-cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
-```
-
-Fix any failures before proceeding.
+**Do NOT run tests, type-checking (`tsc`), or linting unless the plan's PR section explicitly specifies validation steps.** These steps are slow and rarely catch issues for well-scoped changes.
 
 #### 8d. Ship (do NOT merge)
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -199,7 +199,7 @@ ALL work happens here. Do NOT touch the main repo.
 
 ## Workflow
 1. Make the changes in your worktree.
-2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
+2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
 3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
    cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base <feature-branch-name> --merge --assignee @me
 4. Send a message to "lead" with:

--- a/.claude/commands/safe-check-review.md
+++ b/.claude/commands/safe-check-review.md
@@ -84,10 +84,7 @@ If any reviewer requested changes OR CI is failing:
    cd <worktree> && git pull origin <branch>
    ```
 3. If CI is failing, read the failing check logs to understand what went wrong. If reviewers requested changes, read the **unresolved** review threads from step 2. Implement all fixes in the worktree.
-4. Validate:
-   ```bash
-   cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
-   ```
+4. Do NOT run tests, type-checking (tsc), or linting unless the review feedback specifically requires it.
 5. Commit and push:
    ```bash
    cd <worktree>

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -29,11 +29,9 @@ Remember the worktree path printed by the script. ALL work happens in the worktr
 
 ### 2. Implement the changes
 
-Working entirely inside the worktree directory, implement what was requested. Explore the codebase, make changes, add tests if appropriate, and type-check:
+Working entirely inside the worktree directory, implement what was requested. Explore the codebase and make changes.
 
-```bash
-cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
-```
+**Do NOT run tests, type-checking (`tsc`), or linting unless the task specifically requires it** (e.g., "fix the type errors", "make the tests pass"). These steps are slow and rarely catch issues for well-scoped changes.
 
 ### 3. Ship (do NOT merge)
 

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -61,13 +61,7 @@ Read the PR section carefully. Implement all the changes described:
 
 #### 4c. Validate
 
-Run the tests and type-checks specified in the PR section:
-
-```bash
-cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
-```
-
-Fix any failures before proceeding.
+**Do NOT run tests, type-checking (`tsc`), or linting unless the plan's PR section explicitly specifies validation steps.** These steps are slow and rarely catch issues for well-scoped changes.
 
 #### 4d. Ship (do NOT merge)
 

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -67,7 +67,7 @@ ALL work happens here. Do NOT touch the main repo.
 
 ## Workflow
 1. Make the changes in your worktree.
-2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
+2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
 3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
    cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base main --merge --assignee @me
 4. Send a message to "lead" with:


### PR DESCRIPTION
## Summary
- Removed unconditional `bunx tsc --noEmit` validation steps from 8 slash commands: `/do`, `/safe-do`, `/swarm`, `/safe-blitz`, `/execute-plan`, `/safe-execute-plan`, `/resume-plan`, `/safe-check-review`
- Each now explicitly states: do NOT run tests, type-checking, or linting unless the task specifically requires it
- Rationale: these steps are slow and rarely catch issues for well-scoped changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
