### PR TITLE
M4: Done Editing primary CTA in edit mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1714,14 +1714,21 @@ private struct DynamicWorkspaceWrapper: View {
 
             VStack(spacing: 0) {
                 HStack {
-                    // Left: Edit ghost button
-                    GhostButton("Edit", icon: isChatDockOpen ? "pencil.slash" : "pencil") {
-                        if !isChatDockOpen {
-                            windowState.workspaceComposerExpanded = false
+                    // Left: Done Editing primary CTA in edit mode, Edit ghost button otherwise
+                    if case .appEditing = windowState.selection {
+                        VButton(label: "Done Editing", style: .primary) {
+                            onToggleChatDock()
                         }
-                        onToggleChatDock()
+                        .controlSize(.small)
+                    } else {
+                        GhostButton("Edit", icon: "pencil") {
+                            if !isChatDockOpen {
+                                windowState.workspaceComposerExpanded = false
+                            }
+                            onToggleChatDock()
+                        }
+                        .accessibilityLabel("Edit app")
                     }
-                    .accessibilityLabel(isChatDockOpen ? "Close editor" : "Edit app")
 
                     Spacer()
 


### PR DESCRIPTION
When ViewSelection is .appEditing, replaces the Edit ghost button with a Done Editing VButton(.primary) CTA. Clicking transitions from appEditing to app-only view. Edit ghost button remains in .app mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
