### PR TITLE
fix: make proxy host reachable from Docker sandbox

### DIFF
--- a/assistant/src/__tests__/script-proxy-session-manager.test.ts
+++ b/assistant/src/__tests__/script-proxy-session-manager.test.ts
@@ -110,6 +110,33 @@ describe('session-manager', () => {
       const session = createSession(CONV_ID, CRED_IDS);
       expect(() => getSessionEnv(session.id)).toThrow(/not active/);
     });
+
+    test('returns host.docker.internal URL when dockerMode is true', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      const started = await startSession(session.id);
+      const env = getSessionEnv(session.id, { dockerMode: true });
+
+      expect(env.HTTP_PROXY).toBe(`http://host.docker.internal:${started.port}`);
+      expect(env.HTTPS_PROXY).toBe(`http://host.docker.internal:${started.port}`);
+    });
+
+    test('returns 127.0.0.1 URL when dockerMode is false', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      const started = await startSession(session.id);
+      const env = getSessionEnv(session.id, { dockerMode: false });
+
+      expect(env.HTTP_PROXY).toBe(`http://127.0.0.1:${started.port}`);
+      expect(env.HTTPS_PROXY).toBe(`http://127.0.0.1:${started.port}`);
+    });
+
+    test('returns 127.0.0.1 URL when no options are passed', async () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      const started = await startSession(session.id);
+      const env = getSessionEnv(session.id);
+
+      expect(env.HTTP_PROXY).toBe(`http://127.0.0.1:${started.port}`);
+      expect(env.HTTPS_PROXY).toBe(`http://127.0.0.1:${started.port}`);
+    });
   });
 
   describe('getActiveSession', () => {

--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -1036,4 +1036,28 @@ describe('DockerBackend — per-invocation network override', () => {
     expect(result.args).toContain('--memory=512m');
     expect(result.args).toContain('--pids-limit=256');
   });
+
+  test('proxied mode adds --add-host=host.docker.internal:host-gateway', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('curl http://proxy:3128', sandboxRoot, {
+      networkMode: 'proxied',
+    });
+    expect(result.args).toContain('--add-host=host.docker.internal:host-gateway');
+  });
+
+  test('non-proxied mode does not add --add-host flag', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot);
+    const addHostArgs = result.args.filter((a: string) => a.startsWith('--add-host'));
+    expect(addHostArgs).toHaveLength(0);
+  });
+
+  test('--add-host appears before the image argument in proxied mode', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot, { networkMode: 'proxied' });
+    const addHostIdx = result.args.indexOf('--add-host=host.docker.internal:host-gateway');
+    const imageIdx = result.args.indexOf(defaultImage);
+    expect(addHostIdx).toBeGreaterThan(-1);
+    expect(addHostIdx).toBeLessThan(imageIdx);
+  });
 });

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -147,7 +147,10 @@ export async function stopSession(sessionId: ProxySessionId): Promise<void> {
  * Build environment variables to inject into a subprocess so its HTTP
  * traffic flows through this proxy session.
  */
-export function getSessionEnv(sessionId: ProxySessionId): ProxyEnvVars {
+export function getSessionEnv(
+  sessionId: ProxySessionId,
+  options?: { dockerMode?: boolean },
+): ProxyEnvVars {
   const managed = sessions.get(sessionId);
   if (!managed) throw new Error(`Session not found: ${sessionId}`);
   if (managed.session.status !== 'active' || managed.session.port === null) {
@@ -157,7 +160,10 @@ export function getSessionEnv(sessionId: ProxySessionId): ProxyEnvVars {
   // Touch the idle timer on access
   resetIdleTimer(managed);
 
-  const proxyUrl = `http://127.0.0.1:${managed.session.port}`;
+  // Inside Docker, 127.0.0.1 is the container's own loopback — use
+  // host.docker.internal so traffic reaches the host-side proxy.
+  const host = options?.dockerMode ? 'host.docker.internal' : '127.0.0.1';
+  const proxyUrl = `http://${host}:${managed.session.port}`;
   const env: ProxyEnvVars = {
     HTTP_PROXY: proxyUrl,
     HTTPS_PROXY: proxyUrl,

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -278,6 +278,11 @@ export class DockerBackend implements SandboxBackend {
       'run',
       '--rm',
       `--network=${effectiveNetwork}`,
+      // When proxied, map host.docker.internal to the host machine so the
+      // container can reach the proxy daemon listening on the host loopback.
+      ...(options?.networkMode === 'proxied'
+        ? ['--add-host=host.docker.internal:host-gateway']
+        : []),
       `--cpus=${cpus}`,
       `--memory=${memoryMb}m`,
       `--pids-limit=${pidsLimit}`,

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -89,6 +89,12 @@ class ShellTool implements Tool {
 
     log.info({ command: redactSecrets(command), cwd: context.workingDir, timeoutSec, networkMode, credentialIds }, 'Executing shell command');
 
+    // Resolve sandbox config early — needed both for proxy env and command wrapping.
+    const sandboxConfig = context.sandboxOverride != null
+      ? { ...config.sandbox, enabled: context.sandboxOverride }
+      : config.sandbox;
+    const isDockerSandbox = sandboxConfig.enabled && sandboxConfig.backend === 'docker';
+
     // Start proxy session if proxied mode is requested
     let proxySessionId: string | null = null;
     let proxyEnv: import('../network/script-proxy/types.js').ProxyEnvVars | null = null;
@@ -108,7 +114,7 @@ class ShellTool implements Tool {
           const started = await startSession(session.id);
           proxySessionId = started.id;
         }
-        proxyEnv = getSessionEnv(proxySessionId);
+        proxyEnv = getSessionEnv(proxySessionId, { dockerMode: isDockerSandbox });
       } catch (err) {
         log.error({ err }, 'Failed to start proxy session');
         return {
@@ -128,9 +134,6 @@ class ShellTool implements Tool {
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
 
-      const sandboxConfig = context.sandboxOverride != null
-        ? { ...config.sandbox, enabled: context.sandboxOverride }
-        : config.sandbox;
       const wrapped = wrapCommand(command, context.workingDir, sandboxConfig, { networkMode });
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,


### PR DESCRIPTION
## Summary
- Adds `--add-host=host.docker.internal:host-gateway` to Docker run args when `networkMode === 'proxied'`, so the container can resolve the host machine's IP.
- Adds `dockerMode` option to `getSessionEnv()` to emit `http://host.docker.internal:PORT` instead of `http://127.0.0.1:PORT` when running inside Docker.
- Moves `sandboxConfig` computation earlier in `shell.ts` so Docker detection is available before proxy env var generation.

## Test plan
- [x] Docker backend test: proxied mode includes `--add-host=host.docker.internal:host-gateway`
- [x] Docker backend test: non-proxied mode does not add `--add-host`
- [x] Docker backend test: `--add-host` appears before image argument
- [x] Session manager test: `dockerMode: true` returns `host.docker.internal` URL
- [x] Session manager test: `dockerMode: false` returns `127.0.0.1` URL
- [x] Session manager test: no options returns `127.0.0.1` URL
- [x] All existing tests pass (76 docker tests, 22 session manager tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
