### PR TITLE
fix: add missing mouse and bringToFront to Page type and test mocks

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -32,6 +32,8 @@ function createMockPage(closed = false) {
     unroute: async () => {},
     screenshot: async () => Buffer.from(''),
     keyboard: { press: async () => {} },
+    mouse: { click: async () => {}, move: async () => {}, wheel: async () => {} },
+    bringToFront: async () => {},
   };
 }
 

--- a/assistant/src/tools/browser/__tests__/auth-detector.test.ts
+++ b/assistant/src/tools/browser/__tests__/auth-detector.test.ts
@@ -35,6 +35,8 @@ function mockPage(url: string, evaluateResult: unknown = null): Page {
     unroute: async () => {},
     screenshot: async () => Buffer.from(''),
     keyboard: { press: async () => {} },
+    mouse: { click: async () => {}, move: async () => {}, wheel: async () => {} },
+    bringToFront: async () => {},
   };
 }
 

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -49,6 +49,7 @@ export type Page = {
     move(x: number, y: number): Promise<void>;
     wheel(deltaX: number, deltaY: number): Promise<void>;
   };
+  bringToFront(): Promise<void>;
 };
 
 type ScreencastFrameMetadata = {


### PR DESCRIPTION
## Summary
- Add `bringToFront()` to the `Page` type so PR #4654 can call it without a TS error
- Add `mouse` and `bringToFront` stubs to mock Page objects in `browser-manager.test.ts` and `auth-detector.test.ts` (missing since `mouse` was added to the `Page` type in #4516)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
