### PR TITLE
fix: exclude ui_show from default allow rules to preserve strict mode gate

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -207,11 +207,10 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   }));
 
-  // UI surface tools are purely local rendering operations with no security
-  // implications — they just display content in the user's client.  Default
-  // allow rules ensure they never trigger permission prompts (including in
-  // strict mode).
-  const UI_SURFACE_TOOLS = ['ui_show', 'ui_update', 'ui_dismiss'] as const;
+  // ui_update and ui_dismiss are purely passive operations (modify/remove existing
+  // surfaces). ui_show is excluded because it can create forms that collect user
+  // input — it goes through normal permission checking instead.
+  const UI_SURFACE_TOOLS = ['ui_update', 'ui_dismiss'] as const;
   const uiSurfaceRules: DefaultRuleTemplate[] = UI_SURFACE_TOOLS.map((tool) => ({
     id: `default:allow-${tool}-global`,
     tool,


### PR DESCRIPTION
Addresses review feedback on PR #4417: ui_show supports form inputs (including password fields) and file_upload, so it should not be auto-allowed in strict mode. Only ui_update and ui_dismiss (passive operations) are auto-allowed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
