### PR TITLE
M3: Skill invocation chip — add label and fix casing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/SkillInvocationChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/SkillInvocationChip.swift
@@ -11,7 +11,11 @@ struct SkillInvocationChip: View {
                     .font(VFont.cardEmoji)
             }
 
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Using skill")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textMuted)
+
                 Text(data.name)
                     .font(VFont.mono)
                     .foregroundColor(VColor.textPrimary)


### PR DESCRIPTION
- Add 'Using skill' header label (sentence case) above the skill name
- Clarifies context when the assistant invokes a skill
- Uses VFont.captionMedium + VColor.textMuted to match the muted label style used elsewhere in the UI

Part of permission-cards-polish polish pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
