### PR TITLE
M3: Open Home Base with chat docked after creation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -19,6 +19,9 @@ struct MainWindowView: View {
     @State private var isHoveredThread: UUID?
     @State private var isHoveredApp: String?
     @State private var requestedHomeBaseAtLaunch = false
+    /// Set when the Home Base dashboard is about to open so the surface handler
+    /// can auto-dock the chat panel alongside it.
+    @State private var pendingHomeBaseAppId: String?
     @State private var threadPendingDeletion: UUID?
     @State private var showAllThreads: Bool = false
     @State private var showAllApps: Bool = false
@@ -179,6 +182,7 @@ struct MainWindowView: View {
                 name: homeBase.preview.title,
                 icon: homeBase.preview.icon
             )
+            self.pendingHomeBaseAppId = homeBase.appId
             try? self.daemonClient.sendAppOpen(appId: homeBase.appId)
         }
 
@@ -459,7 +463,19 @@ struct MainWindowView: View {
                 if let surface = windowState.activeDynamicParsedSurface,
                    case .dynamicPage(let dpData) = surface.data,
                    let appId = dpData.appId {
-                    windowState.selection = .app(appId)
+                    // Auto-dock chat alongside the Home Base dashboard
+                    if appId == pendingHomeBaseAppId {
+                        pendingHomeBaseAppId = nil
+                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
+                        if let threadId {
+                            threadManager.selectThread(id: threadId)
+                            windowState.setAppEditing(appId: appId, threadId: threadId)
+                        } else {
+                            windowState.selection = .app(appId)
+                        }
+                    } else {
+                        windowState.selection = .app(appId)
+                    }
                 } else {
                     windowState.selection = .app(msg.surfaceId)
                 }


### PR DESCRIPTION
Part of #4563. When the Home Base dashboard opens (either at launch or after bootstrap creation), automatically docks the chat panel alongside it using appEditing mode. Uses a pendingHomeBaseAppId state flag to detect when the Home Base surface arrives and transitions to split view.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
