### PR TITLE
fix: move preferredColorScheme to View scope and add missing contextTooLarge switch case

### DIFF
--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -18,14 +18,16 @@ struct VellumAssistantApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if onboardingCompleted {
-                ContentView()
-                    .environmentObject(appDelegate.clientProvider)
-            } else {
-                OnboardingView(isCompleted: $onboardingCompleted)
+            Group {
+                if onboardingCompleted {
+                    ContentView()
+                        .environmentObject(appDelegate.clientProvider)
+                } else {
+                    OnboardingView(isCompleted: $onboardingCompleted)
+                }
             }
+            .preferredColorScheme(preferredScheme)
         }
-        .preferredColorScheme(preferredScheme)
     }
 }
 #else

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -231,6 +231,7 @@ struct ChatContentView: View {
         case .queueFull: return "tray.full.fill"
         case .sessionAborted: return "stop.circle.fill"
         case .processingFailed, .regenerateFailed: return "arrow.triangle.2.circlepath"
+        case .contextTooLarge: return "doc.text.fill.viewfinder"
         case .unknown: return "exclamationmark.triangle.fill"
         }
     }


### PR DESCRIPTION
## Summary
- Move `.preferredColorScheme()` from `WindowGroup` (a Scene type) to inside a `Group` wrapper (a View type) in `VellumAssistantApp.swift` — this modifier only exists on `View`, not `Scene`, so the iOS target failed to compile
- Add missing `.contextTooLarge` case to the `sessionErrorIcon()` switch statement in `ChatContentView.swift` — the `SessionErrorCategory` enum gained a new case that wasn't handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
