### PR TITLE
fix: clear TitleGenerator titledThreads on failure to allow retries

### DIFF
--- a/clients/ios/App/TitleGenerator.swift
+++ b/clients/ios/App/TitleGenerator.swift
@@ -18,6 +18,7 @@ actor TitleGenerator {
 
         guard let apiKey = APIKeyManager.shared.getAPIKey(provider: "anthropic")
                 ?? ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] else {
+            titledThreads.remove(threadId)
             return nil
         }
 
@@ -35,7 +36,10 @@ actor TitleGenerator {
             "messages": [["role": "user", "content": prompt]]
         ]
 
-        guard let httpBody = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+        guard let httpBody = try? JSONSerialization.data(withJSONObject: body) else {
+            titledThreads.remove(threadId)
+            return nil
+        }
         request.httpBody = httpBody
 
         do {
@@ -44,11 +48,13 @@ actor TitleGenerator {
                   let content = json["content"] as? [[String: Any]],
                   let firstBlock = content.first,
                   let text = firstBlock["text"] as? String else {
+                titledThreads.remove(threadId)
                 return nil
             }
             let title = text.trimmingCharacters(in: .whitespacesAndNewlines)
             return title.isEmpty ? nil : title
         } catch {
+            titledThreads.remove(threadId)
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Remove threadId from titledThreads set in all error/failure paths in TitleGenerator.generateTitle()
- Prevents permanent lockout of threads from title generation after transient failures (timeouts, network errors)
- Preserves deduplication of concurrent in-flight requests (insert before request, remove on failure)

Addresses feedback from PR #4583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
