### PR TITLE
fix: address review feedback on PR #4078 (memory regression tests)

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3875,8 +3875,11 @@ describe('Memory regressions', () => {
     expect(privRecall.injectedText.toLowerCase()).toContain('zephyr');
 
     // 5. Standard thread recall — must NOT find the Zephyr fact (no leak)
+    // Mirror the production call in session-memory.ts: for standard threads
+    // (scopeId === 'default'), scopePolicyOverride is undefined.
     const stdRecall = await buildMemoryRecall('Zephyr framework microservices', stdConv.id, recallConfig, {
-      scopeId: 'default',
+      scopeId: stdScope,
+      scopePolicyOverride: undefined,
     });
     const stdCandidateKeys = stdRecall.topCandidates.map((c) => c.key);
     const hasZephyrInStandard = privateItemKeys.some((k) => stdCandidateKeys.includes(k));


### PR DESCRIPTION
## Summary
- Updated standard-thread recall test to mirror the production call pattern in session-memory.ts
- Uses `stdScope` variable (derived from conversation) instead of hardcoded `'default'` string
- Explicitly passes `scopePolicyOverride: undefined` to match runtime behavior for standard threads

Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4078

## Test plan
- [x] Change is test-only — aligns the regression test with the actual production code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
