### PR TITLE
fix: address review feedback for PRs #4648, #4651

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarEvolutionState.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarEvolutionState.swift
@@ -90,6 +90,7 @@ final class AvatarEvolutionState {
             userOverrides: userOverrides.reduce(into: [:]) { $0[$1.key.rawValue] = $1.value },
             lockedFields: Array(lockedFields.map(\.rawValue)),
             lastCheckpointTurn: lastCheckpointTurn,
+            lastCheckpointDate: lastCheckpointDate,
             appliedMilestones: Array(appliedMilestones)
         )
         if let encoded = try? JSONEncoder().encode(data) {
@@ -111,6 +112,7 @@ final class AvatarEvolutionState {
         }
         lockedFields = Set(state.lockedFields.compactMap { AppearanceField(rawValue: $0) })
         lastCheckpointTurn = state.lastCheckpointTurn
+        lastCheckpointDate = state.lastCheckpointDate
         appliedMilestones = Set(state.appliedMilestones)
     }
 
@@ -125,6 +127,7 @@ final class AvatarEvolutionState {
         let userOverrides: [String: String]
         let lockedFields: [String]
         let lastCheckpointTurn: Int
+        let lastCheckpointDate: Date?
         let appliedMilestones: [String]
     }
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/ModelTraitInferenceService.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/ModelTraitInferenceService.swift
@@ -14,7 +14,7 @@ final class ModelTraitInferenceService {
     /// Run trait inference on the conversation so far.
     /// Returns updated TraitScores, or nil if no inference was needed (too soon since last checkpoint).
     func infer(
-        messages: [ConversationMessage],
+        messages: [TraitInferenceMessage],
         identityName: String?,
         identityPersonality: String?,
         identityEmoji: String?,
@@ -74,7 +74,7 @@ final class ModelTraitInferenceService {
     private func analyzeEnergy(text: String, personality: String?) -> Double {
         var score = 0.5
 
-        let highSignals = ["energetic", "chaotic", "hyper", "excited", "fast", "wild", "intense", "enthusiastic", "dynamic", "!", "!!", "!!!"]
+        let highSignals = ["energetic", "chaotic", "hyper", "excited", "fast", "wild", "intense", "enthusiastic", "dynamic"]
         let lowSignals = ["calm", "steady", "chill", "relaxed", "peaceful", "zen", "quiet", "serene", "measured", "patient"]
 
         score += signalBalance(text: text, positive: highSignals, negative: lowSignals)
@@ -94,7 +94,7 @@ final class ModelTraitInferenceService {
         var score = 0.5
 
         let formalSignals = ["formal", "professional", "proper", "sophisticated", "elegant", "refined", "polished", "respectful", "sir", "madam"]
-        let casualSignals = ["casual", "laid back", "informal", "chill", "lol", "haha", "nah", "yeah", "dude", "bro", "yo", "gonna", "wanna"]
+        let casualSignals = ["casual", "laid back", "informal", "chill", "lol", "haha", "nah", "yeah", "dude", "bro", "gonna", "wanna"]
 
         score += signalBalance(text: text, positive: formalSignals, negative: casualSignals)
 
@@ -130,21 +130,28 @@ final class ModelTraitInferenceService {
     /// Calculate a balance score from positive and negative signal words.
     /// Returns a value in roughly -0.3 to +0.3 range.
     private func signalBalance(text: String, positive: [String], negative: [String]) -> Double {
-        let posCount = positive.filter { text.contains($0) }.count
-        let negCount = negative.filter { text.contains($0) }.count
+        let posCount = positive.filter { matchesWholeWord($0, in: text) }.count
+        let negCount = negative.filter { matchesWholeWord($0, in: text) }.count
         let total = posCount + negCount
         guard total > 0 else { return 0.0 }
         return Double(posCount - negCount) / Double(total) * 0.3
+    }
+
+    /// Match a signal word using word boundaries to avoid substring collisions
+    /// (e.g., "formal" in "informal").
+    private func matchesWholeWord(_ word: String, in text: String) -> Bool {
+        let pattern = "\\b\(NSRegularExpression.escapedPattern(for: word))\\b"
+        return text.range(of: pattern, options: .regularExpression) != nil
     }
 }
 
 /// Simple message representation for trait inference.
 /// Keeps the service decoupled from specific chat message types.
-struct ConversationMessage {
-    let role: ConversationRole
+struct TraitInferenceMessage {
+    let role: TraitInferenceRole
     let text: String
 
-    enum ConversationRole {
+    enum TraitInferenceRole {
         case user
         case assistant
     }


### PR DESCRIPTION
## Summary
- **Rename `ConversationMessage` to `TraitInferenceMessage`** in `ModelTraitInferenceService.swift` to resolve naming conflict with the existing `ConversationMessage` type in `Features/Session/`
- **Remove `"!"`, `"!!"`, `"!!!"` from energy `highSignals`** — these caused triple-counting since `text.contains("!!!")` also matches `"!!"` and `"!"`; the exclamation mark ratio check already handles this separately
- **Remove `"yo"` from `casualSignals`** — substring of "you"/"your"/"yourself" causing false positives with `text.contains()`
- **Fix `"formal"`/`"informal"` substring collision** — replaced `text.contains()` with regex word-boundary matching (`\b...\b`) in `signalBalance` so "informal" no longer falsely matches "formal"
- **Persist `lastCheckpointDate`** in `AvatarEvolutionState` — was declared but missing from `PersistableState`, `save()`, and `load()`

## Test plan
- [ ] Build succeeds: `./build.sh` in `clients/macos/`
- [ ] Verify `TraitInferenceMessage` compiles without ambiguity against `ConversationMessage` in `Features/Session/`
- [ ] Verify energy scoring no longer double/triple counts exclamation marks via signal words
- [ ] Verify text containing "your" does not inflate casual score (no "yo" substring match)
- [ ] Verify text containing "informal" does not also match "formal" as a positive signal
- [ ] Verify `lastCheckpointDate` round-trips through `save()`/`load()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
