### PR TITLE
fix: address review feedback on PR #4234 (persistentDecisionsAllowed)

### DIFF
--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -30,6 +30,8 @@ export interface PendingConfirmation {
   principalId?: string;
   /** Content-hash of the skill source for version tracking. */
   principalVersion?: string;
+  /** When false, the client should hide "always allow" / trust-rule persistence affordances. */
+  persistentDecisionsAllowed?: boolean;
 }
 
 export interface Run {

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -157,6 +157,13 @@ export async function handleAddTrustRule(
     );
   }
 
+  if (run.pendingConfirmation.persistentDecisionsAllowed === false) {
+    return Response.json(
+      { error: 'Persistent trust rules are not allowed for this tool invocation' },
+      { status: 403 },
+    );
+  }
+
   const body = await req.json() as {
     pattern?: string;
     scope?: string;

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -111,6 +111,7 @@ export class RunOrchestrator {
           principalKind: msg.principalKind,
           principalId: msg.principalId,
           principalVersion: msg.principalVersion,
+          persistentDecisionsAllowed: msg.persistentDecisionsAllowed,
         });
         this.pending.set(run.id, {
           prompterRequestId: msg.requestId,


### PR DESCRIPTION
Address review feedback from PR #4234.

- Add persistentDecisionsAllowed to PendingConfirmation interface in runs-store
- Forward persistentDecisionsAllowed from confirmation_request to run store in orchestrator
- Guard trust-rule HTTP endpoint against persistence when flag is false
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
