### PR TITLE
fix: add ownerSkillBundled to fallback CU tool registrations

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -289,6 +289,7 @@ export class ComputerUseSession {
         ...t,
         origin: 'skill' as const,
         ownerSkillId: fallbackSkillId,
+        ownerSkillBundled: true,
       }));
       registerSkillTools(fallbackTools);
       // Track in the session map so resetSkillToolProjection cleans up


### PR DESCRIPTION
Address review feedback on PR #4395. Fallback CU tools were missing ownerSkillBundled, causing the permission checker to treat them as prompt-by-default. Added the flag so fallback tools get auto-allow treatment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
