### PR TITLE
M2: Evolving avatar view + onboarding UI integration

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
@@ -36,10 +36,10 @@ struct FirstMeetingIntroductionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Main content: creature left, chat panel right
+            // Main content: evolving avatar left, chat panel right
             HStack(alignment: .center, spacing: VSpacing.xxxl) {
-                // Hatched creature — same visual size as in hatch scene
-                CreatureView(visible: true, animated: false)
+                // Evolving avatar — shows progressive visual changes during conversation
+                EvolvingAvatarView(evolutionState: state.avatarEvolutionState, animated: false)
                     .scaleEffect(0.5)
                     .frame(width: 200, height: 200)
 
@@ -85,12 +85,17 @@ struct FirstMeetingIntroductionView: View {
             }
         }
         .onAppear {
+            // Ensure hatched milestone is applied so the avatar is visible
+            DeterministicEvolutionEngine.applyMilestone(.hatched, to: state.avatarEvolutionState)
             viewModel.startConversation()
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 withAnimation(.easeOut(duration: 0.5)) {
                     showControls = true
                 }
             }
+        }
+        .onChange(of: viewModel.turnCount) { _, newTurnCount in
+            applyConversationMilestones(turnCount: newTurnCount)
         }
         .onChange(of: viewModel.isFinished) {
             if viewModel.isFinished {
@@ -145,6 +150,39 @@ struct FirstMeetingIntroductionView: View {
                     }
                 )
         )
