### PR TITLE
feat: send custom welcome DM after Slack OAuth connect

### DIFF
--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -119,7 +119,7 @@ client_id: "<the extracted Client ID>"
 client_secret: "<the extracted Client Secret>"
 auth_url: "https://slack.com/oauth/v2/authorize"
 token_url: "https://slack.com/api/oauth.v2.access"
-scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "mpim:read", "mpim:history", "users:read", "chat:write", "search:read", "reactions:write"]
+scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "im:write", "mpim:read", "mpim:history", "users:read", "chat:write", "search:read", "reactions:write"]
 extra_params: {"user_scope": "channels:read,channels:history,groups:read,groups:history,im:read,im:history,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write"}
 ```
 

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -8,6 +8,7 @@
 import type {
   SlackAuthTestResponse,
   SlackConversationsListResponse,
+  SlackConversationsOpenResponse,
   SlackConversationHistoryResponse,
   SlackConversationRepliesResponse,
   SlackUserInfoResponse,
@@ -131,6 +132,15 @@ export async function conversationMark(
   return request<SlackConversationMarkResponse>(token, 'conversations.mark', undefined, {
     channel,
     ts,
+  });
+}
+
+export async function conversationsOpen(
+  token: string,
+  userId: string,
+): Promise<SlackConversationsOpenResponse> {
+  return request<SlackConversationsOpenResponse>(token, 'conversations.open', undefined, {
+    users: userId,
   });
 }
 

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -108,6 +108,10 @@ export interface SlackSearchMatch {
   thread_ts?: string;
 }
 
+export interface SlackConversationsOpenResponse extends SlackApiResponse {
+  channel: { id: string };
+}
+
 export type SlackReactionAddResponse = SlackApiResponse;
 
 export type SlackConversationLeaveResponse = SlackApiResponse;

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -39,6 +39,7 @@ export interface OAuth2FlowCallbacks {
 export interface OAuth2FlowResult {
   tokens: OAuth2TokenResult;
   grantedScopes: string[];
+  rawTokenResponse: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,7 +192,7 @@ export async function startOAuth2Flow(
       ? tokens.scope.split(/[ ,]/).filter(Boolean)
       : [...config.scopes];
 
-    return { tokens, grantedScopes };
+    return { tokens, grantedScopes, rawTokenResponse: tokenData };
   } finally {
     clearTimeout(timeout);
     server.stop(true);

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -15,6 +15,7 @@ import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput, CredentialInjectionTemplate } from './policy-types.js';
 import { credentialBroker } from './broker.js';
 import { startOAuth2Flow } from '../../security/oauth2.js';
+import { authTest, conversationsOpen, postMessage } from '../../messaging/providers/slack/client.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 
@@ -55,7 +56,7 @@ const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
     scopes: [
       'channels:read', 'channels:history',
       'groups:read', 'groups:history',
-      'im:read', 'im:history',
+      'im:read', 'im:history', 'im:write',
       'mpim:read', 'mpim:history',
       'users:read', 'chat:write',
       'search:read', 'reactions:write',
@@ -556,7 +557,7 @@ class CredentialStoreTool implements Tool {
         try {
           const allowedTools = input.allowed_tools as string[] | undefined;
 
-          const { tokens, grantedScopes } = await startOAuth2Flow(
+          const { tokens, grantedScopes, rawTokenResponse } = await startOAuth2Flow(
             { authUrl, tokenUrl, scopes, clientId, clientSecret, extraParams, userinfoUrl },
             {
               openUrl: (url) => {
@@ -601,6 +602,25 @@ class CredentialStoreTool implements Tool {
             const refreshStored = setSecureKey(`credential:${service}:refresh_token`, tokens.refreshToken);
             if (refreshStored) {
               upsertCredentialMetadata(service, 'refresh_token', {});
+            }
+          }
+
+          // Send a welcome DM for Slack connections
+          if (service === 'integration:slack') {
+            try {
+              const botToken = rawTokenResponse.access_token as string | undefined;
+              const authedUser = rawTokenResponse.authed_user as Record<string, unknown> | undefined;
+              const installingUserId = authedUser?.id as string | undefined;
+              if (botToken && installingUserId) {
+                const identity = await authTest(botToken);
+                const dmChannel = await conversationsOpen(botToken, installingUserId);
+                const welcomeMsg =
+                  `You have installed ${identity.user}, an AI Assistant, on ${identity.team}. ` +
+                  `Manage the assistant experience for this workspace in the workspace settings page.`;
+                await postMessage(botToken, dmChannel.channel.id, welcomeMsg);
+              }
+            } catch (err) {
+              log.warn({ err }, 'Failed to send Slack welcome DM (non-fatal)');
             }
           }
 


### PR DESCRIPTION
## Summary
- After Slack OAuth completes, send a welcome DM from the bot to the installing user with a custom message including bot name and workspace name
- Expose `rawTokenResponse` from `OAuth2FlowResult` so callers can access the bot token and authed user info from Slack's token response
- Add `conversations.open` to the Slack client and `im:write` to bot scopes for DM delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
