### PR TITLE
fix: address review feedback on PR #4349 (secret persistence on ingress failure)

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -205,7 +205,16 @@ export async function handleChannelInbound(
       });
 
       const contentToCheck = content ?? '';
-      const ingressCheck = checkIngressForSecrets(contentToCheck);
+      let ingressCheck: ReturnType<typeof checkIngressForSecrets>;
+      try {
+        ingressCheck = checkIngressForSecrets(contentToCheck);
+      } catch (checkErr) {
+        // If the secret check itself throws (e.g. ConfigError from corrupt
+        // config), clear the stored payload so secret-bearing content is
+        // never left on disk.
+        channelDeliveryStore.clearPayload(result.eventId);
+        throw checkErr;
+      }
       if (ingressCheck.blocked) {
         channelDeliveryStore.clearPayload(result.eventId);
         throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);


### PR DESCRIPTION
Wraps checkIngressForSecrets in try-catch to ensure clearPayload is called if the check throws, restoring the invariant that secret-bearing content is never left on disk.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
