### PR TITLE
fix: wire document editor so RTE appears when assistant opens it

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -383,6 +383,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self.handleEscalationToComputerUse(routed: routed)
         }
 
+        daemonClient.onDocumentEditorShow = { [weak self] msg in
+            self?.mainWindow?.handleDocumentEditorShow(msg)
+        }
+        daemonClient.onDocumentEditorUpdate = { [weak self] msg in
+            self?.mainWindow?.handleDocumentEditorUpdate(msg)
+        }
+        daemonClient.onDocumentSaveResponse = { [weak self] msg in
+            self?.mainWindow?.handleDocumentSaveResponse(msg)
+        }
+
         // Handle diagnostics export response — show a toast in the main window
         daemonClient.onDiagnosticsExportResponse = { [weak self] response in
             guard let self else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -94,6 +94,7 @@ final class MainWindow {
     let appListManager = AppListManager()
     let traceStore = TraceStore()
     let windowState = MainWindowState()
+    let documentManager = DocumentManager()
     var onMicrophoneToggle: (() -> Void)?
 
     // Forwarding accessors — keeps existing references working while
@@ -126,6 +127,7 @@ final class MainWindow {
             activityNotificationService: services.activityNotificationService
         )
         self.threadManager.ambientAgent = services.ambientAgent
+        documentManager.daemonClient = daemonClient
         services.daemonClient.onTraceEvent = { [weak self] msg in
             Task { @MainActor in
                 self?.traceStore.ingest(msg)
@@ -157,6 +159,25 @@ final class MainWindow {
             }
     }
 
+    func handleDocumentEditorShow(_ msg: DocumentEditorShowMessage) {
+        documentManager.createDocument(
+            surfaceId: msg.surfaceId,
+            sessionId: msg.sessionId,
+            title: msg.title,
+            initialContent: msg.initialContent
+        )
+        show()
+        windowState.togglePanel(.documentEditor)
+    }
+
+    func handleDocumentEditorUpdate(_ msg: DocumentEditorUpdateMessage) {
+        documentManager.updateDocument(markdown: msg.markdown, mode: msg.mode)
+    }
+
+    func handleDocumentSaveResponse(_ msg: DocumentSaveResponseMessage) {
+        documentManager.handleSaveResponse(success: msg.success, error: msg.error)
+    }
+
     func show() {
         // Switch to regular activation policy FIRST so macOS allows window
         // foregrounding — calling makeKeyAndOrderFront while still .accessory
@@ -173,7 +194,7 @@ final class MainWindow {
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let windowWidth: CGFloat = 780

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -44,9 +44,10 @@ struct MainWindowView: View {
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
     let settingsStore: SettingsStore
+    @ObservedObject var documentManager: DocumentManager
     let onMicrophoneToggle: () -> Void
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, onMicrophoneToggle: @escaping () -> Void = {}) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
@@ -56,6 +57,7 @@ struct MainWindowView: View {
         self.ambientAgent = ambientAgent
         self.settingsStore = settingsStore
         self.windowState = windowState
+        self.documentManager = documentManager
         self.onMicrophoneToggle = onMicrophoneToggle
     }
 
@@ -1165,6 +1167,20 @@ struct MainWindowView: View {
                         }
                     }
                 )
+            } else if panelType == .documentEditor {
+                let config = windowState.layoutConfig
+                VSplitView(
+                    panelWidth: $sidePanelWidth,
+                    showPanel: documentManager.hasActiveDocument,
+                    main: { slotView(for: config.center.content) },
+                    panel: {
+                        DocumentEditorPanelView(
+                            documentManager: documentManager,
+                            daemonClient: daemonClient,
+                            onClose: { windowState.selection = nil }
+                        )
+                    }
+                )
             } else {
                 // Full-window panels: settings, skills, debug, doctor, identity
                 fullWindowPanel(panelType)
@@ -1252,6 +1268,10 @@ struct MainWindowView: View {
             // if we reach here, isDynamicExpanded is false — clear selection so
             // the user falls back to the chat view instead of seeing a blank screen.
             Color.clear.frame(width: 0, height: 0)
+                .onAppear { windowState.dismissOverlay() }
+        case .documentEditor:
+            // Document editor is handled inline in chatContentView
+            EmptyView()
                 .onAppear { windowState.dismissOverlay() }
         default:
             EmptyView()
@@ -1772,7 +1792,7 @@ private struct DynamicWorkspaceWrapper: View {
 struct MainWindowView_Previews: PreviewProvider {
     static var previews: some View {
         let dc = DaemonClient()
-        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), windowState: MainWindowState())
+        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), windowState: MainWindowState(), documentManager: DocumentManager())
             .frame(width: 900, height: 600)
             .padding(.top, 36)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct DocumentEditorPanelView: View {
+    @ObservedObject var documentManager: DocumentManager
+    let daemonClient: DaemonClient
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header toolbar
+            HStack {
+                Text(documentManager.title)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                Spacer()
+                if documentManager.isSaving {
+                    ProgressView().controlSize(.small).scaleEffect(0.7)
+                } else {
+                    VIconButton(label: "Save", icon: "square.and.arrow.down", isActive: false, iconOnly: true) {
+                        documentManager.save()
+                    }
+                }
+                VIconButton(label: "Close", icon: "xmark", isActive: false, iconOnly: true, action: onClose)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.backgroundSubtle)
+
+            Divider().background(VColor.surfaceBorder)
+
+            DocumentEditorView(
+                documentManager: documentManager,
+                onContentChanged: { title, content, wordCount in
+                    documentManager.updateContent(title: title, content: content, wordCount: wordCount)
+                }
+            )
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -7,6 +7,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case doctor
     case activity
     case identity
+    case documentEditor
 
     init?(rawValue: String) {
         switch rawValue {
@@ -18,6 +19,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "doctor": self = .doctor
         case "activity": self = .activity
         case "identity": self = .identity
+        case "documentEditor": self = .documentEditor
         default: return nil
         }
     }


### PR DESCRIPTION
## Summary
- Assign `onDocumentEditorShow`, `onDocumentEditorUpdate`, `onDocumentSaveResponse` daemon callbacks in `AppDelegate.setupDaemonClient()` — previously these were defined but never wired, so messages were silently dropped
- Add `DocumentManager` to `MainWindow` and handler methods that call `createDocument`/`updateDocument`/`handleSaveResponse` and toggle the new `.documentEditor` panel
- Add `.documentEditor` case to `SidePanelType` and render `DocumentEditorPanelView` as a VSplitView side panel in `MainWindowView`
- Create `DocumentEditorPanelView` with a header toolbar (title, save, close) wrapping `DocumentEditorView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
