### PR TITLE
fix: address review feedback on PR #4343 (vault keychain fallback list)

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -158,6 +158,15 @@ export function getBackendType(): 'keychain' | 'encrypted' | null {
   return getBackend();
 }
 
+/**
+ * Whether the backend was downgraded from keychain to encrypted at runtime.
+ * When true, credentials may still be readable from keychain via fallback
+ * even though the active backend is encrypted.
+ */
+export function isDowngradedFromKeychain(): boolean {
+  return downgradedFromKeychain;
+}
+
 /** @internal Test-only: reset the cached backend so it's re-evaluated. */
 export function _resetBackend(): void {
   resolvedBackend = undefined;

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -6,6 +6,7 @@ import {
   deleteSecureKey,
   getBackendType,
   listSecureKeys,
+  isDowngradedFromKeychain,
 } from '../../security/secure-keys.js';
 import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata, listCredentialMetadata, assertMetadataWritable } from './metadata-store.js';
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
@@ -246,7 +247,10 @@ class CredentialStoreTool implements Tool {
         // all key names once (instead of per-entry getSecureKey calls that each
         // re-read/re-derive the store). On keychain we trust metadata since the
         // OS keychain has no batch list API.
-        const verifySecrets = getBackendType() === 'encrypted';
+        // In downgraded mode (keychain failed, switched to encrypted), skip
+        // strict filtering — credentials may still be readable from keychain
+        // via getSecureKey's fallback path, so we trust metadata instead.
+        const verifySecrets = getBackendType() === 'encrypted' && !isDowngradedFromKeychain();
         let secureKeySet: Set<string> | undefined;
         if (verifySecrets) {
           try {


### PR DESCRIPTION
Ensures credential_store list includes credentials readable via keychain fallback in downgraded mode, preventing false 'missing' results that trigger unnecessary re-auth flows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
