### PR TITLE
test: tighten onboarding template contract assertions

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -15,7 +15,7 @@ describe('onboarding template contracts', () => {
     });
 
     test('uses "personality" for the personality step', () => {
-      expect(bootstrap).toContain('personality');
+      expect(bootstrap).toContain('What is my personality?');
       // Should not use "character" or "vibe" as a field/step label
       expect(bootstrap).not.toMatch(/what is my (character|vibe)/i);
     });
@@ -28,6 +28,8 @@ describe('onboarding template contracts', () => {
 
     test('contains the Home Base handoff format', () => {
       expect(bootstrap).toContain('Identity locked in');
+      expect(bootstrap).toMatch(/I thought of X ways to help you/i);
+      expect(bootstrap).toContain('check this out');
     });
   });
 


### PR DESCRIPTION
Tighten test assertions per review feedback on PR #4626: (1) assert specific personality step text 'What is my personality?' instead of just 'personality', (2) assert full handoff format including task count placeholder and 'check this out'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
