### PR TITLE
feat: lazy-load app preview thumbnails in directory

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -20,6 +20,9 @@ struct AppDirectoryView: View {
     @State private var sharedApps: [SharedAppItem] = []
     @State private var pendingResponses = 0
 
+    /// Cache of lazily-loaded preview screenshots keyed by local app ID.
+    @State private var previewCache: [String: String] = [:]
+
     private let columns = [
         GridItem(.flexible(minimum: 200), spacing: VSpacing.lg, alignment: .top),
         GridItem(.flexible(minimum: 200), spacing: VSpacing.lg, alignment: .top),
@@ -90,6 +93,7 @@ struct AppDirectoryView: View {
                 LazyVGrid(columns: columns, spacing: VSpacing.lg) {
                     ForEach(filteredItems) { item in
                         appCard(item)
+                            .onAppear { fetchPreviewIfNeeded(item) }
                     }
                 }
                 .padding(.bottom, VSpacing.md)
@@ -102,6 +106,7 @@ struct AppDirectoryView: View {
 
     private func appCard(_ item: DirectoryAppItem) -> some View {
         let isHovered = hoveredAppId == item.id
+        let preview = item.isShared ? item.preview : previewCache[item.localAppId ?? ""]
 
         return Button {
             openApp(item)
@@ -109,7 +114,7 @@ struct AppDirectoryView: View {
             VStack(alignment: .leading, spacing: 0) {
                 // Preview thumbnail or placeholder
                 Group {
-                    if let preview = item.preview,
+                    if let preview,
                        let data = Data(base64Encoded: preview),
                        let nsImage = NSImage(data: data) {
                         Image(nsImage: nsImage)
@@ -290,6 +295,29 @@ struct AppDirectoryView: View {
         }
     }
 
+    /// Fetch preview for a local app when its card appears on screen.
+    private func fetchPreviewIfNeeded(_ item: DirectoryAppItem) {
+        guard let appId = item.localAppId, !item.isShared else { return }
+        guard previewCache[appId] == nil else { return }
+
+        let stream = daemonClient.subscribe()
+        do {
+            try daemonClient.sendAppPreview(appId: appId)
+        } catch { return }
+
+        Task { @MainActor in
+            for await message in stream {
+                if case .appPreviewResponse(let response) = message,
+                   response.appId == appId {
+                    if let preview = response.preview {
+                        self.previewCache[appId] = preview
+                    }
+                    return
+                }
+            }
+        }
+    }
+
     private func buildDisplayItems() {
         var items: [DirectoryAppItem] = []
 
@@ -299,7 +327,7 @@ struct AppDirectoryView: View {
                 name: app.name,
                 description: app.description,
                 icon: app.icon,
-                preview: app.preview,
+                preview: nil,
                 dateLabel: formatDate(app.createdAt),
                 isShared: false,
                 appType: app.appType,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -44,6 +44,9 @@ struct GeneratedPanel: View {
     // Track how many list responses we're waiting for
     @State private var pendingResponses = 0
 
+    /// Cache of lazily-loaded preview screenshots keyed by local app ID.
+    @State private var previewCache: [String: String] = [:]
+
     // Slack sharing state
     @State private var slackSharingAppId: String?
     @State private var slackShareResult: (appId: String, success: Bool)?
@@ -163,6 +166,7 @@ struct GeneratedPanel: View {
                                     VStack(spacing: VSpacing.md) {
                                         ForEach(documentItems) { item in
                                             appRow(item)
+                                                .onAppear { fetchPreviewIfNeeded(item) }
                                         }
                                     }
                                 }
@@ -187,6 +191,7 @@ struct GeneratedPanel: View {
                                     VStack(spacing: VSpacing.md) {
                                         ForEach(otherItems) { item in
                                             appRow(item)
+                                                .onAppear { fetchPreviewIfNeeded(item) }
                                         }
                                     }
                                 }
@@ -229,10 +234,11 @@ struct GeneratedPanel: View {
     private func appRow(_ item: DisplayAppItem) -> some View {
         let isHovered = hoveredAppId == item.id
         let isBundlingThis = sharingAppId == item.id && isBundling
+        let preview = item.isShared ? item.preview : previewCache[item.localAppId ?? ""]
 
         return HStack(spacing: VSpacing.md) {
             // Icon / Preview thumbnail
-            if let preview = item.preview,
+            if let preview,
                let data = Data(base64Encoded: preview),
                let nsImage = NSImage(data: data) {
                 Image(nsImage: nsImage)
@@ -572,17 +578,40 @@ struct GeneratedPanel: View {
         }
     }
 
+    /// Fetch preview for a local app when its row appears on screen.
+    private func fetchPreviewIfNeeded(_ item: DisplayAppItem) {
+        guard let appId = item.localAppId, !item.isShared else { return }
+        guard previewCache[appId] == nil else { return }
+
+        let stream = daemonClient.subscribe()
+        do {
+            try daemonClient.sendAppPreview(appId: appId)
+        } catch { return }
+
+        Task { @MainActor in
+            for await message in stream {
+                if case .appPreviewResponse(let response) = message,
+                   response.appId == appId {
+                    if let preview = response.preview {
+                        self.previewCache[appId] = preview
+                    }
+                    return
+                }
+            }
+        }
+    }
+
     private func buildDisplayItems() {
         var items: [DisplayAppItem] = []
 
-        // Local apps
+        // Local apps — preview is loaded lazily via fetchPreviewIfNeeded
         for app in localApps {
             items.append(DisplayAppItem(
                 id: "local-\(app.id)",
                 name: app.name,
                 description: app.description,
                 icon: app.icon,
-                preview: app.preview,
+                preview: nil,
                 dateLabel: formatDate(app.createdAt),
                 isShared: false,
                 trustTier: nil,


### PR DESCRIPTION
## Summary
- Cards now appear instantly with icon placeholders, then preview thumbnails fill in as each card scrolls into view
- Uses the `app_preview_request` IPC endpoint added in #4692 to fetch previews one at a time
- Applied to both `AppDirectoryView` (full directory) and `GeneratedPanel` (sidebar app list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
