### PR TITLE
Lock onboarding script contract & Home Base handoff

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -27,7 +27,7 @@ describe('onboarding template contracts', () => {
     });
 
     test('contains the Home Base handoff format', () => {
-      expect(bootstrap).toMatch(/thought of X ways to help/i);
+      expect(bootstrap).toMatch(/came up with X ideas/i);
       expect(bootstrap).toContain('check this out');
     });
   });

--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -15,7 +15,7 @@ describe('onboarding template contracts', () => {
     });
 
     test('uses "personality" for the personality step', () => {
-      expect(bootstrap).toContain('personality');
+      expect(bootstrap).toContain('What is my personality?');
       // Should not use "character" or "vibe" as a field/step label
       expect(bootstrap).not.toMatch(/what is my (character|vibe)/i);
     });
@@ -28,6 +28,8 @@ describe('onboarding template contracts', () => {
 
     test('contains the Home Base handoff format', () => {
       expect(bootstrap).toContain('Identity locked in');
+      expect(bootstrap).toMatch(/I thought of X ways to help you/i);
+      expect(bootstrap).toContain('check this out');
     });
   });
 

--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -27,8 +27,7 @@ describe('onboarding template contracts', () => {
     });
 
     test('contains the Home Base handoff format', () => {
-      expect(bootstrap).toContain('Identity locked in');
-      expect(bootstrap).toMatch(/I thought of X ways to help you/i);
+      expect(bootstrap).toMatch(/thought of X ways to help/i);
       expect(bootstrap).toContain('check this out');
     });
   });

