### PR TITLE
feat: add default allow rules for UI surface tools

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -207,6 +207,20 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   }));
 
+  // UI surface tools are purely local rendering operations with no security
+  // implications — they just display content in the user's client.  Default
+  // allow rules ensure they never trigger permission prompts (including in
+  // strict mode).
+  const UI_SURFACE_TOOLS = ['ui_show', 'ui_update', 'ui_dismiss'] as const;
+  const uiSurfaceRules: DefaultRuleTemplate[] = UI_SURFACE_TOOLS.map((tool) => ({
+    id: `default:allow-${tool}-global`,
+    tool,
+    pattern: `${tool}:*`,
+    scope: 'everywhere',
+    decision: 'allow' as const,
+    priority: 100,
+  }));
+
   return [
     ...protectedFileRules,
     ...hostFileRules,
@@ -219,5 +233,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     skillLoadRule,
     browserNavigateRule,
     ...browserToolRules,
+    ...uiSurfaceRules,
   ];
 }


### PR DESCRIPTION
## Summary
- Added default allow rules for `ui_show`, `ui_update`, and `ui_dismiss` in the permission defaults
- These tools only render content in the user's client and have no security implications
- Ensures frictionless UX even in strict permission mode, following the same pattern as browser tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
