### PR TITLE
refactor: replace thread context menu with inline pin/archive icons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -423,6 +423,7 @@ struct MainWindowView: View {
             default: return thread.id == threadManager.activeThreadId && windowState.selection == nil
             }
         }()
+        let isHovered = isHoveredThread == thread.id
         Button(action: {
             if case .appEditing(let appId, _) = windowState.selection {
                 // Stay in editing mode, just switch the thread
@@ -435,12 +436,6 @@ struct MainWindowView: View {
             }
         }) {
             HStack(spacing: VSpacing.sm) {
-                if thread.isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                        .rotationEffect(.degrees(-45))
-                }
                 if thread.kind == .private {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10, weight: .medium))
@@ -456,7 +451,7 @@ struct MainWindowView: View {
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
             .background {
-                if isSelected || isHoveredThread == thread.id {
+                if isSelected || isHovered {
                     VColor.hoverOverlay.opacity(0.08)
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
@@ -468,6 +463,27 @@ struct MainWindowView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .overlay(alignment: .leading) {
+            if thread.isPinned || isHovered {
+                Button {
+                    if thread.isPinned {
+                        threadManager.unpinThread(id: thread.id)
+                    } else {
+                        threadManager.pinThread(id: thread.id)
+                    }
+                } label: {
+                    Image(systemName: thread.isPinned ? "pin.fill" : "pin")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
+                        .rotationEffect(.degrees(-45))
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, VSpacing.xs)
+                .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+            }
+        }
         .overlay(alignment: .trailing) {
             if threadPendingDeletion == thread.id {
                 Button {
@@ -485,31 +501,19 @@ struct MainWindowView: View {
                 .buttonStyle(.plain)
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
-            } else if isHoveredThread == thread.id {
-                Menu {
-                    Button(thread.isPinned ? "Unpin" : "Pin to Top") {
-                        if thread.isPinned {
-                            threadManager.unpinThread(id: thread.id)
-                        } else {
-                            threadManager.pinThread(id: thread.id)
-                        }
-                    }
-                    Divider()
-                    Button("Archive", role: .destructive) {
-                        threadPendingDeletion = thread.id
-                    }
+            } else if isHovered {
+                Button {
+                    threadPendingDeletion = thread.id
                 } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 13, weight: .medium))
+                    Image(systemName: "archivebox")
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(VColor.textSecondary)
-                        .rotationEffect(.degrees(90))
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .frame(width: 24)
+                .buttonStyle(.plain)
                 .padding(.trailing, VSpacing.xs)
+                .accessibilityLabel("Archive \(thread.title)")
             }
         }
         .padding(.horizontal, VSpacing.sm)
@@ -522,19 +526,6 @@ struct MainWindowView: View {
                     isHoveredThread = nil
                 }
                 NSCursor.pop()
-            }
-        }
-        .contextMenu {
-            Button(thread.isPinned ? "Unpin" : "Pin to Top") {
-                if thread.isPinned {
-                    threadManager.unpinThread(id: thread.id)
-                } else {
-                    threadManager.pinThread(id: thread.id)
-                }
-            }
-            Divider()
-            Button("Archive", role: .destructive) {
-                threadPendingDeletion = thread.id
             }
         }
         .draggable(thread.id.uuidString)


### PR DESCRIPTION
## Summary
- Removed the three-dot ellipsis context menu and native right-click context menu from thread rows
- Added a pin icon button on the left side of each row (visible on hover, always visible when pinned)
- Added an archive icon button on the right side (visible on hover), keeping the existing confirm-before-archive flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
