### PR TITLE
fix: address review feedback on PR #4364 (credential injection headers)

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -162,12 +162,8 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
         shouldIntercept: (hostname: string, port: number) =>
           routeConnection(hostname, port, managed.session.credentialIds, templates),
         rewriteCallback: async (req) => {
-          // Inject credential values into HTTPS requests that match a
-          // template host pattern. Secret values are read at injection time
-          // and MUST NEVER be logged or returned to callers.
-
-          // Collect all matching candidates first so we can detect ambiguity
-          // (same guard as the HTTP policyCallback path).
+          // Collect all matching candidates to detect ambiguity before
+          // injecting any secrets — mirrors the HTTP policyCallback guard.
           const candidates: { credId: string; tpl: CredentialInjectionTemplate }[] = [];
           for (const [credId, tpls] of templates) {
             for (const tpl of tpls) {
@@ -177,27 +173,28 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
             }
           }
 
-          // Ambiguous — multiple templates match; don't inject the wrong secret.
-          if (candidates.length > 1) {
+          if (candidates.length === 0) return req.headers;
+          // Ambiguous — multiple templates match; block to avoid injecting
+          // the wrong secret (403 Forbidden via null return).
+          if (candidates.length > 1) return null;
+
+          const { credId, tpl } = candidates[0];
+
+          // Query param injection requires URL path rewriting, which the
+          // current RewriteCallback interface doesn't support. Pass through
+          // unchanged — query injection will be wired once the MITM handler
+          // gains path-rewrite capability.
+          if (tpl.injectionType === 'query') return req.headers;
+
+          if (tpl.injectionType === 'header' && tpl.headerName) {
+            const resolved = resolveById(credId);
+            if (!resolved) return req.headers;
+            const value = getSecureKey(resolved.storageKey);
+            if (!value) return req.headers;
+
+            req.headers[tpl.headerName.toLowerCase()] =
+              (tpl.valuePrefix ?? '') + value;
             return req.headers;
-          }
-
-          for (const { credId, tpl } of candidates) {
-            // Query param injection requires URL path rewriting, which the
-            // current RewriteCallback interface doesn't support. Skip so
-            // other matching templates can still apply.
-            if (tpl.injectionType === 'query') continue;
-
-            if (tpl.injectionType === 'header' && tpl.headerName) {
-              const resolved = resolveById(credId);
-              if (!resolved) continue;
-              const value = getSecureKey(resolved.storageKey);
-              if (!value) continue;
-
-              req.headers[tpl.headerName.toLowerCase()] =
-                (tpl.valuePrefix ?? '') + value;
-              return req.headers;
-            }
           }
 
           return req.headers;


### PR DESCRIPTION
Three fixes for the MITM rewriteCallback and HTTP policyCallback credential injection:

1. **P1**: Collect all matching candidates before injecting secrets in the MITM path. When multiple credentials match the same host, return null (403 Forbidden) instead of injecting the first match. Mirrors the ambiguity guard in the HTTP policyCallback.

2. **P2**: When a matched template uses query injection (unsupported), the MITM path no longer short-circuits — it falls through to the pass-through return, avoiding silently skipping valid header templates.

3. **Header case**: Lowercase header name in policyCallback to match the MITM path, preventing duplicate headers when Node.js lowercases incoming request header keys.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
