### PR TITLE
M1: Permission cards — button order, labels, and styles

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -350,12 +350,10 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var buttonRow: some View {
-        // "Allow" comes first — intentional design choice to make the
-        // positive action the default leftmost (primary) button.
         HStack(spacing: VSpacing.xs) {
-            confirmationButton("Allow", isPrimary: true, isDanger: false) { onAllow() }
-            confirmationButton("Don\u{2019}t Allow", isPrimary: false, isDanger: true) { onDeny() }
             if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
+            confirmationButton("Allow Once", isPrimary: false, isDanger: false) { onAllow() }
+            confirmationButton("Don\u{2019}t Allow", isPrimary: false, isDanger: false) { onDeny() }
             Spacer()
         }
     }
@@ -386,7 +384,7 @@ public struct ToolConfirmationBubble: View {
             alwaysAllowDropdown
         } else {
             let patternDesc = confirmation.allowlistOptions.first?.description ?? ""
-            confirmationButton("Always Allow", isPrimary: false, isDanger: false) {
+            confirmationButton("Always Allow", isPrimary: true, isDanger: false) {
                 let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
                 let scope = confirmation.scopeOptions.first?.scope ?? ""
                 if !pattern.isEmpty && !scope.isEmpty {
@@ -402,7 +400,7 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var alwaysAllowDropdown: some View {
-        confirmationButton("Always Allow", isPrimary: false, isDanger: false) {
+        confirmationButton("Always Allow", isPrimary: true, isDanger: false) {
             withAnimation(VAnimation.fast) {
                 showAlwaysAllowMenu.toggle()
             }


### PR DESCRIPTION
- Rename 'Allow' → 'Allow Once'
- Reorder buttons: Always Allow (primary) | Allow Once (ghost) | Don't Allow (ghost)
- Remove danger style from Don't Allow button
- Always Allow uses primary style when available

Closes #4543
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
