### PR TITLE
M2: Always show Pinned Apps heading + pin from directory

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -611,22 +611,22 @@ struct MainWindowView: View {
                     }
 
                     // MARK: Apps Section
-                    if !appListManager.apps.isEmpty {
-                        VStack(spacing: VSpacing.xs) {
-                            HStack {
-                                SidebarSectionHeader(title: "Pinned Apps")
-                                Spacer()
-                                Button {
-                                    windowState.togglePanel(.directory)
-                                } label: {
-                                    Text("View more")
-                                        .font(VFont.caption)
-                                        .foregroundColor(VColor.accent)
-                                }
-                                .buttonStyle(.plain)
-                                .padding(.trailing, VSpacing.lg)
+                    VStack(spacing: VSpacing.xs) {
+                        HStack {
+                            SidebarSectionHeader(title: "Pinned Apps")
+                            Spacer()
+                            Button {
+                                windowState.togglePanel(.directory)
+                            } label: {
+                                Text("View more")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.accent)
                             }
+                            .buttonStyle(.plain)
+                            .padding(.trailing, VSpacing.lg)
+                        }
 
+                        if !appListManager.apps.isEmpty {
                             ForEach(displayedApps) { app in
                                 sidebarAppItem(app)
                                     .dropDestination(for: String.self) { items, _ in
@@ -937,6 +937,10 @@ struct MainWindowView: View {
                 },
                 onRecordAppOpen: { id, name, icon, appType in
                     appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                },
+                onPinApp: { id, name, icon, appType in
+                    appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                    appListManager.pinApp(id: id)
                 }
             )
         case .generated:
@@ -1058,6 +1062,10 @@ struct MainWindowView: View {
                     },
                     onRecordAppOpen: { id, name, icon, appType in
                         appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                    },
+                    onPinApp: { id, name, icon, appType in
+                        appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                        appListManager.pinApp(id: id)
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -8,6 +8,8 @@ struct AppDirectoryView: View {
     let onOpenApp: (UiSurfaceShowMessage) -> Void
     /// Called to record an app open in the sidebar's recent apps list.
     var onRecordAppOpen: ((_ id: String, _ name: String, _ icon: String?, _ appType: String?) -> Void)?
+    /// Called to pin an app from the directory into the sidebar.
+    var onPinApp: ((_ id: String, _ name: String, _ icon: String?, _ appType: String?) -> Void)?
 
     @State private var searchText = ""
     @State private var displayItems: [DirectoryAppItem] = []
@@ -178,6 +180,26 @@ struct AppDirectoryView: View {
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+        .overlay(alignment: .topTrailing) {
+            if isHovered, let localId = item.localAppId, onPinApp != nil {
+                Button {
+                    onPinApp?(localId, item.name, item.icon, item.appType)
+                } label: {
+                    Image(systemName: "pin")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(VColor.textPrimary)
+                        .rotationEffect(.degrees(-45))
+                        .frame(width: 28, height: 28)
+                        .background(VColor.surface.opacity(0.9))
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .padding(VSpacing.sm)
+                .transition(.opacity)
+                .accessibilityLabel("Pin \(item.name)")
+            }
+        }
         .scaleEffect(isHovered ? 1.02 : 1.0)
         .animation(VAnimation.fast, value: isHovered)
         .contentShape(Rectangle())


### PR DESCRIPTION
Always display the Pinned Apps section header and View More button in sidebar even when no apps exist. Add pin button to app cards in AppDirectoryView so users can pin apps directly from the directory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
