### PR TITLE
fix: descriptive tool confirmation messages for skill_load and integration_manage

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -80,6 +80,14 @@ public struct ToolConfirmationData: Equatable {
                 return "The assistant wants to open \(host)"
             }
             return "The assistant wants to open a page"
+        case "skill_load":
+            let skillName = (input["skill"]?.value as? String) ?? ""
+            if skillName.isEmpty { return "The assistant wants to load a skill" }
+            return "The assistant wants to load the \(skillName) skill"
+        case "integration_manage":
+            let service = (input["service"]?.value as? String) ?? ""
+            if service.isEmpty { return "The assistant wants to manage an integration" }
+            return "The assistant wants to manage the \(service) integration"
         default:
             return "The assistant wants to use \(toolName)"
         }
@@ -100,6 +108,14 @@ public struct ToolConfirmationData: Equatable {
             return "fetch \((input["url"]?.value as? String) ?? "")"
         case "browser_navigate":
             return "navigate \((input["url"]?.value as? String) ?? "")"
+        case "skill_load":
+            return "load skill: \((input["skill"]?.value as? String) ?? "")"
+        case "integration_manage":
+            let service = (input["service"]?.value as? String) ?? ""
+            let action = (input["action"]?.value as? String) ?? ""
+            if !service.isEmpty && !action.isEmpty { return "\(action) \(service) integration" }
+            if !service.isEmpty { return "manage \(service) integration" }
+            return "manage integration"
         case "request_system_permission":
             return (input["permission_type"]?.value as? String) ?? "system permission"
         default:
@@ -126,8 +142,9 @@ public struct ToolConfirmationData: Equatable {
         case _ where toolName.hasPrefix("schedule_"): return "Scheduling"
         case _ where toolName.hasPrefix("watcher_"):  return "Watcher"
         case _ where toolName.hasPrefix("memory_"):   return "Memory"
-        case "skill_load":                            return "Skill"
+        case "skill_load":                            return "Load Skill"
         case "evaluate_typescript_code":              return "Code Sandbox"
+        case "integration_manage":                    return "Integration"
         case "reminder":                              return "Reminder"
         case "document_create", "document_update":    return "Document"
         default:
@@ -156,6 +173,7 @@ public struct ToolConfirmationData: Equatable {
         case _ where toolName.hasPrefix("memory_"):   return "brain"
         case "skill_load":                            return "puzzlepiece.extension"
         case "evaluate_typescript_code":              return "chevron.left.forwardslash.chevron.right"
+        case "integration_manage":                    return "link"
         case "reminder":                              return "bell"
         case "document_create", "document_update":    return "doc.richtext"
         default:                                      return "puzzlepiece.extension"
@@ -289,6 +307,20 @@ public struct ToolConfirmationData: Equatable {
             default:
                 return "I would like to access secure storage."
             }
+        case "skill_load":
+            let skillName = (input["skill"]?.value as? String) ?? ""
+            if skillName.isEmpty { return "I would like to load a skill." }
+            let displayName = skillName
+                .replacingOccurrences(of: "-", with: " ")
+                .replacingOccurrences(of: "_", with: " ")
+                .split(separator: " ")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
+            return "I would like to load the \(displayName) skill."
+        case "integration_manage":
+            let service = (input["service"]?.value as? String) ?? ""
+            if service.isEmpty { return "I would like to manage an integration." }
+            return "I would like to manage the \(service.capitalized) integration."
         default:
             return "I would like to use \(toolCategory)."
         }


### PR DESCRIPTION
## Summary
- `skill_load` confirmation now shows "I would like to load the **Messaging** skill." instead of generic "I would like to use Skill."
- `integration_manage` confirmation now shows "I would like to manage the **Gmail** integration." instead of auto-formatted "I would like to use Integration Manage."
- Updated all 5 display properties: `toolCategory`, `toolCategoryIcon`, `humanDescription`, `detailsSummary`, and `commandPreview`

## Test plan
- [ ] Trigger `skill_load` (e.g. "help me declutter my email") and verify confirmation says "I would like to load the Messaging skill."
- [ ] Trigger `integration_manage` and verify confirmation shows the service name
- [ ] Verify collapsed state after approval shows "Load Skill allowed" / "Integration allowed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
