### PR TITLE
fix: address review feedback on PR #4088 (webview navigation restrict)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -139,11 +139,12 @@ struct InlineVideoWebView: NSViewRepresentable {
                     return
                 }
 
-                if let host = navigationAction.request.url?.host,
+                if let host = navigationAction.request.url?.host?.lowercased(),
                    InlineVideoWebView.isAllowedHost(host, forProvider: provider) {
                     decisionHandler(.allow)
                 } else {
-                    Self.openExternallyIfSafe(navigationAction.request.url)
+                    // Silently block — unlike user-initiated navigations, programmatic
+                    // requests (analytics, telemetry, CDN) shouldn't open browser tabs.
                     decisionHandler(.cancel)
                 }
             default:


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4088

- Silently cancel blocked programmatic navigations instead of opening them in browser (Devin feedback)
- Lowercase host before allowlist matching for case-insensitive comparison (Codex feedback)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
