### PR TITLE
Fix duplicate assistant messages after tool calls

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -203,11 +203,14 @@ export class AgentLoop {
             block.type === 'tool_use',
         );
 
+        // Check if the assistant turn contained any visible text (used for
+        // both the empty-response nudge and the anti-repetition notice).
+        const hasTextBlock = response.content.some(
+          (block) => block.type === 'text' && block.text.trim().length > 0,
+        );
+
         if (toolUseBlocks.length === 0 || !this.toolExecutor) {
           // Check if the LLM returned no text after tool results — nudge it to respond
-          const hasTextBlock = response.content.some(
-            (block) => block.type === 'text' && block.text.trim().length > 0,
-          );
           const lastUserMsg = history.length >= 2 ? history[history.length - 2] : undefined;
           const lastWasToolResult =
             lastUserMsg?.role === 'user' &&
@@ -365,6 +368,14 @@ export class AgentLoop {
           resultBlocks.push({
             type: 'text',
             text: `<system_notice>${PROGRESS_CHECK_REMINDER}</system_notice>`,
+          });
+        }
+
+        // Remind the LLM not to repeat text it already streamed
+        if (hasTextBlock) {
+          resultBlocks.push({
+            type: 'text',
+            text: '<system_notice>Your previous text was already displayed to the user in real-time as you generated it. Continue naturally from where you left off — do not repeat or rephrase what you already said above.</system_notice>',
           });
         }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -619,7 +619,7 @@ struct ChatView: View {
                         }
                     }
 
