### PR TITLE
M5: Add app emoji icons beside pinned apps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -706,6 +706,8 @@ struct MainWindowView: View {
             openAppInWorkspace(app: app)
         }) {
             HStack(spacing: VSpacing.sm) {
+                Text(app.icon ?? "📱")
+                    .font(.system(size: 14))
                 Text(app.name)
                     .font(.system(size: 13))
                     .foregroundColor(VColor.textPrimary)


### PR DESCRIPTION
Added app emoji icon (from app.icon field) to the left of each pinned app name in the sidebar. Falls back to 📱 when no icon is set. Helps differentiate apps from threads visually.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
