### PR TITLE
M2: Auto-enable homeBaseDashboardDefaultEnabled after bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -157,7 +157,10 @@ struct MainWindowView: View {
 
     private func requestHomeBaseDashboardIfNeeded() {
         guard !isBootstrapOnboardingActive else { return }
-        guard homeBaseDashboardDefaultEnabled else { return }
+        // Auto-enable the dashboard once bootstrap is complete.
+        if !homeBaseDashboardDefaultEnabled {
+            homeBaseDashboardDefaultEnabled = true
+        }
         guard daemonClient.isConnected else { return }
         guard !requestedHomeBaseAtLaunch else { return }
         guard !windowState.isDynamicExpanded else {


### PR DESCRIPTION
Part of #4563. When bootstrap is complete (BOOTSTRAP.md deleted), automatically enables the Home Base dashboard flag so it opens by default on subsequent launches. Zero daemon changes — pure client-side detection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
