### PR TITLE
fix: eliminate emoji-prefix fallback in openAppById

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -127,7 +127,7 @@ extension AppDelegate {
             let emoji = app.icon ?? "\u{1F4F1}"
             let item = NSMenuItem(title: "\(emoji) \(app.name)", action: #selector(openAppById(_:)), keyEquivalent: "")
             item.target = self
-            item.representedObject = app.id
+            item.representedObject = ["id": app.id, "name": app.name, "icon": app.icon ?? ""]
             appsSubmenu.addItem(item)
         }
 
@@ -246,11 +246,13 @@ extension AppDelegate {
     }
 
     @objc func openAppById(_ sender: NSMenuItem) {
-        guard let appId = sender.representedObject as? String else { return }
+        guard let info = sender.representedObject as? [String: String],
+              let appId = info["id"] else { return }
         showMainWindow()
         let cachedApp = cachedApps.first(where: { $0.id == appId })
-        let appName = cachedApp?.name ?? sender.title
-        let appIcon = cachedApp?.icon
+        let appName = cachedApp?.name ?? info["name"] ?? appId
+        let storedIcon = info["icon"]
+        let appIcon = cachedApp?.icon ?? (storedIcon?.isEmpty == false ? storedIcon : nil)
         mainWindow?.appListManager.recordAppOpen(id: appId, name: appName, icon: appIcon)
         try? daemonClient.sendAppOpen(appId: appId)
     }


### PR DESCRIPTION
Stores app ID and clean name in menu item representedObject instead of just the ID, so the fallback never uses the emoji-prefixed sender.title.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
