### PR TITLE
fix: bind proxy to 0.0.0.0 when Docker sandbox is active

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -117,7 +117,7 @@ export function createSession(
  * is configured with a MITM handler that selectively intercepts HTTPS
  * connections to credential-matched hosts.
  */
-export async function startSession(sessionId: ProxySessionId): Promise<ProxySession> {
+export async function startSession(sessionId: ProxySessionId, options?: { listenHost?: string }): Promise<ProxySession> {
   const managed = sessions.get(sessionId);
   if (!managed) throw new Error(`Session not found: ${sessionId}`);
   if (managed.session.status !== 'starting') {
@@ -264,7 +264,7 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
 
   try {
     return await new Promise<ProxySession>((resolve, reject) => {
-      server.listen(0, '127.0.0.1', () => {
+      server.listen(0, options?.listenHost ?? '127.0.0.1', () => {
         const addr = server.address();
         if (!addr || typeof addr === 'string') {
           reject(new Error('Failed to get server address'));
@@ -385,6 +385,7 @@ export async function getOrStartSession(
   config?: Partial<ProxySessionConfig>,
   dataDir?: string,
   approvalCallback?: ProxyApprovalCallback,
+  options?: { listenHost?: string },
 ): Promise<{ session: ProxySession; created: boolean }> {
   // Fast path — session already active, no lock needed.
   const existing = getActiveSession(conversationId);
@@ -417,7 +418,7 @@ export async function getOrStartSession(
     }
 
     const session = createSession(conversationId, credentialIds, config, dataDir, approvalCallback);
-    const started = await startSession(session.id);
+    const started = await startSession(session.id, options);
     return { session: started, created: true };
   })();
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -107,6 +107,7 @@ class ShellTool implements Tool {
           undefined,
           getDataDir(),
           context.proxyApprovalCallback,
+          isDockerSandbox ? { listenHost: '0.0.0.0' } : undefined,
         );
         proxyEnv = getSessionEnv(session.id, { dockerMode: isDockerSandbox });
       } catch (err) {


### PR DESCRIPTION
On Linux with native Docker Engine, host.docker.internal resolves to the Docker bridge gateway IP (e.g. 172.17.0.1), not 127.0.0.1. The proxy server was bound to 127.0.0.1, making it unreachable from Docker containers on Linux. This adds a listenHost option to startSession/getOrStartSession and passes 0.0.0.0 when Docker sandbox mode is active, so the proxy is reachable via the bridge interface.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
