### PR TITLE
fix: task_save falls back to context conversationId

### DIFF
--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -125,11 +125,16 @@ describe('task_save tool', () => {
     expect(result.content).toContain('My Custom Title');
   });
 
-  test('returns error for missing conversation_id', async () => {
+  test('uses context conversation_id when missing', async () => {
+    const convId = createTestConversation(stubContext.conversationId);
+    addTestMessage(convId, 'user', 'Summarize the report');
+    addTestMessage(convId, 'assistant', 'Done.');
+
     const result = await taskSaveTool.execute({}, stubContext);
 
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain('conversation_id is required');
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Task saved successfully');
+    expect(result.content).toContain('Summarize the report');
   });
 
   test('returns error for nonexistent conversation', async () => {

--- a/assistant/src/tools/tasks/task-save.ts
+++ b/assistant/src/tools/tasks/task-save.ts
@@ -12,14 +12,14 @@ const definition: ToolDefinition = {
     properties: {
       conversation_id: {
         type: 'string',
-        description: 'The conversation to capture as a reusable task',
+        description: 'The conversation to capture as a reusable task. If omitted, uses the current conversation.',
       },
       title: {
         type: 'string',
         description: 'Optional override for the auto-generated task title',
       },
     },
-    required: ['conversation_id'],
+    required: [],
   },
 };
 
@@ -33,8 +33,8 @@ class TaskSaveTool implements Tool {
     return definition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const conversationId = input.conversation_id as string | undefined;
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const conversationId = (input.conversation_id as string | undefined) || context.conversationId;
     if (!conversationId || typeof conversationId !== 'string' || conversationId.trim().length === 0) {
       return { content: 'Error: conversation_id is required and must be a non-empty string', isError: true };
     }


### PR DESCRIPTION
## Summary
- The `task_save` tool required the model to pass a `conversation_id` parameter, but the model had no way to know the current conversation ID — it was never in the system prompt or visible context
- Now falls back to `context.conversationId` when the model omits the parameter
- Made `conversation_id` optional in the tool schema

## Test plan
- [x] Existing task-tools tests updated and passing (16/16)
- [ ] Manual: open the app, complete a task, ask to save it — should succeed without "conversation_id not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
