### PR TITLE
feat: add task compiler for capturing conversations as reusable tasks

### DIFF
--- a/assistant/src/__tests__/task-compiler.test.ts
+++ b/assistant/src/__tests__/task-compiler.test.ts
@@ -1,0 +1,283 @@
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mock } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'task-compiler-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({ memory: {} }),
+}));
+
+mock.module('./indexer.js', () => ({
+  indexMessageNow: () => {},
+}));
+
+import type { Database } from 'bun:sqlite';
+import { initializeDb, getDb } from '../memory/db.js';
+import { renderTemplate } from '../tasks/task-runner.js';
+import { compileTaskFromConversation, saveCompiledTask } from '../tasks/task-compiler.js';
+import { getTask } from '../tasks/task-store.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function getRawDb(): Database {
+  return (getDb() as unknown as { $client: Database }).$client;
+}
+
+function createTestConversation(id: string): string {
+  const raw = getRawDb();
+  const now = Date.now();
+  raw.query(
+    `INSERT INTO conversations (id, title, created_at, updated_at, thread_type, memory_scope_id) VALUES (?, 'Test', ?, ?, 'standard', 'default')`,
+  ).run(id, now, now);
+  return id;
+}
+
+function addTestMessage(conversationId: string, role: string, content: string): void {
+  const raw = getRawDb();
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  raw.query(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+  ).run(id, conversationId, role, content, now);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('compileTaskFromConversation', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+    raw.run('DELETE FROM messages');
+    raw.run('DELETE FROM conversations');
+  });
+
+  test('extracts first user message as template basis', () => {
+    const convId = createTestConversation('conv-1');
+    addTestMessage(convId, 'user', 'Please summarize the document for me');
+    addTestMessage(convId, 'assistant', 'Here is the summary...');
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.template).toBe('Please summarize the document for me');
+    expect(compiled.title).toBe('Please summarize the document for me');
+  });
+
+  test('identifies tool names from assistant messages', () => {
+    const convId = createTestConversation('conv-2');
+    addTestMessage(convId, 'user', 'Read this file and fix the bug');
+    addTestMessage(
+      convId,
+      'assistant',
+      JSON.stringify([
+        { type: 'text', text: 'Let me read the file.' },
+        { type: 'tool_use', id: 'tu1', name: 'read_file', input: { path: '/tmp/foo.ts' } },
+      ]),
+    );
+    addTestMessage(
+      convId,
+      'assistant',
+      JSON.stringify([
+        { type: 'tool_use', id: 'tu2', name: 'write_file', input: { path: '/tmp/foo.ts', content: '...' } },
+      ]),
+    );
+    // Duplicate tool_use should only appear once
+    addTestMessage(
+      convId,
+      'assistant',
+      JSON.stringify([
+        { type: 'tool_use', id: 'tu3', name: 'read_file', input: { path: '/tmp/bar.ts' } },
+      ]),
+    );
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.requiredTools).toContain('read_file');
+    expect(compiled.requiredTools).toContain('write_file');
+    expect(compiled.requiredTools).toHaveLength(2);
+  });
+
+  test('replaces file paths in template with placeholders', () => {
+    const convId = createTestConversation('conv-3');
+    addTestMessage(convId, 'user', 'Please lint the file at /Users/alice/project/main.ts');
+    addTestMessage(convId, 'assistant', 'Done!');
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.template).toBe('Please lint the file at {{file_path}}');
+    expect(compiled.inputSchema).toBeTruthy();
+    expect((compiled.inputSchema as Record<string, unknown>).type).toBe('object');
+    const props = (compiled.inputSchema as Record<string, unknown>).properties as Record<string, Record<string, string>>;
+    expect(props.file_path.type).toBe('string');
+  });
+
+  test('replaces URLs in template with placeholders', () => {
+    const convId = createTestConversation('conv-4');
+    addTestMessage(convId, 'user', 'Fetch data from https://api.example.com/data and save it');
+    addTestMessage(convId, 'assistant', 'Done!');
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.template).toBe('Fetch data from {{url}} and save it');
+    expect(compiled.inputSchema).toBeTruthy();
+    const props = (compiled.inputSchema as Record<string, unknown>).properties as Record<string, Record<string, string>>;
+    expect(props.url.type).toBe('string');
+  });
+
+  test('renderTemplate roundtrip with compiled template', () => {
+    const convId = createTestConversation('conv-5');
+    addTestMessage(convId, 'user', 'Deploy /Users/alice/project/app to https://prod.example.com/api');
+    addTestMessage(convId, 'assistant', 'Deployed!');
+
+    const compiled = compileTaskFromConversation(convId);
+
+    // Template should have placeholders
+    expect(compiled.template).toContain('{{file_path}}');
+    expect(compiled.template).toContain('{{url}}');
+
+    // Render with concrete values
+    const rendered = renderTemplate(compiled.template, {
+      file_path: '/Users/bob/other/app',
+      url: 'https://staging.example.com/api',
+    });
+
+    expect(rendered).toBe('Deploy /Users/bob/other/app to https://staging.example.com/api');
+  });
+
+  test('handles conversation with no tool use', () => {
+    const convId = createTestConversation('conv-6');
+    addTestMessage(convId, 'user', 'What is the meaning of life?');
+    addTestMessage(convId, 'assistant', '42');
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.requiredTools).toEqual([]);
+    expect(compiled.template).toBe('What is the meaning of life?');
+    expect(compiled.contextFlags).toEqual([]);
+  });
+
+  test('throws on empty conversation', () => {
+    const convId = createTestConversation('conv-7');
+
+    expect(() => compileTaskFromConversation(convId)).toThrow(
+      'No messages found for conversation: conv-7',
+    );
+  });
+
+  test('throws when no user messages exist', () => {
+    const convId = createTestConversation('conv-8');
+    addTestMessage(convId, 'assistant', 'Hello there');
+
+    expect(() => compileTaskFromConversation(convId)).toThrow(
+      'No user messages found in conversation: conv-8',
+    );
+  });
+
+  test('truncates long titles to 60 characters', () => {
+    const convId = createTestConversation('conv-9');
+    const longMessage = 'A'.repeat(100);
+    addTestMessage(convId, 'user', longMessage);
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.title.length).toBe(60);
+    expect(compiled.title).toBe('A'.repeat(57) + '...');
+  });
+
+  test('handles JSON content blocks in user message', () => {
+    const convId = createTestConversation('conv-10');
+    addTestMessage(
+      convId,
+      'user',
+      JSON.stringify([
+        { type: 'text', text: 'Please analyze this data' },
+        { type: 'text', text: ' and create a report' },
+      ]),
+    );
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.template).toBe('Please analyze this data\n and create a report');
+  });
+
+  test('returns null inputSchema when no placeholders are found', () => {
+    const convId = createTestConversation('conv-11');
+    addTestMessage(convId, 'user', 'List all running processes');
+
+    const compiled = compileTaskFromConversation(convId);
+
+    expect(compiled.inputSchema).toBeNull();
+  });
+});
+
+// ── saveCompiledTask ────────────────────────────────────────────────
+
+describe('saveCompiledTask', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+    raw.run('DELETE FROM messages');
+    raw.run('DELETE FROM conversations');
+  });
+
+  test('creates a task in the database from compiled output', () => {
+    const convId = createTestConversation('conv-save-1');
+    addTestMessage(convId, 'user', 'Read /Users/alice/file.txt and summarize');
+    addTestMessage(
+      convId,
+      'assistant',
+      JSON.stringify([
+        { type: 'tool_use', id: 'tu1', name: 'read_file', input: { path: '/tmp/x' } },
+      ]),
+    );
+
+    const compiled = compileTaskFromConversation(convId);
+    const task = saveCompiledTask(compiled, convId);
+
+    expect(task.id).toBeTruthy();
+    expect(task.title).toBe(compiled.title);
+    expect(task.template).toBe(compiled.template);
+    expect(task.status).toBe('active');
+    expect(task.createdFromConversationId).toBe(convId);
+
+    // Verify it persists to DB
+    const fetched = getTask(task.id);
+    expect(fetched).toBeTruthy();
+    expect(fetched!.title).toBe(compiled.title);
+    expect(fetched!.template).toBe(compiled.template);
+
+    // Verify required tools are stored as JSON
+    const tools = JSON.parse(fetched!.requiredTools!);
+    expect(tools).toContain('read_file');
+  });
+});

