### PR TITLE
fix: show RunningIndicator for entire generation duration

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -133,7 +133,7 @@ struct ChatView: View {
     ]
 
     private var isEmptyState: Bool {
-        messages.isEmpty && !isThinking
+        messages.isEmpty && !isSending
     }
 
     private let composerMinHeight: CGFloat = 34
@@ -619,7 +619,7 @@ struct ChatView: View {
                         }
                     }
 
-                    if isThinking && !(messages.last?.isStreaming == true) {
+                    if isSending {
                         RunningIndicator(
                             label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
                             showIcon: false
@@ -640,17 +640,20 @@ struct ChatView: View {
                 .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)
-            .scrollDisabled(messages.isEmpty && !isThinking)
+            .scrollDisabled(messages.isEmpty && !isSending)
             .onAppear {
                 // Scroll to bottom on initial load
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
-            .onChange(of: isThinking) {
-                if isThinking {
+            .onChange(of: isSending) {
+                if isSending {
                     withAnimation(VAnimation.standard) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
-                } else {
+                }
+            }
+            .onChange(of: isThinking) {
+                if !isThinking {
                     // Thinking finished — mark flag so next message shows "Thinking"
                     if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                         hasEverSentMessage = true


### PR DESCRIPTION
Changed RunningIndicator visibility from isThinking to isSending so the indicator stays visible throughout the entire assistant generation, not just the initial thinking phase before text arrives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
