### PR TITLE
fix: address review feedback for PRs #4652, #4655

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -265,12 +265,12 @@ struct AvatarCustomizationPanel: View {
         resolveAndApply()
     }
 
-    /// Toggle lock on a field. Unlocking keeps the override as fallback but
-    /// re-resolves so auto-evolution can potentially change it.
+    /// Toggle lock on a field. Unlocking removes the override so the resolver
+    /// falls back to trait-based values and auto-evolution can control the field.
     private func toggleLock(field: AvatarEvolutionState.AppearanceField) {
         if evolutionState.lockedFields.contains(field) {
             evolutionState.lockedFields.remove(field)
-            // Keep userOverrides value as fallback — resolver still uses it
+            evolutionState.userOverrides.removeValue(forKey: field)
         } else {
             evolutionState.lockedFields.insert(field)
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -129,6 +129,8 @@ final class OnboardingState {
         if currentStep > maxStep {
             currentStep = maxStep
         }
+
+        avatarEvolutionState.load()
     }
 
     func advance(by steps: Int = 1) {


### PR DESCRIPTION
## Summary
- **Load avatar evolution state on init**: Call `avatarEvolutionState.load()` at the end of `OnboardingState.init()` so that persisted avatar evolution progress is restored when the app restarts.
- **Remove user override when unlocking a field**: In `AvatarCustomizationPanel.toggleLock`, when a field is unlocked, remove the corresponding `userOverrides` entry so the resolver falls back to trait-based values instead of keeping a stale manual override.

## Test plan
- [ ] Verify avatar evolution state persists across app restarts (set some evolution traits, quit, relaunch — traits should be restored)
- [ ] Verify unlocking a customized field in the Avatar Customization Panel reverts to the auto-evolved value rather than keeping the manual override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
