### PR TITLE
fix: restrict external popup opens to user-activated links

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -181,14 +181,19 @@ struct InlineVideoWebView: NSViewRepresentable {
 
         // MARK: - WKUIDelegate
 
-        /// Block popup windows and open their URL in the default browser instead.
+        /// Handle popup/new-window requests. Only open the URL externally when the
+        /// user explicitly clicked a link; script-driven window.open() calls are
+        /// silently blocked to prevent malicious embeds from triggering unsolicited
+        /// browser navigations.
         func webView(
             _ webView: WKWebView,
             createWebViewWith configuration: WKWebViewConfiguration,
             for navigationAction: WKNavigationAction,
             windowFeatures: WKWindowFeatures
         ) -> WKWebView? {
-            Self.openExternallyIfSafe(navigationAction.request.url)
+            if navigationAction.navigationType == .linkActivated {
+                Self.openExternallyIfSafe(navigationAction.request.url)
+            }
             return nil
         }
 


### PR DESCRIPTION
Gate openExternallyIfSafe to user-initiated navigations (linkActivated) only. Script-driven window.open() calls are now blocked by returning nil, preventing malicious embeds from triggering unsolicited browser navigations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
