### PR TITLE
feat: Chrome restart flow with CDP confirmation dialog (M2 #4510)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1068,8 +1068,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                                 }
                             }
                         }
-                        try? await Task.sleep(nanoseconds: 3_000_000_000)
-                        success = true
+                        // Poll for CDP availability instead of blind sleep
+                        success = await Self.pollForCDP()
                     } catch {
                         success = false
                     }
@@ -1088,6 +1088,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Poll http://localhost:9222/json/version until CDP responds or we time out.
+    private static func pollForCDP(maxAttempts: Int = 10, intervalNs: UInt64 = 1_000_000_000) async -> Bool {
+        for _ in 0..<maxAttempts {
+            try? await Task.sleep(nanoseconds: intervalNs)
+            if let url = URL(string: "http://localhost:9222/json/version"),
+               let (_, response) = try? await URLSession.shared.data(from: url),
+               let http = response as? HTTPURLResponse,
+               http.statusCode == 200 {
+                return true
+            }
+        }
+        return false
+    }
+
     private func createChromeDebugLaunchAgent() {
         let plistContent = """
         <?xml version="1.0" encoding="UTF-8"?>
@@ -1098,15 +1112,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             <string>com.vellum.chrome-debug</string>
             <key>ProgramArguments</key>
             <array>
-                <string>open</string>
-                <string>-a</string>
-                <string>Google Chrome</string>
-                <string>--args</string>
+                <string>/Applications/Google Chrome.app/Contents/MacOS/Google Chrome</string>
                 <string>--remote-debugging-port=9222</string>
                 <string>--force-renderer-accessibility</string>
             </array>
             <key>RunAtLoad</key>
-            <false/>
+            <true/>
         </dict>
         </plist>
         """

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -484,6 +484,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // Give BrowserPiPManager a reference to DaemonClient for sending interactive input
         browserPiPManager.daemonClient = daemonClient
 
+        daemonClient.onBrowserCDPRequest = { [weak self] msg in
+            Task { @MainActor in
+                await self?.handleBrowserCDPRequest(msg)
+            }
+        }
+
+
         // Reload webviews for surfaces whose app files changed (cross-session broadcast)
         daemonClient.onAppFilesChanged = { [weak self] appId in
             guard let self else { return }
@@ -1021,4 +1028,99 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         secretPromptManager.dismissAll()
         daemonLauncher.stop()
     }
+
+    // MARK: - Browser CDP Request Handling
+
+    @MainActor
+    private func handleBrowserCDPRequest(_ msg: BrowserCDPRequestMessage) async {
+        // Show confirmation dialog
+        let alert = NSAlert()
+        alert.messageText = "Browser Remote Control"
+        alert.informativeText = "To control your browser, Chrome needs to be restarted with remote debugging enabled. Your tabs will be automatically restored."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Restart Chrome")
+        alert.addButton(withTitle: "Use Background Browser")
+
+        // Add "Always launch" checkbox
+        let checkbox = NSButton(checkboxWithTitle: "Always launch Chrome with remote debugging", target: nil, action: nil)
+        alert.accessoryView = checkbox
+
+        let response = alert.runModal()
+
+        if response == .alertFirstButtonReturn {
+            // User chose to restart Chrome
+            var success = false
+            if let chrome = ChromeAccessibilityHelper.findRunningChrome() {
+                success = await ChromeAccessibilityHelper.restartChromeForCDP(app: chrome)
+            } else {
+                // Chrome not running — launch it with flags
+                if let chromeURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") {
+                    do {
+                        let config = NSWorkspace.OpenConfiguration()
+                        config.arguments = ["--remote-debugging-port=9222", "--force-renderer-accessibility"]
+                        config.activates = true
+                        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                            NSWorkspace.shared.openApplication(at: chromeURL, configuration: config) { _, error in
+                                if let error {
+                                    continuation.resume(throwing: error)
+                                } else {
+                                    continuation.resume()
+                                }
+                            }
+                        }
+                        try? await Task.sleep(nanoseconds: 3_000_000_000)
+                        success = true
+                    } catch {
+                        success = false
+                    }
+                }
+            }
+
+            // Handle "Always launch" checkbox
+            if checkbox.state == .on {
+                createChromeDebugLaunchAgent()
+            }
+
+            try? daemonClient.send(BrowserCDPResponseMessage(sessionId: msg.sessionId, success: success))
+        } else {
+            // User chose background browser
+            try? daemonClient.send(BrowserCDPResponseMessage(sessionId: msg.sessionId, success: false, declined: true))
+        }
+    }
+
+    private func createChromeDebugLaunchAgent() {
+        let plistContent = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>com.vellum.chrome-debug</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>open</string>
+                <string>-a</string>
+                <string>Google Chrome</string>
+                <string>--args</string>
+                <string>--remote-debugging-port=9222</string>
+                <string>--force-renderer-accessibility</string>
+            </array>
+            <key>RunAtLoad</key>
+            <false/>
+        </dict>
+        </plist>
+        """
+
+        let launchAgentsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents")
+        let plistPath = launchAgentsDir.appendingPathComponent("com.vellum.chrome-debug.plist")
+
+        do {
+            try FileManager.default.createDirectory(at: launchAgentsDir, withIntermediateDirectories: true)
+            try plistContent.write(to: plistPath, atomically: true, encoding: .utf8)
+        } catch {
+            // Best effort — log but don't fail
+        }
+    }
+
 }

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -47,25 +47,24 @@ final class ChromeAccessibilityHelper {
         return result
     }
 
-    /// Restart Chrome with `--force-renderer-accessibility` so the full AX tree is available.
-    /// Chrome's built-in session restore will reopen all tabs.
-    /// Returns true if Chrome was successfully restarted.
+    /// Restart Chrome with custom command-line flags.
+    /// Chrome's session restore will reopen all tabs.
     @MainActor
-    static func restartChromeWithAccessibility(app: NSRunningApplication) async -> Bool {
+    static func restartChromeWithFlags(app: NSRunningApplication, flags: [String]) async -> Bool {
         guard let bundleId = app.bundleIdentifier,
               let bundleURL = app.bundleURL else {
             log.error("Cannot restart: missing bundle info")
             return false
         }
 
-        log.info("Restarting \(bundleId, privacy: .public) with --force-renderer-accessibility")
+        log.info("Restarting \(bundleId, privacy: .public) with flags: \(flags, privacy: .public)")
 
         // Gracefully terminate — Chrome will save session state
         app.terminate()
 
         // Wait for Chrome to fully quit (up to 5 seconds)
         for _ in 0..<50 {
-            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            try? await Task.sleep(nanoseconds: 100_000_000)
             if app.isTerminated { break }
         }
 
@@ -75,12 +74,11 @@ final class ChromeAccessibilityHelper {
             try? await Task.sleep(nanoseconds: 500_000_000)
         }
 
-        // Relaunch with accessibility flag
+        // Relaunch with flags
         do {
-            // Use completion handler to avoid Sendable warnings with NSWorkspace types
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 let config = NSWorkspace.OpenConfiguration()
-                config.arguments = ["--force-renderer-accessibility"]
+                config.arguments = flags
                 config.activates = true
                 NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { _, error in
                     if let error {
@@ -90,9 +88,7 @@ final class ChromeAccessibilityHelper {
                     }
                 }
             }
-            log.info("Chrome relaunched with accessibility flag")
-
-            // Wait for Chrome to start and restore tabs
+            log.info("Chrome relaunched with flags")
             try? await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
             return true
         } catch {
@@ -100,4 +96,45 @@ final class ChromeAccessibilityHelper {
             return false
         }
     }
+
+    /// Convenience: restart with just accessibility flag (backward compat).
+    @MainActor
+    static func restartChromeWithAccessibility(app: NSRunningApplication) async -> Bool {
+        return await restartChromeWithFlags(app: app, flags: ["--force-renderer-accessibility"])
+    }
+
+    /// Restart Chrome for CDP mode with both remote debugging and accessibility flags.
+    @MainActor
+    static func restartChromeForCDP(app: NSRunningApplication) async -> Bool {
+        let success = await restartChromeWithFlags(app: app, flags: [
+            "--remote-debugging-port=9222",
+            "--force-renderer-accessibility"
+        ])
+        guard success else { return false }
+
+        // Poll CDP endpoint to confirm it's ready
+        for _ in 0..<30 {
+            try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
+            if let url = URL(string: "http://localhost:9222/json/version"),
+               let (_, response) = try? await URLSession.shared.data(from: url),
+               let httpResponse = response as? HTTPURLResponse,
+               httpResponse.statusCode == 200 {
+                log.info("CDP endpoint confirmed ready")
+                return true
+            }
+        }
+        log.warning("CDP endpoint not responding after Chrome restart")
+        return false
+    }
+
+    /// Find the running Chrome app.
+    static func findRunningChrome() -> NSRunningApplication? {
+        for bundleId in chromeBundleIds {
+            if let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first {
+                return app
+            }
+        }
+        return nil
+    }
 }
+

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -127,9 +127,13 @@ final class ChromeAccessibilityHelper {
         return false
     }
 
-    /// Find the running Chrome app.
+    /// Find a running Chromium browser, preferring Google Chrome.
     static func findRunningChrome() -> NSRunningApplication? {
-        for bundleId in chromeBundleIds {
+        // Check Google Chrome first since the UI references "Chrome" specifically,
+        // then fall back to other Chromium browsers in deterministic order.
+        let orderedIds = ["com.google.Chrome", "com.google.Chrome.canary",
+                          "com.brave.Browser", "com.microsoft.edgemac", "com.vivaldi.Vivaldi"]
+        for bundleId in orderedIds {
             if let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first {
                 return app
             }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -246,6 +246,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `browser_interactive_mode_changed` message.
     public var onBrowserInteractiveModeChanged: ((BrowserInteractiveModeChangedMessage) -> Void)?
 
+    /// Called when the daemon sends a `browser_cdp_request` message.
+    public var onBrowserCDPRequest: ((BrowserCDPRequestMessage) -> Void)?
+
     /// Called when the daemon sends a `diagnostics_export_response` message.
     public var onDiagnosticsExportResponse: ((DiagnosticsExportResponseMessage) -> Void)?
 
@@ -1319,6 +1322,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onBrowserFrame?(msg)
         case .browserInteractiveModeChanged(let msg):
             onBrowserInteractiveModeChanged?(msg)
+        case .browserCDPRequest(let msg):
+            onBrowserCDPRequest?(msg)
         case .envVarsResponse(let msg):
             onEnvVarsResponse?(msg)
         default:

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1748,6 +1748,7 @@ public enum ServerMessage: Decodable, Sendable {
     case diagnosticsExportResponse(DiagnosticsExportResponseMessage)
     case browserFrame(BrowserFrameMessage)
     case browserInteractiveModeChanged(BrowserInteractiveModeChangedMessage)
+    case browserCDPRequest(BrowserCDPRequestMessage)
     case envVarsResponse(EnvVarsResponseMessage)
     case pong
     case unknown(String)
@@ -1998,6 +1999,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "browser_interactive_mode_changed":
             let message = try BrowserInteractiveModeChangedMessage(from: decoder)
             self = .browserInteractiveModeChanged(message)
+        case "browser_cdp_request":
+            let message = try BrowserCDPRequestMessage(from: decoder)
+            self = .browserCDPRequest(message)
         case "env_vars_response":
             let message = try EnvVarsResponseMessage(from: decoder)
             self = .envVarsResponse(message)
@@ -2006,6 +2010,28 @@ public enum ServerMessage: Decodable, Sendable {
         default:
             self = .unknown(type)
         }
+    }
+}
+
+
+// MARK: - Browser CDP Messages
+
+/// Received when daemon needs Chrome restarted with CDP.
+public struct BrowserCDPRequestMessage: Decodable, Sendable {
+    public let sessionId: String
+}
+
+/// Sent back to daemon after Chrome restart attempt.
+public struct BrowserCDPResponseMessage: Encodable, Sendable {
+    public let type: String = "browser_cdp_response"
+    public let sessionId: String
+    public let success: Bool
+    public let declined: Bool?
+
+    public init(sessionId: String, success: Bool, declined: Bool? = nil) {
+        self.sessionId = sessionId
+        self.success = success
+        self.declined = declined
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `BrowserCDPRequestMessage` / `BrowserCDPResponseMessage` IPC message types for daemon-client CDP negotiation
- Extend `ChromeAccessibilityHelper` with `restartChromeWithFlags`, `restartChromeForCDP` (with CDP endpoint polling), and `findRunningChrome`; refactor existing `restartChromeWithAccessibility` to use shared `restartChromeWithFlags`
- Wire `onBrowserCDPRequest` callback through `DaemonClient` to `AppDelegate`, showing an NSAlert confirmation dialog with "Restart Chrome" / "Use Background Browser" options and an "Always launch" checkbox that creates a LaunchAgent

Closes #4510

## Test plan
- [ ] Verify build succeeds on macOS
- [ ] Test CDP request flow: daemon sends `browser_cdp_request`, client shows confirmation dialog
- [ ] Test "Restart Chrome" path: Chrome restarts with `--remote-debugging-port=9222`, CDP endpoint polled
- [ ] Test "Use Background Browser" path: response sent with `declined: true`
- [ ] Test "Always launch" checkbox creates `~/Library/LaunchAgents/com.vellum.chrome-debug.plist`
- [ ] Test Chrome not running case: launches Chrome with CDP flags directly
- [ ] Verify backward compat: `restartChromeWithAccessibility` still works via `restartChromeWithFlags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
