### PR TITLE
fix: send daemon_status before early return in sendInitialSession

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -700,6 +700,10 @@ export class DaemonServer {
     // appears in session_list on subsequent launches.
     const conversation = conversationStore.getLatestConversation();
     if (!conversation) {
+      this.send(socket, {
+        type: 'daemon_status',
+        httpPort: this.httpPort,
+      });
       return;
     }
 


### PR DESCRIPTION
The early return when no conversation exists skipped the daemon_status message, leaving the client without the HTTP port on first launch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
