### PR TITLE
fix: make pin icon inline with thread title instead of overlapping

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -435,7 +435,25 @@ struct MainWindowView: View {
                 threadManager.selectThread(id: thread.id)
             }
         }) {
-            HStack(spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.xs) {
+                Button {
+                    if thread.isPinned {
+                        threadManager.unpinThread(id: thread.id)
+                    } else {
+                        threadManager.pinThread(id: thread.id)
+                    }
+                } label: {
+                    Image(systemName: thread.isPinned ? "pin.fill" : "pin")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
+                        .rotationEffect(.degrees(-45))
+                        .frame(width: 20, height: 20)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .opacity(thread.isPinned || isHovered ? 1 : 0)
+                .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+
                 if thread.kind == .private {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10, weight: .medium))
@@ -448,7 +466,8 @@ struct MainWindowView: View {
                     .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, VSpacing.sm)
+            .padding(.leading, VSpacing.xs)
+            .padding(.trailing, VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
             .background {
                 if isSelected || isHovered {
@@ -463,27 +482,6 @@ struct MainWindowView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .overlay(alignment: .leading) {
-            if thread.isPinned || isHovered {
-                Button {
-                    if thread.isPinned {
-                        threadManager.unpinThread(id: thread.id)
-                    } else {
-                        threadManager.pinThread(id: thread.id)
-                    }
-                } label: {
-                    Image(systemName: thread.isPinned ? "pin.fill" : "pin")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
-                        .rotationEffect(.degrees(-45))
-                        .frame(width: 24, height: 24)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .padding(.leading, VSpacing.xs)
-                .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
-            }
-        }
         .overlay(alignment: .trailing) {
             if threadPendingDeletion == thread.id {
                 Button {


### PR DESCRIPTION
## Summary
- Moved pin icon from `.overlay(alignment: .leading)` into the HStack content
- Pin icon always reserves space (opacity-toggled) so the title doesn't shift on hover
- Adjusted spacing and padding to keep the row compact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
