### PR TITLE
fix: address review feedback on PR #4130 (README updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Once loaded, the following tools become available for the remainder of the sessi
 
 ### Permissions
 
-Both `skill_load` and all `browser_*` tools are default-allowed — no permission prompts are required to use them.
+All `browser_*` tools are declared as low-risk. The system seeds default trust rules for `skill_load` and every `browser_*` tool, so they are auto-allowed in both legacy and strict permission modes out of the box. Users can remove or override these default rules via `~/.vellum/protected/trust.json` if they want to require explicit approval.
 
 ## Permission Modes and Trust Rules
 


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4130 — corrects the browser permissions section to explain the default trust rule mechanism instead of incorrectly claiming tools are inherently default-allowed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
