### PR TITLE
Update scrub command to run daemon and app in background

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -53,15 +53,24 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 8. Confirm everything is clean by listing what remains (if anything) in `~/Library/Application Support/vellum-assistant/`.
 
-9. Start the daemon fresh from the repo root:
+9. Start the daemon fresh from the repo root (in background):
    ```bash
-   cd assistant && bun run src/index.ts daemon start && cd ..
+   cd assistant && bun run src/index.ts daemon start > ~/.vellum/daemon-stdout.log 2>&1 & cd ..
+   ```
+   Wait a moment for the daemon to initialize:
+   ```bash
+   sleep 3
    ```
 
 10. Build and launch the macOS app (from the repo root):
     ```bash
-    cd clients/macos && ./build.sh run
+    cd clients/macos && ./build.sh run &
     ```
-    Run this in the background so it doesn't block.
 
-Report what was cleaned up and confirm both the daemon and app are running.
+11. Wait for the app to launch and verify both processes are running:
+    ```bash
+    sleep 5
+    ps aux | grep -E "(Vellum|bun.*daemon)" | grep -v grep
+    ```
+
+Report what was cleaned up and confirm both the daemon and app are running. The app should show the onboarding flow since all UserDefaults and data were reset.


### PR DESCRIPTION
## Summary
- Run the daemon process in background with stdout/stderr redirected to a log file
- Run the macOS app build in background so it doesn't block the shell
- Add a verification step that checks both processes are running after launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
