### PR TITLE
fix: align tests with recent tool additions and fix CI failures

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -577,6 +577,127 @@ exports[`IPC message snapshots ClientMessage types integration_disconnect serial
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types browser_cdp_response serializes to expected JSON 1`] = `
+{
+  "sessionId": "test-session",
+  "success": true,
+  "type": "browser_cdp_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types browser_user_click serializes to expected JSON 1`] = `
+{
+  "sessionId": "test-session",
+  "surfaceId": "test-surface",
+  "type": "browser_user_click",
+  "x": 100,
+  "y": 200,
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types browser_user_scroll serializes to expected JSON 1`] = `
+{
+  "deltaX": 0,
+  "deltaY": -100,
+  "sessionId": "test-session",
+  "surfaceId": "test-surface",
+  "type": "browser_user_scroll",
+  "x": 100,
+  "y": 200,
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types browser_user_keypress serializes to expected JSON 1`] = `
+{
+  "key": "Enter",
+  "sessionId": "test-session",
+  "surfaceId": "test-surface",
+  "type": "browser_user_keypress",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types browser_interactive_mode serializes to expected JSON 1`] = `
+{
+  "enabled": true,
+  "sessionId": "test-session",
+  "surfaceId": "test-surface",
+  "type": "browser_interactive_mode",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_items_list serializes to expected JSON 1`] = `
+{
+  "status": "queued",
+  "type": "work_items_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_item_get serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "type": "work_item_get",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_item_create serializes to expected JSON 1`] = `
+{
+  "notes": "High priority",
+  "priorityTier": 1,
+  "sortIndex": 0,
+  "taskId": "task-001",
+  "title": "Process report",
+  "type": "work_item_create",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_item_update serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "status": "running",
+  "title": "Updated title",
+  "type": "work_item_update",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_item_complete serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "type": "work_item_complete",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_item_run_task serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "type": "work_item_run_task",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types document_save serializes to expected JSON 1`] = `
+{
+  "content": "# Hello",
+  "conversationId": "conv-001",
+  "surfaceId": "doc-001",
+  "title": "My Document",
+  "type": "document_save",
+  "wordCount": 1,
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types document_load serializes to expected JSON 1`] = `
+{
+  "surfaceId": "doc-001",
+  "type": "document_load",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types document_list serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-001",
+  "type": "document_list",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,
@@ -1658,5 +1779,204 @@ exports[`IPC message snapshots ServerMessage types integration_connect_result se
   "integrationId": "gmail",
   "success": true,
   "type": "integration_connect_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types browser_cdp_request serializes to expected JSON 1`] = `
