### PR TITLE
Broadcast work_item_status_changed on work item creation

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -54,6 +54,9 @@ export function handleWorkItemCreate(
     sortIndex: msg.sortIndex,
   });
   ctx.send(socket, { type: 'work_item_create_response', item });
+
+  // Notify all connected clients so open Task Queue views refresh immediately
+  broadcastWorkItemStatus(ctx, item.id);
 }
 
 export function handleWorkItemUpdate(


### PR DESCRIPTION
## Summary
- Adds a `broadcastWorkItemStatus` call in `handleWorkItemCreate` after the work item is created and the response is sent to the requesting client
- This ensures all connected clients (e.g. the macOS Task Queue panel) receive a `work_item_status_changed` notification and refresh immediately when a new work item is enqueued
- Follows the existing pattern already used by `handleWorkItemComplete` and `handleWorkItemRunTask`

## Test plan
- [ ] Create a new work item via the daemon IPC while the Task Queue panel is open — verify the panel refreshes automatically without manual intervention
- [ ] Verify existing work item completion and run-task broadcasts still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
