### PR TITLE
fix: also require provider in onboarding skip check

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -140,11 +140,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         #endif
 
         if !skipOnboarding && !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
-            // If the user already has an API key and model configured,
+            // If the user already has an API key, model, and provider configured,
             // skip onboarding entirely — they're a returning user whose
             // hasCompletedOnboarding flag was cleared (e.g. by /scrub).
             let config = WorkspaceConfigIO.read()
-            if APIKeyManager.hasAnyKey(), config["model"] != nil {
+            if APIKeyManager.hasAnyKey(), config["model"] != nil, config["provider"] != nil {
                 UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
             } else {
                 showOnboarding()


### PR DESCRIPTION
## Summary
- Add `config["provider"] != nil` to the onboarding skip condition so all three pieces (API key, model, provider) must be configured before skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
