### PR TITLE
fix: clear legacy daemon_auth_token on logout and remove duplicate vault.ts import

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -4,7 +4,6 @@ import type { ToolDefinition } from '../../providers/types.js';
 import {
   getSecureKey,
   setSecureKey,
-  getSecureKey,
   deleteSecureKey,
   getBackendType,
   listSecureKeys,

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -288,6 +288,8 @@ struct DaemonSetupStep: View {
                 UserDefaults.standard.set(portInt, forKey: UserDefaultsKeys.daemonPort)
                 if sessionToken.isEmpty {
                     _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
+                    // Also clear legacy UserDefaults key so migrateAuthToken() can't resurrect it
+                    UserDefaults.standard.removeObject(forKey: "daemon_auth_token")
                 } else {
                     _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
                 }

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -105,6 +105,8 @@ struct SettingsView: View {
                             UserDefaults.standard.set(port, forKey: UserDefaultsKeys.daemonPort)
                             if sessionToken.isEmpty {
                                 _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
+                                // Also clear legacy UserDefaults key so migrateAuthToken() can't resurrect it
+                                UserDefaults.standard.removeObject(forKey: "daemon_auth_token")
                             } else {
                                 _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
                             }


### PR DESCRIPTION
## Summary
- Clear `UserDefaults["daemon_auth_token"]` alongside Keychain on explicit daemon token removal in `SettingsView` and `OnboardingView`, preventing `migrateAuthToken()` from resurrecting a stale token after the user explicitly disconnects
- Remove duplicate `getSecureKey` import in `vault.ts` that was causing a `TS2300: Duplicate identifier` type-check CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
