### PR TITLE
feat: add Task Queue panel to macOS app

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Codable, Equatable, Sendable {
-    case chat, threadList, activity, settings, agent, debug, doctor, directory, generated, identity
+    case chat, threadList, activity, settings, agent, debug, doctor, directory, generated, identity, taskQueue
 }
 
 public enum SlotContent: Equatable, Sendable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -348,6 +348,10 @@ struct MainWindowView: View {
                                 showControlCenterDrawer = false
                                 windowState.togglePanel(.agent)
                             },
+                            onTaskQueue: {
+                                showControlCenterDrawer = false
+                                windowState.togglePanel(.taskQueue)
+                            },
                             onSettings: {
                                 showControlCenterDrawer = false
                                 windowState.togglePanel(.settings)
@@ -1026,6 +1030,11 @@ struct MainWindowView: View {
             sidebarView
         case .identity:
             IdentityPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
+        case .taskQueue:
+            TaskQueuePanel(
+                daemonClient: daemonClient,
+                onClose: { windowState.selection = nil }
+            )
         }
     }
 
@@ -1427,6 +1436,7 @@ private struct ControlCenterMenuButton: View {
 private struct DrawerMenuView: View {
     let onIdentity: () -> Void
     let onSkills: () -> Void
+    let onTaskQueue: () -> Void
     let onSettings: () -> Void
     let onDebug: () -> Void
     let onDoctor: () -> Void
@@ -1435,6 +1445,7 @@ private struct DrawerMenuView: View {
         VStack(alignment: .leading, spacing: 0) {
             DrawerMenuItem(icon: "person.crop.circle", label: "Identity", action: onIdentity)
             DrawerMenuItem(icon: "wand.and.stars", label: "Skills", action: onSkills)
+            DrawerMenuItem(icon: "list.bullet.clipboard", label: "Task Queue", action: onTaskQueue)
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct TaskQueuePanel: View {
+    @ObservedObject var daemonClient: DaemonClient
+    let onClose: () -> Void
+
+    @State private var items: [IPCWorkItemsListResponseItem] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VSidePanel(title: "Task Queue", onClose: onClose) {
+            if isLoading {
+                VStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            } else if items.isEmpty {
+                VEmptyState(
+                    title: "No tasks",
+                    subtitle: "Queued work items will appear here",
+                    icon: "list.bullet.clipboard"
+                )
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: VSpacing.xs) {
+                        ForEach(items, id: \.id) { item in
+                            TaskQueueRow(
+                                item: item,
+                                onRun: { runTask(id: item.id) },
+                                onComplete: { completeTask(id: item.id) }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.sm)
+                }
+            }
+        }
+        .onAppear {
+            fetchWorkItems()
+            listenForStatusChanges()
+        }
+    }
+
+    // MARK: - Data Fetching
+
+    private func fetchWorkItems() {
+        isLoading = true
+        errorMessage = nil
+
+        daemonClient.onWorkItemsListResponse = { response in
+            self.items = response.items
+            self.isLoading = false
+        }
+
+        do {
+            try daemonClient.sendWorkItemsList()
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    private func listenForStatusChanges() {
+        daemonClient.onWorkItemStatusChanged = { changed in
+            // Update the item in-place or re-fetch the list
+            // Re-fetch the full list to pick up changes
+            do {
+                try daemonClient.sendWorkItemsList()
+            } catch {
+                // Silently ignore; the list will refresh on next status change
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func runTask(id: String) {
+        do {
+            try daemonClient.sendWorkItemRunTask(id: id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func completeTask(id: String) {
+        do {
+            try daemonClient.sendWorkItemComplete(id: id)
+            // Optimistic removal
+            items.removeAll { $0.id == id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Task Queue Row
+
+private struct TaskQueueRow: View {
+    let item: IPCWorkItemsListResponseItem
+    let onRun: () -> Void
+    let onComplete: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(alignment: .center, spacing: VSpacing.sm) {
+                priorityIndicator
+                Text(item.title)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                Spacer()
+                statusBadge
+            }
+
+            if let notes = item.notes, !notes.isEmpty {
+                Text(notes)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(2)
+            }
+
+            // Action buttons based on status
+            HStack(spacing: VSpacing.sm) {
+                if item.status == "queued" {
+                    Button(action: onRun) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "play.fill")
+                                .font(.system(size: 10))
+                            Text("Run")
+                                .font(VFont.caption)
+                        }
+                        .foregroundColor(VColor.accent)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.accent.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if item.status == "awaiting_review" {
+                    Button(action: onComplete) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 10))
+                            Text("Mark Reviewed")
+                                .font(VFont.caption)
+                        }
+                        .foregroundColor(VColor.success)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.success.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+
+                if let lastRunStatus = item.lastRunStatus {
+                    Text("Last run: \(lastRunStatus)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .background(isHovered ? VColor.surface.opacity(0.8) : VColor.surface.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+        )
+        .onHover { hovering in
+            isHovered = hovering
+        }
+    }
+
+    // MARK: - Priority Indicator
+
+    @ViewBuilder
+    private var priorityIndicator: some View {
+        let tier = item.priorityTier
+        Circle()
+            .fill(priorityColor(tier: tier))
+            .frame(width: 8, height: 8)
+            .accessibilityLabel("Priority \(Int(tier))")
+    }
+
+    private func priorityColor(tier: Double) -> Color {
+        switch tier {
+        case 0: return VColor.error      // Urgent
+        case 1: return VColor.warning    // High
+        case 2: return VColor.accent     // Normal
+        default: return VColor.textMuted // Low
+        }
+    }
+
+    // MARK: - Status Badge
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        let (label, color, showSpinner) = statusInfo(item.status)
+        HStack(spacing: VSpacing.xs) {
+            if showSpinner {
+                ProgressView()
+                    .controlSize(.mini)
+            }
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(color)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, 2)
+        .background(color.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+    }
+
+    private func statusInfo(_ status: String) -> (String, Color, Bool) {
+        switch status {
+        case "queued":
+            return ("Queued", VColor.textSecondary, false)
+        case "running":
+            return ("Running", VColor.accent, true)
+        case "awaiting_review":
+            return ("Awaiting Review", VColor.warning, false)
+        case "failed":
+            return ("Failed", VColor.error, false)
+        case "done":
+            return ("Done", VColor.success, false)
+        default:
+            return (status, VColor.textMuted, false)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct TaskQueuePanelPreview: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            TaskQueuePanel(
+                daemonClient: DaemonClient(),
+                onClose: {}
+            )
+            .frame(width: 400, height: 600)
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -8,6 +8,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case activity
     case identity
     case documentEditor
+    case taskQueue
 
     init?(rawValue: String) {
         switch rawValue {
@@ -20,6 +21,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "activity": self = .activity
         case "identity": self = .identity
         case "documentEditor": self = .documentEditor
+        case "taskQueue": self = .taskQueue
         default: return nil
         }
     }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -255,6 +255,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `env_vars_response` message (debug builds only).
     public var onEnvVarsResponse: ((EnvVarsResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `work_items_list_response` message.
+    public var onWorkItemsListResponse: ((IPCWorkItemsListResponse) -> Void)?
+
+    /// Called when the daemon sends a `work_item_status_changed` broadcast.
+    public var onWorkItemStatusChanged: ((IPCWorkItemStatusChanged) -> Void)?
+
+    /// Called when the daemon sends a `work_item_run_task_response` message.
+    public var onWorkItemRunTaskResponse: ((IPCWorkItemRunTaskResponse) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -810,6 +819,28 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(ReminderCancelMessage(id: id))
     }
 
+    // MARK: - Work Items (Task Queue)
+
+    /// Request the list of work items from the daemon, optionally filtered by status.
+    public func sendWorkItemsList(status: String? = nil) throws {
+        try send(IPCWorkItemsListRequest(type: "work_items_list", status: status))
+    }
+
+    /// Mark a work item as complete (reviewed).
+    public func sendWorkItemComplete(id: String) throws {
+        try send(IPCWorkItemCompleteRequest(type: "work_item_complete", id: id))
+    }
+
+    /// Run the task associated with a work item.
+    public func sendWorkItemRunTask(id: String) throws {
+        try send(IPCWorkItemRunTaskRequest(type: "work_item_run_task", id: id))
+    }
+
+    /// Update fields on an existing work item.
+    public func sendWorkItemUpdate(id: String, title: String? = nil, notes: String? = nil, status: String? = nil, priorityTier: Double? = nil, sortIndex: Int? = nil) throws {
+        try send(IPCWorkItemUpdateRequest(type: "work_item_update", id: id, title: title, notes: notes, status: status, priorityTier: priorityTier, sortIndex: sortIndex))
+    }
+
     // MARK: - Skills Management
 
     /// Enable a skill by name.
@@ -1326,6 +1357,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onBrowserCDPRequest?(msg)
         case .envVarsResponse(let msg):
             onEnvVarsResponse?(msg)
+        case .workItemsListResponse(let msg):
+            onWorkItemsListResponse?(msg)
+        case .workItemStatusChanged(let msg):
+            onWorkItemStatusChanged?(msg)
+        case .workItemRunTaskResponse(let msg):
+            onWorkItemRunTaskResponse?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1835,3 +1835,155 @@ public struct IPCWatchStarted: Codable, Sendable {
     public let durationSeconds: Double
     public let intervalSeconds: Double
 }
+
+public struct IPCWorkItemCompleteRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
+public struct IPCWorkItemCreateRequest: Codable, Sendable {
+    public let type: String
+    public let taskId: String
+    public let title: String?
+    public let notes: String?
+    public let priorityTier: Double?
+    public let sortIndex: Int?
+}
+
+public struct IPCWorkItemCreateResponse: Codable, Sendable {
+    public let type: String
+    public let item: IPCWorkItemCreateResponseItem
+}
+
+public struct IPCWorkItemCreateResponseItem: Codable, Sendable {
+    public let id: String
+    public let taskId: String
+    public let title: String
+    public let notes: String?
+    public let status: String
+    public let priorityTier: Double
+    public let sortIndex: Int?
+    public let lastRunId: String?
+    public let lastRunConversationId: String?
+    public let lastRunStatus: String?
+    public let sourceType: String?
+    public let sourceId: String?
+    public let createdAt: Int
+    public let updatedAt: Int
+}
+
+public struct IPCWorkItemGetRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
+public struct IPCWorkItemGetResponse: Codable, Sendable {
+    public let type: String
+    public let item: IPCWorkItemGetResponseItem?
+}
+
+public struct IPCWorkItemGetResponseItem: Codable, Sendable {
+    public let id: String
+    public let taskId: String
+    public let title: String
+    public let notes: String?
+    public let status: String
+    public let priorityTier: Double
+    public let sortIndex: Int?
+    public let lastRunId: String?
+    public let lastRunConversationId: String?
+    public let lastRunStatus: String?
+    public let sourceType: String?
+    public let sourceId: String?
+    public let createdAt: Int
+    public let updatedAt: Int
+}
+
+public struct IPCWorkItemRunTaskRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
+public struct IPCWorkItemRunTaskResponse: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let lastRunId: String
+    public let success: Bool
+    public let error: String?
+}
+
+public struct IPCWorkItemsListRequest: Codable, Sendable {
+    public let type: String
+    public let status: String?
+}
+
+public struct IPCWorkItemsListResponse: Codable, Sendable {
+    public let type: String
+    public let items: [IPCWorkItemsListResponseItem]
+}
+
+public struct IPCWorkItemsListResponseItem: Codable, Sendable {
+    public let id: String
+    public let taskId: String
+    public let title: String
+    public let notes: String?
+    public let status: String
+    public let priorityTier: Double
+    public let sortIndex: Int?
+    public let lastRunId: String?
+    public let lastRunConversationId: String?
+    public let lastRunStatus: String?
+    public let sourceType: String?
+    public let sourceId: String?
+    public let createdAt: Int
+    public let updatedAt: Int
+}
+
+/// Server push — broadcast when a work item status changes (e.g. running -> awaiting_review).
+public struct IPCWorkItemStatusChanged: Codable, Sendable {
+    public let type: String
+    public let item: IPCWorkItemStatusChangedItem
+}
+
+public struct IPCWorkItemStatusChangedItem: Codable, Sendable {
+    public let id: String
+    public let taskId: String
+    public let title: String
+    public let status: String
+    public let lastRunId: String?
+    public let lastRunConversationId: String?
+    public let lastRunStatus: String?
+    public let updatedAt: Int
+}
+
+public struct IPCWorkItemUpdateRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let title: String?
+    public let notes: String?
+    public let status: String?
+    public let priorityTier: Double?
+    public let sortIndex: Int?
+}
+
+public struct IPCWorkItemUpdateResponse: Codable, Sendable {
+    public let type: String
+    public let item: IPCWorkItemUpdateResponseItem?
+}
+
+public struct IPCWorkItemUpdateResponseItem: Codable, Sendable {
+    public let id: String
+    public let taskId: String
+    public let title: String
+    public let notes: String?
+    public let status: String
+    public let priorityTier: Double
+    public let sortIndex: Int?
+    public let lastRunId: String?
+    public let lastRunConversationId: String?
+    public let lastRunStatus: String?
+    public let sourceType: String?
+    public let sourceId: String?
+    public let createdAt: Int
+    public let updatedAt: Int
+}

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1750,6 +1750,9 @@ public enum ServerMessage: Decodable, Sendable {
     case browserInteractiveModeChanged(BrowserInteractiveModeChangedMessage)
     case browserCDPRequest(BrowserCDPRequestMessage)
     case envVarsResponse(EnvVarsResponseMessage)
+    case workItemsListResponse(IPCWorkItemsListResponse)
+    case workItemStatusChanged(IPCWorkItemStatusChanged)
+    case workItemRunTaskResponse(IPCWorkItemRunTaskResponse)
     case pong
     case unknown(String)
 
@@ -2005,6 +2008,15 @@ public enum ServerMessage: Decodable, Sendable {
         case "env_vars_response":
             let message = try EnvVarsResponseMessage(from: decoder)
             self = .envVarsResponse(message)
+        case "work_items_list_response":
+            let message = try IPCWorkItemsListResponse(from: decoder)
+            self = .workItemsListResponse(message)
+        case "work_item_status_changed":
+            let message = try IPCWorkItemStatusChanged(from: decoder)
+            self = .workItemStatusChanged(message)
+        case "work_item_run_task_response":
+            let message = try IPCWorkItemRunTaskResponse(from: decoder)
+            self = .workItemRunTaskResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add a Task Queue side panel to the macOS app, accessible from the Control Center drawer
- Wire up work_item IPC messages (list, complete, run_task, status_changed) with DaemonClient callbacks and send methods
- Regenerate Swift IPC types to include work_item message structs from the TS contract
- Show queued work items with status badges (Queued/Running/Awaiting Review/Failed/Done), priority indicators, and action buttons (Run, Mark Reviewed)
- Listen for real-time `work_item_status_changed` broadcasts to keep the list current

## Test plan
- [ ] Open Control Center drawer and verify "Task Queue" entry appears
- [ ] Click "Task Queue" to open the side panel
- [ ] Verify empty state shows when no work items exist
- [ ] Create work items via CLI/daemon and verify they appear in the panel
- [ ] Test "Run" button on queued items
- [ ] Test "Mark Reviewed" button on awaiting_review items
- [ ] Verify status badges update in real-time when item status changes
- [ ] Verify panel closes when clicking the X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
