### PR TITLE
add task_delete tool for deleting tasks

### DIFF
--- a/assistant/src/tasks/task-store.ts
+++ b/assistant/src/tasks/task-store.ts
@@ -1,6 +1,6 @@
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, inArray } from 'drizzle-orm';
 import { getDb } from '../memory/db.js';
-import { tasks, taskRuns } from '../memory/schema.js';
+import { tasks, taskRuns, workItems } from '../memory/schema.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -67,6 +67,28 @@ export function getTask(id: string): Task | undefined {
 export function listTasks(): Task[] {
   const db = getDb();
   return db.select().from(tasks).orderBy(desc(tasks.createdAt)).all();
+}
+
+export function deleteTask(id: string): boolean {
+  const db = getDb();
+  const existing = db.select().from(tasks).where(eq(tasks.id, id)).get();
+  if (!existing) return false;
+  db.delete(workItems).where(eq(workItems.taskId, id)).run();
+  db.delete(taskRuns).where(eq(taskRuns.taskId, id)).run();
+  db.delete(tasks).where(eq(tasks.id, id)).run();
+  return true;
+}
+
+export function deleteTasks(ids: string[]): number {
+  if (ids.length === 0) return 0;
+  const db = getDb();
+  const existing = db.select().from(tasks).where(inArray(tasks.id, ids)).all();
+  if (existing.length === 0) return 0;
+  const foundIds = existing.map((t) => t.id);
+  db.delete(workItems).where(inArray(workItems.taskId, foundIds)).run();
+  db.delete(taskRuns).where(inArray(taskRuns.taskId, foundIds)).run();
+  db.delete(tasks).where(inArray(tasks.id, foundIds)).run();
+  return existing.length;
 }
 
 // ── TaskRun CRUD ─────────────────────────────────────────────────────

--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -1,3 +1,4 @@
 export { taskSaveTool } from './task-save.js';
 export { taskRunTool } from './task-run.js';
 export { taskListTool } from './task-list.js';
+export { taskDeleteTool } from './task-delete.js';

--- a/assistant/src/tools/tasks/task-delete.ts
+++ b/assistant/src/tools/tasks/task-delete.ts
@@ -1,0 +1,69 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { deleteTask, deleteTasks, getTask } from '../../tasks/task-store.js';
+
+const definition: ToolDefinition = {
+  name: 'task_delete',
+  description: 'Delete one or more saved tasks by ID. Also removes associated task runs and work items.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      task_ids: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'One or more task IDs to delete.',
+      },
+    },
+    required: ['task_ids'],
+  },
+};
+
+class TaskDeleteTool implements Tool {
+  name = 'task_delete';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const raw = input.task_ids;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      return { content: 'Error: task_ids must be a non-empty array of task ID strings', isError: true };
+    }
+    const ids = raw.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+    if (ids.length === 0) {
+      return { content: 'Error: task_ids must contain at least one non-empty string', isError: true };
+    }
+
+    try {
+      if (ids.length === 1) {
+        const task = getTask(ids[0]);
+        const deleted = deleteTask(ids[0]);
+        if (!deleted) {
+          return { content: `No task found with ID ${ids[0]}`, isError: true };
+        }
+        return { content: `Deleted task: ${task?.title ?? ids[0]}`, isError: false };
+      }
+
+      const titles = ids.map((id) => {
+        const t = getTask(id);
+        return t ? t.title : id;
+      });
+      const count = deleteTasks(ids);
+      if (count === 0) {
+        return { content: 'No matching tasks found to delete.', isError: true };
+      }
+      const lines = [`Deleted ${count} task(s):`, ...titles.map((t) => `- ${t}`)];
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const taskDeleteTool = new TaskDeleteTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,7 +18,7 @@ import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 import { followupCreateTool, followupListTool, followupResolveTool } from './followups/index.js';
-import { taskSaveTool, taskRunTool, taskListTool } from './tasks/index.js';
+import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool } from './tasks/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -109,6 +109,7 @@ export const explicitTools: Tool[] = [
   taskSaveTool,
   taskRunTool,
   taskListTool,
+  taskDeleteTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `deleteTask(id)` and `deleteTasks(ids)` to `task-store.ts` with cascade deletion of associated task runs and work items
- Adds `task_delete` tool accepting `task_ids` array to delete one or more tasks
- Registers the tool in `tool-manifest.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
