### PR TITLE
feat: push gateway image to both dev and production GCP environments

### DIFF
--- a/.github/workflows/cd-gateway-image.yml
+++ b/.github/workflows/cd-gateway-image.yml
@@ -14,8 +14,13 @@ permissions:
 
 jobs:
   push:
-    name: Build & Push Image
+    name: Build & Push Image (${{ matrix.environment }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, production]
+    environment: ${{ matrix.environment }}
 
     steps:
       - name: Checkout
@@ -57,8 +62,9 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Gateway Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "## Gateway Image Published (${{ matrix.environment }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** \`${{ matrix.environment }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**SHA tag:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Summary
- Updated CD gateway image workflow to push to both `dev` and `production` GitHub environments using a matrix strategy
- Each environment uses its own GCP credentials (service account, workload identity provider, registry host, project ID)
- Both environments run in parallel with `fail-fast: false` so one failure doesn't block the other

## Environment Setup Required

Both the **dev** and **production** GitHub environments need these secrets configured:

| Secret | Description |
|--------|-------------|
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload identity provider for the environment |
| `GCP_SERVICE_ACCOUNT` | GCP service account for the environment |
| `GCP_REGISTRY_HOST` | GCR registry host (e.g. `us-docker.pkg.dev`) |
| `GCP_PROJECT_ID` | GCP project ID for the environment |
| `GATEWAY_IMAGE_NAME` | Name of the gateway image in the registry |

> **Migration note:** These secrets currently exist at the repo level. Move them into each GitHub environment (`dev` and `production`) with the appropriate per-environment values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
