### PR TITLE
fix: address review feedback on PR #4355 (session-manager allKnown templates)

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -17,6 +17,7 @@ import { getCAPath, ensureLocalCA } from './certs.js';
 import { minimatch } from 'minimatch';
 import { resolveById } from '../../credentials/resolve.js';
 import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
+import { listCredentialMetadata } from '../../credentials/metadata-store.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
 
 const DEFAULT_CONFIG: ProxySessionConfig = {
@@ -196,9 +197,14 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
 
   // Build the policy callback for HTTP/CONNECT request gating
   const policyCallback: PolicyCallback = async (hostname: string, reqPath: string) => {
+    // Build from the full credential registry (not just the session's
+    // credentials) so evaluateRequestWithApproval can distinguish
+    // ask_missing_credential from ask_unauthenticated.
     const allKnown: CredentialInjectionTemplate[] = [];
-    for (const tpls of templates.values()) {
-      allKnown.push(...tpls);
+    for (const meta of listCredentialMetadata()) {
+      if (meta.injectionTemplates?.length) {
+        allKnown.push(...meta.injectionTemplates);
+      }
     }
 
     const decision = evaluateRequestWithApproval(


### PR DESCRIPTION
Builds allKnown templates from the full credential registry via listCredentialMetadata() instead of only the session's credentials. This makes the ask_missing_credential decision path reachable, allowing the policy engine to correctly distinguish between 'host is known but session lacks the credential' vs 'host is completely unknown'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
