### PR TITLE
fix: address review feedback on PR #4278 (network_request trust rules)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1018,7 +1018,7 @@ describe('Permission Checker', () => {
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
-      expect(options[2].pattern).toBe('web_fetch:*');
+      expect(options[2].pattern).toBe('**');
     });
 
     test('web_fetch: strips fragments when generating allowlist options', () => {
@@ -1026,7 +1026,7 @@ describe('Permission Checker', () => {
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
-      expect(options[2].pattern).toBe('web_fetch:*');
+      expect(options[2].pattern).toBe('**');
     });
 
     test('web_fetch: strips trailing-dot hostnames when generating allowlist options', () => {
@@ -1034,7 +1034,7 @@ describe('Permission Checker', () => {
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
-      expect(options[2].pattern).toBe('web_fetch:*');
+      expect(options[2].pattern).toBe('**');
     });
 
     test('web_fetch: strips userinfo when generating allowlist options', () => {
@@ -1047,7 +1047,7 @@ describe('Permission Checker', () => {
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
-      expect(options[2].pattern).toBe('web_fetch:*');
+      expect(options[2].pattern).toBe('**');
       expect(options[0].pattern).not.toContain('demo:cred123@');
     });
 
@@ -1056,14 +1056,14 @@ describe('Permission Checker', () => {
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com:8443/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com:8443/*');
-      expect(options[2].pattern).toBe('web_fetch:*');
+      expect(options[2].pattern).toBe('**');
     });
 
     test('web_fetch: does not coerce path-only urls to https hostnames in allowlist options', () => {
       const options = generateAllowlistOptions('web_fetch', { url: '/docs/getting-started' });
       expect(options).toHaveLength(2);
       expect(options[0].pattern).toBe('web_fetch:/docs/getting-started');
-      expect(options[1].pattern).toBe('web_fetch:*');
+      expect(options[1].pattern).toBe('**');
     });
 
     test('scaffold_managed_skill: generates per-skill and wildcard options', () => {
@@ -1097,7 +1097,7 @@ describe('Permission Checker', () => {
       expect(options[0].label).toBe('https://[2001:db8::1]/search?q=test');
       expect(options[0].pattern).toBe('web_fetch:https://\\[2001:db8::1\\]/search\\?q=test');
       expect(options[1].pattern).toBe('web_fetch:https://\\[2001:db8::1\\]/*');
-      expect(options[2].pattern).toBe('web_fetch:*');
+      expect(options[2].pattern).toBe('**');
     });
 
     // ── network_request allowlist options ─────────────────────────
@@ -1107,7 +1107,8 @@ describe('Permission Checker', () => {
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('network_request:https://api.example.com/v1/data');
       expect(options[1].pattern).toBe('network_request:https://api.example.com/*');
-      expect(options[2].pattern).toBe('network_request:*');
+      expect(options[2].pattern).toBe('**');
+      expect(options[2].label).toBe('network_request:*');
       expect(options[2].description).toBe('All network requests');
     });
 
@@ -1121,7 +1122,7 @@ describe('Permission Checker', () => {
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('network_request:https://api.example.com:8443/v1/data');
       expect(options[1].pattern).toBe('network_request:https://api.example.com:8443/*');
-      expect(options[2].pattern).toBe('network_request:*');
+      expect(options[2].pattern).toBe('**');
     });
 
     test('network_request: strips fragments and userinfo', () => {
@@ -1147,7 +1148,7 @@ describe('Permission Checker', () => {
     test('network_request: empty url produces only tool wildcard', () => {
       const options = generateAllowlistOptions('network_request', { url: '' });
       expect(options).toHaveLength(1);
-      expect(options[0].pattern).toBe('network_request:*');
+      expect(options[0].pattern).toBe('**');
     });
   });
 

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -357,8 +357,8 @@ describe('createProxyApprovalCallback', () => {
       // Should include an origin-level wildcard pattern (port 443 is normalized
       // away by the URL constructor since it's the default HTTPS port)
       expect(patterns.some((p) => p.includes('https://api.fal.ai/*'))).toBe(true);
-      // Should include the catch-all tool wildcard
-      expect(patterns).toContain('network_request:*');
+      // Should include the catch-all globstar wildcard
+      expect(patterns).toContain('**');
       prompter.resolveConfirmation(msg.requestId, 'allow');
       return p;
     };

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -533,7 +533,10 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
       });
     }
     const toolLabel = TOOL_DISPLAY_NAMES[toolName] ?? toolName;
-    options.push({ label: `${toolName}:*`, description: `All ${toolLabel}`, pattern: `${toolName}:*` });
+    // Use standalone "**" globstar — minimatch only treats ** as globstar when
+    // it is its own path segment, so "${toolName}:*" would fail to match URL
+    // candidates containing "/".  The tool field is already filtered separately.
+    options.push({ label: `${toolName}:*`, description: `All ${toolLabel}`, pattern: `**` });
 
     const seen = new Set<string>();
     return options.filter((o) => {


### PR DESCRIPTION
Address review feedback from PR #4278.

Fix the catch-all allowlist pattern for URL-based tools (web_fetch, browser_navigate, network_request) to use globstar '**' instead of 'toolName:*'. The single '*' in minimatch does not cross '/' separators, making it unable to match URL candidates like 'network_request:https://api.example.com/v1/data'. This was a silent no-op for network_request (Medium risk) where users selecting 'All network requests' would keep getting prompted. The fix uses standalone '**' as the pattern (consistent with starter bundle rules in trust-store.ts), while keeping the display label as 'toolName:*' for user-facing clarity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
