### PR TITLE
fix: resolve OAuth client credentials from metadata on reconnect

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
@@ -95,6 +95,7 @@ describe('CU session skill tool lifecycle cleanup', () => {
     const hangingProvider: Provider = {
       name: 'mock',
       sendMessage: (_msgs, _tools, _sys, opts) => new Promise<ProviderResponse>((_, reject) => {
+        if (opts?.signal?.aborted) { reject(new DOMException('Aborted', 'AbortError')); return; }
         opts?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
       }),
     };

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -94,6 +94,18 @@ function findStoredOAuthField(service: string, fieldNames: string[]): string | u
       if (value) return value;
     }
   }
+
+  // Fallback: check credential metadata on the access_token record, where
+  // oauth2_connect persists the client config after a successful flow.
+  const metadataKey = fieldNames.some((f) => f.includes('client_id'))
+    ? 'oauth2ClientId' as const
+    : 'oauth2ClientSecret' as const;
+  for (const svc of servicesToCheck) {
+    const meta = getCredentialMetadata(svc, 'access_token');
+    const value = meta?.[metadataKey];
+    if (value) return value;
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
Extends findStoredOAuthField to also check credential metadata (oauth2ClientId/oauth2ClientSecret) stored by previous oauth2_connect calls. This fixes the reconnect path where calling oauth2_connect with just a service name would fail to find previously stored client credentials.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
