### PR TITLE
Swap pin/archive button order and align pin icon on thread rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -598,20 +598,6 @@ struct MainWindowView: View {
             } else if isHovered {
                 HStack(spacing: VSpacing.xs) {
                     Button {
-                        threadPendingDeletion = thread.id
-                    } label: {
-                        Image(systemName: "archivebox")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 20, height: 20)
-                            .background(VColor.backgroundSubtle)
-                            .clipShape(Circle())
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Archive \(thread.title)")
-
-                    Button {
                         if thread.isPinned {
                             threadManager.unpinThread(id: thread.id)
                         } else {
@@ -629,6 +615,20 @@ struct MainWindowView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+
+                    Button {
+                        threadPendingDeletion = thread.id
+                    } label: {
+                        Image(systemName: "archivebox")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 20, height: 20)
+                            .background(VColor.backgroundSubtle)
+                            .clipShape(Circle())
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Archive \(thread.title)")
                 }
                 .padding(.trailing, VSpacing.xs)
             } else if thread.isPinned {
@@ -639,7 +639,7 @@ struct MainWindowView: View {
                     .frame(width: 20, height: 20)
                     .background(VColor.backgroundSubtle)
                     .clipShape(Circle())
-                    .padding(.trailing, VSpacing.xs)
+                    .padding(.trailing, VSpacing.xs + 20 + VSpacing.xs)
             }
         }
         .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Swap the order of pin and archive buttons on thread row hover: pin is now first (left), archive second (right)
- Adjust non-hover pinned icon trailing padding so the pin icon stays in the same position whether the row is hovered or not

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
