### PR TITLE
perf: parallelize test runner (58s → ~15s)

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -8,58 +8,101 @@ set -uo pipefail
 # specifier wins across ALL test files in the process.  This means test files
 # that mock a module break other test files that need the real implementation.
 # To avoid order-dependent CI flakes, run each test file in its own Bun process.
+#
+# Files run in parallel (configurable via TEST_WORKERS, default: CPU count).
 # ---------------------------------------------------------------------------
 
 EXCLUDE_EXPERIMENTAL="${EXCLUDE_EXPERIMENTAL:-false}"
+WORKERS="${TEST_WORKERS:-$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 8)}"
 
 EXPERIMENTAL_FILES=(
   "skill-load-tool.test.ts"
   "memory-regressions.experimental.test.ts"
 )
 
-found_test=0
-any_failed=0
-failed_files=()
+# Collect test files, filtering experimental if needed
+test_files=()
 while IFS= read -r test_file; do
-  found_test=1
-
   if [[ "${EXCLUDE_EXPERIMENTAL}" == "true" ]]; then
     base_name="$(basename "${test_file}")"
     skip=0
     for ef in "${EXPERIMENTAL_FILES[@]}"; do
-      if [[ "${base_name}" == "${ef}" ]]; then skip=1; break; fi
+      if [[ "${base_name}" == "${ef}" ]]; then
+        skip=1
+        break
+      fi
     done
     if [[ ${skip} -eq 1 ]]; then
-      echo "==> Skipping ${test_file} (experimental)"
       continue
     fi
-    echo "==> Running ${test_file}"
-    if ! bun test --test-name-pattern '^(?!.*\[experimental\])' "${test_file}"; then
-      any_failed=1
-      failed_files+=("${test_file}")
-    fi
-  else
-    echo "==> Running ${test_file}"
-    if ! bun test "${test_file}"; then
-      any_failed=1
-      failed_files+=("${test_file}")
-    fi
   fi
+  test_files+=("${test_file}")
 done < <(find src/__tests__ -maxdepth 1 -type f -name '*.test.ts' | sort)
 
-if [[ ${found_test} -eq 0 ]]; then
+if [[ ${#test_files[@]} -eq 0 ]]; then
   echo "No test files found under src/__tests__"
   exit 1
 fi
 
-if [[ ${any_failed} -ne 0 ]]; then
+echo "Running ${#test_files[@]} test files (${WORKERS} workers)"
+
+# Temp dir for per-file output capture and failure tracking
+results_dir="$(mktemp -d)"
+trap 'rm -rf "${results_dir}"' EXIT
+
+# Run tests in parallel, capturing output per file
+printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
+  test_file="$1"
+  results_dir="$2"
+  exclude_exp="$3"
+
+  safe_name="$(echo "${test_file}" | tr "/" "_")"
+  out_file="${results_dir}/${safe_name}.out"
+  time_file="${results_dir}/${safe_name}.time"
+
+  start_ms=$(perl -MTime::HiRes=time -e "printf \"%d\", time*1000")
+
+  if [[ "${exclude_exp}" == "true" ]]; then
+    bun test --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
+  else
+    bun test "${test_file}" > "${out_file}" 2>&1
+  fi
+  exit_code=$?
+
+  end_ms=$(perl -MTime::HiRes=time -e "printf \"%d\", time*1000")
+  elapsed=$(( end_ms - start_ms ))
+
+  base="$(basename "${test_file}")"
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "${test_file}" >> "${results_dir}/failures"
+    echo "  ✗ ${base} (${elapsed}ms)"
+  else
+    echo "  ✓ ${base} (${elapsed}ms)"
+  fi
+' _ {} "${results_dir}" "${EXCLUDE_EXPERIMENTAL}"
+
+# Print output for any failed tests
+if [[ -f "${results_dir}/failures" ]]; then
   echo ""
+  failed_count=0
+  while IFS= read -r f; do
+    failed_count=$((failed_count + 1))
+    safe_name="$(echo "${f}" | tr "/" "_")"
+    echo "──────────────────────────────────────────"
+    echo "FAIL: ${f}"
+    echo "──────────────────────────────────────────"
+    cat "${results_dir}/${safe_name}.out"
+    echo ""
+  done < "${results_dir}/failures"
+
   echo "========================================"
-  echo "  FAILED TEST FILES (${#failed_files[@]}):"
+  echo "  FAILED TEST FILES (${failed_count}):"
   echo "========================================"
-  for f in "${failed_files[@]}"; do
+  while IFS= read -r f; do
     echo "  ✗ ${f}"
-  done
+  done < "${results_dir}/failures"
   echo "========================================"
   exit 1
 fi
+
+echo "All ${#test_files[@]} test files passed"


### PR DESCRIPTION
## Summary
- Replace serial `while` loop in `scripts/test.sh` with parallel execution via `xargs -P`
- Default worker count is CPU core count, configurable via `TEST_WORKERS` env var
- Per-file output capture with clean progress lines (`✓`/`✗` + timing) and full failure output at the end
- ~4x speedup: 58s serial → 12-20s parallel (on 16-core machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
