### PR TITLE
refactor: move request_computer_control to computer-use skill as computer_use_request_control

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bun run src/index.ts daemon start
 - Default tool workspace: `~/.vellum/workspace` (persistent global sandbox filesystem).
 - Sandbox-scoped tools: `file_read`, `file_write`, `file_edit`, and `bash`.
 - Explicit host tools: `host_file_read`, `host_file_write`, `host_file_edit`, and `host_bash` (absolute host paths only for host file tools).
-- Host/computer-use prompts: `host_*`, `request_computer_control`, and `computer_use_*` default to `ask` unless allowlisted/denylisted in trust rules.
+- Host/computer-use prompts: `host_*` and `computer_use_*` (including `computer_use_request_control`) default to `ask` unless allowlisted/denylisted in trust rules.
 - Runtime override removal: CLI `--no-sandbox` is removed; legacy `sandbox_set` IPC messages are accepted but ignored (deprecated no-op).
 
 ### Sandbox Backend Selection

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -98,8 +98,10 @@ registerTool(mockBundledSkillTool);
 
 // Register CU tools so classifyRisk returns their declared Low risk level
 // instead of falling through to Medium (unknown tool).
-import { registerComputerUseTools } from '../tools/computer-use/registry.js';
-registerComputerUseTools();
+import { registerComputerUseActionTools } from '../tools/computer-use/registry.js';
+import { requestComputerControlTool } from '../tools/computer-use/request-computer-control.js';
+registerComputerUseActionTools();
+registerTool(requestComputerControlTool);
 
 function writeSkill(skillId: string, name: string, description = 'Test skill'): void {
   const skillDir = join(checkerTestDir, 'skills', skillId);
@@ -488,11 +490,11 @@ describe('Permission Checker', () => {
       expect(result.matchedRule?.id).toBe('default:ask-computer_use_click-global');
     });
 
-    test('request_computer_control prompts by default via computer-use ask rule', async () => {
-      const result = await check('request_computer_control', { task: 'Open system settings' }, '/tmp');
+    test('computer_use_request_control prompts by default via computer-use ask rule', async () => {
+      const result = await check('computer_use_request_control', { task: 'Open system settings' }, '/tmp');
       expect(result.decision).toBe('prompt');
       expect(result.reason).toContain('ask rule');
-      expect(result.matchedRule?.id).toBe('default:ask-request_computer_control-global');
+      expect(result.matchedRule?.id).toBe('default:ask-computer_use_request_control-global');
     });
 
     test('higher-priority allow rule can override default computer-use ask rule', async () => {
@@ -3855,8 +3857,8 @@ describe('computer-use tool permission defaults', () => {
     }
   });
 
-  test('request_computer_control classifies as Low risk', async () => {
-    const risk = await classifyRisk('request_computer_control', {});
+  test('computer_use_request_control classifies as Low risk', async () => {
+    const risk = await classifyRisk('computer_use_request_control', {});
     expect(risk).toBe(RiskLevel.Low);
   });
 });

--- a/assistant/src/__tests__/computer-use-skill-baseline.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-baseline.test.ts
@@ -24,14 +24,6 @@ describe('computer-use skill baseline: registry tool surfaces', () => {
     }
   });
 
-  test('request_computer_control is registered after initializeTools()', async () => {
-    await initializeTools();
-
-    const tool = getTool('request_computer_control');
-    expect(tool).toBeDefined();
-    expect(tool?.executionMode).toBe('proxy');
-  });
-
   test('getAllToolDefinitions() excludes all computer_use_* tools (proxy exclusion)', async () => {
     await initializeTools();
 
@@ -39,25 +31,29 @@ describe('computer-use skill baseline: registry tool surfaces', () => {
     assertComputerUseToolsAbsent(defNames);
   });
 
-  test('getAllToolDefinitions() excludes request_computer_control (proxy exclusion)', async () => {
+  test('getAllToolDefinitions() excludes computer_use_request_control (proxy exclusion)', async () => {
     await initializeTools();
 
     const defNames = getAllToolDefinitions().map((d) => d.name);
-    expect(defNames).not.toContain('request_computer_control');
+    expect(defNames).not.toContain('computer_use_request_control');
   });
 
-  test('buildToolDefinitions() includes request_computer_control for text sessions', async () => {
+  test('buildToolDefinitions() includes computer_use_request_control for text sessions', async () => {
     await initializeTools();
 
     const defNames = buildToolDefinitions().map((d) => d.name);
-    expect(defNames).toContain('request_computer_control');
+    expect(defNames).toContain('computer_use_request_control');
   });
 
-  test('buildToolDefinitions() excludes all computer_use_* tools from text sessions', async () => {
+  test('buildToolDefinitions() excludes all computer_use_* action tools from text sessions', async () => {
     await initializeTools();
 
     const defNames = buildToolDefinitions().map((d) => d.name);
-    assertComputerUseToolsAbsent(defNames);
+    // The only computer_use_* tool in text sessions is the escalation tool
+    const cuActionTools = defNames.filter(
+      (n) => n.startsWith('computer_use_') && n !== 'computer_use_request_control',
+    );
+    expect(cuActionTools).toHaveLength(0);
   });
 
   test('post-cutover count: 0 computer_use_* tools in core registry', async () => {

--- a/assistant/src/__tests__/computer-use-skill-endstate.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-endstate.test.ts
@@ -35,12 +35,6 @@ describe('computer-use skill end-state', () => {
     }
   });
 
-  test('request_computer_control is still present in core registry', () => {
-    const tool = getTool('request_computer_control');
-    expect(tool).toBeDefined();
-    expect(tool!.name).toBe('request_computer_control');
-  });
-
   // ── getAllToolDefinitions (excludes proxy & skill tools) ──────────
 
   test('getAllToolDefinitions() excludes computer_use_* tools', () => {
@@ -49,23 +43,25 @@ describe('computer-use skill end-state', () => {
     expect(cuDefs).toHaveLength(0);
   });
 
-  test('getAllToolDefinitions() excludes request_computer_control (proxy exclusion)', () => {
+  test('getAllToolDefinitions() excludes computer_use_request_control (proxy exclusion)', () => {
     const defs = getAllToolDefinitions();
-    const found = defs.find((d) => d.name === 'request_computer_control');
+    const found = defs.find((d) => d.name === 'computer_use_request_control');
     expect(found).toBeUndefined();
   });
 
   // ── buildToolDefinitions (text session tool set) ─────────────────
 
-  test('buildToolDefinitions() includes request_computer_control', () => {
+  test('buildToolDefinitions() includes computer_use_request_control', () => {
     const defs = buildToolDefinitions();
-    const found = defs.find((d) => d.name === 'request_computer_control');
+    const found = defs.find((d) => d.name === 'computer_use_request_control');
     expect(found).toBeDefined();
   });
 
   test('buildToolDefinitions() excludes computer_use_* action tools', () => {
     const defs = buildToolDefinitions();
-    const cuDefs = defs.filter((d) => d.name.startsWith('computer_use_'));
+    const cuDefs = defs.filter(
+      (d) => d.name.startsWith('computer_use_') && d.name !== 'computer_use_request_control',
+    );
     expect(cuDefs).toHaveLength(0);
   });
 

--- a/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
@@ -203,10 +203,9 @@ describe('CU session skill tool lifecycle cleanup', () => {
     expect(cuTools).toHaveLength(0);
   });
 
-  test('request_computer_control remains in registry after CU session lifecycle', async () => {
+  test('computer_use_request_control is not in core registry after CU session lifecycle', async () => {
     const { getTool } = await import('../tools/registry.js');
-    const tool = getTool('request_computer_control');
-    expect(tool).toBeDefined();
-    expect(tool!.name).toBe('request_computer_control');
+    const tool = getTool('computer_use_request_control');
+    expect(tool).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -482,35 +482,6 @@ describe('computer-use registration split', () => {
     const registered = getAllTools();
     expect(registered).toHaveLength(12);
     expect(registered.every((t) => t.name.startsWith('computer_use_'))).toBe(true);
-    expect(getTool('request_computer_control')).toBeUndefined();
-  });
-
-  test('registerRequestComputerControlTool registers the escalation tool', async () => {
-    const { registerRequestComputerControlTool } = await import('../tools/computer-use/registry.js');
-
-    __clearRegistryForTesting();
-    expect(getAllTools()).toHaveLength(0);
-
-    registerRequestComputerControlTool();
-
-    const registered = getAllTools();
-    expect(registered).toHaveLength(1);
-    expect(registered[0].name).toBe('request_computer_control');
-  });
-
-  test('registerComputerUseTools (wrapper) registers both action and escalation', async () => {
-    const { registerComputerUseTools } = await import('../tools/computer-use/registry.js');
-
-    __clearRegistryForTesting();
-    expect(getAllTools()).toHaveLength(0);
-
-    registerComputerUseTools();
-
-    const registered = getAllTools();
-    expect(registered).toHaveLength(13);
-
-    const cuActionTools = registered.filter((t) => t.name.startsWith('computer_use_'));
-    expect(cuActionTools).toHaveLength(12);
-    expect(getTool('request_computer_control')).toBeDefined();
+    expect(getTool('computer_use_request_control')).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
@@ -2,7 +2,7 @@
  * Reusable constants and helpers for the computer-use skill migration test suite.
  */
 
-/** The 12 computer_use_* tool names in the core registry. */
+/** The 13 computer_use_* tool names provided by the bundled computer-use skill. */
 export const COMPUTER_USE_TOOL_NAMES = [
   'computer_use_click',
   'computer_use_double_click',
@@ -16,13 +16,14 @@ export const COMPUTER_USE_TOOL_NAMES = [
   'computer_use_run_applescript',
   'computer_use_done',
   'computer_use_respond',
+  'computer_use_request_control',
 ] as const;
 
 /** The skill ID for the bundled computer-use skill (used in later PRs). */
 export const COMPUTER_USE_SKILL_ID = 'computer-use';
 
 /** Number of computer_use_* tools. */
-export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 12
+export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 13
 
 import { expect } from 'bun:test';
 

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -740,7 +740,7 @@ describe('Trust Store', () => {
         'host_file_edit',
         'host_file_read',
         'host_file_write',
-        'request_computer_control',
+        'computer_use_request_control',
         'scaffold_managed_skill',
         'skill_load',
       ]);
@@ -859,12 +859,12 @@ describe('Trust Store', () => {
       expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-computer_use_click-global')!);
     });
 
-    test('findHighestPriorityRule matches default ask for request_computer_control', () => {
-      const match = findHighestPriorityRule('request_computer_control', ['request_computer_control:'], '/tmp');
+    test('findHighestPriorityRule matches default ask for computer_use_request_control', () => {
+      const match = findHighestPriorityRule('computer_use_request_control', ['computer_use_request_control:'], '/tmp');
       expect(match).not.toBeNull();
-      expect(match!.id).toBe('default:ask-request_computer_control-global');
+      expect(match!.id).toBe('default:ask-computer_use_request_control-global');
       expect(match!.decision).toBe('ask');
-      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-request_computer_control-global')!);
+      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-computer_use_request_control-global')!);
     });
 
     test('bootstrap delete rule matches only when workingDir is the workspace dir', () => {
@@ -2053,7 +2053,7 @@ describe('computer-use tool trust rule matching', () => {
     const actionableCuTools = [
       'computer_use_click',
       'computer_use_type_text',
-      'request_computer_control',
+      'computer_use_request_control',
     ];
 
     for (const name of actionableCuTools) {

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -5,9 +5,12 @@ user-invocable: false
 disable-model-invocation: true
 ---
 
-This skill provides the 12 computer_use_* action tools used by ComputerUseSession
-to control the macOS desktop. It is internally preactivated for computer-use sessions
-and is not available in text sessions.
+This skill provides the 13 computer_use_* tools: 12 action tools for controlling
+the macOS desktop (used by CU sessions) and the `computer_use_request_control`
+escalation tool (used by text_qa sessions to hand off to foreground computer use).
+
+The skill is internally preactivated for computer-use sessions. The escalation
+tool is also projected into text_qa sessions via `buildToolDefinitions()`.
 
 Tools in this skill are proxy tools — execution is forwarded to the connected
 macOS client, never handled locally by the daemon.

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -321,6 +321,24 @@
       },
       "executor": "tools/computer-use-respond.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "computer_use_request_control",
+      "description": "Escalate to foreground computer use. Call this when the user explicitly asks you to take control of their computer to perform a task (e.g. \"go ahead and do it\", \"take over\", \"open that for me\"). Provide a concise description of the task that computer use should accomplish.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "task": {
+            "type": "string",
+            "description": "Concise description of what computer use should accomplish"
+          }
+        },
+        "required": ["task"]
+      },
+      "executor": "tools/computer-use-request-control.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-request-control.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-request-control.ts
@@ -1,0 +1,9 @@
+import { forwardComputerUseProxyTool } from '../../../../tools/computer-use/skill-proxy-bridge.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool('computer_use_request_control', input, context);
+}

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -96,7 +96,7 @@ export async function handleTaskSubmit(
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
 
-      // Wire escalation handler so the agent can call request_computer_control
+      // Wire escalation handler so the agent can call computer_use_request_control
       wireEscalationHandler(session, socket, ctx, msg.screenWidth, msg.screenHeight);
 
       ctx.send(socket, {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -158,7 +158,7 @@ export function findSocketForSession(
 
 /**
  * Wire the escalation handler on a text_qa session so that invoking
- * `request_computer_control` creates a CU session and notifies the client.
+ * `computer_use_request_control` creates a CU session and notifies the client.
  *
  * Instead of closing over the original `socket`, the handler looks up the
  * current socket for the session at call time via `ctx.socketToSession`.

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1110,7 +1110,7 @@ export interface TaskRouted {
   interactionType: 'computer_use' | 'text_qa';
   /** The task text passed to the escalated session. */
   task?: string;
-  /** Set when a text_qa session escalates to computer_use via request_computer_control. */
+  /** Set when a text_qa session escalates to computer_use via computer_use_request_control. */
   escalatedFrom?: string;
 }
 

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -393,7 +393,7 @@ export function buildCompletionSummary(surfaceType: string | undefined, actionId
 
 /**
  * Resolve a proxy tool call that targets a UI surface.
- * Handles ui_show, ui_update, ui_dismiss, request_file, request_computer_control, and app_open.
+ * Handles ui_show, ui_update, ui_dismiss, request_file, computer_use_request_control, and app_open.
  */
 export async function surfaceProxyResolver(
   ctx: SurfaceSessionContext,
@@ -555,7 +555,7 @@ export async function surfaceProxyResolver(
     return { content: lastAction ? 'Surface completed' : 'Surface dismissed', isError: false };
   }
 
-  if (toolName === 'request_computer_control') {
+  if (toolName === 'computer_use_request_control') {
     const task = typeof input.task === 'string' ? input.task : 'Perform the requested task';
     if (!ctx.onEscalateToComputerUse) {
       return {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -376,7 +376,7 @@ export class Session {
 
   /**
    * Set a callback for when a text_qa session escalates to computer use
-   * via the `request_computer_control` tool.
+   * via the `computer_use_request_control` tool.
    */
   setEscalationHandler(handler: (task: string, sourceSessionId: string) => boolean): void {
     this.onEscalateToComputerUse = handler;

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -26,7 +26,7 @@ const COMPUTER_USE_TOOLS = [
   'computer_use_wait',
   'computer_use_open_app',
   'computer_use_run_applescript',
-  'request_computer_control',
+  'computer_use_request_control',
   // computer_use_done and computer_use_respond are terminal signal tools
   // (RiskLevel.Low) — they don't perform any computer action, so they
   // should NOT get an 'ask' rule.

--- a/assistant/src/tools/computer-use/registry.ts
+++ b/assistant/src/tools/computer-use/registry.ts
@@ -1,38 +1,22 @@
 /**
  * Registers computer-use tools with the daemon's tool registry.
  *
- * Split into action tools (12 `computer_use_*`) and the escalation tool
- * (`request_computer_control`) so the cutover (PR 09) can stop registering
- * action tools without affecting the escalation tool.
+ * The 12 computer_use_* action tools and the computer_use_request_control
+ * escalation tool are now provided by the bundled computer-use skill.
+ * This module retains registerComputerUseActionTools() for backward
+ * compatibility (used by tests), but it is no longer called during
+ * normal startup.
  */
 
 import { registerTool } from '../registry.js';
 import { allComputerUseTools } from './definitions.js';
-import { requestComputerControlTool } from './request-computer-control.js';
 
 /**
  * Register the 12 `computer_use_*` action proxy tools.
- * After cutover these will be provided by the bundled computer-use skill instead.
+ * After cutover these are provided by the bundled computer-use skill instead.
  */
 export function registerComputerUseActionTools(): void {
   for (const tool of allComputerUseTools) {
     registerTool(tool);
   }
-}
-
-/**
- * Register the `request_computer_control` escalation proxy tool.
- * This remains a core tool even after cutover.
- */
-export function registerRequestComputerControlTool(): void {
-  registerTool(requestComputerControlTool);
-}
-
-/**
- * Register all computer-use tools (action + escalation).
- * Backward-compatible wrapper — call sites that need both can still use this.
- */
-export function registerComputerUseTools(): void {
-  registerComputerUseActionTools();
-  registerRequestComputerControlTool();
 }

--- a/assistant/src/tools/computer-use/request-computer-control.ts
+++ b/assistant/src/tools/computer-use/request-computer-control.ts
@@ -1,5 +1,5 @@
 /**
- * request_computer_control tool definition.
+ * computer_use_request_control tool definition.
  *
  * This tool allows a text_qa session to escalate to foreground computer use
  * when the user explicitly requests it (e.g. "go ahead and do it", "take over
@@ -9,6 +9,10 @@
  *
  * This tool is only available to text_qa sessions. It must NOT be added to
  * CU sessions (that would be recursive).
+ *
+ * Part of the bundled computer-use skill. The definition here is imported by
+ * buildToolDefinitions() so text_qa sessions can include it without
+ * preactivating the entire skill.
  */
 
 import { RiskLevel } from '../../permissions/types.js';
@@ -16,7 +20,7 @@ import type { Tool, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 
 export const requestComputerControlTool: Tool = {
-  name: 'request_computer_control',
+  name: 'computer_use_request_control',
   description:
     'Escalate to foreground computer use. Call this when the user explicitly asks you to ' +
     'take control of their computer to perform a task (e.g. "go ahead and do it", ' +

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -662,7 +662,7 @@ function resolveExecutionTarget(toolName: string): ExecutionTarget {
     return 'host';
   }
   // Prefix heuristics for core tools that don't declare an explicit target.
-  if (toolName.startsWith('host_') || toolName.startsWith('computer_use_') || toolName === 'request_computer_control') {
+  if (toolName.startsWith('host_') || toolName.startsWith('computer_use_')) {
     return 'host';
   }
   return 'sandbox';

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -2,7 +2,6 @@ import { RiskLevel } from '../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from './types.js';
 import type { ToolDefinition } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
-import { registerRequestComputerControlTool } from './computer-use/registry.js';
 import { allComputerUseTools } from './computer-use/definitions.js';
 import { requestComputerControlTool } from './computer-use/request-computer-control.js';
 import { registerUiSurfaceTools } from './ui-surface/registry.js';
@@ -223,10 +222,8 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
-  // Only register the escalation tool in core. The 12 computer_use_* action
-  // tools are now provided by the bundled computer-use skill, projected into
-  // CU sessions via preactivatedSkillIds.
-  registerRequestComputerControlTool();
+  // All computer_use_* tools (including the escalation tool) are now provided
+  // by the bundled computer-use skill. No CU tools are registered in core.
   registerUiSurfaceTools();
   registerAppTools();
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -371,7 +371,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        // Handle escalation: text_qa -> computer_use via request_computer_control
+        // Handle escalation: text_qa -> computer_use via computer_use_request_control
         daemonClient.onTaskRouted = { [weak self] routed in
             guard let self else { return }
             // Only handle escalation messages (those with escalatedFrom set)

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1324,7 +1324,7 @@ public struct IPCTaskRouted: Codable, Sendable {
     public let interactionType: String
     /// The task text passed to the escalated session.
     public let task: String?
-    /// Set when a text_qa session escalates to computer_use via request_computer_control.
+    /// Set when a text_qa session escalates to computer_use via computer_use_request_control.
     public let escalatedFrom: String?
 }
 


### PR DESCRIPTION
## Summary
- Renamed `request_computer_control` → `computer_use_request_control` to follow the `computer_use_*` naming convention
- Added the tool to the bundled computer-use skill's `TOOLS.json` with an executor wrapper, alongside the other 12 action tools
- Removed core tool registration — the tool definition is still imported by `buildToolDefinitions()` for text_qa session availability
- Updated proxy resolver, permissions defaults, executor heuristics, tests, and docs

> Note: ARCHITECTURE.md reference updates were blocked by a pre-commit hook false positive (`client_secret` in pre-existing OAuth documentation). Those references still use the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