--- a/assistant/src/tasks/task-compiler.ts
+++ b/assistant/src/tasks/task-compiler.ts
@@ -1,0 +1,198 @@
+import { eq } from 'drizzle-orm';
+import { getDb } from '../memory/db.js';
+import { messages as messagesTable } from '../memory/schema.js';
+import { createTask } from './task-store.js';
+import type { Task } from './task-store.js';
+
+/** Output schema for the task compiler. */
+export interface CompiledTask {
+  title: string;
+  template: string;
+  inputSchema: Record<string, unknown> | null;
+  contextFlags: string[];
+  requiredTools: string[];
+}
+
+/**
+ * Extract a reusable task definition from a conversation's message history.
+ *
+ * Pattern-based extraction (v1) that:
+ * 1. Reads the conversation messages
+ * 2. Identifies the user's original request (first user message)
+ * 3. Identifies which tools were used (from assistant tool_use messages)
+ * 4. Builds a template from the original request
+ * 5. Extracts likely input variables (file paths, URLs, quoted strings)
+ */
+export function compileTaskFromConversation(conversationId: string): CompiledTask {
+  const db = getDb();
+  const msgs = db
+    .select()
+    .from(messagesTable)
+    .where(eq(messagesTable.conversationId, conversationId))
+    .all();
+
+  if (msgs.length === 0) {
+    throw new Error(`No messages found for conversation: ${conversationId}`);
+  }
+
+  // Find the first user message to use as the template basis
+  const firstUserMsg = msgs.find((m) => m.role === 'user');
+  if (!firstUserMsg) {
+    throw new Error(`No user messages found in conversation: ${conversationId}`);
+  }
+
+  // Extract user message text content
+  const userText = extractTextContent(firstUserMsg.content);
+
+  // Extract unique tool names from assistant messages
+  const requiredTools = extractToolNames(msgs);
+
+  // Build template with placeholder substitutions
+  const { template, properties } = buildTemplate(userText);
+
+  // Build JSON Schema for extracted placeholders
+  const inputSchema =
+    Object.keys(properties).length > 0
+      ? { type: 'object' as const, properties }
+      : null;
+
+  // Derive title from the first user message (truncated to 60 chars)
+  const title = deriveTitle(userText);
+
+  return {
+    title,
+    template,
+    inputSchema,
+    contextFlags: [],
+    requiredTools,
+  };
+}
+
+/**
+ * Save a compiled task to the database.
+ */
+export function saveCompiledTask(compiled: CompiledTask, conversationId: string): Task {
+  return createTask({
+    title: compiled.title,
+    template: compiled.template,
+    inputSchema: compiled.inputSchema ?? undefined,
+    contextFlags: compiled.contextFlags,
+    requiredTools: compiled.requiredTools,
+    createdFromConversationId: conversationId,
+  });
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+/**
+ * Extract plain text from a message content field. Content may be a plain
+ * string or a JSON array of Anthropic content blocks.
+ */
+function extractTextContent(content: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((block: Record<string, unknown>) => block.type === 'text')
+        .map((block: Record<string, unknown>) => block.text as string)
+        .join('\n');
+    }
+    // If it parsed but isn't an array, treat as plain text
+    return content;
+  } catch {
+    // Not JSON — it's a plain text message
+    return content;
+  }
+}
+
+/**
+ * Extract unique tool names from assistant messages that contain tool_use blocks.
+ */
+function extractToolNames(
+  msgs: { role: string; content: string }[],
+): string[] {
+  const tools = new Set<string>();
+
+  for (const msg of msgs) {
+    if (msg.role !== 'assistant') continue;
+
+    try {
+      const parsed = JSON.parse(msg.content);
+      if (!Array.isArray(parsed)) continue;
+
+      for (const block of parsed) {
+        if (
+          block &&
+          typeof block === 'object' &&
+          block.type === 'tool_use' &&
+          typeof block.name === 'string'
+        ) {
+          tools.add(block.name);
+        }
+      }
+    } catch {
+      // Not JSON content — skip
+    }
+  }
+
+  return [...tools];
+}
+
+/**
+ * Build a template from user text by replacing variable-looking parts
+ * with mustache-style placeholders.
+ *
+ * Returns the template string and a map of property schemas for the
+ * identified placeholders.
+ */
+function buildTemplate(text: string): {
+  template: string;
+  properties: Record<string, { type: string; description: string }>;
+} {
+  const properties: Record<string, { type: string; description: string }> = {};
+  let template = text;
+  let urlIndex = 0;
+  let filePathIndex = 0;
+
+  // Replace URLs first so they don't get partially matched by file path regex
+  template = template.replace(
+    /https?:\/\/[^\s)>]+/g,
+    () => {
+      const key = urlIndex === 0 ? 'url' : `url_${urlIndex}`;
+      urlIndex++;
+      properties[key] = {
+        type: 'string',
+        description: 'The URL to use',
+      };
+      return `{{${key}}}`;
+    },
+  );
+
+  // Replace absolute file paths (e.g. /Users/foo/bar.txt, ~/docs/file)
+  // Only match paths starting with / or ~/ that have at least two segments
+  template = template.replace(
+    /(?:~\/|\/(?:[a-zA-Z0-9._-]+\/)+[a-zA-Z0-9._-]+)/g,
+    () => {
+      const key = filePathIndex === 0 ? 'file_path' : `file_path_${filePathIndex}`;
+      filePathIndex++;
+      properties[key] = {
+        type: 'string',
+        description: 'The file path to operate on',
+      };
+      return `{{${key}}}`;
+    },
+  );
+
+  return { template, properties };
+}
+
+/**
+ * Derive a short title from the user's first message.
+ * Truncates to 60 characters with ellipsis if needed.
+ */
+function deriveTitle(text: string): string {
+  // Take the first line and trim whitespace
+  const firstLine = text.split('\n')[0].trim();
+  if (firstLine.length <= 60) return firstLine;
+  return firstLine.slice(0, 57) + '...';
+}


### PR DESCRIPTION
## Summary
- Add `task-compiler.ts` with `compileTaskFromConversation()` that extracts a reusable task definition from a conversation's message history
- Pattern-based v1 extraction: identifies the user's first message as the template basis, collects tool names from assistant tool_use blocks, and substitutes file paths/URLs with mustache-style placeholders
- Add `saveCompiledTask()` to persist compiled tasks to the database via the existing task store
- 12 tests covering template extraction, tool identification, placeholder substitution, renderTemplate roundtrip, edge cases (empty conversation, no tools, long titles, JSON content blocks)

## Test plan
- [x] All 12 tests pass in `task-compiler.test.ts`
- [x] Type-check passes (only pre-existing vault.ts errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
