### PR TITLE
fix: remove unused imports flagged by eslint

### DIFF
--- a/assistant/src/daemon/handlers/documents.ts
+++ b/assistant/src/daemon/handlers/documents.ts
@@ -1,5 +1,5 @@
 import type { HandlerContext } from './shared.js';
-import type { ServerMessage, DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } from '../ipc-protocol.js';
+import type { DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } from '../ipc-protocol.js';
 import type * as net from 'node:net';
 import type { Database } from 'bun:sqlite';
 import { getDb } from '../../memory/db.js';

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -8,7 +8,7 @@
 
 import type { ToolDefinition } from '../providers/types.js';
 import type { ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
-import type { ServerMessage, SurfaceType, SurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, UiSurfaceShow } from './ipc-protocol.js';
 import type { ToolExecutor } from '../tools/executor.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,10 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import * as appStore from '../../memory/app-store.js';
 import { randomUUID } from 'node:crypto';
-import { generateEditorHTML } from './editor-template.js';
-import { openAppViaSurface } from '../apps/open-proxy.js';
 
 // ── document_create ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Remove unused `ServerMessage` import from `documents.ts`
- Remove unused `SurfaceType` and `SurfaceData` imports from `session-tool-setup.ts`
- Remove unused `appStore`, `generateEditorHTML`, and `openAppViaSurface` imports from `document-tool.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
