### PR TITLE
fix: address review feedback on PR #4237 (CI instruction)

### DIFF
--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -7,7 +7,6 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide the plan filename. E
 ## Repo-specific gotchas
 
 - **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
-- **CI**: Do NOT wait for CI checks to pass before merging. Merge immediately.
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
 - **Project structure**: Bun + TypeScript project. Code is in `assistant/`.


### PR DESCRIPTION
## Summary
- Remove 'do not wait for CI' instruction from safe-execute-plan.md
- This command explicitly does NOT merge (it's a human-review gate), so the merge-immediately instruction was contradictory

Address review feedback from PR #4237. See individual commits for details.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
