### PR TITLE
fix: add connectivity guard, preserve context, fix text capture in sendAnyway()

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -505,11 +505,26 @@ extension ChatViewModel {
             if !wasCancelling {
                 errorText = err.message
                 // When the backend blocks a message for containing secrets,
-                // stash the last user message text so "Send Anyway" can resend
-                // with the bypass flag.
-                if err.category == "secret_blocked",
-                   let lastUserMsg = messages.last(where: { $0.role == .user }) {
-                    secretBlockedMessageText = lastUserMsg.text
+                // stash the full send context so "Send Anyway" can reconstruct
+                // the original UserMessageMessage with attachments and surface metadata.
+                if err.category == "secret_blocked" {
+                    // Prefer currentTurnUserText (the text that was actually sent)
+                    // over the transcript lookup, which can miss workspace refinements
+                    // that don't append a user chat message.
+                    if let sendText = currentTurnUserText {
+                        secretBlockedMessageText = sendText
+                    } else if let lastUserMsg = messages.last(where: { $0.role == .user }) {
+                        secretBlockedMessageText = lastUserMsg.text
+                    }
+                    // Reconstruct IPC attachments from the last user message's ChatAttachments
+                    if let lastUserMsg = messages.last(where: { $0.role == .user }),
+                       !lastUserMsg.attachments.isEmpty {
+                        secretBlockedAttachments = lastUserMsg.attachments.map {
+                            IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+                        }
+                    }
+                    secretBlockedActiveSurfaceId = activeSurfaceId
+                    secretBlockedCurrentPage = currentPage
                 }
             }
             // Reset processing messages to sent

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -73,6 +73,11 @@ public final class ChatViewModel: ObservableObject {
     /// Stores the text of a message that was blocked by the secret-ingress check.
     /// Set when an error with category "secret_blocked" arrives.
     private(set) var secretBlockedMessageText: String?
+    /// Stashed context from the blocked send, so sendAnyway() can reconstruct
+    /// the original UserMessageMessage with attachments and surface metadata.
+    private(set) var secretBlockedAttachments: [IPCAttachment]?
+    private(set) var secretBlockedActiveSurfaceId: String?
+    private(set) var secretBlockedCurrentPage: String?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?
@@ -233,6 +238,9 @@ public final class ChatViewModel: ObservableObject {
                 lastFailedMessageAttachments = nil
                 lastFailedSendError = nil
                 secretBlockedMessageText = nil
+                secretBlockedAttachments = nil
+                secretBlockedActiveSurfaceId = nil
+                secretBlockedCurrentPage = nil
                 currentTurnUserText = text
                 return
             }
@@ -276,6 +284,9 @@ public final class ChatViewModel: ObservableObject {
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
         secretBlockedMessageText = nil
+        secretBlockedAttachments = nil
+        secretBlockedActiveSurfaceId = nil
+        secretBlockedCurrentPage = nil
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
@@ -724,6 +735,9 @@ public final class ChatViewModel: ObservableObject {
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
         secretBlockedMessageText = nil
+        secretBlockedAttachments = nil
+        secretBlockedActiveSurfaceId = nil
+        secretBlockedCurrentPage = nil
     }
 
     /// Dismiss the typed session error state. Clears both the typed error
@@ -792,7 +806,20 @@ public final class ChatViewModel: ObservableObject {
     public func sendAnyway() {
         guard let text = secretBlockedMessageText, let sessionId else { return }
 
+        guard daemonClient.isConnected else {
+            errorText = "Cannot connect to assistant. Please ensure it's running."
+            return
+        }
+
+        // Snapshot and clear stashed context
+        let attachments = secretBlockedAttachments
+        let surfaceId = secretBlockedActiveSurfaceId
+        let page = secretBlockedCurrentPage
+
         secretBlockedMessageText = nil
+        secretBlockedAttachments = nil
+        secretBlockedActiveSurfaceId = nil
+        secretBlockedCurrentPage = nil
         errorText = nil
 
         isSending = true
@@ -806,6 +833,9 @@ public final class ChatViewModel: ObservableObject {
             try daemonClient.send(UserMessageMessage(
                 sessionId: sessionId,
                 content: text,
+                attachments: attachments,
+                activeSurfaceId: surfaceId,
+                currentPage: surfaceId != nil ? page : nil,
                 bypassSecretCheck: true
             ))
         } catch {


### PR DESCRIPTION
Addresses review feedback on PR #4416: (1) Add daemonClient.isConnected guard to prevent stuck UI when daemon disconnected, (2) Preserve original attachments and surface metadata when resending, (3) Capture blocked text from send state instead of transcript lookup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
