### PR TITLE
fix: address review feedback on PR #4358 (ARCHITECTURE.md proxy docs)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2619,10 +2619,10 @@ All proxy logging passes through sanitization helpers (`logging.ts`) that redact
 
 ### Runtime Wiring Summary
 
-The proxy subsystem is fully wired. The session manager's `startSession()` calls `createProxyServer()` with:
+The proxy subsystem is wired for routing, policy evaluation, and approval prompts. Credential injection (header rewriting) is **not yet implemented** — the `rewriteCallback` and `policyCallback` currently pass through without injecting credentials (see TODO comments in `session-manager.ts`). The session manager's `startSession()` calls `createProxyServer()` with:
 
-- **MITM handler config**: `mitmHandler` is configured with the local CA path and a `rewriteCallback` that injects credential headers for matched hosts
-- **Policy callback**: `evaluateRequestWithApproval()` is called on every request via the `policyCallback`; credential injection happens for both HTTP (via `policyCallback`) and HTTPS (via `rewriteCallback` in the MITM path)
+- **MITM handler config**: `mitmHandler` is configured with the local CA path and a `rewriteCallback` that currently passes through unmodified headers (credential header injection is planned for a later PR)
+- **Policy callback**: `evaluateRequestWithApproval()` is called via the `policyCallback` for access control on non-MITM requests; CONNECT requests routed to the MITM handler skip the `policyCallback` path. Credential injection is not yet implemented for either HTTP or HTTPS
 - **Approval callback**: `createProxyApprovalCallback()` from `session-tool-setup.ts` routes approval prompts through the `PermissionPrompter`, using the `network_request` tool name with URL-based trust rules
 - **Docker network override**: `network_mode: 'proxied'` switches the sandbox to `--network=bridge` with `--add-host=host.docker.internal:host-gateway`; proxy env vars use `host.docker.internal` so containers can reach the host-side proxy
 - **networkMode plumbing**: `shell.ts` passes `{ networkMode }` to `wrapCommand()`, which forwards it to the Docker backend


### PR DESCRIPTION
Fixes ARCHITECTURE.md to accurately state that routing, policy, and approval are wired but credential injection is not yet implemented. Removes false claims about credential header injection being active.

Changes:
- Replaced "fully wired" with accurate description of what is wired (routing, policy, approval) vs what is not (credential injection)
- Corrected rewriteCallback description: it currently passes through unmodified headers, not injecting credentials
- Corrected policyCallback description: CONNECT requests routed to MITM skip the policyCallback path, and credential injection is not implemented for either path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
