### PR TITLE
feat: add task_candidates table for silent candidate recording

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -729,9 +729,22 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS task_candidates (
+      id TEXT PRIMARY KEY,
+      source_conversation_id TEXT NOT NULL,
+      compiled_template TEXT NOT NULL,
+      confidence REAL,
+      required_tools TEXT,
+      created_at INTEGER NOT NULL,
+      promoted_task_id TEXT
+    )
+  `);
+
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_task_id ON task_runs(task_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_status ON task_runs(status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_candidates_promoted ON task_candidates(promoted_task_id)`);
 
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -415,6 +415,16 @@ export const taskRuns = sqliteTable('task_runs', {
   createdAt: integer('created_at').notNull(),
 });
 
+export const taskCandidates = sqliteTable('task_candidates', {
+  id: text('id').primaryKey(),
+  sourceConversationId: text('source_conversation_id').notNull(),
+  compiledTemplate: text('compiled_template').notNull(),
+  confidence: real('confidence'),
+  requiredTools: text('required_tools'),               // JSON array string
+  createdAt: integer('created_at').notNull(),
+  promotedTaskId: text('promoted_task_id'),             // set when candidate is promoted to a real task
+});
+
 export const homeBaseAppLinks = sqliteTable('home_base_app_links', {
   id: text('id').primaryKey(),
   appId: text('app_id').notNull(),

--- a/assistant/src/tasks/candidate-store.ts
+++ b/assistant/src/tasks/candidate-store.ts
@@ -1,0 +1,86 @@
+import { eq, desc, isNull } from 'drizzle-orm';
+import { getDb } from '../memory/db.js';
+import { taskCandidates } from '../memory/schema.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface TaskCandidate {
+  id: string;
+  sourceConversationId: string;
+  compiledTemplate: string;
+  confidence: number | null;
+  requiredTools: string[] | null;
+  createdAt: number;
+  promotedTaskId: string | null;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Convert a raw DB row to a TaskCandidate, deserializing the JSON requiredTools field. */
+function rowToCandidate(row: typeof taskCandidates.$inferSelect): TaskCandidate {
+  return {
+    id: row.id,
+    sourceConversationId: row.sourceConversationId,
+    compiledTemplate: row.compiledTemplate,
+    confidence: row.confidence,
+    requiredTools: row.requiredTools ? JSON.parse(row.requiredTools) : null,
+    createdAt: row.createdAt,
+    promotedTaskId: row.promotedTaskId,
+  };
+}
+
+// ── CRUD ─────────────────────────────────────────────────────────────
+
+/** Record a new task candidate from a conversation. */
+export function createCandidate(opts: {
+  sourceConversationId: string;
+  compiledTemplate: string;
+  confidence?: number;
+  requiredTools?: string[];
+}): TaskCandidate {
+  const db = getDb();
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  const row = {
+    id,
+    sourceConversationId: opts.sourceConversationId,
+    compiledTemplate: opts.compiledTemplate,
+    confidence: opts.confidence ?? null,
+    requiredTools: opts.requiredTools ? JSON.stringify(opts.requiredTools) : null,
+    createdAt: now,
+    promotedTaskId: null,
+  };
+  db.insert(taskCandidates).values(row).run();
+  return {
+    ...row,
+    requiredTools: opts.requiredTools ?? null,
+  };
+}
+
+/** List unpromoted candidates (most recent first). */
+export function listUnpromotedCandidates(limit?: number): TaskCandidate[] {
+  const db = getDb();
+  const query = db
+    .select()
+    .from(taskCandidates)
+    .where(isNull(taskCandidates.promotedTaskId))
+    .orderBy(desc(taskCandidates.createdAt));
+  const rows = limit ? query.limit(limit).all() : query.all();
+  return rows.map(rowToCandidate);
+}
+
+/** Mark a candidate as promoted to a real task. */
+export function promoteCandidate(candidateId: string, taskId: string): void {
+  const db = getDb();
+  db.update(taskCandidates)
+    .set({ promotedTaskId: taskId })
+    .where(eq(taskCandidates.id, candidateId))
+    .run();
+}
+
+/** Get a candidate by ID. */
+export function getCandidate(id: string): TaskCandidate | undefined {
+  const db = getDb();
+  const row = db.select().from(taskCandidates).where(eq(taskCandidates.id, id)).get();
+  return row ? rowToCandidate(row) : undefined;
+}


### PR DESCRIPTION
Add task_candidates schema and candidate-store.ts for recording potential reusable tasks from conversations. Candidates are recorded silently and can be promoted to real tasks later.

## Changes

- **`assistant/src/memory/db.ts`** — Add `task_candidates` CREATE TABLE statement in `initializeDb()` and an index on `promoted_task_id`
- **`assistant/src/memory/schema.ts`** — Add `taskCandidates` drizzle schema definition following the `tasks`/`taskRuns` pattern
- **`assistant/src/tasks/candidate-store.ts`** — New module with CRUD functions:
  - `createCandidate()` — Record a new task candidate from a conversation
  - `listUnpromotedCandidates()` — List candidates not yet promoted (most recent first)
  - `promoteCandidate()` — Mark a candidate as promoted to a real task
  - `getCandidate()` — Retrieve a candidate by ID

## Schema

```sql
CREATE TABLE IF NOT EXISTS task_candidates (
  id TEXT PRIMARY KEY,
  source_conversation_id TEXT NOT NULL,
  compiled_template TEXT NOT NULL,
  confidence REAL,
  required_tools TEXT,          -- JSON array string
  created_at INTEGER NOT NULL,
  promoted_task_id TEXT          -- set when candidate is promoted to a real task
)
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
