### PR TITLE
feat: add ephemeral permission overlay for task-scoped permissions

### DIFF
--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -1,0 +1,311 @@
+import { describe, test, expect, beforeAll, beforeEach, mock } from 'bun:test';
+import { mkdtempSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Use a temp directory so trust-store doesn't touch ~/.vellum
+const testDir = mkdtempSync(join(tmpdir(), 'ephemeral-perm-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => join(testDir, 'data'),
+  getWorkspaceSkillsDir: () => join(testDir, 'skills'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const testConfig: Record<string, any> = {
+  permissions: { mode: 'legacy' as 'legacy' | 'strict' },
+  skills: { load: { extraDirs: [] as string[] } },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => testConfig,
+  loadConfig: () => testConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+import { setTaskRunRules, getTaskRunRules, clearTaskRunRules, buildTaskRules } from '../tasks/ephemeral-permissions.js';
+import { findHighestPriorityRule, addRule, clearCache } from '../permissions/trust-store.js';
+import { check, classifyRisk } from '../permissions/checker.js';
+import type { TrustRule, PolicyContext } from '../permissions/types.js';
+
+// Ensure the protected directory exists for trust-store disk operations
+mkdirSync(join(testDir, 'protected'), { recursive: true });
+
+describe('ephemeral-permissions', () => {
+  // Warm up the shell parser (loads WASM) — required before any check() call
+  // that involves bash commands, otherwise the parser init may hang.
+  beforeAll(async () => {
+    await classifyRisk('bash', { command: 'echo warmup' });
+  });
+  describe('buildTaskRules', () => {
+    test('generates correct rule structure for each required tool', () => {
+      const taskRunId = 'run-123';
+      const requiredTools = ['file_read', 'bash', 'file_write'];
+      const workingDir = '/home/user/project';
+
+      const rules = buildTaskRules(taskRunId, requiredTools, workingDir);
+
+      expect(rules).toHaveLength(3);
+
+      // Check the first rule in detail
+      const fileReadRule = rules[0];
+      expect(fileReadRule.id).toBe('ephemeral:run-123:file_read');
+      expect(fileReadRule.tool).toBe('file_read');
+      expect(fileReadRule.pattern).toBe('**');
+      expect(fileReadRule.scope).toBe('/home/user/project');
+      expect(fileReadRule.decision).toBe('allow');
+      expect(fileReadRule.priority).toBe(50);
+      expect(fileReadRule.principalKind).toBe('task');
+      expect(fileReadRule.principalId).toBe('run-123');
+      expect(fileReadRule.createdAt).toBeGreaterThan(0);
+
+      // Verify allowHighRisk is NOT set
+      expect(fileReadRule.allowHighRisk).toBeUndefined();
+
+      // Check other rules have correct tool names
+      expect(rules[1].tool).toBe('bash');
+      expect(rules[1].id).toBe('ephemeral:run-123:bash');
+      expect(rules[2].tool).toBe('file_write');
+      expect(rules[2].id).toBe('ephemeral:run-123:file_write');
+    });
+
+    test('returns empty array for empty required tools', () => {
+      const rules = buildTaskRules('run-456', [], '/tmp');
+      expect(rules).toHaveLength(0);
+    });
+  });
+
+  describe('setTaskRunRules / getTaskRunRules / clearTaskRunRules', () => {
+    beforeEach(() => {
+      // Clean up any leftover state
+      clearTaskRunRules('test-run-1');
+      clearTaskRunRules('test-run-2');
+    });
+
+    test('returns empty array for unknown task run', () => {
+      expect(getTaskRunRules('nonexistent')).toEqual([]);
+    });
+
+    test('stores and retrieves rules for a task run', () => {
+      const rules = buildTaskRules('test-run-1', ['file_read'], '/tmp');
+      setTaskRunRules('test-run-1', rules);
+
+      const retrieved = getTaskRunRules('test-run-1');
+      expect(retrieved).toHaveLength(1);
+      expect(retrieved[0].tool).toBe('file_read');
+    });
+
+    test('clears rules for a task run', () => {
+      const rules = buildTaskRules('test-run-1', ['file_read'], '/tmp');
+      setTaskRunRules('test-run-1', rules);
+      expect(getTaskRunRules('test-run-1')).toHaveLength(1);
+
+      clearTaskRunRules('test-run-1');
+      expect(getTaskRunRules('test-run-1')).toEqual([]);
+    });
+
+    test('isolates rules between task runs', () => {
+      const rules1 = buildTaskRules('test-run-1', ['file_read'], '/tmp');
+      const rules2 = buildTaskRules('test-run-2', ['bash', 'file_write'], '/home');
+
+      setTaskRunRules('test-run-1', rules1);
+      setTaskRunRules('test-run-2', rules2);
+
+      expect(getTaskRunRules('test-run-1')).toHaveLength(1);
+      expect(getTaskRunRules('test-run-2')).toHaveLength(2);
+
+      clearTaskRunRules('test-run-1');
+      expect(getTaskRunRules('test-run-1')).toEqual([]);
+      expect(getTaskRunRules('test-run-2')).toHaveLength(2);
+    });
+  });
+
+  describe('findHighestPriorityRule with ephemeral rules', () => {
+    beforeEach(() => {
+      clearCache();
+    });
+
+    test('ephemeral rules are found by findHighestPriorityRule', () => {
+      const ephemeralRules: TrustRule[] = [{
+        id: 'ephemeral:run-1:file_read',
+        tool: 'file_read',
+        pattern: '**',
+        scope: '/home/user/project',
+        decision: 'allow',
+        priority: 50,
+        createdAt: Date.now(),
+        principalKind: 'task',
+        principalId: 'run-1',
+      }];
+
+      const ctx: PolicyContext = {
+        principal: { kind: 'task', id: 'run-1' },
+        ephemeralRules,
+      };
+
+      const result = findHighestPriorityRule(
+        'file_read',
+        ['file_read:/home/user/project/foo.txt'],
+        '/home/user/project',
+        ctx,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('ephemeral:run-1:file_read');
+      expect(result!.decision).toBe('allow');
+    });
+
+    test('user deny rules at higher priority override ephemeral allow rules', () => {
+      // Add a persistent user deny rule with priority 100
+      addRule('file_read', '**', '/home/user/project', 'deny', 100);
+
+      const ephemeralRules: TrustRule[] = [{
+        id: 'ephemeral:run-1:file_read',
+        tool: 'file_read',
+        pattern: '**',
+        scope: '/home/user/project',
+        decision: 'allow',
+        priority: 50,
+        createdAt: Date.now(),
+        principalKind: 'task',
+        principalId: 'run-1',
+      }];
+
+      const ctx: PolicyContext = {
+        principal: { kind: 'task', id: 'run-1' },
+        ephemeralRules,
+      };
+
+      const result = findHighestPriorityRule(
+        'file_read',
+        ['file_read:/home/user/project/foo.txt'],
+        '/home/user/project',
+        ctx,
+      );
+
+      expect(result).not.toBeNull();
+      // The user deny rule (priority 100) should win over the ephemeral allow (priority 50)
+      expect(result!.decision).toBe('deny');
+    });
+
+    test('ephemeral rules do not match when scope is outside working dir', () => {
+      const ephemeralRules: TrustRule[] = [{
+        id: 'ephemeral:run-1:file_read',
+        tool: 'file_read',
+        pattern: '**',
+        scope: '/home/user/project',
+        decision: 'allow',
+        priority: 50,
+        createdAt: Date.now(),
+        principalKind: 'task',
+        principalId: 'run-1',
+      }];
+
+      const ctx: PolicyContext = {
+        principal: { kind: 'task', id: 'run-1' },
+        ephemeralRules,
+      };
+
+      // Query with a different scope that doesn't match the ephemeral rule's scope
+      const result = findHighestPriorityRule(
+        'file_read',
+        ['file_read:/other/path/foo.txt'],
+        '/other/path',
+        ctx,
+      );
+
+      // Should not match the ephemeral rule (scope mismatch)
+      // May or may not match a default rule
+      if (result) {
+        expect(result.id).not.toBe('ephemeral:run-1:file_read');
+      }
+    });
+  });
+
+  describe('check() with ephemeral rules', () => {
+    beforeEach(() => {
+      clearCache();
+      testConfig.permissions.mode = 'legacy';
+    });
+
+    test('ephemeral allow rule auto-allows non-high-risk tool', async () => {
+      const ephemeralRules: TrustRule[] = [{
+        id: 'ephemeral:run-1:file_read',
+        tool: 'file_read',
+        pattern: '**',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 50,
+        createdAt: Date.now(),
+        principalKind: 'task',
+        principalId: 'run-1',
+      }];
+
+      const ctx: PolicyContext = {
+        principal: { kind: 'task', id: 'run-1' },
+        ephemeralRules,
+      };
+
+      // Use testDir (a real temp path) to avoid EPERM on macOS /home
+      const fakePath = join(testDir, 'foo.txt');
+      const result = await check(
+        'file_read',
+        { path: fakePath },
+        testDir,
+        ctx,
+      );
+
+      expect(result.decision).toBe('allow');
+    });
+
+    test('high-risk tool still prompts even with ephemeral allow rule (no allowHighRisk)', async () => {
+      const ephemeralRules: TrustRule[] = [{
+        id: 'ephemeral:run-1:bash',
+        tool: 'bash',
+        pattern: '**',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 50,
+        createdAt: Date.now(),
+        principalKind: 'task',
+        principalId: 'run-1',
+        // Note: allowHighRisk is NOT set
+      }];
+
+      const ctx: PolicyContext = {
+        principal: { kind: 'task', id: 'run-1' },
+        ephemeralRules,
+      };
+
+      // sudo is high-risk
+      const result = await check(
+        'bash',
+        { command: 'sudo rm -rf /' },
+        '/home/user/project',
+        ctx,
+      );
+
+      expect(result.decision).toBe('prompt');
+    });
+  });
+});

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -418,8 +418,20 @@ function matchesExecutionTarget(rule: TrustRule, ctx?: PolicyContext): boolean {
  * those constraints act as wildcards and match any context.
  */
 export function findHighestPriorityRule(tool: string, commands: string[], scope: string, ctx?: PolicyContext): TrustRule | null {
-  const rules = getRules();
-  for (const rule of rules) {
+  // Check ephemeral (task-scoped) rules first — they take precedence over
+  // file-based rules at the same priority because they are evaluated earlier.
+  // The ruleOrder sort (highest priority first, deny wins ties) still applies
+  // across the combined set because ephemeral rules use a lower default
+  // priority (50) than user rules (100), so user deny rules still win.
+  const ephemeral = ctx?.ephemeralRules ?? [];
+  const fileRules = getRules();
+
+  // Concatenate and re-sort so priority ordering is respected across both sets.
+  const allRules = ephemeral.length > 0
+    ? [...ephemeral, ...fileRules].sort(ruleOrder)
+    : fileRules;
+
+  for (const rule of allRules) {
     if (rule.tool !== tool) continue;
     if (!matchesScope(rule.scope, scope)) continue;
     if (!matchesPrincipal(rule, ctx)) continue;

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -57,4 +57,6 @@ export interface ToolPrincipal {
 export interface PolicyContext {
   principal?: ToolPrincipal;
   executionTarget?: string;
+  /** Ephemeral rules for task-scoped permissions — checked before persistent trust.json rules. */
+  ephemeralRules?: TrustRule[];
 }

--- a/assistant/src/tasks/ephemeral-permissions.ts
+++ b/assistant/src/tasks/ephemeral-permissions.ts
@@ -1,0 +1,41 @@
+import type { TrustRule } from '../permissions/types.js';
+
+// In-memory map: task_run_id -> ephemeral rules
+const activeTaskRules = new Map<string, TrustRule[]>();
+
+/** Register ephemeral permission rules for a task run. */
+export function setTaskRunRules(taskRunId: string, rules: TrustRule[]): void {
+  activeTaskRules.set(taskRunId, rules);
+}
+
+/** Get ephemeral rules for a task run (returns empty array if none). */
+export function getTaskRunRules(taskRunId: string): TrustRule[] {
+  return activeTaskRules.get(taskRunId) ?? [];
+}
+
+/** Remove ephemeral rules when a task run ends. */
+export function clearTaskRunRules(taskRunId: string): void {
+  activeTaskRules.delete(taskRunId);
+}
+
+/**
+ * Build ephemeral TrustRule entries from a task's required_tools list.
+ *
+ * Each rule allows the specified tool with a wildcard pattern scoped to the
+ * given working directory. Priority is set to 50 — lower than user rules (100)
+ * so that user deny rules still take precedence. `allowHighRisk` is NOT set,
+ * so high-risk operations continue to prompt for approval.
+ */
+export function buildTaskRules(taskRunId: string, requiredTools: string[], workingDir: string): TrustRule[] {
+  return requiredTools.map((tool) => ({
+    id: `ephemeral:${taskRunId}:${tool}`,
+    tool,
+    pattern: '**',
+    scope: workingDir,
+    decision: 'allow' as const,
+    priority: 50,
+    createdAt: Date.now(),
+    principalKind: 'task',
+    principalId: taskRunId,
+  }));
+}


### PR DESCRIPTION
## Summary

- Add `ephemeralRules` field to `PolicyContext` in `permissions/types.ts`, enabling task-scoped in-memory allowlists to be passed alongside permission checks
- Update `findHighestPriorityRule()` in `trust-store.ts` to merge ephemeral rules with file-based rules, sorted by priority so user deny rules (priority 100) still override ephemeral allows (priority 50)
- Create `tasks/ephemeral-permissions.ts` module with `setTaskRunRules`, `getTaskRunRules`, `clearTaskRunRules`, and `buildTaskRules` for managing per-task-run rule sets
- Add comprehensive test suite covering rule building, lifecycle management, priority ordering, scope matching, and high-risk tool prompting

## Test plan

- [x] `buildTaskRules` generates correct rule structure (id, tool, pattern, scope, decision, priority, principalKind, principalId) with no `allowHighRisk`
- [x] `setTaskRunRules` / `getTaskRunRules` / `clearTaskRunRules` properly manage in-memory state with isolation between task runs
- [x] Ephemeral rules are found by `findHighestPriorityRule`
- [x] User deny rules at higher priority override ephemeral allow rules
- [x] Ephemeral rules respect scope boundaries
- [x] `check()` with ephemeral rules auto-allows non-high-risk tools
- [x] High-risk tools still prompt even with ephemeral allow rules (no `allowHighRisk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
