### PR TITLE
fix: preserve document content on editor panel reopen

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -44,12 +44,18 @@ struct DocumentEditorView: NSViewRepresentable {
         webView.navigationDelegate = context.coordinator
         context.coordinator.webView = webView
 
-        // Register coordinator with DocumentManager
+        // Load document content first (existing doc or empty placeholder).
+        // contentForEditorView() also clears pendingInitialContent so the coordinator
+        // didSet won't trigger a redundant second loadHTMLString.
+        if let doc = documentManager.contentForEditorView() {
+            loadEditorHTML(webView: webView, title: doc.title, content: doc.content)
+        } else {
+            loadEditorHTML(webView: webView, title: "Untitled Document", content: "")
+        }
+
+        // Register coordinator with DocumentManager (after loading so no double-load)
         documentManager.editorCoordinator = context.coordinator
         print("🔧 Coordinator registered with DocumentManager")
-
-        // Load initial empty document
-        loadEditorHTML(webView: webView, title: "Untitled Document", content: "")
 
         log.info("DocumentEditorView created")
         print("📄 DocumentEditorView created, loading HTML...")

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -16,8 +16,11 @@ final class DocumentManager: ObservableObject {
     @Published var lastSaveError: String?
 
     /// Current document content and metadata
-    private var currentContent: String = ""
+    private(set) var currentContent: String = ""
     private var currentWordCount: Int = 0
+
+    /// Initial content from daemon — persisted for panel reopen after the coordinator consumes pendingInitialContent
+    private(set) var initialContent: String = ""
 
     /// Pending initial content to be set when coordinator becomes ready
     private var pendingInitialContent: String?
@@ -42,6 +45,7 @@ final class DocumentManager: ObservableObject {
         self.surfaceId = surfaceId
         self.sessionId = sessionId
         self.title = title
+        self.initialContent = initialContent
         self.hasActiveDocument = true
 
         // Initialize editor with content (or store as pending if coordinator not ready)
@@ -52,6 +56,15 @@ final class DocumentManager: ObservableObject {
             pendingInitialContent = initialContent
             log.info("Document created (pending): surfaceId=\(surfaceId), title=\(title), waiting for coordinator")
         }
+    }
+
+    /// Returns the content the editor WebView should load when (re)created.
+    /// Clears pendingInitialContent so the coordinator didSet won't double-load.
+    func contentForEditorView() -> (title: String, content: String)? {
+        guard hasActiveDocument else { return nil }
+        let content = currentContent.isEmpty ? initialContent : currentContent
+        pendingInitialContent = nil
+        return (title: title, content: content)
     }
 
     func updateDocument(markdown: String, mode: String) {
@@ -79,6 +92,7 @@ final class DocumentManager: ObservableObject {
         title = "Untitled Document"
         currentContent = ""
         currentWordCount = 0
+        initialContent = ""
         pendingInitialContent = nil
         log.info("Document closed")
     }


### PR DESCRIPTION
## Summary
- Adds `contentForEditorView()` to `DocumentManager` to return the correct content (current or initial) when the editor WebView is (re)created, preventing blank panels on reopen.
- Stores `initialContent` from the daemon persistently so it survives after `pendingInitialContent` is consumed.
- Reorders `DocumentEditorView.makeNSView` to load content before registering the coordinator, eliminating the double-load race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)