### PR TITLE
feat: consolidate markdown parsers into shared MarkdownBlockParser (#4561)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -1,257 +1,39 @@
 import Foundation
+import VellumAssistantShared
 
-/// A segment of message content — either plain text or a parsed table.
-struct ListItem {
-    let indent: Int
-    let ordered: Bool
-    let number: Int      // meaningful only when ordered == true
-    let text: String
-}
+// Backward-compatible typealiases — macOS ChatView.swift references these types.
+typealias ListItem = MarkdownListItem
+typealias MarkdownSegment = MarkdownBlock
 
-enum MarkdownSegment {
-    case text(String)
-    case table(headers: [String], rows: [[String]])
-    case image(alt: String, url: String)
-    case heading(level: Int, text: String)
-    case codeBlock(language: String?, code: String)
-    case horizontalRule
-    case list(items: [ListItem])
-}
-
-/// Returns a heading if `line` starts with 1–6 `#` chars followed by a space.
+/// Delegates to the shared `MarkdownBlockParser`.
 func isHeadingLine(_ line: String) -> (level: Int, text: String)? {
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    let hashes = trimmed.prefix(while: { $0 == "#" })
-    let level = hashes.count
-    guard level >= 1, level <= 6 else { return nil }
-    let rest = trimmed.dropFirst(level)
-    guard rest.first == " " else { return nil }
-    return (level, String(rest.dropFirst()).trimmingCharacters(in: .whitespaces))
+    MarkdownBlockParser.parseHeading(line)
 }
 
-/// Returns true if `line` is a horizontal rule (`---`, `***`, or `___` with 3+ chars).
 func isHorizontalRule(_ line: String) -> Bool {
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    let stripped = trimmed.filter { !$0.isWhitespace }
-    guard stripped.count >= 3 else { return false }
-    guard let ch = stripped.first, (ch == "-" || ch == "*" || ch == "_") else { return false }
-    return stripped.allSatisfy { $0 == ch }
+    MarkdownBlockParser.isHorizontalRule(line)
 }
 
-/// Returns a `ListItem` if the line looks like a list entry, otherwise nil.
 func parseListLine(_ line: String) -> ListItem? {
-    // Measure indent (count leading spaces, tabs count as 4)
-    var indent = 0
-    for ch in line {
-        if ch == " " { indent += 1 }
-        else if ch == "\t" { indent += 4 }
-        else { break }
-    }
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-
-    // Unordered: `- `, `* `, `+ `
-    if (trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ")) {
-        return ListItem(indent: indent, ordered: false, number: 0, text: String(trimmed.dropFirst(2)))
-    }
-    // Ordered: `1. `, `2. `, etc.
-    let digits = trimmed.prefix(while: { $0.isNumber })
-    if !digits.isEmpty {
-        let rest = trimmed.dropFirst(digits.count)
-        if rest.hasPrefix(". ") {
-            return ListItem(indent: indent, ordered: true, number: Int(digits) ?? 1,
-                            text: String(rest.dropFirst(2)))
-        }
-    }
-    return nil
+    MarkdownBlockParser.parseListLine(line)
 }
 
 func isTableRow(_ line: String) -> Bool {
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    return trimmed.hasPrefix("|") && trimmed.hasSuffix("|")
-        && trimmed.filter({ $0 == "|" }).count >= 2
+    MarkdownBlockParser.isTableRow(line)
 }
 
 func isTableSeparator(_ line: String) -> Bool {
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    guard trimmed.hasPrefix("|") && trimmed.hasSuffix("|") else { return false }
-    let inner = trimmed.dropFirst().dropLast()
-    // Each cell should be dashes (with optional colons for alignment)
-    return inner.split(separator: "|").allSatisfy { cell in
-        let c = cell.trimmingCharacters(in: .whitespaces)
-        return !c.isEmpty && c.allSatisfy({ $0 == "-" || $0 == ":" })
-    }
+    MarkdownBlockParser.isTableSeparator(line)
 }
 
 func parseTableCells(_ line: String) -> [String] {
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    let inner = String(trimmed.dropFirst().dropLast())  // strip outer pipes
-    return inner.components(separatedBy: "|")
-        .map { $0.trimmingCharacters(in: .whitespaces) }
+    MarkdownBlockParser.parseTableCells(line)
 }
 
-/// Parses message text into segments, extracting markdown tables, code blocks, headings, lists, and rules.
 func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
-    let lines = text.components(separatedBy: .newlines)
-    var segments: [MarkdownSegment] = []
-    var currentText: [String] = []
-    var i = 0
-    var fenceDelimiter: (character: Character, length: Int)? = nil
-    var codeBlockLanguage: String? = nil
-    var codeBlockLines: [String] = []
-
-    func flushText() {
-        let pending = currentText.joined(separator: "\n")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if !pending.isEmpty {
-            segments.append(.text(pending))
-        }
-        currentText = []
-    }
-
-    while i < lines.count {
-        let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
-
-        // --- Inside a fenced code block ---
-        if let fence = fenceDelimiter {
-            let closeCount = trimmed.prefix(while: { $0 == fence.character }).count
-            if closeCount >= fence.length && trimmed.drop(while: { $0 == fence.character }).allSatisfy(\.isWhitespace) {
-                // Closing fence — emit code block
-                fenceDelimiter = nil
-                segments.append(.codeBlock(language: codeBlockLanguage, code: codeBlockLines.joined(separator: "\n")))
-                codeBlockLines = []
-                codeBlockLanguage = nil
-            } else {
-                codeBlockLines.append(lines[i])
-            }
-            i += 1
-            continue
-        }
-
-        // --- Opening a new fence ---
-        if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
-            flushText()
-            let fenceChar = trimmed.first!
-            let fenceLen = trimmed.prefix(while: { $0 == fenceChar }).count
-            fenceDelimiter = (fenceChar, fenceLen)
-            let lang = trimmed.dropFirst(fenceLen).trimmingCharacters(in: .whitespaces)
-            codeBlockLanguage = lang.isEmpty ? nil : lang
-            i += 1
-            continue
-        }
-
-        // --- Table detection ---
-        if i + 2 < lines.count,
-           isTableRow(lines[i]),
-           isTableSeparator(lines[i + 1]),
-           isTableRow(lines[i + 2]) {
-            flushText()
-            let headers = parseTableCells(lines[i])
-            i += 2  // skip separator
-            var rows: [[String]] = []
-            while i < lines.count, isTableRow(lines[i]) {
-                let cells = parseTableCells(lines[i])
-                let padded = Array(cells.prefix(headers.count))
-                    + Array(repeating: "", count: max(0, headers.count - cells.count))
-                rows.append(padded)
-                i += 1
-            }
-            segments.append(.table(headers: headers, rows: rows))
-            continue
-        }
-
-        // --- Heading detection ---
-        if let heading = isHeadingLine(lines[i]) {
-            flushText()
-            segments.append(.heading(level: heading.level, text: heading.text))
-            i += 1
-            continue
-        }
-
-        // --- Horizontal rule detection ---
-        if isHorizontalRule(trimmed) {
-            flushText()
-            segments.append(.horizontalRule)
-            i += 1
-            continue
-        }
-
-        // --- List detection (consecutive list lines) ---
-        if parseListLine(lines[i]) != nil {
-            flushText()
-            var items: [ListItem] = []
-            while i < lines.count, let item = parseListLine(lines[i]) {
-                items.append(item)
-                i += 1
-            }
-            segments.append(.list(items: items))
-            continue
-        }
-
-        // --- Plain text ---
-        currentText.append(lines[i])
-        i += 1
-    }
-
-    // If a fence was never closed, emit accumulated code block lines as text
-    if fenceDelimiter != nil {
-        let fenceChar = fenceDelimiter!.character
-        let fenceLen = fenceDelimiter!.length
-        let opener = String(repeating: String(fenceChar), count: fenceLen) + (codeBlockLanguage ?? "")
-        currentText.append(opener)
-        currentText.append(contentsOf: codeBlockLines)
-    }
-
-    flushText()
-
-    // Post-process .text segments to extract inline images.
-    return segments.flatMap { segment -> [MarkdownSegment] in
-        if case .text(let content) = segment {
-            return extractImageSegments(from: content)
-        }
-        return [segment]
-    }
+    MarkdownBlockParser.parse(text)
 }
 
