### PR TITLE
fix: propagate includes field through catalog skill install

### DIFF
--- a/assistant/src/tools/skills/vellum-catalog.ts
+++ b/assistant/src/tools/skills/vellum-catalog.ts
@@ -20,6 +20,7 @@ interface CatalogEntry {
   name: string;
   description: string;
   emoji?: string;
+  includes?: string[];
 }
 
 function parseCatalogEntry(directory: string): CatalogEntry | null {
@@ -66,7 +67,21 @@ function parseCatalogEntry(directory: string): CatalogEntry | null {
       }
     }
 
-    return { id: basename(directory), name, description, emoji };
+    let includes: string[] | undefined;
+    const includesRaw = fields.includes?.trim();
+    if (includesRaw) {
+      try {
+        const parsed = JSON.parse(includesRaw);
+        if (Array.isArray(parsed) && parsed.every((item: unknown) => typeof item === 'string')) {
+          const filtered = (parsed as string[]).map((s) => s.trim()).filter((s) => s.length > 0);
+          if (filtered.length > 0) includes = filtered;
+        }
+      } catch {
+        // ignore malformed includes
+      }
+    }
+
+    return { id: basename(directory), name, description, emoji, includes };
   } catch (err) {
     log.warn({ err, directory }, 'Failed to read catalog entry');
     return null;
@@ -173,6 +188,7 @@ class VellumSkillsCatalogTool implements Tool {
           description: entry.description,
           bodyMarkdown,
           emoji: entry.emoji,
+          includes: entry.includes,
           overwrite: input.overwrite === true,
           addToIndex: true,
         });


### PR DESCRIPTION
The includes frontmatter field (e.g. includes: ["browser"]) was silently dropped when installing skills via the vellum_skills_catalog tool. This fix adds includes to CatalogEntry, parses it from frontmatter, passes it through createManagedSkill, and emits it in the generated SKILL.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
