### PR TITLE
fix: address review feedback on PR #4055 (video chat embed)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -64,10 +64,8 @@ struct InlineVideoEmbedCard: View {
         switch stateManager.state {
         case .placeholder:
             placeholderView
-        case .initializing:
-            initializingView
-        case .playing:
-            playingView
+        case .initializing, .playing:
+            activePlayerView
         case .failed(let message):
             failedView(message)
         }
@@ -89,20 +87,14 @@ struct InlineVideoEmbedCard: View {
         }
     }
 
-    private var initializingView: some View {
+    /// Single view for both .initializing and .playing so SwiftUI preserves
+    /// the WKWebView identity across the state transition, avoiding a
+    /// redundant teardown-and-reload cycle.
+    private var activePlayerView: some View {
         InlineVideoWebView(
             url: playerURL,
             provider: provider,
             onLoadSuccess: { stateManager.didStartPlaying() },
-            onLoadFailure: { msg in stateManager.didFail(msg) }
-        )
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-    }
-
-    private var playingView: some View {
-        InlineVideoWebView(
-            url: playerURL,
-            provider: provider,
             onLoadFailure: { msg in stateManager.didFail(msg) }
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4055

Merges .initializing and .playing cases in stateContent into a single activePlayerView
so SwiftUI preserves WKWebView identity across the state transition. Previously, the
.initializing branch created an InlineVideoWebView, then onAppear immediately flipped
state to .playing which entered a different ViewBuilder branch — destroying the first
webview and creating a new one, causing a double-load on every play action.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
