### PR TITLE
fix: prefix unused response variable in proxy policy test

### DIFF
--- a/assistant/src/__tests__/script-proxy-policy-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy-runtime.test.ts
@@ -144,7 +144,7 @@ describe('policy runtime enforcement', () => {
     const session = createSession(CONV_ID, ['cred-a']);
     const started = await startSession(session.id);
 
-    const response = await proxyGet(started.port!, `http://127.0.0.1:${upstream.port}/test`);
+    const _response = await proxyGet(started.port!, `http://127.0.0.1:${upstream.port}/test`);
     // evaluateRequestWithApproval returns ask_missing_credential or ask_unauthenticated
     // depending on registry; with no approval callback and known pattern not matching,
     // the result is ask_unauthenticated (no pattern match in allKnown for 127.0.0.1),


### PR DESCRIPTION
## Summary
- Prefixed unused `response` variable with underscore in `script-proxy-policy-runtime.test.ts` to fix ESLint `no-unused-vars` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
