### PR TITLE
fix: Swift build errors — inaccessible setter and unused variable

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -72,12 +72,12 @@ public final class ChatViewModel: ObservableObject {
     private(set) var lastFailedSendError: String?
     /// Stores the text of a message that was blocked by the secret-ingress check.
     /// Set when an error with category "secret_blocked" arrives.
-    private(set) var secretBlockedMessageText: String?
+    internal(set) var secretBlockedMessageText: String?
     /// Stashed context from the blocked send, so sendAnyway() can reconstruct
     /// the original UserMessageMessage with attachments and surface metadata.
-    private(set) var secretBlockedAttachments: [IPCAttachment]?
-    private(set) var secretBlockedActiveSurfaceId: String?
-    private(set) var secretBlockedCurrentPage: String?
+    internal(set) var secretBlockedAttachments: [IPCAttachment]?
+    internal(set) var secretBlockedActiveSurfaceId: String?
+    internal(set) var secretBlockedCurrentPage: String?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1208,7 +1208,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onDocumentEditorUpdate?(msg)
         case .documentSaveResponse(let msg):
             onDocumentSaveResponse?(msg)
-        case .documentLoadResponse(let msg):
+        case .documentLoadResponse(_):
             // TODO: Handle document load response
             break
         case .documentListResponse(let msg):


### PR DESCRIPTION
## Summary
- Change `private(set)` to `internal(set)` on `secretBlockedMessageText`, `secretBlockedAttachments`, `secretBlockedActiveSurfaceId`, and `secretBlockedCurrentPage` so the `ChatViewModel+MessageHandling.swift` extension (separate file) can assign to them
- Replace `let msg` with `_` in the unused `documentLoadResponse` case in `DaemonClient.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
