### PR TITLE
fix: address review feedback on PR #4357 (escapeSqlLike double-escaping)

### DIFF
--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -216,6 +216,11 @@ export function escapeSqlLike(s: string): string {
   return s.replace(/'/g, "''").replace(/%/g, '').replace(/_/g, '');
 }
 
+/** Escape only LIKE wildcards (% and _) for use with parameterized queries where the driver handles quoting. */
+export function escapeLikeWildcards(s: string): string {
+  return s.replace(/%/g, '').replace(/_/g, '');
+}
+
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return `${text.slice(0, max - 3)}...`;

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -17,7 +17,7 @@ import { attachments, messageAttachments, messages, conversations, conversationK
 import type { StoredAttachment } from '../../memory/attachments-store.js';
 import type { AttachmentContext } from '../../daemon/media-visibility-policy.js';
 import { getConversationThreadType } from '../../memory/conversation-store.js';
-import { escapeSqlLike } from '../../memory/search/lexical.js';
+import { escapeLikeWildcards } from '../../memory/search/lexical.js';
 
 // ---------------------------------------------------------------------------
 // Recency presets — map human-readable labels to epoch-ms cutoff offsets
@@ -151,7 +151,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
 
   // Filename filter — case-insensitive substring match (escape LIKE wildcards)
   if (params.filename) {
-    conditions.push(like(attachments.originalFilename, `%${escapeSqlLike(params.filename)}%`));
+    conditions.push(like(attachments.originalFilename, `%${escapeLikeWildcards(params.filename)}%`));
   }
 
   // Recency filter — computed cutoff timestamp
@@ -198,7 +198,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
     }
     if (params.filename) {
       whereParts.push(`a.original_filename LIKE ?`);
-      bindValues.push(`%${escapeSqlLike(params.filename)}%`);
+      bindValues.push(`%${escapeLikeWildcards(params.filename)}%`);
     }
     if (params.recency) {
       const offsetMs = RECENCY_MS[params.recency];


### PR DESCRIPTION
Adds escapeLikeWildcards function that only escapes % and _ without touching single quotes, for use with parameterized queries. Keeps existing escapeSqlLike for string-interpolated SQL callers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
