### PR TITLE
fix: include private threads in stale-thread guard

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -195,10 +195,10 @@ struct MainWindowView: View {
                 // Guard against archived threads: if the thread was archived while an
                 // overlay was open, persistentThreadId may still point to the stale ID.
                 if case .thread(let id) = newSelection {
-                    if threadManager.visibleThreads.contains(where: { $0.id == id }) {
+                    if threadManager.threads.contains(where: { $0.id == id && !$0.isArchived }) {
                         threadManager.selectThread(id: id)
                     } else {
-                        // Thread was archived — fall back to the first visible thread
+                        // Thread was archived/deleted — fall back to the first visible thread
                         if let fallback = threadManager.visibleThreads.first {
                             windowState.selection = .thread(fallback.id)
                         } else {


### PR DESCRIPTION
Changes the stale-thread guard to check all threads (including private/temporary) instead of only visibleThreads, so temporary chat isn't disrupted when dismissing overlays.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