-                    if isThinking {
+                    if isThinking && !(messages.last?.isStreaming == true) {
                         ThinkingIndicator(label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking")
                             .id("thinking-indicator")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -620,9 +620,12 @@ struct ChatView: View {
                     }
 
                     if isThinking && !(messages.last?.isStreaming == true) {
-                        ThinkingIndicator(label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking")
-                            .id("thinking-indicator")
-                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        RunningIndicator(
+                            label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking"
+                        )
+                        .frame(maxWidth: 520, alignment: .leading)
+                        .id("thinking-indicator")
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
 
                     // Invisible anchor at the very bottom of all content
@@ -2350,9 +2353,9 @@ private struct MarkdownTableView: View {
     }
 }
 
-// MARK: - Thinking Indicator
+// MARK: - Running Indicator
 
-/// Minimal in-progress indicator for tool execution, matching ThinkingIndicator style.
+/// Minimal in-progress indicator for thinking and tool execution.
 /// Supports progressive labels that cycle on a timer for long-running tools.
 private struct RunningIndicator: View {
     var label: String = "Running"
@@ -2479,57 +2482,6 @@ private struct CodePreviewView: View {
             return lines.suffix(30).joined(separator: "\n")
         }
         return code
-    }
-}
-
-private struct ThinkingIndicator: View {
-    var label: String = "Thinking"
-    @State private var phase: Int = 0
-    @State private var timer: Timer?
-
-    var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            HStack(spacing: 5) {
-                ForEach(0..<3, id: \.self) { index in
-                    Circle()
-                        .fill(VColor.textSecondary)
-                        .frame(width: 6, height: 6)
-                        .scaleEffect(dotScale(for: index))
-                        .opacity(dotOpacity(for: index))
-                }
-            }
-
-            Text(label)
-                .font(VFont.body)
-                .foregroundColor(VColor.textSecondary)
-
-            Spacer()
-        }
-        .padding(.horizontal, VSpacing.md)
-        .padding(.vertical, VSpacing.sm)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.backgroundSubtle.opacity(0.5))
-        )
-        .frame(maxWidth: 160, alignment: .leading)
-        .onAppear { startAnimation() }
-        .onDisappear { timer?.invalidate() }
-    }
-
-    private func dotOpacity(for index: Int) -> Double {
-        phase == index ? 1.0 : 0.35
-    }
-
-    private func dotScale(for index: Int) -> CGFloat {
-        phase == index ? 1.15 : 0.85
-    }
-
-    private func startAnimation() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
-            withAnimation(.easeInOut(duration: 0.4)) {
-                phase = (phase + 1) % 3
-            }
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -621,7 +621,8 @@ struct ChatView: View {
 
                     if isThinking && !(messages.last?.isStreaming == true) {
                         RunningIndicator(
-                            label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking"
+                            label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
+                            showIcon: false
                         )
                         .frame(maxWidth: 520, alignment: .leading)
                         .id("thinking-indicator")
@@ -2359,6 +2360,8 @@ private struct MarkdownTableView: View {
 /// Supports progressive labels that cycle on a timer for long-running tools.
 private struct RunningIndicator: View {
     var label: String = "Running"
+    /// Whether to show the terminal icon (appropriate for tool execution states).
+    var showIcon: Bool = true
     /// Optional sequence of labels to cycle through over time.
     var progressiveLabels: [String] = []
     /// Seconds between each label transition.
@@ -2393,9 +2396,11 @@ private struct RunningIndicator: View {
 
     private var indicatorContent: some View {
         HStack(spacing: VSpacing.xs) {
-            Image(systemName: "terminal")
-                .font(.system(size: 10))
-                .foregroundColor(VColor.textSecondary)
+            if showIcon {
+                Image(systemName: "terminal")
+                    .font(.system(size: 10))
+                    .foregroundColor(VColor.textSecondary)
+            }
 
             Text(displayLabel)
                 .font(VFont.caption)

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -145,28 +145,31 @@ public struct MessageBubbleView: View {
     @ViewBuilder
     private var interleavedContent: some View {
         let groups = groupContentBlocks()
-        ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
-            switch group {
-            case .text(let i):
-                if i < message.textSegments.count {
-                    let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !segmentText.isEmpty {
-                        messageBubble(text: segmentText, role: message.role)
-                    }
-                }
-            case .toolCalls(let indices):
-                let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
-                if !calls.isEmpty {
-                    ToolCallProgressBar(toolCalls: calls)
-                }
-            case .surface(let i):
-                if i < message.inlineSurfaces.count {
-                    InlineSurfaceRouter(
-                        surface: message.inlineSurfaces[i],
-                        onAction: { surfaceId, actionId, data in
-                            onSurfaceAction?(surfaceId, actionId, data)
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+                switch group {
+                case .text(let i):
+                    if i < message.textSegments.count {
+                        let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !segmentText.isEmpty {
+                            messageBubble(text: segmentText, role: message.role)
                         }
-                    )
+                    }
+                case .toolCalls(let indices):
+                    let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
+                    if !calls.isEmpty {
+                        ToolCallProgressBar(toolCalls: calls)
+                            .padding(.vertical, VSpacing.xs)
+                    }
+                case .surface(let i):
+                    if i < message.inlineSurfaces.count {
+                        InlineSurfaceRouter(
+                            surface: message.inlineSurfaces[i],
+                            onAction: { surfaceId, actionId, data in
+                                onSurfaceAction?(surfaceId, actionId, data)
+                            }
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes duplicate/repeated text in assistant messages during the bootstrap conversation (and any multi-turn agent loop with tool calls). The LLM was repeating previously-streamed text after tool call results, and text segments in interleaved messages had insufficient visual separation.

## Changes
- **Anti-repetition system notice** — Injects a `<system_notice>` into tool-result messages when the previous assistant turn contained visible text, instructing the LLM not to repeat content already streamed to the user
- **Visual separation** — Wraps interleaved content in its own VStack with 12pt spacing (up from 4pt) and adds vertical padding around tool call progress bars

## Milestone PRs (merged into feature branch)
- #4544: M1 — Add anti-repetition system notice after tool results
- #4545: M2 — Improve visual separation between text segments in interleaved messages

## Project issue
Closes #4537

## Test plan
- [ ] Start a fresh bootstrap conversation and verify the assistant doesn't repeat text after tool calls (SOUL.md edit, memory_save, etc.)
- [ ] Verify interleaved messages have clear visual separation between text segments and tool call indicators
- [ ] Verify non-bootstrap conversations still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
