### PR TITLE
M2: Permission cards — divider + rename Technical Details to More details

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -157,7 +157,9 @@ public struct ToolConfirmationBubble: View {
             // Action buttons at top
             buttonRow
 
-            // Technical details accordion (collapsed by default)
+            Divider()
+
+            // More Details accordion (collapsed by default)
             VStack(alignment: .leading, spacing: 0) {
                 Button {
                     withAnimation(VAnimation.fast) {
@@ -169,7 +171,7 @@ public struct ToolConfirmationBubble: View {
                             .font(.system(size: 9, weight: .semibold))
                             .foregroundColor(VColor.textMuted)
                             .rotationEffect(.degrees(showTechnicalDetails ? 90 : 0))
-                        Text("Technical details")
+                        Text("More details")
                             .font(VFont.captionMedium)
                             .foregroundColor(VColor.textMuted)
                     }


### PR DESCRIPTION
- Add Divider() between button row and collapsible details section
- Rename 'Technical details' label to 'More details'

Closes #4547
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
