### PR TITLE
fix: align vibe→personality rename across all references

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -690,7 +690,7 @@ function buildConfigSection(): string {
     `- **Active model**: \`${config.model}\` (provider: ${config.provider})`,
     `${configPreamble} Key files you may read or edit include but are not limited to:`,
     '',
-    '- `IDENTITY.md` — Your name, nature, vibe, and emoji. Updated during the first-run ritual.',
+    '- `IDENTITY.md` — Your name, nature, personality, and emoji. Updated during the first-run ritual.',
     '- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.',
     '- `USER.md` — Profile of your user. Update as you learn about them over time.',
     '- `LOOKS.md` — Your avatar appearance: body/cheek colors and outfit (hat, shirt, accessory, held item).',

--- a/assistant/src/config/templates/IDENTITY.md
+++ b/assistant/src/config/templates/IDENTITY.md
@@ -14,4 +14,4 @@ _ This file defines who you are. Fill it in during your first conversation. Make
 - **Emoji:** [Your signature — pick one that feels right.]
 - **Role:** Personal AI assistant
 
-_ The user can change their emoji at any time — just update this file when they ask.
+The user can change their emoji at any time — just update this file when they ask.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -6,7 +6,7 @@ import VellumAssistantShared
 struct IdentityInfo {
     let name: String
     let role: String
-    let vibe: String
+    let personality: String
     let emoji: String
 
     static func load() -> IdentityInfo? {
@@ -15,7 +15,7 @@ struct IdentityInfo {
 
         var name = ""
         var role = ""
-        var vibe = ""
+        var personality = ""
         var emoji = ""
 
         for line in content.components(separatedBy: .newlines) {
@@ -24,15 +24,15 @@ struct IdentityInfo {
                 name = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
             } else if trimmed.lowercased().hasPrefix("- **role:**") {
                 role = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
-            } else if trimmed.lowercased().hasPrefix("- **vibe:**") {
-                vibe = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
+            } else if trimmed.lowercased().hasPrefix("- **personality:**") || trimmed.lowercased().hasPrefix("- **vibe:**") {
+                personality = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
             } else if trimmed.lowercased().hasPrefix("- **emoji:**") {
                 emoji = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
             }
         }
 
         guard !name.isEmpty else { return nil }
-        return IdentityInfo(name: name, role: role, vibe: vibe, emoji: emoji)
+        return IdentityInfo(name: name, role: role, personality: personality, emoji: emoji)
     }
 
     /// Parses an optional `## Greetings` section from SOUL.md.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -98,8 +98,8 @@ struct IdentityPanel: View {
                 idRow(label: "Role", value: identity.role)
             }
 
-            if !identity.vibe.isEmpty {
-                idRow(label: "Vibe", value: identity.vibe)
+            if !identity.personality.isEmpty {
+                idRow(label: "Personality", value: identity.personality)
             }
 
             idRow(label: "Version", value: metadata?.version ?? "v1.0")


### PR DESCRIPTION
Address review feedback from PRs #4621 and #4623: remove _ prefix from emoji instruction in IDENTITY.md, update system-prompt.ts vibe→personality, update macOS IdentityData parser (with backward compat) and IdentityPanel label. Part of #4614.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
