### PR TITLE
fix: address review feedback on PR #4089 (webview load-failure)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -158,6 +158,7 @@ struct InlineVideoWebView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            guard !Self.isCancellationError(error) else { return }
             onLoadFailure?(error.localizedDescription)
         }
 
@@ -166,7 +167,15 @@ struct InlineVideoWebView: NSViewRepresentable {
             didFailProvisionalNavigation navigation: WKNavigation!,
             withError error: Error
         ) {
+            guard !Self.isCancellationError(error) else { return }
             onLoadFailure?(error.localizedDescription)
+        }
+
+        /// WebKit fires cancellation errors (NSURLErrorCancelled) for benign
+        /// reasons like a load being superseded by a new request or a navigation
+        /// policy cancellation. These are not real failures.
+        private static func isCancellationError(_ error: Error) -> Bool {
+            (error as NSError).code == NSURLErrorCancelled
         }
 
         // MARK: - WKUIDelegate

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
@@ -127,4 +127,50 @@ final class InlineVideoWebViewFailureTests: XCTestCase {
         stateManager.didFail("Connection lost")
         XCTAssertEqual(stateManager.state, .failed("Connection lost"))
     }
+
+    // MARK: - Cancellation error filtering
+
+    func testDidFailIgnoresCancellationError() {
+        var receivedMessage: String?
+        let coordinator = InlineVideoWebView.Coordinator(
+            provider: "youtube",
+            onLoadFailure: { msg in receivedMessage = msg }
+        )
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+        let webView = WKWebView(frame: .zero)
+        coordinator.webView(webView, didFail: nil, withError: error)
+
+        XCTAssertNil(receivedMessage, "Cancellation errors should not invoke onLoadFailure")
+    }
+
+    func testDidFailProvisionalNavigationIgnoresCancellationError() {
+        var receivedMessage: String?
+        let coordinator = InlineVideoWebView.Coordinator(
+            provider: "youtube",
+            onLoadFailure: { msg in receivedMessage = msg }
+        )
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+        let webView = WKWebView(frame: .zero)
+        coordinator.webView(webView, didFailProvisionalNavigation: nil, withError: error)
+
+        XCTAssertNil(receivedMessage, "Cancellation errors should not invoke onLoadFailure")
+    }
+
+    func testDidFailStillReportsNonCancellationErrors() {
+        var receivedMessage: String?
+        let coordinator = InlineVideoWebView.Coordinator(
+            provider: "youtube",
+            onLoadFailure: { msg in receivedMessage = msg }
+        )
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: [
+            NSLocalizedDescriptionKey: "The Internet connection appears to be offline.",
+        ])
+        let webView = WKWebView(frame: .zero)
+        coordinator.webView(webView, didFail: nil, withError: error)
+
+        XCTAssertEqual(receivedMessage, "The Internet connection appears to be offline.")
+    }
 }


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4089

- Filter out NSURLErrorCancelled in didFail and didFailProvisionalNavigation callbacks to prevent spurious .failed state transitions during normal WebKit navigation (Codex feedback)
- Add tests for cancellation error filtering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
