### PR TITLE
fix: cache credential metadata to avoid per-request disk I/O

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -203,16 +203,19 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
     }
   }
 
+  // Pre-load the full credential registry once at session startup so the
+  // policy callback doesn't hit disk on every proxied request.
+  // listCredentialMetadata() uses synchronous readFileSync + JSON.parse,
+  // which would block the event loop in the hot path.
+  const allKnown: CredentialInjectionTemplate[] = [];
+  for (const meta of listCredentialMetadata()) {
+    if (meta.injectionTemplates?.length) {
+      allKnown.push(...meta.injectionTemplates);
+    }
+  }
+
   // Build the policy callback for HTTP/CONNECT request gating
   const policyCallback: PolicyCallback = async (hostname: string, port: number | null, reqPath: string, scheme: 'http' | 'https') => {
-    // Build allKnown from the full credential registry so the policy engine
-    // can distinguish "known host, missing credential" from "unknown host".
-    const allKnown: CredentialInjectionTemplate[] = [];
-    for (const meta of listCredentialMetadata()) {
-      if (meta.injectionTemplates?.length) {
-        allKnown.push(...meta.injectionTemplates);
-      }
-    }
 
     const decision = evaluateRequestWithApproval(
       hostname, port, reqPath,


### PR DESCRIPTION
Address review feedback on PR #4398. Cache listCredentialMetadata() results at session startup instead of reading from disk on every proxied request. The allKnown array is now pre-loaded once and captured by the policyCallback closure, eliminating synchronous readFileSync + JSON.parse from the hot path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
