### PR TITLE
fix: use adaptive colors in onboarding for dark/light mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -198,7 +198,7 @@ struct APIKeyStepView: View {
         Button(action: { saveAndContinue() }) {
             Text(userHostedEnabled ? "Continue" : "Save API key")
                 .font(.system(size: 15, weight: .medium))
-                .foregroundColor(adaptiveColor(light: .white, dark: .white))
+                .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, VSpacing.lg)
                 .background(
@@ -229,7 +229,7 @@ struct APIKeyStepView: View {
             Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
                 Text("Get an API key")
                     .font(.system(size: 13))
-                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: .white))
+                    .foregroundColor(VColor.accent)
             }
             .onHover { hovering in
                 if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -50,7 +50,7 @@ struct ModelSelectionStepView: View {
             Button(action: { saveModelAndContinue() }) {
                 Text("Select model")
                     .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: .white, dark: .white))
+                    .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, VSpacing.lg)
                     .background(

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -144,11 +144,11 @@ struct WakeUpStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(adaptiveColor(light: Slate._300.opacity(0.3), dark: Color.white.opacity(0.02)))
+                .fill(adaptiveColor(light: Slate._300.opacity(0.3), dark: Slate._800.opacity(0.4)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(Slate._800, lineWidth: 1)
+                .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
         )
     }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `Slate._800` card border in WakeUpStepView with `VColor.surfaceBorder` (adaptive)
- Replace near-invisible dark mode card background (`Color.white.opacity(0.02)`) with `Slate._800.opacity(0.4)`
- Remove redundant `adaptiveColor(light: .white, dark: .white)` wrappers in APIKeyStepView and ModelSelectionStepView
- Use `VColor.accent` for the "Get an API key" footer link instead of raw `.white` in dark mode

## Test plan
- [ ] Toggle System Settings → Appearance between Light and Dark
- [ ] Verify WakeUpStepView cards have visible borders and subtle fill in both modes
- [ ] Verify APIKeyStepView and ModelSelectionStepView button text remains legible
- [ ] Verify "Get an API key" link uses accent color in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
