### PR TITLE
feat: persist document widget in chat after app reload

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -8,7 +8,7 @@
 
 import type { ToolDefinition } from '../providers/types.js';
 import type { ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
-import type { ServerMessage } from './ipc-protocol.js';
+import type { ServerMessage, SurfaceType, SurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import type { ToolExecutor } from '../tools/executor.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
@@ -97,7 +97,23 @@ export function createToolExecutor(
       memoryScopeId: ctx.memoryPolicy.scopeId,
       forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
       onToolLifecycleEvent: handleToolLifecycleEvent,
-      sendToClient: (msg) => ctx.sendToClient(msg as unknown as ServerMessage),
+      sendToClient: (msg) => {
+        const serverMsg = msg as unknown as ServerMessage;
+        ctx.sendToClient(serverMsg);
+        // Auto-track ui_surface_show for history persistence, mirroring what
+        // session-surfaces.ts does when sending surfaces through its own path.
+        if (serverMsg.type === 'ui_surface_show') {
+          const s = serverMsg as unknown as UiSurfaceShow;
+          ctx.currentTurnSurfaces.push({
+            surfaceId: s.surfaceId,
+            surfaceType: s.surfaceType,
+            title: s.title,
+            data: s.data,
+            actions: s.actions,
+            display: s.display,
+          });
+        }
+      },
       isInteractive: !ctx.hasNoClient,
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),
       proxyApprovalCallback: createProxyApprovalCallback(prompter, ctx),

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -392,6 +392,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         daemonClient.onDocumentSaveResponse = { [weak self] msg in
             self?.mainWindow?.handleDocumentSaveResponse(msg)
         }
+        daemonClient.onDocumentLoadResponse = { [weak self] msg in
+            self?.mainWindow?.handleDocumentLoadResponse(msg)
+        }
 
         // Handle diagnostics export response — show a toast in the main window
         daemonClient.onDiagnosticsExportResponse = { [weak self] response in

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -180,6 +180,12 @@ struct DocumentEditorView: NSViewRepresentable {
             isInitialized = true
             log.info("Document editor loaded")
             print("✅ WebView finished loading - editor initialized!")
+            // Apply any content that accumulated while the WebView was loading
+            // (document_editor_update messages that arrived before isInitialized was set)
+            let tracked = documentManager.currentContent
+            if !tracked.isEmpty {
+                setInitialContent(title: documentManager.title, markdown: tracked)
+            }
         }
 
         private func escapeForJS(_ str: String) -> String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -25,6 +25,9 @@ final class DocumentManager: ObservableObject {
     /// Pending initial content to be set when coordinator becomes ready
     private var pendingInitialContent: String?
 
+    /// Debounced auto-save task — cancelled and rescheduled on every content update
+    private var autoSaveTask: Task<Void, Never>?
+
     /// Reference to daemon client for saving documents
     weak var daemonClient: DaemonClient?
 
@@ -68,15 +71,36 @@ final class DocumentManager: ObservableObject {
     }
 
     func updateDocument(markdown: String, mode: String) {
+        // Always track content so it survives WebView recreation and load races
+        if mode == "replace" {
+            currentContent = markdown
+        } else {
+            let sep = currentContent.isEmpty ? "" : "\n\n"
+            currentContent += sep + markdown
+        }
+
         guard let coordinator = editorCoordinator else {
-            log.warning("⚠️ Cannot update document: editor coordinator not ready")
-            print("⚠️ Cannot update document: editor coordinator not ready")
+            log.warning("⚠️ Cannot update document: editor coordinator not ready, content tracked for later")
+            print("⚠️ Cannot update document: editor coordinator not ready, content tracked for later")
             return
         }
 
         print("📝 Sending update to coordinator: mode=\(mode), length=\(markdown.count)")
         coordinator.sendContentUpdate(markdown: markdown, mode: mode)
         log.info("Document updated: mode=\(mode), length=\(markdown.count)")
+
+        scheduleAutoSave()
+    }
+
+    /// Cancels any pending auto-save and schedules a new one 2 seconds from now.
+    /// Fires after streaming completes so the document survives app reload.
+    private func scheduleAutoSave() {
+        autoSaveTask?.cancel()
+        autoSaveTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            self?.save()
+        }
     }
 
     func updateContent(title: String, content: String, wordCount: Int) {
@@ -86,6 +110,8 @@ final class DocumentManager: ObservableObject {
     }
 
     func closeDocument() {
+        autoSaveTask?.cancel()
+        autoSaveTask = nil
         hasActiveDocument = false
         surfaceId = nil
         sessionId = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -179,6 +179,19 @@ final class MainWindow {
         documentManager.handleSaveResponse(success: msg.success, error: msg.error)
     }
 
+    func handleDocumentLoadResponse(_ msg: DocumentLoadResponseMessage) {
+        let title = msg.success && !msg.title.isEmpty ? msg.title : "Document"
+        let content = msg.success ? msg.content : ""
+        documentManager.createDocument(
+            surfaceId: msg.surfaceId,
+            sessionId: msg.conversationId,
+            title: title,
+            initialContent: content
+        )
+        show()
+        windowState.togglePanel(.documentEditor)
+    }
+
     func show() {
         // Switch to regular activation policy FIRST so macOS allows window
         // foregrounding — calling makeKeyAndOrderFront while still .accessory

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -484,8 +484,15 @@ struct MainWindowView: View {
                 }
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .openDocumentEditor)) { _ in
-            windowState.selection = .panel(.documentEditor)
+        .onReceive(NotificationCenter.default.publisher(for: .openDocumentEditor)) { notification in
+            guard let surfaceId = notification.userInfo?["documentSurfaceId"] as? String else { return }
+            if documentManager.hasActiveDocument && documentManager.surfaceId == surfaceId {
+                // Document already in memory — just show the panel
+                windowState.selection = .panel(.documentEditor)
+            } else {
+                // Load from daemon — handleDocumentLoadResponse will open the panel when ready
+                try? daemonClient.sendDocumentLoad(surfaceId: surfaceId)
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .updateDynamicWorkspace)) { notification in
             if let updated = notification.userInfo?["surface"] as? Surface,


### PR DESCRIPTION
## Summary
- Intercept `ui_surface_show` in `createToolExecutor` to push document preview surfaces into `currentTurnSurfaces`, so they are serialized as `ui_surface` blocks on `message_complete` and restored from history on reload
- Fix click-to-open: `openDocumentEditor` notification now calls `sendDocumentLoad` when the document isn't already in memory; `handleDocumentLoadResponse` recreates the document state and opens the panel
- Fix empty editor: track content in `DocumentManager.currentContent` as daemon streams updates, apply it in `webView(_:didFinish:)` to handle WebView initialization races, and auto-save to DB 2s after streaming completes so content survives reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
