### PR TITLE
fix: use dynamic sidebar width for control center drawer offset

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -684,6 +684,7 @@ struct MainWindowView: View {
                 VColor.surfaceBorder.frame(height: 1)
 
                 ControlCenterMenuButton(
+                    sidebarWidth: threadDrawerWidth,
                     onSettings: { windowState.togglePanel(.settings) },
                     onDebug: { windowState.togglePanel(.debug) },
                     onDoctor: { windowState.togglePanel(.doctor) }
@@ -1328,6 +1329,7 @@ private struct SidebarBottomItem: View {
 }
 
 private struct ControlCenterMenuButton: View {
+    let sidebarWidth: Double
     let onSettings: () -> Void
     let onDebug: () -> Void
     let onDoctor: () -> Void
@@ -1374,7 +1376,7 @@ private struct ControlCenterMenuButton: View {
                     onDoctor: { showDrawer = false; onDoctor() }
                 )
                 .frame(width: 200)
-                .offset(x: 240)
+                .offset(x: sidebarWidth)
                 .transition(.move(edge: .leading).combined(with: .opacity))
             }
         }


### PR DESCRIPTION
Pass threadDrawerWidth to ControlCenterMenuButton and use it for the drawer overlay offset instead of hardcoded 240. Fixes misalignment when sidebar is resized.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