-/// Splits text around `![alt](url)` matches, returning mixed `.text` / `.image` segments.
 func extractImageSegments(from text: String) -> [MarkdownSegment] {
-    let pattern = #"!\[([^\]]*)\]\(([^)]+)\)"#
-    guard let regex = try? NSRegularExpression(pattern: pattern) else {
-        return [.text(text)]
-    }
-
-    let nsText = text as NSString
-    let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
-
-    if matches.isEmpty { return [.text(text)] }
-
-    var segments: [MarkdownSegment] = []
-    var lastEnd = 0
-
-    for match in matches {
-        // Text before the image
-        if match.range.location > lastEnd {
-            let before = nsText.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if !before.isEmpty {
-                segments.append(.text(before))
-            }
-        }
-
-        let alt = nsText.substring(with: match.range(at: 1))
-        let url = nsText.substring(with: match.range(at: 2))
-        segments.append(.image(alt: alt, url: url))
-
-        lastEnd = match.range.location + match.range.length
-    }
-
-    // Text after the last image
-    if lastEnd < nsText.length {
-        let after = nsText.substring(from: lastEnd)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if !after.isEmpty {
-            segments.append(.text(after))
-        }
-    }
-
-    return segments
+    MarkdownBlockParser.extractImageBlocks(from: text)
 }

