### PR TITLE
fix: preserve request scheme and canonicalize proxy trust candidates

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -61,7 +61,7 @@ function makeAskMissingCredentialRequest(
   return {
     decision: {
       kind: 'ask_missing_credential',
-      target: { hostname: 'api.fal.ai', port: 443, path: '/v1/run' },
+      target: { hostname: 'api.fal.ai', port: 443, path: '/v1/run', scheme: 'https' },
       matchingPatterns: ['*.fal.ai'],
     },
     sessionId: 'session-1',
@@ -75,7 +75,7 @@ function makeAskUnauthenticatedRequest(
   return {
     decision: {
       kind: 'ask_unauthenticated',
-      target: { hostname: 'example.com', port: null, path: '/data' },
+      target: { hostname: 'example.com', port: null, path: '/data', scheme: 'https' },
     },
     sessionId: 'session-2',
     ...overrides,

--- a/assistant/src/__tests__/script-proxy-policy.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy.test.ts
@@ -175,7 +175,7 @@ describe('evaluateRequestWithApproval', () => {
     );
     expect(result).toEqual({
       kind: 'ask_missing_credential',
-      target: { hostname: 'api.fal.ai', port: 443, path: '/v1/run' },
+      target: { hostname: 'api.fal.ai', port: 443, path: '/v1/run', scheme: 'https' },
       matchingPatterns: ['*.fal.ai'],
     });
   });
@@ -213,7 +213,7 @@ describe('evaluateRequestWithApproval', () => {
     );
     expect(result).toEqual({
       kind: 'ask_missing_credential',
-      target: { hostname: 'api.fal.ai', port: 8080, path: '/generate' },
+      target: { hostname: 'api.fal.ai', port: 8080, path: '/generate', scheme: 'https' },
       matchingPatterns: ['*.fal.ai'],
     });
   });
@@ -225,7 +225,7 @@ describe('evaluateRequestWithApproval', () => {
     );
     expect(result).toEqual({
       kind: 'ask_unauthenticated',
-      target: { hostname: 'example.com', port: null, path: '/data' },
+      target: { hostname: 'example.com', port: null, path: '/data', scheme: 'https' },
     });
   });
 
@@ -239,7 +239,7 @@ describe('evaluateRequestWithApproval', () => {
     );
     expect(result).toEqual({
       kind: 'ask_unauthenticated',
-      target: { hostname: 'example.com', port: 443, path: '/' },
+      target: { hostname: 'example.com', port: 443, path: '/', scheme: 'https' },
     });
   });
 
@@ -257,7 +257,7 @@ describe('evaluateRequestWithApproval', () => {
     );
     expect(result).toEqual({
       kind: 'ask_unauthenticated',
-      target: { hostname: 'unknown-service.internal', port: null, path: '/api' },
+      target: { hostname: 'unknown-service.internal', port: null, path: '/api', scheme: 'https' },
     });
   });
 
