### PR TITLE
fix: stop voice transcription from auto-sending in chat window

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -701,8 +701,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                let mainWindow = self?.mainWindow, mainWindow.isVisible,
                let viewModel = mainWindow.activeViewModel {
                 viewModel.inputText = text
-                viewModel.pendingVoiceMessage = true
-                viewModel.sendMessage()
                 return
             }
 


### PR DESCRIPTION
## Summary
- Remove automatic `sendMessage()` and `pendingVoiceMessage` flag when voice transcription completes in the main chat window
- Transcribed text now lands in the input field for user review/edit before sending, matching how partial transcriptions already work
- Fixes cascading send behavior caused by the auto-send triggering additional side effects on mic disable

## Test plan
- [ ] Hold Fn to record voice, release — verify transcribed text appears in input field without auto-sending
- [ ] Click mic button to record, click again to stop — verify same behavior
- [ ] Confirm toggling mic on/off after transcription doesn't trigger extra sends
- [ ] Verify voice input still auto-sends in TextResponseWindow and new-session contexts (those paths are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
