### PR TITLE
fix: address review feedback on PR #4342 (CA bootstrap and MITM gating)

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -139,9 +139,23 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
     const caDir = join(managed.dataDir, 'proxy-ca');
 
     if (templates.size > 0) {
-      // Ensure the CA directory and cert/key exist before starting MITM
-      await ensureLocalCA(managed.dataDir);
+      // Ensure the CA directory and cert/key exist before starting MITM.
+      // If this fails (e.g. missing openssl, unwritable dir), clean up the
+      // session so it doesn't linger as 'starting' and count toward the
+      // per-conversation limit.
+      try {
+        await ensureLocalCA(managed.dataDir);
+      } catch (err) {
+        sessions.delete(sessionId);
+        throw err;
+      }
 
+      // MITM interception relies on NODE_EXTRA_CA_CERTS to make the
+      // generated CA trusted by child processes. This only works for
+      // Node/Bun runtimes — non-Node clients (curl, Python, Go) will
+      // reject the proxy's TLS certificates. For now, MITM is only
+      // enabled when credential injection templates require it, and the
+      // primary use case is Node/Bun subprocesses launched by the agent.
       config.mitmHandler = {
         caDir,
         shouldIntercept: (hostname: string, port: number) =>
@@ -235,21 +249,29 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
 
   const server = createProxyServer(config);
 
-  return new Promise<ProxySession>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('Failed to get server address'));
-        return;
-      }
-      managed.server = server;
-      managed.session.port = addr.port;
-      managed.session.status = 'active';
-      resetIdleTimer(managed);
-      resolve(cloneSession(managed.session));
+  try {
+    return await new Promise<ProxySession>((resolve, reject) => {
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address();
+        if (!addr || typeof addr === 'string') {
+          reject(new Error('Failed to get server address'));
+          return;
+        }
+        managed.server = server;
+        managed.session.port = addr.port;
+        managed.session.status = 'active';
+        resetIdleTimer(managed);
+        resolve(cloneSession(managed.session));
+      });
+      server.on('error', reject);
     });
-    server.on('error', reject);
-  });
+  } catch (err) {
+    // Clean up: close the server if it started, and remove the session so it
+    // doesn't linger as 'starting' and block future session creation.
+    server.close(() => {});
+    sessions.delete(sessionId);
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
Adds try-catch around ensureLocalCA in startSession to clean up session state on failure (deletes from session map instead of leaving as 'starting'). Also wraps the server.listen path in try-catch for the same cleanup. Adds documentation comment explaining MITM is limited to Node/Bun runtimes that honor NODE_EXTRA_CA_CERTS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
