### PR TITLE
M2: Extract shared utilities from macOS ChatView.swift

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -2,53 +2,6 @@ import SwiftUI
 import VellumAssistantShared
 import UniformTypeIdentifiers
 
-private enum ChatTimestampTimeZone {
-    private static var cachedZone: TimeZone?
-    private static var cacheTimestamp: Date?
-    private static let cacheInterval: TimeInterval = 60
-    private static var observer: NSObjectProtocol?
-
-    /// Prefer the host's configured timezone over process-level TZ overrides
-    /// so chat dividers stay in the user's real local timezone.
-    /// Caches the result to avoid repeated filesystem reads in hot rendering paths.
-    static func resolve() -> TimeZone {
-        // Check if we have a valid cached value
-        if let cached = cachedZone,
-           let timestamp = cacheTimestamp,
-           Date().timeIntervalSince(timestamp) < cacheInterval {
-            return cached
-        }
-
-        // Register for timezone change notifications if not already registered
-        if observer == nil {
-            observer = NotificationCenter.default.addObserver(
-                forName: NSNotification.Name.NSSystemTimeZoneDidChange,
-                object: nil,
-                queue: .main
-            ) { _ in
-                cachedZone = nil
-                cacheTimestamp = nil
-            }
-        }
-
-        // Resolve timezone from /etc/localtime
-        let resolved: TimeZone
-        if let symlink = try? FileManager.default.destinationOfSymbolicLink(atPath: "/etc/localtime"),
-           let markerRange = symlink.range(of: "/zoneinfo/") {
-            let identifier = String(symlink[markerRange.upperBound...])
-            resolved = TimeZone(identifier: identifier) ?? .autoupdatingCurrent
-        } else {
-            resolved = .autoupdatingCurrent
-        }
-
-        // Update cache
-        cachedZone = resolved
-        cacheTimestamp = Date()
-
-        return resolved
-    }
-}
-
 struct ChatView: View {
     let messages: [ChatMessage]
     @Binding var inputText: String
@@ -1206,171 +1159,32 @@ private struct ChatBubble: View {
     /// Maps tool names to user-friendly past-tense labels.
     /// When `inputSummary` is provided, produces contextual labels like "Read config.json".
     private static func friendlyToolLabel(_ toolName: String, inputSummary: String = "") -> String {
-        let name = toolName.lowercased()
-        let summary = inputSummary
-            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespaces)
-
-        // Extract just the filename from a file path.
-        let fileName: String? = {
-            guard !summary.isEmpty else { return nil }
-            let last = (summary as NSString).lastPathComponent
-            guard !last.isEmpty, last != "." else { return nil }
-            return last
-        }()
-
-        switch name {
-        case "run command":
-            if !summary.isEmpty {
-                let display = summary.count > 30 ? String(summary.prefix(27)) + "..." : summary
-                return "Ran `\(display)`"
-            }
-            return "Ran a command"
-        case "read file":
-            if let f = fileName { return "Read \(f)" }
-            return "Read a file"
-        case "write file":
-            if let f = fileName { return "Wrote \(f)" }
-            return "Wrote a file"
-        case "edit file":
-            if let f = fileName { return "Edited \(f)" }
-            return "Edited a file"
-        case "search files":
-            if !summary.isEmpty {
-                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
-                return "Searched for '\(display)'"
-            }
-            return "Searched files"
-        case "find files":
-            if !summary.isEmpty {
-                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
-                return "Searched for \(display)"
-            }
-            return "Found files"
-        case "web search":
-            if !summary.isEmpty {
-                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
-                return "Searched '\(display)'"
-            }
-            return "Searched the web"
-        case "fetch url":              return "Fetched a webpage"
-        case "browser navigate":       return "Opened a page"
-        case "browser click":          return "Clicked on the page"
-        case "browser screenshot":     return "Took a screenshot"
-        case "request system permission":
-            return "\(Self.permissionFriendlyName(from: summary)) granted"
-        default:                       return "Used \(toolName)"
-        }
+        ToolDisplayHelpers.friendlyToolLabel(toolName, inputSummary: inputSummary)
     }
 
     /// Plural past-tense labels for multiple tool calls of the same type.
     private static func friendlyToolLabelPlural(_ toolName: String, count: Int) -> String {
-        switch toolName.lowercased() {
-        case "run command":        return "Ran \(count) commands"
-        case "read file":          return "Read \(count) files"
-        case "write file":         return "Wrote \(count) files"
-        case "edit file":          return "Edited \(count) files"
-        case "search files":       return "Ran \(count) searches"
-        case "find files":         return "Ran \(count) searches"
-        case "web search":         return "Searched the web \(count) times"
-        case "fetch url":          return "Fetched \(count) webpages"
-        case "browser navigate":   return "Opened \(count) pages"
-        case "browser click":      return "Clicked \(count) times"
-        case "browser screenshot":  return "Took \(count) screenshots"
-        default:                   return "Used \(toolName) \(count) times"
-        }
+        ToolDisplayHelpers.friendlyToolLabelPlural(toolName, count: count)
     }
 
     /// Maps tool names to user-friendly present-tense labels for the running state.
     private static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil, buildingStatus: String? = nil) -> String {
-        // For app file tools, prefer the descriptive building status from tool input
-        if let status = buildingStatus {
-            let lower = toolName.lowercased()
-            if lower == "app file edit" || lower == "app file write" || lower == "app create" || lower == "app update" {
-                return status
-            }
-        }
-        switch toolName.lowercased() {
-        case "run command":            return "Running a command"
-        case "read file":              return "Reading a file"
-        case "write file":             return "Writing a file"
-        case "edit file":              return "Editing a file"
-        case "search files":           return "Searching files"
-        case "find files":             return "Finding files"
-        case "web search":             return "Searching the web"
-        case "fetch url":              return "Fetching a webpage"
-        case "browser navigate":       return "Opening a page"
-        case "browser click":          return "Clicking on the page"
-        case "browser screenshot":     return "Taking a screenshot"
-        case "app create":             return "Building your app"
-        case "app update":             return "Updating your app"
-        case "skill load":
-            if let name = inputSummary, !name.isEmpty {
-                let display = name.replacingOccurrences(of: "-", with: " ").replacingOccurrences(of: "_", with: " ")
-                return "Loading \(display)"
-            }
-            return "Loading a skill"
-        default:                       return "Running \(toolName)"
-        }
+        ToolDisplayHelpers.friendlyRunningLabel(toolName, inputSummary: inputSummary, buildingStatus: buildingStatus)
     }
 
     /// Progressive labels for long-running tools. Cycles through these over time.
     private static func progressiveLabels(for toolName: String) -> [String] {
-        switch toolName.lowercased() {
-        case "app create":
-            return [
-                "Choosing a visual direction",
-                "Designing the layout",
-                "Writing the interface",
-                "Adding styles and colors",
-                "Wiring up interactions",
-                "Polishing the details",
-                "Almost there",
-            ]
-        case "app update":
-            return [
-                "Reviewing your app",
-                "Applying changes",
-                "Updating the interface",
-                "Polishing the details",
-            ]
-        default:
-            return []
-        }
+        ToolDisplayHelpers.progressiveLabels(for: toolName)
     }
 
     /// Icon for a tool category.
     private static func friendlyToolIcon(_ toolName: String) -> String {
-        switch toolName.lowercased() {
-        case "run command":                                 return "terminal"
-        case "read file":                                   return "doc.text"
-        case "write file":                                  return "doc.badge.plus"
-        case "edit file":                                   return "pencil"
-        case "search files", "find files", "web search":    return "magnifyingglass"
-        case "fetch url":                                   return "globe"
-        case "browser navigate", "browser click":           return "safari"
-        case "browser screenshot":                          return "camera"
-        case "request system permission":                   return "lock.shield"
-        default:                                            return "gearshape"
-        }
+        ToolDisplayHelpers.friendlyToolIcon(toolName)
     }
 
     /// Convert raw permission_type (e.g. "full_disk_access") to a user-facing label.
     private static func permissionFriendlyName(from rawType: String) -> String {
-        switch rawType {
-        case "full_disk_access": return "Full Disk Access"
-        case "accessibility": return "Accessibility"
-        case "screen_recording": return "Screen Recording"
-        case "calendar": return "Calendar"
-        case "contacts": return "Contacts"
-        case "photos": return "Photos"
-        case "location": return "Location Services"
-        case "microphone": return "Microphone"
-        case "camera": return "Camera"
-        default:
-            if rawType.isEmpty { return "Permission" }
-            return rawType.replacingOccurrences(of: "_", with: " ").capitalized
-        }
+        ToolDisplayHelpers.permissionFriendlyName(from: rawType)
     }
 
     private var compactToolChip: some View {
@@ -1964,20 +1778,11 @@ private struct ChatBubble: View {
     }
 
     private func fileIcon(for mimeType: String) -> String {
-        if mimeType.hasPrefix("text/") { return "doc.text.fill" }
-        if mimeType == "application/pdf" { return "doc.fill" }
-        if mimeType.contains("zip") || mimeType.contains("archive") { return "doc.zipper" }
-        if mimeType.contains("json") || mimeType.contains("xml") { return "doc.text.fill" }
-        return "doc.fill"
+        FileDisplayHelpers.fileIcon(for: mimeType)
     }
 
     private func formattedFileSize(base64Length: Int) -> String {
-        let bytes = base64Length * 3 / 4
-        if bytes < 1024 { return "\(bytes) B" }
-        let kb = Double(bytes) / 1024
-        if kb < 1024 { return String(format: "%.1f KB", kb) }
-        let mb = kb / 1024
-        return String(format: "%.1f MB", mb)
+        FileDisplayHelpers.formattedFileSize(base64Length: base64Length)
     }
 
     /// Cached markdown parser to avoid re-parsing on every render.

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -178,19 +178,7 @@ public struct ToolConfirmationData: Equatable {
 
     /// Friendly display name for the permission type.
     public var permissionFriendlyName: String {
-        guard let type = permissionType else { return "Permission" }
-        switch type {
-        case "full_disk_access": return "Full Disk Access"
-        case "accessibility": return "Accessibility"
-        case "screen_recording": return "Screen Recording"
-        case "calendar": return "Calendar"
-        case "contacts": return "Contacts"
-        case "photos": return "Photos"
-        case "location": return "Location Services"
-        case "microphone": return "Microphone"
-        case "camera": return "Camera"
-        default: return type.replacingOccurrences(of: "_", with: " ").capitalized
-        }
+        ToolDisplayHelpers.permissionFriendlyName(from: permissionType ?? "")
     }
 
     /// The macOS System Settings deep-link URL for the permission.

--- a/clients/shared/Utilities/ChatTimestampTimeZone.swift
+++ b/clients/shared/Utilities/ChatTimestampTimeZone.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Resolves the host's configured timezone with caching.
+/// Prefers the host's configured timezone over process-level TZ overrides
+/// so chat dividers stay in the user's real local timezone.
+public enum ChatTimestampTimeZone {
+    private static var cachedZone: TimeZone?
+    private static var cacheTimestamp: Date?
+    private static let cacheInterval: TimeInterval = 60
+    private static var observer: NSObjectProtocol?
+
+    /// Resolve the host timezone, caching the result to avoid repeated filesystem reads
+    /// in hot rendering paths.
+    public static func resolve() -> TimeZone {
+        // Check if we have a valid cached value
+        if let cached = cachedZone,
+           let timestamp = cacheTimestamp,
+           Date().timeIntervalSince(timestamp) < cacheInterval {
+            return cached
+        }
+
+        // Register for timezone change notifications if not already registered
+        if observer == nil {
+            observer = NotificationCenter.default.addObserver(
+                forName: NSNotification.Name.NSSystemTimeZoneDidChange,
+                object: nil,
+                queue: .main
+            ) { _ in
+                cachedZone = nil
+                cacheTimestamp = nil
+            }
+        }
+
+        // Resolve timezone from /etc/localtime
+        let resolved: TimeZone
+        #if os(macOS)
+        if let symlink = try? FileManager.default.destinationOfSymbolicLink(atPath: "/etc/localtime"),
+           let markerRange = symlink.range(of: "/zoneinfo/") {
+            let identifier = String(symlink[markerRange.upperBound...])
+            resolved = TimeZone(identifier: identifier) ?? .autoupdatingCurrent
+        } else {
+            resolved = .autoupdatingCurrent
+        }
+        #else
+        // iOS doesn't have /etc/localtime — use autoupdating directly
+        resolved = .autoupdatingCurrent
+        #endif
+
+        // Update cache
+        cachedZone = resolved
+        cacheTimestamp = Date()
+
+        return resolved
+    }
+}

--- a/clients/shared/Utilities/FileDisplayHelpers.swift
+++ b/clients/shared/Utilities/FileDisplayHelpers.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Shared file display helpers for icon selection and size formatting.
+public enum FileDisplayHelpers {
+
+    /// Returns an SF Symbol name appropriate for the given MIME type.
+    public static func fileIcon(for mimeType: String) -> String {
+        if mimeType.hasPrefix("text/") { return "doc.text.fill" }
+        if mimeType == "application/pdf" { return "doc.fill" }
+        if mimeType.contains("zip") || mimeType.contains("archive") { return "doc.zipper" }
+        if mimeType.contains("json") || mimeType.contains("xml") { return "doc.text.fill" }
+        return "doc.fill"
+    }
+
+    /// Formats a base64-encoded payload length into a human-readable file size.
+    public static func formattedFileSize(base64Length: Int) -> String {
+        let bytes = base64Length * 3 / 4
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024
+        if kb < 1024 { return String(format: "%.1f KB", kb) }
+        let mb = kb / 1024
+        return String(format: "%.1f MB", mb)
+    }
+}

--- a/clients/shared/Utilities/ToolDisplayHelpers.swift
+++ b/clients/shared/Utilities/ToolDisplayHelpers.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// Shared tool display helpers used by both macOS and iOS clients.
+/// Maps raw tool names to user-friendly labels, icons, and progressive status text.
+public enum ToolDisplayHelpers {
+
+    /// Maps tool names to user-friendly past-tense labels.
+    /// When `inputSummary` is provided, produces contextual labels like "Read config.json".
+    public static func friendlyToolLabel(_ toolName: String, inputSummary: String = "") -> String {
+        let name = toolName.lowercased()
+        let summary = inputSummary
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
+
+        // Extract just the filename from a file path.
+        let fileName: String? = {
+            guard !summary.isEmpty else { return nil }
+            let last = (summary as NSString).lastPathComponent
+            guard !last.isEmpty, last != "." else { return nil }
+            return last
+        }()
+
+        switch name {
+        case "run command":
+            if !summary.isEmpty {
+                let display = summary.count > 30 ? String(summary.prefix(27)) + "..." : summary
+                return "Ran `\(display)`"
+            }
+            return "Ran a command"
+        case "read file":
+            if let f = fileName { return "Read \(f)" }
+            return "Read a file"
+        case "write file":
+            if let f = fileName { return "Wrote \(f)" }
+            return "Wrote a file"
+        case "edit file":
+            if let f = fileName { return "Edited \(f)" }
+            return "Edited a file"
+        case "search files":
+            if !summary.isEmpty {
+                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
+                return "Searched for '\(display)'"
+            }
+            return "Searched files"
+        case "find files":
+            if !summary.isEmpty {
+                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
+                return "Searched for \(display)"
+            }
+            return "Found files"
+        case "web search":
+            if !summary.isEmpty {
+                let display = summary.count > 25 ? String(summary.prefix(22)) + "..." : summary
+                return "Searched '\(display)'"
+            }
+            return "Searched the web"
+        case "fetch url":              return "Fetched a webpage"
+        case "browser navigate":       return "Opened a page"
+        case "browser click":          return "Clicked on the page"
+        case "browser screenshot":     return "Took a screenshot"
+        case "request system permission":
+            return "\(permissionFriendlyName(from: summary)) granted"
+        default:                       return "Used \(toolName)"
+        }
+    }
+
+    /// Plural past-tense labels for multiple tool calls of the same type.
+    public static func friendlyToolLabelPlural(_ toolName: String, count: Int) -> String {
+        switch toolName.lowercased() {
+        case "run command":        return "Ran \(count) commands"
+        case "read file":          return "Read \(count) files"
+        case "write file":         return "Wrote \(count) files"
+        case "edit file":          return "Edited \(count) files"
+        case "search files":       return "Ran \(count) searches"
+        case "find files":         return "Ran \(count) searches"
+        case "web search":         return "Searched the web \(count) times"
+        case "fetch url":          return "Fetched \(count) webpages"
+        case "browser navigate":   return "Opened \(count) pages"
+        case "browser click":      return "Clicked \(count) times"
+        case "browser screenshot":  return "Took \(count) screenshots"
+        default:                   return "Used \(toolName) \(count) times"
+        }
+    }
+
+    /// Maps tool names to user-friendly present-tense labels for the running state.
+    public static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil, buildingStatus: String? = nil) -> String {
+        // For app file tools, prefer the descriptive building status from tool input
+        if let status = buildingStatus {
+            let lower = toolName.lowercased()
+            if lower == "app file edit" || lower == "app file write" || lower == "app create" || lower == "app update" {
+                return status
+            }
+        }
+        switch toolName.lowercased() {
+        case "run command":            return "Running a command"
+        case "read file":              return "Reading a file"
+        case "write file":             return "Writing a file"
+        case "edit file":              return "Editing a file"
+        case "search files":           return "Searching files"
+        case "find files":             return "Finding files"
+        case "web search":             return "Searching the web"
+        case "fetch url":              return "Fetching a webpage"
+        case "browser navigate":       return "Opening a page"
+        case "browser click":          return "Clicking on the page"
+        case "browser screenshot":     return "Taking a screenshot"
+        case "app create":             return "Building your app"
+        case "app update":             return "Updating your app"
+        case "skill load":
+            if let name = inputSummary, !name.isEmpty {
+                let display = name.replacingOccurrences(of: "-", with: " ").replacingOccurrences(of: "_", with: " ")
+                return "Loading \(display)"
+            }
+            return "Loading a skill"
+        default:                       return "Running \(toolName)"
+        }
+    }
+
+    /// Progressive labels for long-running tools. Cycles through these over time.
+    public static func progressiveLabels(for toolName: String) -> [String] {
+        switch toolName.lowercased() {
+        case "app create":
+            return [
+                "Choosing a visual direction",
+                "Designing the layout",
+                "Writing the interface",
+                "Adding styles and colors",
+                "Wiring up interactions",
+                "Polishing the details",
+                "Almost there",
+            ]
+        case "app update":
+            return [
+                "Reviewing your app",
+                "Applying changes",
+                "Updating the interface",
+                "Polishing the details",
+            ]
+        default:
+            return []
+        }
+    }
+
+    /// Icon for a tool category.
+    public static func friendlyToolIcon(_ toolName: String) -> String {
+        switch toolName.lowercased() {
+        case "run command":                                 return "terminal"
+        case "read file":                                   return "doc.text"
+        case "write file":                                  return "doc.badge.plus"
+        case "edit file":                                   return "pencil"
+        case "search files", "find files", "web search":    return "magnifyingglass"
+        case "fetch url":                                   return "globe"
+        case "browser navigate", "browser click":           return "safari"
+        case "browser screenshot":                          return "camera"
+        case "request system permission":                   return "lock.shield"
+        default:                                            return "gearshape"
+        }
+    }
+
+    /// Convert raw permission_type (e.g. "full_disk_access") to a user-facing label.
+    public static func permissionFriendlyName(from rawType: String) -> String {
+        switch rawType {
+        case "full_disk_access": return "Full Disk Access"
+        case "accessibility": return "Accessibility"
+        case "screen_recording": return "Screen Recording"
+        case "calendar": return "Calendar"
+        case "contacts": return "Contacts"
+        case "photos": return "Photos"
+        case "location": return "Location Services"
+        case "microphone": return "Microphone"
+        case "camera": return "Camera"
+        default:
+            if rawType.isEmpty { return "Permission" }
+            return rawType.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create ToolDisplayHelpers.swift with tool display functions (friendlyToolLabel, friendlyToolIcon, etc.)
- Create FileDisplayHelpers.swift with fileIcon and formattedFileSize
- Create ChatTimestampTimeZone.swift with timezone resolution
- Update ChatView.swift to delegate to shared helpers
- Update ChatMessage.permissionFriendlyName to use ToolDisplayHelpers

Part of #4553

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
