### PR TITLE
fix: address review feedback on PR #4344 (session timer cleanup)

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -159,6 +159,10 @@ export class ComputerUseSession {
       // occur before runAgentLoop's internal try-catch takes over.
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, sessionId: this.sessionId }, 'Agent loop startup failed');
+      if (this.sessionTimer) {
+        clearTimeout(this.sessionTimer);
+        this.sessionTimer = null;
+      }
       if (this.state !== 'complete' && this.state !== 'error') {
         this.state = 'error';
         this.sendToClient({


### PR DESCRIPTION
Clears sessionTimer in the .catch() handler for runAgentLoop startup failures, preventing a 30-minute timer from retaining session objects and causing memory leaks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
