### PR TITLE
Rename "Task Queue" to "Tasks" in macOS UI labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1424,7 +1424,7 @@ private struct DrawerMenuView: View {
         VStack(alignment: .leading, spacing: 0) {
             DrawerMenuItem(icon: "person.crop.circle", label: "Identity", action: onIdentity)
             DrawerMenuItem(icon: "wand.and.stars", label: "Skills", action: onSkills)
-            DrawerMenuItem(icon: "list.bullet.clipboard", label: "Task Queue", action: onTaskQueue)
+            DrawerMenuItem(icon: "list.bullet.clipboard", label: "Tasks", action: onTaskQueue)
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
@@ -10,7 +10,7 @@ struct TaskQueuePanel: View {
     @State private var errorMessage: String?
 
     var body: some View {
-        VSidePanel(title: "Task Queue", onClose: onClose) {
+        VSidePanel(title: "Tasks", onClose: onClose) {
             if isLoading {
                 VStack {
                     Spacer()


### PR DESCRIPTION
## Summary
- Renamed the user-facing label "Task Queue" to "Tasks" in the macOS side panel title and drawer menu item
- Only string literals were changed; no Swift types, variables, file names, or enum cases were modified

## Files changed
- `clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift` — panel title
- `clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift` — drawer menu label

## Test plan
- [ ] Open the app, click the drawer menu, and verify the menu item reads "Tasks" instead of "Task Queue"
- [ ] Open the Tasks panel and verify the panel header reads "Tasks"
- [ ] Verify Swift compilation passes (`swift build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
