### PR TITLE
fix: replace proxy session stub with real proxy server

### DIFF
--- a/assistant/src/__tests__/script-proxy-session-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-session-runtime.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { createServer, type Server, request as httpRequest } from 'node:http';
+import {
+  createSession,
+  startSession,
+  stopSession,
+  stopAllSessions,
+} from '../tools/network/script-proxy/index.js';
+
+let upstreamServer: Server | null = null;
+
+afterEach(async () => {
+  await stopAllSessions();
+  if (upstreamServer) {
+    await new Promise<void>((resolve) => {
+      upstreamServer!.close(() => resolve());
+    });
+    upstreamServer = null;
+  }
+});
+
+/**
+ * Start a simple HTTP server that responds with a known body on every request.
+ * Listens on an ephemeral port on 127.0.0.1.
+ */
+function startUpstream(responseBody: string): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(responseBody);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get upstream address'));
+        return;
+      }
+      resolve({ server, port: addr.port });
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Make an HTTP GET through a proxy using the absolute-URL form
+ * that forward proxies expect.
+ */
+function proxyGet(proxyPort: number, targetUrl: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: '127.0.0.1',
+        port: proxyPort,
+        // Forward proxies expect the full absolute URL as the path
+        path: targetUrl,
+        method: 'GET',
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf-8'),
+          });
+        });
+        res.on('error', reject);
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('session-manager runtime proxy', () => {
+  const CONV_ID = 'conv-runtime-test';
+  const CRED_IDS: string[] = [];
+
+  test('proxy session forwards HTTP requests to upstream', async () => {
+    const expectedBody = 'hello from upstream';
+
+    // 1. Start a local upstream HTTP server
+    const upstream = await startUpstream(expectedBody);
+    upstreamServer = upstream.server;
+
+    // 2. Create and start a proxy session
+    const session = createSession(CONV_ID, CRED_IDS);
+    const started = await startSession(session.id);
+    expect(started.port).toBeGreaterThan(0);
+
+    // 3. Make an HTTP request through the proxy to the upstream
+    const targetUrl = `http://127.0.0.1:${upstream.port}/test-path`;
+    const response = await proxyGet(started.port!, targetUrl);
+
+    // 4. Assert the response matches the upstream's response
+    expect(response.status).toBe(200);
+    expect(response.body).toBe(expectedBody);
+
+    // 5. Stop the proxy session
+    await stopSession(session.id);
+  });
+
+  test('proxy session returns 400 for non-HTTP protocol requests', async () => {
+    const session = createSession(CONV_ID, CRED_IDS);
+    const started = await startSession(session.id);
+
+    // Sending a relative path (not absolute-URL form) should be rejected
+    const response = await proxyGet(started.port!, '/relative-path');
+    expect(response.status).toBe(400);
+
+    await stopSession(session.id);
+  });
+});

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -1,5 +1,6 @@
-import { createServer, type Server } from 'node:http';
+import type { Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
+import { createProxyServer } from './server.js';
 import type {
   ProxySession,
   ProxySessionId,
@@ -97,11 +98,7 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
     throw new Error(`Session ${sessionId} is ${managed.session.status}, expected starting`);
   }
 
-  const server = createServer((_req, res) => {
-    // Placeholder — no traffic routing in this PR
-    res.writeHead(502, { 'Content-Type': 'text/plain' });
-    res.end('Proxy not yet implemented');
-  });
+  const server = createProxyServer();
 
   return new Promise<ProxySession>((resolve, reject) => {
     server.listen(0, '127.0.0.1', () => {


### PR DESCRIPTION
## Summary
- Replaces the 502 stub HTTP server in `session-manager.ts` with `createProxyServer()` from `server.ts`
- Proxy sessions now forward HTTP requests and handle CONNECT tunnelling instead of returning 502 for all traffic
- Adds runtime integration test verifying HTTP forwarding through a proxy session to a local upstream

## Test plan
- [x] New test `script-proxy-session-runtime.test.ts` validates HTTP forwarding through the proxy session
- [x] Existing `script-proxy-session-manager.test.ts` tests continue to pass (19/19)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
