### PR TITLE
Land on wake-up conversation thread after onboarding

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -693,10 +693,14 @@ export class DaemonServer {
   }
 
   private async sendInitialSession(socket: net.Socket): Promise<void> {
-    // Get or create a session
-    let conversation = conversationStore.getLatestConversation();
+    // Only send session info for an existing conversation. Don't create one —
+    // the client will create its own session via session_create when the user
+    // sends a message. Creating one here would produce an orphaned session
+    // that the macOS client rejects (correlation ID mismatch) but that still
+    // appears in session_list on subsequent launches.
+    const conversation = conversationStore.getLatestConversation();
     if (!conversation) {
-      conversation = conversationStore.createConversation('New Conversation');
+      return;
     }
 
     // Warm session state for commands like undo/usage after reconnect without

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -700,6 +700,10 @@ export class DaemonServer {
     // appears in session_list on subsequent launches.
     const conversation = conversationStore.getLatestConversation();
     if (!conversation) {
+      this.send(socket, {
+        type: 'daemon_status',
+        httpPort: this.httpPort,
+      });
       return;
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -184,7 +184,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupWindowObserver()
         setupNotifications()
         setupAutoUpdate()
-        showMainWindow(initialMessage: isFirstLaunch ? "Wake up, my friend" : nil)
+        showMainWindow(initialMessage: isFirstLaunch ? "Wake up, my friend" : nil, isFirstLaunch: isFirstLaunch)
     }
 
     private func showAuthWindow() {
@@ -887,12 +887,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Main Window
 
-    func showMainWindow(initialMessage: String? = nil) {
+    func showMainWindow(initialMessage: String? = nil, isFirstLaunch: Bool = false) {
         if let existing = mainWindow {
             existing.show()
             return
         }
-        let main = MainWindow(services: services)
+        let main = MainWindow(services: services, isFirstLaunch: isFirstLaunch)
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -120,11 +120,12 @@ final class MainWindow {
         threadManager.activeViewModel
     }
 
-    init(services: AppServices) {
+    init(services: AppServices, isFirstLaunch: Bool = false) {
         self.services = services
         self.threadManager = ThreadManager(
             daemonClient: services.daemonClient,
-            activityNotificationService: services.activityNotificationService
+            activityNotificationService: services.activityNotificationService,
+            isFirstLaunch: isFirstLaunch
         )
         self.threadManager.ambientAgent = services.ambientAgent
         documentManager.daemonClient = daemonClient

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -72,16 +72,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         return chatViewModels[activeThreadId]
     }
 
-    init(daemonClient: DaemonClient, activityNotificationService: ActivityNotificationService? = nil) {
+    init(daemonClient: DaemonClient, activityNotificationService: ActivityNotificationService? = nil, isFirstLaunch: Bool = false) {
         self.daemonClient = daemonClient
         self.activityNotificationService = activityNotificationService
         self.sessionRestorer = ThreadSessionRestorer(daemonClient: daemonClient)
-        // Suppress lastActiveThreadIdString writes during initialization
-        self.isRestoringThreads = true
+        // On first launch (post-onboarding), skip session restoration — there are
+        // no meaningful prior sessions. Allow activeThreadId writes immediately so
+        // the wake-up thread's UUID is persisted.
+        // On normal launches, suppress writes during restoration so the saved
+        // value isn't overwritten before restoreLastActiveThread() reads it.
+        self.isRestoringThreads = !isFirstLaunch
         // Create one default thread so the window is never empty
         createThread()
         sessionRestorer.delegate = self
-        sessionRestorer.startObserving()
+        sessionRestorer.startObserving(skipInitialFetch: isFirstLaunch)
     }
 
     func createThread() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -39,13 +39,18 @@ final class ThreadSessionRestorer {
         self.daemonClient = daemonClient
     }
 
-    func startObserving() {
+    func startObserving(skipInitialFetch: Bool = false) {
         daemonClient.onSessionListResponse = { [weak self] response in
             self?.handleSessionListResponse(response)
         }
         daemonClient.onHistoryResponse = { [weak self] response in
             self?.handleHistoryResponse(response)
         }
+
+        // On first launch after onboarding, skip the initial session list fetch
+        // so the session restorer doesn't override the wake-up conversation thread.
+        // The handlers above are still registered for later use (e.g. history loading).
+        guard !skipInitialFetch else { return }
 
         connectionCancellable = daemonClient.$isConnected
             .removeDuplicates()


### PR DESCRIPTION
## Summary
After finishing onboarding, the user now lands on their wake-up conversation thread by default instead of an empty "New Conversation" thread.

The root cause was two-fold:
1. The daemon's `sendInitialSession` created an orphaned "New Conversation" session on first connection
2. The session restorer fetched this session and activated a restored thread, overriding the wake-up conversation

## Changes
- **Client (Swift)**: Pass `isFirstLaunch` from `AppDelegate` through `MainWindow` → `ThreadManager` → `ThreadSessionRestorer`. When true, skip the initial session list fetch so the wake-up thread stays active.
- **Daemon (TypeScript)**: In `sendInitialSession`, return early when no conversations exist instead of creating an orphaned one.

## Milestone PRs (merged into feature branch)
- #4521: M1 — Skip session restoration on first launch after onboarding
- #4522: M2 — Don't create orphaned session in sendInitialSession

## Project issue
Closes #4517

## Test plan
- [ ] Complete onboarding flow from scratch (delete `~/.vellum` and reset `hasCompletedOnboarding`)
- [ ] After onboarding, verify the active thread is the wake-up conversation (not "New Conversation")
- [ ] Verify subsequent app restarts restore sessions normally
- [ ] Verify the sidebar shows only the wake-up conversation thread (no stale "New Conversation")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
