### PR TITLE
feat: add Perplexity as default web search provider

### DIFF
--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -27,14 +27,14 @@ describe('WebSearchTool', () => {
       delete process.env.BRAVE_API_KEY;
       const result = await executeWebSearch({ query: 'test' }, undefined, 'brave');
       expect(result.isError).toBe(true);
-      expect(result.content).toContain('API key not configured');
+      expect(result.content).toContain('No web search API key configured');
     });
 
     test('returns error when no API key is configured (perplexity)', async () => {
       delete process.env.PERPLEXITY_API_KEY;
       const result = await executeWebSearch({ query: 'test' }, undefined, 'perplexity');
       expect(result.isError).toBe(true);
-      expect(result.content).toContain('API key not configured');
+      expect(result.content).toContain('No web search API key configured');
     });
   });
 
@@ -413,11 +413,8 @@ async function executeWebSearch(
   }
 
   if (!apiKey) {
-    const envVar = provider === 'brave' ? 'BRAVE_API_KEY' : 'PERPLEXITY_API_KEY';
-    const configKey = provider === 'brave' ? 'apiKeys.brave' : 'apiKeys.perplexity';
-    const providerName = provider === 'brave' ? 'Brave Search' : 'Perplexity';
     return {
-      content: `Error: ${providerName} API key not configured. Set ${envVar} environment variable or run: vellum config set ${configKey} <your-key>`,
+      content: 'Error: No web search API key configured. Set PERPLEXITY_API_KEY or BRAVE_API_KEY environment variable, or configure a key in settings.',
       isError: true,
     };
   }

--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -23,9 +23,16 @@ describe('WebSearchTool', () => {
   // by importing the module and testing the registered tool's execute method.
 
   describe('API key resolution', () => {
-    test('returns error when no API key is configured', async () => {
+    test('returns error when no API key is configured (brave)', async () => {
       delete process.env.BRAVE_API_KEY;
-      const result = await executeWebSearch({ query: 'test' }, undefined);
+      const result = await executeWebSearch({ query: 'test' }, undefined, 'brave');
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('API key not configured');
+    });
+
+    test('returns error when no API key is configured (perplexity)', async () => {
+      delete process.env.PERPLEXITY_API_KEY;
+      const result = await executeWebSearch({ query: 'test' }, undefined, 'perplexity');
       expect(result.isError).toBe(true);
       expect(result.content).toContain('API key not configured');
     });
@@ -45,20 +52,20 @@ describe('WebSearchTool', () => {
       // We need to test the tool's execute method directly
       // Since bun:test module mocking is limited for re-imports,
       // we'll create a minimal test using the tool's logic
-      const result = await executeWebSearch({}, 'test-key');
+      const result = await executeWebSearch({}, 'test-key', 'brave');
       expect(result.isError).toBe(true);
       expect(result.content).toContain('query is required');
       expect(fetchCalled).toBe(false);
     });
 
     test('rejects non-string query', async () => {
-      const result = await executeWebSearch({ query: 123 }, 'test-key');
+      const result = await executeWebSearch({ query: 123 }, 'test-key', 'brave');
       expect(result.isError).toBe(true);
       expect(result.content).toContain('query is required');
     });
   });
 
-  describe('parameter handling', () => {
+  describe('Brave parameter handling', () => {
     test('clamps count to valid range', async () => {
       let capturedUrl = '';
       globalThis.fetch = (async (url: string) => {
@@ -69,10 +76,10 @@ describe('WebSearchTool', () => {
         });
       }) as any;
 
-      await executeWebSearch({ query: 'test', count: 50 }, 'test-key');
+      await executeWebSearch({ query: 'test', count: 50 }, 'test-key', 'brave');
       expect(capturedUrl).toContain('count=20');
 
-      await executeWebSearch({ query: 'test', count: -5 }, 'test-key');
+      await executeWebSearch({ query: 'test', count: -5 }, 'test-key', 'brave');
       expect(capturedUrl).toContain('count=1');
     });
 
@@ -86,7 +93,7 @@ describe('WebSearchTool', () => {
         });
       }) as any;
 
-      await executeWebSearch({ query: 'test', offset: 20 }, 'test-key');
+      await executeWebSearch({ query: 'test', offset: 20 }, 'test-key', 'brave');
       expect(capturedUrl).toContain('offset=9');
     });
 
@@ -100,7 +107,7 @@ describe('WebSearchTool', () => {
         });
       }) as any;
 
-      await executeWebSearch({ query: 'test', freshness: 'pw' }, 'test-key');
+      await executeWebSearch({ query: 'test', freshness: 'pw' }, 'test-key', 'brave');
       expect(capturedUrl).toContain('freshness=pw');
     });
 
