### PR TITLE
fix: address review feedback on PR #4336 (proxied-mode checker)

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -360,7 +360,7 @@ export async function check(
   // proxy with injected credentials. This runs after deny rules but
   // before allow/ask rules so that trust rules cannot auto-approve
   // proxied commands.
-  if ((toolName === 'bash' || toolName === 'host_bash') && input.network_mode === 'proxied') {
+  if (toolName === 'bash' && input.network_mode === 'proxied') {
     return { decision: 'prompt', reason: 'Proxied network mode requires explicit approval for each invocation.' };
   }
 


### PR DESCRIPTION
Reverts the addition of host_bash to the proxied-mode force-prompt check. Prior commit d56d73e2 intentionally excluded host_bash, and the existing test expects host_bash to follow normal flow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
