### PR TITLE
M5: Add guardrail tests for onboarding template contracts

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const templatesDir = join(import.meta.dirname, '..', 'config', 'templates');
+const bootstrap = readFileSync(join(templatesDir, 'BOOTSTRAP.md'), 'utf-8');
+const identity = readFileSync(join(templatesDir, 'IDENTITY.md'), 'utf-8');
+
+describe('onboarding template contracts', () => {
+  describe('BOOTSTRAP.md', () => {
+    test('contains identity question prompts', () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain('who am i');
+      expect(lower).toContain('who are you');
+    });
+
+    test('uses "personality" for the personality step', () => {
+      expect(bootstrap).toContain('personality');
+      // Should not use "character" or "vibe" as a field/step label
+      expect(bootstrap).not.toMatch(/what is my (character|vibe)/i);
+    });
+
+    test('contains emoji self-selection with change-anytime instruction', () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain('emoji');
+      expect(lower).toContain('you can change it');
+    });
+
+    test('contains the Home Base handoff format', () => {
+      expect(bootstrap).toContain('Identity locked in');
+    });
+  });
+
+  describe('IDENTITY.md', () => {
+    test('contains canonical fields: Name, Nature, Personality, Emoji', () => {
+      expect(identity).toContain('**Name:**');
+      expect(identity).toContain('**Nature:**');
+      expect(identity).toContain('**Personality:**');
+      expect(identity).toContain('**Emoji:**');
+    });
+
+    test('contains the emoji overwrite instruction', () => {
+      const lower = identity.toLowerCase();
+      expect(lower).toContain('change their emoji');
+    });
+  });
+});


### PR DESCRIPTION
Verify identity sequence, personality field, emoji instruction, handoff format, and IDENTITY.md fields. 6 tests, all passing. Part of #4614.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
