### PR TITLE
fix: verify tests actually ran after xargs pipeline in test runner

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -81,6 +81,13 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   fi
 ' _ {} "${results_dir}" "${EXCLUDE_EXPERIMENTAL}"
 
+# Verify tests actually ran — catch xargs startup failures
+actual_runs=$(ls "${results_dir}"/*.out 2>/dev/null | wc -l)
+if [[ ${actual_runs} -eq 0 ]]; then
+  echo "ERROR: No tests were executed (xargs may have failed to start)"
+  exit 1
+fi
+
 # Print output for any failed tests
 if [[ -f "${results_dir}/failures" ]]; then
   echo ""


### PR DESCRIPTION
Addresses review feedback on PR #4409: Add a safety check after the xargs pipeline to verify that output files were actually created. Without this, if xargs fails to start (e.g. invalid TEST_WORKERS), the script falsely reports all tests passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
