### PR TITLE
fix: prevent watermark loss on pagination failure and allow oauth2 secret clearing

### DIFF
--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -184,7 +184,8 @@ export function upsertCredentialMetadata(
     accountInfo?: string | null;
     oauth2TokenUrl?: string;
     oauth2ClientId?: string;
-    oauth2ClientSecret?: string;
+    /** Pass `null` to explicitly clear a previously-set client secret. */
+    oauth2ClientSecret?: string | null;
     /** Pass `null` to explicitly clear a previously-set alias. */
     alias?: string | null;
     /** Pass `null` to explicitly clear injection templates. */
@@ -223,7 +224,13 @@ export function upsertCredentialMetadata(
     }
     if (policy?.oauth2TokenUrl !== undefined) existing.oauth2TokenUrl = policy.oauth2TokenUrl;
     if (policy?.oauth2ClientId !== undefined) existing.oauth2ClientId = policy.oauth2ClientId;
-    if (policy?.oauth2ClientSecret !== undefined) existing.oauth2ClientSecret = policy.oauth2ClientSecret;
+    if (policy?.oauth2ClientSecret !== undefined) {
+      if (policy.oauth2ClientSecret === null) {
+        delete existing.oauth2ClientSecret;
+      } else {
+        existing.oauth2ClientSecret = policy.oauth2ClientSecret;
+      }
+    }
     if (policy?.alias !== undefined) {
       if (policy.alias === null) {
         delete existing.alias;
@@ -255,7 +262,7 @@ export function upsertCredentialMetadata(
     accountInfo: policy?.accountInfo ?? undefined,
     oauth2TokenUrl: policy?.oauth2TokenUrl,
     oauth2ClientId: policy?.oauth2ClientId,
-    oauth2ClientSecret: policy?.oauth2ClientSecret,
+    oauth2ClientSecret: policy?.oauth2ClientSecret ?? undefined,
     alias: policy?.alias ?? undefined,
     injectionTemplates: policy?.injectionTemplates ?? undefined,
     createdAt: now,

--- a/assistant/src/watcher/providers/slack.ts
+++ b/assistant/src/watcher/providers/slack.ts
@@ -65,9 +65,13 @@ export const slackProvider: WatcherProvider = {
       const items: WatcherItem[] = [];
       let latestTs = watermark;
 
-      // Poll each DM channel for new messages, paginating to fetch all
+      // Poll each DM channel for new messages, paginating to fetch all.
+      // We track a per-channel watermark candidate and only merge it into the
+      // global watermark after the entire pagination loop succeeds. This prevents
+      // advancing past unread messages when a later page fails (rate limit, etc.).
       for (const channel of dmChannels) {
         try {
+          let channelLatestTs = watermark;
           let cursor: string | undefined;
           do {
             const histResp = await slack.conversationHistory(token, channel.id, 100, undefined, watermark, cursor);
@@ -81,12 +85,16 @@ export const slackProvider: WatcherProvider = {
               const eventType = channel.is_im ? 'slack_dm' : 'slack_group_dm';
               items.push(messageToItem({ ...msg, channel: channel.id }, eventType, channelName));
 
-              if (parseFloat(msg.ts) > parseFloat(latestTs)) {
-                latestTs = msg.ts;
+              if (parseFloat(msg.ts) > parseFloat(channelLatestTs)) {
+                channelLatestTs = msg.ts;
               }
             }
             cursor = histResp.has_more ? histResp.response_metadata?.next_cursor : undefined;
           } while (cursor);
+          // Only advance after all pages for this channel succeeded
+          if (parseFloat(channelLatestTs) > parseFloat(latestTs)) {
+            latestTs = channelLatestTs;
+          }
         } catch (err) {
           // Skip channels we can't read (archived, permissions, etc.)
           log.debug({ channelId: channel.id, err }, 'Skipping channel in Slack watcher');


### PR DESCRIPTION
## Summary
- Track per-channel `channelLatestTs` in Slack watcher and only merge into global watermark after all pagination pages succeed, preventing permanent message loss on transient failures
- Allow `oauth2ClientSecret` to be explicitly cleared via `null` in credential metadata store, matching the pattern used by `accountInfo` and `alias`

Addresses review feedback from Codex on #4378.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
