### PR TITLE
M5: Require reason field in all permission-prompting tool schemas

### DIFF
--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -35,8 +35,12 @@ class FileEditTool implements Tool {
             type: 'boolean',
             description: 'Replace all occurrences of old_string instead of requiring a unique match (default: false)',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief human-readable explanation of why this file is being edited, shown to the user in the permission prompt',
+          },
         },
-        required: ['path', 'old_string', 'new_string'],
+        required: ['path', 'old_string', 'new_string', 'reason'],
       },
     };
   }

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -27,8 +27,12 @@ class FileWriteTool implements Tool {
             type: 'string',
             description: 'The content to write to the file',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief human-readable explanation of why this file is being written, shown to the user in the permission prompt',
+          },
         },
-        required: ['path', 'content'],
+        required: ['path', 'content', 'reason'],
       },
     };
   }

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -34,8 +34,12 @@ class HostFileEditTool implements Tool {
             type: 'boolean',
             description: 'Replace all occurrences instead of requiring a unique match (default: false)',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief human-readable explanation of why this file is being edited, shown to the user in the permission prompt',
+          },
         },
-        required: ['path', 'old_string', 'new_string'],
+        required: ['path', 'old_string', 'new_string', 'reason'],
       },
     };
   }

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -29,8 +29,12 @@ class HostFileReadTool implements Tool {
             type: 'number',
             description: 'Maximum number of lines to read',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief human-readable explanation of why this file is being read, shown to the user in the permission prompt',
+          },
         },
-        required: ['path'],
+        required: ['path', 'reason'],
       },
     };
   }

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -26,8 +26,12 @@ class HostFileWriteTool implements Tool {
             type: 'string',
             description: 'The content to write to the file',
           },
+          reason: {
+            type: 'string',
+            description: 'Brief human-readable explanation of why this file is being written, shown to the user in the permission prompt',
+          },
         },
-        required: ['path', 'content'],
+        required: ['path', 'content', 'reason'],
       },
     };
   }

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -73,7 +73,7 @@ class HostShellTool implements Tool {
             description: 'Optional timeout in seconds. Uses configured default and max limits.',
           },
         },
-        required: ['command'],
+        required: ['command', 'reason'],
       },
     };
   }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -53,7 +53,7 @@ class ShellTool implements Tool {
             description: 'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
           },
         },
-        required: ['command'],
+        required: ['command', 'reason'],
       },
     };
   }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -290,7 +290,9 @@ public struct ToolConfirmationData: Equatable {
                 return "I would like to access secure storage."
             }
         default:
-            return "I would like to use \(toolCategory)."
+            let tc = toolCategory.lowercased()
+            if !r.isEmpty { return "I would like to use \(tc) \(r)." }
+            return "I would like to use \(tc)."
         }
     }
 


### PR DESCRIPTION
## Context
Part of the Permission Cards Polish feature. Fixes permission titles that showed generic descriptions like "I would like to run a shell command" with no context.

## Changes

### Tool schemas — `reason` now required
All tools that trigger confirmation prompts now require a `reason` field so Claude always provides a human-readable explanation:
- `bash` / `host_bash` — shell commands
- `file_write` / `host_file_write` — file writes
- `file_edit` / `host_file_edit` — file edits
- `host_file_read` — file reads

### Swift — `humanDescription` improvements
- Default case now lowercases `toolCategory` so sentence casing is correct: "I would like to use memory to …" not "I would like to use Memory to …"
- All cases weave `reason` into natural language mid-sentence (first letter lowercased)

## Examples
- Before: "I would like to run a shell command."
- After: "I would like to run a shell command to find available Bluetooth devices."

- Before: "I would like to use Memory."
- After: "I would like to use memory to store your location preferences."
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
