### PR TITLE
Strip old screenshot images from conversation history

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -447,23 +447,32 @@ function summarizeMessage(msg: Message): { role: string; blockTypes: string[] } 
 
 /**
  * Strip image contentBlocks from all tool_result blocks except those in the
- * last user message. This prevents screenshots from accumulating in the
- * context window — each image is seen once by the LLM on the turn it was
- * captured, then replaced with a text placeholder on subsequent turns.
+ * most recent user message that contains tool_result blocks. This prevents
+ * screenshots from accumulating in the context window — each image is seen
+ * once by the LLM on the turn it was captured, then replaced with a text
+ * placeholder on subsequent turns.
+ *
+ * We look for the last user message with tool_results (not just the last user
+ * message) because the empty-response nudge path appends a text-only user
+ * message after the tool results. Preserving images in that case ensures
+ * the model still sees the screenshot on the retry.
  */
 function stripOldImageBlocks(history: Message[]): Message[] {
-  // Find the index of the last user message (current turn's tool results)
-  let lastUserIdx = -1;
+  // Find the last user message that contains tool_result blocks.
+  let lastToolResultUserIdx = -1;
   for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i].role === 'user') {
-      lastUserIdx = i;
+    if (
+      history[i].role === 'user' &&
+      history[i].content.some((b) => b.type === 'tool_result')
+    ) {
+      lastToolResultUserIdx = i;
       break;
     }
   }
 
   return history.map((msg, idx) => {
-    // Keep the most recent user message intact (current turn)
-    if (idx === lastUserIdx || msg.role !== 'user') return msg;
+    // Keep the most recent tool-result user message intact (current turn)
+    if (idx === lastToolResultUserIdx || msg.role !== 'user') return msg;
 
     // Check if any tool_result blocks have image contentBlocks
     const hasImages = msg.content.some(

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -3,6 +3,7 @@ import type { Provider, Message, ToolDefinition, ContentBlock } from '../provide
 import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
 import { getHookManager } from '../hooks/manager.js';
 import { truncateOversizedToolResults } from '../context/tool-result-truncation.js';
+import type { ToolResultContent } from '../providers/types.js';
 
 const log = getLogger('agent-loop');
 
@@ -133,8 +134,14 @@ export class AgentLoop {
 
         const providerStart = Date.now();
 
+        // Strip image contentBlocks from older tool results to prevent
+        // screenshots from accumulating in the context window. The LLM
+        // already saw each image on the turn it was captured; keeping
+        // base64 blobs in history rapidly exhausts the context budget.
+        const providerHistory = stripOldImageBlocks(history);
+
         const response = await this.provider.sendMessage(
-          history,
+          providerHistory,
           currentTools.length > 0 ? currentTools : undefined,
           this.systemPrompt,
           {
@@ -436,4 +443,47 @@ function summarizeMessage(msg: Message): { role: string; blockTypes: string[] } 
     role: msg.role,
     blockTypes: msg.content.map((b) => b.type),
   };
+}
+
+/**
+ * Strip image contentBlocks from all tool_result blocks except those in the
+ * last user message. This prevents screenshots from accumulating in the
+ * context window — each image is seen once by the LLM on the turn it was
+ * captured, then replaced with a text placeholder on subsequent turns.
+ */
+function stripOldImageBlocks(history: Message[]): Message[] {
+  // Find the index of the last user message (current turn's tool results)
+  let lastUserIdx = -1;
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  return history.map((msg, idx) => {
+    // Keep the most recent user message intact (current turn)
+    if (idx === lastUserIdx || msg.role !== 'user') return msg;
+
+    // Check if any tool_result blocks have image contentBlocks
+    const hasImages = msg.content.some(
+      (b) => b.type === 'tool_result' && (b as ToolResultContent).contentBlocks?.some(cb => cb.type === 'image'),
+    );
+    if (!hasImages) return msg;
+
+    // Strip images from tool_result blocks, replacing with text marker
+    return {
+      ...msg,
+      content: msg.content.map((b) => {
+        if (b.type !== 'tool_result') return b;
+        const tr = b as ToolResultContent;
+        if (!tr.contentBlocks?.some(cb => cb.type === 'image')) return b;
+        return {
+          ...tr,
+          contentBlocks: undefined,
+          content: tr.content + '\n[Screenshot was captured and shown previously — image data removed to save context.]',
+        };
+      }),
+    };
+  });
 }

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -481,7 +481,7 @@ function stripOldImageBlocks(history: Message[]): Message[] {
         return {
           ...tr,
           contentBlocks: undefined,
-          content: tr.content + '\n[Screenshot was captured and shown previously — image data removed to save context.]',
+          content: (tr.content || '') + '\n[Screenshot was captured and shown previously — image data removed to save context.]',
         };
       }),
     };


### PR DESCRIPTION
## Summary
- Strips base64 image data from older tool_result blocks before sending conversation history to the provider
- Only the most recent user message retains its images — older screenshots are replaced with a text placeholder
- Prevents context window exhaustion during multi-turn browser automation sessions where each turn captures a screenshot

Extracted from #4654 to ship this context optimization independently.

## Test plan
- [ ] Run a multi-turn browser session and verify screenshots don't accumulate in context
- [ ] Verify the most recent turn's screenshot is still visible to the LLM
- [ ] Verify non-image tool results are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
