### PR TITLE
fix: wire proxy approval callback into session runtime

### DIFF
--- a/assistant/src/__tests__/script-proxy-session-manager.test.ts
+++ b/assistant/src/__tests__/script-proxy-session-manager.test.ts
@@ -352,4 +352,27 @@ describe('session-manager', () => {
       expect(decision.reason).toBe('tunnel:no_credentials');
     });
   });
+
+  // ── Approval callback storage ──────────────────────────────────────
+
+  describe('approval callback', () => {
+    test('stores approval callback when provided', () => {
+      const callback = async () => true;
+      const session = createSession(CONV_ID, CRED_IDS, undefined, undefined, callback);
+      expect(session.id).toBeTruthy();
+      expect(session.status).toBe('starting');
+    });
+
+    test('works without approval callback (undefined)', () => {
+      const session = createSession(CONV_ID, CRED_IDS);
+      expect(session.id).toBeTruthy();
+      expect(session.status).toBe('starting');
+    });
+
+    test('works without approval callback (explicit undefined)', () => {
+      const session = createSession(CONV_ID, CRED_IDS, undefined, undefined, undefined);
+      expect(session.id).toBeTruthy();
+      expect(session.status).toBe('starting');
+    });
+  });
 });

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -100,6 +100,7 @@ export function createToolExecutor(
       sendToClient: (msg) => ctx.sendToClient(msg as unknown as ServerMessage),
       isInteractive: !ctx.hasNoClient,
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),
+      proxyApprovalCallback: createProxyApprovalCallback(prompter, ctx),
       requestSecret: async (params) => {
         return secretPrompter.prompt(
           params.service, params.field, params.label,

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -9,6 +9,7 @@ import type {
   ProxySessionId,
   ProxySessionConfig,
   ProxyEnvVars,
+  ProxyApprovalCallback,
 } from './types.js';
 import { getCAPath, ensureLocalCA } from './certs.js';
 import { resolveById } from '../../credentials/resolve.js';
@@ -25,6 +26,7 @@ interface ManagedSession {
   idleTimer: ReturnType<typeof setTimeout> | null;
   config: ProxySessionConfig;
   dataDir: string | null;
+  approvalCallback: ProxyApprovalCallback | null;
 }
 
 const sessions = new Map<ProxySessionId, ManagedSession>();
@@ -58,6 +60,7 @@ export function createSession(
   credentialIds: string[],
   config?: Partial<ProxySessionConfig>,
   dataDir?: string,
+  approvalCallback?: ProxyApprovalCallback,
 ): ProxySession {
   const merged: ProxySessionConfig = { ...DEFAULT_CONFIG, ...config };
 
@@ -87,6 +90,7 @@ export function createSession(
     idleTimer: null,
     config: merged,
     dataDir: dataDir ?? null,
+    approvalCallback: approvalCallback ?? null,
   });
 
   return cloneSession(session);

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -110,6 +110,7 @@ class ShellTool implements Tool {
             credentialIds,
             undefined,
             getDataDir(),
+            context.proxyApprovalCallback,
           );
           const started = await startSession(session.id);
           proxySessionId = started.id;

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -133,6 +133,8 @@ export interface ToolContext {
   memoryScopeId?: string;
   /** When true, tools with private side-effects should always prompt for confirmation. */
   forcePromptSideEffects?: boolean;
+  /** Approval callback for proxy policy decisions that require user confirmation. */
+  proxyApprovalCallback?: import('./network/script-proxy/types.js').ProxyApprovalCallback;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
Threads ProxyApprovalCallback through ToolContext → shell.ts → createSession() → ManagedSession so the proxy server can invoke user approval prompts at request time.

### Changes
- Added `ProxyApprovalCallback` import and `approvalCallback` field to `ManagedSession` in `session-manager.ts`
- Added optional `approvalCallback` parameter to `createSession()`
- Added `proxyApprovalCallback` field to `ToolContext` in `types.ts`
- Wired `createProxyApprovalCallback()` into the `ToolContext` in `session-tool-setup.ts`
- Passed `context.proxyApprovalCallback` through `shell.ts` → `createSession()`
- Added tests for approval callback storage and null/undefined handling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
