### PR TITLE
feat: add task execution pipeline with template rendering

### DIFF
--- a/assistant/src/__tests__/task-runner.test.ts
+++ b/assistant/src/__tests__/task-runner.test.ts
@@ -1,0 +1,215 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'task-runner-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { createTask } from '../tasks/task-store.js';
+import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
+import { renderTemplate, runTask } from '../tasks/task-runner.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ── renderTemplate ──────────────────────────────────────────────────
+
+describe('renderTemplate', () => {
+  test('correctly substitutes placeholders', () => {
+    const template = 'Hello {{name}}, welcome to {{place}}!';
+    const result = renderTemplate(template, { name: 'Alice', place: 'Wonderland' });
+    expect(result).toBe('Hello Alice, welcome to Wonderland!');
+  });
+
+  test('leaves unmatched placeholders as-is', () => {
+    const template = 'Hello {{name}}, your id is {{id}}';
+    const result = renderTemplate(template, { name: 'Bob' });
+    expect(result).toBe('Hello Bob, your id is {{id}}');
+  });
+
+  test('handles template with no placeholders', () => {
+    const template = 'No placeholders here.';
+    const result = renderTemplate(template, { key: 'value' });
+    expect(result).toBe('No placeholders here.');
+  });
+
+  test('handles empty inputs', () => {
+    const template = '{{greeting}} world';
+    const result = renderTemplate(template, {});
+    expect(result).toBe('{{greeting}} world');
+  });
+});
+
+// ── runTask ─────────────────────────────────────────────────────────
+
+describe('runTask', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM task_runs');
+    db.run('DELETE FROM tasks');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('creates a conversation and task run, calls processMessage with rendered template', async () => {
+    const task = createTask({
+      title: 'Greet User',
+      template: 'Hello {{name}}, please do {{action}}',
+      requiredTools: ['read_file'],
+    });
+
+    const processedMessages: { conversationId: string; message: string }[] = [];
+    const mockProcess = async (conversationId: string, message: string) => {
+      processedMessages.push({ conversationId, message });
+    };
+
+    const result = await runTask(
+      { taskId: task.id, inputs: { name: 'Alice', action: 'testing' }, workingDir: '/tmp' },
+      mockProcess,
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.taskRunId).toBeTruthy();
+    expect(result.conversationId).toBeTruthy();
+    expect(result.error).toBeUndefined();
+
+    // Verify processMessage was called with rendered template
+    expect(processedMessages).toHaveLength(1);
+    expect(processedMessages[0].message).toBe('Hello Alice, please do testing');
+    expect(processedMessages[0].conversationId).toBe(result.conversationId);
+  });
+
+  test('sets up and cleans up ephemeral permissions', async () => {
+    const task = createTask({
+      title: 'File Task',
+      template: 'Read the file',
+      requiredTools: ['read_file', 'write_file'],
+    });
+
+    let rulesWhileRunning: ReturnType<typeof getTaskRunRules> = [];
+    let capturedTaskRunId = '';
+
+    const mockProcess = async (_conversationId: string, _message: string) => {
+      const db = getDb();
+      const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+      const row = raw.query('SELECT id FROM task_runs WHERE task_id = ?').get(task.id) as { id: string };
+      capturedTaskRunId = row.id;
+      rulesWhileRunning = getTaskRunRules(capturedTaskRunId);
+    };
+
+    await runTask(
+      { taskId: task.id, workingDir: '/home/user' },
+      mockProcess,
+    );
+
+    // During execution, rules should have been set
+    expect(rulesWhileRunning).toHaveLength(2);
+    expect(rulesWhileRunning[0].tool).toBe('read_file');
+    expect(rulesWhileRunning[1].tool).toBe('write_file');
+    expect(rulesWhileRunning[0].scope).toBe('/home/user');
+    expect(rulesWhileRunning[0].decision).toBe('allow');
+    expect(rulesWhileRunning[0].priority).toBe(50);
+
+    // After execution, rules should be cleaned up
+    const rulesAfter = getTaskRunRules(capturedTaskRunId);
+    expect(rulesAfter).toHaveLength(0);
+  });
+
+  test('handles errors and sets failed status', async () => {
+    const task = createTask({
+      title: 'Failing Task',
+      template: 'Do something',
+    });
+
+    const mockProcess = async (_conversationId: string, _message: string) => {
+      throw new Error('Something went wrong');
+    };
+
+    const result = await runTask(
+      { taskId: task.id, workingDir: '/tmp' },
+      mockProcess,
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('Something went wrong');
+    expect(result.taskRunId).toBeTruthy();
+    expect(result.conversationId).toBeTruthy();
+  });
+
+  test('cleans up ephemeral rules even on error', async () => {
+    const task = createTask({
+      title: 'Error Cleanup Task',
+      template: 'Do something',
+      requiredTools: ['shell'],
+    });
+
+    let capturedTaskRunId = '';
+
+    const mockProcess = async (_conversationId: string, _message: string) => {
+      const db = getDb();
+      const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+      const row = raw.query('SELECT id FROM task_runs WHERE task_id = ?').get(task.id) as { id: string };
+      capturedTaskRunId = row.id;
+
+      // Verify rules are active during execution
+      const rules = getTaskRunRules(capturedTaskRunId);
+      expect(rules).toHaveLength(1);
+
+      throw new Error('Boom');
+    };
+
+    await runTask({ taskId: task.id, workingDir: '/tmp' }, mockProcess);
+
+    // Rules should be cleaned up in finally block
+    const rulesAfter = getTaskRunRules(capturedTaskRunId);
+    expect(rulesAfter).toHaveLength(0);
+  });
+
+  test('throws if task not found', async () => {
+    const mockProcess = async (_conversationId: string, _message: string) => {};
+
+    await expect(
+      runTask({ taskId: 'nonexistent-id', workingDir: '/tmp' }, mockProcess),
+    ).rejects.toThrow('Task not found: nonexistent-id');
+  });
+
+  test('works with no required tools', async () => {
+    const task = createTask({
+      title: 'Simple Task',
+      template: 'Just a message',
+    });
+
+    const mockProcess = async (_conversationId: string, _message: string) => {};
+
+    const result = await runTask(
+      { taskId: task.id, workingDir: '/tmp' },
+      mockProcess,
+    );
+
+    expect(result.status).toBe('completed');
+  });
+});

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -1,0 +1,85 @@
+import { getLogger } from '../util/logger.js';
+import { createConversation } from '../memory/conversation-store.js';
+import { getTask, createTaskRun, updateTaskRun } from './task-store.js';
+import { buildTaskRules, setTaskRunRules, clearTaskRunRules } from './ephemeral-permissions.js';
+
+const log = getLogger('task-runner');
+
+export interface TaskRunOptions {
+  taskId: string;
+  inputs?: Record<string, string>;
+  workingDir: string;
+}
+
+export interface TaskRunResult {
+  taskRunId: string;
+  conversationId: string;
+  status: 'completed' | 'failed';
+  error?: string;
+}
+
+/** Replace {{key}} placeholders in template with values from inputs. */
+export function renderTemplate(template: string, inputs: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    if (key in inputs) return inputs[key];
+    return match;
+  });
+}
+
+/**
+ * Execute a task: create a run, set up ephemeral permissions,
+ * render the template, and process it as a message.
+ */
+export async function runTask(
+  opts: TaskRunOptions,
+  processMessage: (conversationId: string, message: string) => Promise<void>,
+): Promise<TaskRunResult> {
+  const task = getTask(opts.taskId);
+  if (!task) {
+    throw new Error(`Task not found: ${opts.taskId}`);
+  }
+
+  const run = createTaskRun(task.id);
+  const conversation = createConversation({ title: `Task: ${task.title}`, threadType: 'background' });
+
+  updateTaskRun(run.id, {
+    conversationId: conversation.id,
+    memoryScopeId: `task:${task.id}`,
+  });
+
+  // Build and register ephemeral permission rules from the task's required tools
+  const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
+  const rules = buildTaskRules(run.id, requiredTools, opts.workingDir);
+  setTaskRunRules(run.id, rules);
+
+  try {
+    const renderedTemplate = renderTemplate(task.template, opts.inputs ?? {});
+
+    updateTaskRun(run.id, { status: 'running', startedAt: Date.now() });
+
+    log.info({ taskId: task.id, taskRunId: run.id, conversationId: conversation.id }, 'Executing task');
+    await processMessage(conversation.id, renderedTemplate);
+
+    updateTaskRun(run.id, { status: 'completed', finishedAt: Date.now() });
+
+    return {
+      taskRunId: run.id,
+      conversationId: conversation.id,
+      status: 'completed',
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log.warn({ err, taskId: task.id, taskRunId: run.id }, 'Task execution failed');
+
+    updateTaskRun(run.id, { status: 'failed', error: errorMessage, finishedAt: Date.now() });
+
+    return {
+      taskRunId: run.id,
+      conversationId: conversation.id,
+      status: 'failed',
+      error: errorMessage,
+    };
+  } finally {
+    clearTaskRunRules(run.id);
+  }
+}


### PR DESCRIPTION
## Summary
- Implement `runTask()` in `assistant/src/tasks/task-runner.ts` that orchestrates task execution: looks up the task, creates a conversation and task run, sets up ephemeral permissions from `requiredTools`, renders the template with `{{placeholder}}` substitution, executes via `processMessage`, and cleans up permissions in a `finally` block
- Add `renderTemplate()` helper for `{{key}}` placeholder substitution that leaves unmatched placeholders intact
- Add comprehensive tests covering happy path, error handling, permission lifecycle, and edge cases (10 tests, all passing)

## Test plan
- [x] `renderTemplate` correctly substitutes placeholders
- [x] `renderTemplate` leaves unmatched placeholders as-is
- [x] `runTask` creates conversation and task run, calls processMessage with rendered template
- [x] `runTask` sets up and cleans up ephemeral permissions
- [x] `runTask` handles errors and sets failed status
- [x] `runTask` throws if task not found
- [x] Type-checks cleanly (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