+    }
+
+    // MARK: - Milestone Detection
+
+    /// Apply evolution milestones based on conversation progress.
+    /// Uses turn count as a proxy for conversation phases:
+    /// - Turn 2+: name likely discussed -> nameChosen
+    /// - Turn 4+: personality emerging -> personalityDefined
+    /// - Turn 6+: emoji/identity solidifying -> emojiChosen
+    private func applyConversationMilestones(turnCount: Int) {
+        let evo = state.avatarEvolutionState
+        if turnCount >= 2 {
+            DeterministicEvolutionEngine.applyMilestone(
+                .nameChosen,
+                to: evo,
+                context: MilestoneContext(assistantName: state.assistantName)
+            )
+        }
+        if turnCount >= 4 {
+            // Gather personality text from assistant messages
+            let personalityText = viewModel.messages
+                .filter { $0.role == .assistant }
+                .map(\.text)
+                .joined(separator: " ")
+            DeterministicEvolutionEngine.applyMilestone(
+                .personalityDefined,
+                to: evo,
+                context: MilestoneContext(personalityText: personalityText)
+            )
+        }
+        if turnCount >= 6 {
+            DeterministicEvolutionEngine.applyMilestone(.emojiChosen, to: evo)
+        }
     }
 
     // MARK: - Conversation Completion

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EvolvingAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EvolvingAvatarView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Renders the dino avatar with progressive evolution based on AvatarEvolutionState.
+/// Shows unlock animations when new visual features appear.
+struct EvolvingAvatarView: View {
+    let evolutionState: AvatarEvolutionState
+    var animated: Bool = true
+
+    private let appearance = AvatarAppearanceManager.shared
+
+    @State private var appeared = false
+    @State private var breatheScaleY: CGFloat = 1.0
+    @State private var breatheScaleX: CGFloat = 1.0
+    @State private var glowOpacity: Double = 0.0
+    @State private var previousUnlockCount: Int = 0
+
+    var body: some View {
+        ZStack {
+            // Glow pulse on new unlock
+            if glowOpacity > 0 {
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [Meadow.avatarGradientStart.opacity(glowOpacity), .clear],
+                            center: .center,
+                            startRadius: 40,
+                            endRadius: 160
+                        )
+                    )
+                    .frame(width: 320, height: 320)
+                    .allowsHitTesting(false)
+            }
+
+            // Avatar image with feature-based opacity masking
+            avatarImage
+                .scaleEffect(x: breatheScaleX, y: breatheScaleY, anchor: .bottom)
+                .scaleEffect(appeared ? 1.0 : 0.0, anchor: .bottom)
+                .opacity(evolutionState.unlockedFeatures.contains(.blob) ? 1.0 : 0.0)
+        }
+        .onChange(of: evolutionState.unlockedFeatures.count) { oldCount, newCount in
+            if newCount > oldCount {
+                triggerUnlockGlow()
+            }
+        }
+        .onAppear {
+            previousUnlockCount = evolutionState.unlockedFeatures.count
+            if animated {
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                    appeared = true
+                }
+                startBreathing()
+            } else {
+                appeared = true
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var avatarImage: some View {
+        let palette = currentPalette
+        let image = PixelSpriteBuilder.buildDinoNSImage(pixelSize: Meadow.artPixelSize, palette: palette)
+        Image(nsImage: image)
+            .interpolation(.none)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 400, height: 360)
+            .shadow(radius: 8)
+            .opacity(avatarOpacity)
+    }
+
+    /// Determine palette based on evolution state.
+    /// Before baseBody is unlocked, use a muted/default palette.
+    /// After baseBody, use the appearance manager's palette (which reflects LOOKS.md or overrides).
+    private var currentPalette: DinoPalette {
+        if evolutionState.unlockedFeatures.contains(.baseBody) {
+            return appearance.palette
+        }
+        // Before body color is unlocked, use the default violet palette
+        return .violet
+    }
+
+    /// Progressive opacity based on unlock level
+    private var avatarOpacity: Double {
+        let features = evolutionState.unlockedFeatures
+        if features.contains(.fullExpression) { return 1.0 }
+        if features.contains(.baseBody) { return 0.95 }
+        if features.contains(.coreFace) { return 0.85 }
+        if features.contains(.eyes) { return 0.75 }
+        if features.contains(.blob) { return 0.6 }
+        return 0.0
+    }
+
+    private func startBreathing() {
+        withAnimation(.easeInOut(duration: 3).repeatForever(autoreverses: true)) {
+            breatheScaleY = 1.03
+            breatheScaleX = 0.98
+        }
+    }
+
+    private func triggerUnlockGlow() {
+        withAnimation(.easeIn(duration: 0.3)) {
+            glowOpacity = 0.6
+        }
+        withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+            glowOpacity = 0.0
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -41,6 +41,9 @@ final class OnboardingState {
     var cloudProvider: String = "local"
     var onboardingVariant: OnboardingVariant = .default
 
+    // Avatar evolution state for progressive visual changes during onboarding
+    var avatarEvolutionState = AvatarEvolutionState()
+
     /// When false, step changes are not written to UserDefaults (used by auth gate).
     var shouldPersist: Bool = true
 
@@ -135,6 +138,11 @@ final class OnboardingState {
         if shouldPersist { persist() }
     }
 
+    /// Load persisted avatar evolution state from UserDefaults.
+    func loadAvatarEvolution() {
+        avatarEvolutionState.load()
+    }
+
     /// Persist progress so we can resume after a forced restart.
     private func persist() {
         UserDefaults.standard.set(currentStep, forKey: "onboarding.step")
@@ -152,5 +160,6 @@ final class OnboardingState {
         for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
+        AvatarEvolutionState.clearPersistedState()
     }
 }


### PR DESCRIPTION
## Summary
- Add `EvolvingAvatarView` that renders the dino with progressive evolution based on `AvatarEvolutionState`, including unlock glow animations, progressive opacity, palette transitions, and breathing animation
- Wire `avatarEvolutionState` into `OnboardingState` with load/clear persistence support
- Replace `CreatureView` with `EvolvingAvatarView` in `FirstMeetingIntroductionView` and add turn-based milestone detection to fire `hatched`, `nameChosen`, `personalityDefined`, and `emojiChosen` milestones during the conversation

## Test plan
- [ ] Verify the evolving avatar appears during the first-meeting introduction conversation
- [ ] Confirm progressive opacity increases as conversation turns advance (0.6 at blob, 0.75 at eyes, etc.)
- [ ] Confirm glow pulse animation fires when new visual features unlock
- [ ] Verify palette switches from violet to appearance-manager palette after baseBody unlock
- [ ] Verify `OnboardingState.clearPersistedState()` also clears avatar evolution state

Closes #4642
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
