### PR TITLE
feat(ios): store daemon session token in Keychain and extract UserDefaults key constants

### DIFF
--- a/clients/ios/App/UserDefaultsKeys.swift
+++ b/clients/ios/App/UserDefaultsKeys.swift
@@ -1,0 +1,11 @@
+#if canImport(UIKit)
+import Foundation
+
+enum UserDefaultsKeys {
+    static let connectionMode = "connection_mode"
+    static let daemonHostname = "daemon_hostname"
+    static let daemonPort = "daemon_port"
+    static let daemonTLSEnabled = "daemon_tls_enabled"
+    static let appearanceMode = "appearance_mode"
+}
+#endif

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -99,7 +99,7 @@ struct ConnectionModeStep: View {
                     isSelected: selectedMode == ConnectionMode.standalone.rawValue
                 ) {
                     selectedMode = ConnectionMode.standalone.rawValue
-                    UserDefaults.standard.set(ConnectionMode.standalone.rawValue, forKey: "connection_mode")
+                    UserDefaults.standard.set(ConnectionMode.standalone.rawValue, forKey: UserDefaultsKeys.connectionMode)
                 }
 
                 ModeCard(
@@ -109,7 +109,7 @@ struct ConnectionModeStep: View {
                     isSelected: selectedMode == ConnectionMode.connected.rawValue
                 ) {
                     selectedMode = ConnectionMode.connected.rawValue
-                    UserDefaults.standard.set(ConnectionMode.connected.rawValue, forKey: "connection_mode")
+                    UserDefaults.standard.set(ConnectionMode.connected.rawValue, forKey: UserDefaultsKeys.connectionMode)
                 }
             }
             .padding(.horizontal, VSpacing.lg)
@@ -122,7 +122,7 @@ struct ConnectionModeStep: View {
         }
         .padding(VSpacing.xl)
         .onAppear {
-            let saved = UserDefaults.standard.string(forKey: "connection_mode") ?? ConnectionMode.standalone.rawValue
+            let saved = UserDefaults.standard.string(forKey: UserDefaultsKeys.connectionMode) ?? ConnectionMode.standalone.rawValue
             selectedMode = saved
         }
     }
@@ -284,9 +284,13 @@ struct DaemonSetupStep: View {
                     showingAlert = true
                     return
                 }
-                UserDefaults.standard.set(hostname, forKey: "daemon_hostname")
-                UserDefaults.standard.set(portInt, forKey: "daemon_port")
-                UserDefaults.standard.set(sessionToken.isEmpty ? nil : sessionToken, forKey: "daemon_" + "auth" + "_token")
+                UserDefaults.standard.set(hostname, forKey: UserDefaultsKeys.daemonHostname)
+                UserDefaults.standard.set(portInt, forKey: UserDefaultsKeys.daemonPort)
+                if sessionToken.isEmpty {
+                    _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
+                } else {
+                    _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
+                }
                 onContinue?()
             }
             .buttonStyle(.borderedProminent)
@@ -306,10 +310,10 @@ struct DaemonSetupStep: View {
             Text(alertMessage)
         }
         .onAppear {
-            hostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
-            let portValue = UserDefaults.standard.integer(forKey: "daemon_port")
+            hostname = UserDefaults.standard.string(forKey: UserDefaultsKeys.daemonHostname) ?? "localhost"
+            let portValue = UserDefaults.standard.integer(forKey: UserDefaultsKeys.daemonPort)
             port = portValue > 0 ? String(portValue) : "8765"
-            sessionToken = UserDefaults.standard.string(forKey: "daemon_" + "auth" + "_token") ?? ""
+            sessionToken = APIKeyManager.shared.getAPIKey(provider: "daemon-token") ?? ""
         }
     }
 }

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -9,9 +9,9 @@ enum ConnectionMode: String, CaseIterable {
 
 struct SettingsView: View {
     @EnvironmentObject var clientProvider: ClientProvider
-    @AppStorage("connection_mode") private var connectionMode: String = ConnectionMode.standalone.rawValue
-    @AppStorage("daemon_tls_enabled") private var tlsEnabled: Bool = false
-    @AppStorage("appearance_mode") private var appearanceMode: String = "system"
+    @AppStorage(UserDefaultsKeys.connectionMode) private var connectionMode: String = ConnectionMode.standalone.rawValue
+    @AppStorage(UserDefaultsKeys.daemonTLSEnabled) private var tlsEnabled: Bool = false
+    @AppStorage(UserDefaultsKeys.appearanceMode) private var appearanceMode: String = "system"
     @State private var apiKey: String = ""
     @State private var daemonHostname: String = ""
     @State private var daemonPort: String = ""
@@ -101,10 +101,13 @@ struct SettingsView: View {
                                 showingDaemonAlert = true
                                 return
                             }
-                            UserDefaults.standard.set(daemonHostname, forKey: "daemon_hostname")
-                            UserDefaults.standard.set(port, forKey: "daemon_port")
-                            let tokenKey = "daemon_" + "auth" + "_token"
-                            UserDefaults.standard.set(sessionToken.isEmpty ? nil : sessionToken, forKey: tokenKey)
+                            UserDefaults.standard.set(daemonHostname, forKey: UserDefaultsKeys.daemonHostname)
+                            UserDefaults.standard.set(port, forKey: UserDefaultsKeys.daemonPort)
+                            if sessionToken.isEmpty {
+                                _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
+                            } else {
+                                _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
+                            }
                             daemonAlertMessage = "Daemon connection settings updated"
                             showingDaemonAlert = true
                         }
@@ -156,10 +159,10 @@ struct SettingsView: View {
 
     private func loadSettings() {
         apiKey = APIKeyManager.shared.getAPIKey() ?? ""
-        daemonHostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
-        let portValue = UserDefaults.standard.integer(forKey: "daemon_port")
+        daemonHostname = UserDefaults.standard.string(forKey: UserDefaultsKeys.daemonHostname) ?? "localhost"
+        let portValue = UserDefaults.standard.integer(forKey: UserDefaultsKeys.daemonPort)
         daemonPort = portValue > 0 ? String(portValue) : "8765"
-        sessionToken = UserDefaults.standard.string(forKey: "daemon_" + "auth" + "_token") ?? ""
+        sessionToken = APIKeyManager.shared.getAPIKey(provider: "daemon-token") ?? ""
     }
 }
 

--- a/clients/shared/Utilities/APIKeyManager.swift
+++ b/clients/shared/Utilities/APIKeyManager.swift
@@ -65,6 +65,21 @@ public class APIKeyManager {
         #endif
     }
 
+    public func deleteAPIKey(provider: String = "anthropic") -> Bool {
+        #if targetEnvironment(simulator)
+        UserDefaults.standard.removeObject(forKey: udKey(provider))
+        return true
+        #else
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: provider
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+        #endif
+    }
+
     private func udKey(_ provider: String) -> String {
         "apikey_\(service)_\(provider)"
     }


### PR DESCRIPTION
## Summary
- Move daemon session token from plaintext UserDefaults to Keychain via `APIKeyManager`
- Add `deleteAPIKey(provider:)` to `APIKeyManager` for token removal
- Extract all magic-string UserDefaults keys into `UserDefaultsKeys` enum constants
- Update `SettingsView` and `OnboardingView` to use constants and Keychain

## Security improvement
The daemon session token was previously stored in plaintext UserDefaults (world-readable by any app with sandbox access). It is now stored in the device Keychain like the Anthropic API key, falling back to UserDefaults on simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
