### PR TITLE
M2: Don't create orphaned session in sendInitialSession

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -693,10 +693,14 @@ export class DaemonServer {
   }
 
   private async sendInitialSession(socket: net.Socket): Promise<void> {
-    // Get or create a session
-    let conversation = conversationStore.getLatestConversation();
+    // Only send session info for an existing conversation. Don't create one —
+    // the client will create its own session via session_create when the user
+    // sends a message. Creating one here would produce an orphaned session
+    // that the macOS client rejects (correlation ID mismatch) but that still
+    // appears in session_list on subsequent launches.
+    const conversation = conversationStore.getLatestConversation();
     if (!conversation) {
-      conversation = conversationStore.createConversation('New Conversation');
+      return;
     }
 
     // Warm session state for commands like undo/usage after reconnect without


### PR DESCRIPTION
## Summary
- In `sendInitialSession`, return early when no conversations exist instead of creating one
- Prevents orphaned 'New Conversation' sessions that appear as stale threads on subsequent launches
- The client creates its own session via `session_create` when the user sends a message

Closes #4519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
