### PR TITLE
fix: re-check lock after credential mismatch teardown in getOrStartSession

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -400,13 +400,18 @@ export async function getOrStartSession(
 
   // Serialize: if another caller is already creating a session for this
   // conversation, wait for it rather than creating a second one.
-  const inflight = acquireLocks.get(conversationId);
-  if (inflight) {
+  // Loop so that after a credential-mismatch teardown we re-check for a new
+  // inflight lock — otherwise 3+ concurrent callers with different credentials
+  // can all fall through and create duplicate sessions.
+  for (;;) {
+    const inflight = acquireLocks.get(conversationId);
+    if (!inflight) break;
     const session = await inflight;
     if (credentialIdsMatch(session.credentialIds, credentialIds)) {
       return { session, created: false };
     }
-    // Credential mismatch — tear down and fall through to create a new session.
+    // Credential mismatch — tear down and loop back to re-check whether
+    // another waiter has already started a replacement session.
     await stopSession(session.id);
   }
 


### PR DESCRIPTION
Addresses review feedback on PR #4425: wrap the inflight-check and credential-mismatch teardown in a loop so that after stopping a mismatched session, the code re-checks acquireLocks before falling through to create a new session. This prevents 3+ concurrent callers with different credentials from bypassing serialization and creating duplicate sessions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
