### PR TITLE
M1: Add anti-repetition system notice after tool results

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -203,11 +203,14 @@ export class AgentLoop {
             block.type === 'tool_use',
         );
 
+        // Check if the assistant turn contained any visible text (used for
+        // both the empty-response nudge and the anti-repetition notice).
+        const hasTextBlock = response.content.some(
+          (block) => block.type === 'text' && block.text.trim().length > 0,
+        );
+
         if (toolUseBlocks.length === 0 || !this.toolExecutor) {
           // Check if the LLM returned no text after tool results — nudge it to respond
-          const hasTextBlock = response.content.some(
-            (block) => block.type === 'text' && block.text.trim().length > 0,
-          );
           const lastUserMsg = history.length >= 2 ? history[history.length - 2] : undefined;
           const lastWasToolResult =
             lastUserMsg?.role === 'user' &&
@@ -365,6 +368,14 @@ export class AgentLoop {
           resultBlocks.push({
             type: 'text',
             text: `<system_notice>${PROGRESS_CHECK_REMINDER}</system_notice>`,
+          });
+        }
+
+        // Remind the LLM not to repeat text it already streamed
+        if (hasTextBlock) {
+          resultBlocks.push({
+            type: 'text',
+            text: '<system_notice>Your previous text was already displayed to the user in real-time as you generated it. Continue naturally from where you left off — do not repeat or rephrase what you already said above.</system_notice>',
           });
         }
 


### PR DESCRIPTION
Injects a system_notice into the tool-result user message when the previous assistant turn contained visible text, preventing the LLM from repeating content that was already streamed to the user.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
