### PR TITLE
fix: track worker PIDs and check individual exit codes in check-pr-reviews

### DIFF
--- a/.claude/check-pr-reviews
+++ b/.claude/check-pr-reviews
@@ -188,11 +188,24 @@ check_pr() {
     }' > "$pr_dir/result.json"
 }
 
-# Process all PRs in parallel
+# Process all PRs in parallel, tracking PIDs to surface failures
+WORKER_PIDS=()
 for pr in "${PR_NUMBERS[@]}"; do
   check_pr "$pr" &
+  WORKER_PIDS+=($!)
 done
-wait
+
+# Wait on each worker individually so non-zero exits fail the command
+FAILED=0
+for pid in "${WORKER_PIDS[@]}"; do
+  if ! wait "$pid"; then
+    FAILED=1
+  fi
+done
+if [ "$FAILED" -ne 0 ]; then
+  echo "error: one or more PR checks failed" >&2
+  exit 1
+fi
 
 # Collect results in argument order
 RESULTS=()


### PR DESCRIPTION
Address review feedback on PR #4659. Replace bare wait with individual PID tracking and exit code checking to surface worker failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
