### PR TITLE
M4: Evolution resolver + LOOKS.md persistence

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -11,7 +11,7 @@ final class AvatarAppearanceManager {
 
     static let shared = AvatarAppearanceManager()
 
-    private var looksPath: String {
+    var looksPath: String {
         NSHomeDirectory() + "/.vellum/workspace/LOOKS.md"
     }
 
@@ -60,5 +60,32 @@ final class AvatarAppearanceManager {
 
         fileMonitor = source
         source.resume()
+    }
+
+    // MARK: - Evolution Write-Back
+
+    /// Write a resolved LooksConfig to LOOKS.md.
+    /// Only writes if the config actually changed from current.
+    func applyEvolutionResult(_ newConfig: LooksConfig) {
+        guard newConfig != config else { return }
+
+        let content = """
+        - **Body:** \(newConfig.bodyColor)
+        - **Cheeks:** \(newConfig.cheekColor)
+        - **Hat:** \(formatOutfitField(newConfig.hat, color: newConfig.hatColor))
+        - **Shirt:** \(formatOutfitField(newConfig.shirt, color: newConfig.shirtColor))
+        - **Accessory:** \(formatOutfitField(newConfig.accessory, color: newConfig.accessoryColor))
+        - **Held Item:** \(newConfig.heldItem)
+        """
+
+        try? content.write(toFile: looksPath, atomically: true, encoding: .utf8)
+        // File watcher will pick up the change and call reload()
+    }
+
+    private func formatOutfitField(_ item: String, color: String?) -> String {
+        if let color = color, color != "none" {
+            return "\(item) (\(color))"
+        }
+        return item
     }
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarEvolutionResolver.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarEvolutionResolver.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Merges deterministic baseline, model-driven traits, and user overrides
+/// into a resolved LooksConfig for avatar appearance.
+/// Precedence: user overrides > deterministic constraints > model-driven traits > defaults
+@MainActor
+enum AvatarEvolutionResolver {
+
+    /// Resolve the current evolution state into a LooksConfig.
+    static func resolve(state: AvatarEvolutionState) -> LooksConfig {
+        // Start with defaults
+        var bodyColor = "violet"
+        var cheekColor = "rose"
+        var hat = "none"
+        var hatColor: String?
+        var shirt = "none"
+        var shirtColor: String?
+        var accessory = "none"
+        var accessoryColor: String?
+        var heldItem = "none"
+
+        // Layer 1: Model-driven traits (only if enough features unlocked)
+        if state.unlockedFeatures.contains(.baseBody) {
+            bodyColor = colorFromWarmth(state.traits.warmth)
+            cheekColor = cheekColorFromWarmth(state.traits.warmth)
+        }
+
+        if state.unlockedFeatures.contains(.accessories) {
+            hat = hatFromTraits(state.traits)
+            shirt = shirtFromTraits(state.traits)
+            accessory = accessoryFromTraits(state.traits)
+            heldItem = heldItemFromTraits(state.traits)
+        }
+
+        // Layer 2: User overrides (always win for unlocked fields)
+        applyOverride(state: state, field: .bodyColor, value: &bodyColor)
+        applyOverride(state: state, field: .cheekColor, value: &cheekColor)
+        applyOverride(state: state, field: .hat, value: &hat)
+        applyOptionalOverride(state: state, field: .hatColor, value: &hatColor)
+        applyOverride(state: state, field: .shirt, value: &shirt)
+        applyOptionalOverride(state: state, field: .shirtColor, value: &shirtColor)
+        applyOverride(state: state, field: .accessory, value: &accessory)
+        applyOptionalOverride(state: state, field: .accessoryColor, value: &accessoryColor)
+        applyOverride(state: state, field: .heldItem, value: &heldItem)
+
+        return LooksConfig(
+            bodyColor: bodyColor,
+            cheekColor: cheekColor,
+            hat: hat,
+            hatColor: hatColor,
+            shirt: shirt,
+            shirtColor: shirtColor,
+            accessory: accessory,
+            accessoryColor: accessoryColor,
+            heldItem: heldItem
+        )
+    }
+
+    // MARK: - Override Helpers
+
+    private static func applyOverride(
+        state: AvatarEvolutionState,
+        field: AvatarEvolutionState.AppearanceField,
+        value: inout String
+    ) {
+        if let override = state.userOverrides[field] {
+            value = override
+        }
+    }
+
+    private static func applyOptionalOverride(
+        state: AvatarEvolutionState,
+        field: AvatarEvolutionState.AppearanceField,
+        value: inout String?
+    ) {
+        if let override = state.userOverrides[field] {
+            value = override == "none" ? nil : override
+        }
+    }
+
+    // MARK: - Trait-to-Appearance Mapping
+
+    /// Map warmth score to body color.
+    /// High warmth -> warm colors (rose, amber, orange)
+    /// Low warmth -> cool colors (cyan, blue, indigo, slate)
+    private static func colorFromWarmth(_ warmth: Double) -> String {
+        switch warmth {
+        case 0.0..<0.2: return "slate"
+        case 0.2..<0.35: return "cyan"
+        case 0.35..<0.45: return "blue"
+        case 0.45..<0.55: return "violet"
+        case 0.55..<0.65: return "indigo"
+        case 0.65..<0.75: return "emerald"
+        case 0.75..<0.85: return "amber"
+        case 0.85..<0.95: return "rose"
+        default: return "orange"
+        }
+    }
+
+    private static func cheekColorFromWarmth(_ warmth: Double) -> String {
+        if warmth > 0.6 { return "rose" }
+        if warmth > 0.3 { return "pink" }
+        return "slate"
+    }
+
+    /// Map formality + playfulness to hat choice
+    private static func hatFromTraits(_ traits: AvatarEvolutionState.TraitScores) -> String {
+        if traits.formality > 0.7 { return "tophat" }
+        if traits.playfulness > 0.7 { return "party_hat" }
+        if traits.energy > 0.7 { return "headband" }
+        return "none"
+    }
+
+    /// Map formality to shirt choice
+    private static func shirtFromTraits(_ traits: AvatarEvolutionState.TraitScores) -> String {
+        if traits.formality > 0.7 { return "suit" }
+        if traits.formality > 0.5 { return "vest" }
+        if traits.playfulness > 0.6 { return "tshirt" }
+        return "hoodie"
+    }
+
+    /// Map playfulness to accessory choice
+    private static func accessoryFromTraits(_ traits: AvatarEvolutionState.TraitScores) -> String {
+        if traits.playfulness > 0.7 { return "sunglasses" }
+        if traits.formality > 0.7 { return "monocle" }
+        if traits.warmth > 0.7 { return "scarf" }
+        return "none"
+    }
+
+    /// Map energy + playfulness to held item
+    private static func heldItemFromTraits(_ traits: AvatarEvolutionState.TraitScores) -> String {
+        if traits.energy > 0.7 && traits.playfulness > 0.5 { return "balloon" }
+        if traits.formality > 0.7 { return "briefcase" }
+        if traits.playfulness > 0.7 { return "wand" }
+        return "none"
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Avatar/LooksConfig.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/LooksConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Parses LOOKS.md from the workspace and provides a color palette and outfit for the dino avatar.
-struct LooksConfig {
+struct LooksConfig: Equatable {
     var bodyColor: String
     var cheekColor: String
 


### PR DESCRIPTION
## Summary
- Add `AvatarEvolutionResolver` that merges deterministic baseline, model traits, and user overrides into a resolved `LooksConfig` with clear precedence: user overrides > deterministic constraints > model-driven traits > defaults
- Add `applyEvolutionResult` write-back method to `AvatarAppearanceManager` so resolved appearance persists to `LOOKS.md` across surfaces
- Add `Equatable` conformance to `LooksConfig` for change detection
- Make `looksPath` internally readable for external callers

Closes #4644
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
