### PR TITLE
fix: address review feedback on PR #4264 (re-register skill tools)

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -98,6 +98,7 @@ mock.module('../tools/skills/skill-tool-factory.js', () => ({
     skillId: string,
     _skillDir: string,
     versionHash: string,
+    bundled?: boolean,
   ): Tool[] => {
     return entries.map((entry) => ({
       name: entry.name,
@@ -107,6 +108,7 @@ mock.module('../tools/skills/skill-tool-factory.js', () => ({
       origin: 'skill' as const,
       ownerSkillId: skillId,
       ownerSkillVersionHash: versionHash,
+      ownerSkillBundled: bundled ?? undefined,
       getDefinition: () => ({
         name: entry.name,
         description: entry.description,
@@ -140,6 +142,14 @@ mock.module('../tools/registry.js', () => ({
     }
     mockSkillRefCount.delete(skillId);
     mockRegisteredTools.delete(skillId);
+  },
+  getTool: (name: string): Tool | undefined => {
+    for (const tools of mockRegisteredTools.values()) {
+      for (const tool of tools) {
+        if (tool.name === name) return tool;
+      }
+    }
+    return undefined;
   },
   getSkillToolNames: () => {
     const names: string[] = [];


### PR DESCRIPTION
Address review feedback from PR #4264.

- Add getTool to the registry mock so importing it doesn't break module load
- Add bundled param to createSkillToolsFromManifest mock so ownerSkillBundled is set on mock tools
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
