### PR TITLE
fix: return personalized app metadata in handleHomeBaseGet

### DIFF
--- a/assistant/src/daemon/handlers/home-base.ts
+++ b/assistant/src/daemon/handlers/home-base.ts
@@ -6,6 +6,7 @@ import {
   getPrebuiltHomeBaseTaskPayload,
 } from '../../home-base/prebuilt/seed.js';
 import { getHomeBaseAppLink } from '../../home-base/app-link-store.js';
+import { getApp } from '../../memory/app-store.js';
 import { log, type HandlerContext } from './shared.js';
 
 export function handleHomeBaseGet(
@@ -24,15 +25,41 @@ export function handleHomeBaseGet(
       return;
     }
 
-    const tasks = getPrebuiltHomeBaseTaskPayload();
-    const preview = getPrebuiltHomeBasePreview();
     const link = getHomeBaseAppLink();
+    const source = link?.source ?? 'prebuilt_seed';
+
+    let preview: {
+      title: string;
+      subtitle: string;
+      description: string;
+      icon: string;
+      metrics: Array<{ label: string; value: string }>;
+    };
+
+    if (source === 'personalized') {
+      const app = getApp(appId);
+      if (app) {
+        preview = {
+          title: app.name,
+          subtitle: 'Dashboard',
+          description: app.description ?? '',
+          icon: app.icon ?? '🏠',
+          metrics: [],
+        };
+      } else {
+        preview = getPrebuiltHomeBasePreview();
+      }
+    } else {
+      preview = getPrebuiltHomeBasePreview();
+    }
+
+    const tasks = getPrebuiltHomeBaseTaskPayload();
 
     ctx.send(socket, {
       type: 'home_base_get_response',
       homeBase: {
         appId,
-        source: link?.source ?? 'prebuilt_seed',
+        source,
         starterTasks: tasks.starterTasks,
         onboardingTasks: tasks.onboardingTasks,
         preview,


### PR DESCRIPTION
When the Home Base link source is 'personalized', look up the app from the app store and return its actual name/description/icon instead of always returning hardcoded prebuilt metadata. Falls back to prebuilt metadata if the app lookup fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
