### PR TITLE
fix: resolve 2 TypeScript type errors in test files

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1253,7 +1253,7 @@ describe('IPC message snapshots', () => {
     });
 
     test('session_list_response sessions include threadType field', () => {
-      const list = serverMessages.session_list_response;
+      const list = serverMessages.session_list_response as unknown as { sessions: Array<Record<string, unknown>> };
       for (const s of list.sessions) {
         expect('threadType' in s).toBe(true);
         expect(s.threadType).toBe('standard');

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -519,7 +519,7 @@ describe('createProxyApprovalCallback', () => {
     // Verify findHighestPriorityRule was called with network_request
     // and URL-based candidates
     expect(findHighestPriorityRuleMock).toHaveBeenCalledTimes(1);
-    const [toolArg, candidatesArg] = findHighestPriorityRuleMock.mock.calls[0] as [string, string[], string];
+    const [toolArg, candidatesArg] = findHighestPriorityRuleMock.mock.calls[0] as unknown as [string, string[], string];
     expect(toolArg).toBe('network_request');
     // Candidates should include URL-based patterns
     expect(candidatesArg.some((c: string) => c.startsWith('network_request:https://api.fal.ai'))).toBe(true);


### PR DESCRIPTION
## Summary
- Fixed `ipc-snapshot.test.ts`: `session_list_response` needs explicit cast to access `.sessions` property on the union type
- Fixed `proxy-approval-callback.test.ts`: empty array type from `mock.calls` can't directly cast to tuple — added intermediate `unknown` cast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
