### PR TITLE
feat: add tasks and task_runs schema foundation

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -697,6 +697,42 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_followups_channel_thread ON followups(channel, thread_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_followups_status_expected ON followups(status, expected_response_by)`);
 
+  // ── Tasks ─────────────────────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS tasks (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      template TEXT NOT NULL,
+      input_schema TEXT,
+      context_flags TEXT,
+      required_tools TEXT,
+      created_from_conversation_id TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS task_runs (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL REFERENCES tasks(id),
+      conversation_id TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      started_at INTEGER,
+      finished_at INTEGER,
+      error TEXT,
+      principal_id TEXT,
+      memory_scope_id TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_task_id ON task_runs(task_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_status ON task_runs(status)`);
+
   migrateMemoryFtsBackfill(database);
 }
 

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -385,6 +385,36 @@ export const followups = sqliteTable('followups', {
   updatedAt: integer('updated_at').notNull(),
 });
 
+// ── Tasks ────────────────────────────────────────────────────────────
+
+export const tasks = sqliteTable('tasks', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  template: text('template').notNull(),
+  inputSchema: text('input_schema'),
+  contextFlags: text('context_flags'),
+  requiredTools: text('required_tools'),
+  createdFromConversationId: text('created_from_conversation_id'),
+  status: text('status').notNull().default('active'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
+export const taskRuns = sqliteTable('task_runs', {
+  id: text('id').primaryKey(),
+  taskId: text('task_id')
+    .notNull()
+    .references(() => tasks.id),
+  conversationId: text('conversation_id'),
+  status: text('status').notNull().default('pending'),
+  startedAt: integer('started_at'),
+  finishedAt: integer('finished_at'),
+  error: text('error'),
+  principalId: text('principal_id'),
+  memoryScopeId: text('memory_scope_id'),
+  createdAt: integer('created_at').notNull(),
+});
+
 export const homeBaseAppLinks = sqliteTable('home_base_app_links', {
   id: text('id').primaryKey(),
   appId: text('app_id').notNull(),

--- a/assistant/src/tasks/task-store.ts
+++ b/assistant/src/tasks/task-store.ts
@@ -1,0 +1,105 @@
+import { eq, desc } from 'drizzle-orm';
+import { getDb } from '../memory/db.js';
+import { tasks, taskRuns } from '../memory/schema.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface Task {
+  id: string;
+  title: string;
+  template: string;
+  inputSchema: string | null;
+  contextFlags: string | null;
+  requiredTools: string | null;
+  createdFromConversationId: string | null;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface TaskRun {
+  id: string;
+  taskId: string;
+  conversationId: string | null;
+  status: string;
+  startedAt: number | null;
+  finishedAt: number | null;
+  error: string | null;
+  principalId: string | null;
+  memoryScopeId: string | null;
+  createdAt: number;
+}
+
+// ── Task CRUD ────────────────────────────────────────────────────────
+
+export function createTask(opts: {
+  title: string;
+  template: string;
+  inputSchema?: object;
+  contextFlags?: string[];
+  requiredTools?: string[];
+  createdFromConversationId?: string;
+}): Task {
+  const db = getDb();
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  const task: Task = {
+    id,
+    title: opts.title,
+    template: opts.template,
+    inputSchema: opts.inputSchema ? JSON.stringify(opts.inputSchema) : null,
+    contextFlags: opts.contextFlags ? JSON.stringify(opts.contextFlags) : null,
+    requiredTools: opts.requiredTools ? JSON.stringify(opts.requiredTools) : null,
+    createdFromConversationId: opts.createdFromConversationId ?? null,
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(tasks).values(task).run();
+  return task;
+}
+
+export function getTask(id: string): Task | undefined {
+  const db = getDb();
+  return db.select().from(tasks).where(eq(tasks.id, id)).get();
+}
+
+export function listTasks(): Task[] {
+  const db = getDb();
+  return db.select().from(tasks).orderBy(desc(tasks.createdAt)).all();
+}
+
+// ── TaskRun CRUD ─────────────────────────────────────────────────────
+
+export function createTaskRun(taskId: string): TaskRun {
+  const db = getDb();
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  const run: TaskRun = {
+    id,
+    taskId,
+    conversationId: null,
+    status: 'pending',
+    startedAt: null,
+    finishedAt: null,
+    error: null,
+    principalId: null,
+    memoryScopeId: null,
+    createdAt: now,
+  };
+  db.insert(taskRuns).values(run).run();
+  return run;
+}
+
+export function updateTaskRun(
+  id: string,
+  updates: Partial<Pick<TaskRun, 'status' | 'conversationId' | 'error' | 'principalId' | 'memoryScopeId' | 'startedAt' | 'finishedAt'>>,
+): void {
+  const db = getDb();
+  db.update(taskRuns).set(updates).where(eq(taskRuns.id, id)).run();
+}
+
+export function getTaskRun(id: string): TaskRun | undefined {
+  const db = getDb();
+  return db.select().from(taskRuns).where(eq(taskRuns.id, id)).get();
+}


### PR DESCRIPTION
## Summary
- Add `tasks` and `task_runs` tables to SQLite inline migrations in `initializeDb()` with appropriate indexes
- Add corresponding drizzle schema definitions in `schema.ts`
- Create `task-store.ts` with CRUD operations (`createTask`, `getTask`, `listTasks`, `createTaskRun`, `updateTaskRun`, `getTaskRun`) for one-shot task management

## Test plan
- [ ] Verify `initializeDb()` creates both tables on fresh DB
- [ ] Verify idempotent re-creation (run `initializeDb()` twice)
- [ ] Verify task CRUD operations via `task-store.ts`
- [ ] Verify task run lifecycle (create, update status, query)
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
