### PR TITLE
fix: address review feedback on PR #4364 (credential injection fixes)

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -165,30 +165,41 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
           // Inject credential values into HTTPS requests that match a
           // template host pattern. Secret values are read at injection time
           // and MUST NEVER be logged or returned to callers.
+
+          // Collect all matching candidates first so we can detect ambiguity
+          // (same guard as the HTTP policyCallback path).
+          const candidates: { credId: string; tpl: CredentialInjectionTemplate }[] = [];
           for (const [credId, tpls] of templates) {
             for (const tpl of tpls) {
-              if (!minimatch(req.hostname, tpl.hostPattern, { nocase: true })) continue;
+              if (minimatch(req.hostname, tpl.hostPattern, { nocase: true })) {
+                candidates.push({ credId, tpl });
+              }
+            }
+          }
 
+          // Ambiguous — multiple templates match; don't inject the wrong secret.
+          if (candidates.length > 1) {
+            return req.headers;
+          }
+
+          for (const { credId, tpl } of candidates) {
+            // Query param injection requires URL path rewriting, which the
+            // current RewriteCallback interface doesn't support. Skip so
+            // other matching templates can still apply.
+            if (tpl.injectionType === 'query') continue;
+
+            if (tpl.injectionType === 'header' && tpl.headerName) {
               const resolved = resolveById(credId);
               if (!resolved) continue;
               const value = getSecureKey(resolved.storageKey);
               if (!value) continue;
 
-              if (tpl.injectionType === 'header' && tpl.headerName) {
-                req.headers[tpl.headerName.toLowerCase()] =
-                  (tpl.valuePrefix ?? '') + value;
-                return req.headers;
-              }
-              // Query param injection requires URL path rewriting, which the
-              // current RewriteCallback interface doesn't support. For now,
-              // return headers unchanged — query injection will be wired once
-              // the MITM handler gains path-rewrite capability.
-              if (tpl.injectionType === 'query') {
-                return req.headers;
-              }
+              req.headers[tpl.headerName.toLowerCase()] =
+                (tpl.valuePrefix ?? '') + value;
               return req.headers;
             }
           }
+
           return req.headers;
         },
       };
@@ -225,7 +236,7 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
 
         if (template.injectionType === 'header' && template.headerName) {
           const headerValue = (template.valuePrefix ?? '') + value;
-          return { [template.headerName]: headerValue };
+          return { [template.headerName.toLowerCase()]: headerValue };
         }
         // Query param injection is handled via URL rewriting in the MITM path
         return {};


### PR DESCRIPTION
Adds ambiguity guard in MITM rewriteCallback, uses continue instead of return for query-only templates, and lowercases header names in policyCallback to match MITM path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
