### PR TITLE
fix: address review feedback on PR #4371 (hanging provider abort signal)

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
@@ -94,7 +94,9 @@ describe('CU session skill tool lifecycle cleanup', () => {
     // enough to abort after skill projection has occurred.
     const hangingProvider: Provider = {
       name: 'mock',
-      sendMessage: () => new Promise<ProviderResponse>(() => {}),
+      sendMessage: (_msgs, _tools, _sys, opts) => new Promise<ProviderResponse>((_, reject) => {
+        opts?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+      }),
     };
 
     const session = new ComputerUseSession(


### PR DESCRIPTION
Updates the hangingProvider mock to listen for the abort signal and reject with AbortError, preventing the test from hanging when session.abort() is called.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
