### PR TITLE
fix: close left sidebar when RTE is shown

### DIFF
--- a/assistant/src/tools/document/editor-template.ts
+++ b/assistant/src/tools/document/editor-template.ts
@@ -94,7 +94,6 @@ export function generateEditorHTML(title: string, initialContent: string): strin
     .editor-container {
       flex: 1;
       overflow: hidden;
-      padding: 24px;
     }
 
     #editor {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -234,8 +234,10 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = nil
                 }
 
-                // Close the left sidebar when the activity panel opens to avoid crowding
-                if case .panel(.activity) = newSelection, sidebarOpen {
+                // Close the left sidebar when the activity or document editor panel opens to avoid crowding
+                if case .panel(let panel) = newSelection,
+                   (panel == .activity || panel == .documentEditor),
+                   sidebarOpen {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         sidebarOpen = false
                     }


### PR DESCRIPTION
## Summary
- Close the left sidebar when the document editor (RTE) panel opens, matching existing behavior for the activity panel
- Prevents sidebar crowding when the document editor takes up the right panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
