### PR TITLE
M3: Rename Apps to Pinned Apps with View More → directory

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -564,6 +564,7 @@ struct MainWindowView: View {
                     // MARK: Threads Section
                     VStack(spacing: VSpacing.xs) {
                         SidebarSectionHeader(title: "Threads")
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
                         ForEach(displayedThreads) { thread in
                             threadItem(thread)
@@ -593,7 +594,19 @@ struct MainWindowView: View {
                     // MARK: Apps Section
                     if !appListManager.apps.isEmpty {
                         VStack(spacing: VSpacing.xs) {
-                            SidebarSectionHeader(title: "Apps")
+                            HStack {
+                                SidebarSectionHeader(title: "Pinned Apps")
+                                Spacer()
+                                Button {
+                                    windowState.selection = .panel(.directory)
+                                } label: {
+                                    Text("View more")
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.accent)
+                                }
+                                .buttonStyle(.plain)
+                                .padding(.trailing, VSpacing.lg)
+                            }
 
                             ForEach(displayedApps) { app in
                                 sidebarAppItem(app)
@@ -1214,7 +1227,6 @@ private struct SidebarSectionHeader: View {
             .font(VFont.headline)
             .foregroundColor(VColor.textSecondary)
             .textCase(.uppercase)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.lg)
             .padding(.bottom, VSpacing.xs)
     }


### PR DESCRIPTION
## Summary
- Renamed sidebar Apps section to 'Pinned Apps'
- Added 'View more' button to the right of the section header that opens the app directory

Closes #4446
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
