### PR TITLE
fix: address review feedback on PR #4360 (CU global registry pollution)

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -10,14 +10,14 @@ import { v4 as uuid } from 'uuid';
 import type { Provider, Message, ContentBlock, ToolDefinition } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
 import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
-import type { ToolExecutionResult } from '../tools/types.js';
+import type { Tool, ToolExecutionResult } from '../tools/types.js';
 import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { SecretPrompter } from '../permissions/secret-prompter.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { allComputerUseTools } from '../tools/computer-use/definitions.js';
-import { registerComputerUseActionTools } from '../tools/computer-use/registry.js';
+import { registerSkillTools } from '../tools/registry.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getSandboxWorkingDir } from '../util/platform.js';
 import { getConfig } from '../config/loader.js';
@@ -279,9 +279,20 @@ export class ComputerUseSession {
 
     let cuToolDefs = this.getProjectedCuToolDefinitions();
     if (!cuToolDefs) {
-      // Fallback: register the legacy hardcoded CU tools in the global
-      // registry so ToolExecutor can resolve them, then use their definitions.
-      registerComputerUseActionTools();
+      // Fallback: register the legacy CU tools as skill-origin tools so
+      // ToolExecutor can resolve them via getTool(), but using the same
+      // ownerSkillId as the bundled computer-use skill. This avoids
+      // core-vs-skill collisions that would permanently block skill
+      // projection recovery on subsequent sessions.
+      const fallbackSkillId = this.preactivatedSkillIds[0] ?? 'computer-use';
+      const fallbackTools: Tool[] = allComputerUseTools.map((t) => ({
+        ...t,
+        origin: 'skill' as const,
+        ownerSkillId: fallbackSkillId,
+      }));
+      registerSkillTools(fallbackTools);
+      // Track in the session map so resetSkillToolProjection cleans up
+      this.skillProjectionState.set(fallbackSkillId, 'fallback');
       cuToolDefs = allComputerUseTools.map((t) => t.getDefinition());
     }
 


### PR DESCRIPTION
Avoids registering CU action tools as core tools in the global registry during the fallback path, preventing permanent skill projection failures after transient errors.

Instead of calling registerComputerUseActionTools() (which registers tools without origin, making them appear as core tools), the fallback now registers tools via registerSkillTools() with origin: 'skill' and the same ownerSkillId as the bundled computer-use skill. This ensures:

- ToolExecutor can still resolve the tools via getTool()
- Future skill projections won't collide (registerSkillTools allows same-owner replacement)
- The fallback tools are cleaned up via resetSkillToolProjection on session teardown
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
