### PR TITLE
fix: replace empty interfaces with type aliases in Slack types

### DIFF
--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -108,8 +108,8 @@ export interface SlackSearchMatch {
   thread_ts?: string;
 }
 
-export interface SlackReactionAddResponse extends SlackApiResponse {}
+export type SlackReactionAddResponse = SlackApiResponse;
 
-export interface SlackConversationLeaveResponse extends SlackApiResponse {}
+export type SlackConversationLeaveResponse = SlackApiResponse;
 
-export interface SlackConversationMarkResponse extends SlackApiResponse {}
+export type SlackConversationMarkResponse = SlackApiResponse;


### PR DESCRIPTION
## Summary
- Converted 3 empty interfaces (`SlackReactionAddResponse`, `SlackConversationLeaveResponse`, `SlackConversationMarkResponse`) to type aliases to fix ESLint `no-empty-object-type` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
