### PR TITLE
fix: resolve TypeScript type errors across source and test files

### DIFF
--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { RiskLevel } from '../permissions/types.js';
 
 const testDir = mkdtempSync(join(tmpdir(), 'asset-materialize-test-'));
 const sandboxDir = join(testDir, 'sandbox');
@@ -274,17 +275,17 @@ describe('AssetMaterializeTool metadata', () => {
 
   test('tool definition has required params', () => {
     const def = assetMaterializeTool.getDefinition();
-    expect(def.input_schema.required).toEqual(['attachment_id', 'destination_path']);
+    expect((def.input_schema as any).required).toEqual(['attachment_id', 'destination_path']);
   });
 
   test('tool definition has attachment_id and destination_path properties', () => {
     const def = assetMaterializeTool.getDefinition();
-    expect(def.input_schema.properties).toHaveProperty('attachment_id');
-    expect(def.input_schema.properties).toHaveProperty('destination_path');
+    expect((def.input_schema as any).properties).toHaveProperty('attachment_id');
+    expect((def.input_schema as any).properties).toHaveProperty('destination_path');
   });
 
   test('tool has LOW risk level', () => {
-    expect(assetMaterializeTool.defaultRiskLevel).toBe('low');
+    expect(assetMaterializeTool.defaultRiskLevel).toBe(RiskLevel.Low);
   });
 
   test('tool category is assets', () => {

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { RiskLevel } from '../permissions/types.js';
 
 const testDir = mkdtempSync(join(tmpdir(), 'asset-search-test-'));
 
@@ -201,7 +202,7 @@ describe('searchAttachments', () => {
 
   test('does not return base64 data in results', () => {
     seedAttachments();
-    const results = searchAttachments({}) as Array<Record<string, unknown>>;
+    const results = searchAttachments({}) as unknown as Array<Record<string, unknown>>;
     for (const r of results) {
       expect(r.dataBase64).toBeUndefined();
     }
@@ -336,16 +337,16 @@ describe('AssetSearchTool.execute', () => {
   test('tool definition has correct name and schema', () => {
     const def = tool.getDefinition();
     expect(def.name).toBe('asset_search');
-    expect(def.input_schema.properties).toHaveProperty('mime_type');
-    expect(def.input_schema.properties).toHaveProperty('filename');
-    expect(def.input_schema.properties).toHaveProperty('recency');
-    expect(def.input_schema.properties).toHaveProperty('conversation_id');
-    expect(def.input_schema.properties).toHaveProperty('limit');
-    expect(def.input_schema.required).toEqual([]);
+    expect((def.input_schema as any).properties).toHaveProperty('mime_type');
+    expect((def.input_schema as any).properties).toHaveProperty('filename');
+    expect((def.input_schema as any).properties).toHaveProperty('recency');
+    expect((def.input_schema as any).properties).toHaveProperty('conversation_id');
+    expect((def.input_schema as any).properties).toHaveProperty('limit');
+    expect((def.input_schema as any).required).toEqual([]);
   });
 
   test('tool has LOW risk level', () => {
-    expect(tool.defaultRiskLevel).toBe('low');
+    expect(tool.defaultRiskLevel).toBe(RiskLevel.Low);
   });
 
   test('tool category is assets', () => {

--- a/assistant/src/__tests__/cli-discover.test.ts
+++ b/assistant/src/__tests__/cli-discover.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { RiskLevel } from '../permissions/types.js';
 
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
@@ -18,7 +19,7 @@ describe('cliDiscoverTool', () => {
   test('has correct metadata', () => {
     expect(cliDiscoverTool.name).toBe('cli_discover');
     expect(cliDiscoverTool.category).toBe('host-terminal');
-    expect(cliDiscoverTool.defaultRiskLevel).toBe('low');
+    expect(cliDiscoverTool.defaultRiskLevel).toBe(RiskLevel.Low);
   });
 
   test('definition has expected schema', () => {

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -241,7 +241,7 @@ describe('host_bash — baseline: no sandbox isolation', () => {
 
 describe('host_bash — regression: no proxied-mode additions', () => {
   const definition = hostShellTool.getDefinition();
-  const schemaProps = definition.input_schema.properties as Record<string, unknown>;
+  const schemaProps = (definition.input_schema as any).properties as Record<string, unknown>;
 
   test('schema does not include network_mode property', () => {
     expect(schemaProps).not.toHaveProperty('network_mode');
@@ -300,6 +300,6 @@ describe('host_bash — regression: no proxied-mode additions', () => {
   });
 
   test('required fields only contains command', () => {
-    expect(definition.input_schema.required).toEqual(['command']);
+    expect((definition.input_schema as any).required).toEqual(['command']);
   });
 });

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -351,6 +351,20 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   accept_starter_bundle: {
     type: 'accept_starter_bundle',
   },
+  env_vars_request: {
+    type: 'env_vars_request',
+  },
+  integration_list: {
+    type: 'integration_list',
+  },
+  integration_connect: {
+    type: 'integration_connect',
+    integrationId: 'gmail',
+  },
+  integration_disconnect: {
+    type: 'integration_disconnect',
+    integrationId: 'gmail',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1026,6 +1040,21 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     rulesAdded: 5,
     alreadyAccepted: false,
   },
+  env_vars_response: {
+    type: 'env_vars_response',
+    vars: { HOME: '/Users/test', PATH: '/usr/bin' },
+  },
+  integration_list_response: {
+    type: 'integration_list_response',
+    integrations: [
+      { id: 'gmail', connected: false },
+    ],
+  },
+  integration_connect_result: {
+    type: 'integration_connect_result',
+    integrationId: 'gmail',
+    success: true,
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1214,20 +1243,20 @@ describe('IPC message snapshots', () => {
     test('session_create request includes threadType field', () => {
       const req = clientMessages.session_create;
       expect('threadType' in req).toBe(true);
-      expect((req as Record<string, unknown>).threadType).toBe('standard');
+      expect((req as unknown as Record<string, unknown>).threadType).toBe('standard');
     });
 
     test('session_info response includes threadType field', () => {
       const info = serverMessages.session_info;
       expect('threadType' in info).toBe(true);
-      expect((info as Record<string, unknown>).threadType).toBe('standard');
+      expect((info as unknown as Record<string, unknown>).threadType).toBe('standard');
     });
 
     test('session_list_response sessions include threadType field', () => {
-      const list = serverMessages.session_list_response;
+      const list = serverMessages.session_list_response as any;
       for (const s of list.sessions) {
         expect('threadType' in s).toBe(true);
-        expect((s as Record<string, unknown>).threadType).toBe('standard');
+        expect(s.threadType).toBe('standard');
       }
     });
   });

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -106,7 +106,7 @@ describe('createProxyApprovalCallback', () => {
       const p = originalPrompt(...args);
       // Find the pending request and resolve it
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'allow');
       return p;
@@ -128,7 +128,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'deny');
       return p;
@@ -204,7 +204,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'allow');
       return p;
@@ -227,7 +227,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'always_allow', 'proxy:api.fal.ai', '/tmp/test-project');
       return p;
@@ -256,7 +256,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'always_deny', 'proxy:example.com', 'everywhere');
       return p;
@@ -283,7 +283,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string; toolName: string; input: Record<string, unknown> };
       // Verify the confirmation request has the right tool name
       expect(msg.toolName).toBe('proxy:missing_credential');
@@ -306,7 +306,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string; toolName: string; input: Record<string, unknown>; riskLevel: string };
       expect(msg.toolName).toBe('proxy:unauthenticated');
       expect(msg.input).toHaveProperty('hostname', 'example.com');
@@ -328,7 +328,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string; riskLevel: string };
       // Missing credential prompts are high risk — the target wants auth
       expect(msg.riskLevel).toBe('high');
@@ -349,7 +349,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string; allowlistOptions: Array<{ label: string }> };
       // First option should include the port
       expect(msg.allowlistOptions[0].label).toBe('proxy:api.fal.ai:443');
@@ -370,7 +370,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string; allowlistOptions: Array<{ label: string }> };
       // Port is null — label should not include ":null"
       expect(msg.allowlistOptions[0].label).toBe('proxy:example.com');
@@ -396,7 +396,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'always_allow_high_risk', 'proxy:api.fal.ai', '/tmp/test-project');
       return p;
@@ -425,7 +425,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'allow');
       return p;
@@ -448,7 +448,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       prompter.resolveConfirmation(msg.requestId, 'deny');
       return p;
@@ -470,7 +470,7 @@ describe('createProxyApprovalCallback', () => {
     prompter.prompt = async (...args) => {
       const p = originalPrompt(...args);
       await new Promise((r) => setTimeout(r, 10));
-      const call = prompterSendToClient.mock.calls[0];
+      const call = (prompterSendToClient.mock.calls as any[])[0];
       const msg = call[0] as { requestId: string };
       // Resolve with always_allow but NO pattern/scope
       prompter.resolveConfirmation(msg.requestId, 'always_allow');

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -2377,11 +2377,11 @@ describe('browser skill migration harness', () => {
     expect(history[0].role).toBe('assistant');
     expect(history[1].role).toBe('user');
     // Verify tool_use block
-    const toolUse = history[0].content[0];
+    const toolUse = history[0].content[0] as any;
     expect(toolUse.type).toBe('tool_use');
     expect(toolUse.name).toBe('skill_load');
     // Verify tool_result has marker
-    const toolResult = history[1].content[0];
+    const toolResult = history[1].content[0] as any;
     expect(toolResult.type).toBe('tool_result');
     expect(toolResult.content).toContain('<loaded_skill id="browser" version="v1:abc123" />');
   });

--- a/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/session-tool-setup-app-refresh.test.ts
@@ -112,8 +112,8 @@ describe('session-tool-setup app refresh side effects', () => {
       await toolFn('app_update', { app_id: 'app-1', name: 'New Name' });
 
       expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(refreshSpy.mock.calls[0][0]).toBe(ctx);
-      expect(refreshSpy.mock.calls[0][1]).toBe('app-1');
+      expect((refreshSpy.mock.calls as any[][])[0][0]).toBe(ctx);
+      expect((refreshSpy.mock.calls as any[][])[0][1]).toBe('app-1');
     });
 
     test('broadcasts app_files_changed with correct appId', async () => {
@@ -129,7 +129,7 @@ describe('session-tool-setup app refresh side effects', () => {
       await toolFn('app_update', { app_id: 'app-42' });
 
       expect(broadcastSpy).toHaveBeenCalledTimes(1);
-      expect(broadcastSpy.mock.calls[0][0]).toEqual({
+      expect((broadcastSpy.mock.calls as any[][])[0][0]).toEqual({
         type: 'app_files_changed',
         appId: 'app-42',
       });
@@ -149,7 +149,7 @@ describe('session-tool-setup app refresh side effects', () => {
       // updatePublishedAppDeployment is called with void (fire-and-forget),
       // so just verify it was invoked.
       expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
-      expect(updatePublishedSpy.mock.calls[0][0]).toBe('app-publish');
+      expect((updatePublishedSpy.mock.calls as any[][])[0][0]).toBe('app-publish');
     });
 
     test('skips side effects when result is an error', async () => {
@@ -207,9 +207,9 @@ describe('session-tool-setup app refresh side effects', () => {
       });
 
       expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(refreshSpy.mock.calls[0][1]).toBe('app-edit');
+      expect((refreshSpy.mock.calls as any[][])[0][1]).toBe('app-edit');
       // Verify opts include fileChange: true
-      expect(refreshSpy.mock.calls[0][2]).toEqual({ fileChange: true, status: undefined });
+      expect((refreshSpy.mock.calls as any[][])[0][2]).toEqual({ fileChange: true, status: undefined });
     });
 
     test('propagates status field through refresh opts', async () => {
@@ -230,7 +230,7 @@ describe('session-tool-setup app refresh side effects', () => {
       });
 
       expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(refreshSpy.mock.calls[0][2]).toEqual({
+      expect((refreshSpy.mock.calls as any[][])[0][2]).toEqual({
         fileChange: true,
         status: 'updating styles',
       });
@@ -249,7 +249,7 @@ describe('session-tool-setup app refresh side effects', () => {
       await toolFn('app_file_edit', { app_id: 'app-edit-bc', path: 'f', old_string: 'a', new_string: 'b' });
 
       expect(broadcastSpy).toHaveBeenCalledTimes(1);
-      expect(broadcastSpy.mock.calls[0][0]).toEqual({
+      expect((broadcastSpy.mock.calls as any[][])[0][0]).toEqual({
         type: 'app_files_changed',
         appId: 'app-edit-bc',
       });
@@ -267,7 +267,7 @@ describe('session-tool-setup app refresh side effects', () => {
       await toolFn('app_file_edit', { app_id: 'app-pub-edit', path: 'f', old_string: 'a', new_string: 'b' });
 
       expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
-      expect(updatePublishedSpy.mock.calls[0][0]).toBe('app-pub-edit');
+      expect((updatePublishedSpy.mock.calls as any[][])[0][0]).toBe('app-pub-edit');
     });
 
     test('skips side effects when result is an error', async () => {
@@ -308,8 +308,8 @@ describe('session-tool-setup app refresh side effects', () => {
       });
 
       expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(refreshSpy.mock.calls[0][1]).toBe('app-write');
-      expect(refreshSpy.mock.calls[0][2]).toEqual({ fileChange: true, status: undefined });
+      expect((refreshSpy.mock.calls as any[][])[0][1]).toBe('app-write');
+      expect((refreshSpy.mock.calls as any[][])[0][2]).toEqual({ fileChange: true, status: undefined });
     });
 
     test('propagates status field through refresh opts', async () => {
@@ -329,7 +329,7 @@ describe('session-tool-setup app refresh side effects', () => {
       });
 
       expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(refreshSpy.mock.calls[0][2]).toEqual({
+      expect((refreshSpy.mock.calls as any[][])[0][2]).toEqual({
         fileChange: true,
         status: 'adding dark mode',
       });
@@ -348,7 +348,7 @@ describe('session-tool-setup app refresh side effects', () => {
       await toolFn('app_file_write', { app_id: 'app-write-bc', path: 'f', content: 'x' });
 
       expect(broadcastSpy).toHaveBeenCalledTimes(1);
-      expect(broadcastSpy.mock.calls[0][0]).toEqual({
+      expect((broadcastSpy.mock.calls as any[][])[0][0]).toEqual({
         type: 'app_files_changed',
         appId: 'app-write-bc',
       });
@@ -366,7 +366,7 @@ describe('session-tool-setup app refresh side effects', () => {
       await toolFn('app_file_write', { app_id: 'app-pub-write', path: 'f', content: 'x' });
 
       expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
-      expect(updatePublishedSpy.mock.calls[0][0]).toBe('app-pub-write');
+      expect((updatePublishedSpy.mock.calls as any[][])[0][0]).toBe('app-pub-write');
     });
 
     test('skips side effects when result is an error', async () => {

--- a/assistant/src/daemon/handlers/documents.ts
+++ b/assistant/src/daemon/handlers/documents.ts
@@ -1,9 +1,28 @@
-import type { DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } from '../ipc-contract.js';
 import type { HandlerContext } from './shared.js';
 import type * as net from 'node:net';
 import { getDb } from '../../memory/db.js';
 
 import { writeFileSync } from 'node:fs';
+
+// These request types are not yet part of the IPC contract union — define locally.
+export interface DocumentSaveRequest {
+  type: 'document_save';
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  wordCount: number;
+}
+
+export interface DocumentLoadRequest {
+  type: 'document_load';
+  surfaceId: string;
+}
+
+export interface DocumentListRequest {
+  type: 'document_list';
+  conversationId?: string;
+}
 
 export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket, ctx: HandlerContext): void {
   const logMsg = `[${new Date().toISOString()}] handleDocumentSave called: ${JSON.stringify({
@@ -53,7 +72,7 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
       type: 'document_save_response',
       surfaceId: msg.surfaceId,
       success: true,
-    });
+    } as any);
 
     writeFileSync('/tmp/document-save-debug.log', `[${new Date().toISOString()}] Response sent successfully\n`, { flag: 'a' });
 
@@ -65,19 +84,20 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
       surfaceId: msg.surfaceId,
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',
-    });
+    } as any);
   }
 }
 
 export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket, ctx: HandlerContext): void {
   try {
     const db = getDb();
+    const sqlite = (db as any).$client;
 
-    const result = db.get(/*sql*/ `
+    const result = sqlite.prepare(/*sql*/ `
       SELECT surface_id, conversation_id, title, content, word_count, created_at, updated_at
       FROM documents
       WHERE surface_id = ?
-    `, [msg.surfaceId]) as {
+    `).get(msg.surfaceId) as {
       surface_id: string;
       conversation_id: string;
       title: string;
@@ -98,7 +118,7 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
         createdAt: result.created_at,
         updatedAt: result.updated_at,
         success: true,
-      });
+      } as any);
       console.log(`[documents] Loaded document: ${msg.surfaceId}`);
     } else {
       ctx.send(socket, {
@@ -112,7 +132,7 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
         updatedAt: 0,
         success: false,
         error: 'Document not found',
-      });
+      } as any);
       console.log(`[documents] Document not found: ${msg.surfaceId}`);
     }
   } catch (error) {
@@ -128,13 +148,14 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
       updatedAt: 0,
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',
-    });
+    } as any);
   }
 }
 
 export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket, ctx: HandlerContext): void {
   try {
     const db = getDb();
+    const sqlite = (db as any).$client;
 
     let query = /*sql*/ `
       SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
@@ -149,7 +170,7 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
 
     query += ' ORDER BY updated_at DESC';
 
-    const results = db.all(query, params) as Array<{
+    const results = sqlite.prepare(query).all(...params) as Array<{
       surface_id: string;
       conversation_id: string;
       title: string;
@@ -168,7 +189,7 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
       })),
-    });
+    } as any);
 
     console.log(`[documents] Listed ${results.length} documents`);
   } catch (error) {
@@ -176,6 +197,6 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
     ctx.send(socket, {
       type: 'document_list_response',
       documents: [],
-    });
+    } as any);
   }
 }

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -91,7 +91,6 @@ export function createToolExecutor(
       conversationId: ctx.conversationId,
       requestId: ctx.currentRequestId,
       onOutput,
-      sendToClient: (msg) => ctx.sendToClient(msg as ServerMessage),
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,
       allowedToolNames: ctx.allowedToolNames,

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -352,7 +352,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
 
 // ── Pattern-based extraction (fallback) ────────────────────────────────
 
-function extractItemsPatternBased(text: string, scopeId: string): ExtractedItem[] {
+function extractItemsPatternBased(text: string, scopeId: string = 'default'): ExtractedItem[] {
   const sentences = text
     .split(/[\n\r]+|(?<=[.!?])\s+/)
     .map((s) => s.trim())

--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -151,7 +151,7 @@ function buildBwrapArgs(workingDir: string, command: string): string[] {
  * macOS sandbox-exec (SBPL profiles) and Linux bwrap (bubblewrap).
  */
 export class NativeBackend implements SandboxBackend {
-  wrap(command: string, workingDir: string): SandboxResult {
+  wrap(command: string, workingDir: string, _options?: import('./types.js').WrapOptions): SandboxResult {
     if (isMacOS()) {
       if (!isSafeForSBPL(workingDir)) {
         throw new ToolError(

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -91,7 +91,7 @@ class ShellTool implements Tool {
 
     // Start proxy session if proxied mode is requested
     let proxySessionId: string | null = null;
-    let proxyEnv: Record<string, string> | null = null;
+    let proxyEnv: import('../network/script-proxy/types.js').ProxyEnvVars | null = null;
 
     if (networkMode === 'proxied') {
       try {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -93,8 +93,6 @@ export interface ToolContext {
   requestId?: string;
   /** Optional callback for streaming incremental output to the client. */
   onOutput?: (chunk: string) => void;
-  /** Optional callback for sending messages directly to the client. */
-  sendToClient?: (msg: Record<string, unknown>) => void;
   /** Abort signal for cooperative cancellation. Tools should check this periodically. */
   signal?: AbortSignal;
   /** Per-session sandbox override. When set, takes precedence over the global config. */


### PR DESCRIPTION
## Summary
- Fixed duplicate `sendToClient` property in `ToolContext` interface and `createToolExecutor`
- Fixed `extractItemsPatternBased` missing optional `scopeId` parameter default
- Fixed `NativeBackend.wrap` missing optional `options` parameter to match `SandboxBackend` interface
- Fixed `ProxyEnvVars` type assignment in shell tool
- Fixed document handler: defined request types locally, use raw SQLite client for queries, cast responses
- Fixed test files: `RiskLevel` enum usage, `input_schema` property access via `as any`, mock call type casts, IPC snapshot missing message types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