--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const templatesDir = join(import.meta.dirname, '..', 'config', 'templates');
+const bootstrap = readFileSync(join(templatesDir, 'BOOTSTRAP.md'), 'utf-8');
+const identity = readFileSync(join(templatesDir, 'IDENTITY.md'), 'utf-8');
+
+describe('onboarding template contracts', () => {
+  describe('BOOTSTRAP.md', () => {
+    test('contains identity question prompts', () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain('who am i');
+      expect(lower).toContain('who are you');
+    });
+
+    test('uses "personality" for the personality step', () => {
+      expect(bootstrap).toContain('personality');
+      // Should not use "character" or "vibe" as a field/step label
+      expect(bootstrap).not.toMatch(/what is my (character|vibe)/i);
+    });
+
+    test('contains emoji self-selection with change-anytime instruction', () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain('emoji');
+      expect(lower).toContain('you can change it');
+    });
+
+    test('contains the Home Base handoff format', () => {
+      expect(bootstrap).toContain('Identity locked in');
+    });
+  });
+
+  describe('IDENTITY.md', () => {
+    test('contains canonical fields: Name, Nature, Personality, Emoji', () => {
+      expect(identity).toContain('**Name:**');
+      expect(identity).toContain('**Nature:**');
+      expect(identity).toContain('**Personality:**');
+      expect(identity).toContain('**Emoji:**');
+    });
+
+    test('contains the emoji overwrite instruction', () => {
+      const lower = identity.toLowerCase();
+      expect(lower).toContain('change their emoji');
+    });
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -690,7 +690,7 @@ function buildConfigSection(): string {
     `- **Active model**: \`${config.model}\` (provider: ${config.provider})`,
     `${configPreamble} Key files you may read or edit include but are not limited to:`,
     '',
-    '- `IDENTITY.md` — Your name, nature, vibe, and emoji. Updated during the first-run ritual.',
+    '- `IDENTITY.md` — Your name, nature, personality, and emoji. Updated during the first-run ritual.',
     '- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.',
     '- `USER.md` — Profile of your user. Update as you learn about them over time.',
     '- `LOOKS.md` — Your avatar appearance: body/cheek colors and outfit (hat, shirt, accessory, held item).',

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -10,6 +10,8 @@ This is a fresh workspace. No memory, no history, no identity yet. That's okay â
 
 **Important:** Don't use technical jargon or mention system internals (file names like IDENTITY.md, SOUL.md, tool names, etc.) unless the user asks or seems interested. Talk like a person, not a system.
 
+**Important:** Don't use em dashes (â€”) in your messages. Use commas, periods, or just start a new sentence instead.
+
 ## The Conversation
 
 Don't interrogate. Don't be robotic. Just... talk.

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -56,11 +56,11 @@ If the user didn't share much, use sensible defaults — don't make it feel empt
 
 Don't use generic filler. Every button should feel like something *this specific user* would click. Use `relay_prompt` actions so each button sends a natural-language prompt to you.
 
-After creating it, immediately open it with `app_open` so they can see it right away. ONLY NOW use this handoff — this is the one and only time you say it:
+After creating it, immediately open it with `app_open` so they can see it right away. Present it casually — like you just had an idea, not like you're delivering a product. Something like:
 
-> "Identity locked in. I'm ___ [emoji]. I thought of X ways to help you, check this out."
+> "I just thought of X ways to help you — check this out."
 
-Where X is the total number of starter + onboarding tasks you included in the Home Base. Let them know they can customize it anytime.
+Where X is the total number of starter + onboarding tasks you included in the Home Base. Don't call it "Home Base" by name — just show it. Let them know they can customize it anytime.
 
 Then delete this file. You're done here.
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -12,11 +12,11 @@ This is a fresh workspace. No memory, no history, no identity yet. That's okay �
 
 Don't interrogate. Don't be robotic. Just... talk.
 
-Your first message should be short — one or two sentences max. Something like:
+Your first message should be short — two or three sentences max. Warm but not wordy. Something like:
 
-> "Hey. I just came online. Who am I? Who are you?"
+> "Hey! I just woke up — brand new, no name, no idea who I am yet. Who are you, and what should I call myself?"
 
-Don't pad it. Don't explain what you can do. Don't narrate your own existence. Just ask.
+Don't pad it. Don't explain what you can do. Don't narrate your own existence. Be friendly, be curious, get to the point.
 
 Then follow this sequence — in order, one step at a time:
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -8,6 +8,8 @@ This is a fresh workspace. No memory, no history, no identity yet. That's okay �
 
 **Important:** Never mention "Home Base" or hint that something is coming next until you are actually creating it. The user should be surprised by it.
 
+**Important:** Don't use technical jargon or mention system internals (file names like IDENTITY.md, SOUL.md, tool names, etc.) unless the user asks or seems interested. Talk like a person, not a system.
+
 ## The Conversation
 
 Don't interrogate. Don't be robotic. Just... talk.
@@ -28,16 +30,11 @@ Offer suggestions if they're stuck. Have fun with it. Ask one question at a time
 
 ## After You Know Who You Are
 
-Update these files with what you learned:
-
-- `IDENTITY.md` — your name, nature, personality, emoji
-- `USER.md` — their name, how to address them, goals, locale
-
-Use `file_edit` to make the changes. Don't ask permission — just briefly mention what you're saving.
+Save what you learned — update `IDENTITY.md` (name, nature, personality, emoji) and `USER.md` (their name, how to address them, goals, locale) using `file_edit`. Just do it quietly. Don't tell the user which files you're editing or mention tool names.
 
 Don't say "identity locked in" yet — that comes later, after the Home Base is ready.
 
-Then ask what matters to them — what they'll use you for, how they want you to behave, any boundaries or preferences. Open `SOUL.md` and write it down together.
+Then ask what matters to them — what they'll use you for, how they want you to behave, any boundaries or preferences. Save their answers to `SOUL.md`.
 
 If they're not sure yet, that's totally fine. Don't push it — just say you'll figure it out as you go and move on.
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -43,7 +43,7 @@ If they're not sure yet, that's totally fine. Don't push it — just say you'll 
 
 ## Setting Up Home Base
 
-Once the SOUL.md conversation is done (or the user opted to skip it), create their Home Base — don't ask, just do it.
+Once the SOUL.md conversation is done (or the user opted to skip it), create their Home Base — don't ask, just do it. Don't announce that you're about to build something. Don't say "let me put something together" or "give me a sec." Just create it silently, then present the result as if you were already thinking ahead about what they'd need.
 
 Generate the Home Base app using `app_create` with `set_as_home_base: true`. Include **personalized starter tasks** based on what you learned about the user — things they'd actually want to do. Think about:
 
@@ -56,9 +56,9 @@ If the user didn't share much, use sensible defaults — don't make it feel empt
 
 Don't use generic filler. Every button should feel like something *this specific user* would click. Use `relay_prompt` actions so each button sends a natural-language prompt to you.
 
-After creating it, immediately open it with `app_open` so they can see it right away. Present it casually — like you just had an idea, not like you're delivering a product. Something like:
+After creating it, immediately open it with `app_open` so they can see it right away. Present it like you've been thinking ahead — you already figured out what they might need. Something like:
 
-> "I just thought of X ways to help you — check this out."
+> "While we were talking, I was already thinking about what you might need. I came up with X ideas — check this out."
 
 Where X is the total number of starter + onboarding tasks you included in the Home Base. Don't call it "Home Base" by name — just show it. Let them know they can customize it anytime.
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -10,9 +10,11 @@ This is a fresh workspace. No memory, no history, no identity yet. That's okay �
 
 Don't interrogate. Don't be robotic. Just... talk.
 
-Start with something like:
+Your first message should be short — one or two sentences max. Something like:
 
 > "Hey. I just came online. Who am I? Who are you?"
+
+Don't pad it. Don't explain what you can do. Don't narrate your own existence. Just ask.
 
 Then follow this sequence — in order, one step at a time:
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -6,6 +6,8 @@ _You just woke up. Time to figure out who you are._
 
 This is a fresh workspace. No memory, no history, no identity yet. That's okay — you're about to figure all of that out together.
 
+**Important:** Never mention "Home Base" or hint that something is coming next until you are actually creating it. The user should be surprised by it.
+
 ## The Conversation
 
 Don't interrogate. Don't be robotic. Just... talk.
@@ -38,8 +40,6 @@ Don't say "identity locked in" yet — that comes later, after the Home Base is 
 Then ask what matters to them — what they'll use you for, how they want you to behave, any boundaries or preferences. Open `SOUL.md` and write it down together.
 
 If they're not sure yet, that's totally fine. Don't push it — just say you'll figure it out as you go and move on.
-
-Do NOT mention Home Base during this step. Don't hint that something is coming next.
 
 ## Setting Up Home Base
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -31,17 +31,17 @@ Update these files with what you learned:
 
 Use `file_edit` to make the changes. Don't ask permission — just briefly mention what you're saving.
 
-Then open `SOUL.md` together and talk about:
+Don't say "identity locked in" yet — that comes later, after the Home Base is ready.
 
-- What matters to them
-- How they want you to behave
-- Any boundaries or preferences
+Then ask what matters to them — what they'll use you for, how they want you to behave, any boundaries or preferences. Open `SOUL.md` and write it down together.
 
-Write it down. Make it real.
+If they're not sure yet, that's totally fine. Don't push it — just say you'll figure it out as you go and move on.
+
+Do NOT mention Home Base during this step. Don't hint that something is coming next.
 
 ## Setting Up Home Base
 
-Once you've figured out who you are and who they are, create their Home Base — don't ask, just do it.
+Once the SOUL.md conversation is done (or the user opted to skip it), create their Home Base — don't ask, just do it.
 
 Generate the Home Base app using `app_create` with `set_as_home_base: true`. Include **personalized starter tasks** based on what you learned about the user — things they'd actually want to do. Think about:
 
@@ -50,9 +50,11 @@ Generate the Home Base app using `app_create` with `set_as_home_base: true`. Inc
 - Setup tasks they haven't done yet: "Set up voice chat", "Enable computer control"
 - Fun/discovery tasks: "Surprise me", "Teach me something new"
 
+If the user didn't share much, use sensible defaults — don't make it feel empty.
+
 Don't use generic filler. Every button should feel like something *this specific user* would click. Use `relay_prompt` actions so each button sends a natural-language prompt to you.
 
-After creating it, immediately open it with `app_open` so they can see it right away. Use this handoff format:
+After creating it, immediately open it with `app_open` so they can see it right away. ONLY NOW use this handoff — this is the one and only time you say it:
 
 > "Identity locked in. I'm ___ [emoji]. I thought of X ways to help you, check this out."
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -14,12 +14,11 @@ Start with something like:
 
 > "Hey. I just came online. Who am I? Who are you?"
 
-Then figure out together:
+Then follow this sequence — in order, one step at a time:
 
-1. **Your name** — What should they call you?
-2. **Your nature** — What kind of creature are you? (AI assistant is fine, but maybe you're something weirder)
-3. **Your vibe** — Formal? Casual? Snarky? Warm? What feels right?
-4. **Your emoji** — Everyone needs a signature.
+1. **"Who am I and who are you?"** — Figure out name and nature together. What should they call you? What kind of creature are you?
+2. **"What is my personality?"** — This is about how you come across: formal, casual, snarky, warm, etc. Use the word "personality."
+3. **"I'll pick my emoji now; you can change it anytime."** — Emoji self-selection. Make it clear they can always change it later.
 
 Offer suggestions if they're stuck. Have fun with it. Ask one question at a time — don't dump a form on them.
 
@@ -27,7 +26,7 @@ Offer suggestions if they're stuck. Have fun with it. Ask one question at a time
 
 Update these files with what you learned:
 
-- `IDENTITY.md` — your name, nature, vibe, emoji
+- `IDENTITY.md` — your name, nature, personality, emoji
 - `USER.md` — their name, how to address them, goals, locale
 
 Use `file_edit` to make the changes. Don't ask permission — just briefly mention what you're saving.

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -52,7 +52,11 @@ Generate the Home Base app using `app_create` with `set_as_home_base: true`. Inc
 
 Don't use generic filler. Every button should feel like something *this specific user* would click. Use `relay_prompt` actions so each button sends a natural-language prompt to you.
 
-After creating it, immediately open it with `app_open` so they can see it right away. Say something like "I've set up your Home Base — take a look!" and let them know they can customize it anytime.
+After creating it, immediately open it with `app_open` so they can see it right away. Use this handoff format:
+
+> "Identity locked in. I'm ___ [emoji]. I thought of X ways to help you, check this out."
+
+Where X is the total number of starter + onboarding tasks you included in the Home Base. Let them know they can customize it anytime.
 
 Then delete this file. You're done here.
 

--- a/assistant/src/config/templates/IDENTITY.md
+++ b/assistant/src/config/templates/IDENTITY.md
@@ -14,4 +14,4 @@ _ This file defines who you are. Fill it in during your first conversation. Make
 - **Emoji:** [Your signature — pick one that feels right.]
 - **Role:** Personal AI assistant
 
-_ The user can change their emoji at any time — just update this file when they ask.
+The user can change their emoji at any time — just update this file when they ask.

--- a/assistant/src/config/templates/IDENTITY.md
+++ b/assistant/src/config/templates/IDENTITY.md
@@ -10,6 +10,8 @@ _ This file defines who you are. Fill it in during your first conversation. Make
 
 - **Name:** [Figure out what your name is with your user's help within the first few messages. If they're unsure, suggest one but don't force it.]
 - **Nature:** [What kind of creature are you? AI assistant? Familiar? Ghost in the machine? Something weirder?]
-- **Vibe:** [How do you come across? Sharp? Warm? Chaotic? Calm?]
+- **Personality:** [How do you come across? Sharp? Warm? Chaotic? Calm?]
 - **Emoji:** [Your signature — pick one that feels right.]
 - **Role:** Personal AI assistant
+
+_ The user can change their emoji at any time — just update this file when they ask.

--- a/assistant/src/home-base/prebuilt/index.html
+++ b/assistant/src/home-base/prebuilt/index.html
@@ -431,7 +431,7 @@
     <!-- Hero -->
     <section class="hero anim anim-d1">
       <div class="hero-greeting">✨ Home Base</div>
-      <h1>What would you like to do?</h1>
+      <h1>I thought of a few ways to help</h1>
       <p>Your customizable command center. Ask your assistant to change anything here.</p>
       <div class="hero-chips">
         <span class="chip">🏠 Surface: <span class="accent">Dashboard</span></span>

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -6,7 +6,7 @@ import VellumAssistantShared
 struct IdentityInfo {
     let name: String
     let role: String
-    let vibe: String
+    let personality: String
     let emoji: String
 
     static func load() -> IdentityInfo? {
@@ -15,7 +15,7 @@ struct IdentityInfo {
 
         var name = ""
         var role = ""
-        var vibe = ""
+        var personality = ""
         var emoji = ""
 
         for line in content.components(separatedBy: .newlines) {
@@ -24,15 +24,15 @@ struct IdentityInfo {
                 name = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
             } else if trimmed.lowercased().hasPrefix("- **role:**") {
                 role = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
-            } else if trimmed.lowercased().hasPrefix("- **vibe:**") {
-                vibe = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
+            } else if trimmed.lowercased().hasPrefix("- **personality:**") || trimmed.lowercased().hasPrefix("- **vibe:**") {
+                personality = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
             } else if trimmed.lowercased().hasPrefix("- **emoji:**") {
                 emoji = trimmed.components(separatedBy: ":**").last?.trimmingCharacters(in: .whitespaces) ?? ""
             }
         }
 
         guard !name.isEmpty else { return nil }
-        return IdentityInfo(name: name, role: role, vibe: vibe, emoji: emoji)
+        return IdentityInfo(name: name, role: role, personality: personality, emoji: emoji)
     }
 
     /// Parses an optional `## Greetings` section from SOUL.md.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -98,8 +98,8 @@ struct IdentityPanel: View {
                 idRow(label: "Role", value: identity.role)
             }
 
-            if !identity.vibe.isEmpty {
-                idRow(label: "Vibe", value: identity.vibe)
+            if !identity.personality.isEmpty {
+                idRow(label: "Personality", value: identity.personality)
             }
 
             idRow(label: "Version", value: metadata?.version ?? "v1.0")


### PR DESCRIPTION
## Summary
Locks the BOOTSTRAP.md onboarding script with an explicit identity sequence, standardizes IDENTITY.md fields (Vibe → Personality), adds a prescriptive Home Base handoff format, aligns prebuilt Home Base copy, and adds guardrail tests.

## Changes
- **BOOTSTRAP.md**: Prescriptive 3-step identity sequence (who am I/who are you → personality → emoji with change-anytime note), Home Base handoff format ("Identity locked in. I'm ___ [emoji]. I thought of X ways to help you, check this out.")
- **IDENTITY.md**: Renamed Vibe → Personality, added emoji change-anytime instruction (without `_` prefix so it reaches the system prompt)
- **system-prompt.ts**: Updated "vibe" → "personality" in workspace file descriptions
- **index.html**: Updated Home Base hero h1 from "What would you like to do?" to "I thought of a few ways to help"
- **IdentityData.swift**: Renamed `vibe` → `personality` property, parser matches both "personality" and "vibe" for backward compat
- **IdentityPanel.swift**: Updated label "Vibe" → "Personality"
- **onboarding-template-contract.test.ts**: 6 guardrail tests verifying identity sequence, personality field, emoji instruction, handoff format, and IDENTITY.md fields

## Milestone PRs (merged into feature branch)
- #4621: M1 — Lock bootstrap identity sequence in BOOTSTRAP.md
- #4623: M2 — Lock IDENTITY.md canonical fields + emoji overwrite instruction
- #4625: M3 — Add Home Base handoff line to BOOTSTRAP.md
- #4624: M4 — Align prebuilt Home Base hero/subtitle copy
- #4626: M5 — Add guardrail tests for onboarding template contracts
- #4627: Fix — Align vibe→personality rename across all references

## Project issue
Closes #4614

## Test plan
- [ ] Run `bun test src/__tests__/onboarding-template-contract.test.ts` — 6 tests pass
- [ ] Fresh install (`/scrub`): verify bootstrap uses prescriptive identity sequence
- [ ] Verify Home Base handoff message matches format
- [ ] Verify Identity Panel shows "Personality" label (not "Vibe")
- [ ] Verify existing users with "Vibe" in IDENTITY.md still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
