### PR TITLE
feat: add Send Anyway button to bypass secret-ingress block

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -53,16 +53,19 @@ export async function handleUserMessage(
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
 
     // Block inbound messages that contain secrets and redirect to secure prompt
-    const ingressCheck = checkIngressForSecrets(msg.content ?? '');
-    if (ingressCheck.blocked) {
-      rlog.warn({ detectedTypes: ingressCheck.detectedTypes }, 'Blocked user message containing secrets');
-      ctx.send(socket, {
-        type: 'error',
-        message: ingressCheck.userNotice!,
-      });
-      // Redirect: trigger a secure prompt so the user can enter the secret safely
-      session.redirectToSecurePrompt(ingressCheck.detectedTypes);
-      return;
+    if (!msg.bypassSecretCheck) {
+      const ingressCheck = checkIngressForSecrets(msg.content ?? '');
+      if (ingressCheck.blocked) {
+        rlog.warn({ detectedTypes: ingressCheck.detectedTypes }, 'Blocked user message containing secrets');
+        ctx.send(socket, {
+          type: 'error',
+          message: ingressCheck.userNotice!,
+          category: 'secret_blocked',
+        });
+        // Redirect: trigger a secure prompt so the user can enter the secret safely
+        session.redirectToSecurePrompt(ingressCheck.detectedTypes);
+        return;
+      }
     }
 
     session.traceEmitter.emit('request_received', 'User message received', {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -33,6 +33,8 @@ export interface UserMessage {
   activeSurfaceId?: string;
   /** The page currently displayed in the WebView (e.g. "settings.html"). */
   currentPage?: string;
+  /** When true, skip the secret-ingress check. Set by the client when the user clicks "Send Anyway". */
+  bypassSecretCheck?: boolean;
 }
 
 export interface UserMessageAttachment {
@@ -894,6 +896,8 @@ export interface SessionsClearResponse {
 export interface ErrorMessage {
   type: 'error';
   message: string;
+  /** Categorizes the error so the client can offer contextual actions (e.g. "Send Anyway" for secret_blocked). */
+  category?: string;
 }
 
 export interface AuthResult {

--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -111,7 +111,17 @@ struct ChatTabView: View {
                         .foregroundColor(.white)
                         .lineLimit(2)
                     Spacer()
-                    if viewModel.isRetryableError {
+                    if viewModel.isSecretBlockError {
+                        Button(action: { viewModel.sendAnyway() }) {
+                            Text("Send Anyway")
+                                .font(VFont.captionMedium)
+                                .foregroundColor(.white)
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, VSpacing.xs)
+                                .background(Color.white.opacity(0.25))
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        }
+                    } else if viewModel.isRetryableError {
                         Button(action: { viewModel.retryLastMessage() }) {
                             Text("Retry")
                                 .font(VFont.captionMedium)

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -397,7 +397,17 @@ struct ThreadChatView: View {
                 .foregroundColor(.white)
                 .lineLimit(2)
             Spacer()
-            if viewModel.isRetryableError {
+            if viewModel.isSecretBlockError {
+                Button(action: { viewModel.sendAnyway() }) {
+                    Text("Send Anyway")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(Color.white.opacity(0.25))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+            } else if viewModel.isRetryableError {
                 Button(action: { viewModel.retryLastMessage() }) {
                     Text("Retry")
                         .font(VFont.captionMedium)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -66,6 +66,8 @@ struct ChatView: View {
     let onDismissError: () -> Void
     let isRetryableError: Bool
     let onRetryError: () -> Void
+    let isSecretBlockError: Bool
+    let onSendAnyway: () -> Void
     let onAcceptSuggestion: () -> Void
     let onAttach: () -> Void
     let onRemoveAttachment: (String) -> Void
@@ -684,7 +686,18 @@ struct ChatView: View {
 
             Spacer()
 
-            if isRetryableError {
+            if isSecretBlockError {
+                Button(action: onSendAnyway) {
+                    Text("Send Anyway")
+                        .font(VFont.captionMedium)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(Color.white.opacity(0.2))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Send message anyway")
+            } else if isRetryableError {
                 Button(action: onRetryError) {
                     Text("Retry")
                         .font(VFont.captionMedium)
@@ -2607,6 +2620,8 @@ private struct ChatViewPreviewWrapper: View {
                 onDismissError: {},
                 isRetryableError: false,
                 onRetryError: {},
+                isSecretBlockError: false,
+                onSendAnyway: {},
                 onAcceptSuggestion: {},
                 onAttach: {},
                 onRemoveAttachment: { _ in },

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1422,6 +1422,8 @@ private struct ActiveChatViewWrapper: View {
             onDismissError: viewModel.dismissError,
             isRetryableError: viewModel.isRetryableError,
             onRetryError: { viewModel.retryLastMessage() },
+            isSecretBlockError: viewModel.isSecretBlockError,
+            onSendAnyway: { viewModel.sendAnyway() },
             onAcceptSuggestion: viewModel.acceptSuggestion,
             onAttach: { openFilePicker(viewModel: viewModel) },
             onRemoveAttachment: { viewModel.removeAttachment(id: $0) },

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -504,6 +504,13 @@ extension ChatViewModel {
             lastContentWasToolCall = false
             if !wasCancelling {
                 errorText = err.message
+                // When the backend blocks a message for containing secrets,
+                // stash the last user message text so "Send Anyway" can resend
+                // with the bypass flag.
+                if err.category == "secret_blocked",
+                   let lastUserMsg = messages.last(where: { $0.role == .user }) {
+                    secretBlockedMessageText = lastUserMsg.text
+                }
             }
             // Reset processing messages to sent
             for i in messages.indices {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -70,6 +70,9 @@ public final class ChatViewModel: ObservableObject {
     /// actual send failures, not for unrelated errors (attachment validation,
     /// confirmation response failures, regenerate errors, etc.).
     private(set) var lastFailedSendError: String?
+    /// Stores the text of a message that was blocked by the secret-ingress check.
+    /// Set when an error with category "secret_blocked" arrives.
+    private(set) var secretBlockedMessageText: String?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?
@@ -229,6 +232,7 @@ public final class ChatViewModel: ObservableObject {
                 lastFailedMessageText = nil
                 lastFailedMessageAttachments = nil
                 lastFailedSendError = nil
+                secretBlockedMessageText = nil
                 currentTurnUserText = text
                 return
             }
@@ -271,6 +275,7 @@ public final class ChatViewModel: ObservableObject {
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
+        secretBlockedMessageText = nil
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
@@ -718,6 +723,7 @@ public final class ChatViewModel: ObservableObject {
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
+        secretBlockedMessageText = nil
     }
 
     /// Dismiss the typed session error state. Clears both the typed error
@@ -775,6 +781,39 @@ public final class ChatViewModel: ObservableObject {
     /// offering to resend a stale cached message.
     public var isRetryableError: Bool {
         lastFailedMessageText != nil && lastFailedSendError != nil
+    }
+
+    /// Whether the current error is a secret-ingress block that can be bypassed.
+    public var isSecretBlockError: Bool {
+        secretBlockedMessageText != nil
+    }
+
+    /// Resend the secret-blocked message with the bypass flag so the backend skips the check.
+    public func sendAnyway() {
+        guard let text = secretBlockedMessageText, let sessionId else { return }
+
+        secretBlockedMessageText = nil
+        errorText = nil
+
+        isSending = true
+        isThinking = true
+
+        if messageLoopTask == nil {
+            startMessageLoop()
+        }
+
+        do {
+            try daemonClient.send(UserMessageMessage(
+                sessionId: sessionId,
+                content: text,
+                bypassSecretCheck: true
+            ))
+        } catch {
+            log.error("Failed to send bypassed message: \(error.localizedDescription)")
+            isSending = false
+            isThinking = false
+            errorText = "Failed to send message."
+        }
     }
 
     /// Retry sending the last user message that failed (e.g. due to daemon disconnection).

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -386,6 +386,8 @@ public struct IPCEnvVarsResponse: Codable, Sendable {
 public struct IPCErrorMessage: Codable, Sendable {
     public let type: String
     public let message: String
+    /// Categorizes the error so the client can offer contextual actions (e.g. "Send Anyway" for secret_blocked).
+    public let category: String?
 }
 
 public struct IPCFileUploadSurfaceData: Codable, Sendable {
@@ -1611,6 +1613,8 @@ public struct IPCUserMessage: Codable, Sendable {
     public let activeSurfaceId: String?
     /// The page currently displayed in the WebView (e.g. "settings.html").
     public let currentPage: String?
+    /// When true, skip the secret-ingress check. Set by the client when the user clicks "Send Anyway".
+    public let bypassSecretCheck: Bool?
 }
 
 public struct IPCUserMessageAttachment: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -279,8 +279,8 @@ extension IPCSessionCreateRequest {
 public typealias UserMessageMessage = IPCUserMessage
 
 extension IPCUserMessage {
-    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil) {
-        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage)
+    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil) {
+        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage, bypassSecretCheck: bypassSecretCheck)
     }
 }
 
@@ -949,8 +949,8 @@ extension IPCMessageDequeued {
 public typealias ErrorMessage = IPCErrorMessage
 
 extension IPCErrorMessage {
-    public init(message: String) {
-        self.init(type: "error", message: message)
+    public init(message: String, category: String? = nil) {
+        self.init(type: "error", message: message, category: category)
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `bypassSecretCheck` field to the `UserMessage` IPC contract and `category` field to `ErrorMessage`
- Backend sends `category: "secret_blocked"` when blocking a message, and skips the check when `bypassSecretCheck` is true
- Client stores the blocked message text and shows a "Send Anyway" button on the error banner (macOS + iOS)
- Clicking "Send Anyway" resends the same message with the bypass flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
