### PR TITLE
fix: restrict computer_use_request_control to text sessions only

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -481,6 +481,11 @@ export class ComputerUseSession {
       });
     };
 
+    // Build a set of tool names the CU session is allowed to execute.
+    // This prevents tools registered globally (e.g. computer_use_request_control)
+    // but not advertised to the CU model from executing during CU sessions.
+    const allowedToolNames = new Set(toolDefs.map((td) => td.name));
+
     const toolExecutor = async (
       name: string,
       input: Record<string, unknown>,
@@ -490,6 +495,7 @@ export class ComputerUseSession {
         sessionId: this.sessionId,
         conversationId: this.sessionId,
         proxyToolResolver: proxyResolver,
+        allowedToolNames,
         requestSecret: async (params) => {
           return secretPrompter.prompt(
             params.service, params.field, params.label,


### PR DESCRIPTION
Addresses review feedback on PR #4428: prevents the escalation tool from executing during CU sessions by passing allowedToolNames to the CU session's ToolExecutor context, restricting execution to only the tools advertised in toolDefs. This leverages the existing allowedToolNames gating in ToolExecutor to prevent premature handoff behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
