### PR TITLE
M1: Pin and archive icons side by side, floating right

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -455,24 +455,6 @@ struct MainWindowView: View {
             }
         }) {
             HStack(spacing: VSpacing.xs) {
-                Button {
-                    if thread.isPinned {
-                        threadManager.unpinThread(id: thread.id)
-                    } else {
-                        threadManager.pinThread(id: thread.id)
-                    }
-                } label: {
-                    Image(systemName: thread.isPinned ? "pin.fill" : "pin")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
-                        .rotationEffect(.degrees(-45))
-                        .frame(width: 20, height: 20)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .opacity(thread.isPinned || isHovered ? 1 : 0)
-                .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
-
                 if thread.kind == .private {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10, weight: .medium))
@@ -519,18 +501,44 @@ struct MainWindowView: View {
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
             } else if isHovered {
-                Button {
-                    threadPendingDeletion = thread.id
-                } label: {
-                    Image(systemName: "archivebox")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(width: 24, height: 24)
-                        .contentShape(Rectangle())
+                HStack(spacing: VSpacing.xs) {
+                    Button {
+                        if thread.isPinned {
+                            threadManager.unpinThread(id: thread.id)
+                        } else {
+                            threadManager.pinThread(id: thread.id)
+                        }
+                    } label: {
+                        Image(systemName: thread.isPinned ? "pin.fill" : "pin")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
+                            .rotationEffect(.degrees(-45))
+                            .frame(width: 20, height: 20)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+
+                    Button {
+                        threadPendingDeletion = thread.id
+                    } label: {
+                        Image(systemName: "archivebox")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 20, height: 20)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Archive \(thread.title)")
                 }
-                .buttonStyle(.plain)
                 .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Archive \(thread.title)")
+            } else if thread.isPinned {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+                    .rotationEffect(.degrees(-45))
+                    .frame(width: 20, height: 20)
+                    .padding(.trailing, VSpacing.xs)
             }
         }
         .padding(.horizontal, VSpacing.sm)
@@ -697,12 +705,6 @@ struct MainWindowView: View {
             openAppInWorkspace(app: app)
         }) {
             HStack(spacing: VSpacing.sm) {
-                if app.isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                        .rotationEffect(.degrees(-45))
-                }
                 Text(app.name)
                     .font(.system(size: 13))
                     .foregroundColor(VColor.textPrimary)
@@ -719,33 +721,44 @@ struct MainWindowView: View {
         .buttonStyle(.plain)
         .overlay(alignment: .trailing) {
             if isHoveredApp == app.id {
-                Menu {
-                    Button(app.isPinned ? "Unpin" : "Pin to Top") {
+                HStack(spacing: VSpacing.xs) {
+                    Button {
                         if app.isPinned {
                             appListManager.unpinApp(id: app.id)
                         } else {
                             appListManager.pinApp(id: app.id)
                         }
+                    } label: {
+                        Image(systemName: app.isPinned ? "pin.fill" : "pin")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(app.isPinned ? VColor.textMuted : VColor.textSecondary)
+                            .rotationEffect(.degrees(-45))
+                            .frame(width: 20, height: 20)
+                            .contentShape(Rectangle())
                     }
-                    Button("Open") {
-                        openAppInWorkspace(app: app)
-                    }
-                    Divider()
-                    Button("Remove from Recents", role: .destructive) {
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(app.isPinned ? "Unpin \(app.name)" : "Pin \(app.name)")
+
+                    Button {
                         appListManager.removeApp(id: app.id)
+                    } label: {
+                        Image(systemName: "archivebox")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 20, height: 20)
+                            .contentShape(Rectangle())
                     }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                        .rotationEffect(.degrees(90))
-                        .frame(width: 24, height: 24)
-                        .contentShape(Rectangle())
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Remove \(app.name)")
                 }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .frame(width: 24)
                 .padding(.trailing, VSpacing.xs)
+            } else if app.isPinned {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+                    .rotationEffect(.degrees(-45))
+                    .frame(width: 20, height: 20)
+                    .padding(.trailing, VSpacing.xs)
             }
         }
         .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
Move pin and archive/remove icons to float right on sidebar thread and app items. Both icons appear side by side on hover. Pin icon persists when item is pinned. Removes ellipsis menu from app items in favor of direct actions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
