### PR TITLE
feat: add scheduling integration for one-shot tasks

### DIFF
--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'task-scheduler-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { createTask } from '../tasks/task-store.js';
+import { scheduleTask } from '../tasks/task-scheduler.js';
+import {
+  createSchedule,
+  getSchedule,
+  getScheduleRuns,
+} from '../schedule/schedule-store.js';
+import { startScheduler } from '../schedule/scheduler.js';
+
+initializeDb();
+
+/** Access the underlying bun:sqlite Database for raw parameterized queries. */
+function getRawDb(): import('bun:sqlite').Database {
+  return (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+}
+
+/** Force a schedule to be due by setting next_run_at in the past. */
+function forceScheduleDue(scheduleId: string): void {
+  getRawDb().run('UPDATE cron_jobs SET next_run_at = ? WHERE id = ?', [Date.now() - 1000, scheduleId]);
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ── scheduleTask helper ─────────────────────────────────────────────
+
+describe('scheduleTask', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM cron_runs');
+    db.run('DELETE FROM cron_jobs');
+    db.run('DELETE FROM task_runs');
+    db.run('DELETE FROM tasks');
+  });
+
+  test('creates a schedule with run_task:<taskId> message format', () => {
+    const task = createTask({
+      title: 'Daily Report',
+      template: 'Generate the daily report',
+    });
+
+    const schedule = scheduleTask({
+      taskId: task.id,
+      name: 'Daily Report Schedule',
+      cronExpression: '0 9 * * *',
+      timezone: 'America/New_York',
+    });
+
+    expect(schedule.name).toBe('Daily Report Schedule');
+    expect(schedule.message).toBe(`run_task:${task.id}`);
+    expect(schedule.cronExpression).toBe('0 9 * * *');
+    expect(schedule.timezone).toBe('America/New_York');
+    expect(schedule.enabled).toBe(true);
+  });
+
+  test('creates a schedule without timezone', () => {
+    const task = createTask({
+      title: 'Hourly Check',
+      template: 'Check status',
+    });
+
+    const schedule = scheduleTask({
+      taskId: task.id,
+      name: 'Hourly Check',
+      cronExpression: '0 * * * *',
+    });
+
+    expect(schedule.message).toBe(`run_task:${task.id}`);
+    expect(schedule.timezone).toBeNull();
+  });
+
+  test('schedule is persisted and retrievable', () => {
+    const task = createTask({
+      title: 'Persisted Task',
+      template: 'Do something',
+    });
+
+    const schedule = scheduleTask({
+      taskId: task.id,
+      name: 'Persisted Schedule',
+      cronExpression: '*/5 * * * *',
+    });
+
+    const retrieved = getSchedule(schedule.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.message).toBe(`run_task:${task.id}`);
+    expect(retrieved!.name).toBe('Persisted Schedule');
+  });
+});
+
+// ── Scheduler run_task: detection ───────────────────────────────────
+
+describe('scheduler run_task detection', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM cron_runs');
+    db.run('DELETE FROM cron_jobs');
+    db.run('DELETE FROM task_runs');
+    db.run('DELETE FROM tasks');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('run_task:<id> messages trigger runTask instead of processMessage', async () => {
+    const task = createTask({
+      title: 'Scheduled Task',
+      template: 'Execute this scheduled task',
+    });
+
+    // Create a schedule with run_task: message
+    const schedule = scheduleTask({
+      taskId: task.id,
+      name: 'Task Schedule',
+      cronExpression: '* * * * *',
+    });
+
+    forceScheduleDue(schedule.id);
+
+    // Track all processMessage calls
+    const directCalls: { conversationId: string; message: string }[] = [];
+    const processMessage = async (conversationId: string, message: string) => {
+      directCalls.push({ conversationId, message });
+    };
+
+    const scheduler = startScheduler(processMessage, () => {}, () => {});
+
+    // Wait for the initial tick to complete
+    await new Promise(resolve => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // runTask delegates to processMessage with the rendered template, not the raw run_task: message
+    const runTaskCalls = directCalls.filter(c => c.message === 'Execute this scheduled task');
+    const rawCalls = directCalls.filter(c => c.message.startsWith('run_task:'));
+
+    expect(runTaskCalls.length).toBe(1);
+    // The scheduler should NOT pass the raw run_task: message to processMessage
+    expect(rawCalls.length).toBe(0);
+  });
+
+  test('regular messages still go through processMessage normally', async () => {
+    // Create a regular schedule (no run_task: prefix)
+    const schedule = createSchedule({
+      name: 'Regular Schedule',
+      cronExpression: '* * * * *',
+      message: 'Do something normal',
+    });
+
+    forceScheduleDue(schedule.id);
+
+    const processedMessages: { conversationId: string; message: string }[] = [];
+    const processMessage = async (conversationId: string, message: string) => {
+      processedMessages.push({ conversationId, message });
+    };
+
+    const scheduler = startScheduler(processMessage, () => {}, () => {});
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // processMessage should have been called with the regular message
+    expect(processedMessages.some(m => m.message === 'Do something normal')).toBe(true);
+  });
+
+  test('handles task not found gracefully', async () => {
+    // Create a schedule pointing to a nonexistent task
+    const schedule = createSchedule({
+      name: 'Bad Task Schedule',
+      cronExpression: '* * * * *',
+      message: 'run_task:nonexistent-task-id',
+    });
+
+    forceScheduleDue(schedule.id);
+
+    const processMessage = async (_conversationId: string, _message: string) => {};
+
+    const scheduler = startScheduler(processMessage, () => {}, () => {});
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // The schedule run should be recorded as an error
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs.length).toBeGreaterThanOrEqual(1);
+    expect(runs[0].status).toBe('error');
+    expect(runs[0].error).toContain('Task not found');
+  });
+});

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -76,6 +76,38 @@ async function runScheduleOnce(
   // ── Cron jobs ───────────────────────────────────────────────────────
   const jobs = claimDueSchedules(now);
   for (const job of jobs) {
+    // Check if message is a task invocation (run_task:<task_id>)
+    const taskMatch = job.message.match(/^run_task:(\S+)$/);
+    if (taskMatch) {
+      const taskId = taskMatch[1];
+      try {
+        log.info({ jobId: job.id, name: job.name, taskId }, 'Executing scheduled task');
+        const { runTask } = await import('../tasks/task-runner.js');
+        const result = await runTask(
+          { taskId, workingDir: process.cwd() },
+          processMessage as (conversationId: string, message: string) => Promise<void>,
+        );
+
+        // Track the schedule run using the task's conversation
+        const runId = createScheduleRun(job.id, result.conversationId);
+        if (result.status === 'failed') {
+          completeScheduleRun(runId, { status: 'error', error: result.error ?? 'Task run failed' });
+        } else {
+          completeScheduleRun(runId, { status: 'ok' });
+          notifySchedule({ id: job.id, name: job.name });
+        }
+        processed += 1;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn({ err, jobId: job.id, name: job.name, taskId }, 'Scheduled task execution failed');
+        // Create a fallback conversation for the schedule run record
+        const fallbackConversation = createConversation(`Schedule: ${job.name}`);
+        const runId = createScheduleRun(job.id, fallbackConversation.id);
+        completeScheduleRun(runId, { status: 'error', error: message });
+      }
+      continue;
+    }
+
     const conversation = createConversation(`Schedule: ${job.name}`);
     const runId = createScheduleRun(job.id, conversation.id);
 

--- a/assistant/src/tasks/task-scheduler.ts
+++ b/assistant/src/tasks/task-scheduler.ts
@@ -1,0 +1,20 @@
+import { createSchedule } from '../schedule/schedule-store.js';
+
+/**
+ * Create a schedule that runs a task on a cron expression.
+ * The scheduler detects the `run_task:<taskId>` message format
+ * and delegates to runTask() instead of processMessage().
+ */
+export function scheduleTask(opts: {
+  taskId: string;
+  name: string;
+  cronExpression: string;
+  timezone?: string;
+}): ReturnType<typeof createSchedule> {
+  return createSchedule({
+    name: opts.name,
+    cronExpression: opts.cronExpression,
+    timezone: opts.timezone ?? null,
+    message: `run_task:${opts.taskId}`,
+  });
+}


### PR DESCRIPTION
## Summary
- Update `scheduler.ts` to detect `run_task:<task_id>` message format and delegate to `runTask()` instead of `processMessage()`, enabling cron schedules to trigger task execution
- Add `task-scheduler.ts` helper with a `scheduleTask()` function that creates schedules with the `run_task:<taskId>` message format
- Add comprehensive tests covering task schedule creation, run_task detection, regular message pass-through, and error handling

## Test plan
- [x] `scheduleTask()` creates a schedule with correct `run_task:<taskId>` message format
- [x] `run_task:<id>` messages trigger `runTask()` — processMessage receives the rendered template, not the raw prefix
- [x] Regular (non-task) messages still flow through `processMessage()` normally
- [x] Nonexistent task IDs are handled gracefully with error status recorded
- [x] Existing task-runner tests still pass (no regression)
- [x] Type-check passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
