### PR TITLE
fix: pass networkMode to wrapCommand in shell tool

### DIFF
--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -58,8 +58,14 @@ mock.module('../security/secret-scanner.js', () => ({
   redactSecrets: (s: string) => s,
 }));
 
+// Track wrapCommand calls to verify networkMode is forwarded
+let wrapCommandCalls: { cmd: string; workingDir: string; config: unknown; options: unknown }[] = [];
+
 mock.module('../tools/terminal/sandbox.js', () => ({
-  wrapCommand: (cmd: string) => ({ command: '/bin/sh', args: ['-c', cmd], sandboxed: false }),
+  wrapCommand: (cmd: string, workingDir: string, config: unknown, options?: unknown) => {
+    wrapCommandCalls.push({ cmd, workingDir, config, options });
+    return { command: '/bin/sh', args: ['-c', cmd], sandboxed: false };
+  },
 }));
 
 mock.module('../util/platform.js', () => ({
@@ -124,6 +130,7 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
 
 afterEach(() => {
   spawnCalls.length = 0;
+  wrapCommandCalls = [];
   createSessionCalls = [];
   startSessionCalls = [];
   stopSessionCalls = [];
@@ -236,5 +243,38 @@ describe('shell tool proxy mode', () => {
     const props = (def.input_schema as { properties: Record<string, unknown> }).properties;
     expect(props.network_mode).toBeDefined();
     expect(props.credential_ids).toBeDefined();
+  });
+
+  test('wrapCommand receives { networkMode: "proxied" } when network_mode=proxied', async () => {
+    const result = await shellTool.execute(
+      { command: 'echo proxied-wrap', network_mode: 'proxied' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(wrapCommandCalls).toHaveLength(1);
+    expect(wrapCommandCalls[0].options).toEqual({ networkMode: 'proxied' });
+  });
+
+  test('wrapCommand receives { networkMode: "off" } when network_mode is absent', async () => {
+    const result = await shellTool.execute(
+      { command: 'echo default-wrap' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(wrapCommandCalls).toHaveLength(1);
+    expect(wrapCommandCalls[0].options).toEqual({ networkMode: 'off' });
+  });
+
+  test('wrapCommand receives { networkMode: "off" } when network_mode=off', async () => {
+    const result = await shellTool.execute(
+      { command: 'echo off-wrap', network_mode: 'off' },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(wrapCommandCalls).toHaveLength(1);
+    expect(wrapCommandCalls[0].options).toEqual({ networkMode: 'off' });
   });
 });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -131,7 +131,7 @@ class ShellTool implements Tool {
       const sandboxConfig = context.sandboxOverride != null
         ? { ...config.sandbox, enabled: context.sandboxOverride }
         : config.sandbox;
-      const wrapped = wrapCommand(command, context.workingDir, sandboxConfig);
+      const wrapped = wrapCommand(command, context.workingDir, sandboxConfig, { networkMode });
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
         env,


### PR DESCRIPTION
## Summary
- **Bug**: `shell.ts` extracted `networkMode` from the tool input but never passed it to `wrapCommand()`. The sandbox backend's per-invocation network override (e.g. `--network=bridge` for Docker) was unreachable.
- **Fix**: Pass `{ networkMode }` as the 4th argument to `wrapCommand()` on line 134.
- **Tests**: Added 3 new test cases verifying `wrapCommand` receives the correct `networkMode` option for `proxied`, `off`, and absent `network_mode` inputs.

## Test plan
- [x] All 9 existing + new tests pass in `shell-tool-proxy-mode.test.ts`
- [x] No regressions in existing proxy session lifecycle tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
