### PR TITLE
M4: Increase section spacing, smaller new conversation button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -582,12 +582,12 @@ struct MainWindowView: View {
             .frame(height: 36)
 
             NewConversationButton(action: { windowState.selection = nil; threadManager.createThread() })
-                .padding(.horizontal, VSpacing.sm)
+                .padding(.horizontal, VSpacing.md)
                 .padding(.top, VSpacing.md)
-                .padding(.bottom, VSpacing.lg)
+                .padding(.bottom, VSpacing.xl)
 
             ScrollView {
-                VStack(spacing: VSpacing.xl) {
+                VStack(spacing: VSpacing.xxl) {
                     // MARK: Threads Section
                     VStack(spacing: VSpacing.xs) {
                         SidebarSectionHeader(title: "Threads")
@@ -1294,6 +1294,7 @@ private struct NewConversationButton: View {
 
     var body: some View {
         VButton(label: "New conversation", icon: "plus", style: .primary, isFullWidth: true, action: action)
+            .controlSize(.small)
     }
 }
 


### PR DESCRIPTION
Increased spacing between New Conversation button and Threads section (lg→xl). Increased spacing between Threads and Pinned Apps (xl→xxl). Made New Conversation button slightly smaller.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
