### PR TITLE
M5: Remove static composer from app view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1567,18 +1567,6 @@ private struct DynamicWorkspaceWrapper: View {
     let onToggleChatDock: () -> Void
     let onMicrophoneToggle: () -> Void
 
-    private var composerReservedHeight: CGFloat {
-        guard !isChatDockOpen else { return 0 }
-        let editorClamped = min(max(workspaceEditorContentHeight, 14), 200)
-        let contentHeight = max(editorClamped, 28)
-        let expanded = windowState.workspaceComposerExpanded
-        let topPad: CGFloat = expanded ? VSpacing.lg : VSpacing.sm
-        let buttonRow: CGFloat = expanded ? 28 + VSpacing.xs : 0
-        let hasAttachments = !viewModel.pendingAttachments.isEmpty
-        let attachmentStrip: CGFloat = hasAttachments ? VSpacing.sm + 36 + VSpacing.xs : 0
-        return VSpacing.sm + VSpacing.md + topPad + VSpacing.sm + contentHeight + buttonRow + attachmentStrip
-    }
-
     var body: some View {
         ZStack {
             DynamicPageSurfaceView(
@@ -1608,7 +1596,7 @@ private struct DynamicWorkspaceWrapper: View {
                     surfaceManager.onLinkOpen?(url, metadata)
                 },
                 topContentInset: 56,
-                bottomContentInset: composerReservedHeight
+                bottomContentInset: 0
             )
 
             VStack(spacing: 0) {
@@ -1798,34 +1786,6 @@ private struct DynamicWorkspaceWrapper: View {
                 .padding(.top, VSpacing.md)
 
                 Spacer()
-
-                if !isChatDockOpen {
-                    WorkspaceActivityFeed(viewModel: viewModel)
-                }
-
-                if !isChatDockOpen {
-                    ComposerView(
-                        inputText: Binding(
-                            get: { viewModel.inputText },
-                            set: { viewModel.inputText = $0 }
-                        ),
-                        hasAPIKey: windowState.hasAPIKey,
-                        isSending: viewModel.isSending,
-                        isRecording: viewModel.isRecording,
-                        suggestion: viewModel.suggestion,
-                        pendingAttachments: viewModel.pendingAttachments,
-                        onSend: viewModel.sendMessage,
-                        onStop: viewModel.stopGenerating,
-                        onAcceptSuggestion: viewModel.acceptSuggestion,
-                        onAttach: { openFilePicker(viewModel: viewModel) },
-                        onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
-                        onPaste: { viewModel.addAttachmentFromPasteboard() },
-                        onMicrophoneToggle: onMicrophoneToggle,
-                        placeholderText: "Message your assistant...",
-                        editorContentHeight: $workspaceEditorContentHeight,
-                        isComposerExpanded: $windowState.workspaceComposerExpanded
-                    )
-                }
             }
         }
     }


### PR DESCRIPTION
Remove the ComposerView and WorkspaceActivityFeed from the app view when not in editing mode. The app view now shows only the app content without a text input at the bottom.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
