### PR TITLE
Fix context overflow for image-heavy conversations

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -118,4 +118,18 @@ describe('token estimator', () => {
 
     expect(largeFileTokens).toBe(smallFileTokens);
   });
+
+  test('scales image token estimate with base64 payload size', () => {
+    const smallImageTokens = estimateContentBlockTokens({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'a'.repeat(64) },
+    });
+    const largeImageTokens = estimateContentBlockTokens({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'a'.repeat(60_000) },
+    });
+
+    expect(largeImageTokens).toBeGreaterThan(smallImageTokens);
+    expect(largeImageTokens - smallImageTokens).toBeGreaterThan(1000);
+  });
 });

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../context/window-manager.js';
 import type { ContextWindowConfig } from '../config/types.js';
 import type { Message, Provider, ProviderResponse } from '../providers/types.js';
+import { estimateTextTokens } from '../context/token-estimator.js';
 
 function makeConfig(overrides: Partial<ContextWindowConfig> = {}): ContextWindowConfig {
   return {
@@ -335,5 +336,41 @@ describe('ContextWindowManager', () => {
     });
     expect(result.compacted).toBe(true);
     expect(result.reason).toBeUndefined();
+  });
+
+  test('image-heavy payload is no longer underestimated as below-threshold', async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: 'text', text: '## Goals\n- compacted image-heavy history' }],
+      model: 'mock-model',
+      usage: { inputTokens: 75, outputTokens: 20 },
+      stopReason: 'end_turn',
+    }));
+    const manager = new ContextWindowManager(
+      provider,
+      'system prompt',
+      makeConfig({ maxInputTokens: 7000, targetInputTokens: 5000, compactThreshold: 0.8, preserveRecentUserTurns: 1 }),
+    );
+
+    const images = Array.from({ length: 5 }, (_, i) => ({
+      type: 'image' as const,
+      source: {
+        type: 'base64' as const,
+        media_type: 'image/png',
+        data: `${String(i)}${'A'.repeat(40_000)}`,
+      },
+    }));
+
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Please analyze these screenshots.' }, ...images] },
+      message('assistant', 'Sure, uploading now.'),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.reason).not.toBe('below compaction threshold');
+
+    // Sanity check for this repro: counting raw base64 as text would exceed threshold.
+    const rawBase64Chars = images.reduce((sum, img) => sum + img.source.data.length, 0);
+    const rawBase64TokenEquivalent = estimateTextTokens('A'.repeat(rawBase64Chars));
+    expect(rawBase64TokenEquivalent).toBeGreaterThan(result.thresholdTokens);
   });
 });

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { Message, ProviderResponse } from '../providers/types.js';
 import type { AgentEvent } from '../agent/loop.js';
