### PR TITLE
fix: reject empty host in CONNECT tunnel and guard writable check

### DIFF
--- a/assistant/src/tools/network/script-proxy/connect-tunnel.ts
+++ b/assistant/src/tools/network/script-proxy/connect-tunnel.ts
@@ -28,6 +28,7 @@ function parseTarget(url: string | undefined): { host: string; port: number } | 
   // Strip brackets from IPv6 literals — net.connect expects the raw address
   if (host.startsWith('[') && host.endsWith(']')) {
     host = host.slice(1, -1);
+    if (!host) return null;
   }
 
   return { host, port };

--- a/assistant/src/tools/network/script-proxy/server.ts
+++ b/assistant/src/tools/network/script-proxy/server.ts
@@ -51,6 +51,7 @@ function parseConnectTarget(url: string | undefined): { host: string; port: numb
   // Strip brackets from IPv6 literals — net.connect expects the raw address
   if (host.startsWith('[') && host.endsWith(']')) {
     host = host.slice(1, -1);
+    if (!host) return null;
   }
   return { host, port };
 }
@@ -118,7 +119,9 @@ export function createProxyServer(config: ProxyServerConfig = {}): Server {
           handleConnect(req, clientSocket, head);
         })
         .catch(() => {
-          clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+          if (clientSocket.writable) {
+            clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+          }
           clientSocket.destroy();
         });
     } else {


### PR DESCRIPTION
Two proxy fixes: (1) reject CONNECT targets with empty host after IPv6 bracket stripping to prevent localhost tunneling, (2) add clientSocket.writable guard in policyCallback catch handler to prevent errors on disconnected sockets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