@@ -114,12 +121,12 @@ describe('WebSearchTool', () => {
         });
       }) as any;
 
-      await executeWebSearch({ query: 'test', freshness: 'invalid' }, 'test-key');
+      await executeWebSearch({ query: 'test', freshness: 'invalid' }, 'test-key', 'brave');
       expect(capturedUrl).not.toContain('freshness');
     });
   });
 
-  describe('API responses', () => {
+  describe('Brave API responses', () => {
     test('formats results correctly', async () => {
       const mockResults = {
         web: {
@@ -137,7 +144,7 @@ describe('WebSearchTool', () => {
         })
       ) as any;
 
-      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
       expect(result.content).toContain('Test Result');
       expect(result.content).toContain('https://example.com');
@@ -154,7 +161,7 @@ describe('WebSearchTool', () => {
         })
       ) as any;
 
-      const result = await executeWebSearch({ query: 'noresults' }, 'test-key');
+      const result = await executeWebSearch({ query: 'noresults' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
       expect(result.content).toContain('No results found');
     });
@@ -167,7 +174,7 @@ describe('WebSearchTool', () => {
         })
       ) as any;
 
-      const result = await executeWebSearch({ query: 'empty' }, 'test-key');
+      const result = await executeWebSearch({ query: 'empty' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
       expect(result.content).toContain('No results found');
     });
@@ -177,7 +184,7 @@ describe('WebSearchTool', () => {
         new Response('Unauthorized', { status: 401 })
       ) as any;
 
-      const result = await executeWebSearch({ query: 'test' }, 'bad-key');
+      const result = await executeWebSearch({ query: 'test' }, 'bad-key', 'brave');
       expect(result.isError).toBe(true);
       expect(result.content).toContain('Invalid or expired');
     });
@@ -195,7 +202,7 @@ describe('WebSearchTool', () => {
         );
       }) as any;
 
-      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
       expect(result.content).toContain('Result');
       expect(callCount).toBe(3);
@@ -206,7 +213,7 @@ describe('WebSearchTool', () => {
         new Response('Too Many Requests', { status: 429 })
       ) as any;
 
-      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(true);
       expect(result.content).toContain('rate limit');
       expect(result.content).toContain('after retries');
@@ -230,7 +237,7 @@ describe('WebSearchTool', () => {
         );
       }) as any;
 
-      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
       expect(callCount).toBe(2);
     });
@@ -240,7 +247,7 @@ describe('WebSearchTool', () => {
         throw new Error('Network unreachable');
       }) as any;
 
-      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(true);
       expect(result.content).toContain('Network unreachable');
     });
@@ -257,7 +264,7 @@ describe('WebSearchTool', () => {
         });
       }) as any;
 
-      await executeWebSearch({ query: 'test' }, 'my-api-key');
+      await executeWebSearch({ query: 'test' }, 'my-api-key', 'brave');
       expect(capturedHeaders['X-Subscription-Token']).toBe('my-api-key');
       expect(capturedHeaders['Accept']).toBe('application/json');
     });
@@ -283,10 +290,109 @@ describe('WebSearchTool', () => {
         })
       ) as any;
 
-      const result = await executeWebSearch({ query: 'test' }, 'test-key');
+      const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
       expect(result.content).toContain('Extra snippet 1');
       expect(result.content).toContain('Extra snippet 2');