@@ -268,7 +268,7 @@ describe('evaluateRequestWithApproval', () => {
     );
     expect(result.kind).toBe('ask_unauthenticated');
     if (result.kind === 'ask_unauthenticated') {
-      expect(result.target).toEqual({ hostname: 'localhost', port: 3000, path: '/webhook' });
+      expect(result.target).toEqual({ hostname: 'localhost', port: 3000, path: '/webhook', scheme: 'https' });
     }
   });
 });

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -13,7 +13,7 @@ import type { ToolExecutor } from '../tools/executor.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
-import { generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
+import { generateAllowlistOptions, generateScopeOptions, normalizeWebFetchUrl } from '../permissions/checker.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { coreAppProxyTools } from '../tools/apps/definitions.js';
@@ -194,7 +194,8 @@ export function createProxyApprovalCallback(
     // Use the standard network_request tool name so trust rules align with
     // the checker's URL-based candidate generation and allowlist options.
     const toolName = 'network_request';
-    const url = `https://${hostname}${port ? ':' + port : ''}${path}`;
+    const { scheme } = decision.target;
+    const url = `${scheme}://${hostname}${port ? ':' + port : ''}${path}`;
 
     const input: Record<string, unknown> = {
       url,
@@ -208,13 +209,11 @@ export function createProxyApprovalCallback(
 
     // Check trust store before prompting — build candidates that mirror
     // buildCommandCandidates() in checker.ts for network_request.
-    let urlObj: URL | null = null;
-    try { urlObj = new URL(url); } catch { /* invalid URL — fall through */ }
-
     const candidates: string[] = [`${toolName}:${url}`];
-    if (urlObj) {
-      candidates.push(`${toolName}:${urlObj.href}`);
-      candidates.push(`${toolName}:${urlObj.origin}/*`);
+    const normalized = normalizeWebFetchUrl(url);
+    if (normalized) {
+      candidates.push(`${toolName}:${normalized.href}`);
+      candidates.push(`${toolName}:${normalized.origin}/*`);
     }
     candidates.push(`${toolName}:*`);
     // Deduplicate

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -102,7 +102,7 @@ function canonicalizeWebFetchUrl(parsed: URL): URL {
   return parsed;
 }
 
-function normalizeWebFetchUrl(rawUrl: string): URL | null {
+export function normalizeWebFetchUrl(rawUrl: string): URL | null {
   const trimmed = rawUrl.trim();
   if (!trimmed) return null;
 

--- a/assistant/src/tools/network/script-proxy/http-forwarder.ts
+++ b/assistant/src/tools/network/script-proxy/http-forwarder.ts
@@ -28,6 +28,7 @@ export type PolicyCallback = (
   hostname: string,
   port: number | null,
   path: string,
+  scheme: 'http' | 'https',
 ) => Promise<Record<string, string> | null>;
 
 /**
@@ -129,7 +130,7 @@ export function forwardHttpRequest(
   };
 
   if (policyCallback) {
-    policyCallback(hostname, parsed.port ? Number(parsed.port) : null, path)
+    policyCallback(hostname, parsed.port ? Number(parsed.port) : null, path, 'http')
       .then((extraHeaders) => {
         if (extraHeaders === null) {
           clientRes.writeHead(403, { 'Content-Type': 'text/plain' });

--- a/assistant/src/tools/network/script-proxy/policy.ts
+++ b/assistant/src/tools/network/script-proxy/policy.ts
@@ -90,6 +90,7 @@ export function evaluateRequestWithApproval(
   credentialIds: string[],
   sessionTemplates: Map<string, CredentialInjectionTemplate[]>,
   allKnownTemplates: CredentialInjectionTemplate[],
+  scheme: 'http' | 'https' = 'https',
 ): PolicyDecision {
   const base = evaluateRequest(hostname, path, credentialIds, sessionTemplates);
 
@@ -97,7 +98,7 @@ export function evaluateRequestWithApproval(
     return base;
   }
 
-  const target: RequestTargetContext = { hostname, port, path };
+  const target: RequestTargetContext = { hostname, port, path, scheme };
 
   // Check whether any template in the full registry covers this host.
   const matchingPatterns: string[] = [];

--- a/assistant/src/tools/network/script-proxy/server.ts
+++ b/assistant/src/tools/network/script-proxy/server.ts
@@ -108,7 +108,7 @@ export function createProxyServer(config: ProxyServerConfig = {}): Server {
         config.onRequest('CONNECT', req.url!);
       }
 
-      config.policyCallback(connectTarget.host, connectTarget.port === 443 ? null : connectTarget.port, '/')
+      config.policyCallback(connectTarget.host, connectTarget.port === 443 ? null : connectTarget.port, '/', 'https')
         .then((extraHeaders) => {
           if (extraHeaders === null) {
             clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n');

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -204,7 +204,7 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
   }
 
   // Build the policy callback for HTTP/CONNECT request gating
-  const policyCallback: PolicyCallback = async (hostname: string, port: number | null, reqPath: string) => {
+  const policyCallback: PolicyCallback = async (hostname: string, port: number | null, reqPath: string, scheme: 'http' | 'https') => {
     // Build allKnown from the full credential registry so the policy engine
     // can distinguish "known host, missing credential" from "unknown host".
     const allKnown: CredentialInjectionTemplate[] = [];
@@ -216,7 +216,7 @@ export async function startSession(sessionId: ProxySessionId): Promise<ProxySess
 
     const decision = evaluateRequestWithApproval(
       hostname, port, reqPath,
-      managed.session.credentialIds, templates, allKnown,
+      managed.session.credentialIds, templates, allKnown, scheme,
     );
 
     switch (decision.kind) {

--- a/assistant/src/tools/network/script-proxy/types.ts
+++ b/assistant/src/tools/network/script-proxy/types.ts
@@ -65,6 +65,8 @@ export interface RequestTargetContext {
   hostname: string;
   port: number | null;
   path: string;
+  /** The protocol scheme of the original request ('http' or 'https'). */
+  scheme: 'http' | 'https';
 }
 
 /**


### PR DESCRIPTION
Two proxy trust fixes: (1) use actual request scheme (http/https) instead of hardcoding https:// when building trust URLs, (2) normalize proxy candidate URLs consistently with allowlist option generation via normalizeWebFetchUrl.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
