### PR TITLE
fix(ios): only delete legacy daemon_auth_token after successful Keychain write

### DIFF
--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -54,7 +54,10 @@ public struct DaemonConfig {
         guard let legacy = UserDefaults.standard.string(forKey: "daemon_auth_token"), !legacy.isEmpty else {
             return nil
         }
-        _ = APIKeyManager.shared.setAPIKey(legacy, provider: "daemon-token")
+        guard APIKeyManager.shared.setAPIKey(legacy, provider: "daemon-token") else {
+            // Keychain write failed — keep the legacy key so the next launch can retry migration.
+            return legacy
+        }
         UserDefaults.standard.removeObject(forKey: "daemon_auth_token")
         return legacy
     }


### PR DESCRIPTION
## Summary
- Follow-up to #4440: `migrateAuthToken()` was deleting the legacy `UserDefaults["daemon_auth_token"]` key even when `setAPIKey` returned `false` (Keychain write failed)
- On Keychain write failure (e.g. device locked, background access denied), the token was permanently lost — next launch would find nothing in either Keychain or UserDefaults
- Fix: gate the `removeObject` call behind a `guard` on `setAPIKey`'s return value; if Keychain write fails, keep the legacy key so the next launch can retry migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
