### PR TITLE
feat: add temporary chat toggle in top-right corner

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -91,6 +91,7 @@ struct ChatView: View {
     let isActivityPanelOpen: Bool
     var onReportMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
+    var isTemporaryChat: Bool = false
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
@@ -140,7 +141,11 @@ struct ChatView: View {
             VStack(spacing: 0) {
                 apiKeyBanner
                 if isEmptyState {
-                    emptyStateView
+                    if isTemporaryChat {
+                        temporaryChatEmptyStateView
+                    } else {
+                        emptyStateView
+                    }
                 } else {
                     ZStack(alignment: .bottom) {
                         messageList
@@ -260,6 +265,73 @@ struct ChatView: View {
             .offset(y: -40)
             .opacity(emptyStateVisible ? 1 : 0)
         )
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.5)) {
+                emptyStateVisible = true
+            }
+        }
+        .onDisappear {
+            emptyStateVisible = false
+        }
+    }
+
+    private var temporaryChatEmptyStateView: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            Spacer()
+
+            Image(systemName: "circle.dashed")
+                .font(.system(size: 40, weight: .light))
+                .foregroundColor(VColor.accent)
+                .opacity(emptyStateVisible ? 1 : 0)
+                .scaleEffect(emptyStateVisible ? 1 : 0.8)
+                .padding(.bottom, VSpacing.lg)
+
+            Text("Temporary Chat")
+                .font(.system(size: 28, weight: .medium))
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .opacity(emptyStateVisible ? 1 : 0)
+                .offset(y: emptyStateVisible ? 0 : 8)
+                .padding(.bottom, VSpacing.sm)
+
+            Text("Memory is disabled for this chat, and it won\u{2019}t appear in your history.")
+                .font(VFont.body)
+                .foregroundColor(VColor.textMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 400)
+                .opacity(emptyStateVisible ? 1 : 0)
+                .offset(y: emptyStateVisible ? 0 : 8)
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.bottom, VSpacing.xl)
+
+            ComposerView(
+                inputText: $inputText,
+                hasAPIKey: hasAPIKey,
+                isSending: isSending,
+                isRecording: isRecording,
+                suggestion: suggestion,
+                pendingAttachments: pendingAttachments,
+                onSend: onSend,
+                onStop: onStop,
+                onAcceptSuggestion: onAcceptSuggestion,
+                onAttach: onAttach,
+                onRemoveAttachment: onRemoveAttachment,
+                onPaste: onPaste,
+                onMicrophoneToggle: onMicrophoneToggle,
+                placeholderText: "Ask me anything...",
+                editorContentHeight: $editorContentHeight,
+                isComposerExpanded: $isComposerExpanded
+            )
+            .opacity(emptyStateVisible ? 1 : 0)
+            .offset(y: emptyStateVisible ? 0 : 10)
+
+            Spacer()
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.chatBackground)
         .onAppear {
             withAnimation(.easeOut(duration: 0.5)) {
                 emptyStateVisible = true

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -129,6 +129,19 @@ struct MainWindowView: View {
         FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.vellum/workspace/BOOTSTRAP.md")
     }
 
+    private func toggleTemporaryChat() {
+        if threadManager.activeThread?.kind == .private {
+            // Switch back to the most recent visible standard thread, or create one
+            if let recent = threadManager.visibleThreads.first {
+                threadManager.selectThread(id: recent.id)
+            } else {
+                threadManager.createThread()
+            }
+        } else {
+            threadManager.createPrivateThread()
+        }
+    }
+
     private func requestHomeBaseDashboardIfNeeded() {
         guard !isBootstrapOnboardingActive else { return }
         guard homeBaseDashboardDefaultEnabled else { return }
@@ -258,6 +271,16 @@ struct MainWindowView: View {
                                 .padding(.trailing, VSpacing.lg)
                                 .frame(height: 36)
                                 .transition(.opacity)
+                            }
+                        }
+                        .overlay(alignment: .topTrailing) {
+                            if !isGeneratedWorkspaceOpen {
+                                TemporaryChatToggle(
+                                    isActive: threadManager.activeThread?.kind == .private,
+                                    onToggle: { toggleTemporaryChat() }
+                                )
+                                .padding(.trailing, VSpacing.lg)
+                                .frame(height: 36)
                             }
                         }
                 }
@@ -1066,7 +1089,8 @@ struct MainWindowView: View {
                 daemonClient: daemonClient,
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
-                onMicrophoneToggle: onMicrophoneToggle
+                onMicrophoneToggle: onMicrophoneToggle,
+                isTemporaryChat: threadManager.activeThread?.kind == .private
             )
             .overlay(alignment: .bottomTrailing) {
                 DemoOverlayView()
@@ -1363,6 +1387,7 @@ private struct ActiveChatViewWrapper: View {
     let ambientAgent: AmbientAgent
     @ObservedObject var settingsStore: SettingsStore
     let onMicrophoneToggle: () -> Void
+    var isTemporaryChat: Bool = false
 
     var body: some View {
         ChatView(
@@ -1442,7 +1467,8 @@ private struct ActiveChatViewWrapper: View {
                 enabled: settingsStore.mediaEmbedsEnabled,
                 enabledSince: settingsStore.mediaEmbedsEnabledSince,
                 allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
-            )
+            ),
+            isTemporaryChat: isTemporaryChat
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatToggle.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatToggle.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct TemporaryChatToggle: View {
+    let isActive: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        VIconButton(
+            label: isActive ? "Turn off temporary chat" : "Turn on temporary chat",
+            icon: "circle.dashed",
+            isActive: isActive,
+            iconOnly: true,
+            action: onToggle
+        )
+        .foregroundColor(isActive ? VColor.accent : nil)
+    }
+}
+
+#Preview("TemporaryChatToggle") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 16) {
+            TemporaryChatToggle(isActive: false, onToggle: {})
+            TemporaryChatToggle(isActive: true, onToggle: {})
+        }
+        .padding()
+    }
+    .frame(width: 200, height: 80)
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -62,6 +62,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads.filter { $0.isArchived }
     }
 
+    var activeThread: ThreadModel? {
+        guard let id = activeThreadId else { return nil }
+        return threads.first { $0.id == id }
+    }
+
     var activeViewModel: ChatViewModel? {
         guard let activeThreadId else { return nil}
         return chatViewModels[activeThreadId]


### PR DESCRIPTION
## Summary
- Adds a dashed-circle toggle button in the top-right corner of the main content area that creates/exits temporary (private) chats
- Temporary chats show a dedicated empty state with "Temporary Chat" title and subtitle about disabled memory
- Leverages existing private thread infrastructure — no sidebar visibility, no session restoration, memory isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
