### PR TITLE
feat: add task_save, task_run, and task_list LLM tools

### DIFF
--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -1,0 +1,353 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'task-tools-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({ memory: {} }),
+}));
+
+mock.module('./indexer.js', () => ({
+  indexMessageNow: () => {},
+}));
+
+import type { Database } from 'bun:sqlite';
+import { initializeDb, getDb } from '../memory/db.js';
+import { createTask } from '../tasks/task-store.js';
+import { taskSaveTool } from '../tools/tasks/task-save.js';
+import { taskRunTool } from '../tools/tasks/task-run.js';
+import { taskListTool } from '../tools/tasks/task-list.js';
+import type { ToolContext } from '../tools/types.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function getRawDb(): Database {
+  return (getDb() as unknown as { $client: Database }).$client;
+}
+
+function createTestConversation(id: string): string {
+  const raw = getRawDb();
+  const now = Date.now();
+  raw.query(
+    `INSERT INTO conversations (id, title, created_at, updated_at, thread_type, memory_scope_id) VALUES (?, 'Test', ?, ?, 'standard', 'default')`,
+  ).run(id, now, now);
+  return id;
+}
+
+function addTestMessage(conversationId: string, role: string, content: string): void {
+  const raw = getRawDb();
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  raw.query(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+  ).run(id, conversationId, role, content, now);
+}
+
+const stubContext: ToolContext = {
+  workingDir: '/tmp',
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+};
+
+// ── task_save ────────────────────────────────────────────────────────
+
+describe('task_save tool', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+    raw.run('DELETE FROM messages');
+    raw.run('DELETE FROM conversations');
+  });
+
+  test('creates a task from a conversation', async () => {
+    const convId = createTestConversation('conv-save-1');
+    addTestMessage(convId, 'user', 'Please summarize the document');
+    addTestMessage(
+      convId,
+      'assistant',
+      JSON.stringify([
+        { type: 'tool_use', id: 'tu1', name: 'file_read', input: { path: '/tmp/doc.txt' } },
+      ]),
+    );
+    addTestMessage(convId, 'assistant', 'Here is the summary...');
+
+    const result = await taskSaveTool.execute(
+      { conversation_id: convId },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Task saved successfully');
+    expect(result.content).toContain('Please summarize the document');
+    expect(result.content).toContain('file_read');
+  });
+
+  test('uses title override when provided', async () => {
+    const convId = createTestConversation('conv-save-2');
+    addTestMessage(convId, 'user', 'Read and analyze the logs');
+    addTestMessage(convId, 'assistant', 'Done!');
+
+    const result = await taskSaveTool.execute(
+      { conversation_id: convId, title: 'My Custom Title' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('My Custom Title');
+  });
+
+  test('returns error for missing conversation_id', async () => {
+    const result = await taskSaveTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('conversation_id is required');
+  });
+
+  test('returns error for nonexistent conversation', async () => {
+    const result = await taskSaveTool.execute(
+      { conversation_id: 'nonexistent' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No messages found');
+  });
+});
+
+// ── task_run ─────────────────────────────────────────────────────────
+
+describe('task_run tool', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+    raw.run('DELETE FROM messages');
+    raw.run('DELETE FROM conversations');
+  });
+
+  test('resolves task by name (fuzzy match)', async () => {
+    createTask({
+      title: 'Summarize Document',
+      template: 'Please summarize {{file_path}}',
+      inputSchema: { type: 'object', properties: { file_path: { type: 'string', description: 'The file path' } } },
+      requiredTools: ['file_read'],
+    });
+
+    const result = await taskRunTool.execute(
+      { task_name: 'summarize', inputs: { file_path: '/tmp/report.txt' } },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Summarize Document');
+    expect(result.content).toContain('Please summarize /tmp/report.txt');
+  });
+
+  test('resolves task by ID', async () => {
+    const task = createTask({
+      title: 'Deploy App',
+      template: 'Deploy the application to {{url}}',
+      inputSchema: { type: 'object', properties: { url: { type: 'string', description: 'URL' } } },
+    });
+
+    const result = await taskRunTool.execute(
+      { task_id: task.id, inputs: { url: 'https://prod.example.com' } },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Deploy App');
+    expect(result.content).toContain('Deploy the application to https://prod.example.com');
+  });
+
+  test('returns error when task not found by name', async () => {
+    createTask({
+      title: 'Existing Task',
+      template: 'Do something',
+    });
+
+    const result = await taskRunTool.execute(
+      { task_name: 'nonexistent' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No task matching "nonexistent" found');
+    expect(result.content).toContain('Existing Task');
+  });
+
+  test('returns error when task not found by ID', async () => {
+    const result = await taskRunTool.execute(
+      { task_id: 'bad-id' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No task found with ID "bad-id"');
+  });
+
+  test('renders template with inputs', async () => {
+    createTask({
+      title: 'Multi-input Task',
+      template: 'Read {{file_path}} and post to {{url}}',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file_path: { type: 'string', description: 'File' },
+          url: { type: 'string', description: 'URL' },
+        },
+      },
+    });
+
+    const result = await taskRunTool.execute(
+      {
+        task_name: 'multi-input',
+        inputs: { file_path: '/home/user/data.csv', url: 'https://api.example.com/upload' },
+      },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Read /home/user/data.csv and post to https://api.example.com/upload');
+  });
+
+  test('returns error when required inputs are missing', async () => {
+    createTask({
+      title: 'Input Required Task',
+      template: 'Process {{file_path}}',
+      inputSchema: {
+        type: 'object',
+        properties: { file_path: { type: 'string', description: 'File' } },
+      },
+    });
+
+    const result = await taskRunTool.execute(
+      { task_name: 'input required' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Missing required inputs: file_path');
+  });
+
+  test('returns error when neither task_name nor task_id provided', async () => {
+    const result = await taskRunTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('At least one of task_name or task_id must be provided');
+  });
+
+  test('returns error with helpful message when no tasks exist', async () => {
+    const result = await taskRunTool.execute(
+      { task_name: 'anything' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No saved tasks found');
+  });
+
+  test('includes required tools in output', async () => {
+    createTask({
+      title: 'Tools Task',
+      template: 'Do the thing',
+      requiredTools: ['file_read', 'bash'],
+    });
+
+    const result = await taskRunTool.execute(
+      { task_name: 'tools' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Required tools: file_read, bash');
+  });
+});
+
+// ── task_list ────────────────────────────────────────────────────────
+
+describe('task_list tool', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+    raw.run('DELETE FROM messages');
+    raw.run('DELETE FROM conversations');
+  });
+
+  test('returns formatted list of tasks', async () => {
+    createTask({
+      title: 'Task Alpha',
+      template: 'Do alpha things',
+      requiredTools: ['file_read'],
+    });
+    createTask({
+      title: 'Task Beta',
+      template: 'Do beta {{file_path}}',
+      inputSchema: {
+        type: 'object',
+        properties: { file_path: { type: 'string', description: 'File' } },
+      },
+      requiredTools: ['file_read', 'file_write'],
+    });
+
+    const result = await taskListTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Found 2 saved task(s)');
+    expect(result.content).toContain('Task Alpha');
+    expect(result.content).toContain('Task Beta');
+    expect(result.content).toContain('file_read');
+    expect(result.content).toContain('file_write');
+    expect(result.content).toContain('file_path');
+  });
+
+  test('returns empty message when no tasks exist', async () => {
+    const result = await taskListTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No saved tasks found');
+  });
+
+  test('shows task status and creation date', async () => {
+    createTask({
+      title: 'Dated Task',
+      template: 'Something',
+    });
+
+    const result = await taskListTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Status: active');
+    expect(result.content).toContain('Created:');
+  });
+});

--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -1,0 +1,3 @@
+export { taskSaveTool } from './task-save.js';
+export { taskRunTool } from './task-run.js';
+export { taskListTool } from './task-list.js';

--- a/assistant/src/tools/tasks/task-list.ts
+++ b/assistant/src/tools/tasks/task-list.ts
@@ -1,0 +1,63 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { listTasks } from '../../tasks/task-store.js';
+
+const definition: ToolDefinition = {
+  name: 'task_list',
+  description: 'List all saved tasks. Shows each task\'s ID, title, required tools, and creation date.',
+  input_schema: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+class TaskListTool implements Tool {
+  name = 'task_list';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(_input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    try {
+      const tasks = listTasks();
+
+      if (tasks.length === 0) {
+        return { content: 'No saved tasks found. Use task_save to create one from a conversation.', isError: false };
+      }
+
+      const lines = [`Found ${tasks.length} saved task(s):`, ''];
+
+      for (const task of tasks) {
+        const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
+        const createdAt = new Date(task.createdAt).toISOString();
+
+        lines.push(`- ${task.title}`);
+        lines.push(`    ID: ${task.id}`);
+        lines.push(`    Status: ${task.status}`);
+        lines.push(`    Created: ${createdAt}`);
+        if (requiredTools.length > 0) {
+          lines.push(`    Required tools: ${requiredTools.join(', ')}`);
+        }
+        if (task.inputSchema) {
+          const schema = JSON.parse(task.inputSchema) as { properties?: Record<string, unknown> };
+          if (schema.properties) {
+            lines.push(`    Inputs: ${Object.keys(schema.properties).join(', ')}`);
+          }
+        }
+        lines.push('');
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const taskListTool = new TaskListTool();

--- a/assistant/src/tools/tasks/task-run.ts
+++ b/assistant/src/tools/tasks/task-run.ts
@@ -1,0 +1,125 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { getTask, listTasks } from '../../tasks/task-store.js';
+import { renderTemplate } from '../../tasks/task-runner.js';
+
+const definition: ToolDefinition = {
+  name: 'task_run',
+  description:
+    'Run a previously saved task. Resolves the task by name (fuzzy match) or ID, renders its template with the provided inputs, and returns the rendered template for execution.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      task_name: {
+        type: 'string',
+        description: 'Fuzzy match a task by name (case-insensitive substring match)',
+      },
+      task_id: {
+        type: 'string',
+        description: 'Exact match a task by ID',
+      },
+      inputs: {
+        type: 'object',
+        description: 'Values for template placeholders (e.g. {"file_path": "/tmp/foo.txt", "url": "https://example.com"})',
+        additionalProperties: { type: 'string' },
+      },
+    },
+  },
+};
+
+class TaskRunTool implements Tool {
+  name = 'task_run';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const taskName = input.task_name as string | undefined;
+    const taskId = input.task_id as string | undefined;
+    const inputs = (input.inputs as Record<string, string> | undefined) ?? {};
+
+    if (!taskName && !taskId) {
+      return {
+        content: 'Error: At least one of task_name or task_id must be provided',
+        isError: true,
+      };
+    }
+
+    try {
+      // Resolve the task
+      let task;
+
+      if (taskId) {
+        task = getTask(taskId);
+        if (!task) {
+          return { content: `Error: No task found with ID "${taskId}"`, isError: true };
+        }
+      } else if (taskName) {
+        const allTasks = listTasks();
+        const needle = taskName.toLowerCase();
+
+        // Case-insensitive substring match
+        task = allTasks.find((t) => t.title.toLowerCase().includes(needle));
+
+        if (!task) {
+          if (allTasks.length === 0) {
+            return { content: 'Error: No saved tasks found. Use task_save to create one first.', isError: true };
+          }
+          const available = allTasks.map((t) => `  - "${t.title}" (${t.id})`).join('\n');
+          return {
+            content: `Error: No task matching "${taskName}" found. Available tasks:\n${available}`,
+            isError: true,
+          };
+        }
+      }
+
+      if (!task) {
+        return { content: 'Error: Could not resolve task', isError: true };
+      }
+
+      // Check if required inputs are provided
+      if (task.inputSchema) {
+        const schema = JSON.parse(task.inputSchema) as { properties?: Record<string, unknown> };
+        if (schema.properties) {
+          const requiredKeys = Object.keys(schema.properties);
+          const missingKeys = requiredKeys.filter((k) => !(k in inputs));
+          if (missingKeys.length > 0) {
+            return {
+              content: `Error: Missing required inputs: ${missingKeys.join(', ')}. Provide them in the "inputs" parameter.`,
+              isError: true,
+            };
+          }
+        }
+      }
+
+      // Render the template
+      const rendered = renderTemplate(task.template, inputs);
+
+      const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
+
+      const lines = [
+        `Task "${task.title}" resolved and template rendered.`,
+        ``,
+        `Task template rendered. I'll now execute the following task:`,
+        ``,
+        rendered,
+      ];
+
+      if (requiredTools.length > 0) {
+        lines.push('', `Required tools: ${requiredTools.join(', ')}`);
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const taskRunTool = new TaskRunTool();

--- a/assistant/src/tools/tasks/task-save.ts
+++ b/assistant/src/tools/tasks/task-save.ts
@@ -1,0 +1,79 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { compileTaskFromConversation, saveCompiledTask } from '../../tasks/task-compiler.js';
+
+const definition: ToolDefinition = {
+  name: 'task_save',
+  description:
+    'Save the current conversation as a reusable task. Extracts the conversation pattern into a template with placeholders that can be re-run later with different inputs.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      conversation_id: {
+        type: 'string',
+        description: 'The conversation to capture as a reusable task',
+      },
+      title: {
+        type: 'string',
+        description: 'Optional override for the auto-generated task title',
+      },
+    },
+    required: ['conversation_id'],
+  },
+};
+
+class TaskSaveTool implements Tool {
+  name = 'task_save';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const conversationId = input.conversation_id as string | undefined;
+    if (!conversationId || typeof conversationId !== 'string' || conversationId.trim().length === 0) {
+      return { content: 'Error: conversation_id is required and must be a non-empty string', isError: true };
+    }
+
+    const titleOverride = input.title as string | undefined;
+
+    try {
+      const compiled = compileTaskFromConversation(conversationId);
+
+      if (titleOverride && typeof titleOverride === 'string' && titleOverride.trim().length > 0) {
+        compiled.title = titleOverride.trim();
+      }
+
+      const task = saveCompiledTask(compiled, conversationId);
+
+      const lines = [
+        `Task saved successfully.`,
+        `  ID: ${task.id}`,
+        `  Title: ${task.title}`,
+        `  Template: ${task.template}`,
+      ];
+
+      if (compiled.requiredTools.length > 0) {
+        lines.push(`  Required tools: ${compiled.requiredTools.join(', ')}`);
+      }
+
+      if (compiled.inputSchema) {
+        const props = (compiled.inputSchema as Record<string, unknown>).properties as Record<string, unknown> | undefined;
+        if (props) {
+          lines.push(`  Input placeholders: ${Object.keys(props).join(', ')}`);
+        }
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const taskSaveTool = new TaskSaveTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,6 +18,7 @@ import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 import { followupCreateTool, followupListTool, followupResolveTool } from './followups/index.js';
+import { taskSaveTool, taskRunTool, taskListTool } from './tasks/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -105,6 +106,9 @@ export const explicitTools: Tool[] = [
   followupCreateTool,
   followupListTool,
   followupResolveTool,
+  taskSaveTool,
+  taskRunTool,
+  taskListTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds three new LLM-callable tools (`task_save`, `task_run`, `task_list`) in `assistant/src/tools/tasks/`
- `task_save` compiles a conversation into a reusable task template with placeholder extraction
- `task_run` resolves tasks by fuzzy name match or exact ID, renders the template with provided inputs, and returns the rendered template for LLM execution (v1 — no recursive message processing)
- `task_list` lists all saved tasks with ID, title, status, required tools, and creation date
- Registers all three tools in the tool manifest as explicit tool instances
- Includes 16 tests covering all tools (save, run by name/ID, error handling, template rendering, listing)

## Test plan
- [x] `bun test src/__tests__/task-tools.test.ts` — 16 tests pass
- [x] Type-check passes (`bunx tsc --noEmit` — no errors in new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
