### PR TITLE
M4: Show human-readable reason in shell command permission prompts

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -60,6 +60,10 @@ class HostShellTool implements Tool {
             type: 'string',
             description: 'The host shell command to execute',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief human-readable explanation of what this command does and why, shown to the user in the permission prompt (e.g. "to find available location services")',
+          },
           working_dir: {
             type: 'string',
             description: 'Optional absolute host working directory (defaults to user home)',

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -34,6 +34,10 @@ class ShellTool implements Tool {
             type: 'string',
             description: 'The shell command to execute',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief human-readable explanation of what this command does and why, shown to the user in the permission prompt (e.g. "to find available location services")',
+          },
           timeout_seconds: {
             type: 'number',
             description: 'Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.',


### PR DESCRIPTION
- Add optional `reason` field to `host_bash` and `bash` tool schemas
- When Claude provides a reason, the permission card shows e.g. 'I would like to run a shell command to give me information about location services I can use.'
- Falls back to the generic 'I would like to run a shell command.' when no reason is provided
- Swift client already reads `input["reason"]` — only schema change needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
