### PR TITLE
fix: remove redundant internal(set) modifiers in ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -72,12 +72,12 @@ public final class ChatViewModel: ObservableObject {
     private(set) var lastFailedSendError: String?
     /// Stores the text of a message that was blocked by the secret-ingress check.
     /// Set when an error with category "secret_blocked" arrives.
-    internal(set) var secretBlockedMessageText: String?
+    var secretBlockedMessageText: String?
     /// Stashed context from the blocked send, so sendAnyway() can reconstruct
     /// the original UserMessageMessage with attachments and surface metadata.
-    internal(set) var secretBlockedAttachments: [IPCAttachment]?
-    internal(set) var secretBlockedActiveSurfaceId: String?
-    internal(set) var secretBlockedCurrentPage: String?
+    var secretBlockedAttachments: [IPCAttachment]?
+    var secretBlockedActiveSurfaceId: String?
+    var secretBlockedCurrentPage: String?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?


### PR DESCRIPTION
## Summary
- Remove redundant `internal(set)` modifiers from four `secretBlocked*` properties in `ChatViewModel.swift`
- Properties are already `internal` by default in Swift, so the explicit modifier produces compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
