### PR TITLE
M3: Control center popover opens to the right

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1350,15 +1350,16 @@ private struct ControlCenterMenuButton: View {
             }
         }
         .buttonStyle(.plain)
-        .overlay(alignment: .bottom) {
+        .overlay(alignment: .bottomLeading) {
             if showDrawer {
                 DrawerMenuView(
                     onSettings: { showDrawer = false; onSettings() },
                     onDebug: { showDrawer = false; onDebug() },
                     onDoctor: { showDrawer = false; onDoctor() }
                 )
-                .offset(y: -140)
-                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .frame(width: 200)
+                .offset(x: 240)
+                .transition(.move(edge: .leading).combined(with: .opacity))
             }
         }
     }
@@ -1380,15 +1381,13 @@ private struct DrawerMenuView: View {
             DrawerMenuItem(icon: "stethoscope", label: "Vellum Doctor", action: onDoctor)
         }
         .padding(.vertical, VSpacing.sm)
-        .frame(maxWidth: .infinity)
         .background(VColor.surface)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
         )
-        .shadow(color: .black.opacity(0.3), radius: 12, y: -4)
-        .padding(.horizontal, VSpacing.sm)
+        .shadow(color: .black.opacity(0.3), radius: 12, x: 4)
     }
 }
 


### PR DESCRIPTION
Changed control center drawer to open to the right of the sidebar instead of above the button. Adjusted overlay alignment, offset, transition direction, and shadow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
