### PR TITLE
Fix menu bar app name corruption in recordAppOpen

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -248,7 +248,10 @@ extension AppDelegate {
     @objc func openAppById(_ sender: NSMenuItem) {
         guard let appId = sender.representedObject as? String else { return }
         showMainWindow()
-        mainWindow?.appListManager.recordAppOpen(id: appId, name: sender.title)
+        let cachedApp = cachedApps.first(where: { $0.id == appId })
+        let appName = cachedApp?.name ?? sender.title
+        let appIcon = cachedApp?.icon
+        mainWindow?.appListManager.recordAppOpen(id: appId, name: appName, icon: appIcon)
         try? daemonClient.sendAppOpen(appId: appId)
     }
 


### PR DESCRIPTION
Look up original app metadata from cachedApps instead of using sender.title which includes emoji prefix. Pass clean name and icon separately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
