### PR TITLE
fix: close activity panel when source message disappears

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -244,9 +244,11 @@ struct MainWindowView: View {
                     threadManager.activeViewModel?.activeSurfaceId = surfaceId
                 }
             }
-            .onChange(of: threadManager.activeViewModel?.messages.count) { _, _ in
-                // Close activity panel if the referenced message no longer exists
-                // (e.g., after regenerate, undo, or message rebuild flows)
+            .onChange(of: threadManager.activeViewModel?.messages.map(\.id)) { _, _ in
+                // Close activity panel if the referenced message no longer exists.
+                // Watch message IDs (not just count) so that regenerate/undo flows
+                // that replace a message with a new ID at the same array position
+                // also trigger a close.
                 if let messageId = windowState.activityMessageId,
                    windowState.activePanel == .activity,
                    let viewModel = threadManager.activeViewModel {


### PR DESCRIPTION
## Summary
- When the message referenced by `activityMessageId` is removed from the messages array (e.g. after undo/regenerate), the Activity panel now automatically closes instead of staying open and empty
- Strengthens the existing `onChange` guard to watch message IDs (not just count), so regenerate/undo flows that replace a message with a new ID at the same array position also trigger a close
- Addresses Codex P2 feedback on #2949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
