### PR TITLE
fix: use opacity transition for control center drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -354,7 +354,7 @@ struct MainWindowView: View {
                         .frame(width: 200)
                         .offset(x: threadDrawerWidth + 8, y: -8)
                         .zIndex(10)
-                        .transition(.move(edge: .leading).combined(with: .opacity))
+                        .transition(.opacity)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Changed the control center drawer transition from `.move(edge: .leading).combined(with: .opacity)` to `.opacity` so it fades in/out in place instead of flying in from the left

## Test plan
- [ ] Open sidebar, click Control Center button — drawer should fade in without sliding
- [ ] Close the drawer — should fade out without sliding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
