### PR TITLE
fix: preserve source-domain allowlist semantics for video embeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -101,7 +101,7 @@ enum MediaEmbedResolver {
     ) -> VideoParseResult? {
         for parser in videoParsers {
             if let result = parser(url) {
-                guard DomainAllowlistMatcher.isAllowed(result.embedURL, allowedDomains: allowedDomains) else {
+                guard DomainAllowlistMatcher.isAllowed(url, allowedDomains: allowedDomains) else {
                     return nil
                 }
                 return result


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4075

Reverts the allowlist check to use the original source URL instead of the embed URL. Checking the embed URL broke domain-specific allowlist behavior -- e.g. a youtu.be short link would be checked against youtube.com (the embed host), so if the allowlist contained only youtu.be, the video would be incorrectly rejected. The DomainAllowlistMatcher already handles case-insensitive scheme comparison via lowercased(), so no additional normalization is needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
