### PR TITLE
fix: replace missing IPC type aliases with inline Swift structs

### DIFF
--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -44,7 +44,7 @@ const SWIFT_OMIT_ALLOWLIST = new Set<string>([
   // Page publishing — not yet consumed by the macOS client
   'publish_page_response',
   'unpublish_page_response',
-  // Daemon-internal watcher events not surfaced to macOS client
+  // Watcher messages — not yet consumed by the macOS client
   'watcher_escalation',
   'watcher_notification',
 ]);
@@ -68,7 +68,7 @@ const INVENTORY_UNEXTRACTABLE = new Set<string>([
 const SWIFT_AHEAD_ALLOWLIST = new Set<string>([
   // Defined in Swift LayoutConfig.swift ahead of daemon implementation
   'ui_layout_config',
-  // Document editor types defined in Swift ahead of daemon implementation
+  // Document editor types — removed from IPC contract but still used by macOS client
   'document_editor_show',
   'document_editor_update',
   'document_save_response',

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -828,20 +828,77 @@ public struct UiSurfaceCompleteMessage: Decodable, Sendable {
 }
 
 /// Document editor show command from daemon.
-/// Backed by generated `IPCDocumentEditorShow`.
-public typealias DocumentEditorShowMessage = IPCDocumentEditorShow
+/// Defined inline — removed from the IPC contract but still used by the macOS client.
+public struct DocumentEditorShowMessage: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String
+    public let initialContent: String
+}
 
 /// Document editor update command from daemon.
-/// Backed by generated `IPCDocumentEditorUpdate`.
-public typealias DocumentEditorUpdateMessage = IPCDocumentEditorUpdate
+public struct DocumentEditorUpdateMessage: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let markdown: String
+    public let mode: String
+}
 
-/// Document persistence messages
-public typealias DocumentSaveRequestMessage = IPCDocumentSaveRequest
-public typealias DocumentSaveResponseMessage = IPCDocumentSaveResponse
-public typealias DocumentLoadRequestMessage = IPCDocumentLoadRequest
-public typealias DocumentLoadResponseMessage = IPCDocumentLoadResponse
-public typealias DocumentListRequestMessage = IPCDocumentListRequest
-public typealias DocumentListResponseMessage = IPCDocumentListResponse
+/// Document persistence messages — defined inline (removed from IPC contract).
+public struct DocumentSaveRequestMessage: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let conversationId: String
+    public let title: String
+    public let content: String
+    public let wordCount: Int
+}
+
+public struct DocumentSaveResponseMessage: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let success: Bool
+    public let error: String?
+}
+
+public struct DocumentLoadRequestMessage: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+}
+
+public struct DocumentLoadResponseMessage: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let conversationId: String
+    public let title: String
+    public let content: String
+    public let wordCount: Int
+    public let createdAt: Int
+    public let updatedAt: Int
+    public let success: Bool
+    public let error: String?
+}
+
+public struct DocumentListRequestMessage: Codable, Sendable {
+    public let type: String
+    public let conversationId: String?
+}
+
+public struct DocumentListResponseMessage: Codable, Sendable {
+    public let type: String
+    public let documents: [DocumentListResponseDocument]
+}
+
+public struct DocumentListResponseDocument: Codable, Sendable {
+    public let surfaceId: String
+    public let conversationId: String
+    public let title: String
+    public let wordCount: Int
+    public let createdAt: Int
+    public let updatedAt: Int
+}
 
 /// Confirms undo/regenerate removed messages.
 public typealias UndoCompleteMessage = IPCUndoComplete


### PR DESCRIPTION
## Summary
- Document IPC types (`IPCDocumentEditorShow`, `IPCDocumentSaveRequest`, etc.) were removed from the TS contract but `IPCMessages.swift` still referenced them as typealiases, breaking the macOS build
- Replaced 8 typealiases with inline `Codable, Sendable` struct definitions matching the daemon's wire format
- Updated drift checker comments to reflect current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
