### PR TITLE
fix: put Allow button before Don't Allow in permission prompts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
@@ -146,13 +146,14 @@ struct JITPermissionView: View {
             )
             .opacity(showContent ? 1 : 0)
 
-            // Action buttons
+            // Action buttons — "Allow" comes first; intentional design
+            // choice to make the positive action the default leftmost button.
             HStack(spacing: VSpacing.sm) {
-                permissionButton("Don't Allow", isPrimary: false) {
-                    dismiss()
-                }
                 permissionButton("Allow", isPrimary: false) {
                     manager.grantActivePermission()
+                }
+                permissionButton("Don't Allow", isPrimary: false) {
+                    dismiss()
                 }
                 permissionButton("Always Allow", isPrimary: true) {
                     manager.grantActivePermission(always: true)

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -350,9 +350,11 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var buttonRow: some View {
+        // "Allow" comes first — intentional design choice to make the
+        // positive action the default leftmost (primary) button.
         HStack(spacing: VSpacing.xs) {
-            confirmationButton("Don\u{2019}t Allow", isPrimary: false, isDanger: true) { onDeny() }
             confirmationButton("Allow", isPrimary: true, isDanger: false) { onAllow() }
+            confirmationButton("Don\u{2019}t Allow", isPrimary: false, isDanger: true) { onDeny() }
             if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
             Spacer()
         }


### PR DESCRIPTION
## Summary
- Swap button order in `ToolConfirmationBubble.swift` and `JITPermissionView.swift` so "Allow" appears first (leftmost)
- Add comments documenting this as an intentional design choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
