### PR TITLE
fix: address review feedback on PR #4242 (restore app-builder prerequisite)

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -236,7 +236,7 @@ function buildDynamicUiSection(): string {
     '- **Interactive apps only**: `app_create` (calculators, dashboards, tools - NOT text content)',
     '',
     '### Loading app tools',
-    'Most `app_*` tools (`app_create`, `app_file_edit`, `app_file_write`, `app_file_read`, `app_file_list`, `app_delete`, `app_list`, `app_query`) are provided by the `app-builder` skill. If they are not yet available, call `skill_load` with `id: "app-builder"` to load them. You only need to load the skill once per session. Note: `app_open` is always available as a core tool and does not require skill_load.',
+    'Most `app_*` tools (`app_create`, `app_update`, `app_file_edit`, `app_file_write`, `app_file_read`, `app_file_list`, `app_delete`, `app_list`, `app_query`) are provided by the `app-builder` skill. If they are not yet available, call `skill_load` with `id: "app-builder"` to load them. You only need to load the skill once per session. Note: `app_open` is always available as a core tool and does not require skill_load.',
     '',
     '### App type selection',
     'When using `app_create`, set the `type` parameter:',


### PR DESCRIPTION
Address review feedback from PR #4242. Adds missing app_update to the list of app-builder skill-provided tools in the system prompt.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
