### PR TITLE
chore: remove all references to DONE.md

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -196,7 +196,7 @@ gh project view "$GH_PROJECT_NUMBER" --owner "$GH_PROJECT_OWNER" --format json |
 
 ## Important
 
-- `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md` are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
+- `.private/TODO.md` and `.private/UNREVIEWED_PRS.md` are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
 - Don't sleep for more than 15 seconds at a time while waiting for agents to finish.
 - If an agent reports failure, put the item back in TODO.md and note the failure.
 - If an agent hits merge conflicts, tell it to rebase: `git pull --rebase origin main`.

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -219,7 +219,6 @@ For "Address the feedback on <PR URL>" tasks:
 1. Read its completion message.
 2. Update tracking files (read fresh each time, write back carefully):
    - Remove the completed item from .private/TODO.md.
-   - Append a detailed description of what was done to the end of .private/DONE.md, separated by a horizontal rule.
    - Append the PR link to .private/UNREVIEWED_PRS.md.
 3. Mark the TaskCreate entry as completed.
 4. Increment the **completed count**.
@@ -323,7 +322,7 @@ gh project view "$GH_PROJECT_NUMBER" --owner "$GH_PROJECT_OWNER" --format json |
 
 ## Important
 
-- `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md` are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
+- `.private/TODO.md` and `.private/UNREVIEWED_PRS.md` are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
 - Don't sleep for more than 15 seconds at a time while waiting for agents to finish.
 - If an agent reports failure, put the item back in TODO.md and note the failure.
 - If an agent hits merge conflicts after another agent's PR landed, tell it to rebase against the **feature branch**: `git pull --rebase origin <feature-branch-name>`.

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -90,7 +90,6 @@ For "Address the feedback on <PR URL>" tasks:
 1. Read its completion message.
 2. Update tracking files (read fresh each time, write back carefully):
    - Remove the completed item from .private/TODO.md.
-   - Append a deatiled description of what was done to the end of .private/DONE.md, separated by a horizontal rule.
    - Append the PR link to .private/UNREVIEWED_PRS.md.
 3. Mark the TaskCreate entry as completed.
 4. Increment the **completed count**.
@@ -107,7 +106,7 @@ For "Address the feedback on <PR URL>" tasks:
 When the user says to stop, the max-tasks limit is reached, or TODO.md is empty (and all agents have finished):
 
 1. Let all in-progress agents finish their current task. Do NOT interrupt them.
-2. Process all remaining results (update TODO.md, DONE.md, UNREVIEWED_PRS.md, clean up worktrees).
+2. Process all remaining results (update TODO.md, UNREVIEWED_PRS.md, clean up worktrees).
 3. Delete the team with `TeamDelete`.
 4. Print a final summary table:
 
@@ -120,6 +119,6 @@ When the user says to stop, the max-tasks limit is reached, or TODO.md is empty 
 ## Important
 
 - Don't sleep for more than 15 seconds at a time while waiting for agents to finish.
-- .private/TODO.md, .private/DONE.md, and .private/UNREVIEWED_PRS.md are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
+- .private/TODO.md and .private/UNREVIEWED_PRS.md are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
 - If an agent reports failure, put the item back in TODO.md at its original priority position and note the failure in the summary.
 - If an agent hits merge conflicts after another agent's PR landed, tell it to rebase: `git pull --rebase origin main`.

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -37,8 +37,7 @@ If you can implement it in a single PR:
 
 After you've handled the item:
 
-- Append a deatiled description of what was done to the end of .private/DONE.md, separated by a horizontal rule.
 - If the handled task exists in `.private/TODO.md`, remove that exact item from the list. Be very careful to not accidentally overwrite other changes or remove other items unless you're absolutely sure you're doing the right thing.
 - Provide a detailed description of what you did.
 
-IMPORTANT: .private/TODO.md, .private/DONE.md and .private/UNREVIEWED_PRS.md are written to by other processes so make sure you read them before writing to them and after writing to them. Don't be alarmed if you see changes that you didn't make, but make sure your changes are persisted and you're not overwriting other changes. .private/TODO.md, .private/DONE.md and .private/UNREVIEWED_PRS.md are gitignored.
+IMPORTANT: .private/TODO.md and .private/UNREVIEWED_PRS.md are written to by other processes so make sure you read them before writing to them and after writing to them. Don't be alarmed if you see changes that you didn't make, but make sure your changes are persisted and you're not overwriting other changes. .private/TODO.md and .private/UNREVIEWED_PRS.md are gitignored.

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Or for a focused feature: **`/blitz <feature>`** handles all of the above in one
 
 For controlled, sequential plan execution with human review at every step: **`/safe-execute-plan <file>`** → **`/safe-check-review`** → **`/resume-plan`** → repeat.
 
-All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md`.
+All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md` and `.private/UNREVIEWED_PRS.md`.
 
 **Validation**: Slash commands do **not** run tests, type-checking (`tsc`), or linting by default. These steps are only performed when the task specifically requires it (e.g., "fix the type errors", "make the tests pass"). This keeps agent-driven workflows fast for well-scoped changes.
 


### PR DESCRIPTION
## Summary
- Removed all references to `.private/DONE.md` from slash commands (`work`, `swarm`, `blitz`, `safe-blitz`) and README
- No longer appending completed task descriptions to DONE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
