### PR TITLE
fix: clean up projected skill tools on CU session terminal state

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -19,7 +19,7 @@ import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getSandboxWorkingDir } from '../util/platform.js';
 import { getConfig } from '../config/loader.js';
-import { projectSkillTools } from './session-skill-tools.js';
+import { projectSkillTools, resetSkillToolProjection } from './session-skill-tools.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('computer-use-session');
@@ -559,6 +559,7 @@ export class ComputerUseSession {
   private notifyTerminal(): void {
     if (this.terminalNotified) return;
     this.terminalNotified = true;
+    resetSkillToolProjection(this.skillProjectionState);
     this.onTerminal?.(this.sessionId);
   }
 


### PR DESCRIPTION
## Summary
- `ComputerUseSession` projected skill tools into the global registry via `projectSkillTools()` but never called `resetSkillToolProjection()` on terminal state, causing refcount growth and cross-test contamination.
- Adds `resetSkillToolProjection(this.skillProjectionState)` in `notifyTerminal()`, which is the single bottleneck for all terminal paths (complete, error, abort). This matches the pattern used by text sessions in `Session.dispose()`.

## Test plan
- [x] `bun test src/__tests__/computer-use-session-lifecycle.test.ts` — 6/6 pass
- [x] `bun test src/__tests__/computer-use-skill-baseline.test.ts` — 7/7 pass
- [x] Combined cross-suite run (lifecycle + baseline in one process) — 13/13 pass, no contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
