### PR TITLE
fix: exclude query templates from ambiguity guard before counting

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -162,11 +162,16 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
         shouldIntercept: (hostname: string, port: number) =>
           routeConnection(hostname, port, managed.session.credentialIds, templates),
         rewriteCallback: async (req) => {
-          // Collect all matching candidates to detect ambiguity before
-          // injecting any secrets — mirrors the HTTP policyCallback guard.
+          // Collect matching header-injection candidates to detect ambiguity
+          // before injecting any secrets — mirrors the HTTP policyCallback
+          // guard. Query templates are excluded because the MITM
+          // RewriteCallback can't rewrite URL paths; counting them would
+          // cause false ambiguity when a host has both query and header
+          // templates.
           const candidates: { credId: string; tpl: CredentialInjectionTemplate }[] = [];
           for (const [credId, tpls] of templates) {
             for (const tpl of tpls) {
+              if (tpl.injectionType === 'query') continue;
               if (minimatch(req.hostname, tpl.hostPattern, { nocase: true })) {
                 candidates.push({ credId, tpl });
               }
@@ -179,12 +184,6 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
           if (candidates.length > 1) return null;
 
           const { credId, tpl } = candidates[0];
-
-          // Query param injection requires URL path rewriting, which the
-          // current RewriteCallback interface doesn't support. Pass through
-          // unchanged — query injection will be wired once the MITM handler
-          // gains path-rewrite capability.
-          if (tpl.injectionType === 'query') return req.headers;
 
           if (tpl.injectionType === 'header' && tpl.headerName) {
             const resolved = resolveById(credId);


### PR DESCRIPTION
Address review feedback on PR #4399. Filter out unsupported query templates before the ambiguity check so header-based injection isn't skipped for hosts with both query and header templates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