+    });
+  });
+
+  describe('Perplexity API responses', () => {
+    test('formats results with citations', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'Perplexity found this information about the topic.' } }],
+        citations: ['https://example.com/source1', 'https://example.com/source2'],
+      };
+
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      ) as any;
+
+      const result = await executeWebSearch({ query: 'test' }, 'pplx-key', 'perplexity');
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('Perplexity found this information');
+      expect(result.content).toContain('https://example.com/source1');
+      expect(result.content).toContain('https://example.com/source2');
+    });
+
+    test('handles empty response', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: '' } }],
+      };
+
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      ) as any;
+
+      const result = await executeWebSearch({ query: 'noresults' }, 'pplx-key', 'perplexity');
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('No results found');
+    });
+
+    test('handles 401 unauthorized', async () => {
+      globalThis.fetch = (async () =>
+        new Response('Unauthorized', { status: 401 })
+      ) as any;
+
+      const result = await executeWebSearch({ query: 'test' }, 'bad-key', 'perplexity');
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Invalid or expired');
+    });
+
+    test('sends correct headers', async () => {
+      let capturedHeaders: Record<string, string> = {};
+      let capturedBody: any;
+      globalThis.fetch = (async (_url: string, init: any) => {
+        capturedHeaders = Object.fromEntries(
+          Object.entries(init.headers as Record<string, string>),
+        );
+        capturedBody = JSON.parse(init.body);
+        return new Response(JSON.stringify({ choices: [{ message: { content: 'result' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as any;
+
+      await executeWebSearch({ query: 'test query' }, 'pplx-my-key', 'perplexity');
+      expect(capturedHeaders['Authorization']).toBe('Bearer pplx-my-key');
+      expect(capturedHeaders['Content-Type']).toBe('application/json');
+      expect(capturedBody.model).toBe('sonar');
+      expect(capturedBody.messages[0].content).toBe('test query');
+    });
+
+    test('retries on 429 and succeeds', async () => {
+      let callCount = 0;
+      globalThis.fetch = (async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return new Response('Too Many Requests', { status: 429 });
+        }
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: 'Found it' } }] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }) as any;
+
+      const result = await executeWebSearch({ query: 'test' }, 'pplx-key', 'perplexity');
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('Found it');
+      expect(callCount).toBe(3);
+    });
+
+    test('handles network errors', async () => {
+      globalThis.fetch = (async () => {
+        throw new Error('Network unreachable');
+      }) as any;
+
+      const result = await executeWebSearch({ query: 'test' }, 'pplx-key', 'perplexity');
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Network unreachable');
     });
   });
 });
