### PR TITLE
fix(ios): add legacy UserDefaults migration fallback for daemon auth token

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -558,8 +558,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// allowing the connection to be marked as ready.
     /// If no token is configured, marks the connection as authenticated immediately.
     private func authenticateIfNeeded() async throws {
-        // Re-read from Keychain on each call to pick up runtime changes (mirrors hostname/port pattern)
+        // Re-read from Keychain on each call to pick up runtime changes (mirrors hostname/port pattern).
+        // Falls back to legacy UserDefaults key with one-time migration (same logic as DaemonConfig).
         let tokenFromKeychain = APIKeyManager.shared.getAPIKey(provider: "daemon-token")
+            ?? DaemonConfig.migrateAuthToken()
         guard let token = tokenFromKeychain ?? config.authToken else {
             // No token configured — treat as unauthenticated (plain TCP, no handshake).
             isAuthenticated = true

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -35,7 +35,8 @@ public struct DaemonConfig {
 
     /// Create a `DaemonConfig` populated from UserDefaults / Keychain, falling back to safe defaults.
     /// Reads: `daemon_hostname`, `daemon_port`, `daemon_tls_enabled` from UserDefaults;
-    /// reads auth token from Keychain via `APIKeyManager` (provider: `"daemon-token"`).
+    /// reads auth token from Keychain via `APIKeyManager` (provider: `"daemon-token"`),
+    /// with a one-time migration from the legacy `daemon_auth_token` UserDefaults key.
     public static func fromUserDefaults() -> DaemonConfig {
         // Treat empty string as nil to ensure fallback to "localhost"
         let hostname = UserDefaults.standard.string(forKey: "daemon_hostname").flatMap { $0.isEmpty ? nil : $0 } ?? "localhost"
@@ -43,8 +44,19 @@ public struct DaemonConfig {
         // Validate port is in valid UInt16 range (1-65535) before converting to avoid crash
         let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
         let tlsEnabled = UserDefaults.standard.bool(forKey: "daemon_tls_enabled")
-        let authToken = APIKeyManager.shared.getAPIKey(provider: "daemon-token")
+        let authToken = APIKeyManager.shared.getAPIKey(provider: "daemon-token") ?? migrateAuthToken()
         return DaemonConfig(hostname: hostname, port: finalPort, tlsEnabled: tlsEnabled, authToken: authToken)
+    }
+
+    /// One-time migration: reads the legacy `daemon_auth_token` UserDefaults key, persists it
+    /// to Keychain, removes the old key, and returns the value. Returns nil if no legacy token exists.
+    static func migrateAuthToken() -> String? {
+        guard let legacy = UserDefaults.standard.string(forKey: "daemon_auth_token"), !legacy.isEmpty else {
+            return nil
+        }
+        _ = APIKeyManager.shared.setAPIKey(legacy, provider: "daemon-token")
+        UserDefaults.standard.removeObject(forKey: "daemon_auth_token")
+        return legacy
     }
     #else
     #error("Unsupported platform")


### PR DESCRIPTION
## Summary
- Follow-up to #4436: adds a one-time migration path for users who configured "Connected to Mac" before the Keychain switch
- `DaemonConfig.migrateAuthToken()`: reads legacy `UserDefaults["daemon_auth_token"]`, persists to Keychain, deletes old key, returns value
- `DaemonConfig.fromUserDefaults()`: uses `?? migrateAuthToken()` so existing users are migrated transparently on first launch after upgrade
- `DaemonClient.authenticateIfNeeded()`: same fallback via `DaemonConfig.migrateAuthToken()`
- After migration runs once, the legacy key is gone and subsequent calls read cleanly from Keychain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
