### PR TITLE
fix(ios): read daemon session token from Keychain in DaemonConfig and DaemonClient

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -558,9 +558,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// allowing the connection to be marked as ready.
     /// If no token is configured, marks the connection as authenticated immediately.
     private func authenticateIfNeeded() async throws {
-        // Re-read from UserDefaults on each call to pick up runtime changes (mirrors hostname/port pattern)
-        let tokenFromDefaults = UserDefaults.standard.string(forKey: "daemon_auth_token").flatMap { $0.isEmpty ? nil : $0 }
-        guard let token = tokenFromDefaults ?? config.authToken else {
+        // Re-read from Keychain on each call to pick up runtime changes (mirrors hostname/port pattern)
+        let tokenFromKeychain = APIKeyManager.shared.getAPIKey(provider: "daemon-token")
+        guard let token = tokenFromKeychain ?? config.authToken else {
             // No token configured — treat as unauthenticated (plain TCP, no handshake).
             isAuthenticated = true
             return

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -33,8 +33,9 @@ public struct DaemonConfig {
         return DaemonConfig(hostname: "localhost", port: 8765)
     }
 
-    /// Create a `DaemonConfig` populated from UserDefaults, falling back to safe defaults.
-    /// Reads: `daemon_hostname`, `daemon_port`, `daemon_tls_enabled`, `daemon_auth_token`.
+    /// Create a `DaemonConfig` populated from UserDefaults / Keychain, falling back to safe defaults.
+    /// Reads: `daemon_hostname`, `daemon_port`, `daemon_tls_enabled` from UserDefaults;
+    /// reads auth token from Keychain via `APIKeyManager` (provider: `"daemon-token"`).
     public static func fromUserDefaults() -> DaemonConfig {
         // Treat empty string as nil to ensure fallback to "localhost"
         let hostname = UserDefaults.standard.string(forKey: "daemon_hostname").flatMap { $0.isEmpty ? nil : $0 } ?? "localhost"
@@ -42,8 +43,8 @@ public struct DaemonConfig {
         // Validate port is in valid UInt16 range (1-65535) before converting to avoid crash
         let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
         let tlsEnabled = UserDefaults.standard.bool(forKey: "daemon_tls_enabled")
-        let authToken = UserDefaults.standard.string(forKey: "daemon_auth_token")
-        return DaemonConfig(hostname: hostname, port: finalPort, tlsEnabled: tlsEnabled, authToken: authToken.flatMap { $0.isEmpty ? nil : $0 })
+        let authToken = APIKeyManager.shared.getAPIKey(provider: "daemon-token")
+        return DaemonConfig(hostname: hostname, port: finalPort, tlsEnabled: tlsEnabled, authToken: authToken)
     }
     #else
     #error("Unsupported platform")


### PR DESCRIPTION
## Summary
- Follow-up to #4306: the write path was moved to Keychain but the read paths were missed
- `DaemonConfig.fromUserDefaults()`: reads auth token from `APIKeyManager.shared.getAPIKey(provider: "daemon-token")` instead of `UserDefaults["daemon_auth_token"]`
- `DaemonClient.authenticateIfNeeded()`: same fix — re-reads token from Keychain on each auth attempt
- Updates doc comment to reflect new storage location

🤖 Generated with [Claude Code](https://claude.com/claude-code)