### PR TITLE
feat: add work_items schema and store for Task Queue

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -741,6 +741,31 @@ export function initializeDb(): void {
     )
   `);
 
+  // ── Work Items (Task Queue) ─────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS work_items (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL REFERENCES tasks(id),
+      title TEXT NOT NULL,
+      notes TEXT,
+      status TEXT NOT NULL DEFAULT 'queued',
+      priority_tier INTEGER NOT NULL DEFAULT 1,
+      sort_index INTEGER,
+      last_run_id TEXT,
+      last_run_conversation_id TEXT,
+      last_run_status TEXT,
+      source_type TEXT,
+      source_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_work_items_status ON work_items(status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_work_items_task_id ON work_items(task_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_work_items_priority_sort ON work_items(priority_tier, sort_index)`);
+
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_task_id ON task_runs(task_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_status ON task_runs(status)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -425,6 +425,25 @@ export const taskCandidates = sqliteTable('task_candidates', {
   promotedTaskId: text('promoted_task_id'),             // set when candidate is promoted to a real task
 });
 
+// ── Work Items (Task Queue) ──────────────────────────────────────────
+
+export const workItems = sqliteTable('work_items', {
+  id: text('id').primaryKey(),
+  taskId: text('task_id').notNull().references(() => tasks.id),
+  title: text('title').notNull(),
+  notes: text('notes'),
+  status: text('status').notNull().default('queued'),  // queued | running | awaiting_review | failed | done | archived
+  priorityTier: integer('priority_tier').notNull().default(1), // 0=urgent, 1=high, 2=normal, 3=low
+  sortIndex: integer('sort_index'),  // manual ordering within same priority tier; null = fall back to updated_at
+  lastRunId: text('last_run_id'),
+  lastRunConversationId: text('last_run_conversation_id'),
+  lastRunStatus: text('last_run_status'),  // 'completed' | 'failed' | null
+  sourceType: text('source_type'),  // reserved for future bridge (e.g. 'followup', 'triage')
+  sourceId: text('source_id'),      // reserved for future bridge
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 export const homeBaseAppLinks = sqliteTable('home_base_app_links', {
   id: text('id').primaryKey(),
   appId: text('app_id').notNull(),

--- a/assistant/src/work-items/work-item-store.ts
+++ b/assistant/src/work-items/work-item-store.ts
@@ -1,0 +1,91 @@
+import { eq, desc, asc } from 'drizzle-orm';
+import { getDb } from '../memory/db.js';
+import { workItems } from '../memory/schema.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type WorkItemStatus = 'queued' | 'running' | 'awaiting_review' | 'failed' | 'done' | 'archived';
+
+export interface WorkItem {
+  id: string;
+  taskId: string;
+  title: string;
+  notes: string | null;
+  status: WorkItemStatus;
+  priorityTier: number;
+  sortIndex: number | null;
+  lastRunId: string | null;
+  lastRunConversationId: string | null;
+  lastRunStatus: string | null;
+  sourceType: string | null;
+  sourceId: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ── CRUD ─────────────────────────────────────────────────────────────
+
+export function createWorkItem(opts: {
+  taskId: string;
+  title: string;
+  notes?: string;
+  priorityTier?: number;
+  sortIndex?: number;
+  sourceType?: string;
+  sourceId?: string;
+}): WorkItem {
+  const db = getDb();
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  const item: WorkItem = {
+    id,
+    taskId: opts.taskId,
+    title: opts.title,
+    notes: opts.notes ?? null,
+    status: 'queued',
+    priorityTier: opts.priorityTier ?? 1,
+    sortIndex: opts.sortIndex ?? null,
+    lastRunId: null,
+    lastRunConversationId: null,
+    lastRunStatus: null,
+    sourceType: opts.sourceType ?? null,
+    sourceId: opts.sourceId ?? null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(workItems).values(item).run();
+  return item;
+}
+
+export function getWorkItem(id: string): WorkItem | undefined {
+  const db = getDb();
+  return db.select().from(workItems).where(eq(workItems.id, id)).get() as WorkItem | undefined;
+}
+
+export function listWorkItems(opts?: { status?: WorkItemStatus }): WorkItem[] {
+  const db = getDb();
+  let query = db.select().from(workItems);
+  if (opts?.status) {
+    query = query.where(eq(workItems.status, opts.status)) as typeof query;
+  }
+  return query
+    .orderBy(asc(workItems.priorityTier), asc(workItems.sortIndex), desc(workItems.updatedAt))
+    .all() as WorkItem[];
+}
+
+export function updateWorkItem(
+  id: string,
+  updates: Partial<Pick<WorkItem, 'title' | 'notes' | 'status' | 'priorityTier' | 'sortIndex' | 'lastRunId' | 'lastRunConversationId' | 'lastRunStatus'>>,
+): WorkItem | undefined {
+  const db = getDb();
+  db.update(workItems)
+    .set({ ...updates, updatedAt: Date.now() })
+    .where(eq(workItems.id, id))
+    .run();
+  return getWorkItem(id);
+}
+
+export function deleteWorkItem(id: string): void {
+  const db = getDb();
+  db.delete(workItems).where(eq(workItems.id, id)).run();
+}


### PR DESCRIPTION
Adds the work_items table (schema + inline migration) and a CRUD store. This is the data layer for the Task Queue feature — an ordered list of Task templates to run and review.

**Fields:** task_id, title, notes, status (queued/running/awaiting_review/failed/done/archived), priority_tier, sort_index, last_run_id/conversation_id/status, reserved source_type/source_id for future bridge support.

**Changes:**
- `assistant/src/memory/schema.ts` — added `workItems` drizzle table definition after `taskCandidates`
- `assistant/src/memory/db.ts` — added `CREATE TABLE IF NOT EXISTS work_items` migration + indexes
- `assistant/src/work-items/work-item-store.ts` — new CRUD store (create, get, list, update, delete)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
