### PR TITLE
fix: address review feedback on PR #4122 (browser cutover)

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -293,7 +293,7 @@ describe('skill_load tool', () => {
     expect(result.content).toContain('Included Skills (immediate): none');
   });
 
-  test('e2e: load parent with includes shows child metadata and emits only parent marker', async () => {
+  test('e2e: load parent with includes shows child metadata and emits markers for parent and included children', async () => {
     // Set up a parent + child fixture using the helpers
     writeSkill('e2e-child', 'E2E Child', 'Child for e2e test', 'Child instructions.');
     writeSkillWithIncludes('e2e-parent', 'E2E Parent', 'Parent with includes', 'Parent instructions.', ['e2e-child']);
@@ -309,13 +309,11 @@ describe('skill_load tool', () => {
     expect(result.content).toContain('Included Skills (immediate):');
     expect(result.content).toContain('e2e-child: E2E Child');
 
-    // Should emit exactly one <loaded_skill> marker — for the parent only
+    // Should emit markers for both parent and included child so child tools get projected
     const markers = result.content.match(/<loaded_skill/g) || [];
-    expect(markers.length).toBe(1);
+    expect(markers.length).toBe(2);
     expect(result.content).toMatch(/<loaded_skill id="e2e-parent" version="v1:[a-f0-9]{64}" \/>/);
-
-    // Should NOT contain a loaded_skill marker for the child
-    expect(result.content).not.toContain('<loaded_skill id="e2e-child"');
+    expect(result.content).toMatch(/<loaded_skill id="e2e-child" version="v1:[a-f0-9]{64}" \/>/);
   });
 
   test('parent skill lists only immediate children, not transitive grandchildren', async () => {
@@ -347,7 +345,7 @@ describe('skill_load tool', () => {
     expect(result.content).toMatch(/<loaded_skill id="grandparent" version="v1:[a-f0-9]{64}" \/>/);
   });
 
-  test('succeeds with diamond dependency and shows only immediate children', async () => {
+  test('succeeds with diamond dependency and emits markers for root and immediate children', async () => {
     // Diamond: root includes A and B, both A and B include shared-leaf
     writeSkill('shared-leaf', 'Shared Leaf', 'Shared dependency', 'Shared body');
     writeSkillWithIncludes('branch-a', 'Branch A', 'First branch', 'Branch A body', ['shared-leaf']);
@@ -373,10 +371,12 @@ describe('skill_load tool', () => {
     expect(immediateSection).not.toBeNull();
     expect(immediateSection![0]).not.toContain('shared-leaf');
 
-    // Exactly one loaded_skill marker (for root only)
+    // Markers for root + immediate includes (branch-a and branch-b)
     const markers = result.content.match(/<loaded_skill/g) || [];
-    expect(markers.length).toBe(1);
+    expect(markers.length).toBe(3);
     expect(result.content).toMatch(/<loaded_skill id="diamond-root" version="v1:[a-f0-9]{64}" \/>/);
+    expect(result.content).toMatch(/<loaded_skill id="branch-a" version="v1:[a-f0-9]{64}" \/>/);
+    expect(result.content).toMatch(/<loaded_skill id="branch-b" version="v1:[a-f0-9]{64}" \/>/);
   });
 
   test('returns error when skill includes itself (self-cycle)', async () => {

--- a/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
@@ -2,6 +2,7 @@
 name: "Google OAuth Setup"
 description: "Create Google Cloud OAuth credentials for Gmail integration using browser automation"
 user-invocable: true
+includes: ["browser"]
 metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
 ---
 

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -99,6 +99,24 @@ export class SkillLoadTool implements Tool {
     }
 
     const versionAttr = versionHash ? ` version="${versionHash}"` : '';
+
+    // Emit markers for included skills so their tools get projected
+    const includeMarkers: string[] = [];
+    if (skill.includes && skill.includes.length > 0 && catalogIndex) {
+      for (const childId of skill.includes) {
+        const child = catalogIndex.get(childId);
+        if (!child) continue;
+        let childHash: string | undefined;
+        try {
+          childHash = computeSkillVersionHash(child.directoryPath);
+        } catch (err) {
+          log.warn({ err, skillId: childId }, 'Failed to compute included skill version hash');
+        }
+        const childVersionAttr = childHash ? ` version="${childHash}"` : '';
+        includeMarkers.push(`<loaded_skill id="${childId}"${childVersionAttr} />`);
+      }
+    }
+
     return {
       content: [
         `Skill: ${skill.name}`,
@@ -111,6 +129,7 @@ export class SkillLoadTool implements Tool {
         immediateChildrenSection,
         '',
         `<loaded_skill id="${skill.id}"${versionAttr} />`,
+        ...includeMarkers,
       ].join('\n'),
       isError: false,
     };


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4122

## Summary
- Add `includes: ["browser"]` to google-oauth-setup skill frontmatter so loading this skill also activates browser tools
- Update skill_load to emit `<loaded_skill>` markers for included skills, enabling projectSkillTools to project their tools
- Update tests to reflect the new behavior (included skills now get markers)

## Problem
PR #4122 removed browser tools from eager core registration, moving them to the browser skill. But the google-oauth-setup skill instructs the model to use browser_* tools and has no TOOLS.json of its own. Without eager registration, loading google-oauth-setup no longer makes browser tools available.

## Fix
Wire up the existing `includes` mechanism end-to-end: when a skill declares `includes: ["browser"]`, loading that skill now also emits activation markers for the browser skill, causing its tools to be projected into the session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
