### PR TITLE
fix: wire up CDP auto-detection on first browser use

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -639,7 +639,7 @@ export async function executeBrowserScroll(
       if (bounds) {
         // Convert screencast coords back to page coords for mouse.move
         const result = await page.evaluate(`(() => ({ vw: window.innerWidth, vh: window.innerHeight }))()`) as { vw: number; vh: number };
-        const scale = Math.min(800 / result.vw, 600 / result.vh);
+        const scale = Math.min(1280 / result.vw, 960 / result.vh);
         const pageX = (bounds.x + bounds.w / 2) / scale;
         const pageY = (bounds.y + bounds.h / 2) / scale;
         await page.mouse.move(pageX, pageY);

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -101,9 +101,18 @@ class BrowserManager {
   private cdpRequestResolvers = new Map<string, (response: { success: boolean; declined?: boolean }) => void>();
   private interactiveModeSessions = new Set<string>();
   private handoffResolvers = new Map<string, () => void>();
+  private sessionSenders = new Map<string, (msg: { type: string; sessionId: string }) => void>();
 
   get browserMode(): 'headless' | 'cdp' {
     return this._browserMode;
+  }
+
+  registerSender(sessionId: string, sendToClient: (msg: { type: string; sessionId: string }) => void): void {
+    this.sessionSenders.set(sessionId, sendToClient);
+  }
+
+  unregisterSender(sessionId: string): void {
+    this.sessionSenders.delete(sessionId);
   }
 
   setBrowserMode(mode: 'headless' | 'cdp', cdpUrl?: string): void {
@@ -171,6 +180,32 @@ class BrowserManager {
     if (this.contextCreating) return this.contextCreating;
 
     this.contextCreating = (async () => {
+      // If not already in CDP mode, try to detect or negotiate CDP
+      if (this._browserMode !== 'cdp') {
+        const cdpAvailable = await this.detectCDP();
+        if (cdpAvailable) {
+          this.setBrowserMode('cdp');
+        } else {
+          // Try requesting Chrome restart from the client
+          const [sessionId, sender] = this.sessionSenders.entries().next().value ?? [];
+          if (sessionId && sender) {
+            log.info({ sessionId }, 'Requesting CDP from client');
+            const accepted = await this.requestCDPFromClient(sessionId, sender);
+            if (accepted) {
+              // Verify CDP is now available after client confirmed restart
+              const nowAvailable = await this.detectCDP();
+              if (nowAvailable) {
+                this.setBrowserMode('cdp');
+              } else {
+                log.warn('Client accepted CDP request but CDP not detected, falling back to headless');
+              }
+            } else {
+              log.info('Client declined CDP request, falling back to headless');
+            }
+          }
+        }
+      }
+
       if (this._browserMode === 'cdp') {
         const pw = await import('playwright');
         const browser = await pw.chromium.connectOverCDP(this.cdpUrl);

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -405,8 +405,8 @@ class BrowserManager {
     await cdp.send('Page.startScreencast', {
       format: 'jpeg',
       quality: 60,
-      maxWidth: 800,
-      maxHeight: 600,
+      maxWidth: 1280,
+      maxHeight: 960,
       everyNthFrame: 1,
     });
   }

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -175,27 +175,28 @@ class BrowserManager {
     }
   }
 
-  private async ensureContext(): Promise<BrowserContext> {
+  private async ensureContext(invokingSessionId?: string): Promise<BrowserContext> {
     if (this.context) return this.context;
     if (this.contextCreating) return this.contextCreating;
 
     this.contextCreating = (async () => {
       // If not already in CDP mode, try to detect or negotiate CDP
-      if (this._browserMode !== 'cdp') {
+      let useCdp = this._browserMode === 'cdp';
+      if (!useCdp) {
         const cdpAvailable = await this.detectCDP();
         if (cdpAvailable) {
-          this.setBrowserMode('cdp');
+          useCdp = true;
         } else {
-          // Try requesting Chrome restart from the client
-          const [sessionId, sender] = this.sessionSenders.entries().next().value ?? [];
-          if (sessionId && sender) {
-            log.info({ sessionId }, 'Requesting CDP from client');
-            const accepted = await this.requestCDPFromClient(sessionId, sender);
+          // Try requesting Chrome restart from the client using the invoking session's sender
+          const sender = invokingSessionId ? this.sessionSenders.get(invokingSessionId) : undefined;
+          if (invokingSessionId && sender) {
+            log.info({ sessionId: invokingSessionId }, 'Requesting CDP from client');
+            const accepted = await this.requestCDPFromClient(invokingSessionId, sender);
             if (accepted) {
               // Verify CDP is now available after client confirmed restart
               const nowAvailable = await this.detectCDP();
               if (nowAvailable) {
-                this.setBrowserMode('cdp');
+                useCdp = true;
               } else {
                 log.warn('Client accepted CDP request but CDP not detected, falling back to headless');
               }
@@ -206,14 +207,20 @@ class BrowserManager {
         }
       }
 
-      if (this._browserMode === 'cdp') {
-        const pw = await import('playwright');
-        const browser = await pw.chromium.connectOverCDP(this.cdpUrl);
-        this.cdpBrowser = browser;
-        const contexts = browser.contexts();
-        const ctx = contexts[0] || await browser.newContext();
-        log.info({ cdpUrl: this.cdpUrl }, 'Connected to Chrome via CDP');
-        return ctx as unknown as BrowserContext;
+      if (useCdp) {
+        try {
+          const pw = await import('playwright');
+          const browser = await pw.chromium.connectOverCDP(this.cdpUrl);
+          this.cdpBrowser = browser;
+          const contexts = browser.contexts();
+          const ctx = contexts[0] || await browser.newContext();
+          this.setBrowserMode('cdp');
+          log.info({ cdpUrl: this.cdpUrl }, 'Connected to Chrome via CDP');
+          return ctx as unknown as BrowserContext;
+        } catch (err) {
+          log.warn({ err }, 'CDP connection failed, falling back to headless');
+          this._browserMode = 'headless';
+        }
       }
 
       const profileDir = getProfileDir();
@@ -295,7 +302,7 @@ class BrowserManager {
   }
 
   async getOrCreateSessionPage(sessionId: string): Promise<Page> {
-    const context = await this.ensureContext();
+    const context = await this.ensureContext(sessionId);
 
     const existing = this.pages.get(sessionId);
     if (existing && !existing.isClosed()) {

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -160,7 +160,7 @@ export async function getElementBounds(
       })()
     `) as { x: number; y: number; w: number; h: number; vw: number; vh: number } | null;
     if (!result) return null;
-    const scale = Math.min(800 / result.vw, 600 / result.vh);
+    const scale = Math.min(1280 / result.vw, 960 / result.vh);
     return {
       x: result.x * scale,
       y: result.y * scale,

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -14,6 +14,7 @@ const sessionSenders = new Map<string, (msg: ServerMessage) => void>();
  */
 export function registerSessionSender(sessionId: string, sendToClient: (msg: ServerMessage) => void): void {
   sessionSenders.set(sessionId, sendToClient);
+  browserManager.registerSender(sessionId, sendToClient as (msg: { type: string; sessionId: string }) => void);
 }
 
 /**
@@ -21,6 +22,7 @@ export function registerSessionSender(sessionId: string, sendToClient: (msg: Ser
  */
 export function unregisterSessionSender(sessionId: string): void {
   sessionSenders.delete(sessionId);
+  browserManager.unregisterSender(sessionId);
 }
 
 function getSender(sessionId: string): ((msg: ServerMessage) => void) | undefined {

--- a/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
+++ b/clients/macos/vellum-assistant/Features/BrowserPiP/BrowserPiPManager.swift
@@ -16,7 +16,7 @@ final class BrowserPiPManager: ObservableObject {
     @Published var highlights: [BrowserHighlight] = []
     @Published var isInteractive: Bool = false
     var handoffMessage: String?
-    var frameSize: CGSize = CGSize(width: 800, height: 600)
+    var frameSize: CGSize = CGSize(width: 1280, height: 960)
 
     var activePage: BrowserPage? {
         pages.first(where: { $0.active })
@@ -263,7 +263,7 @@ final class BrowserPiPManager: ObservableObject {
                 height: max(defaults.double(forKey: Self.sizeHKey), 150)
             )
         }
-        return NSRect(x: 0, y: 0, width: 400, height: 300)
+        return NSRect(x: 0, y: 0, width: 800, height: 600)
     }
 
     private func hasSavedPosition() -> Bool {


### PR DESCRIPTION
## Summary
- The CDP infrastructure (M1–M4: connection manager, Chrome restart dialog, interactive PiP, handoff protocol) was fully built but never activated — `setBrowserMode('cdp')` was never called anywhere
- `ensureContext()` now tries CDP detection before falling back to headless Playwright, and requests Chrome restart from the client via IPC if CDP isn't already available
- Session senders are now registered on `BrowserManager` so it can initiate the CDP negotiation when the first browser tool is invoked

## Test plan
- [x] Existing `browser-manager.test.ts` (16 tests), `connection-policy.test.ts`, and `browser-runtime-check.test.ts` all pass
- [ ] Manual: trigger a browser tool — verify Chrome restart dialog appears on client
- [ ] Manual: confirm CDP → auth page → verify PiP handoff activates instead of JIT form fallback
- [ ] Manual: decline CDP request → verify graceful fallback to headless Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
