### PR TITLE
M4: Edit toggles to full-screen app, move Edit button left

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1218,14 +1218,9 @@ struct MainWindowView: View {
                 onBundleAndShare: bundleAndShare,
                 isChatDockOpen: windowState.isChatDockOpen,
                 onToggleChatDock: {
-                    if case .appEditing = windowState.selection {
-                        // Toggle off: close app, keep thread visible
-                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
-                        if let threadId {
-                            windowState.selection = .thread(threadId)
-                        } else {
-                            windowState.selection = nil
-                        }
+                    if case .appEditing(let appId, _) = windowState.selection {
+                        // Toggle off: go back to full-screen app view
+                        windowState.selection = .app(appId)
                     } else if case .app(let appId) = windowState.selection {
                         // Toggle on: find most recent thread and enter editing mode
                         let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
@@ -1793,7 +1788,7 @@ private struct DynamicWorkspaceWrapper: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel("Close workspace")
                 }
-                .padding(.leading, trafficLightPadding)
+                .padding(.leading, VSpacing.lg)
                 .padding(.trailing, VSpacing.xl)
                 .padding(.top, VSpacing.md)
 


### PR DESCRIPTION
Changed Edit button behavior: clicking Edit while editing now returns to full-screen app view instead of closing the app. Moved Edit button closer to the left edge of the app workspace.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
