### PR TITLE
fix: respect homeBaseDashboardDefaultEnabled after one-time auto-enable

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -165,6 +165,7 @@ struct MainWindowView: View {
             homeBaseDashboardAutoEnabled = true
             homeBaseDashboardDefaultEnabled = true
         }
+        guard homeBaseDashboardDefaultEnabled else { return }
         guard daemonClient.isConnected else { return }
         guard !requestedHomeBaseAtLaunch else { return }
         guard !windowState.isDynamicExpanded else {


### PR DESCRIPTION
Add missing guard after the one-time auto-enable block so users can later disable Home Base on launch and have it stay disabled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
