### PR TITLE
fix: address review feedback on PR #4053 (scopeId threading)

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3507,7 +3507,7 @@ describe('Memory regressions', () => {
     const withoutScope = await extractAndUpsertMemoryItemsForMessage('msg-scope-pass');
     expect(withoutScope).toBeGreaterThan(0);
 
-    // Call with explicit scopeId — should also succeed (scopeId is threaded but not yet used)
+    // Call with explicit scopeId — should also succeed and scope items accordingly
     db.insert(messages).values({
       id: 'msg-scope-pass-2',
       conversationId: 'conv-scope-pass',


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4053

The Codex review flagged that scopeId was unused in extractAndUpsertMemoryItemsForMessage. A subsequent PR already wired scopeId into the function body, so the lint concern is resolved. This PR updates a stale test comment that still said 'scopeId is threaded but not yet used' — it is now actively used for scoping items.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
