### PR TITLE
fix: address review feedback on PR #4256 (proxy skeleton)

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -29,6 +29,8 @@ interface ManagedSession {
   config: ProxySessionConfig;
   dataDir: string | null;
   approvalCallback: ProxyApprovalCallback | null;
+  /** In-flight stop promise so concurrent callers can await the same shutdown. */
+  stopPromise: Promise<void> | null;
 }
 
 const sessions = new Map<ProxySessionId, ManagedSession>();
@@ -93,6 +95,7 @@ export function createSession(
     config: merged,
     dataDir: dataDir ?? null,
     approvalCallback: approvalCallback ?? null,
+    stopPromise: null,
   });
 
   return cloneSession(session);
@@ -205,24 +208,35 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
 export async function stopSession(sessionId: ProxySessionId): Promise<void> {
   const managed = sessions.get(sessionId);
   if (!managed) throw new Error(`Session not found: ${sessionId}`);
-  if (managed.session.status === 'stopped' || managed.session.status === 'stopping') return;
+  if (managed.session.status === 'stopped') return;
+
+  // If a shutdown is already in flight, await it instead of returning early.
+  if (managed.session.status === 'stopping' && managed.stopPromise) {
+    return managed.stopPromise;
+  }
 
   managed.session.status = 'stopping';
 
-  if (managed.idleTimer !== null) {
-    clearTimeout(managed.idleTimer);
-    managed.idleTimer = null;
-  }
+  const doStop = async () => {
+    if (managed.idleTimer !== null) {
+      clearTimeout(managed.idleTimer);
+      managed.idleTimer = null;
+    }
 
-  if (managed.server) {
-    await new Promise<void>((resolve, reject) => {
-      managed.server!.close((err) => (err ? reject(err) : resolve()));
-    });
-    managed.server = null;
-  }
+    if (managed.server) {
+      await new Promise<void>((resolve, reject) => {
+        managed.server!.close((err) => (err ? reject(err) : resolve()));
+      });
+      managed.server = null;
+    }
 
-  managed.session.status = 'stopped';
-  managed.session.port = null;
+    managed.session.status = 'stopped';
+    managed.session.port = null;
+    managed.stopPromise = null;
+  };
+
+  managed.stopPromise = doStop();
+  return managed.stopPromise;
 }
 
 /**


### PR DESCRIPTION
Address review feedback from PR #4256.

- Codex P1: stopSession now stores the in-flight shutdown promise so concurrent callers await the same shutdown instead of returning early while the session is still stopping. This ensures callers can rely on stop completion semantics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
