### PR TITLE
feat: add size variants to VButton and refine sidebar spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -702,7 +702,7 @@ struct MainWindowView: View {
                             .buttonStyle(.plain)
                         }
                     }
-                    .padding(.bottom, VSpacing.md)
+                    .padding(.bottom, VSpacing.lg)
 
                     VColor.background.frame(height: 1)
                         .padding(.horizontal, VSpacing.sm)
@@ -741,9 +741,10 @@ struct MainWindowView: View {
                             }
                         }
                     }
-                    .padding(.top, VSpacing.md)
+                    .padding(.top, VSpacing.lg)
                 }
                 .padding(VSpacing.xs)
+                .padding(.top, VSpacing.sm)
                 .background(VColor.surface)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .padding(.horizontal, VSpacing.xs)
@@ -1405,38 +1406,11 @@ private struct NewConversationButton: View {
 private struct ControlCenterMenuButton: View {
     let isOpen: Bool
     let onToggle: () -> Void
-    @State private var isHovered = false
 
     var body: some View {
-        Button {
+        VButton(label: "Control Center", icon: "gearshape", style: .ghost, size: .large, isFullWidth: true) {
             onToggle()
-        } label: {
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: "gearshape")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(isOpen ? VColor.textPrimary : VColor.textSecondary)
-
-                Text("Control Center")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(isOpen ? VColor.textPrimary : VColor.textSecondary)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .background(
-                Capsule()
-                    .fill(isHovered || isOpen ? VColor.hoverOverlay.opacity(0.08) : VColor.backgroundSubtle)
-                    .overlay(
-                        Capsule()
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-            )
-            .contentShape(Capsule())
-            .onHover { hovering in
-                isHovered = hovering
-                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
         }
-        .buttonStyle(.plain)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -757,7 +757,6 @@ struct MainWindowView: View {
 
             // Control Center pill button
             ControlCenterMenuButton(
-                isOpen: showControlCenterDrawer,
                 onToggle: {
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
                         showControlCenterDrawer.toggle()
@@ -1404,7 +1403,6 @@ private struct NewConversationButton: View {
 }
 
 private struct ControlCenterMenuButton: View {
-    let isOpen: Bool
     let onToggle: () -> Void
 
     var body: some View {

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -5,20 +5,23 @@ import AppKit
 
 public struct VButton: View {
     public enum Style: Hashable { case primary, ghost, danger }
+    public enum Size: Hashable { case small, medium, large }
 
     public let label: String
     public var icon: String? = nil
     public var style: Style = .primary
+    public var size: Size = .small
     public var isFullWidth: Bool = false
     public var isDisabled: Bool = false
     public let action: () -> Void
 
     @State private var isHovered = false
 
-    public init(label: String, icon: String? = nil, style: Style = .primary, isFullWidth: Bool = false, isDisabled: Bool = false, action: @escaping () -> Void) {
+    public init(label: String, icon: String? = nil, style: Style = .primary, size: Size = .small, isFullWidth: Bool = false, isDisabled: Bool = false, action: @escaping () -> Void) {
         self.label = label
         self.icon = icon
         self.style = style
+        self.size = size
         self.isFullWidth = isFullWidth
         self.isDisabled = isDisabled
         self.action = action
@@ -29,13 +32,13 @@ public struct VButton: View {
             HStack(spacing: VSpacing.sm) {
                 if let icon {
                     Image(systemName: icon)
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.system(size: iconSize, weight: .semibold))
                 }
                 Text(label)
-                    .font(VFont.monoMedium)
+                    .font(labelFont)
             }
         }
-        .buttonStyle(VButtonStyle(style: style, isHovered: isHovered, isFullWidth: isFullWidth))
+        .buttonStyle(VButtonStyle(style: style, size: size, isHovered: isHovered, isFullWidth: isFullWidth))
         #if os(macOS)
         .onHover { hovering in
             isHovered = isDisabled ? false : hovering
@@ -51,19 +54,36 @@ public struct VButton: View {
         .opacity(isDisabled ? 0.5 : 1.0)
         .accessibilityHint(isDisabled ? "Button is currently disabled" : "")
     }
+
+    private var iconSize: CGFloat {
+        switch size {
+        case .small: return 10
+        case .medium: return 12
+        case .large: return 14
+        }
+    }
+
+    private var labelFont: Font {
+        switch size {
+        case .small: return VFont.monoSmall
+        case .medium: return VFont.monoSmall
+        case .large: return VFont.monoMedium
+        }
+    }
 }
 
 private struct VButtonStyle: ButtonStyle {
     let style: VButton.Style
+    let size: VButton.Size
     let isHovered: Bool
     let isFullWidth: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundColor(foregroundColor)
-            .padding(.horizontal, VSpacing.md)
+            .padding(.horizontal, horizontalPadding)
             .padding(.vertical, VSpacing.buttonV)
-            .frame(height: 28)
+            .frame(height: height)
             .frame(maxWidth: isFullWidth ? .infinity : nil)
             .background(backgroundColor(isPressed: configuration.isPressed))
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
@@ -78,6 +98,22 @@ private struct VButtonStyle: ButtonStyle {
             .animation(VAnimation.fast, value: isHovered)
     }
 
+    private var height: CGFloat {
+        switch size {
+        case .small: return 24
+        case .medium: return 28
+        case .large: return 32
+        }
+    }
+
+    private var horizontalPadding: CGFloat {
+        switch size {
+        case .small: return VSpacing.md
+        case .medium: return VSpacing.md
+        case .large: return VSpacing.lg
+        }
+    }
+
     private var shadowColor: Color {
         switch style {
         case .primary:
@@ -85,7 +121,7 @@ private struct VButtonStyle: ButtonStyle {
         case .danger:
             return isHovered ? Rose._700 : Rose._800
         case .ghost:
-            return isHovered ? VColor.ghostPressed : VColor.ghostHover
+            return .clear
         }
     }
 
@@ -129,13 +165,14 @@ private struct VButtonStyle: ButtonStyle {
     ZStack {
         VColor.background.ignoresSafeArea()
         VStack(spacing: 16) {
-            VButton(label: "Primary", style: .primary) {}
-            VButton(label: "Ghost", style: .ghost) {}
-            VButton(label: "Danger", style: .danger) {}
-            VButton(label: "Disabled", style: .primary, isDisabled: true) {}
+            VButton(label: "Small", style: .primary, size: .small) {}
+            VButton(label: "Medium", style: .primary, size: .medium) {}
+            VButton(label: "Large", style: .primary, size: .large) {}
+            VButton(label: "Ghost Small", style: .ghost, size: .small) {}
+            VButton(label: "Ghost Large", style: .ghost, size: .large) {}
             VButton(label: "Full Width", style: .primary, isFullWidth: true) {}
         }
         .padding()
     }
-    .frame(width: 300, height: 300)
+    .frame(width: 300, height: 400)
 }


### PR DESCRIPTION
## Summary
- Add `Size` enum (`.small` 24pt, `.medium` 28pt, `.large` 32pt) to VButton with corresponding font and icon scaling
- Increase sidebar top padding and divider spacing between Threads and Apps sections
- Restyle Control Center as full-width ghost VButton with `.large` size

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
