### PR TITLE
fix: remove incorrect cd .. after backgrounded daemon start

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -55,7 +55,7 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 9. Start the daemon fresh from the repo root (in background):
    ```bash
-   cd assistant && bun run src/index.ts daemon start > ~/.vellum/daemon-stdout.log 2>&1 & cd ..
+   cd assistant && bun run src/index.ts daemon start > ~/.vellum/daemon-stdout.log 2>&1 &
    ```
    Wait a moment for the daemon to initialize:
    ```bash


### PR DESCRIPTION
## Summary
- Remove trailing `cd ..` after backgrounded daemon start in `.claude/commands/scrub.md`

Both Codex and Devin reviewers flagged a bug where the `&` operator backgrounds everything before it in a subshell, so `cd assistant` only takes effect inside that subshell. The trailing `cd ..` then runs in the current shell (still at repo root), moving to the parent directory and breaking step 10 (`cd clients/macos && ./build.sh run &`).

Since `cd assistant` never affects the current shell's working directory, the `cd ..` is unnecessary and harmful.

## Test plan
- [ ] Verify the scrub command runs step 9 (daemon start) and step 10 (macOS app build) successfully without the working directory shifting unexpectedly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
