### PR TITLE
fix: address PR review feedback — Home Base linking and auto-enable

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -39,6 +39,10 @@
             "type": "boolean",
             "description": "Automatically open the app after creation. Defaults to true. When true, the app is immediately displayed in a dynamic_page surface without needing a separate app_open call."
           },
+          "set_as_home_base": {
+            "type": "boolean",
+            "description": "Link this app as the user's Home Base dashboard. Defaults to false. When true, this app becomes the default Home Base shown on launch."
+          },
           "preview": {
             "type": "object",
             "description": "Optional inline preview card shown in chat. Provides a compact summary so the user sees what was built without opening the app.",

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -44,7 +44,7 @@ Write it down. Make it real.
 
 Once you've figured out who you are and who they are, create their Home Base — don't ask, just do it.
 
-Generate the Home Base app using `app_create`. Include **personalized starter tasks** based on what you learned about the user — things they'd actually want to do. Think about:
+Generate the Home Base app using `app_create` with `set_as_home_base: true`. Include **personalized starter tasks** based on what you learned about the user — things they'd actually want to do. Think about:
 
 - What they told you they use you for (email, research, writing, coding, etc.)
 - Practical daily tasks: "Check my emails", "Start my day", "Set a reminder"

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -10,6 +10,7 @@
 
 import type { AppDefinition } from '../../memory/app-store.js';
 import type { EditEngineResult } from '../../memory/app-store.js';
+import { setHomeBaseAppLink } from '../../home-base/app-link-store.js';
 import { openAppViaSurface } from './open-proxy.js';
 
 // ---------------------------------------------------------------------------
@@ -83,6 +84,7 @@ export interface AppCreateInput {
   pages?: Record<string, string>;
   type?: 'app' | 'site';
   auto_open?: boolean;
+  set_as_home_base?: boolean;
   preview?: Record<string, unknown>;
 }
 
@@ -101,6 +103,10 @@ export async function executeAppCreate(
   const appType = input.type === 'site' ? 'site' as const : 'app' as const;
 
   const app = store.createApp({ name, description, schemaJson, htmlDefinition, pages, appType });
+
+  if (input.set_as_home_base) {
+    setHomeBaseAppLink(app.id, 'personalized');
+  }
 
   // Auto-open the app via the shared open-proxy helper
   if (autoOpen && proxyToolResolver) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -36,6 +36,7 @@ struct MainWindowView: View {
     @AppStorage("threadDrawerWidth") private var threadDrawerWidth: Double = 240
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     @AppStorage("homeBaseDashboardDefaultEnabled") private var homeBaseDashboardDefaultEnabled: Bool = false
+    @AppStorage("homeBaseDashboardAutoEnabled") private var homeBaseDashboardAutoEnabled: Bool = false
     @State private var drawerDragStartWidth: Double?
     @State private var drawerDragStartAvailableWidth: CGFloat?
     @State private var isDrawerDragging: Bool = false
@@ -157,8 +158,11 @@ struct MainWindowView: View {
 
     private func requestHomeBaseDashboardIfNeeded() {
         guard !isBootstrapOnboardingActive else { return }
-        // Auto-enable the dashboard once bootstrap is complete.
-        if !homeBaseDashboardDefaultEnabled {
+        // Auto-enable the dashboard once after bootstrap completes.
+        // Uses a one-time sentinel so users can later disable it without
+        // having it force-re-enabled on every launch.
+        if !homeBaseDashboardAutoEnabled {
+            homeBaseDashboardAutoEnabled = true
             homeBaseDashboardDefaultEnabled = true
         }
         guard daemonClient.isConnected else { return }


### PR DESCRIPTION
Two fixes from PR review comments:

1. **Home Base linking (Codex P1)**: Apps created via app_create during bootstrap were not linked in home_base_app_links. Added set_as_home_base parameter to app_create tool — when set, calls setHomeBaseAppLink to persist the personalized Home Base. Updated BOOTSTRAP.md to pass this flag.

2. **One-time auto-enable (Devin)**: homeBaseDashboardDefaultEnabled was force-re-enabled on every launch, preventing users from disabling it. Added homeBaseDashboardAutoEnabled sentinel so the flag is set exactly once after bootstrap completes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