+{
+  "sessionId": "test-session",
+  "type": "browser_cdp_request",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types browser_interactive_mode_changed serializes to expected JSON 1`] = `
+{
+  "enabled": true,
+  "sessionId": "test-session",
+  "surfaceId": "test-surface",
+  "type": "browser_interactive_mode_changed",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types browser_handoff_request serializes to expected JSON 1`] = `
+{
+  "message": "Login required",
+  "reason": "auth",
+  "sessionId": "test-session",
+  "surfaceId": "test-surface",
+  "type": "browser_handoff_request",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types document_editor_show serializes to expected JSON 1`] = `
+{
+  "initialContent": "# Hello World",
+  "sessionId": "sess-001",
+  "surfaceId": "doc-001",
+  "title": "My Document",
+  "type": "document_editor_show",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types document_editor_update serializes to expected JSON 1`] = `
+{
+  "markdown": "# Updated Content",
+  "mode": "replace",
+  "sessionId": "sess-001",
+  "surfaceId": "doc-001",
+  "type": "document_editor_update",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types document_save_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "surfaceId": "doc-001",
+  "type": "document_save_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types document_load_response serializes to expected JSON 1`] = `
+{
+  "content": "# Hello",
+  "conversationId": "conv-001",
+  "createdAt": 1700000000,
+  "success": true,
+  "surfaceId": "doc-001",
+  "title": "My Document",
+  "type": "document_load_response",
+  "updatedAt": 1700001000,
+  "wordCount": 1,
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types document_list_response serializes to expected JSON 1`] = `
+{
+  "documents": [
+    {
+      "conversationId": "conv-001",
+      "createdAt": 1700000000,
+      "surfaceId": "doc-001",
+      "title": "My Document",
+      "updatedAt": 1700001000,
+      "wordCount": 100,
+    },
+  ],
+  "type": "document_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_items_list_response serializes to expected JSON 1`] = `
+{
+  "items": [
+    {
+      "createdAt": 1700000000,
+      "id": "wi-001",
+      "lastRunConversationId": null,
+      "lastRunId": null,
+      "lastRunStatus": null,
+      "notes": null,
+      "priorityTier": 1,
+      "sortIndex": null,
+      "sourceId": null,
+      "sourceType": null,
+      "status": "queued",
+      "taskId": "task-001",
+      "title": "Process report",
+      "updatedAt": 1700000000,
+    },
+  ],
+  "type": "work_items_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_get_response serializes to expected JSON 1`] = `
+{
+  "item": {
+    "createdAt": 1700000000,
+    "id": "wi-001",
+    "lastRunConversationId": null,
+    "lastRunId": null,
+    "lastRunStatus": null,
+    "notes": null,
+    "priorityTier": 1,
+    "sortIndex": null,
+    "sourceId": null,
+    "sourceType": null,
+    "status": "queued",
+    "taskId": "task-001",
+    "title": "Process report",
+    "updatedAt": 1700000000,
+  },
+  "type": "work_item_get_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_create_response serializes to expected JSON 1`] = `
+{
+  "item": {
+    "createdAt": 1700000000,
+    "id": "wi-001",
+    "lastRunConversationId": null,
+    "lastRunId": null,
+    "lastRunStatus": null,
+    "notes": null,
+    "priorityTier": 1,
+    "sortIndex": null,
+    "sourceId": null,
+    "sourceType": null,
+    "status": "queued",
+    "taskId": "task-001",
+    "title": "Process report",
+    "updatedAt": 1700000000,
+  },
+  "type": "work_item_create_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_update_response serializes to expected JSON 1`] = `
+{
+  "item": {
+    "createdAt": 1700000000,
+    "id": "wi-001",
+    "lastRunConversationId": null,
+    "lastRunId": null,
+    "lastRunStatus": null,
+    "notes": null,
+    "priorityTier": 1,
+    "sortIndex": null,
+    "sourceId": null,
+    "sourceType": null,
+    "status": "running",
+    "taskId": "task-001",
+    "title": "Updated title",
+    "updatedAt": 1700001000,
+  },
+  "type": "work_item_update_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_run_task_response serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "lastRunId": "run-001",
+  "success": true,
+  "type": "work_item_run_task_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_status_changed serializes to expected JSON 1`] = `
+{
+  "item": {
+    "id": "wi-001",
+    "lastRunConversationId": "conv-001",
+    "lastRunId": "run-001",
+    "lastRunStatus": "completed",
+    "status": "awaiting_review",
+    "taskId": "task-001",
+    "title": "Process report",
+    "updatedAt": 1700001000,
+  },
+  "type": "work_item_status_changed",
 }
 `;

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -39,6 +39,7 @@ mock.module('../security/secure-keys.js', () => ({
   deleteSecureKey: (key: string) => storedKeys.delete(key),
   listSecureKeys: () => [...storedKeys.keys()],
   getBackendType: () => 'encrypted',
+  isDowngradedFromKeychain: () => false,
 }));
 
 // In-memory metadata store that mirrors storedKeys for list/get operations

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -231,10 +231,8 @@ describe('policyCallback credential injection', () => {
     }
   });
 
-  test('unresolvable credential ID returns empty headers', async () => {
-    let receivedHeaders: http.IncomingHttpHeaders = {};
-    const echo = http.createServer((req, res) => {
-      receivedHeaders = req.headers;
+  test('unresolvable credential ID blocks request (known host, missing credential)', async () => {
+    const echo = http.createServer((_req, res) => {
       res.writeHead(200);
       res.end('ok');
     });
@@ -260,9 +258,9 @@ describe('policyCallback credential injection', () => {
         `http://127.0.0.1:${echoPort}/test`,
       );
 
-      // Should allow through with empty headers (fail-safe)
-      expect(status).toBe(200);
-      expect(receivedHeaders['authorization']).toBeUndefined();
+      // Known host with missing credential: policy blocks with 403 rather
+      // than leaking an unauthenticated request to a credentialed service.
+      expect(status).toBe(403);
     } finally {
       echo.close();
     }

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -34,6 +34,7 @@ mock.module('../security/secure-keys.js', () => ({
   deleteSecureKey: (key: string) => storedKeys.delete(key),
   listSecureKeys: () => [],
   getBackendType: () => 'keychain',
+  isDowngradedFromKeychain: () => false,
 }));
 
 mock.module('./metadata-store.js', () => ({

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -743,6 +743,8 @@ describe('Trust Store', () => {
         'host_file_write',
         'scaffold_managed_skill',
         'skill_load',
+        'ui_dismiss',
+        'ui_update',
       ]);
     });
 

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -126,6 +126,7 @@ export interface HandlerContext {
  */
 export function getScreenDimensions(): { width: number; height: number } {
   if (cachedScreenDims) return cachedScreenDims;
+  if (process.platform !== 'darwin') return FALLBACK_SCREEN;
   try {
     const out = execSync(
       `swift -e 'import CoreGraphics; let b = CGDisplayBounds(CGMainDisplayID()); print("\\(Int(b.width))x\\(Int(b.height))")'`,

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -13,6 +13,7 @@ export function getDb() {
     ensureDataDir();
     const sqlite = new Database(getDbPath());
     sqlite.exec('PRAGMA journal_mode=WAL');
+    sqlite.exec('PRAGMA busy_timeout = 5000');
     sqlite.exec('PRAGMA foreign_keys = ON');
     db = drizzle(sqlite, { schema });
   }


### PR DESCRIPTION
## Summary
- Bump tool definition count bounds for ui_update/ui_dismiss additions
- Add missing isDowngradedFromKeychain to secure-keys mocks
- Add ui_dismiss/ui_update to trust-store expected default tools list
- Update IPC snapshots for new message types
- Skip CoreGraphics screen detection on non-macOS (fixes 10s timeout in CI)
- Add PRAGMA busy_timeout to prevent SQLite lock errors in parallel tests
- Fix script-proxy test to expect 403 for missing-credential policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
