### PR TITLE
fix: address review feedback on PR #4362 (test mock getTool ordering)

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -144,12 +144,15 @@ mock.module('../tools/registry.js', () => ({
     mockRegisteredTools.delete(skillId);
   },
   getTool: (name: string): Tool | undefined => {
+    // Return the last matching tool to match production behavior where
+    // re-registering a tool overwrites the previous entry (last wins).
+    let found: Tool | undefined;
     for (const tools of mockRegisteredTools.values()) {
       for (const tool of tools) {
-        if (tool.name === name) return tool;
+        if (tool.name === name) found = tool;
       }
     }
-    return undefined;
+    return found;
   },
   getSkillToolNames: () => {
     const names: string[] = [];


### PR DESCRIPTION
Updates getTool mock to return the last (newest) matching tool instead of the first, matching production registry behavior where the latest registration wins.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
