### PR TITLE
feat: add dino avatar to temporary chat empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -278,10 +278,16 @@ struct ChatView: View {
     private var temporaryChatEmptyStateView: some View {
         VStack(spacing: 0) {
             Spacer()
+            Spacer()
+
+            DinoFaceView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                .frame(width: 80, height: 80)
+                .allowsHitTesting(false)
+                .padding(.bottom, VSpacing.lg)
 
             Text("Temporary Chat")
-                .font(.system(size: 24, weight: .medium))
-                .foregroundColor(VColor.textPrimary)
+                .font(.system(size: 28, weight: .medium))
+                .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.bottom, VSpacing.sm)
 
@@ -314,9 +320,22 @@ struct ChatView: View {
 
             Spacer()
             Spacer()
+            Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(VColor.chatBackground)
+        .background(
+            RadialGradient(
+                gradient: Gradient(colors: [
+                    VColor.accent.opacity(0.07),
+                    VColor.accent.opacity(0.02),
+                    Color.clear,
+                ]),
+                center: .center,
+                startRadius: 20,
+                endRadius: 350
+            )
+            .offset(y: -40)
+        )
     }
 
     /// Height reserved at the bottom of the scroll view so the last message isn't hidden behind the composer.


### PR DESCRIPTION
## Summary
- Adds the dino avatar (DinoFaceView) to the temporary chat empty state so it matches the regular empty state
- Adds the radial gradient background and uses consistent font size/color with the standard state
- Temporary chat now shows: dino avatar + "Temporary Chat" title + subtitle + composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
