### PR TITLE
chore: remove duplicate iOS view stubs

### DIFF
--- a/clients/ios/Views/AttachmentStripView.swift
+++ b/clients/ios/Views/AttachmentStripView.swift
@@ -1,2 +1,0 @@
-// AttachmentStripView has moved to clients/shared/Features/Chat/AttachmentStripView.swift
-// It is now part of VellumAssistantShared and available to all platforms.

--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -1,2 +1,0 @@
-// MessageBubbleView has moved to clients/shared/Features/Chat/MessageBubbleView.swift
-// It is now part of VellumAssistantShared and available to all platforms.


### PR DESCRIPTION
## Summary
- Delete leftover comment-only stubs `clients/ios/Views/MessageBubbleView.swift` and `AttachmentStripView.swift`
- Both views moved to `clients/shared/Features/Chat/` and all callers already import from VellumAssistantShared
- No functional changes — these files contained only redirect comments

## Test plan
- [ ] Verify iOS build succeeds
- [ ] Verify MessageBubbleView and AttachmentStripView render correctly on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
