### PR TITLE
fix: check signal.aborted before registering abort listener in test mock

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
@@ -95,6 +95,7 @@ describe('CU session skill tool lifecycle cleanup', () => {
     const hangingProvider: Provider = {
       name: 'mock',
       sendMessage: (_msgs, _tools, _sys, opts) => new Promise<ProviderResponse>((_, reject) => {
+        if (opts?.signal?.aborted) { reject(new DOMException('Aborted', 'AbortError')); return; }
         opts?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
       }),
     };


### PR DESCRIPTION
Handle the edge case where the abort signal is already aborted when sendMessage executes. Without this check, addEventListener('abort', ...) silently does nothing and the promise hangs indefinitely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
