### PR TITLE
fix: toolbar padding accounts for chat dock in split-view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1779,7 +1779,7 @@ private struct DynamicWorkspaceWrapper: View {
                         .accessibilityLabel("Close workspace")
                     }
                 }
-                .padding(.leading, isSidebarOpen ? VSpacing.lg : trafficLightPadding)
+                .padding(.leading, (isSidebarOpen || isChatDockOpen) ? VSpacing.lg : trafficLightPadding)
                 .padding(.trailing, VSpacing.xl)
                 .padding(.top, VSpacing.md)
 


### PR DESCRIPTION
Changes toolbar leading padding condition from isSidebarOpen to (isSidebarOpen || isChatDockOpen) so the workspace toolbar in appEditing split-view mode uses VSpacing.lg instead of trafficLightPadding.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
