### PR TITLE
fix: skip onboarding when API key and model are already configured

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -140,8 +140,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         #endif
 
         if !skipOnboarding && !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
-            showOnboarding()
-            return
+            // If the user already has an API key and model configured,
+            // skip onboarding entirely — they're a returning user whose
+            // hasCompletedOnboarding flag was cleared (e.g. by /scrub).
+            let config = WorkspaceConfigIO.read()
+            if APIKeyManager.hasAnyKey(), config["model"] != nil {
+                UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+            } else {
+                showOnboarding()
+                return
+            }
         }
 
         startAuthenticatedFlow()
@@ -150,7 +158,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private func startAuthenticatedFlow() {
         Task {
             await authManager.checkSession()
-            if authManager.isAuthenticated {
+            if authManager.isAuthenticated || APIKeyManager.hasAnyKey() {
                 proceedToApp()
             } else {
                 showAuthWindow()


### PR DESCRIPTION
## Summary
- In `applicationDidFinishLaunching`, when `hasCompletedOnboarding` is false, check if the user already has an API key and model configured — if so, mark onboarding complete and skip to the main window
- In `startAuthenticatedFlow`, treat having an API key in keychain as sufficient auth (for "Own API Key" users who don't have a Vellum Account session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
