### PR TITLE
fix: validate credential_ids in lock waiter path and suppress unhandled rejection

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -403,7 +403,11 @@ export async function getOrStartSession(
   const inflight = acquireLocks.get(conversationId);
   if (inflight) {
     const session = await inflight;
-    return { session, created: false };
+    if (credentialIdsMatch(session.credentialIds, credentialIds)) {
+      return { session, created: false };
+    }
+    // Credential mismatch — tear down and fall through to create a new session.
+    await stopSession(session.id);
   }
 
   const promise = (async () => {
@@ -424,6 +428,7 @@ export async function getOrStartSession(
 
   // Wrap the inner promise to extract just the session for lock waiters.
   const sessionPromise = promise.then((r) => r.session);
+  sessionPromise.catch(() => {}); // Rejection handled by `await promise` below
   acquireLocks.set(conversationId, sessionPromise);
   try {
     return await promise;


### PR DESCRIPTION
Addresses review feedback on PR #4402: (1) Add credentialIdsMatch check in the lock-waiter path so concurrent callers with different credentials don't get a session bound to wrong credentials, (2) Add .catch() to sessionPromise to suppress unhandled rejection when session creation fails with no concurrent waiters.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
