### PR TITLE
M2: Improve visual separation between text segments in interleaved messages

### DIFF
--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -145,28 +145,31 @@ public struct MessageBubbleView: View {
     @ViewBuilder
     private var interleavedContent: some View {
         let groups = groupContentBlocks()
-        ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
-            switch group {
-            case .text(let i):
-                if i < message.textSegments.count {
-                    let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !segmentText.isEmpty {
-                        messageBubble(text: segmentText, role: message.role)
-                    }
-                }
-            case .toolCalls(let indices):
-                let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
-                if !calls.isEmpty {
-                    ToolCallProgressBar(toolCalls: calls)
-                }
-            case .surface(let i):
-                if i < message.inlineSurfaces.count {
-                    InlineSurfaceRouter(
-                        surface: message.inlineSurfaces[i],
-                        onAction: { surfaceId, actionId, data in
-                            onSurfaceAction?(surfaceId, actionId, data)
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+                switch group {
+                case .text(let i):
+                    if i < message.textSegments.count {
+                        let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !segmentText.isEmpty {
+                            messageBubble(text: segmentText, role: message.role)
                         }
-                    )
+                    }
+                case .toolCalls(let indices):
+                    let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
+                    if !calls.isEmpty {
+                        ToolCallProgressBar(toolCalls: calls)
+                            .padding(.vertical, VSpacing.xs)
+                    }
+                case .surface(let i):
+                    if i < message.inlineSurfaces.count {
+                        InlineSurfaceRouter(
+                            surface: message.inlineSurfaces[i],
+                            onAction: { surfaceId, actionId, data in
+                                onSurfaceAction?(surfaceId, actionId, data)
+                            }
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Wraps the interleaved content ForEach in its own VStack with VSpacing.md (12pt) spacing and adds vertical padding around ToolCallProgressBar, so text segments separated by tool calls are visually distinct.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
