### PR TITLE
feat: agent-user handoff protocol for auth/checkout (M4 #4511)

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -370,6 +370,34 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     sessionId: 'test-session',
     success: true,
   },
+  browser_user_click: {
+    type: 'browser_user_click',
+    sessionId: 'test-session',
+    surfaceId: 'test-surface',
+    x: 100,
+    y: 200,
+  },
+  browser_user_scroll: {
+    type: 'browser_user_scroll',
+    sessionId: 'test-session',
+    surfaceId: 'test-surface',
+    deltaX: 0,
+    deltaY: -100,
+    x: 100,
+    y: 200,
+  },
+  browser_user_keypress: {
+    type: 'browser_user_keypress',
+    sessionId: 'test-session',
+    surfaceId: 'test-surface',
+    key: 'Enter',
+  },
+  browser_interactive_mode: {
+    type: 'browser_interactive_mode',
+    sessionId: 'test-session',
+    surfaceId: 'test-surface',
+    enabled: true,
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1063,6 +1091,19 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   browser_cdp_request: {
     type: 'browser_cdp_request',
     sessionId: 'test-session',
+  },
+  browser_interactive_mode_changed: {
+    type: 'browser_interactive_mode_changed',
+    sessionId: 'test-session',
+    surfaceId: 'test-surface',
+    enabled: true,
+  },
+  browser_handoff_request: {
+    type: 'browser_handoff_request',
+    sessionId: 'test-session',
+    surfaceId: 'test-surface',
+    reason: 'auth' as const,
+    message: 'Login required',
   },
 };
 

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -293,6 +293,7 @@ const handlers: DispatchMap = {
 
   browser_interactive_mode: (msg, socket, ctx) => {
     log.info({ sessionId: msg.sessionId, enabled: msg.enabled }, 'Interactive mode toggled');
+    browserManager.setInteractiveMode(msg.sessionId, msg.enabled);
     ctx.send(socket, {
       type: 'browser_interactive_mode_changed',
       sessionId: msg.sessionId,

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -722,6 +722,14 @@ export interface BrowserInteractiveModeChanged {
   reason?: string;
   message?: string;
 }
+export interface BrowserHandoffRequest {
+  type: 'browser_handoff_request';
+  sessionId: string;
+  surfaceId: string;
+  reason: 'auth' | 'checkout' | 'captcha' | 'custom';
+  message: string;
+  bringToFront?: boolean;
+}
 
 export type ClientMessage =
   | AuthMessage
@@ -1829,7 +1837,8 @@ export type ServerMessage =
   | DocumentLoadResponse
   | DocumentListResponse
   | BrowserCDPRequest
-  | BrowserInteractiveModeChanged;
+  | BrowserInteractiveModeChanged
+  | BrowserHandoffRequest;
 
 // === Contract schema ===
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -231,14 +231,31 @@ export async function executeBrowserNavigate(
     try {
       const authChallenge = await detectAuthChallenge(page);
       if (authChallenge) {
-        lines.push('');
-        lines.push(formatAuthChallenge(authChallenge));
-        lines.push('');
-        lines.push('To handle this auth challenge, use ui_show with surface_type "form" and the following fields:');
-        const { buildAuthForm } = await import('./jit-auth.js');
-        const formData = buildAuthForm(authChallenge);
-        lines.push(JSON.stringify(formData, null, 2));
-        lines.push('After the user submits, use browser_type to enter the values into the corresponding page elements.');
+        if (browserManager.browserMode === 'cdp') {
+          // In CDP mode, hand off to user for direct interaction
+          if (sender) {
+            const { startHandoff } = await import('./browser-handoff.js');
+            await startHandoff(context.sessionId, sender, {
+              reason: 'auth',
+              message: formatAuthChallenge(authChallenge),
+              bringToFront: true,
+            });
+          }
+          // After handoff completes, return updated page state
+          const newUrl = page.url();
+          const newTitle = await page.title();
+          lines.push('');
+          lines.push(`Auth handled by user. Current page: ${newTitle} (${newUrl})`);
+        } else {
+          lines.push('');
+          lines.push(formatAuthChallenge(authChallenge));
+          lines.push('');
+          lines.push('To handle this auth challenge, use ui_show with surface_type "form" and the following fields:');
+          const { buildAuthForm } = await import('./jit-auth.js');
+          const formData = buildAuthForm(authChallenge);
+          lines.push(JSON.stringify(formData, null, 2));
+          lines.push('After the user submits, use browser_type to enter the values into the corresponding page elements.');
+        }
       }
     } catch {
       // Auth detection is best-effort; don't fail navigation

--- a/assistant/src/tools/browser/browser-handoff.ts
+++ b/assistant/src/tools/browser/browser-handoff.ts
@@ -19,6 +19,12 @@ export async function startHandoff(
   sendToClient: (msg: ServerMessage) => void,
   options: HandoffOptions,
 ): Promise<void> {
+  // In headless mode there's no visible browser for the user to interact with
+  if (browserManager.browserMode === 'headless') {
+    log.info({ sessionId, reason: options.reason }, 'Skipping handoff in headless mode — no visible browser');
+    return;
+  }
+
   log.info({ sessionId, reason: options.reason }, 'Starting handoff to user');
 
   const surfaceId = getScreencastSurfaceId(sessionId);

--- a/assistant/src/tools/browser/browser-handoff.ts
+++ b/assistant/src/tools/browser/browser-handoff.ts
@@ -1,0 +1,53 @@
+import { getLogger } from '../../util/logger.js';
+import { browserManager } from './browser-manager.js';
+import { getScreencastSurfaceId } from './browser-screencast.js';
+import type { ServerMessage } from '../../daemon/ipc-contract.js';
+
+const log = getLogger('browser-handoff');
+
+export interface HandoffOptions {
+  reason: 'auth' | 'checkout' | 'captcha' | 'custom';
+  message: string;
+  bringToFront?: boolean;
+}
+
+/**
+ * Hand control to the user by enabling interactive mode and waiting for them to finish.
+ */
+export async function startHandoff(
+  sessionId: string,
+  sendToClient: (msg: ServerMessage) => void,
+  options: HandoffOptions,
+): Promise<void> {
+  log.info({ sessionId, reason: options.reason }, 'Starting handoff to user');
+
+  const surfaceId = getScreencastSurfaceId(sessionId);
+  if (!surfaceId) {
+    log.warn({ sessionId }, 'No active screencast surface for handoff');
+    return;
+  }
+
+  // Send interactive mode change with reason and message
+  sendToClient({
+    type: 'browser_interactive_mode_changed',
+    sessionId,
+    surfaceId,
+    enabled: true,
+    reason: options.reason,
+    message: options.message,
+  } as ServerMessage);
+
+  browserManager.setInteractiveMode(sessionId, true);
+
+  // Wait for user to hand back control (5 min timeout)
+  await browserManager.waitForHandoffComplete(sessionId);
+
+  sendToClient({
+    type: 'browser_interactive_mode_changed',
+    sessionId,
+    surfaceId,
+    enabled: false,
+  } as ServerMessage);
+
+  log.info({ sessionId }, 'Handoff complete, agent resuming');
+}

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -238,6 +238,12 @@ class BrowserManager {
           this.context = null;
           this.contextCloseHandler = null;
           this.cdpBrowser = null;
+          // Resolve any pending handoffs before clearing state
+          for (const resolver of this.handoffResolvers.values()) {
+            resolver();
+          }
+          this.handoffResolvers.clear();
+          this.interactiveModeSessions.clear();
           this.pages.clear();
           this.rawPages.clear();
           this.cdpSessions.clear();
@@ -274,6 +280,13 @@ class BrowserManager {
 
   async closeSessionPage(sessionId: string): Promise<void> {
     await this.stopScreencast(sessionId);
+    // Clean up any pending handoff for this session
+    this.interactiveModeSessions.delete(sessionId);
+    const handoffResolver = this.handoffResolvers.get(sessionId);
+    if (handoffResolver) {
+      handoffResolver();
+      this.handoffResolvers.delete(sessionId);
+    }
     const page = this.pages.get(sessionId);
     if (page && !page.isClosed()) {
       await page.close();
@@ -413,17 +426,30 @@ class BrowserManager {
   async waitForHandoffComplete(sessionId: string, timeoutMs: number = 300_000): Promise<void> {
     if (!this.interactiveModeSessions.has(sessionId)) return;
 
+    // Cancel any existing pending handoff for this session
+    const existing = this.handoffResolvers.get(sessionId);
+    if (existing) {
+      existing();
+    }
+
     return new Promise<void>((resolve) => {
+      const resolver = () => {
+        clearTimeout(timer);
+        if (this.handoffResolvers.get(sessionId) === resolver) {
+          this.handoffResolvers.delete(sessionId);
+        }
+        resolve();
+      };
+
       const timer = setTimeout(() => {
-        this.handoffResolvers.delete(sessionId);
+        if (this.handoffResolvers.get(sessionId) === resolver) {
+          this.handoffResolvers.delete(sessionId);
+        }
         this.interactiveModeSessions.delete(sessionId);
         resolve();
       }, timeoutMs);
 
-      this.handoffResolvers.set(sessionId, () => {
-        clearTimeout(timer);
-        resolve();
-      });
+      this.handoffResolvers.set(sessionId, resolver);
     });
   }
 

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -99,6 +99,8 @@ class BrowserManager {
   private cdpUrl: string = 'http://localhost:9222';
   private cdpBrowser: unknown = null; // Store CDP browser reference separately
   private cdpRequestResolvers = new Map<string, (response: { success: boolean; declined?: boolean }) => void>();
+  private interactiveModeSessions = new Set<string>();
+  private handoffResolvers = new Map<string, () => void>();
 
   get browserMode(): 'headless' | 'cdp' {
     return this._browserMode;
@@ -389,6 +391,40 @@ class BrowserManager {
     const map = this.snapshotMaps.get(sessionId);
     if (!map) return null;
     return map.get(elementId) ?? null;
+  }
+
+  isInteractive(sessionId: string): boolean {
+    return this.interactiveModeSessions.has(sessionId);
+  }
+
+  setInteractiveMode(sessionId: string, enabled: boolean): void {
+    if (enabled) {
+      this.interactiveModeSessions.add(sessionId);
+    } else {
+      this.interactiveModeSessions.delete(sessionId);
+      const resolver = this.handoffResolvers.get(sessionId);
+      if (resolver) {
+        resolver();
+        this.handoffResolvers.delete(sessionId);
+      }
+    }
+  }
+
+  async waitForHandoffComplete(sessionId: string, timeoutMs: number = 300_000): Promise<void> {
+    if (!this.interactiveModeSessions.has(sessionId)) return;
+
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.handoffResolvers.delete(sessionId);
+        this.interactiveModeSessions.delete(sessionId);
+        resolve();
+      }, timeoutMs);
+
+      this.handoffResolvers.set(sessionId, () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
   }
 
   hasContext(): boolean {

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -208,3 +208,8 @@ export function isScreencastActive(sessionId: string): boolean {
 }
 
 export { getSender };
+
+export function getScreencastSurfaceId(sessionId: string): string | null {
+  const state = activeScreencasts.get(sessionId);
+  return state?.surfaceId ?? null;
+}


### PR DESCRIPTION
## Summary
- Adds `BrowserHandoffRequest` IPC type for agent-to-user control transfer during auth/checkout/captcha flows
- Implements `startHandoff()` in new `browser-handoff.ts` module that sends interactive mode notifications, waits for user completion (5min timeout), then resumes agent control
- Adds `setInteractiveMode()` / `waitForHandoffComplete()` to `BrowserManager` with promise-based handoff resolution
- Integrates handoff into `executeBrowserNavigate()` auth detection — CDP mode hands off to user, managed mode falls back to JIT auth forms

Closes #4511

## Test plan
- [ ] Verify `BrowserHandoffRequest` type is correctly defined in IPC contract
- [ ] Verify `setInteractiveMode()` correctly tracks sessions and resolves pending handoffs
- [ ] Verify `waitForHandoffComplete()` resolves on mode disable or after 5min timeout
- [ ] Verify CDP mode auth detection triggers handoff instead of JIT form
- [ ] Verify managed mode auth detection still uses JIT form flow
- [ ] Verify IPC snapshot test passes with new message type fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
