### PR TITLE
feat: add 'task' to ToolPrincipalKind union

### DIFF
--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -41,13 +41,13 @@ export interface ScopeOption {
 
 // ── Principal + policy context types (PR 3) ──────────────────
 
-/** Distinguishes whether a tool is a built-in core tool or provided by a skill. */
-export type ToolPrincipalKind = 'core' | 'skill';
+/** Distinguishes whether a tool is a built-in core tool, provided by a skill, or scoped to a one-shot task. */
+export type ToolPrincipalKind = 'core' | 'skill' | 'task';
 
 /** Identifies the security principal that owns a tool invocation. */
 export interface ToolPrincipal {
   kind: ToolPrincipalKind;
-  /** Skill ID when kind is 'skill'. */
+  /** Skill ID when kind is 'skill'; task ID when kind is 'task'. */
   id?: string;
   /** Content-hash of the skill source at the time of approval. */
   version?: string;

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -12,9 +12,9 @@ interface ToolLifecycleEventBase {
   conversationId: string;
   requestId?: string;
   executionTarget?: ExecutionTarget;
-  /** Security principal kind (e.g. 'core' or 'skill'). */
+  /** Security principal kind (e.g. 'core', 'skill', or 'task'). */
   principalKind?: ToolPrincipalKind;
-  /** Security principal ID (skill ID when principalKind is 'skill'). */
+  /** Security principal ID (skill ID when principalKind is 'skill'; task ID when 'task'). */
   principalId?: string;
   /** Content-hash of the principal's source at invocation time. */
   principalVersion?: string;


### PR DESCRIPTION
## Summary
- Extend `ToolPrincipalKind` type from `'core' | 'skill'` to `'core' | 'skill' | 'task'` to support one-shot task-scoped permissions.
- Update JSDoc comments in `permissions/types.ts` and `tools/types.ts` to document the new `'task'` kind.
- No logic changes needed — principal matching is string-based throughout the checker, trust-store, and executor, so `'task'` is accepted everywhere automatically.

## Test plan
- [x] `bunx tsc --noEmit` passes (only pre-existing unrelated error in `vault.ts`)
- [x] Verified no switch statements or exhaustive checks on principal kind values exist in the codebase
- [x] Verified `matchesPrincipal()` in trust-store.ts uses string comparison — works with any kind value
- [x] Verified `buildPolicyContext()` in executor.ts has no exhaustive checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