--- a/clients/shared/Features/Chat/MarkdownParser.swift
+++ b/clients/shared/Features/Chat/MarkdownParser.swift
@@ -1,0 +1,290 @@
+import Foundation
+
+// MARK: - MarkdownListItem
+
+/// A single list item with indentation and ordering context.
+public struct MarkdownListItem {
+    public let indent: Int
+    public let ordered: Bool
+    public let number: Int      // meaningful only when ordered == true
+    public let text: String
+
+    public init(indent: Int, ordered: Bool, number: Int, text: String) {
+        self.indent = indent
+        self.ordered = ordered
+        self.number = number
+        self.text = text
+    }
+}
+
+// MARK: - MarkdownBlock
+
+/// A parsed block-level markdown element.
+public enum MarkdownBlock {
+    case text(String)
+    case heading(level: Int, text: String)
+    case codeBlock(language: String?, code: String)
+    case list(items: [MarkdownListItem])
+    case table(headers: [String], rows: [[String]])
+    case image(alt: String, url: String)
+    case horizontalRule
+}
+
+// MARK: - MarkdownBlockParser
+
+/// Block-level markdown parser with support for headings, code blocks (``` and ~~~),
+/// tables, images, lists, and horizontal rules.
+public enum MarkdownBlockParser {
+
+    // MARK: - Public API
+
+    public static func parse(_ text: String) -> [MarkdownBlock] {
+        let lines = text.components(separatedBy: .newlines)
+        var blocks: [MarkdownBlock] = []
+        var currentText: [String] = []
+        var i = 0
+        var fenceDelimiter: (character: Character, length: Int)?
+        var codeBlockLanguage: String?
+        var codeBlockLines: [String] = []
+
+        func flushText() {
+            let pending = currentText.joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !pending.isEmpty {
+                blocks.append(.text(pending))
+            }
+            currentText = []
+        }
+
+        while i < lines.count {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+
+            // --- Inside a fenced code block ---
+            if let fence = fenceDelimiter {
+                let closeCount = trimmed.prefix(while: { $0 == fence.character }).count
+                if closeCount >= fence.length
+                    && trimmed.drop(while: { $0 == fence.character }).allSatisfy(\.isWhitespace) {
+                    fenceDelimiter = nil
+                    blocks.append(.codeBlock(language: codeBlockLanguage,
+                                             code: codeBlockLines.joined(separator: "\n")))
+                    codeBlockLines = []
+                    codeBlockLanguage = nil
+                } else {
+                    codeBlockLines.append(lines[i])
+                }
+                i += 1
+                continue
+            }
+
+            // --- Opening a new fence (``` or ~~~) ---
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                flushText()
+                let fenceChar = trimmed.first!
+                let fenceLen = trimmed.prefix(while: { $0 == fenceChar }).count
+                fenceDelimiter = (fenceChar, fenceLen)
+                let lang = trimmed.dropFirst(fenceLen).trimmingCharacters(in: .whitespaces)
+                codeBlockLanguage = lang.isEmpty ? nil : lang
+                i += 1
+                continue
+            }
+
+            // --- Table detection ---
+            if i + 2 < lines.count,
+               isTableRow(lines[i]),
+               isTableSeparator(lines[i + 1]),
+               isTableRow(lines[i + 2]) {
+                flushText()
+                let headers = parseTableCells(lines[i])
+                i += 2  // skip separator
+                var rows: [[String]] = []
+                while i < lines.count, isTableRow(lines[i]) {
+                    let cells = parseTableCells(lines[i])
+                    let padded = Array(cells.prefix(headers.count))
+                        + Array(repeating: "", count: max(0, headers.count - cells.count))
+                    rows.append(padded)
+                    i += 1
+                }
+                blocks.append(.table(headers: headers, rows: rows))
+                continue
+            }
+
+            // --- Heading detection ---
+            if let heading = parseHeading(lines[i]) {
+                flushText()
+                blocks.append(.heading(level: heading.level, text: heading.text))
+                i += 1
+                continue
+            }
+
+            // --- Horizontal rule detection ---
+            if isHorizontalRule(trimmed) {
+                flushText()
+                blocks.append(.horizontalRule)
+                i += 1
+                continue
+            }
+
+            // --- List detection (consecutive list lines) ---
+            if parseListLine(lines[i]) != nil {
+                flushText()
+                var items: [MarkdownListItem] = []
+                while i < lines.count, let item = parseListLine(lines[i]) {
+                    items.append(item)
+                    i += 1
+                }
+                blocks.append(.list(items: items))
+                continue
+            }
+
+            // --- Empty line ---
+            if trimmed.isEmpty {
+                flushText()
+                i += 1
+                continue
+            }
+
+            // --- Plain text ---
+            currentText.append(lines[i])
+            i += 1
+        }
+
+        // If a fence was never closed, emit accumulated code block lines as text
+        if fenceDelimiter != nil {
+            let fenceChar = fenceDelimiter!.character
+            let fenceLen = fenceDelimiter!.length
+            let opener = String(repeating: String(fenceChar), count: fenceLen) + (codeBlockLanguage ?? "")
+            currentText.append(opener)
+            currentText.append(contentsOf: codeBlockLines)
+        }
+
+        flushText()
+
+        // Post-process paragraphs to extract inline images.
+        return blocks.flatMap { block -> [MarkdownBlock] in
+            if case .text(let content) = block {
+                return extractImageBlocks(from: content)
+            }
+            return [block]
+        }
+    }
+
+    // MARK: - Heading
+
+    public static func parseHeading(_ line: String) -> (level: Int, text: String)? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let hashes = trimmed.prefix(while: { $0 == "#" })
+        let level = hashes.count
+        guard level >= 1, level <= 6 else { return nil }
+        let rest = trimmed.dropFirst(level)
+        guard rest.first == " " else { return nil }
+        return (level, String(rest.dropFirst()).trimmingCharacters(in: .whitespaces))
+    }
+
+    // MARK: - Horizontal Rule
+
+    public static func isHorizontalRule(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let stripped = trimmed.filter { !$0.isWhitespace }
+        guard stripped.count >= 3 else { return false }
+        guard let ch = stripped.first, (ch == "-" || ch == "*" || ch == "_") else { return false }
+        return stripped.allSatisfy { $0 == ch }
+    }
+
+    // MARK: - List
+
+    public static func parseListLine(_ line: String) -> MarkdownListItem? {
+        var indent = 0
+        for ch in line {
+            if ch == " " { indent += 1 }
+            else if ch == "\t" { indent += 4 }
+            else { break }
+        }
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+        // Unordered: `- `, `* `, `+ `
+        if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ") {
+            return MarkdownListItem(indent: indent, ordered: false, number: 0,
+                                    text: String(trimmed.dropFirst(2)))
+        }
+        // Ordered: `1. `, `2. `, etc.
+        let digits = trimmed.prefix(while: { $0.isNumber })
+        if !digits.isEmpty {
+            let rest = trimmed.dropFirst(digits.count)
+            if rest.hasPrefix(". ") {
+                return MarkdownListItem(indent: indent, ordered: true,
+                                        number: Int(digits) ?? 1,
+                                        text: String(rest.dropFirst(2)))
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Table
+
+    public static func isTableRow(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return trimmed.hasPrefix("|") && trimmed.hasSuffix("|")
+            && trimmed.filter({ $0 == "|" }).count >= 2
+    }
+
+    public static func isTableSeparator(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("|") && trimmed.hasSuffix("|") else { return false }
+        let inner = trimmed.dropFirst().dropLast()
+        return inner.split(separator: "|").allSatisfy { cell in
+            let c = cell.trimmingCharacters(in: .whitespaces)
+            return !c.isEmpty && c.allSatisfy({ $0 == "-" || $0 == ":" })
+        }
+    }
+
+    public static func parseTableCells(_ line: String) -> [String] {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let inner = String(trimmed.dropFirst().dropLast())
+        return inner.components(separatedBy: "|")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    // MARK: - Image extraction
+
+    public static func extractImageBlocks(from text: String) -> [MarkdownBlock] {
+        let pattern = #"!\[([^\]]*)\]\(([^)]+)\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return [.text( text)]
+        }
+
+        let nsText = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+
+        if matches.isEmpty { return [.text( text)] }
+
+        var blocks: [MarkdownBlock] = []
+        var lastEnd = 0
+
+        for match in matches {
+            if match.range.location > lastEnd {
+                let before = nsText.substring(with: NSRange(location: lastEnd,
+                                                            length: match.range.location - lastEnd))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !before.isEmpty {
+                    blocks.append(.text( before))
+                }
+            }
+
+            let alt = nsText.substring(with: match.range(at: 1))
+            let url = nsText.substring(with: match.range(at: 2))
+            blocks.append(.image(alt: alt, url: url))
+
+            lastEnd = match.range.location + match.range.length
+        }
+
+        if lastEnd < nsText.length {
+            let after = nsText.substring(from: lastEnd)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !after.isEmpty {
+                blocks.append(.text( after))
+            }
+        }
+
+        return blocks
+    }
+}

--- a/clients/shared/Features/Chat/MarkdownRenderer.swift
+++ b/clients/shared/Features/Chat/MarkdownRenderer.swift
@@ -1,133 +1,9 @@
 import SwiftUI
 
-// MARK: - MarkdownBlock
-
-private enum MarkdownBlock {
-    case heading(level: Int, text: String)
-    case paragraph(text: String)
-    case codeBlock(lang: String, code: String)
-    case list(ordered: Bool, items: [String])
-    case horizontalRule
-}
-
-// MARK: - MarkdownParser
-
-private enum MarkdownParser {
-    static func parse(_ text: String) -> [MarkdownBlock] {
-        let lines = text.components(separatedBy: "\n")
-        var blocks: [MarkdownBlock] = []
-        var i = 0
-
-        while i < lines.count {
-            let line = lines[i]
-
-            // Fenced code block
-            if line.hasPrefix("```") {
-                let lang = String(line.dropFirst(3)).trimmingCharacters(in: .whitespaces)
-                var codeLines: [String] = []
-                i += 1
-                while i < lines.count && !lines[i].hasPrefix("```") {
-                    codeLines.append(lines[i])
-                    i += 1
-                }
-                // Skip closing ```
-                if i < lines.count { i += 1 }
-                blocks.append(.codeBlock(lang: lang, code: codeLines.joined(separator: "\n")))
-                continue
-            }
-
-            // Horizontal rule
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed == "---" || trimmed == "***" || trimmed == "___" {
-                blocks.append(.horizontalRule)
-                i += 1
-                continue
-            }
-
-            // Heading
-            if line.hasPrefix("#") {
-                var level = 0
-                var rest = line
-                while rest.hasPrefix("#") {
-                    level += 1
-                    rest = String(rest.dropFirst())
-                }
-                if rest.hasPrefix(" ") {
-                    rest = String(rest.dropFirst())
-                }
-                blocks.append(.heading(level: level, text: rest))
-                i += 1
-                continue
-            }
-
-            // Unordered list
-            if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ") {
-                var items: [String] = []
-                while i < lines.count {
-                    let t = lines[i].trimmingCharacters(in: .whitespaces)
-                    if t.hasPrefix("- ") || t.hasPrefix("* ") || t.hasPrefix("+ ") {
-                        items.append(String(t.dropFirst(2)))
-                        i += 1
-                    } else {
-                        break
-                    }
-                }
-                blocks.append(.list(ordered: false, items: items))
-                continue
-            }
-
-            // Ordered list
-            if let match = trimmed.range(of: #"^\d+\.\s"#, options: .regularExpression) {
-                var items: [String] = []
-                while i < lines.count {
-                    let t = lines[i].trimmingCharacters(in: .whitespaces)
-                    if t.range(of: #"^\d+\.\s"#, options: .regularExpression) != nil {
-                        // Remove "1. " prefix
-                        if let spaceIdx = t.firstIndex(of: " ") {
-                            items.append(String(t[t.index(after: spaceIdx)...]))
-                        }
-                        i += 1
-                    } else {
-                        break
-                    }
-                }
-                _ = match  // silence unused warning
-                blocks.append(.list(ordered: true, items: items))
-                continue
-            }
-
-            // Empty line — separate paragraphs
-            if trimmed.isEmpty {
-                i += 1
-                continue
-            }
-
-            // Paragraph: accumulate consecutive non-blank lines that don't start block elements
-            var paraLines: [String] = []
-            while i < lines.count {
-                let l = lines[i]
-                let t = l.trimmingCharacters(in: .whitespaces)
-                if t.isEmpty { break }
-                if l.hasPrefix("#") || l.hasPrefix("```") ||
-                   t.hasPrefix("- ") || t.hasPrefix("* ") || t.hasPrefix("+ ") ||
-                   t == "---" || t == "***" || t == "___" { break }
-                if t.range(of: #"^\d+\.\s"#, options: .regularExpression) != nil { break }
-                paraLines.append(l)
-                i += 1
-            }
-            if !paraLines.isEmpty {
-                blocks.append(.paragraph(text: paraLines.joined(separator: "\n")))
-            }
-        }
-
-        return blocks
-    }
-}
-
 // MARK: - MarkdownRenderer
 
 /// Renders markdown text as a structured SwiftUI view, with support for
-/// code blocks, headings, lists, horizontal rules, and inline formatting.
+/// code blocks, headings, lists, tables, images, horizontal rules, and inline formatting.
 public struct MarkdownRenderer: View {
     public let text: String
 
@@ -136,7 +12,7 @@ public struct MarkdownRenderer: View {
     }
 
     public var body: some View {
-        let blocks = MarkdownParser.parse(text)
+        let blocks = MarkdownBlockParser.parse(text)
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
                 blockView(for: block)
@@ -154,7 +30,7 @@ public struct MarkdownRenderer: View {
                 .foregroundColor(VColor.textPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-        case .paragraph(let text):
+        case .text(let text):
             Text(inlineMarkdown(text))
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
@@ -164,7 +40,7 @@ public struct MarkdownRenderer: View {
 
         case .codeBlock(let lang, let code):
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                if !lang.isEmpty {
+                if let lang, !lang.isEmpty {
                     Text(lang)
                         .font(VFont.monoSmall)
                         .foregroundColor(VColor.textMuted)
@@ -181,22 +57,90 @@ public struct MarkdownRenderer: View {
             .background(VColor.backgroundSubtle)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
-        case .list(let ordered, let items):
+        case .list(let items):
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    let prefix = item.ordered ? "\(item.number)." : "\u{2022}"
+                    let indentLevel = item.indent / 2
                     HStack(alignment: .top, spacing: VSpacing.xs) {
-                        Text(ordered ? "\(index + 1)." : "•")
+                        Text(prefix)
                             .font(VFont.body)
                             .foregroundColor(VColor.textSecondary)
-                            .frame(minWidth: ordered ? 24 : 12, alignment: .leading)
-                        Text(inlineMarkdown(item))
+                            .frame(minWidth: item.ordered ? 24 : 12, alignment: .leading)
+                        Text(inlineMarkdown(item.text))
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
                             .tint(VColor.accent)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .textSelection(.enabled)
                     }
+                    .padding(.leading, CGFloat(indentLevel) * 16)
                 }
+            }
+
+        case .table(let headers, let rows):
+            VStack(alignment: .leading, spacing: 0) {
+                // Header row
+                HStack(spacing: 0) {
+                    ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
+                        Text(inlineMarkdown(header))
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.textPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(VSpacing.xs)
+                    }
+                }
+                .background(VColor.backgroundSubtle)
+
+                Rectangle()
+                    .fill(VColor.surfaceBorder)
+                    .frame(height: 1)
+
+                // Data rows
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    HStack(spacing: 0) {
+                        ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
+                            Text(inlineMarkdown(cell))
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(VSpacing.xs)
+                        }
+                    }
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+
+        case .image(let alt, let url):
+            if let imageURL = URL(string: url) {
+                AsyncImage(url: imageURL) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    case .failure:
+                        Text(alt.isEmpty ? "Image failed to load" : alt)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                            .italic()
+                    default:
+                        ProgressView()
+                            .frame(height: 100)
+                    }
+                }
+                .accessibilityLabel(alt)
+            } else {
+                Text(alt.isEmpty ? "Invalid image URL" : alt)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+                    .italic()
             }
 
         case .horizontalRule:
@@ -240,6 +184,11 @@ public struct MarkdownRenderer: View {
         1. First step
         2. Second step
         3. Third step
+
+        | Name | Value |
+        | ---- | ----- |
+        | Foo  | 42    |
+        | Bar  | 99    |
 
         ---
 

--- a/clients/shared/Tests/MarkdownParserTests.swift
+++ b/clients/shared/Tests/MarkdownParserTests.swift
@@ -1,0 +1,292 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class MarkdownParserTests: XCTestCase {
+
+    // MARK: - Headings
+
+    func testHeading() {
+        let blocks = MarkdownBlockParser.parse("# Hello")
+        XCTAssertEqual(blocks.count, 1)
+        if case .heading(let level, let text) = blocks[0] {
+            XCTAssertEqual(level, 1)
+            XCTAssertEqual(text, "Hello")
+        } else {
+            XCTFail("Expected heading block")
+        }
+    }
+
+    func testHeadingLevels() {
+        for level in 1...6 {
+            let hashes = String(repeating: "#", count: level)
+            let blocks = MarkdownBlockParser.parse("\(hashes) Title")
+            XCTAssertEqual(blocks.count, 1)
+            if case .heading(let parsedLevel, let text) = blocks[0] {
+                XCTAssertEqual(parsedLevel, level)
+                XCTAssertEqual(text, "Title")
+            } else {
+                XCTFail("Expected heading at level \(level)")
+            }
+        }
+    }
+
+    func testHeadingRequiresSpace() {
+        let blocks = MarkdownBlockParser.parse("#NoSpace")
+        XCTAssertEqual(blocks.count, 1)
+        if case .text = blocks[0] {} else {
+            XCTFail("Expected text block, not heading")
+        }
+    }
+
+    // MARK: - Paragraphs
+
+    func testParagraph() {
+        let blocks = MarkdownBlockParser.parse("Hello world")
+        XCTAssertEqual(blocks.count, 1)
+        if case .text(let text) = blocks[0] {
+            XCTAssertEqual(text, "Hello world")
+        } else {
+            XCTFail("Expected text block")
+        }
+    }
+
+    func testMultipleParagraphs() {
+        let blocks = MarkdownBlockParser.parse("First\n\nSecond")
+        XCTAssertEqual(blocks.count, 2)
+        if case .text(let t1) = blocks[0] { XCTAssertEqual(t1, "First") }
+        if case .text(let t2) = blocks[1] { XCTAssertEqual(t2, "Second") }
+    }
+
+    // MARK: - Code Blocks
+
+    func testBacktickCodeBlock() {
+        let input = "```swift\nlet x = 1\nprint(x)\n```"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .codeBlock(let lang, let code) = blocks[0] {
+            XCTAssertEqual(lang, "swift")
+            XCTAssertEqual(code, "let x = 1\nprint(x)")
+        } else {
+            XCTFail("Expected code block")
+        }
+    }
+
+    func testTildeCodeBlock() {
+        let input = "~~~python\nprint('hi')\n~~~"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .codeBlock(let lang, let code) = blocks[0] {
+            XCTAssertEqual(lang, "python")
+            XCTAssertEqual(code, "print('hi')")
+        } else {
+            XCTFail("Expected code block")
+        }
+    }
+
+    func testCodeBlockNoLanguage() {
+        let input = "```\nhello\n```"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .codeBlock(let lang, let code) = blocks[0] {
+            XCTAssertNil(lang)
+            XCTAssertEqual(code, "hello")
+        } else {
+            XCTFail("Expected code block")
+        }
+    }
+
+    func testUnclosedCodeBlock() {
+        let input = "```swift\nlet x = 1"
+        let blocks = MarkdownBlockParser.parse(input)
+        // Unclosed fence emits as text
+        XCTAssertEqual(blocks.count, 1)
+        if case .text = blocks[0] {} else {
+            XCTFail("Expected text block for unclosed fence")
+        }
+    }
+
+    // MARK: - Horizontal Rules
+
+    func testHorizontalRule() {
+        for rule in ["---", "***", "___"] {
+            let blocks = MarkdownBlockParser.parse(rule)
+            XCTAssertEqual(blocks.count, 1)
+            if case .horizontalRule = blocks[0] {} else {
+                XCTFail("Expected horizontal rule for \(rule)")
+            }
+        }
+    }
+
+    func testHorizontalRuleLong() {
+        let blocks = MarkdownBlockParser.parse("------")
+        XCTAssertEqual(blocks.count, 1)
+        if case .horizontalRule = blocks[0] {} else {
+            XCTFail("Expected horizontal rule")
+        }
+    }
+
+    // MARK: - Unordered Lists
+
+    func testUnorderedList() {
+        let input = "- Alpha\n- Beta\n- Gamma"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .list(let items) = blocks[0] {
+            XCTAssertEqual(items.count, 3)
+            XCTAssertEqual(items[0].text, "Alpha")
+            XCTAssertFalse(items[0].ordered)
+            XCTAssertEqual(items[1].text, "Beta")
+            XCTAssertEqual(items[2].text, "Gamma")
+        } else {
+            XCTFail("Expected list block")
+        }
+    }
+
+    func testUnorderedListMarkers() {
+        let input = "- Dash\n* Star\n+ Plus"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .list(let items) = blocks[0] {
+            XCTAssertEqual(items.count, 3)
+        }
+    }
+
+    // MARK: - Ordered Lists
+
+    func testOrderedList() {
+        let input = "1. First\n2. Second\n3. Third"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .list(let items) = blocks[0] {
+            XCTAssertEqual(items.count, 3)
+            XCTAssertTrue(items[0].ordered)
+            XCTAssertEqual(items[0].number, 1)
+            XCTAssertEqual(items[0].text, "First")
+            XCTAssertEqual(items[2].number, 3)
+        } else {
+            XCTFail("Expected list block")
+        }
+    }
+
+    // MARK: - Indented Lists
+
+    func testIndentedList() {
+        let input = "- Parent\n  - Child\n    - Grandchild"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .list(let items) = blocks[0] {
+            XCTAssertEqual(items.count, 3)
+            XCTAssertEqual(items[0].indent, 0)
+            XCTAssertEqual(items[1].indent, 2)
+            XCTAssertEqual(items[2].indent, 4)
+        } else {
+            XCTFail("Expected list block")
+        }
+    }
+
+    // MARK: - Tables
+
+    func testTable() {
+        let input = "| Name | Age |\n| ---- | --- |\n| Alice | 30 |\n| Bob | 25 |"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .table(let headers, let rows) = blocks[0] {
+            XCTAssertEqual(headers, ["Name", "Age"])
+            XCTAssertEqual(rows.count, 2)
+            XCTAssertEqual(rows[0], ["Alice", "30"])
+            XCTAssertEqual(rows[1], ["Bob", "25"])
+        } else {
+            XCTFail("Expected table block")
+        }
+    }
+
+    func testTableWithAlignment() {
+        let input = "| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .table(let headers, let rows) = blocks[0] {
+            XCTAssertEqual(headers.count, 3)
+            XCTAssertEqual(rows.count, 1)
+        } else {
+            XCTFail("Expected table block")
+        }
+    }
+
+    // MARK: - Images
+
+    func testImage() {
+        let input = "![alt text](https://example.com/img.png)"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 1)
+        if case .image(let alt, let url) = blocks[0] {
+            XCTAssertEqual(alt, "alt text")
+            XCTAssertEqual(url, "https://example.com/img.png")
+        } else {
+            XCTFail("Expected image block")
+        }
+    }
+
+    func testImageMixedWithText() {
+        let input = "Before ![img](url.png) After"
+        let blocks = MarkdownBlockParser.parse(input)
+        XCTAssertEqual(blocks.count, 3)
+        if case .text(let before) = blocks[0] { XCTAssertEqual(before, "Before") }
+        if case .image(let alt, _) = blocks[1] { XCTAssertEqual(alt, "img") }
+        if case .text(let after) = blocks[2] { XCTAssertEqual(after, "After") }
+    }
+
+    // MARK: - Mixed Content
+
+    func testMixedContent() {
+        let input = """
+        # Title
+
+        A paragraph.
+
+        - Item 1
+        - Item 2
+
+        ```
+        code
+        ```
+
+        ---
+        """
+        let blocks = MarkdownBlockParser.parse(input)
+        // heading, paragraph, list, codeBlock, horizontalRule
+        XCTAssertEqual(blocks.count, 5)
+        if case .heading = blocks[0] {} else { XCTFail("Expected heading") }
+        if case .text = blocks[1] {} else { XCTFail("Expected text") }
+        if case .list = blocks[2] {} else { XCTFail("Expected list") }
+        if case .codeBlock = blocks[3] {} else { XCTFail("Expected codeBlock") }
+        if case .horizontalRule = blocks[4] {} else { XCTFail("Expected horizontalRule") }
+    }
+
+    // MARK: - Helper functions
+
+    func testParseHeading() {
+        let result = MarkdownBlockParser.parseHeading("## Hello World")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.level, 2)
+        XCTAssertEqual(result?.text, "Hello World")
+    }
+
+    func testIsTableRow() {
+        XCTAssertTrue(MarkdownBlockParser.isTableRow("| a | b |"))
+        XCTAssertFalse(MarkdownBlockParser.isTableRow("not a table"))
+        XCTAssertFalse(MarkdownBlockParser.isTableRow("| only one pipe"))
+    }
+
+    func testParseTableCells() {
+        let cells = MarkdownBlockParser.parseTableCells("| foo | bar | baz |")
+        XCTAssertEqual(cells, ["foo", "bar", "baz"])
+    }
+
+    func testParseListLine() {
+        let item = MarkdownBlockParser.parseListLine("  - Hello")
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.indent, 2)
+        XCTAssertEqual(item?.text, "Hello")
+        XCTAssertFalse(item?.ordered ?? true)
+    }
+}


### PR DESCRIPTION
## Summary
Consolidates two independent markdown parsers into a single shared `MarkdownBlockParser` that both iOS and macOS consume. This is M8 of the client refactoring plan.

## Implementation
- **New `MarkdownParser.swift`** in shared module: public `MarkdownBlockParser` enum with `parse(_:)` producing `[MarkdownBlock]`, plus all helper functions (`parseHeading`, `isHorizontalRule`, `parseListLine`, `isTableRow`, `isTableSeparator`, `parseTableCells`, `extractImageBlocks`)
- **Public types**: `MarkdownBlock` (7 cases: text, heading, codeBlock, list, table, image, horizontalRule) and `MarkdownListItem` (indent-aware list items)
- **Updated `MarkdownRenderer.swift`**: removed private parser (~125 lines), now uses shared `MarkdownBlockParser`, added table and image rendering
- **Reduced macOS `ChatMarkdownParser.swift`**: from 257 lines to 39 lines of typealiases + delegation

## Key Technical Choices
- Used `.text(String)` instead of `.paragraph(text: String)` to match existing macOS ChatView.swift pattern matching without requiring changes to 2,100-line file
- Made `MarkdownListItem` a separate public struct (not nested) for ergonomic cross-module access
- Table rendering uses equal-width columns with `VColor.backgroundSubtle` header background
- Image rendering uses `AsyncImage` with loading/error states

## Files Changed
- **New**: `clients/shared/Features/Chat/MarkdownParser.swift` (~230 lines)
- **Modified**: `clients/shared/Features/Chat/MarkdownRenderer.swift` (rewritten to use shared parser)
- **Modified**: `clients/macos/.../ChatMarkdownParser.swift` (257 → 39 lines)
- **New**: `clients/shared/Tests/MarkdownParserTests.swift` (24 tests)

## Testing
- macOS build: passes
- iOS build: passes
- All 813 macOS tests pass (0 unexpected failures)
- All 24 new MarkdownParser tests pass
- All 38 shared module tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
