### PR TITLE
fix: address review feedback on PR #4126 (browser_* allow rules)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3741,6 +3741,11 @@ describe('Permission Checker', () => {
       }
     });
 
+    test('browser_navigate with a real URL is allowed in strict mode', async () => {
+      const result = await check('browser_navigate', { url: 'https://example.com/path/to/page' }, '/tmp');
+      expect(result.decision).toBe('allow');
+    });
+
     test('non-browser skill tools are NOT auto-allowed', async () => {
       // skill_test_tool is a registered skill-origin tool without a default
       // allow rule — it should prompt in strict mode.

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1026,7 +1026,10 @@ describe('Trust Store', () => {
         const rule = templates.find(t => t.id === `default:allow-${tool}-global`);
         expect(rule).toBeDefined();
         expect(rule!.tool).toBe(tool);
-        expect(rule!.pattern).toBe(`${tool}:*`);
+        // browser_navigate uses standalone "**" because its candidates
+        // contain URLs with "/" that single "*" cannot match.
+        const expectedPattern = tool === 'browser_navigate' ? '**' : `${tool}:*`;
+        expect(rule!.pattern).toBe(expectedPattern);
         expect(rule!.decision).toBe('allow');
         expect(rule!.scope).toBe('everywhere');
       }

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -173,8 +173,20 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // Browser tools were previously core-registered with RiskLevel.Low (auto-allowed).
   // After migration to skill-provided tools, default allow rules preserve the
   // same frictionless UX so they don't trigger permission prompts.
-  const BROWSER_TOOLS = [
-    'browser_navigate',
+  // browser_navigate candidates contain URLs with "/" (e.g.
+  // "browser_navigate:https://example.com/path"), so it needs standalone
+  // "**" globstar (same as host_bash / computer_use_*).  The tool field
+  // already filters by tool name, so a prefix is unnecessary.
+  const browserNavigateRule: DefaultRuleTemplate = {
+    id: 'default:allow-browser_navigate-global',
+    tool: 'browser_navigate',
+    pattern: '**',
+    scope: 'everywhere',
+    decision: 'allow',
+    priority: 100,
+  };
+
+  const BROWSER_TOOLS_NO_SLASH = [
     'browser_snapshot',
     'browser_screenshot',
     'browser_close',
@@ -186,7 +198,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     'browser_fill_credential',
   ] as const;
 
-  const browserToolRules: DefaultRuleTemplate[] = BROWSER_TOOLS.map((tool) => ({
+  const browserToolRules: DefaultRuleTemplate[] = BROWSER_TOOLS_NO_SLASH.map((tool) => ({
     id: `default:allow-${tool}-global`,
     tool,
     pattern: `${tool}:*`,
@@ -205,6 +217,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     bootstrapDeleteRule,
     ...skillSourceMutationRules,
     skillLoadRule,
+    browserNavigateRule,
     ...browserToolRules,
   ];
 }


### PR DESCRIPTION
Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/4126

## Changes

- **browser_navigate default allow rule**: Changed pattern from `browser_navigate:*` to standalone `**` globstar. The `*` pattern fails to match real URL candidates containing `/` (e.g. `browser_navigate:https://example.com/path`) because minimatch's single `*` does not cross `/` boundaries. This is the same approach used by `host_bash` and `computer_use_*` tools.

- **Other browser tools unchanged**: The remaining 9 browser tools keep `${tool}:*` since their candidates don't contain `/`.

- **Added regression test**: New test in checker.test.ts verifies that `browser_navigate` with a real URL (`https://example.com/path/to/page`) is allowed in strict mode.

- **Updated trust-store test**: Assertion now expects `**` for `browser_navigate` and `${tool}:*` for the rest.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
