### PR TITLE
M3: Thread action icons need circular background

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -514,6 +514,8 @@ struct MainWindowView: View {
                             .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
                             .rotationEffect(.degrees(-45))
                             .frame(width: 20, height: 20)
+                            .background(VColor.backgroundSubtle)
+                            .clipShape(Circle())
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
@@ -526,6 +528,8 @@ struct MainWindowView: View {
                             .font(.system(size: 12, weight: .medium))
                             .foregroundColor(VColor.textSecondary)
                             .frame(width: 20, height: 20)
+                            .background(VColor.backgroundSubtle)
+                            .clipShape(Circle())
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
@@ -538,6 +542,8 @@ struct MainWindowView: View {
                     .foregroundColor(VColor.textMuted)
                     .rotationEffect(.degrees(-45))
                     .frame(width: 20, height: 20)
+                    .background(VColor.backgroundSubtle)
+                    .clipShape(Circle())
                     .padding(.trailing, VSpacing.xs)
             }
         }


### PR DESCRIPTION
Added subtle circular background (VColor.backgroundSubtle) to pin and archive icons in thread items so they don't visually overlap with white text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
