### PR TITLE
Add /update claude command

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -27,9 +27,9 @@ Pull the latest changes from main, restart the backend daemon, and rebuild/launc
    cd assistant && bun run src/index.ts daemon start && cd ..
    ```
 
-5. Build and launch the macOS app (run in background so it doesn't block):
+5. Build and launch the macOS app. Run this in the background since `build.sh run` enters a watch loop:
    ```bash
-   cd clients/macos && ./build.sh run
+   cd clients/macos && ./build.sh run &
    ```
 
 Report what was pulled (new commits) and confirm both the daemon and app are running.

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,0 +1,34 @@
+# Update — Pull Latest and Restart Vellum
+
+Pull the latest changes from main, restart the backend daemon, and rebuild/launch the macOS app.
+
+## Steps
+
+1. Kill any running Vellum and daemon processes:
+   ```bash
+   pkill -x "Vellum" || true
+   pkill -x "vellum-assistant" || true
+   vellum daemon stop || true
+   ```
+
+2. Pull latest from main:
+   ```bash
+   git pull origin main
+   ```
+
+3. Install any new dependencies:
+   ```bash
+   cd assistant && bun install && cd ..
+   ```
+
+4. Start the daemon fresh:
+   ```bash
+   cd assistant && bun run src/index.ts daemon start && cd ..
+   ```
+
+5. Build and launch the macOS app (run in background so it doesn't block):
+   ```bash
+   cd clients/macos && ./build.sh run
+   ```
+
+Report what was pulled (new commits) and confirm both the daemon and app are running.

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -11,8 +11,9 @@ Pull the latest changes from main, restart the backend daemon, and rebuild/launc
    vellum daemon stop || true
    ```
 
-2. Pull latest from main:
+2. Switch to main and pull latest:
    ```bash
+   git checkout main
    git pull origin main
    ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/safe-check-review [file]` | Check the active plan PR for review feedback from codex/devin/humans. Addresses requested changes, waits if reviews are pending. |
 | `/resume-plan [file]` | Merge the current plan PR, implement the next one, create it, and stop again. Repeats until the plan is complete. |
 | `/scrub` | Kill the running Vellum app (non-fatal if not running), wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+| `/update` | Pull latest from main, restart the backend daemon, and rebuild/launch the macOS app. |
 
 
 ## Track merged PRs


### PR DESCRIPTION
## Summary
- Adds a new `/update` slash command that pulls latest from main, restarts the backend daemon, and rebuilds/launches the macOS app
- Streamlines the common workflow of updating and restarting the local dev environment

## Test plan
- [ ] Run `/update` and verify it pulls, restarts daemon, and launches the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
