### PR TITLE
fix: convert require() to dynamic import() in proxy injection test

### DIFF
--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -267,8 +267,8 @@ describe('MITM rewriteCallback credential injection', () => {
   // handshakes, which is tested separately. Here we verify the core
   // injection logic that the rewriteCallback implements.
 
-  test('injects header for matched host in rewrite callback pattern', () => {
-    const { minimatch } = require('minimatch');
+  test('injects header for matched host in rewrite callback pattern', async () => {
+    const { minimatch } = await import('minimatch');
 
     const tpl = makeTemplate('*.fal.ai', 'authorization', 'Key ');
     const resolved = makeResolved('cred-fal', [tpl]);
@@ -307,8 +307,8 @@ describe('MITM rewriteCallback credential injection', () => {
     expect(headers['content-type']).toBe('application/json');
   });
 
-  test('no injection when hostname does not match any template', () => {
-    const { minimatch } = require('minimatch');
+  test('no injection when hostname does not match any template', async () => {
+    const { minimatch } = await import('minimatch');
 
     const tpl = makeTemplate('*.fal.ai', 'authorization', 'Key ');
     resolveByIdResults.set('cred-fal', makeResolved('cred-fal', [tpl]));


### PR DESCRIPTION
## Summary
- Converted 2 `require('minimatch')` calls to `await import('minimatch')` in `script-proxy-injection-runtime.test.ts` to fix ESLint `no-require-imports` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
