### PR TITLE
M1: Skip session restoration on first launch after onboarding

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -184,7 +184,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupWindowObserver()
         setupNotifications()
         setupAutoUpdate()
-        showMainWindow(initialMessage: isFirstLaunch ? "Wake up, my friend" : nil)
+        showMainWindow(initialMessage: isFirstLaunch ? "Wake up, my friend" : nil, isFirstLaunch: isFirstLaunch)
     }
 
     private func showAuthWindow() {
@@ -887,12 +887,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Main Window
 
-    func showMainWindow(initialMessage: String? = nil) {
+    func showMainWindow(initialMessage: String? = nil, isFirstLaunch: Bool = false) {
         if let existing = mainWindow {
             existing.show()
             return
         }
-        let main = MainWindow(services: services)
+        let main = MainWindow(services: services, isFirstLaunch: isFirstLaunch)
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -120,11 +120,12 @@ final class MainWindow {
         threadManager.activeViewModel
     }
 
-    init(services: AppServices) {
+    init(services: AppServices, isFirstLaunch: Bool = false) {
         self.services = services
         self.threadManager = ThreadManager(
             daemonClient: services.daemonClient,
-            activityNotificationService: services.activityNotificationService
+            activityNotificationService: services.activityNotificationService,
+            isFirstLaunch: isFirstLaunch
         )
         self.threadManager.ambientAgent = services.ambientAgent
         documentManager.daemonClient = daemonClient

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -72,16 +72,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         return chatViewModels[activeThreadId]
     }
 
-    init(daemonClient: DaemonClient, activityNotificationService: ActivityNotificationService? = nil) {
+    init(daemonClient: DaemonClient, activityNotificationService: ActivityNotificationService? = nil, isFirstLaunch: Bool = false) {
         self.daemonClient = daemonClient
         self.activityNotificationService = activityNotificationService
         self.sessionRestorer = ThreadSessionRestorer(daemonClient: daemonClient)
-        // Suppress lastActiveThreadIdString writes during initialization
-        self.isRestoringThreads = true
+        // On first launch (post-onboarding), skip session restoration — there are
+        // no meaningful prior sessions. Allow activeThreadId writes immediately so
+        // the wake-up thread's UUID is persisted.
+        // On normal launches, suppress writes during restoration so the saved
+        // value isn't overwritten before restoreLastActiveThread() reads it.
+        self.isRestoringThreads = !isFirstLaunch
         // Create one default thread so the window is never empty
         createThread()
         sessionRestorer.delegate = self
-        sessionRestorer.startObserving()
+        sessionRestorer.startObserving(skipInitialFetch: isFirstLaunch)
     }
 
     func createThread() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -39,13 +39,18 @@ final class ThreadSessionRestorer {
         self.daemonClient = daemonClient
     }
 
-    func startObserving() {
+    func startObserving(skipInitialFetch: Bool = false) {
         daemonClient.onSessionListResponse = { [weak self] response in
             self?.handleSessionListResponse(response)
         }
         daemonClient.onHistoryResponse = { [weak self] response in
             self?.handleHistoryResponse(response)
         }
+
+        // On first launch after onboarding, skip the initial session list fetch
+        // so the session restorer doesn't override the wake-up conversation thread.
+        // The handlers above are still registered for later use (e.g. history loading).
+        guard !skipInitialFetch else { return }
 
         connectionCancellable = daemonClient.$isConnected
             .removeDuplicates()


### PR DESCRIPTION
## Summary
- Pass `isFirstLaunch` flag from AppDelegate through MainWindow → ThreadManager → ThreadSessionRestorer
- When true, skip the initial session list fetch so the wake-up thread stays active
- Set `isRestoringThreads = false` on first launch so the active thread ID is persisted immediately

Closes #4518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
