### PR TITLE
fix: add comment to documentPreview inline surface case

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -95,6 +95,7 @@ struct SurfaceContainerView: View {
                     }
                 )
             case .table, .browserView, .documentPreview:
+                // These surfaces are rendered inline in chat, not in floating panels.
                 EmptyView()
             }
 


### PR DESCRIPTION
## Summary
- Adds an explanatory comment to the `.documentPreview` case in `SurfaceContainerView` clarifying it renders inline in chat, not in floating panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
