### PR TITLE
feat: add network reachability monitor and improve document load handling

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -720,29 +720,6 @@ exports[`IPC message snapshots ClientMessage types document_list serializes to e
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types subagent_abort serializes to expected JSON 1`] = `
-{
-  "subagentId": "sub-001",
-  "type": "subagent_abort",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types subagent_status serializes to expected JSON 1`] = `
-{
-  "sessionId": "sess-001",
-  "subagentId": "sub-001",
-  "type": "subagent_status",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types subagent_message serializes to expected JSON 1`] = `
-{
-  "content": "Hello subagent",
-  "subagentId": "sub-001",
-  "type": "subagent_message",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,

--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -720,6 +720,29 @@ exports[`IPC message snapshots ClientMessage types document_list serializes to e
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types subagent_abort serializes to expected JSON 1`] = `
+{
+  "subagentId": "sub-001",
+  "type": "subagent_abort",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types subagent_status serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "subagentId": "sub-001",
+  "type": "subagent_status",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types subagent_message serializes to expected JSON 1`] = `
+{
+  "content": "Hello subagent",
+  "subagentId": "sub-001",
+  "type": "subagent_message",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -39,6 +39,7 @@ mock.module('../security/secure-keys.js', () => ({
   deleteSecureKey: (key: string) => storedKeys.delete(key),
   listSecureKeys: () => [...storedKeys.keys()],
   getBackendType: () => 'encrypted',
+  isDowngradedFromKeychain: () => false,
 }));
 
 // In-memory metadata store that mirrors storedKeys for list/get operations

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -34,6 +34,7 @@ mock.module('../security/secure-keys.js', () => ({
   deleteSecureKey: (key: string) => storedKeys.delete(key),
   listSecureKeys: () => [],
   getBackendType: () => 'keychain',
+  isDowngradedFromKeychain: () => false,
 }));
 
 mock.module('./metadata-store.js', () => ({

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -230,13 +230,18 @@ final class MainWindow {
     }
 
     func handleDocumentLoadResponse(_ msg: DocumentLoadResponseMessage) {
-        let title = msg.success && !msg.title.isEmpty ? msg.title : "Document"
-        let content = msg.success ? msg.content : ""
+        guard msg.success else {
+            windowState.showToast(
+                message: "Failed to load document\(msg.error.map { ": \($0)" } ?? "")",
+                style: .error
+            )
+            return
+        }
         documentManager.createDocument(
             surfaceId: msg.surfaceId,
             sessionId: msg.conversationId,
-            title: title,
-            initialContent: content
+            title: msg.title,
+            initialContent: msg.content
         )
         show()
         windowState.selection = .panel(.documentEditor)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -536,6 +536,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                     case .cancelled:
                         log.info("Connection cancelled")
                         self.isConnected = false
+                        self.isConnecting = false
                         self.isAuthenticated = false
                         self.stopPingTimer()
                         if !resumed {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1565,7 +1565,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 try await self.connect()
             } catch {
                 log.error("Immediate reconnect on network change failed: \(error.localizedDescription)")
-                self.startNetworkMonitor()
                 self.scheduleReconnect()
             }
         }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -408,7 +408,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         disconnectInternal(triggerReconnect: false)
 
         shouldReconnect = true
-        startNetworkMonitor()
 
         #if os(macOS)
         log.info("Connecting to daemon socket at \(self.config.socketPath)")
@@ -495,6 +494,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                                     self.isAuthenticated = true
                                     #endif
                                     self.isConnected = true
+                                    self.startNetworkMonitor()
                                     NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
                                     self.reconnectDelay = 1.0
                                     self.startPingTimer()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1174,6 +1174,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         receiveBuffer = Data()
         cuObservationSequenceBySession.removeAll()
         isConnected = false
+        isConnecting = false
         httpPort = nil
         latestMemoryStatus = nil
 
@@ -1565,8 +1566,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         reconnectTask?.cancel()
         reconnectTask = nil
         reconnectDelay = 1.0
+        isConnecting = true
         Task { @MainActor [weak self] in
-            guard let self, self.shouldReconnect else { return }
+            guard let self, self.shouldReconnect else {
+                self?.isConnecting = false
+                return
+            }
             do {
                 try await self.connect()
             } catch {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -331,6 +331,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Reconnect task handle.
     private var reconnectTask: Task<Void, Never>?
 
+    /// Network path monitor — triggers immediate reconnect when network becomes available.
+    private var pathMonitor: NWPathMonitor?
+    private let pathMonitorQueue = DispatchQueue(label: "com.vellum.vellum-assistant.network-monitor", qos: .background)
+
     /// Ping timer task handle.
     private var pingTask: Task<Void, Never>?
 
@@ -376,6 +380,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         pingTask?.cancel()
         pongTimeoutTask?.cancel()
         blobProbeTask?.cancel()
+        pathMonitor?.cancel()
         connection?.cancel()
     }
 
@@ -403,6 +408,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         disconnectInternal(triggerReconnect: false)
 
         shouldReconnect = true
+        startNetworkMonitor()
 
         #if os(macOS)
         log.info("Connecting to daemon socket at \(self.config.socketPath)")
@@ -1133,6 +1139,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         shouldReconnect = triggerReconnect
         reconnectTask?.cancel()
         reconnectTask = nil
+        if !triggerReconnect {
+            stopNetworkMonitor()
+        }
         stopPingTimer()
         #if os(macOS) || os(iOS)
         if let pending = authContinuation {
@@ -1521,6 +1530,42 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 if self.shouldReconnect && self.reconnectTask == nil {
                     self.scheduleReconnect()
                 }
+            }
+        }
+    }
+
+    // MARK: - Network Reachability
+
+    private func startNetworkMonitor() {
+        guard pathMonitor == nil else { return }
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor [weak self] in
+                self?.handleNetworkPathChange(path)
+            }
+        }
+        monitor.start(queue: pathMonitorQueue)
+        pathMonitor = monitor
+    }
+
+    private func stopNetworkMonitor() {
+        pathMonitor?.cancel()
+        pathMonitor = nil
+    }
+
+    private func handleNetworkPathChange(_ path: NWPath) {
+        guard path.status == .satisfied, !isConnected, shouldReconnect else { return }
+        log.info("Network available — resetting backoff and reconnecting immediately")
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        reconnectDelay = 1.0
+        Task { @MainActor [weak self] in
+            guard let self, self.shouldReconnect else { return }
+            do {
+                try await self.connect()
+            } catch {
+                log.error("Immediate reconnect on network change failed: \(error.localizedDescription)")
+                self.scheduleReconnect()
             }
         }
     }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -85,6 +85,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Published State
 
     @Published public var isConnected: Bool = false
+    private var isConnecting: Bool = false
 
     /// Whether blob transport has been verified for this connection.
     /// Resets to `false` on disconnect/reconnect. Only set to `true` after
@@ -407,6 +408,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // Disconnect any existing connection without triggering reconnect.
         disconnectInternal(triggerReconnect: false)
 
+        isConnecting = true
         shouldReconnect = true
 
         #if os(macOS)
@@ -467,6 +469,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 resumed = true
                 log.error("Connection timed out after \(Self.connectTimeout)s")
                 self?.isConnected = false
+                self?.isConnecting = false
                 self?.stopPingTimer()
                 conn.stateUpdateHandler = nil
                 conn.cancel()
@@ -494,6 +497,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                                     self.isAuthenticated = true
                                     #endif
                                     self.isConnected = true
+                                    self.isConnecting = false
                                     self.startNetworkMonitor()
                                     NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
                                     self.reconnectDelay = 1.0
@@ -505,6 +509,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                                 } catch {
                                     log.error("Daemon authentication failed: \(error.localizedDescription)")
                                     self.isConnected = false
+                                    self.isConnecting = false
                                     self.isAuthenticated = false
                                     self.stopPingTimer()
                                     conn.stateUpdateHandler = nil
@@ -517,6 +522,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                     case .failed(let error):
                         log.error("Connection failed: \(error.localizedDescription)")
                         self.isConnected = false
+                        self.isConnecting = false
                         self.isAuthenticated = false
                         self.stopPingTimer()
                         if !resumed {
@@ -1554,7 +1560,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     private func handleNetworkPathChange(_ path: NWPath) {
-        guard path.status == .satisfied, !isConnected, shouldReconnect else { return }
+        guard path.status == .satisfied, !isConnected, !isConnecting, shouldReconnect else { return }
         log.info("Network available — resetting backoff and reconnecting immediately")
         reconnectTask?.cancel()
         reconnectTask = nil

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1565,6 +1565,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 try await self.connect()
             } catch {
                 log.error("Immediate reconnect on network change failed: \(error.localizedDescription)")
+                self.startNetworkMonitor()
                 self.scheduleReconnect()
             }
         }


### PR DESCRIPTION
## Summary

### Network reachability monitor (DaemonClient.swift)
Adds an `NWPathMonitor` to `DaemonClient` that triggers an immediate reconnect when the device regains network connectivity, instead of waiting for the exponential backoff timer (up to 30s).

**What it does:**
- `startNetworkMonitor()` / `stopNetworkMonitor()` manage an `NWPathMonitor` instance
- `handleNetworkPathChange()` resets backoff and calls `connect()` when network becomes available
- An `isConnecting` flag prevents concurrent `connect()` calls — set synchronously before the Task spawn, cleared on all terminal states

**Why this is needed:** When the daemon runs on a remote host, losing WiFi leaves the client waiting for the full backoff interval. The monitor eliminates this delay.

**Why this is safe:**
- Monitor starts only after successful connection, so NWPathMonitor's immediate-fire-on-start hits the `!isConnected` guard and is a no-op
- `isConnecting` flag guards against races: set before Task spawn, reset in `.ready`, `.failed`, `.cancelled`, timeout, auth failure, and `disconnectInternal`
- Monitor is NOT restarted after failed reconnect (prevents tight loop — NWPathMonitor fires immediately on start, bypassing backoff). Falls back to exponential backoff; monitor restarts on next successful connection

### Document load response (MainWindow.swift)
Improves `handleDocumentLoadResponse` to guard on `msg.success` and show an error toast on failure, instead of silently creating an empty document.

### Pre-existing CI fixes (shared with #4870)
Fixes lint, typecheck, and test errors on `origin/main` that block CI for all PRs:
- Lint: remove unused imports/variables across 6 files
- Typecheck: extend `ContentBlock` type for web search blocks, add missing test assertion field
- Tests: add `isDowngradedFromKeychain` mock to 2 test files, fix proxy injection test assertion
- See #4870 for full details on these fixes

## Test plan
- [ ] Disconnect/reconnect WiFi — verify immediate reconnect via logs ("Network available — resetting backoff")
- [ ] If immediate reconnect fails, verify exponential backoff continues without looping
- [ ] Click document in DirectoryPanel — editor opens; on failure, error toast appears
- [ ] `./build.sh lint` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)