### PR TITLE
fix: remove RTE header, show word count in panel toolbar

### DIFF
--- a/assistant/src/tools/document/editor-template.ts
+++ b/assistant/src/tools/document/editor-template.ts
@@ -62,14 +62,7 @@ export function generateEditorHTML(title: string, initialContent: string): strin
       overflow: hidden;
     }
 
-    .header {
-      padding: 16px 24px;
-      border-bottom: 1px solid var(--v-surface-border);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-shrink: 0;
-    }
+    .header { display: none; }
 
     .title-input {
       font-size: 20px;
@@ -107,7 +100,10 @@ export function generateEditorHTML(title: string, initialContent: string): strin
     .toastui-editor-toolbar-icons:hover { background: var(--v-surface-border) !important; }
     .toastui-editor-md-container,
     .toastui-editor-ww-container { background: var(--v-bg) !important; color: var(--v-text) !important; }
-    .toastui-editor-contents { color: var(--v-text) !important; }
+    .toastui-editor-contents { color: var(--v-text) !important; padding: 0 !important; }
+    .toastui-editor-ww-content { padding: 0 !important; }
+    .ProseMirror { padding: 0 !important; }
+    .toastui-editor-md-container .toastui-editor { padding: 0 !important; }
     .toastui-editor-contents h1,
     .toastui-editor-contents h2,
     .toastui-editor-contents h3 { color: var(--v-text) !important; border-bottom-color: var(--v-surface-border) !important; }

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -251,14 +251,7 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
       overflow: hidden;
     }
 
-    .header {
-      padding: 16px 24px;
-      border-bottom: 1px solid var(--v-surface-border);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-shrink: 0;
-    }
+    .header { display: none; }
 
     .title-input {
       font-size: 20px;
@@ -283,7 +276,6 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
     .editor-container {
       flex: 1;
       overflow: hidden;
-      padding: 24px;
     }
 
     #editor {
@@ -297,7 +289,10 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
     .toastui-editor-toolbar-icons:hover { background: var(--v-surface-border) !important; }
     .toastui-editor-md-container,
     .toastui-editor-ww-container { background: var(--v-bg) !important; color: var(--v-text) !important; }
-    .toastui-editor-contents { color: var(--v-text) !important; }
+    .toastui-editor-contents { color: var(--v-text) !important; padding: 0 !important; }
+    .toastui-editor-ww-content { padding: 0 !important; }
+    .ProseMirror { padding: 0 !important; }
+    .toastui-editor-md-container .toastui-editor { padding: 0 !important; }
     .toastui-editor-contents h1,
     .toastui-editor-contents h2,
     .toastui-editor-contents h3 { color: var(--v-text) !important; border-bottom-color: var(--v-surface-border) !important; }

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -17,7 +17,7 @@ final class DocumentManager: ObservableObject {
 
     /// Current document content and metadata
     private(set) var currentContent: String = ""
-    private var currentWordCount: Int = 0
+    @Published var wordCount: Int = 0
 
     /// Initial content from daemon — persisted for panel reopen after the coordinator consumes pendingInitialContent
     private(set) var initialContent: String = ""
@@ -82,7 +82,7 @@ final class DocumentManager: ObservableObject {
     func updateContent(title: String, content: String, wordCount: Int) {
         self.title = title
         self.currentContent = content
-        self.currentWordCount = wordCount
+        self.wordCount = wordCount
     }
 
     func closeDocument() {
@@ -91,7 +91,7 @@ final class DocumentManager: ObservableObject {
         sessionId = nil
         title = "Untitled Document"
         currentContent = ""
-        currentWordCount = 0
+        wordCount = 0
         initialContent = ""
         pendingInitialContent = nil
         log.info("Document closed")
@@ -109,7 +109,7 @@ final class DocumentManager: ObservableObject {
             return
         }
 
-        print("💾 Starting save: title=\(title), contentLength=\(currentContent.count), wordCount=\(currentWordCount)")
+        print("💾 Starting save: title=\(title), contentLength=\(currentContent.count), wordCount=\(wordCount)")
         isSaving = true
         lastSaveError = nil
 
@@ -119,9 +119,9 @@ final class DocumentManager: ObservableObject {
                 conversationId: sessionId,
                 title: title,
                 content: currentContent,
-                wordCount: currentWordCount
+                wordCount: wordCount
             )
-            log.info("Document save requested: \(surfaceId) - \(self.currentWordCount) words")
+            log.info("Document save requested: \(surfaceId) - \(self.wordCount) words")
             print("💾 ✅ IPC message sent successfully")
         } catch {
             log.error("Failed to send document save: \(error.localizedDescription)")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -15,6 +15,11 @@ struct DocumentEditorPanelView: View {
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(1)
                 Spacer()
+                if documentManager.wordCount > 0 {
+                    Text("\(documentManager.wordCount) words")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
                 if documentManager.isSaving {
                     ProgressView().controlSize(.small).scaleEffect(0.7)
                 } else {


### PR DESCRIPTION
## Summary
- Hide the duplicate title/word-count header inside the WebView (the white section below the panel toolbar)
- Move word count display into the Swift panel toolbar next to the save button
- Remove padding from editor container and Toast UI Editor internals so content fills edge-to-edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
