### PR TITLE
fix: address review feedback on PR #4356 (multi-conversation visibility)

### DIFF
--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -15,7 +15,7 @@ import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
 import { attachments, messageAttachments, messages, conversations, conversationKeys } from '../../memory/schema.js';
 import type { StoredAttachment } from '../../memory/attachments-store.js';
-import type { AttachmentContext } from '../../daemon/media-visibility-policy.js';
+import { isAttachmentVisible, type AttachmentContext } from '../../daemon/media-visibility-policy.js';
 import { getConversationThreadType } from '../../memory/conversation-store.js';
 import { escapeSqlLike } from '../../memory/search/lexical.js';
 
@@ -99,7 +99,7 @@ function isAttachmentVisibleFromContext(attachmentId: string, currentContext: At
 
   // All sources are private — visible only if the caller is in one of those threads
   return sources.some(
-    (s) => currentContext.isPrivate && currentContext.conversationId === s.conversationId,
+    (s) => isAttachmentVisible({ conversationId: s.conversationId, isPrivate: true }, currentContext),
   );
 }
 


### PR DESCRIPTION
Fixes attachment visibility in search.ts to use isAttachmentVisible from the policy module instead of an inline check, ensuring consistent visibility logic across both materialize.ts and search.ts. The materialize.ts fix was already applied in the original PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