+import type { UserMessageAttachment } from '../daemon/ipc-protocol.js';
 
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
@@ -22,11 +23,13 @@ mock.module('../config/loader.js', () => ({
     maxTokens: 4096,
     thinking: false,
     contextWindow: {
+      enabled: true,
       maxInputTokens: 100000,
-      thresholdTokens: 80000,
-      preserveRecentMessages: 6,
-      summaryModel: 'mock-model',
-      maxSummaryTokens: 512,
+      targetInputTokens: 70000,
+      compactThreshold: 0.8,
+      preserveRecentUserTurns: 6,
+      summaryMaxTokens: 512,
+      chunkTokens: 12000,
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     apiKeys: {},
@@ -70,6 +73,7 @@ mock.module('../memory/conversation-store.js', () => ({
   addMessage: () => ({ id: 'new-msg' }),
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
+  updateConversationContextWindow: () => {},
 }));
 
 mock.module('../memory/retriever.js', () => ({
@@ -87,10 +91,33 @@ mock.module('../memory/retriever.js', () => ({
   stripMemoryRecallMessages: (msgs: Message[]) => msgs,
 }));
 
+let maybeCompactCalls: Array<{ force: boolean }> = [];
+let forceCompactionEnabled = false;
+
 mock.module('../context/window-manager.js', () => ({
   ContextWindowManager: class {
     constructor() {}
-    async maybeCompact() { return { compacted: false }; }
+    async maybeCompact(messages: Message[], _signal?: AbortSignal, options?: { force?: boolean }) {
+      maybeCompactCalls.push({ force: options?.force === true });
+      if (options?.force && forceCompactionEnabled) {
+        return {
+          compacted: true,
+          messages,
+          previousEstimatedInputTokens: 120000,
+          estimatedInputTokens: 50000,
+          maxInputTokens: 100000,
+          thresholdTokens: 80000,
+          compactedMessages: 2,
+          compactedPersistedMessages: 2,
+          summaryCalls: 1,
+          summaryInputTokens: 200,
+          summaryOutputTokens: 50,
+          summaryModel: 'mock-summary-model',
+          summaryText: '## Goals\n- compacted',
+        };
+      }
+      return { compacted: false };
+    }
   },
   createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
   getSummaryFromContextMessage: () => null,
@@ -98,8 +125,7 @@ mock.module('../context/window-manager.js', () => ({
 
 // Track how many times agentLoop.run was called
 let agentLoopRunCount = 0;
-// Control whether agent loop should emit an ordering error
-let shouldEmitOrderingError = true;
+let firstRunErrorMode: 'none' | 'ordering' | 'context_too_large' = 'ordering';
 
 mock.module('../agent/loop.js', () => ({
   AgentLoop: class {
@@ -107,13 +133,13 @@ mock.module('../agent/loop.js', () => ({
     async run(messages: Message[], onEvent: (event: AgentEvent) => void, _signal?: AbortSignal): Promise<Message[]> {
       agentLoopRunCount++;
 
-      if (shouldEmitOrderingError && agentLoopRunCount === 1) {
-        // First call: simulate provider ordering error (no messages appended)
+      if (agentLoopRunCount === 1 && firstRunErrorMode !== 'none') {
         onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock', providerDurationMs: 0 });
-        onEvent({
-          type: 'error',
-          error: new Error('tool_result blocks that are not immediately after a tool_use block'),
-        });
+        const error =
+          firstRunErrorMode === 'ordering'
+            ? new Error('tool_result blocks that are not immediately after a tool_use block')
+            : new Error('context_length_exceeded: request has too many input tokens');
+        onEvent({ type: 'error', error });
         return [...messages]; // Return unchanged — no progress
       }
 
@@ -143,10 +169,24 @@ function makeSession(): Session {
   return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
 }
 
+function makeImageAttachments(count: number, bytesPerImage = 20_000): UserMessageAttachment[] {
+  return Array.from({ length: count }, (_, i) => ({
+    filename: `shot-${i + 1}.png`,
+    mimeType: 'image/png',
+    data: `${i}${'A'.repeat(bytesPerImage)}`,
+  }));
+}
+
 describe('provider ordering error retry', () => {
-  test('simulated strict provider error triggers exactly one retry', async () => {
+  beforeEach(() => {
     agentLoopRunCount = 0;
-    shouldEmitOrderingError = true;
+    firstRunErrorMode = 'ordering';
+    maybeCompactCalls = [];
+    forceCompactionEnabled = false;
+  });
+
+  test('simulated strict provider error triggers exactly one retry', async () => {
+    firstRunErrorMode = 'ordering';
 
     const session = makeSession();
     await session.loadFromDb();
@@ -159,8 +199,7 @@ describe('provider ordering error retry', () => {
   });
 
   test('[experimental] retry succeeds with repaired history and no spurious error event', async () => {
-    agentLoopRunCount = 0;
-    shouldEmitOrderingError = true;
+    firstRunErrorMode = 'ordering';
 
     const session = makeSession();
     await session.loadFromDb();
@@ -183,11 +222,8 @@ describe('provider ordering error retry', () => {
   });
 
   test('non-ordering errors do not trigger retry', async () => {
-    agentLoopRunCount = 0;
-    shouldEmitOrderingError = false;
+    firstRunErrorMode = 'none';
 
-    // Override the mock to emit a non-ordering error
-    // Since we set shouldEmitOrderingError = false, the mock will succeed immediately
     const session = makeSession();
     await session.loadFromDb();
 
@@ -196,5 +232,75 @@ describe('provider ordering error retry', () => {
 
     // Should have been called exactly 1 time (no retry for non-ordering errors)
     expect(agentLoopRunCount).toBe(1);
+  });
+
+  test('context-too-large triggers one forced-compaction retry for image-heavy input', async () => {
+    firstRunErrorMode = 'context_too_large';
+    forceCompactionEnabled = true;
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: Array<Record<string, unknown>> = [];
+    await session.processMessage(
+      'Please compare these images.',
+      makeImageAttachments(8),
+      (msg) => events.push(msg as unknown as Record<string, unknown>),
+    );
+
+    expect(agentLoopRunCount).toBe(2);
+    expect(maybeCompactCalls).toEqual([
+      { force: false },
+      { force: true },
+    ]);
+    expect(events.some((e) => e.type === 'message_complete')).toBe(true);
+    expect(events.some((e) => e.type === 'session_error')).toBe(false);
+  });
+
+  test('context-too-large can recover by trimming older media when forced compaction cannot run', async () => {
+    firstRunErrorMode = 'context_too_large';
+    forceCompactionEnabled = false;
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: Array<Record<string, unknown>> = [];
+    await session.processMessage(
+      'Please compare these images.',
+      makeImageAttachments(8),
+      (msg) => events.push(msg as unknown as Record<string, unknown>),
+    );
+
+    expect(agentLoopRunCount).toBe(2);
+    expect(maybeCompactCalls).toEqual([
+      { force: false },
+      { force: true },
+    ]);
+
+    expect(events.some((e) => e.type === 'message_complete')).toBe(true);
+    expect(events.some((e) => e.type === 'session_error')).toBe(false);
+  });
+
+  test('context-too-large still surfaces when no media payloads are available to trim', async () => {
+    firstRunErrorMode = 'context_too_large';
+    forceCompactionEnabled = false;
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: Array<Record<string, unknown>> = [];
+    await session.processMessage(
+      'No attachments here.',
+      [],
+      (msg) => events.push(msg as unknown as Record<string, unknown>),
+    );
+
+    expect(agentLoopRunCount).toBe(1);
+    expect(maybeCompactCalls).toEqual([
+      { force: false },
+      { force: true },
+    ]);
+    const sessionError = events.find((e) => e.type === 'session_error') as { code?: string } | undefined;
+    expect(sessionError?.code).toBe('CONTEXT_TOO_LARGE');
   });
 });

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -5,6 +5,7 @@ const MESSAGE_OVERHEAD_TOKENS = 4;
 const TEXT_BLOCK_OVERHEAD_TOKENS = 2;
 const TOOL_BLOCK_OVERHEAD_TOKENS = 16;
 const IMAGE_BLOCK_TOKENS = 1024;
+const IMAGE_BLOCK_OVERHEAD_TOKENS = 16;
 const FILE_BLOCK_OVERHEAD_TOKENS = 48;
 const OTHER_BLOCK_TOKENS = 16;
 const SYSTEM_PROMPT_OVERHEAD_TOKENS = 8;
@@ -24,6 +25,14 @@ function shouldCountFileSourceData(block: Extract<ContentBlock, { type: 'file' }
     return false;
   }
   return GEMINI_INLINE_FILE_MIME_TYPES.has(block.source.media_type);
+}
+
+function estimateImageSourceDataTokens(
+  block: Extract<ContentBlock, { type: 'image' }>,
+): number {
+  // Image payloads are carried inline as base64 for all currently supported
+  // providers, so estimator must scale with payload size (not fixed per image).
+  return estimateTextTokens(block.source.data);
 }
 
 export function estimateContentBlockTokens(block: ContentBlock, options?: TokenEstimatorOptions): number {
@@ -46,7 +55,12 @@ export function estimateContentBlockTokens(block: ContentBlock, options?: TokenE
       return tokens;
     }
     case 'image':
-      return IMAGE_BLOCK_TOKENS;
+      return Math.max(
+        IMAGE_BLOCK_TOKENS,
+        IMAGE_BLOCK_OVERHEAD_TOKENS
+          + estimateTextTokens(block.source.media_type)
+          + estimateImageSourceDataTokens(block),
+      );
     case 'file':
       return FILE_BLOCK_OVERHEAD_TOKENS
         + estimateTextTokens(block.source.filename)

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -37,6 +37,7 @@ import { ToolProfiler, registerToolProfilingListener } from '../events/tool-prof
 import {
   ContextWindowManager,
   createContextSummaryMessage,
+  getSummaryFromContextMessage,
 } from '../context/window-manager.js';
 import { getHookManager } from '../hooks/manager.js';
 import {
@@ -109,6 +110,8 @@ export const DEFAULT_MEMORY_POLICY: Readonly<SessionMemoryPolicy> = Object.freez
 });
 
 const log = getLogger('session');
+const RETRY_KEEP_LATEST_MEDIA_BLOCKS = 3;
+const MAX_MEDIA_STUB_TEXT = 2_000;
 
 export { MAX_QUEUE_DEPTH, type QueueDrainReason, type QueuePolicy } from './session-queue-manager.js';
 export { findLastUndoableUserMessageIndex } from './session-history.js';
@@ -1109,6 +1112,37 @@ export class Session {
           );
         }
 
+        if (contextTooLargeDetected) {
+          const mediaTrimmed = stripMediaPayloadsForRetry(this.messages);
+          if (mediaTrimmed.modified) {
+            rlog.warn(
+              {
+                phase: 'retry',
+                replacedBlocks: mediaTrimmed.replacedBlocks,
+                latestUserIndex: mediaTrimmed.latestUserIndex,
+              },
+              'Context still too large — retrying with older media payloads trimmed',
+            );
+            this.messages = mediaTrimmed.messages;
+            runMessages = applyRuntimeInjections(this.messages, {
+              softConflictInstruction,
+              activeSurface,
+              workspaceTopLevelContext: this.workspaceTopLevelContext,
+            });
+            preRepairMessages = runMessages;
+            preRunHistoryLength = runMessages.length;
+            contextTooLargeDetected = false;
+
+            updatedHistory = await this.agentLoop.run(
+              runMessages,
+              buildEventHandler(),
+              abortController.signal,
+              reqId,
+              onCheckpoint,
+            );
+          }
+        }
+
         // Surface the error if compaction didn't help or wasn't possible
         if (contextTooLargeDetected) {
           const classified = classifySessionError(
@@ -1412,4 +1446,113 @@ export class Session {
     }
   }
 
+}
+
+function stripMediaPayloadsForRetry(messages: Message[]): { messages: Message[]; modified: boolean; replacedBlocks: number; latestUserIndex: number | null } {
+  let latestUserIndex: number | null = null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== 'user') continue;
+    if (getSummaryFromContextMessage(msg) !== null) continue;
+    if (isToolResultOnlyMessage(msg)) continue;
+    latestUserIndex = i;
+    break;
+  }
+
+  let modified = false;
+  let replacedBlocks = 0;
+  let keptLatestMediaBlocks = 0;
+
+  const nextMessages = messages.map((msg, msgIndex) => {
+    const nextContent: ContentBlock[] = [];
+    for (const block of msg.content) {
+      if (block.type === 'image') {
+        const keep = latestUserIndex === msgIndex && keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+        if (keep) {
+          keptLatestMediaBlocks += 1;
+          nextContent.push(block);
+        } else {
+          replacedBlocks += 1;
+          modified = true;
+          nextContent.push(imageBlockToStub(block));
+        }
+        continue;
+      }
+
+      if (block.type === 'file') {
+        const keep = latestUserIndex === msgIndex && keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+        if (keep) {
+          keptLatestMediaBlocks += 1;
+          nextContent.push(block);
+        } else {
+          replacedBlocks += 1;
+          modified = true;
+          nextContent.push(fileBlockToStub(block));
+        }
+        continue;
+      }
+
+      if (block.type === 'tool_result' && block.contentBlocks && block.contentBlocks.length > 0) {
+        let toolResultChanged = false;
+        const nextToolContentBlocks: ContentBlock[] = block.contentBlocks.map((cb) => {
+          if (cb.type === 'image') {
+            replacedBlocks += 1;
+            modified = true;
+            toolResultChanged = true;
+            return imageBlockToStub(cb);
+          }
+          if (cb.type === 'file') {
+            replacedBlocks += 1;
+            modified = true;
+            toolResultChanged = true;
+            return fileBlockToStub(cb);
+          }
+          return cb;
+        });
+        if (toolResultChanged) {
+          nextContent.push({ ...block, contentBlocks: nextToolContentBlocks });
+        } else {
+          nextContent.push(block);
+        }
+        continue;
+      }
+
+      nextContent.push(block);
+    }
+    return { ...msg, content: nextContent };
+  });
+
+  return {
+    messages: modified ? nextMessages : messages,
+    modified,
+    replacedBlocks,
+    latestUserIndex,
+  };
+}
+
+function imageBlockToStub(block: Extract<ContentBlock, { type: 'image' }>): Extract<ContentBlock, { type: 'text' }> {
+  const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
+  return {
+    type: 'text',
+    text: `[Image omitted from retry context: ${block.source.media_type}, ${sizeBytes} bytes]`,
+  };
+}
+
+function fileBlockToStub(block: Extract<ContentBlock, { type: 'file' }>): Extract<ContentBlock, { type: 'text' }> {
+  const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
+  const extracted = (block.extracted_text ?? '').trim();
+  const preview = extracted.length > MAX_MEDIA_STUB_TEXT
+    ? `${extracted.slice(0, MAX_MEDIA_STUB_TEXT)}...`
+    : extracted;
+  return {
+    type: 'text',
+    text: preview.length > 0
+      ? `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]\n${preview}`
+      : `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]`,
+  };
+}
+
+function isToolResultOnlyMessage(message: Message): boolean {
+  return message.content.length > 0
+    && message.content.every((block) => block.type === 'tool_result');
 }


### PR DESCRIPTION
## Summary\n- make image token estimation scale with base64 payload size so context budgeting is image-aware\n- add a context-overflow fallback retry that trims older media payloads into compact text stubs when forced compaction cannot run\n- expand tests for estimator behavior, image-heavy context compaction thresholding, and context-too-large retry paths\n\n## Validation\n- bun test src/__tests__/context-token-estimator.test.ts\n- bun test src/__tests__/context-window-manager.test.ts\n- bun test src/__tests__/session-provider-retry-repair.test.ts\n- bun test src/__tests__/session-error.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
