### PR TITLE
fix: address review feedback on PR #4365 (unified messaging)

### DIFF
--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -162,7 +162,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     // conversationId is the recipient email for Gmail
     const to = conversationId;
     const subject = options?.subject ?? '';
-    const msg = await gmail.sendMessage(token, to, subject, text, options?.inReplyTo);
+    const msg = await gmail.sendMessage(token, to, subject, text, options?.inReplyTo, options?.threadId);
     return {
       id: msg.id,
       timestamp: msg.internalDate ? parseInt(msg.internalDate, 10) : Date.now(),

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -174,6 +174,7 @@ export async function sendMessage(
   subject: string,
   body: string,
   inReplyTo?: string,
+  threadId?: string,
 ): Promise<GmailMessage> {
   const headers = [
     `To: ${to}`,
@@ -189,9 +190,11 @@ export async function sendMessage(
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/, '');
+  const payload: Record<string, unknown> = { raw };
+  if (threadId) payload.threadId = threadId;
   return request<GmailMessage>(token, '/messages/send', {
     method: 'POST',
-    body: JSON.stringify({ raw }),
+    body: JSON.stringify(payload),
   });
 }
 

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -99,12 +99,14 @@ export async function conversationHistory(
   limit = 50,
   latest?: string,
   oldest?: string,
+  cursor?: string,
 ): Promise<SlackConversationHistoryResponse> {
   return request<SlackConversationHistoryResponse>(token, 'conversations.history', {
     channel,
     limit: String(limit),
     latest,
     oldest,
+    cursor,
   });
 }
 

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -98,6 +98,7 @@ function migrateRecordV1toV2(record: Record<string, unknown>): CredentialMetadat
     accountInfo: typeof record.accountInfo === 'string' ? record.accountInfo : undefined,
     oauth2TokenUrl: typeof record.oauth2TokenUrl === 'string' ? record.oauth2TokenUrl : undefined,
     oauth2ClientId: typeof record.oauth2ClientId === 'string' ? record.oauth2ClientId : undefined,
+    oauth2ClientSecret: typeof record.oauth2ClientSecret === 'string' ? record.oauth2ClientSecret : undefined,
     alias: typeof record.alias === 'string' ? record.alias : undefined,
     injectionTemplates: Array.isArray(record.injectionTemplates)
       ? (record.injectionTemplates as CredentialInjectionTemplate[])
@@ -183,6 +184,7 @@ export function upsertCredentialMetadata(
     accountInfo?: string | null;
     oauth2TokenUrl?: string;
     oauth2ClientId?: string;
+    oauth2ClientSecret?: string;
     /** Pass `null` to explicitly clear a previously-set alias. */
     alias?: string | null;
     /** Pass `null` to explicitly clear injection templates. */
@@ -221,6 +223,7 @@ export function upsertCredentialMetadata(
     }
     if (policy?.oauth2TokenUrl !== undefined) existing.oauth2TokenUrl = policy.oauth2TokenUrl;
     if (policy?.oauth2ClientId !== undefined) existing.oauth2ClientId = policy.oauth2ClientId;
+    if (policy?.oauth2ClientSecret !== undefined) existing.oauth2ClientSecret = policy.oauth2ClientSecret;
     if (policy?.alias !== undefined) {
       if (policy.alias === null) {
         delete existing.alias;
@@ -252,6 +255,7 @@ export function upsertCredentialMetadata(
     accountInfo: policy?.accountInfo ?? undefined,
     oauth2TokenUrl: policy?.oauth2TokenUrl,
     oauth2ClientId: policy?.oauth2ClientId,
+    oauth2ClientSecret: policy?.oauth2ClientSecret,
     alias: policy?.alias ?? undefined,
     injectionTemplates: policy?.injectionTemplates ?? undefined,
     createdAt: now,

--- a/assistant/src/watcher/providers/slack.ts
+++ b/assistant/src/watcher/providers/slack.ts
@@ -65,24 +65,28 @@ export const slackProvider: WatcherProvider = {
       const items: WatcherItem[] = [];
       let latestTs = watermark;
 
-      // Poll each DM channel for new messages
+      // Poll each DM channel for new messages, paginating to fetch all
       for (const channel of dmChannels) {
         try {
-          const histResp = await slack.conversationHistory(token, channel.id, 10, undefined, watermark);
-          for (const msg of histResp.messages) {
-            // Skip our own messages
-            if (msg.user === userId) continue;
-            // Skip messages older than watermark (shouldn't happen but guard)
-            if (parseFloat(msg.ts) <= parseFloat(watermark)) continue;
+          let cursor: string | undefined;
+          do {
+            const histResp = await slack.conversationHistory(token, channel.id, 100, undefined, watermark, cursor);
+            for (const msg of histResp.messages) {
+              // Skip our own messages
+              if (msg.user === userId) continue;
+              // Skip messages older than watermark (shouldn't happen but guard)
+              if (parseFloat(msg.ts) <= parseFloat(watermark)) continue;
 
-            const channelName = channel.name ?? channel.user ?? channel.id;
-            const eventType = channel.is_im ? 'slack_dm' : 'slack_group_dm';
-            items.push(messageToItem({ ...msg, channel: channel.id }, eventType, channelName));
+              const channelName = channel.name ?? channel.user ?? channel.id;
+              const eventType = channel.is_im ? 'slack_dm' : 'slack_group_dm';
+              items.push(messageToItem({ ...msg, channel: channel.id }, eventType, channelName));
 
-            if (parseFloat(msg.ts) > parseFloat(latestTs)) {
-              latestTs = msg.ts;
+              if (parseFloat(msg.ts) > parseFloat(latestTs)) {
+                latestTs = msg.ts;
+              }
             }
-          }
+            cursor = histResp.has_more ? histResp.response_metadata?.next_cursor : undefined;
+          } while (cursor);
         } catch (err) {
           // Skip channels we can't read (archived, permissions, etc.)
           log.debug({ channelId: channel.id, err }, 'Skipping channel in Slack watcher');


### PR DESCRIPTION
## Summary
- Persist oauth2ClientSecret in credential metadata store so Slack token refresh works after expiry
- Honor Gmail threadId when sending replies so messages are properly threaded
- Add pagination to Slack history polling to avoid permanently skipping messages

Addresses review feedback from Codex and Devin on #4365.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
