### PR TITLE
feat: code block copy, iOS haptics, trust rule button

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -51,7 +51,10 @@ struct ChatContentView: View {
                                 onSurfaceAction: { surfaceId, actionId, data in
                                     viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
                                 },
-                                onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil
+                                onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
+                                onAddTrustRule: { toolName, pattern, scope, decision in
+                                    viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision)
+                                }
                             )
                             .id(message.id)
                         }

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -116,7 +116,10 @@ struct InputBarView: View {
                     .buttonStyle(.plain)
 
                     // Send button
-                    Button(action: onSend) {
+                    Button(action: {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        onSend()
+                    }) {
                         Image(systemName: "arrow.up.circle.fill")
                             .font(.system(size: 32))
                             .foregroundColor(canSend ? VColor.accent : VColor.textMuted)

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -242,6 +242,12 @@ extension ChatViewModel {
                 refinementStreamingText = refinementTextBuffer
                 return
             }
+            // Haptic on first text chunk (thinking → streaming transition)
+            if isThinking {
+                #if os(iOS)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                #endif
+            }
             isThinking = false
             currentAssistantHasText = true
             if let existingId = currentAssistantMessageId,
@@ -287,6 +293,9 @@ extension ChatViewModel {
             // Only clear isSending if no messages are still queued
             if pendingQueuedCount == 0 {
                 isSending = false
+                #if os(iOS)
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                #endif
             }
             // Surface the AI's text response when a refinement produced no update
             if wasRefinement {
@@ -574,6 +583,9 @@ extension ChatViewModel {
                       shouldAcceptConfirmation?() ?? false else { return }
             }
             isThinking = false
+            #if os(iOS)
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            #endif
             let confirmation = ToolConfirmationData(
                 requestId: msg.requestId,
                 toolName: msg.toolName,

--- a/clients/shared/Features/Chat/MarkdownRenderer.swift
+++ b/clients/shared/Features/Chat/MarkdownRenderer.swift
@@ -1,4 +1,68 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#elseif os(iOS)
+import UIKit
+#endif
+
+// MARK: - CodeBlockView
+
+/// Fenced code block with a copy-to-clipboard button.
+private struct CodeBlockView: View {
+    let lang: String
+    let code: String
+
+    @State private var showCopied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.sm) {
+                if !lang.isEmpty {
+                    Text(lang)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                Button(action: copyCode) {
+                    HStack(spacing: VSpacing.xxs) {
+                        Image(systemName: showCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 11))
+                        if showCopied {
+                            Text("Copied")
+                                .font(VFont.monoSmall)
+                        }
+                    }
+                    .foregroundColor(showCopied ? VColor.success : VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.top, VSpacing.xs)
+
+            Text(code)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textPrimary)
+                .padding(VSpacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        }
+        .background(VColor.backgroundSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    private func copyCode() {
+        #if os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(code, forType: .string)
+        #elseif os(iOS)
+        UIPasteboard.general.string = code
+        #endif
+        showCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            showCopied = false
+        }
+    }
+}
 
 // MARK: - MarkdownBlock
 
@@ -163,23 +227,7 @@ public struct MarkdownRenderer: View {
                 .textSelection(.enabled)
 
         case .codeBlock(let lang, let code):
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                if !lang.isEmpty {
-                    Text(lang)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.textMuted)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.top, VSpacing.xs)
-                }
-                Text(code)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textPrimary)
-                    .padding(VSpacing.sm)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)
-            }
-            .background(VColor.backgroundSubtle)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            CodeBlockView(lang: lang, code: code)
 
         case .list(let ordered, let items):
             VStack(alignment: .leading, spacing: VSpacing.xs) {

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -13,17 +13,20 @@ public struct MessageBubbleView: View {
     /// When non-nil, a "Regenerate" option appears in the long-press context menu
     /// for the last assistant message. Pass nil when generation is in-flight.
     public let onRegenerate: (() -> Void)?
+    public let onAddTrustRule: ((String, String, String, String) -> Bool)?
 
     public init(
         message: ChatMessage,
         onConfirmationResponse: ((String, String) -> Void)?,
         onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?,
-        onRegenerate: (() -> Void)?
+        onRegenerate: (() -> Void)?,
+        onAddTrustRule: ((String, String, String, String) -> Bool)? = nil
     ) {
         self.message = message
         self.onConfirmationResponse = onConfirmationResponse
         self.onSurfaceAction = onSurfaceAction
         self.onRegenerate = onRegenerate
+        self.onAddTrustRule = onAddTrustRule
     }
 
     public var body: some View {
@@ -43,9 +46,8 @@ public struct MessageBubbleView: View {
                         onDeny: {
                             onConfirmationResponse?(confirmation.requestId, "deny")
                         },
-                        onAddTrustRule: { _, _, _, _ in
-                            log.debug("Add trust rule not yet implemented")
-                            return false
+                        onAddTrustRule: { toolName, pattern, scope, decision in
+                            onAddTrustRule?(toolName, pattern, scope, decision) ?? false
                         }
                     )
                 } else if message.role == .assistant && hasInterleavedContent {


### PR DESCRIPTION
## Summary
- **Code block copy button**: Extract `CodeBlockView` in MarkdownRenderer with a clipboard copy button and "Copied" feedback (cross-platform via NSPasteboard/UIPasteboard)
- **iOS haptic feedback**: Add `UIImpactFeedbackGenerator` on first streaming text chunk (light), message complete (medium), send button (light), and `UINotificationFeedbackGenerator` warning on tool confirmation requests
- **Trust rule button**: Add `onAddTrustRule` parameter to `MessageBubbleView` and wire it through iOS `ChatContentView` to `ChatViewModel.addTrustRule()` — previously a no-op that silently logged

## Test plan
- [ ] Verify code blocks in chat show a copy button in top-right corner
- [ ] Click copy button → clipboard contains the code, button shows "Copied" briefly
- [ ] On iOS: send a message and feel light haptic on send tap
- [ ] On iOS: receive a message and feel light haptic on first text, medium on completion
- [ ] On iOS: trigger a tool confirmation and feel warning haptic
- [ ] On iOS: tap "Always Allow" on a tool confirmation → trust rule is persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
