### PR TITLE
fix: address review feedback on PR #4346 (approval callback wiring)

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -304,6 +304,7 @@ export async function stopSession(sessionId: ProxySessionId): Promise<void> {
 
     managed.session.status = 'stopped';
     managed.session.port = null;
+    managed.approvalCallback = null;
     managed.stopPromise = null;
   };
 


### PR DESCRIPTION
- Nulls out approvalCallback reference when sessions are stopped to prevent captured closures from retaining objects indefinitely in long-running daemons (P2 feedback).
- P1 (wire approval callback into proxy server) was already addressed in the current code: the policyCallback closure at lines 229-237 already references managed.approvalCallback for ask_missing_credential/ask_unauthenticated decisions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
