### PR TITLE
docs: update READMEs — shared module structure, iOS status, session token storage, new slash commands

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -159,6 +159,49 @@ Reads a plan file from `.private/plans/`, then sequentially implements and mainl
 /execute-plan AUTH_REFACTOR.md   # executes .private/plans/AUTH_REFACTOR.md
 ```
 
+### `/safe-execute-plan` / `/safe-check-review` / `/resume-plan` - Human-in-the-loop plan execution
+
+A three-command workflow for executing plans one PR at a time with human review between each step:
+
+1. `/safe-execute-plan <file>` — implement the first PR and stop for review
+2. `/safe-check-review [file]` — check for reviewer feedback, push fixes if needed, confirm ready to merge
+3. `/resume-plan [file]` — merge the current PR, implement the next one, stop for review again
+
+Multiple plans can run in parallel by specifying the plan name.
+
+### `/safe-blitz` - End-to-end feature execution on a feature branch
+
+Like `/blitz` but creates a dedicated feature branch and opens a final PR into main for human review instead of merging automatically.
+
+```
+/safe-blitz Add WebSocket transport for daemon IPC
+/safe-blitz --auto Refactor the logger
+/safe-blitz --workers 5 --branch feature/dark-mode Add dark mode support
+```
+
+**Flags:** `--auto` (skip pauses), `--workers N` (parallel workers, default 12), `--skip-plan` (use existing "Ready" issues), `--branch NAME` (custom branch name)
+
+### `/safe-blitz-done` - Finalize a safe-blitz
+
+Squash-merges the feature branch PR into main, closes the project issue, and cleans up the local branch. Auto-detects the PR from the current branch, open `feature/*` PRs, or the project board.
+
+### `/ship-and-merge` - Ship with automated review loop
+
+Ships uncommitted changes via a PR, waits for Codex/Devin reviews, fixes valid feedback (up to 3 rounds), and squash-merges.
+
+### `/plan-html` - Create or refresh a plan with HTML view
+
+Creates or refreshes a rollout plan in `.private/plans/` with both markdown and a polished HTML review view (per-PR file lists, dependency diagram).
+
+### `/release` - Cut a release
+
+Pulls main, determines/creates a version tag, generates release notes from commits, publishes a GitHub Release, and confirms CI was triggered.
+
+```
+/release        # auto-increments patch version
+/release v1.2.0 # specific version
+```
+
 ### `/scrub` - Kill, wipe, and relaunch the macOS app
 
 Kills the running vellum-assistant app, deletes all persistent data (logs, knowledge store, caches, UserDefaults) so the next launch behaves like a first run (including onboarding), then starts the daemon and rebuilds/launches the app.

--- a/clients/README.md
+++ b/clients/README.md
@@ -8,17 +8,21 @@ This directory contains native client applications for the Vellum Assistant, org
 clients/
 ├── Package.swift              # Multi-platform Swift Package Manager manifest
 ├── shared/                    # VellumAssistantShared - cross-platform code
-│   ├── IPC/                   # Daemon communication (both macOS and iOS)
-│   └── App/                   # Shared app utilities
+│   ├── IPC/                   # Daemon communication (DaemonClient, DaemonConfig, IPCMessages)
+│   ├── Features/Chat/         # Shared chat UI (ChatViewModel, MessageBubbleView, InputBarView, etc.)
+│   ├── Features/Surfaces/     # Shared surface rendering (confirmation, form)
+│   ├── DesignSystem/          # Design tokens and components (VColor, VFont, VSpacing, etc.)
+│   ├── Utilities/             # Shared utilities (APIKeyManager, PermissionManager)
+│   └── App/                   # Shared app utilities (SigningIdentityManager)
 ├── macos/                     # macOS-specific code
 │   ├── vellum-assistant/      # VellumAssistantLib - macOS app logic
 │   ├── vellum-assistant-app/  # Executable entry point
 │   ├── build.sh               # Build script (wraps SPM → .app → codesign)
 │   └── CLAUDE.md              # Development guide for Claude Code
 └── ios/                       # iOS-specific code
-    ├── App/                   # App lifecycle (VellumAssistantApp, AppDelegate)
-    ├── Views/                 # SwiftUI views (ChatTabView, MessageBubbleView, etc.)
-    └── Resources/             # Assets, Info.plist
+    ├── App/                   # App lifecycle (VellumAssistantApp, AppDelegate, UserDefaultsKeys)
+    ├── Views/                 # iOS-specific SwiftUI views (ChatTabView, ThreadListView, SettingsView, etc.)
+    └── Resources/             # Assets, Info.plist, background.png
 ```
 
 ## Targets
@@ -34,9 +38,12 @@ clients/
   - Wire types are auto-generated from the TS IPC contract; `IPCMessages.swift` provides
     typealiases, convenience inits, the `ServerMessage` routing enum, and a few hand-maintained
     types that need Swift-specific logic (e.g. typed enums, polymorphic `AnyCodable` data)
-- **Shared utilities** (signing, configuration)
+- **Shared chat features** (`ChatViewModel`, `ChatMessage`, `MessageBubbleView`, `InputBarView`, `AttachmentStripView`, `MarkdownRenderer`, `CurrentStepIndicator`, inline widgets)
+- **Design system** (`VColor`, `VFont`, `VSpacing`, `VRadius`, `VShadow`, `VAnimation`, and all `V`-prefixed components)
+- **Shared utilities** (`APIKeyManager` for Keychain credential storage, `PermissionManager`, `FeatureFlagManager`)
+- **Shared app utilities** (signing identity management)
 
-**Dependencies**: None (only system frameworks: Network)
+**Dependencies**: None (only system frameworks: Network, Security)
 
 ### VellumAssistantLib (Library)
 **Platforms**: macOS 14+ only
@@ -174,11 +181,7 @@ After migration:
 ## Documentation
 
 - **macOS development**: See `clients/macos/CLAUDE.md`
-- **iOS rollout plan**: See `.private/plans/sharded-mapping-shannon.md` (13 PRs)
-- **Completed iOS PRs**:
-  - PR #1821: iOS shared library foundation
-  - PR #1973: iOS app target with basic structure
-  - PR #1975: iOS chat interface implementation
+- **iOS development**: See `clients/ios/README.md`
 
 ## Testing
 

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -136,7 +136,7 @@ swift test --filter VellumAssistantSharedTests
 | Connection mode | `connection_mode` | `Standalone` | `Standalone` or `Connected to Mac` |
 | Daemon hostname | `daemon_hostname` | `localhost` | Mac hostname or IP |
 | Daemon port | `daemon_port` | `8765` | Daemon TCP port |
-| Session token | see `DaemonConfig.fromUserDefaults()` | — | Token from `~/.vellum/session-token` on Mac |
+| Session token | Keychain (device) / UserDefaults (simulator), provider key `"daemon-token"` | — | Token from `~/.vellum/session-token` on Mac |
 | Use TLS | `daemon_tls_enabled` | `false` | Enable TLS for TCP connection |
 | Anthropic API key | (UserDefaults on simulator, Keychain on device) | — | For standalone mode |
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -6,7 +6,7 @@ A native macOS menu bar app that controls your Mac via accessibility APIs and CG
 
 This repository also includes an iOS app target (`vellum-assistant-ios`) that shares ~45-50% of code with the macOS app through the `VellumAssistantShared` library. The iOS app is a chat-focused client that connects to a network-accessible daemon via TCP.
 
-**Status:** Basic structure in place (PR 4 of 13). The iOS target requires xcodebuild with iOS SDK to build - it cannot be built with `swift build` on macOS due to UIKit dependencies.
+**Status:** Fully functional. The iOS target requires xcodebuild with iOS SDK to build — it cannot be built with `swift build` on macOS due to UIKit dependencies. See [clients/ios/README.md](../ios/README.md) for build instructions.
 
 **Code organization:**
 - `clients/shared/` — Shared library (IPC layer, chat models/ViewModels, design system)


### PR DESCRIPTION
## Summary
- `clients/README.md`: update structure diagram and VellumAssistantShared description to reflect DesignSystem, Features/Chat, and Utilities that now live in shared; remove stale iOS rollout plan link and outdated completed-PRs list
- `clients/ios/README.md`: fix session token config row — now stored in Keychain (device) / UserDefaults (simulator) via APIKeyManager, not raw UserDefaults
- `clients/macos/README.md`: replace "Basic structure in place (PR 4 of 13)" iOS status with "Fully functional" + link to iOS README
- `.claude/README.md`: document 8 missing slash commands (`/safe-blitz`, `/safe-blitz-done`, `/safe-execute-plan`, `/safe-check-review`, `/resume-plan`, `/ship-and-merge`, `/plan-html`, `/release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
