### PR TITLE
fix: remove unused beforeEach import in session-manager test

### DIFF
--- a/assistant/src/__tests__/script-proxy-session-manager.test.ts
+++ b/assistant/src/__tests__/script-proxy-session-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach, mock, beforeEach } from 'bun:test';
+import { describe, test, expect, afterEach, mock } from 'bun:test';
 import type { CredentialInjectionTemplate } from '../tools/credentials/policy-types.js';
 import type { ResolvedCredential } from '../tools/credentials/resolve.js';
 


### PR DESCRIPTION
## Summary
- Removed unused `beforeEach` import from `script-proxy-session-manager.test.ts` that was causing ESLint to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
