### PR TITLE
fix: address review feedback on PR #4352 (request smuggling prevention)

### DIFF
--- a/assistant/src/tools/network/script-proxy/mitm-handler.ts
+++ b/assistant/src/tools/network/script-proxy/mitm-handler.ts
@@ -97,6 +97,11 @@ function filterHeaders(raw: Record<string, string>): Record<string, string> {
       out[key] = value;
     }
   }
+  // Prevent request-smuggling: when Transfer-Encoding is present,
+  // Content-Length creates ambiguous framing. Drop it per RFC 7230 §3.3.3.
+  if (out['transfer-encoding']) {
+    delete out['content-length'];
+  }
   return out;
 }
 


### PR DESCRIPTION
Drops Content-Length header when Transfer-Encoding is present to prevent ambiguous message framing and potential request-smuggling in the MITM proxy handler.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
