### PR TITLE
fix: re-register escalation tool in core, fix sort order, remove from CU manifest

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-baseline.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-baseline.test.ts
@@ -15,13 +15,20 @@ import {
 afterAll(() => { __resetRegistryForTesting(); });
 
 describe('computer-use skill baseline: registry tool surfaces', () => {
-  test('no computer_use_* tools are registered after initializeTools() (migrated to skill)', async () => {
+  test('no computer_use_* action tools are registered after initializeTools() (migrated to skill)', async () => {
     await initializeTools();
 
     for (const name of COMPUTER_USE_TOOL_NAMES) {
       const tool = getTool(name);
       expect(tool).toBeUndefined();
     }
+  });
+
+  test('computer_use_request_control is registered in core after initializeTools()', async () => {
+    await initializeTools();
+
+    const tool = getTool('computer_use_request_control');
+    expect(tool).toBeDefined();
   });
 
   test('getAllToolDefinitions() excludes all computer_use_* tools (proxy exclusion)', async () => {
@@ -56,11 +63,12 @@ describe('computer-use skill baseline: registry tool surfaces', () => {
     expect(cuActionTools).toHaveLength(0);
   });
 
-  test('post-cutover count: 0 computer_use_* tools in core registry', async () => {
+  test('post-cutover count: 1 computer_use_* tool in core registry (escalation only)', async () => {
     await initializeTools();
 
     const allTools = getAllTools();
     const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
-    expect(cuTools).toHaveLength(0);
+    expect(cuTools).toHaveLength(1);
+    expect(cuTools[0].name).toBe('computer_use_request_control');
   });
 });

--- a/assistant/src/__tests__/computer-use-skill-endstate.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-endstate.test.ts
@@ -23,13 +23,18 @@ beforeAll(async () => {
 describe('computer-use skill end-state', () => {
   // ── Core Registry ──────────────────────────────────────────────────
 
-  test('core registry contains 0 computer_use_* tools', () => {
+  test('core registry contains 1 computer_use_* tool (escalation only)', () => {
     const allTools = getAllTools();
     const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
-    expect(cuTools).toHaveLength(0);
+    expect(cuTools).toHaveLength(1);
+    expect(cuTools[0].name).toBe('computer_use_request_control');
   });
 
-  test('no individual computer_use_* tool is resolvable from core registry', () => {
+  test('computer_use_request_control is resolvable from core registry', () => {
+    expect(getTool('computer_use_request_control')).toBeDefined();
+  });
+
+  test('no action tool from COMPUTER_USE_TOOL_NAMES is resolvable from core registry', () => {
     for (const name of COMPUTER_USE_TOOL_NAMES) {
       expect(getTool(name)).toBeUndefined();
     }

--- a/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
@@ -155,7 +155,7 @@ describe('CU session skill tool lifecycle cleanup', () => {
     expect(getSkillRefCount('computer-use')).toBe(0);
   });
 
-  test('no computer_use_* tools remain in registry after session cleanup', async () => {
+  test('only escalation tool remains in registry after session cleanup', async () => {
     const provider = createProvider([doneResponse]);
     const session = new ComputerUseSession(
       'cleanup-registry-check',
@@ -172,7 +172,8 @@ describe('CU session skill tool lifecycle cleanup', () => {
 
     const allTools = getAllTools();
     const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
-    expect(cuTools).toHaveLength(0);
+    expect(cuTools).toHaveLength(1);
+    expect(cuTools[0].name).toBe('computer_use_request_control');
   });
 
   test('multiple sequential CU sessions do not leak refcounts', async () => {
@@ -195,19 +196,21 @@ describe('CU session skill tool lifecycle cleanup', () => {
 
     const allTools = getAllTools();
     const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
-    expect(cuTools).toHaveLength(0);
+    expect(cuTools).toHaveLength(1);
+    expect(cuTools[0].name).toBe('computer_use_request_control');
   });
 
   // Cross-suite regression: after CU sessions complete, core registry invariants hold
-  test('core registry has 0 computer_use_* tools after CU session lifecycle', () => {
+  test('core registry has 1 computer_use_* tool after CU session lifecycle (escalation only)', () => {
     const allTools = getAllTools();
     const cuTools = allTools.filter((t) => t.name.startsWith('computer_use_'));
-    expect(cuTools).toHaveLength(0);
+    expect(cuTools).toHaveLength(1);
+    expect(cuTools[0].name).toBe('computer_use_request_control');
   });
 
-  test('computer_use_request_control is not in core registry after CU session lifecycle', async () => {
+  test('computer_use_request_control is in core registry after CU session lifecycle', async () => {
     const { getTool } = await import('../tools/registry.js');
     const tool = getTool('computer_use_request_control');
-    expect(tool).toBeUndefined();
+    expect(tool).toBeDefined();
   });
 });

--- a/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
@@ -2,7 +2,7 @@
  * Reusable constants and helpers for the computer-use skill migration test suite.
  */
 
-/** The 13 computer_use_* tool names provided by the bundled computer-use skill. */
+/** The 12 computer_use_* action tool names provided by the bundled computer-use skill. */
 export const COMPUTER_USE_TOOL_NAMES = [
   'computer_use_click',
   'computer_use_double_click',
@@ -16,14 +16,13 @@ export const COMPUTER_USE_TOOL_NAMES = [
   'computer_use_run_applescript',
   'computer_use_done',
   'computer_use_respond',
-  'computer_use_request_control',
 ] as const;
 
 /** The skill ID for the bundled computer-use skill (used in later PRs). */
 export const COMPUTER_USE_SKILL_ID = 'computer-use';
 
 /** Number of computer_use_* tools. */
-export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 13
+export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 12
 
 import { expect } from 'bun:test';
 

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -727,6 +727,7 @@ describe('Trust Store', () => {
         'computer_use_drag',
         'computer_use_key',
         'computer_use_open_app',
+        'computer_use_request_control',
         'computer_use_right_click',
         'computer_use_run_applescript',
         'computer_use_scroll',
@@ -740,7 +741,6 @@ describe('Trust Store', () => {
         'host_file_edit',
         'host_file_read',
         'host_file_write',
-        'computer_use_request_control',
         'scaffold_managed_skill',
         'skill_load',
       ]);

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -5,12 +5,13 @@ user-invocable: false
 disable-model-invocation: true
 ---
 
-This skill provides the 13 computer_use_* tools: 12 action tools for controlling
-the macOS desktop (used by CU sessions) and the `computer_use_request_control`
-escalation tool (used by text_qa sessions to hand off to foreground computer use).
+This skill provides the 12 computer_use_* action tools for controlling
+the macOS desktop (used by CU sessions).
 
-The skill is internally preactivated for computer-use sessions. The escalation
-tool is also projected into text_qa sessions via `buildToolDefinitions()`.
+The `computer_use_request_control` escalation tool is registered in the core
+registry (not this skill) so text_qa sessions can execute it directly.
+
+The skill is internally preactivated for computer-use sessions.
 
 Tools in this skill are proxy tools — execution is forwarded to the connected
 macOS client, never handled locally by the daemon.

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -321,24 +321,6 @@
       },
       "executor": "tools/computer-use-respond.ts",
       "execution_target": "host"
-    },
-    {
-      "name": "computer_use_request_control",
-      "description": "Escalate to foreground computer use. Call this when the user explicitly asks you to take control of their computer to perform a task (e.g. \"go ahead and do it\", \"take over\", \"open that for me\"). Provide a concise description of the task that computer use should accomplish.",
-      "category": "computer-use",
-      "risk": "low",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "task": {
-            "type": "string",
-            "description": "Concise description of what computer use should accomplish"
-          }
-        },
-        "required": ["task"]
-      },
-      "executor": "tools/computer-use-request-control.ts",
-      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -222,8 +222,9 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
-  // All computer_use_* tools (including the escalation tool) are now provided
-  // by the bundled computer-use skill. No CU tools are registered in core.
+  // The escalation tool is registered in core so text_qa sessions can execute it.
+  // The 12 action tools are provided by the bundled computer-use skill.
+  registerTool(requestComputerControlTool);
   registerUiSurfaceTools();
   registerAppTools();
 


### PR DESCRIPTION
Addresses review feedback on PR #4397: (1) Re-register computer_use_request_control in core registry so text_qa sessions can execute it, (2) Fix alphabetical sort order in trust-store test, (3) Remove escalation tool from CU skill manifest to prevent premature session ends.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
