### PR TITLE
fix: handle session promise rejection and lock race conditions

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -387,16 +387,14 @@ export async function getOrStartSession(
   approvalCallback?: ProxyApprovalCallback,
   options?: { listenHost?: string },
 ): Promise<{ session: ProxySession; created: boolean }> {
-  // Fast path — session already active, no lock needed.
+  // Fast path — session already active with matching credentials, no lock needed.
   const existing = getActiveSession(conversationId);
-  if (existing) {
-    if (credentialIdsMatch(existing.credentialIds, credentialIds)) {
-      return { session: existing, created: false };
-    }
-    // Credential mismatch — tear down the stale session so we can create
-    // one with the correct bindings.
-    await stopSession(existing.id);
+  if (existing && credentialIdsMatch(existing.credentialIds, credentialIds)) {
+    return { session: existing, created: false };
   }
+  // If credentials don't match (or no session exists), fall through to the
+  // lock-protected section. Stopping a mismatched session outside the lock
+  // would let another caller slip in and create a different-credential session.
 
   // Serialize: if another caller is already creating a session for this
   // conversation, wait for it rather than creating a second one.


### PR DESCRIPTION
Address review feedback on PR #4402. Move credential-mismatch teardown into the lock-protected section to prevent a race where another caller can create a different-credential session while the first caller is stopping the mismatched one. The .catch() for unhandled promise rejection and credential validation on lock waiter return were already addressed in the original PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
