### PR TITLE
fix: address review feedback on PR #4066 (extractor scoped memory)

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -891,13 +891,14 @@ function migrateMemoryItemsFingerprintScopeUnique(database: ReturnType<typeof dr
   ).get(checkpointKey);
   if (checkpoint) return;
 
-  // Check if the old column-level UNIQUE constraint still exists — indicated
-  // by the sqlite_autoindex on fingerprint alone.
-  const autoIdx = raw.query(
-    `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'memory_items' AND name LIKE 'sqlite_autoindex_%'`,
-  ).get() as { name: string } | null;
-  if (!autoIdx) {
-    // No auto-index — either fresh DB (no UNIQUE in CREATE TABLE) or already migrated.
+  // Check if the old column-level UNIQUE constraint still exists by inspecting
+  // the CREATE TABLE DDL for the word UNIQUE (the PK also creates an autoindex,
+  // so we cannot rely on sqlite_autoindex_* presence alone).
+  const tableDdl = raw.query(
+    `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_items'`,
+  ).get() as { sql: string } | null;
+  if (!tableDdl || !tableDdl.sql.match(/fingerprint\s+TEXT\s+NOT\s+NULL\s+UNIQUE/i)) {
+    // No column-level UNIQUE on fingerprint — either fresh DB or already migrated.
     raw.query(
       `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
     ).run(checkpointKey, Date.now());


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4066

- Fix migration autoindex detection: the old sqlite_autoindex_* query matched the PK autoindex too, so the fresh-DB skip optimization never fired. Now checks the CREATE TABLE DDL for column-level UNIQUE on fingerprint instead.
- Codex's P1 about fingerprint-only lookups in handlers.ts is already addressed in the merged code (lines 104 and 183 already scope queries by scopeId).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
