### PR TITLE
Fix stale persistentThreadId reactivating archived threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -190,8 +190,19 @@ struct MainWindowView: View {
             .onChange(of: windowState.selection) { oldSelection, newSelection in
                 // When selection transitions to .thread, ensure ThreadManager is synced
                 // so chat content targets the correct thread (e.g. after dismissOverlay).
+                // Guard against archived threads: if the thread was archived while an
+                // overlay was open, persistentThreadId may still point to the stale ID.
                 if case .thread(let id) = newSelection {
-                    threadManager.selectThread(id: id)
+                    if threadManager.visibleThreads.contains(where: { $0.id == id }) {
+                        threadManager.selectThread(id: id)
+                    } else {
+                        // Thread was archived — fall back to the first visible thread
+                        if let fallback = threadManager.visibleThreads.first {
+                            windowState.selection = .thread(fallback.id)
+                        } else {
+                            windowState.selection = nil
+                        }
+                    }
                 }
 
                 // Sync surface and chat dock state when selection changes


### PR DESCRIPTION
Added guard to check thread exists in visibleThreads before calling selectThread. Falls back to first visible thread if the persisted thread was archived.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
