### PR TITLE
Add work_item_list chat tool for Task Queue

### DIFF
--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -2,3 +2,4 @@ export { taskSaveTool } from './task-save.js';
 export { taskRunTool } from './task-run.js';
 export { taskListTool } from './task-list.js';
 export { taskDeleteTool } from './task-delete.js';
+export { workItemListTool } from './work-item-list.js';

--- a/assistant/src/tools/tasks/work-item-list.ts
+++ b/assistant/src/tools/tasks/work-item-list.ts
@@ -1,0 +1,87 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { listWorkItems, type WorkItemStatus } from '../../work-items/work-item-store.js';
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'urgent',
+  1: 'high',
+  2: 'normal',
+  3: 'low',
+};
+
+const definition: ToolDefinition = {
+  name: 'work_item_list',
+  description: 'List all items in the Task Queue with their status, priority, and last run info.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      status: {
+        oneOf: [
+          { type: 'string' },
+          { type: 'array', items: { type: 'string' } },
+        ],
+        description:
+          'Optional status filter. A single status string (e.g. "queued") or an array of statuses to include.',
+      },
+    },
+  },
+};
+
+class WorkItemListTool implements Tool {
+  name = 'work_item_list';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    try {
+      const statusFilter = input.status as string | string[] | undefined;
+
+      let items;
+      if (typeof statusFilter === 'string') {
+        items = listWorkItems({ status: statusFilter as WorkItemStatus });
+      } else if (Array.isArray(statusFilter)) {
+        // listWorkItems only supports a single status filter, so we fetch all
+        // and filter client-side when an array is provided
+        const allItems = listWorkItems();
+        const allowed = new Set(statusFilter);
+        items = allItems.filter((item) => allowed.has(item.status));
+      } else {
+        items = listWorkItems();
+      }
+
+      if (items.length === 0) {
+        return { content: 'No work items found in the Task Queue.', isError: false };
+      }
+
+      const lines = [`Found ${items.length} work item(s):`, ''];
+
+      for (const item of items) {
+        const priority = PRIORITY_LABELS[item.priorityTier] ?? `tier ${item.priorityTier}`;
+        lines.push(`- ${item.title}`);
+        lines.push(`    ID: ${item.id}`);
+        lines.push(`    Status: ${item.status}`);
+        lines.push(`    Priority: ${priority}`);
+        if (item.notes) {
+          lines.push(`    Notes: ${item.notes}`);
+        }
+        if (item.lastRunStatus) {
+          lines.push(`    Last run: ${item.lastRunStatus}`);
+        }
+        lines.push('');
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const workItemListTool = new WorkItemListTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,7 +18,7 @@ import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 import { followupCreateTool, followupListTool, followupResolveTool } from './followups/index.js';
-import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool } from './tasks/index.js';
+import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, workItemListTool } from './tasks/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -110,6 +110,7 @@ export const explicitTools: Tool[] = [
   taskRunTool,
   taskListTool,
   taskDeleteTool,
+  workItemListTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a new `work_item_list` chat tool that returns Task Queue entries with status, priority, notes, and last run info.
- Supports optional `status` filter (single string or array of statuses).
- Follows the same pattern as `task_list` tool.

## Changes
- **New file**: `assistant/src/tools/tasks/work-item-list.ts` — tool implementation
- **Modified**: `assistant/src/tools/tasks/index.ts` — added export
- **Modified**: `assistant/src/tools/tool-manifest.ts` — added import and registration in `explicitTools`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
