### PR TITLE
fix: make BOOTSTRAP.md contract test case-insensitive

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -28,7 +28,7 @@ describe('onboarding template contracts', () => {
 
     test('contains the Home Base handoff format', () => {
       expect(bootstrap).toMatch(/came up with X ideas/i);
-      expect(bootstrap).toContain('check this out');
+      expect(bootstrap).toMatch(/check this out/i);
     });
   });
 


### PR DESCRIPTION
Updates test assertion to case-insensitive regex to handle capitalization after em dash removal. Addresses review feedback from PR #4647.

## Change

`onboarding-template-contract.test.ts` line 31:
- Before: `expect(bootstrap).toContain('check this out');`
- After: `expect(bootstrap).toMatch(/check this out/i);`

## Why

PR #4647 removed em dashes from BOOTSTRAP.md, capitalizing "Check" since it now starts a new sentence. The case-sensitive `toContain` assertion broke. Using case-insensitive regex matches the pattern on the preceding line.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