@@ -299,6 +405,7 @@ describe('WebSearchTool', () => {
 async function executeWebSearch(
   input: Record<string, unknown>,
   apiKey?: string,
+  provider: 'brave' | 'perplexity' = 'brave',
 ): Promise<{ content: string; isError: boolean }> {
   const query = input.query;
   if (!query || typeof query !== 'string') {
@@ -306,17 +413,32 @@ async function executeWebSearch(
   }
 
   if (!apiKey) {
+    const envVar = provider === 'brave' ? 'BRAVE_API_KEY' : 'PERPLEXITY_API_KEY';
+    const configKey = provider === 'brave' ? 'apiKeys.brave' : 'apiKeys.perplexity';
+    const providerName = provider === 'brave' ? 'Brave Search' : 'Perplexity';
     return {
-      content: 'Error: Brave Search API key not configured. Set BRAVE_API_KEY environment variable or run: vellum config set apiKeys.brave <your-key>',
+      content: `Error: ${providerName} API key not configured. Set ${envVar} environment variable or run: vellum config set ${configKey} <your-key>`,
       isError: true,
     };
   }
 
+  if (provider === 'perplexity') {
+    return executePerplexitySearchHelper(query as string, apiKey);
+  }
+
+  return executeBraveSearchHelper(input, query as string, apiKey);
+}
+
+async function executeBraveSearchHelper(
+  input: Record<string, unknown>,
+  query: string,
+  apiKey: string,
+): Promise<{ content: string; isError: boolean }> {
   const count = typeof input.count === 'number' ? Math.min(20, Math.max(1, Math.round(input.count))) : 10;
   const offset = typeof input.offset === 'number' ? Math.min(9, Math.max(0, Math.round(input.offset))) : 0;
 
   const params = new URLSearchParams({
-    q: query as string,
+    q: query,
     count: String(count),
     offset: String(offset),
   });
@@ -389,6 +511,75 @@ async function executeWebSearch(
     }
 
     return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: Web search failed: ${msg}`, isError: true };
+  }
+}
+
+async function executePerplexitySearchHelper(
+  query: string,
+  apiKey: string,
+): Promise<{ content: string; isError: boolean }> {
+  const MAX_RETRIES = 3;
+  const BASE_DELAY_MS = 1;
+
+  try {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const response = await fetch('https://api.perplexity.ai/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'sonar',
+          messages: [{ role: 'user', content: query }],
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json() as any;
+        const content = data.choices?.[0]?.message?.content;
+        if (!content) {
+          return { content: `No results found for "${query}".`, isError: false };
+        }
+
+        const lines: string[] = [`Web search results for "${query}":\n`];
+        lines.push(content);
+
+        if (data.citations && data.citations.length > 0) {
+          lines.push('\nSources:');
+          for (let i = 0; i < data.citations.length; i++) {
+            lines.push(`  [${i + 1}] ${data.citations[i]}`);
+          }
+        }
+
+        return { content: lines.join('\n'), isError: false };
+      }
+
+      await response.text();
+
+      if (response.status === 401 || response.status === 403) {
+        return { content: 'Error: Invalid or expired Perplexity API key', isError: true };
+      }
+
+      if (response.status === 429 && attempt < MAX_RETRIES) {
+        const retryAfter = response.headers.get('retry-after');
+        const delayMs = retryAfter && !isNaN(Number(retryAfter))
+          ? Number(retryAfter) * 1000
+          : BASE_DELAY_MS * Math.pow(2, attempt);
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        continue;
+      }
+
+      if (response.status === 429) {
+        return { content: 'Error: Perplexity rate limit exceeded after retries. Try again shortly.', isError: true };
+      }
+      return { content: `Error: Perplexity API returned status ${response.status}`, isError: true };
+    }
+
+    return { content: 'Error: Perplexity rate limit exceeded after retries. Try again shortly.', isError: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error: Web search failed: ${msg}`, isError: true };

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -5,6 +5,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   provider: 'anthropic',
   model: 'claude-opus-4-6', // alias: claude-opus-4
   apiKeys: {},
+  webSearchProvider: 'perplexity',
   providerOrder: [],
   maxTokens: 64000,
   thinking: {

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -10,7 +10,7 @@ import type { AssistantConfig } from './types.js';
 const log = getLogger('config');
 
 // Providers that store API keys in secure storage (superset of VALID_PROVIDERS)
-export const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'brave'] as const;
+export const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'brave', 'perplexity'] as const;
 
 let cached: AssistantConfig | null = null;
 let loading = false;
@@ -200,6 +200,9 @@ export function loadConfig(): AssistantConfig {
     }
     if (process.env.BRAVE_API_KEY) {
       config.apiKeys.brave = process.env.BRAVE_API_KEY;
+    }
+    if (process.env.PERPLEXITY_API_KEY) {
+      config.apiKeys.perplexity = process.env.PERPLEXITY_API_KEY;
     }
 
     loading = false;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { getDataDir } from '../util/platform.js';
 
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks'] as const;
+const VALID_WEB_SEARCH_PROVIDERS = ['perplexity', 'brave'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
 const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
@@ -751,6 +752,11 @@ export const AssistantConfigSchema = z.object({
   apiKeys: z
     .record(z.string(), z.string({ error: 'Each apiKeys value must be a string' }))
     .default({}),
+  webSearchProvider: z
+    .enum(VALID_WEB_SEARCH_PROVIDERS, {
+      error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(', ')}`,
+    })
+    .default('perplexity'),
   providerOrder: z
     .array(z.enum(VALID_PROVIDERS, {
       error: `Each providerOrder entry must be one of: ${VALID_PROVIDERS.join(', ')}`,

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -274,15 +274,23 @@ class WebSearchTool implements Tool {
       return { content: 'Error: query is required and must be a string', isError: true };
     }
 
-    const provider = getWebSearchProvider();
-    const apiKey = getApiKey(provider);
+    let provider = getWebSearchProvider();
+    let apiKey = getApiKey(provider);
+
+    // Fallback: if the configured provider has no key, try the other provider
     if (!apiKey) {
-      const envVar = provider === 'brave' ? 'BRAVE_API_KEY' : 'PERPLEXITY_API_KEY';
-      const configKey = provider === 'brave' ? 'apiKeys.brave' : 'apiKeys.perplexity';
-      return {
-        content: `Error: ${provider === 'brave' ? 'Brave Search' : 'Perplexity'} API key not configured. Set ${envVar} environment variable or run: vellum config set ${configKey} <your-key>`,
-        isError: true,
-      };
+      const fallback: WebSearchProvider = provider === 'perplexity' ? 'brave' : 'perplexity';
+      const fallbackKey = getApiKey(fallback);
+      if (fallbackKey) {
+        log.info({ from: provider, to: fallback }, 'Configured web search provider has no API key, falling back');
+        provider = fallback;
+        apiKey = fallbackKey;
+      } else {
+        return {
+          content: 'Error: No web search API key configured. Set PERPLEXITY_API_KEY or BRAVE_API_KEY environment variable, or configure a key in settings.',
+          isError: true,
+        };
+      }
     }
 
     try {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -9,6 +9,7 @@ import { getLogger } from '../../util/logger.js';
 const log = getLogger('web-search');
 
 const BRAVE_API_URL = 'https://api.search.brave.com/res/v1/web/search';
+const PERPLEXITY_API_URL = 'https://api.perplexity.ai/chat/completions';
 const RATE_LIMIT_MAX_RETRIES = 3;
 const RATE_LIMIT_BASE_DELAY_MS = 1000;
 
@@ -30,6 +31,8 @@ function parseRetryAfterMs(value: string): number | undefined {
   return undefined;
 }
 
+type WebSearchProvider = 'perplexity' | 'brave';
+
 interface BraveSearchResult {
   title: string;
   url: string;
@@ -43,20 +46,38 @@ interface BraveSearchResponse {
   web?: { results?: BraveSearchResult[] };
 }
 
-function getApiKey(): string | undefined {
-  // Environment variable takes priority
-  if (process.env.BRAVE_API_KEY) return process.env.BRAVE_API_KEY;
-
-  // Try secure storage
-  const secureKey = getSecureKey('brave');
-  if (secureKey) return secureKey;
-
-  // Fall back to config apiKeys
-  const config = getConfig();
-  return config.apiKeys.brave;
+interface PerplexityChoice {
+  message?: { content?: string };
 }
 
-function formatResults(results: BraveSearchResult[], query: string): string {
+interface PerplexityResponse {
+  choices?: PerplexityChoice[];
+  citations?: string[];
+}
+
+function getWebSearchProvider(): WebSearchProvider {
+  const config = getConfig();
+  return config.webSearchProvider ?? 'perplexity';
+}
+
+function getApiKey(provider: WebSearchProvider): string | undefined {
+  if (provider === 'brave') {
+    if (process.env.BRAVE_API_KEY) return process.env.BRAVE_API_KEY;
+    const secureKey = getSecureKey('brave');
+    if (secureKey) return secureKey;
+    const config = getConfig();
+    return config.apiKeys.brave;
+  }
+
+  // Perplexity
+  if (process.env.PERPLEXITY_API_KEY) return process.env.PERPLEXITY_API_KEY;
+  const secureKey = getSecureKey('perplexity');
+  if (secureKey) return secureKey;
+  const config = getConfig();
+  return config.apiKeys.perplexity;
+}
+
+function formatBraveResults(results: BraveSearchResult[], query: string): string {
   if (results.length === 0) {
     return `No results found for "${query}".`;
   }
@@ -84,9 +105,137 @@ function formatResults(results: BraveSearchResult[], query: string): string {
   return lines.join('\n');
 }
 
+function formatPerplexityResults(data: PerplexityResponse, query: string): string {
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    return `No results found for "${query}".`;
+  }
+
+  const lines: string[] = [`Web search results for "${query}":\n`];
+  lines.push(content);
+
+  if (data.citations && data.citations.length > 0) {
+    lines.push('\nSources:');
+    for (let i = 0; i < data.citations.length; i++) {
+      lines.push(`  [${i + 1}] ${data.citations[i]}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+async function executeBraveSearch(
+  query: string,
+  count: number,
+  offset: number,
+  freshness: string | undefined,
+  apiKey: string,
+): Promise<ToolExecutionResult> {
+  const params = new URLSearchParams({
+    q: query,
+    count: String(count),
+    offset: String(offset),
+  });
+
+  const validFreshness = ['pd', 'pw', 'pm', 'py'];
+  if (freshness && validFreshness.includes(freshness)) {
+    params.set('freshness', freshness);
+  }
+
+  const url = `${BRAVE_API_URL}?${params.toString()}`;
+
+  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+        'Accept-Encoding': 'gzip',
+        'X-Subscription-Token': apiKey,
+      },
+    });
+
+    if (response.ok) {
+      const data = await response.json() as BraveSearchResponse;
+      const results = data.web?.results ?? [];
+      return { content: formatBraveResults(results, query), isError: false };
+    }
+
+    await response.text();
+
+    if (response.status === 401 || response.status === 403) {
+      return { content: 'Error: Invalid or expired Brave Search API key', isError: true };
+    }
+
+    if (response.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
+      const retryAfter = response.headers.get('retry-after');
+      const parsed = retryAfter ? parseRetryAfterMs(retryAfter) : undefined;
+      const delayMs = parsed ?? RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
+      log.warn({ attempt: attempt + 1, delayMs }, 'Brave Search rate limited, retrying');
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      continue;
+    }
+
+    log.warn({ status: response.status }, 'Brave Search API error');
+    if (response.status === 429) {
+      return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
+    }
+    return { content: `Error: Brave Search API returned status ${response.status}`, isError: true };
+  }
+
+  return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
+}
+
+async function executePerplexitySearch(
+  query: string,
+  apiKey: string,
+): Promise<ToolExecutionResult> {
+  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+    const response = await fetch(PERPLEXITY_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'sonar',
+        messages: [
+          { role: 'user', content: query },
+        ],
+      }),
+    });
+
+    if (response.ok) {
+      const data = await response.json() as PerplexityResponse;
+      return { content: formatPerplexityResults(data, query), isError: false };
+    }
+
+    await response.text();
+
+    if (response.status === 401 || response.status === 403) {
+      return { content: 'Error: Invalid or expired Perplexity API key', isError: true };
+    }
+
+    if (response.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
+      const retryAfter = response.headers.get('retry-after');
+      const parsed = retryAfter ? parseRetryAfterMs(retryAfter) : undefined;
+      const delayMs = parsed ?? RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
+      log.warn({ attempt: attempt + 1, delayMs }, 'Perplexity rate limited, retrying');
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      continue;
+    }
+
+    log.warn({ status: response.status }, 'Perplexity API error');
+    if (response.status === 429) {
+      return { content: 'Error: Perplexity rate limit exceeded after retries. Try again shortly.', isError: true };
+    }
+    return { content: `Error: Perplexity API returned status ${response.status}`, isError: true };
+  }
+
+  return { content: 'Error: Perplexity rate limit exceeded after retries. Try again shortly.', isError: true };
+}
+
 class WebSearchTool implements Tool {
   name = 'web_search';
-  description = 'Search the web using Brave Search and return results. Useful for looking up current information, documentation, or anything the assistant doesn\'t know.';
+  description = 'Search the web and return results. Useful for looking up current information, documentation, or anything the assistant doesn\'t know.';
   category = 'network';
   defaultRiskLevel = RiskLevel.Low;
 
@@ -103,15 +252,15 @@ class WebSearchTool implements Tool {
           },
           count: {
             type: 'number',
-            description: 'Number of results to return (1-20, default 10)',
+            description: 'Number of results to return (1-20, default 10). Only used with Brave provider.',
           },
           offset: {
             type: 'number',
-            description: 'Pagination offset (0-9, default 0)',
+            description: 'Pagination offset (0-9, default 0). Only used with Brave provider.',
           },
           freshness: {
             type: 'string',
-            description: 'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year)',
+            description: 'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year). Only used with Brave provider.',
           },
         },
         required: ['query'],
