### PR TITLE
fix: increase error banner line limit to prevent text truncation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -680,7 +680,7 @@ struct ChatView: View {
 
             Text(text)
                 .font(VFont.caption)
-                .lineLimit(2)
+                .lineLimit(4)
 
             Spacer()
 


### PR DESCRIPTION
## Summary
- Increased `.lineLimit` on the error banner text from 2 to 4 in `ChatView.swift`
- Fixes the sensitive information warning banner text getting cut off mid-sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)