### PR TITLE
fix: address review feedback on PR #4083 (MIME probe)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -828,6 +828,13 @@ private struct ChatBubble: View {
         !isUser && onReportMessage != nil
     }
 
+    /// Composite identity for the `.task` modifier so it re-runs when either
+    /// the message text or the embed settings change.
+    private var mediaEmbedTaskID: String {
+        let s = mediaEmbedSettings
+        return "\(message.text)|\(s?.enabled ?? false)|\(s?.enabledSince?.timeIntervalSince1970 ?? 0)|\(s?.allowedDomains ?? [])"
+    }
+
     private var statusLabel: String? {
         switch message.status {
         case .queued(let position):
@@ -983,12 +990,14 @@ private struct ChatBubble: View {
                 isHovered = false
             }
         }
-        .task(id: message.text) {
+        .task(id: mediaEmbedTaskID) {
             guard let settings = mediaEmbedSettings else {
                 mediaEmbedIntents = []
                 return
             }
-            mediaEmbedIntents = await MediaEmbedResolver.resolve(message: message, settings: settings)
+            let resolved = await MediaEmbedResolver.resolve(message: message, settings: settings)
+            guard !Task.isCancelled else { return }
+            mediaEmbedIntents = resolved
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
@@ -9,8 +9,8 @@ enum ImageURLClassification {
 /// Classifies URLs as image candidates based purely on file extension.
 ///
 /// This is the first stage of image detection in the media-embed pipeline.
-/// URLs with unrecognized extensions return `.unknown` so that a later
-/// MIME-probe stage can resolve them via HTTP HEAD.
+/// Only truly extensionless URLs return `.unknown` (triggering the MIME-probe
+/// fallback); URLs with a non-image extension return `.notImage`.
 enum ImageURLClassifier {
 
     private static let imageExtensions: Set<String> = [
@@ -44,6 +44,7 @@ enum ImageURLClassifier {
             return .image
         }
 
-        return .unknown
+        // Has a non-image extension — no need for a MIME probe.
+        return .notImage
     }
 }

--- a/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
+++ b/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
@@ -104,21 +104,21 @@ final class ImageURLClassifierExtensionTests: XCTestCase {
         XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
     }
 
-    // MARK: - Unrecognized extensions return unknown (eligible for MIME probe)
+    // MARK: - Non-image extensions return notImage (skip MIME probe)
 
-    func testHTMLReturnsUnknown() {
+    func testHTMLReturnsNotImage() {
         let url = URL(string: "https://example.com/page.html")!
-        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
     }
 
-    func testPDFReturnsUnknown() {
+    func testPDFReturnsNotImage() {
         let url = URL(string: "https://example.com/document.pdf")!
-        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
     }
 
-    func testZIPReturnsUnknown() {
+    func testZIPReturnsNotImage() {
         let url = URL(string: "https://example.com/archive.zip")!
-        XCTAssertEqual(ImageURLClassifier.classify(url), .unknown)
+        XCTAssertEqual(ImageURLClassifier.classify(url), .notImage)
     }
 
     // MARK: - No extension returns unknown

--- a/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
@@ -360,7 +360,7 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
     func testImageURLClassifierNonImageExtension() {
         let url = URL(string: "https://cdn.example.com/document.pdf")!
         let result = ImageURLClassifier.classify(url)
-        XCTAssertEqual(result, .unknown, ".pdf should classify as .unknown")
+        XCTAssertEqual(result, .notImage, ".pdf should classify as .notImage")
     }
 
     func testImageURLClassifierNoExtension() {


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4083

## Changes

1. **ImageURLClassifier: return .notImage for non-image extensions** — URLs with extensions like .pdf, .html, .js were incorrectly classified as .unknown, triggering unnecessary HTTP HEAD MIME probes. Now only truly extensionless URLs return .unknown (eligible for probe).

2. **ChatView: track mediaEmbedSettings in .task(id:)** — The task modifier only re-ran when message.text changed. Toggling media embeds or editing the domain allowlist in Settings had no effect on existing messages until text changed. Now uses a composite task ID that includes enabled, enabledSince, and allowedDomains.

3. **ChatView: cancellation check before state mutation** — A cancelled task run could race and overwrite newer results. Now checks Task.isCancelled before assigning resolved intents.

4. **Updated tests** to expect .notImage (not .unknown) for URLs with non-image extensions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
