### PR TITLE
fix: update ARCHITECTURE.md to reflect implemented credential injection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2629,10 +2629,10 @@ All proxy logging passes through sanitization helpers (`logging.ts`) that redact
 
 ### Runtime Wiring Summary
 
-The proxy subsystem is wired for routing, policy evaluation, and approval prompts. Credential injection (header rewriting) is **not yet implemented** — the `rewriteCallback` and `policyCallback` currently pass through without injecting credentials (see TODO comments in `session-manager.ts`). The session manager's `startSession()` calls `createProxyServer()` with:
+The proxy subsystem is fully wired, including credential injection. The session manager's `startSession()` calls `createProxyServer()` with:
 
-- **MITM handler config**: `mitmHandler` is configured with the local CA path and a `rewriteCallback` that currently passes through unmodified headers (credential header injection is planned for a later PR)
-- **Policy callback**: `evaluateRequestWithApproval()` is called via the `policyCallback` for access control on non-MITM requests; CONNECT requests routed to the MITM handler skip the `policyCallback` path. Credential injection is not yet implemented for either HTTP or HTTPS
+- **MITM handler config**: `mitmHandler` is configured with the local CA path and a `rewriteCallback` that injects credential headers for matched hosts — it collects matching `CredentialInjectionTemplate` candidates by hostname, blocks on ambiguity (multiple matches), and for `header`-type templates resolves the secret from secure storage and sets the outbound header
+- **Policy callback**: `evaluateRequestWithApproval()` is called via the `policyCallback`; for `'matched'` decisions it injects credential headers (reading the secret value at injection time), while `'ambiguous'` decisions are blocked and `'ask_*'` decisions route through the approval callback
 - **Approval callback**: `createProxyApprovalCallback()` from `session-tool-setup.ts` routes approval prompts through the `PermissionPrompter`, using the `network_request` tool name with URL-based trust rules
 - **Docker network override**: `network_mode: 'proxied'` switches the sandbox to `--network=bridge` with `--add-host=host.docker.internal:host-gateway`; proxy env vars use `host.docker.internal` so containers can reach the host-side proxy
 - **networkMode plumbing**: `shell.ts` passes `{ networkMode }` to `wrapCommand()`, which forwards it to the Docker backend


### PR DESCRIPTION
Address review feedback on PR #4390. ARCHITECTURE.md incorrectly stated credential injection was not yet implemented. Updated to accurately reflect the implementation in session-manager.ts rewriteCallback and policyCallback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
