### PR TITLE
fix: address review feedback on PR #4292 (stop running tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ For controlled, sequential plan execution with human review at every step: **`/s
 
 All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md`.
 
+**Validation**: Slash commands do **not** run tests, type-checking (`tsc`), or linting by default. These steps are only performed when the task specifically requires it (e.g., "fix the type errors", "make the tests pass"). This keeps agent-driven workflows fast for well-scoped changes.
+
 ## Release Management
 
 Releases are cut using the `/release` Claude Code command and follow a fully automated pipeline from tag to client update.


### PR DESCRIPTION
Address review feedback from PR #4292. Adds a note to the README documenting that slash commands do not run tests, type-checking, or linting by default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
