### PR TITLE
Fix toolbar overlap with traffic lights when sidebar is closed

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1268,6 +1268,7 @@ struct MainWindowView: View {
                 surfaceManager: surfaceManager,
                 daemonClient: daemonClient,
                 trafficLightPadding: trafficLightPadding,
+                isSidebarOpen: sidebarOpen,
                 isPublishing: $isPublishing,
                 publishedUrl: $publishedUrl,
                 publishError: $publishError,
@@ -1594,6 +1595,7 @@ private struct DynamicWorkspaceWrapper: View {
     let surfaceManager: SurfaceManager
     let daemonClient: DaemonClient
     let trafficLightPadding: CGFloat
+    let isSidebarOpen: Bool
     @Binding var isPublishing: Bool
     @Binding var publishedUrl: String?
     @Binding var publishError: String?
@@ -1821,7 +1823,7 @@ private struct DynamicWorkspaceWrapper: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel("Close workspace")
                 }
-                .padding(.leading, VSpacing.lg)
+                .padding(.leading, isSidebarOpen ? VSpacing.lg : trafficLightPadding)
                 .padding(.trailing, VSpacing.xl)
                 .padding(.top, VSpacing.md)
 


### PR DESCRIPTION
Made toolbar leading padding conditional: uses VSpacing.lg when sidebar is open, trafficLightPadding when closed. Prevents Edit button from overlapping macOS window controls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
