### PR TITLE
fix: use togglePanel for directory View More button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -610,7 +610,7 @@ struct MainWindowView: View {
                                 SidebarSectionHeader(title: "Pinned Apps")
                                 Spacer()
                                 Button {
-                                    windowState.selection = .panel(.directory)
+                                    windowState.togglePanel(.directory)
                                 } label: {
                                     Text("View more")
                                         .font(VFont.caption)


### PR DESCRIPTION
## Summary
- Changed View More button to use windowState.togglePanel(.directory) instead of directly setting selection, ensuring panel persistence for session restoration

Addresses feedback on #4449
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
