### PR TITLE
fix: narrow proxied-mode checks to bash only, restore host_bash parity

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3770,11 +3770,15 @@ describe('bash network_mode=proxied force prompt (PR 14)', () => {
     expect(result.reason).toContain('Proxied network mode');
   });
 
-  test('proxied host_bash always prompts even when trust rules would allow', async () => {
-    addRule('host_bash', '*', 'everywhere');
+  test('host_bash with network_mode=proxied follows normal flow (not force-prompted)', async () => {
+    // host_bash does not support network_mode — proxied-mode force-prompt
+    // applies only to sandboxed bash, not host_bash. The decision may still
+    // be prompt/allow based on normal risk+trust-rule evaluation, but the
+    // reason must NOT be the proxied-mode bypass.
+    addRule('host_bash', '**', 'everywhere');
     const result = await check('host_bash', { command: 'curl https://api.example.com', network_mode: 'proxied' }, '/tmp');
-    expect(result.decision).toBe('prompt');
-    expect(result.reason).toContain('Proxied network mode');
+    expect(result.decision).toBe('allow');
+    expect(result.reason).not.toContain('Proxied network mode');
   });
 
   test('non-proxied bash follows normal flow (auto-allowed)', async () => {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1717,7 +1717,9 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
     expect(capturedPersistent).toBe(false);
   });
 
-  test('host_bash with proxied network_mode also disables persistence', async () => {
+  test('host_bash with proxied network_mode still allows persistent decisions', async () => {
+    // host_bash does not support network_mode — proxied-mode persistence
+    // blocking applies only to sandboxed bash, not host_bash.
     const spy = setupAddRuleSpy();
 
     const prompter = makePrompterWithDecision('always_allow', 'host_bash:*', '/tmp/project');
@@ -1729,7 +1731,7 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1825,7 +1827,7 @@ describe('E2E: proxied bash activation vs proxy approval persistence', () => {
   });
 
   test('file_write with proxied network_mode is NOT affected (persistence still allowed)', async () => {
-    // Only bash/host_bash with proxied mode disable persistence
+    // Only bash with proxied mode disables persistence
     const spy = setupAddRuleSpy();
 
     const prompter = makePrompterWithDecision('always_allow', 'file_write:*', '/tmp/project');
@@ -1840,7 +1842,9 @@ describe('E2E: proxied bash activation vs proxy approval persistence', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  test('host_bash proxied always_allow_high_risk skips rule saving', async () => {
+  test('host_bash proxied always_allow_high_risk still saves rule (host_bash ignores network_mode)', async () => {
+    // host_bash does not support network_mode — persistence blocking
+    // applies only to sandboxed bash.
     const spy = setupAddRuleSpy();
 
     const prompter = makePrompterWithDecision('always_allow_high_risk', 'host_bash:*', 'everywhere');
@@ -1852,7 +1856,7 @@ describe('E2E: proxied bash activation vs proxy approval persistence', () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   test('proxied bash denied result message omits "rule saved" suffix', async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -344,7 +344,7 @@ export async function check(
   // Proxied network mode bypasses all trust rules — every invocation
   // requires explicit user approval because the command will route
   // through an authenticated proxy with injected credentials.
-  if ((toolName === 'bash' || toolName === 'host_bash') && input.network_mode === 'proxied') {
+  if (toolName === 'bash' && input.network_mode === 'proxied') {
     return { decision: 'prompt', reason: 'Proxied network mode requires explicit approval for each invocation.' };
   }
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -156,7 +156,7 @@ export class ToolExecutor {
 
         // Proxied bash prompts are non-persistent — no trust rule saving allowed
         const persistentDecisionsAllowed = !(
-          (name === 'bash' || name === 'host_bash')
+          name === 'bash'
           && input.network_mode === 'proxied'
         );
 


### PR DESCRIPTION
Removes `host_bash` from proxied-mode force-prompt and non-persistent decision checks. `host_bash` doesn't support `network_mode` — including it was dead code that wrongly scoped it into the proxied model.

## Changes

- **`checker.ts`**: Changed force-prompt condition from `(toolName === 'bash' || toolName === 'host_bash')` to `toolName === 'bash'`
- **`executor.ts`**: Changed `persistentDecisionsAllowed` condition from `(name === 'bash' || name === 'host_bash')` to `name === 'bash'`
- **Tests updated**: `host_bash` with `network_mode=proxied` now follows normal permission flow (not force-prompted) and allows persistent decisions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
