### PR TITLE
fix: align avatar IDs with AvatarSpriteBuilder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -18,10 +18,10 @@ struct AvatarCustomizationPanel: View {
     ]
 
     /// Available outfit options per field.
-    private let hatOptions = ["none", "tophat", "party_hat", "headband", "crown", "beret", "cap"]
-    private let shirtOptions = ["none", "hoodie", "tshirt", "vest", "suit", "sweater"]
-    private let accessoryOptions = ["none", "sunglasses", "monocle", "scarf", "bowtie", "glasses"]
-    private let heldItemOptions = ["none", "balloon", "briefcase", "wand", "sword", "coffee", "book"]
+    private let hatOptions = ["none", "top_hat", "crown", "cap", "beanie", "wizard_hat", "cowboy_hat"]
+    private let shirtOptions = ["none", "tshirt", "suit", "hoodie", "tank_top", "sweater"]
+    private let accessoryOptions = ["none", "sunglasses", "monocle", "bowtie", "necklace", "scarf", "cape"]
+    private let heldItemOptions = ["none", "sword", "staff", "shield", "balloon"]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarEvolutionResolver.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarEvolutionResolver.swift
@@ -105,16 +105,16 @@ enum AvatarEvolutionResolver {
 
     /// Map formality + playfulness to hat choice
     private static func hatFromTraits(_ traits: AvatarEvolutionState.TraitScores) -> String {
-        if traits.formality > 0.7 { return "tophat" }
-        if traits.playfulness > 0.7 { return "party_hat" }
-        if traits.energy > 0.7 { return "headband" }
+        if traits.formality > 0.7 { return "top_hat" }
+        if traits.playfulness > 0.7 { return "cap" }
+        if traits.energy > 0.7 { return "beanie" }
         return "none"
     }
 
     /// Map formality to shirt choice
     private static func shirtFromTraits(_ traits: AvatarEvolutionState.TraitScores) -> String {
         if traits.formality > 0.7 { return "suit" }
-        if traits.formality > 0.5 { return "vest" }
+        if traits.formality > 0.5 { return "sweater" }
         if traits.playfulness > 0.6 { return "tshirt" }
         return "hoodie"
     }
@@ -130,8 +130,8 @@ enum AvatarEvolutionResolver {
     /// Map energy + playfulness to held item
     private static func heldItemFromTraits(_ traits: AvatarEvolutionState.TraitScores) -> String {
         if traits.energy > 0.7 && traits.playfulness > 0.5 { return "balloon" }
-        if traits.formality > 0.7 { return "briefcase" }
-        if traits.playfulness > 0.7 { return "wand" }
+        if traits.formality > 0.7 { return "staff" }
+        if traits.playfulness > 0.7 { return "balloon" }
         return "none"
     }
 }


### PR DESCRIPTION
## Summary
- Fix invalid avatar item IDs in `AvatarEvolutionResolver` and `AvatarCustomizationPanel` to match the valid IDs defined in `AvatarSpriteBuilder`
- **Hats**: `tophat` -> `top_hat`, `party_hat` -> `cap`, `headband` -> `beanie`
- **Shirts**: `vest` -> `sweater`
- **Held items**: `briefcase` -> `staff`, `wand` -> `balloon`
- **Customization options**: replaced all invalid IDs (`beret`, `glasses`, `coffee`, `book`, etc.) with valid sprite builder IDs

## Test plan
- [ ] Verify avatar renders correctly with each hat option from the customization panel
- [ ] Verify avatar renders correctly with each shirt option
- [ ] Verify avatar renders correctly with each accessory option
- [ ] Verify avatar renders correctly with each held item option
- [ ] Verify trait-driven evolution produces valid appearances (no missing sprites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