@@ -125,74 +274,28 @@ class WebSearchTool implements Tool {
       return { content: 'Error: query is required and must be a string', isError: true };
     }
 
-    const apiKey = getApiKey();
+    const provider = getWebSearchProvider();
+    const apiKey = getApiKey(provider);
     if (!apiKey) {
+      const envVar = provider === 'brave' ? 'BRAVE_API_KEY' : 'PERPLEXITY_API_KEY';
+      const configKey = provider === 'brave' ? 'apiKeys.brave' : 'apiKeys.perplexity';
       return {
-        content: 'Error: Brave Search API key not configured. Set BRAVE_API_KEY environment variable or run: vellum config set apiKeys.brave <your-key>',
+        content: `Error: ${provider === 'brave' ? 'Brave Search' : 'Perplexity'} API key not configured. Set ${envVar} environment variable or run: vellum config set ${configKey} <your-key>`,
         isError: true,
       };
     }
 
-    const count = typeof input.count === 'number' ? Math.min(20, Math.max(1, Math.round(input.count))) : 10;
-    const offset = typeof input.offset === 'number' ? Math.min(9, Math.max(0, Math.round(input.offset))) : 0;
-
-    const params = new URLSearchParams({
-      q: query,
-      count: String(count),
-      offset: String(offset),
-    });
-
-    const validFreshness = ['pd', 'pw', 'pm', 'py'];
-    if (typeof input.freshness === 'string' && validFreshness.includes(input.freshness)) {
-      params.set('freshness', input.freshness);
-    }
-
-    const url = `${BRAVE_API_URL}?${params.toString()}`;
-
     try {
-      log.debug({ query, count, offset }, 'Executing web search');
+      log.debug({ query, provider }, 'Executing web search');
 
-      for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
-        const response = await fetch(url, {
-          headers: {
-            'Accept': 'application/json',
-            'Accept-Encoding': 'gzip',
-            'X-Subscription-Token': apiKey,
-          },
-        });
-
-        if (response.ok) {
-          const data = await response.json() as BraveSearchResponse;
-          const results = data.web?.results ?? [];
-          return { content: formatResults(results, query), isError: false };
-        }
-
-        // Consume body to release the connection, but don't log it —
-        // upstream error bodies may echo sensitive data from the request.
-        await response.text();
-
-        if (response.status === 401 || response.status === 403) {
-          return { content: 'Error: Invalid or expired Brave Search API key', isError: true };
-        }
-
-        if (response.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
-          const retryAfter = response.headers.get('retry-after');
-          const parsed = retryAfter ? parseRetryAfterMs(retryAfter) : undefined;
-          const delayMs = parsed ?? RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
-          log.warn({ attempt: attempt + 1, delayMs }, 'Brave Search rate limited, retrying');
-          await new Promise(resolve => setTimeout(resolve, delayMs));
-          continue;
-        }
-
-        log.warn({ status: response.status }, 'Brave Search API error');
-        if (response.status === 429) {
-          return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
-        }
-        return { content: `Error: Brave Search API returned status ${response.status}`, isError: true };
+      if (provider === 'brave') {
+        const count = typeof input.count === 'number' ? Math.min(20, Math.max(1, Math.round(input.count))) : 10;
+        const offset = typeof input.offset === 'number' ? Math.min(9, Math.max(0, Math.round(input.offset))) : 0;
+        const freshness = typeof input.freshness === 'string' ? input.freshness : undefined;
+        return await executeBraveSearch(query, count, offset, freshness, apiKey);
       }
 
-      // Should be unreachable, but satisfies TypeScript
-      return { content: 'Error: Brave Search rate limit exceeded after retries. Try again shortly.', isError: true };
+      return await executePerplexitySearch(query, apiKey);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ err }, 'Web search failed');

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -10,6 +10,7 @@ struct SettingsPanel: View {
 
     @State private var apiKeyText: String = ""
     @State private var braveKeyText: String = ""
+    @State private var perplexityKeyText: String = ""
     @State private var showingTrustRules = false
     @State private var showingScheduledTasks = false
     @State private var showingReminders = false
@@ -153,6 +154,61 @@ struct SettingsPanel: View {
                     .animation(VAnimation.fast, value: showModelDropdown)
                     .zIndex(showModelDropdown ? 1 : 0)
                 }
+
+                // PERPLEXITY SEARCH section
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("PERPLEXITY SEARCH")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    if store.hasPerplexityKey {
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(VColor.success)
+                                .font(.system(size: 14))
+                            Text(store.maskedPerplexityKey)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Spacer()
+                            VButton(label: "Clear", style: .danger) {
+                                store.clearPerplexityKey()
+                                perplexityKeyText = ""
+                            }
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.xs) {
+                            Text("Enter Perplexity API Key")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                            Image(systemName: "info.circle")
+                                .font(.system(size: 12))
+                                .foregroundColor(VColor.textMuted)
+                        }
+
+                        SecureField("Your Perplexity API key", text: $perplexityKeyText)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+
+                        Text("Get your API key at perplexity.ai/settings/api")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+
+                        VButton(label: "Save", style: .primary) {
+                            store.savePerplexityKey(perplexityKeyText)
+                            perplexityKeyText = ""
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
 
                 // BRAVE SEARCH section
                 VStack(alignment: .leading, spacing: VSpacing.md) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -10,9 +10,11 @@ public final class SettingsStore: ObservableObject {
 
     @Published var hasKey: Bool
     @Published var hasBraveKey: Bool
+    @Published var hasPerplexityKey: Bool
     @Published var hasVercelKey: Bool = false
     @Published var maskedKey: String = ""
     @Published var maskedBraveKey: String = ""
+    @Published var maskedPerplexityKey: String = ""
 
     // MARK: - Model Selection
 
@@ -76,6 +78,9 @@ public final class SettingsStore: ObservableObject {
         let braveKey = APIKeyManager.getKey(for: "brave")
         self.hasBraveKey = braveKey != nil
         self.maskedBraveKey = Self.maskKey(braveKey)
+        let perplexityKey = APIKeyManager.getKey(for: "perplexity")
+        self.hasPerplexityKey = perplexityKey != nil
+        self.maskedPerplexityKey = Self.maskKey(perplexityKey)
 
         let storedMaxSteps = UserDefaults.standard.double(forKey: "maxStepsPerSession")
         self.maxSteps = storedMaxSteps == 0 ? 50 : storedMaxSteps
@@ -162,6 +167,20 @@ public final class SettingsStore: ObservableObject {
         maskedBraveKey = ""
     }
 
+    func savePerplexityKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setKey(trimmed, for: "perplexity")
+        hasPerplexityKey = true
+        maskedPerplexityKey = Self.maskKey(trimmed)
+    }
+
+    func clearPerplexityKey() {
+        APIKeyManager.deleteKey(for: "perplexity")
+        hasPerplexityKey = false
+        maskedPerplexityKey = ""
+    }
+
     func refreshAPIKeyState() {
         let anthropicKey = APIKeyManager.getKey()
         hasKey = anthropicKey != nil
@@ -170,6 +189,10 @@ public final class SettingsStore: ObservableObject {
         let braveKey = APIKeyManager.getKey(for: "brave")
         hasBraveKey = braveKey != nil
         maskedBraveKey = Self.maskKey(braveKey)
+
+        let perplexityKey = APIKeyManager.getKey(for: "perplexity")
+        hasPerplexityKey = perplexityKey != nil
+        maskedPerplexityKey = Self.maskKey(perplexityKey)
     }
 
     /// Shows the first 10 and last 4 characters of a key, e.g. "sk-ant-api...Ab1x".

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ public struct SettingsView: View {
     @ObservedObject var store: SettingsStore
     @State private var apiKeyText = ""
     @State private var braveKeyText = ""
+    @State private var perplexityKeyText = ""
     @State private var vercelKeyText = ""
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
@@ -77,6 +78,38 @@ public struct SettingsView: View {
                     }
                     .onChange(of: store.selectedModel) { _, newValue in
                         store.setModel(newValue)
+                    }
+                }
+            }
+
+            Section("Perplexity API Key") {
+                if store.hasPerplexityKey {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.system(size: 14))
+                        Text(store.maskedPerplexityKey)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Clear") {
+                            store.clearPerplexityKey()
+                            perplexityKeyText = ""
+                        }
+                        .tint(.red)
+                    }
+                } else {
+                    SecureField("Enter Perplexity API key", text: $perplexityKeyText)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Text("Get your API key at perplexity.ai/settings/api")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Save") {
+                            store.savePerplexityKey(perplexityKeyText)
+                            perplexityKeyText = ""
+                        }
+                        .disabled(perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds Perplexity Sonar API as a web search provider alongside Brave Search, with Perplexity as the new default
- New `webSearchProvider` config option (`'perplexity'` | `'brave'`) to switch between providers
- Perplexity API key can be set via `PERPLEXITY_API_KEY` env var, secure storage, or settings UI
- macOS settings UI updated with Perplexity key entry in both SettingsPanel and SettingsView

## Test plan
- [x] All 24 web search tests pass (including new Perplexity-specific tests)
- [ ] Verify Perplexity search works end-to-end with a real API key
- [ ] Verify Brave search still works when `webSearchProvider` is set to `'brave'`
- [ ] Verify macOS settings UI shows Perplexity key entry and save/clear works
- [ ] Verify switching providers via config correctly routes searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
