### PR TITLE
fix(daemon): replace debug print() with log.debug() in documentEditorShow

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1201,10 +1201,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         case .uiSurfaceComplete(let msg):
             onSurfaceComplete?(msg)
         case .documentEditorShow(let msg):
-            print("🔵 DaemonClient: documentEditorShow received - surfaceId=\(msg.surfaceId), title=\(msg.title)")
-            print("🔵 DaemonClient: callback exists? \(onDocumentEditorShow != nil)")
+            log.debug("documentEditorShow received — surfaceId=\(msg.surfaceId, privacy: .public), title=\(msg.title, privacy: .public)")
             onDocumentEditorShow?(msg)
-            print("🔵 DaemonClient: callback invoked")
+            log.debug("documentEditorShow callback invoked")
         case .documentEditorUpdate(let msg):
             onDocumentEditorUpdate?(msg)
         case .documentSaveResponse(let msg):


### PR DESCRIPTION
## Summary
- Replace 3 production `print()` statements with `log.debug()` in DaemonClient's documentEditorShow handler
- Remove redundant 'callback exists?' print
- Use existing `log` OSLog Logger already in file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
