### PR TITLE
feat: add AssistantEvent types and SSE framing helpers

### DIFF
--- a/assistant/src/__tests__/assistant-event.test.ts
+++ b/assistant/src/__tests__/assistant-event.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect } from 'bun:test';
+import type { AssistantEvent } from '../runtime/assistant-event.js';
+import { formatSseFrame, formatSseHeartbeat } from '../runtime/assistant-event.js';
+
+// ── Type / shape tests ────────────────────────────────────────────────────────
+
+describe('AssistantEvent shape', () => {
+  test('accepts a minimal valid event', () => {
+    const event: AssistantEvent = {
+      id: 'evt_001',
+      assistantId: 'ast_123',
+      emittedAt: '2026-02-18T21:20:00.000Z',
+      message: {
+        type: 'assistant_text_delta',
+        sessionId: 'conv_456',
+        text: 'Working on it...',
+      },
+    };
+
+    expect(event.id).toBe('evt_001');
+    expect(event.assistantId).toBe('ast_123');
+    expect(event.sessionId).toBeUndefined();
+    expect(event.emittedAt).toBe('2026-02-18T21:20:00.000Z');
+    expect(event.message.type).toBe('assistant_text_delta');
+  });
+
+  test('accepts a full event with sessionId', () => {
+    const event: AssistantEvent = {
+      id: 'evt_002',
+      assistantId: 'ast_123',
+      sessionId: 'conv_456',
+      emittedAt: '2026-02-18T21:20:00.000Z',
+      message: {
+        type: 'message_complete',
+        sessionId: 'conv_456',
+      },
+    };
+
+    expect(event.sessionId).toBe('conv_456');
+    expect(event.message.type).toBe('message_complete');
+  });
+});
+
+// ── SSE framing tests ─────────────────────────────────────────────────────────
+
+describe('formatSseFrame', () => {
+  const baseEvent: AssistantEvent = {
+    id: 'evt_003',
+    assistantId: 'ast_abc',
+    sessionId: 'sess_xyz',
+    emittedAt: '2026-02-18T00:00:00.000Z',
+    message: {
+      type: 'assistant_text_delta',
+      sessionId: 'sess_xyz',
+      text: 'hello',
+    },
+  };
+
+  test('produces event, id, and data lines followed by blank line', () => {
+    const frame = formatSseFrame(baseEvent);
+    const lines = frame.split('\n');
+
+    expect(lines[0]).toBe('event: assistant_event');
+    expect(lines[1]).toBe(`id: ${baseEvent.id}`);
+    expect(lines[2]).toStartWith('data: ');
+    // Trailing blank line: frame ends with \n\n, so last two entries are '' ''
+    expect(lines[lines.length - 1]).toBe('');
+    expect(lines[lines.length - 2]).toBe('');
+  });
+
+  test('data line contains valid JSON matching the event', () => {
+    const frame = formatSseFrame(baseEvent);
+    const dataLine = frame.split('\n').find((l) => l.startsWith('data: '))!;
+    const parsed = JSON.parse(dataLine.slice('data: '.length)) as AssistantEvent;
+
+    expect(parsed.id).toBe(baseEvent.id);
+    expect(parsed.assistantId).toBe(baseEvent.assistantId);
+    expect(parsed.sessionId).toBe(baseEvent.sessionId);
+    expect(parsed.emittedAt).toBe(baseEvent.emittedAt);
+    expect(parsed.message.type).toBe('assistant_text_delta');
+  });
+
+  test('id line uses the event id verbatim', () => {
+    const event: AssistantEvent = { ...baseEvent, id: 'unique-evt-id-xyz' };
+    const frame = formatSseFrame(event);
+    expect(frame).toContain('id: unique-evt-id-xyz\n');
+  });
+
+  test('event type field is always "assistant_event"', () => {
+    const frame = formatSseFrame(baseEvent);
+    expect(frame.startsWith('event: assistant_event\n')).toBe(true);
+  });
+
+  test('frame ends with double newline', () => {
+    const frame = formatSseFrame(baseEvent);
+    expect(frame.endsWith('\n\n')).toBe(true);
+  });
+});
+
+// ── Heartbeat tests ───────────────────────────────────────────────────────────
+
+describe('formatSseHeartbeat', () => {
+  test('returns a SSE comment line followed by blank line', () => {
+    const hb = formatSseHeartbeat();
+    expect(hb).toBe(': heartbeat\n\n');
+  });
+
+  test('starts with colon (SSE comment marker)', () => {
+    expect(formatSseHeartbeat().startsWith(':')).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/assistant-event.test.ts
+++ b/assistant/src/__tests__/assistant-event.test.ts
@@ -86,6 +86,18 @@ describe('formatSseFrame', () => {
     expect(frame).toContain('id: unique-evt-id-xyz\n');
   });
 
+  test('strips newline characters from event.id to prevent SSE frame injection', () => {
+    const event: AssistantEvent = { ...baseEvent, id: 'foo\ndata: {"injected":true}' };
+    const frame = formatSseFrame(event);
+    const lines = frame.split('\n');
+    // id line must not contain the injected payload
+    const idLine = lines.find((l) => l.startsWith('id: '))!;
+    expect(idLine).toBe('id: foodata: {"injected":true}');
+    // only one data line must exist
+    const dataLines = lines.filter((l) => l.startsWith('data: '));
+    expect(dataLines).toHaveLength(1);
+  });
+
   test('event type field is always "assistant_event"', () => {
     const frame = formatSseFrame(baseEvent);
     expect(frame.startsWith('event: assistant_event\n')).toBe(true);

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -1,0 +1,57 @@
+/**
+ * Assistant Events — shared types and SSE framing helpers.
+ *
+ * Fully isolated from daemon/runtime orchestration logic.
+ * Import this module from any layer that needs to produce or consume
+ * assistant events without creating circular dependencies.
+ */
+
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * A single assistant event wrapping an IPC ServerMessage payload.
+ * The `message` field is intentionally unchanged from the IPC form so that
+ * delta semantics (text deltas, tool input deltas, etc.) are preserved.
+ */
+export interface AssistantEvent {
+  /** Globally unique event identifier (UUID). */
+  id: string;
+  /** The assistant this event belongs to. */
+  assistantId: string;
+  /** Resolved conversation/session id when available. */
+  sessionId?: string;
+  /** ISO-8601 timestamp of when the event was emitted. */
+  emittedAt: string;
+  /** Unchanged IPC outbound message payload. */
+  message: ServerMessage;
+}
+
+// ── SSE framing ───────────────────────────────────────────────────────────────
+
+/**
+ * Format an AssistantEvent as a Server-Sent Events frame.
+ *
+ * The SSE spec (https://html.spec.whatwg.org/multipage/server-sent-events.html)
+ * requires each field on its own line with a trailing blank line.
+ *
+ * ```
+ * event: assistant_event\n
+ * id: <event.id>\n
+ * data: <JSON>\n
+ * \n
+ * ```
+ */
+export function formatSseFrame(event: AssistantEvent): string {
+  const data = JSON.stringify(event);
+  return `event: assistant_event\nid: ${event.id}\ndata: ${data}\n\n`;
+}
+
+/**
+ * Format a keep-alive SSE comment.
+ * Clients should ignore comment lines (`:`) per the SSE spec.
+ */
+export function formatSseHeartbeat(): string {
+  return ': heartbeat\n\n';
+}

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -44,8 +44,9 @@ export interface AssistantEvent {
  * ```
  */
 export function formatSseFrame(event: AssistantEvent): string {
+  const sanitizedId = event.id.replace(/[\n\r]/g, '');
   const data = JSON.stringify(event);
-  return `event: assistant_event\nid: ${event.id}\ndata: ${data}\n\n`;
+  return `event: assistant_event\nid: ${sanitizedId}\ndata: ${data}\n\n`;
 }
 
 /**

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -114,6 +114,18 @@ public struct IPCAuthResult: Codable, Sendable {
     public let message: String?
 }
 
+public struct IPCBrowserCDPRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+}
+
+public struct IPCBrowserCDPResponse: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let success: Bool
+    public let declined: Bool?
+}
+
 public struct IPCBrowserFrame: Codable, Sendable {
     public let type: String
     public let sessionId: String
@@ -128,6 +140,59 @@ public struct IPCBrowserFrameMetadata: Codable, Sendable {
     public let scrollOffsetX: Double
     public let scrollOffsetY: Double
     public let timestamp: Double
+}
+
+public struct IPCBrowserHandoffRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let reason: String
+    public let message: String
+    public let bringToFront: Bool?
+}
+
+public struct IPCBrowserInteractiveMode: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let enabled: Bool
+}
+
+public struct IPCBrowserInteractiveModeChanged: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let enabled: Bool
+    public let reason: String?
+    public let message: String?
+}
+
+public struct IPCBrowserUserClick: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let x: Double
+    public let y: Double
+    public let button: String?
+    public let doubleClick: Bool?
+}
+
+public struct IPCBrowserUserKeypress: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let key: String
+    public let modifiers: [String]?
+}
+
+public struct IPCBrowserUserScroll: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let deltaX: Double
+    public let deltaY: Double
+    public let x: Double
+    public let y: Double
 }
 
 public struct IPCBrowserViewSurfaceData: Codable, Sendable {
@@ -401,6 +466,12 @@ public struct IPCDocumentLoadResponse: Codable, Sendable {
     public let updatedAt: Int
     public let success: Bool
     public let error: String?
+}
+
+public struct IPCDocumentPreviewSurfaceData: Codable, Sendable {
+    public let title: String
+    public let surfaceId: String
+    public let subtitle: String?
 }
 
 public struct IPCDocumentSaveRequest: Codable, Sendable {
@@ -1516,6 +1587,19 @@ public struct IPCUiSurfaceShowCard: Codable, Sendable {
 public struct IPCUiSurfaceShowConfirmation: Codable, Sendable {
     public let surfaceType: String
     public let data: IPCConfirmationSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+    /// The message ID that this surface belongs to (for history loading).
+    public let messageId: String?
+}
+
+public struct IPCUiSurfaceShowDocumentPreview: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCDocumentPreviewSurfaceData
     public let type: String
     public let sessionId: String
     public let surfaceId: String


### PR DESCRIPTION
## Summary
- Adds `AssistantEvent` interface wrapping unchanged IPC `ServerMessage` payloads with envelope fields (`id`, `assistantId`, `sessionId`, `emittedAt`)
- Adds `formatSseFrame` helper to produce SSE-spec-compliant frames (event/id/data lines + trailing blank)
- Adds `formatSseHeartbeat` helper for keep-alive SSE comments
- Fully isolated from daemon/runtime orchestration — no behavior change
- 9 passing tests covering event shape and SSE frame formatting

Part of plan: ASSISTANT-EVENTS-SSE-INCREMENTAL.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
