### PR TITLE
fix: address review feedback on PR #4073

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-analyze-style.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
@@ -6,6 +5,7 @@ import type { Message, ToolDefinition } from '../../../../providers/types.js';
 import { getProvider } from '../../../../providers/registry.js';
 import { getConfig } from '../../../../config/loader.js';
 import { getDb } from '../../../../memory/db.js';
+import { computeMemoryFingerprint } from '../../../../memory/fingerprint.js';
 import { memoryItems } from '../../../../memory/schema.js';
 import { enqueueMemoryJob } from '../../../../memory/jobs-store.js';
 import * as gmail from '../client.js';
@@ -111,8 +111,7 @@ function upsertMemoryItem(opts: {
 }): void {
   const db = getDb();
   const now = Date.now();
-  const normalized = `${opts.scopeId}|${opts.kind}|${opts.subject.toLowerCase()}|${opts.statement.toLowerCase()}`;
-  const fingerprint = createHash('sha256').update(normalized).digest('hex');
+  const fingerprint = computeMemoryFingerprint(opts.scopeId, opts.kind, opts.subject, opts.statement);
 
   const existing = db
     .select()

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'node:crypto';
 import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { computeMemoryFingerprint } from './fingerprint.js';
 import * as schema from './schema.js';
 import { getDbPath, ensureDataDir, migrateToDataLayout, migrateToWorkspaceLayout } from '../util/platform.js';
 
@@ -1004,8 +1004,7 @@ function migrateMemoryItemsScopeSaltedFingerprints(database: ReturnType<typeof d
     );
 
     for (const item of items) {
-      const normalized = `${item.scope_id}|${item.kind}|${item.subject.toLowerCase()}|${item.statement.toLowerCase()}`;
-      const fingerprint = createHash('sha256').update(normalized).digest('hex');
+      const fingerprint = computeMemoryFingerprint(item.scope_id, item.kind, item.subject, item.statement);
       updateStmt.run(fingerprint, item.id);
     }
 

--- a/assistant/src/memory/fingerprint.ts
+++ b/assistant/src/memory/fingerprint.ts
@@ -1,0 +1,20 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Compute a scope-salted fingerprint for a memory item.
+ *
+ * Format: sha256(`${scopeId}|${kind}|${subject}|${statement}`)
+ *
+ * All writers (memory_save, memory_update, items-extractor, playbook-create,
+ * playbook-update, gmail-analyze-style) MUST use this function so the
+ * fingerprint scheme stays consistent and deduplication works correctly.
+ */
+export function computeMemoryFingerprint(
+  scopeId: string,
+  kind: string,
+  subject: string,
+  statement: string,
+): string {
+  const normalized = `${scopeId}|${kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
+  return createHash('sha256').update(normalized).digest('hex');
+}

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -1,10 +1,10 @@
-import { createHash } from 'node:crypto';
 import Anthropic from '@anthropic-ai/sdk';
 import { and, eq, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getConfig } from '../config/loader.js';
 import type { MemoryExtractionConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
+import { computeMemoryFingerprint } from './fingerprint.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { getDb } from './db.js';
@@ -203,8 +203,7 @@ async function extractItemsWithLLM(
       const statement = String(raw.statement).slice(0, 500);
       const confidence = clamp(parseScore(raw.confidence, 0.5), 0, 1);
       const importance = clamp(parseScore(raw.importance, 0.5), 0, 1);
-      const normalized = `${scopeId}|${raw.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
-      const fingerprint = createHash('sha256').update(normalized).digest('hex');
+      const fingerprint = computeMemoryFingerprint(scopeId, raw.kind, subject, statement);
       items.push({
         kind: raw.kind as MemoryItemKind,
         subject,
@@ -365,8 +364,7 @@ function extractItemsPatternBased(text: string, scopeId: string = 'default'): Ex
     if (!classification) continue;
     const subject = inferSubject(sentence, classification.kind);
     const statement = sentence.replace(/\s+/g, ' ').trim();
-    const normalized = `${scopeId}|${classification.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
-    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+    const fingerprint = computeMemoryFingerprint(scopeId, classification.kind, subject, statement);
     items.push({
       kind: classification.kind,
       subject,

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -1,9 +1,9 @@
-import { createHash } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
 import { getDb } from '../../memory/db.js';
+import { computeMemoryFingerprint } from '../../memory/fingerprint.js';
 import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import { searchMemoryItems, formatRelativeTime } from '../../memory/retriever.js';
@@ -93,10 +93,7 @@ export async function handleMemorySave(
     const now = Date.now();
     const trimmedStatement = statement.trim().slice(0, 500);
 
-    // Build fingerprint for dedup — salt with scopeId so identical statements
-    // in different scopes produce distinct fingerprints and stay separate.
-    const normalized = `${scopeId}|${kind}|${subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
-    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+    const fingerprint = computeMemoryFingerprint(scopeId, kind, subject, trimmedStatement);
 
     const existing = db
       .select()
@@ -190,10 +187,7 @@ export async function handleMemoryUpdate(
     const now = Date.now();
     const trimmedStatement = statement.trim().slice(0, 500);
 
-    // Salt fingerprint with scopeId so identical statements in different
-    // scopes stay distinct — mirrors the pattern in handleMemorySave.
-    const normalized = `${scopeId}|${existing.kind}|${existing.subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
-    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+    const fingerprint = computeMemoryFingerprint(scopeId, existing.kind, existing.subject, trimmedStatement);
 
     // Collision detection also constrained to the current scope.
     const collision = db

--- a/assistant/src/tools/playbooks/playbook-create.ts
+++ b/assistant/src/tools/playbooks/playbook-create.ts
@@ -1,10 +1,10 @@
-import { createHash } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { RiskLevel } from '../../permissions/types.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
+import { computeMemoryFingerprint } from '../../memory/fingerprint.js';
 import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import type { Playbook, PlaybookAutonomyLevel } from '../../playbooks/types.js';
@@ -35,8 +35,7 @@ async function execute(input: Record<string, unknown>, context: ToolContext): Pr
   const subject = `Playbook: ${trigger}`.slice(0, 80);
   const scopeId = context.memoryScopeId ?? 'default';
 
-  const normalized = `${scopeId}|playbook|${subject.toLowerCase()}|${statement.toLowerCase()}`;
-  const fingerprint = createHash('sha256').update(normalized).digest('hex');
+  const fingerprint = computeMemoryFingerprint(scopeId, 'playbook', subject, statement);
 
   try {
     const db = getDb();

--- a/assistant/src/tools/playbooks/playbook-update.ts
+++ b/assistant/src/tools/playbooks/playbook-update.ts
@@ -1,9 +1,9 @@
-import { createHash } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { RiskLevel } from '../../permissions/types.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
+import { computeMemoryFingerprint } from '../../memory/fingerprint.js';
 import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import { parsePlaybookStatement } from '../../playbooks/types.js';
@@ -58,8 +58,7 @@ async function execute(input: Record<string, unknown>, context: ToolContext): Pr
     const subject = `Playbook: ${updated.trigger}`.slice(0, 80);
     const now = Date.now();
 
-    const normalized = `${scopeId}|playbook|${subject.toLowerCase()}|${statement.toLowerCase()}`;
-    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+    const fingerprint = computeMemoryFingerprint(scopeId, 'playbook', subject, statement);
 
     // Check if another playbook already has this fingerprint
     const collision = db


### PR DESCRIPTION
Address review feedback from PR #4073 (constrain memory_update to current scope)

Extracts a shared `computeMemoryFingerprint()` utility so all memory fingerprint writers (memory_save, memory_update, items-extractor, playbook-create, playbook-update, gmail-analyze-style, and the scope-salt migration) use a single canonical implementation. This ensures the fingerprint scheme stays consistent by construction rather than by convention, preventing the dedup mismatch the Codex reviewer flagged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
