### PR TITLE
fix: onboarding screen light/dark mode — replace hardcoded colors with adaptive tokens

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -205,11 +205,11 @@ struct APIKeyStepView: View {
                     RoundedRectangle(cornerRadius: VRadius.lg)
                         .fill(primaryButtonDisabled
                             ? adaptiveColor(
-                                light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 0.3)),
+                                light: Slate._900.opacity(0.3),
                                 dark: Violet._600.opacity(0.3)
                             )
                             : adaptiveColor(
-                                light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                light: Slate._900,
                                 dark: Violet._600
                             )
                         )

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -254,7 +254,7 @@ struct CloudCredentialsStepView: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "doc.fill")
                     .font(.system(size: 14))
-                    .foregroundColor(adaptiveColor(light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)), dark: Violet._600))
+                    .foregroundColor(adaptiveColor(light: Slate._900, dark: Violet._600))
                 Text(fileName)
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
@@ -275,7 +275,7 @@ struct CloudCredentialsStepView: View {
             .padding(.vertical, VSpacing.md)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(adaptiveColor(light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 0.3)), dark: Violet._600.opacity(0.3)), lineWidth: 1)
+                    .stroke(adaptiveColor(light: Slate._900.opacity(0.3), dark: Violet._600.opacity(0.3)), lineWidth: 1)
             )
         }
     }
@@ -335,11 +335,11 @@ struct CloudCredentialsStepView: View {
                     RoundedRectangle(cornerRadius: VRadius.lg)
                         .fill(continueDisabled
                             ? adaptiveColor(
-                                light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 0.3)),
+                                light: Slate._900.opacity(0.3),
                                 dark: Violet._600.opacity(0.3)
                             )
                             : adaptiveColor(
-                                light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                light: Slate._900,
                                 dark: Violet._600
                             )
                         )

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -97,7 +97,7 @@ struct FnKeyStepView: View {
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.lg)
                                 .fill(adaptiveColor(
-                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                    light: Slate._900,
                                     dark: Violet._600
                                 ))
                         )
@@ -117,7 +117,7 @@ struct FnKeyStepView: View {
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.lg)
                                 .fill(adaptiveColor(
-                                    light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                    light: Slate._900,
                                     dark: Violet._600
                                 ))
                         )

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -56,7 +56,7 @@ struct ModelSelectionStepView: View {
                     .background(
                         RoundedRectangle(cornerRadius: VRadius.lg)
                             .fill(adaptiveColor(
-                                light: Color(nsColor: NSColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1)),
+                                light: Slate._900,
                                 dark: Violet._600
                             ))
                     )

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -94,8 +94,8 @@ struct OnboardingFlowView: View {
                 .background(
                     RadialGradient(
                         colors: [
-                            Color(hex: 0x0F172A),
-                            Color(hex: 0x080B17)
+                            adaptiveColor(light: Slate._100, dark: Slate._900),
+                            adaptiveColor(light: Slate._200, dark: Slate._950)
                         ],
                         center: .center,
                         startRadius: 0,

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -144,7 +144,7 @@ struct WakeUpStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(Color.white.opacity(0.02))
+                .fill(adaptiveColor(light: Slate._300.opacity(0.3), dark: Color.white.opacity(0.02)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)


### PR DESCRIPTION
## Summary
- Replace hardcoded dark RadialGradient (0x0F172A, 0x080B17) in OnboardingFlowView with adaptive Slate tokens
- Replace hardcoded Color.white.opacity(0.02) in WakeUpStepView card backgrounds with adaptive colors
- Replace hardcoded NSColor(red: 0.12, ...) in CloudCredentialsStepView, ModelSelectionStepView, APIKeyStepView, FnKeyStepView with Slate._900 tokens
- All text and backgrounds now properly adapt to both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
