### PR TITLE
fix: respect task cancellation in accessibility permission polling loop

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -20,6 +20,7 @@ extension AppDelegate {
         // Poll every 500ms for up to 30 seconds
         for _ in 0..<60 {
             try? await Task.sleep(nanoseconds: 500_000_000)
+            if Task.isCancelled { return false }
             if ActionExecutor.checkAccessibilityPermission(prompt: false) { return true }
         }
         return false


### PR DESCRIPTION
## Summary
- Add `Task.isCancelled` check inside `waitForAccessibilityPermission()` polling loop
- Without this, `try?` on `Task.sleep` swallows `CancellationError`, making the 30s loop uninterruptible when the user cancels via Escape

Addresses review feedback from Devin on #4377.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
