### PR TITLE
M1: Simplify pinned app actions to unpin-only icon

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -722,36 +722,22 @@ struct MainWindowView: View {
         .buttonStyle(.plain)
         .overlay(alignment: .trailing) {
             if isHoveredApp == app.id {
-                HStack(spacing: VSpacing.xs) {
-                    Button {
-                        if app.isPinned {
-                            appListManager.unpinApp(id: app.id)
-                        } else {
-                            appListManager.pinApp(id: app.id)
-                        }
-                    } label: {
-                        Image(systemName: app.isPinned ? "pin.fill" : "pin")
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(app.isPinned ? VColor.textMuted : VColor.textSecondary)
-                            .rotationEffect(.degrees(-45))
-                            .frame(width: 20, height: 20)
-                            .contentShape(Rectangle())
+                Button {
+                    if app.isPinned {
+                        appListManager.unpinApp(id: app.id)
+                    } else {
+                        appListManager.pinApp(id: app.id)
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(app.isPinned ? "Unpin \(app.name)" : "Pin \(app.name)")
-
-                    Button {
-                        appListManager.removeApp(id: app.id)
-                    } label: {
-                        Image(systemName: "archivebox")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 20, height: 20)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Remove \(app.name)")
+                } label: {
+                    Image(systemName: app.isPinned ? "pin.fill" : "pin")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(app.isPinned ? VColor.textMuted : VColor.textSecondary)
+                        .rotationEffect(.degrees(-45))
+                        .frame(width: 20, height: 20)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel(app.isPinned ? "Unpin \(app.name)" : "Pin \(app.name)")
                 .padding(.trailing, VSpacing.xs)
             } else if app.isPinned {
                 Image(systemName: "pin.fill")


### PR DESCRIPTION
Remove archive/remove button from pinned app hover overlay. Only show pin/unpin icon on hover. Context menu retained for full actions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
