### PR TITLE
fix: capture currentTurnUserText before reset in secret_blocked handler

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -491,6 +491,10 @@ extension ChatViewModel {
             isThinking = false
             let wasCancelling = isCancelling
             isCancelling = false
+            // Snapshot turn-specific state before reset so the secret_blocked
+            // handler below can reference the actual blocked text/attachments
+            // rather than falling back to a potentially-wrong transcript lookup.
+            let savedTurnUserText = currentTurnUserText
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -508,10 +512,10 @@ extension ChatViewModel {
                 // stash the full send context so "Send Anyway" can reconstruct
                 // the original UserMessageMessage with attachments and surface metadata.
                 if err.category == "secret_blocked" {
-                    // Prefer currentTurnUserText (the text that was actually sent)
+                    // Prefer the snapshotted turn text (the text that was actually sent)
                     // over the transcript lookup, which can miss workspace refinements
                     // that don't append a user chat message.
-                    if let sendText = currentTurnUserText {
+                    if let sendText = savedTurnUserText {
                         secretBlockedMessageText = sendText
                     } else if let lastUserMsg = messages.last(where: { $0.role == .user }) {
                         secretBlockedMessageText = lastUserMsg.text


### PR DESCRIPTION
Addresses review feedback on PR #4429: snapshots currentTurnUserText into a local variable before the state reset block so the secret_blocked handler can use the actual blocked text instead of falling back to a potentially-wrong transcript lookup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
