### PR TITLE
feat: add browser_scroll tool (M5 #4509)

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -596,7 +596,7 @@ export async function executeBrowserScroll(
     return { content: 'Error: direction is required and must be one of: up, down, left, right.', isError: true };
   }
 
-  const amount = typeof input.amount === 'number' ? input.amount : 500;
+  const amount = typeof input.amount === 'number' ? Math.abs(input.amount) : 500;
 
   const sender = getSender(context.sessionId);
   if (sender) {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -584,6 +584,76 @@ export async function executeBrowserPressKey(
   }
 }
 
+
+// ── browser_scroll ───────────────────────────────────────────────────
+
+export async function executeBrowserScroll(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const direction = typeof input.direction === 'string' ? input.direction : '';
+  if (!direction || !['up', 'down', 'left', 'right'].includes(direction)) {
+    return { content: 'Error: direction is required and must be one of: up, down, left, right.', isError: true };
+  }
+
+  const amount = typeof input.amount === 'number' ? input.amount : 500;
+
+  const sender = getSender(context.sessionId);
+  if (sender) {
+    await ensureScreencast(context.sessionId, sender);
+    updateBrowserStatus(context.sessionId, sender, 'interacting', `Scrolling ${direction}`);
+  }
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+
+    // If element_id or selector is provided, scroll within that element
+    const elementId = typeof input.element_id === 'string' ? input.element_id : null;
+    const rawSelector = typeof input.selector === 'string' ? input.selector : null;
+
+    if (elementId || rawSelector) {
+      const { selector, error } = resolveSelector(context.sessionId, input);
+      if (error) {
+        if (sender) updateBrowserStatus(context.sessionId, sender, 'idle');
+        return { content: error, isError: true };
+      }
+      // Move mouse to element center before scrolling
+      const bounds = await getElementBounds(context.sessionId, selector!);
+      if (bounds) {
+        // Convert screencast coords back to page coords for mouse.move
+        const result = await page.evaluate(`(() => ({ vw: window.innerWidth, vh: window.innerHeight }))()`) as { vw: number; vh: number };
+        const scale = Math.min(800 / result.vw, 600 / result.vh);
+        const pageX = (bounds.x + bounds.w / 2) / scale;
+        const pageY = (bounds.y + bounds.h / 2) / scale;
+        await page.mouse.move(pageX, pageY);
+      }
+    }
+
+    let deltaX = 0;
+    let deltaY = 0;
+    switch (direction) {
+      case 'up': deltaY = -amount; break;
+      case 'down': deltaY = amount; break;
+      case 'left': deltaX = -amount; break;
+      case 'right': deltaX = amount; break;
+    }
+
+    await page.mouse.wheel(deltaX, deltaY);
+
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
+    return { content: `Scrolled ${direction} by ${amount}px`, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, direction }, 'Scroll failed');
+    if (sender) {
+      updateBrowserStatus(context.sessionId, sender, 'idle');
+    }
+    return { content: `Error: Scroll failed: ${msg}`, isError: true };
+  }
+}
+
 // ── browser_wait_for ─────────────────────────────────────────────────
 
 export async function executeBrowserWaitFor(

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -44,6 +44,11 @@ export type Page = {
   unroute(pattern: string, handler?: RouteHandler): Promise<void>;
   screenshot(options?: { type?: string; quality?: number; fullPage?: boolean }): Promise<Buffer>;
   keyboard: { press(key: string): Promise<void> };
+  mouse: {
+    click(x: number, y: number, options?: { button?: string }): Promise<void>;
+    move(x: number, y: number): Promise<void>;
+    wheel(deltaX: number, deltaY: number): Promise<void>;
+  };
 };
 
 type ScreencastFrameMetadata = {

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -10,6 +10,7 @@ import {
   executeBrowserClick,
   executeBrowserType,
   executeBrowserPressKey,
+  executeBrowserScroll,
   executeBrowserWaitFor,
   executeBrowserExtract,
   executeBrowserFillCredential,
@@ -262,6 +263,51 @@ class BrowserPressKeyTool implements Tool {
 
 registerTool(new BrowserPressKeyTool());
 
+// ── browser_scroll ───────────────────────────────────────────────────
+
+class BrowserScrollTool implements Tool {
+  name = 'browser_scroll';
+  description = 'Scroll the page or a specific element in a given direction. Useful for viewing content below the fold on long pages.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          direction: {
+            type: 'string',
+            enum: ['up', 'down', 'left', 'right'],
+            description: 'The direction to scroll.',
+          },
+          amount: {
+            type: 'number',
+            description: 'The number of pixels to scroll (default: 500).',
+          },
+          element_id: {
+            type: 'string',
+            description: 'Optional element ID from browser_snapshot to scroll within.',
+          },
+          selector: {
+            type: 'string',
+            description: 'Optional CSS selector of element to scroll within.',
+          },
+        },
+        required: ['direction'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserScroll(input, context);
+  }
+}
+
+registerTool(new BrowserScrollTool());
+
 // ── browser_wait_for ─────────────────────────────────────────────────
 
 class BrowserWaitForTool implements Tool {
@@ -393,6 +439,7 @@ export {
   executeBrowserClick,
   executeBrowserType,
   executeBrowserPressKey,
+  executeBrowserScroll,
   executeBrowserWaitFor,
   executeBrowserExtract,
   executeBrowserFillCredential,


### PR DESCRIPTION
## Summary
- Add `browser_scroll` tool that scrolls the page or a specific element in a given direction (up/down/left/right) by a configurable pixel amount
- Supports optional element targeting via `element_id` or CSS `selector`, moving the mouse to the element center before scrolling
- Add `mouse` property (click, move, wheel) to the `Page` type in `browser-manager.ts`

Closes #4509

## Test plan
- [ ] Verify `browser_scroll` with `direction: 'down'` scrolls the page viewport
- [ ] Verify scrolling with `element_id` targets the correct element
- [ ] Verify scrolling with `selector` targets the correct element
- [ ] Verify invalid direction returns an error
- [ ] Verify default amount is 500px when not specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
