### PR TITLE
fix: remove provider requirement from onboarding skip check

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -140,11 +140,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         #endif
 
         if !skipOnboarding && !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
-            // If the user already has an API key, model, and provider configured,
+            // If the user already has an API key and model configured,
             // skip onboarding entirely — they're a returning user whose
             // hasCompletedOnboarding flag was cleared (e.g. by /scrub).
+            // Provider is not checked because the daemon defaults to 'anthropic'.
             let config = WorkspaceConfigIO.read()
-            if APIKeyManager.hasAnyKey(), config["model"] != nil, config["provider"] != nil {
+            if APIKeyManager.hasAnyKey(), config["model"] != nil {
                 UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
             } else {
                 showOnboarding()


### PR DESCRIPTION
Address review feedback on PR #4671. The skip condition required a top-level provider key that ModelSelectionStepView never writes. The daemon already defaults provider to anthropic, so remove the provider check — just require API key + model.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
