### PR TITLE
fix: address review feedback on PR #4170 (credential resolver)

### DIFF
--- a/assistant/src/__tests__/credential-resolve.test.ts
+++ b/assistant/src/__tests__/credential-resolve.test.ts
@@ -253,5 +253,17 @@ describe('credential resolver', () => {
       expect(resolveForDomain('api.exact.com')).toHaveLength(1);
       expect(resolveForDomain('other.exact.com')).toHaveLength(0);
     });
+
+    test('matches hostnames case-insensitively', () => {
+      upsertCredentialMetadata('casefold', 'key', {
+        injectionTemplates: [
+          { hostPattern: '*.Example.COM', injectionType: 'header', headerName: 'Authorization' },
+        ],
+      });
+
+      expect(resolveForDomain('api.example.com')).toHaveLength(1);
+      expect(resolveForDomain('API.EXAMPLE.COM')).toHaveLength(1);
+      expect(resolveForDomain('Api.Example.Com')).toHaveLength(1);
+    });
   });
 });

--- a/assistant/src/tools/credentials/resolve.ts
+++ b/assistant/src/tools/credentials/resolve.ts
@@ -79,7 +79,7 @@ export function resolveForDomain(
   for (const meta of all) {
     const templates = meta.injectionTemplates ?? [];
     const matching = templates.filter((t) =>
-      minimatch(hostname, t.hostPattern),
+      minimatch(hostname, t.hostPattern, { nocase: true }),
     );
     if (matching.length === 0) continue;
     results.push({


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4170

- Use case-insensitive matching (`{ nocase: true }`) in `resolveForDomain()` since DNS hostnames are case-insensitive
- Add test for case-insensitive hostname matching
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
