### PR TITLE
feat: migrate document editor IPC messages into official contract

### DIFF
--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -68,12 +68,6 @@ const INVENTORY_UNEXTRACTABLE = new Set<string>([
 const SWIFT_AHEAD_ALLOWLIST = new Set<string>([
   // Defined in Swift LayoutConfig.swift ahead of daemon implementation
   'ui_layout_config',
-  // Document editor types — removed from IPC contract but still used by macOS client
-  'document_editor_show',
-  'document_editor_update',
-  'document_save_response',
-  'document_load_response',
-  'document_list_response',
 ]);
 
 // --- Extract Swift decode cases ---

--- a/assistant/src/__tests__/ipc-validate.test.ts
+++ b/assistant/src/__tests__/ipc-validate.test.ts
@@ -335,6 +335,9 @@ describe('IPC Validate', () => {
       secret_response: { requestId: 'r1' },
       ui_surface_action: { sessionId: 's1', surfaceId: 'sf1', actionId: 'a1' },
       ipc_blob_probe: { probeId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', nonceSha256: 'abc123' },
+      document_save: { surfaceId: 'doc1', conversationId: 'c1', title: 'Doc', content: 'text', wordCount: 1 },
+      document_load: { surfaceId: 'doc1' },
+      document_list: {},
     };
 
     test('KNOWN_CLIENT_TYPES matches live contract wire types', () => {

--- a/assistant/src/daemon/handlers/documents.ts
+++ b/assistant/src/daemon/handlers/documents.ts
@@ -1,30 +1,10 @@
 import type { HandlerContext } from './shared.js';
-import type { ServerMessage } from '../ipc-protocol.js';
+import type { ServerMessage, DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } from '../ipc-protocol.js';
 import type * as net from 'node:net';
 import type { Database } from 'bun:sqlite';
 import { getDb } from '../../memory/db.js';
 
 import { writeFileSync } from 'node:fs';
-
-// These request types are not yet part of the IPC contract union — define locally.
-export interface DocumentSaveRequest {
-  type: 'document_save';
-  surfaceId: string;
-  conversationId: string;
-  title: string;
-  content: string;
-  wordCount: number;
-}
-
-export interface DocumentLoadRequest {
-  type: 'document_load';
-  surfaceId: string;
-}
-
-export interface DocumentListRequest {
-  type: 'document_list';
-  conversationId?: string;
-}
 
 export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket, ctx: HandlerContext): void {
   const logMsg = `[${new Date().toISOString()}] handleDocumentSave called: ${JSON.stringify({
@@ -74,7 +54,7 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
       type: 'document_save_response',
       surfaceId: msg.surfaceId,
       success: true,
-    } as unknown as ServerMessage);
+    });
 
     writeFileSync('/tmp/document-save-debug.log', `[${new Date().toISOString()}] Response sent successfully\n`, { flag: 'a' });
 
@@ -86,7 +66,7 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
       surfaceId: msg.surfaceId,
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',
-    } as unknown as ServerMessage);
+    });
   }
 }
 
@@ -120,7 +100,7 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
         createdAt: result.created_at,
         updatedAt: result.updated_at,
         success: true,
-      } as unknown as ServerMessage);
+      });
       console.log(`[documents] Loaded document: ${msg.surfaceId}`);
     } else {
       ctx.send(socket, {
@@ -134,7 +114,7 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
         updatedAt: 0,
         success: false,
         error: 'Document not found',
-      } as unknown as ServerMessage);
+      });
       console.log(`[documents] Document not found: ${msg.surfaceId}`);
     }
   } catch (error) {
@@ -150,7 +130,7 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
       updatedAt: 0,
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',
-    } as unknown as ServerMessage);
+    });
   }
 }
 
@@ -191,7 +171,7 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
       })),
-    } as unknown as ServerMessage);
+    });
 
     console.log(`[documents] Listed ${results.length} documents`);
   } catch (error) {
@@ -199,6 +179,6 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
     ctx.send(socket, {
       type: 'document_list_response',
       documents: [],
-    } as unknown as ServerMessage);
+    });
   }
 }

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -88,6 +88,12 @@ import {
   handleIpcBlobProbe,
 } from './misc.js';
 
+import {
+  handleDocumentSave,
+  handleDocumentLoad,
+  handleDocumentList,
+} from './documents.js';
+
 // Re-export types and utilities for backwards compatibility
 export type {
   HandlerContext,
@@ -226,6 +232,9 @@ const handlers: DispatchMap = {
   },
   diagnostics_export_request: handleDiagnosticsExport,
   env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
+  document_save: handleDocumentSave,
+  document_load: handleDocumentLoad,
+  document_list: handleDocumentList,
 
   // Stub handlers: the integration registry was removed but the Swift client
   // still sends these messages. Return safe no-op responses so the client

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -735,7 +735,10 @@ export type ClientMessage =
   | EnvVarsRequest
   | IntegrationListRequest
   | IntegrationConnectRequest
-  | IntegrationDisconnectRequest;
+  | IntegrationDisconnectRequest
+  | DocumentSaveRequest
+  | DocumentLoadRequest
+  | DocumentListRequest;
 
 // ── Legacy integration IPC stubs ────────────────────────────────────
 // The macOS Settings panel still sends these messages. Stub types keep
@@ -1592,6 +1595,75 @@ export interface UiSurfaceUndoResult {
   remainingUndos: number;
 }
 
+// ── Document Editor Messages ────────────────────────────────────────
+
+export interface DocumentEditorShow {
+  type: 'document_editor_show';
+  sessionId: string;
+  surfaceId: string;
+  title: string;
+  initialContent: string;
+}
+
+export interface DocumentEditorUpdate {
+  type: 'document_editor_update';
+  sessionId: string;
+  surfaceId: string;
+  markdown: string;
+  mode: string;
+}
+
+export interface DocumentSaveRequest {
+  type: 'document_save';
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  wordCount: number;
+}
+
+export interface DocumentSaveResponse {
+  type: 'document_save_response';
+  surfaceId: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface DocumentLoadRequest {
+  type: 'document_load';
+  surfaceId: string;
+}
+
+export interface DocumentLoadResponse {
+  type: 'document_load_response';
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  wordCount: number;
+  createdAt: number;
+  updatedAt: number;
+  success: boolean;
+  error?: string;
+}
+
+export interface DocumentListRequest {
+  type: 'document_list';
+  conversationId?: string;
+}
+
+export interface DocumentListResponse {
+  type: 'document_list_response';
+  documents: Array<{
+    surfaceId: string;
+    conversationId: string;
+    title: string;
+    wordCount: number;
+    createdAt: number;
+    updatedAt: number;
+  }>;
+}
+
 export type ServerMessage =
   | AuthResult
   | UserMessageEcho
@@ -1677,7 +1749,12 @@ export type ServerMessage =
   | BrowserFrame
   | EnvVarsResponse
   | IntegrationListResponse
-  | IntegrationConnectResult;
+  | IntegrationConnectResult
+  | DocumentEditorShow
+  | DocumentEditorUpdate
+  | DocumentSaveResponse
+  | DocumentLoadResponse
+  | DocumentListResponse;
 
 // === Contract schema ===
 

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -39,80 +39,36 @@ export class DocumentCreateTool implements Tool {
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const title = (input.title as string | undefined) || 'Untitled Document';
     const initialContent = (input.initial_content as string | undefined) || '';
-    const appId = `doc-${randomUUID()}`;
+    const surfaceId = `doc-${randomUUID()}`;
 
-    // Generate the Toast UI Editor HTML
-    const html = generateEditorHTML(title, initialContent);
+    // Send document_editor_show IPC message to open the built-in RTE
+    if (context.sendToClient) {
+      context.sendToClient({
+        type: 'document_editor_show',
+        sessionId: context.sessionId,
+        surfaceId,
+        title,
+        initialContent,
+      });
 
-    // Create the document app in the app store
-    const wordCount = initialContent.split(/\s+/).filter((w) => w.length > 0).length;
-    const app = appStore.createApp({
-      name: title,
-      description: `Document with ${wordCount} words`,
-      icon: '📝',
-      preview: initialContent.slice(0, 200),
-      htmlDefinition: html,
-      schemaJson: JSON.stringify({
-        type: 'object',
-        properties: {
-          title: { type: 'string' },
-          content: { type: 'string' },
-          wordCount: { type: 'number' },
-          documentType: { type: 'string', const: 'document' },
-        },
-      }),
-      appType: 'app',
-    });
-
-    // Open the document via the shared open-proxy helper
-    const openResultText = await openAppViaSurface(
-      app.id,
-      context.proxyToolResolver,
-      {
-        preview: {
-          title,
-          subtitle: 'Document',
-          description: 'Long-form document with rich text editor',
-          icon: '\u{1F4DD}',
-          metrics: [{ label: 'Words', value: String(wordCount) }],
-        },
-      },
-    );
-
-    // The helper returns fallback text when the resolver is missing or throws
-    const opened = !!context.proxyToolResolver &&
-      openResultText !== 'Failed to auto-open app. Use app_open to open it manually.';
-
-    if (opened) {
       return {
         content: JSON.stringify({
-          app_id: appId,
-          surface_id: app.id,
+          surface_id: surfaceId,
           title,
           opened: true,
-          open_result: openResultText,
+          message: 'Document editor opened in Directory panel',
         }),
         isError: false,
       };
     }
 
-    if (!context.proxyToolResolver) {
-      return {
-        content: JSON.stringify({
-          app_id: appId,
-          title,
-          message: 'Document created but could not be opened (no proxy resolver available)',
-        }),
-        isError: false,
-      };
-    }
-
+    // Fallback if no IPC client is connected
     return {
       content: JSON.stringify({
-        app_id: appId,
+        surface_id: surfaceId,
         title,
         opened: false,
-        error: 'Failed to open document editor',
+        error: 'No IPC client connected to open document editor',
       }),
       isError: false,
     };
@@ -160,42 +116,32 @@ export class DocumentUpdateTool implements Tool {
     const content = input.content as string;
     const mode = (input.mode as string | undefined) || 'append';
 
-    // Use the proxy resolver to call ui_update
-    if (context.proxyToolResolver) {
-      try {
-        const updateResult = await context.proxyToolResolver('ui_update', {
-          surface_id: surfaceId,
-          data: {
-            markdown: content,
-            updateMode: mode,
-          },
-        });
+    // Send document_editor_update IPC message to update the built-in RTE
+    if (context.sendToClient) {
+      context.sendToClient({
+        type: 'document_editor_update',
+        sessionId: context.sessionId,
+        surfaceId,
+        markdown: content,
+        mode,
+      });
 
-        return {
-          content: JSON.stringify({
-            success: true,
-            surface_id: surfaceId,
-            mode,
-            update_result: updateResult.content,
-          }),
-          isError: false,
-        };
-      } catch (err) {
-        return {
-          content: JSON.stringify({
-            success: false,
-            error: 'Failed to update document content',
-            details: err instanceof Error ? err.message : String(err),
-          }),
-          isError: true,
-        };
-      }
+      return {
+        content: JSON.stringify({
+          success: true,
+          surface_id: surfaceId,
+          mode,
+          message: 'Document content updated',
+        }),
+        isError: false,
+      };
     }
 
+    // Fallback if no IPC client is connected
     return {
       content: JSON.stringify({
         success: false,
-        error: 'No proxy resolver available to update document',
+        error: 'No IPC client connected to update document',
       }),
       isError: true,
     };

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -350,6 +350,75 @@ public struct IPCDiagnosticsExportResponse: Codable, Sendable {
     public let error: String?
 }
 
+public struct IPCDocumentEditorShow: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String
+    public let initialContent: String
+}
+
+public struct IPCDocumentEditorUpdate: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let markdown: String
+    public let mode: String
+}
+
+public struct IPCDocumentListRequest: Codable, Sendable {
+    public let type: String
+    public let conversationId: String?
+}
+
+public struct IPCDocumentListResponse: Codable, Sendable {
+    public let type: String
+    public let documents: [IPCDocumentListResponseDocument]
+}
+
+public struct IPCDocumentListResponseDocument: Codable, Sendable {
+    public let surfaceId: String
+    public let conversationId: String
+    public let title: String
+    public let wordCount: Int
+    public let createdAt: Int
+    public let updatedAt: Int
+}
+
+public struct IPCDocumentLoadRequest: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+}
+
+public struct IPCDocumentLoadResponse: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let conversationId: String
+    public let title: String
+    public let content: String
+    public let wordCount: Int
+    public let createdAt: Int
+    public let updatedAt: Int
+    public let success: Bool
+    public let error: String?
+}
+
+public struct IPCDocumentSaveRequest: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let conversationId: String
+    public let title: String
+    public let content: String
+    public let wordCount: Int
+}
+
+public struct IPCDocumentSaveResponse: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let success: Bool
+    public let error: String?
+}
+
 public struct IPCDynamicPagePreview: Codable, Sendable {
     public let title: String
     public let subtitle: String?

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -827,78 +827,16 @@ public struct UiSurfaceCompleteMessage: Decodable, Sendable {
     public let submittedData: [String: AnyCodable]?
 }
 
-/// Document editor show command from daemon.
-/// Defined inline — removed from the IPC contract but still used by the macOS client.
-public struct DocumentEditorShowMessage: Codable, Sendable {
-    public let type: String
-    public let sessionId: String
-    public let surfaceId: String
-    public let title: String
-    public let initialContent: String
-}
-
-/// Document editor update command from daemon.
-public struct DocumentEditorUpdateMessage: Codable, Sendable {
-    public let type: String
-    public let sessionId: String
-    public let surfaceId: String
-    public let markdown: String
-    public let mode: String
-}
-
-/// Document persistence messages — defined inline (removed from IPC contract).
-public struct DocumentSaveRequestMessage: Codable, Sendable {
-    public let type: String
-    public let surfaceId: String
-    public let conversationId: String
-    public let title: String
-    public let content: String
-    public let wordCount: Int
-}
-
-public struct DocumentSaveResponseMessage: Codable, Sendable {
-    public let type: String
-    public let surfaceId: String
-    public let success: Bool
-    public let error: String?
-}
-
-public struct DocumentLoadRequestMessage: Codable, Sendable {
-    public let type: String
-    public let surfaceId: String
-}
-
-public struct DocumentLoadResponseMessage: Codable, Sendable {
-    public let type: String
-    public let surfaceId: String
-    public let conversationId: String
-    public let title: String
-    public let content: String
-    public let wordCount: Int
-    public let createdAt: Int
-    public let updatedAt: Int
-    public let success: Bool
-    public let error: String?
-}
-
-public struct DocumentListRequestMessage: Codable, Sendable {
-    public let type: String
-    public let conversationId: String?
-}
-
-public struct DocumentListResponseMessage: Codable, Sendable {
-    public let type: String
-    public let documents: [DocumentListResponseDocument]
-}
-
-public struct DocumentListResponseDocument: Codable, Sendable {
-    public let surfaceId: String
-    public let conversationId: String
-    public let title: String
-    public let wordCount: Int
-    public let createdAt: Int
-    public let updatedAt: Int
-}
+/// Document editor messages — backed by generated types from IPC contract.
+public typealias DocumentEditorShowMessage = IPCDocumentEditorShow
+public typealias DocumentEditorUpdateMessage = IPCDocumentEditorUpdate
+public typealias DocumentSaveRequestMessage = IPCDocumentSaveRequest
+public typealias DocumentSaveResponseMessage = IPCDocumentSaveResponse
+public typealias DocumentLoadRequestMessage = IPCDocumentLoadRequest
+public typealias DocumentLoadResponseMessage = IPCDocumentLoadResponse
+public typealias DocumentListRequestMessage = IPCDocumentListRequest
+public typealias DocumentListResponseMessage = IPCDocumentListResponse
+public typealias DocumentListResponseDocument = IPCDocumentListResponseDocument
 
 /// Confirms undo/regenerate removed messages.
 public typealias UndoCompleteMessage = IPCUndoComplete


### PR DESCRIPTION
## Summary
- Adds document editor and persistence IPC types (save/load/list + editor show/update) to the TypeScript IPC contract and generates matching Swift structs
- Replaces ad-hoc inline Swift struct definitions with typealiases to the new generated types, eliminating duplication
- Wires `document_save`, `document_load`, and `document_list` into the daemon handler dispatch map with proper types (removing `as unknown as ServerMessage` casts)
- Updates the drift-check allowlist and IPC validate tests to reflect the new contract entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
