### PR TITLE
fix: cancel preview tasks, deduplicate requests, cache nil, use LazyVStack

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -21,7 +21,10 @@ struct AppDirectoryView: View {
     @State private var pendingResponses = 0
 
     /// Cache of lazily-loaded preview screenshots keyed by local app ID.
+    /// Empty string is used as a sentinel for "fetched but no preview available".
     @State private var previewCache: [String: String] = [:]
+    /// In-flight preview fetch tasks, keyed by local app ID, so they can be cancelled.
+    @State private var previewTasks: [String: Task<Void, Never>] = [:]
 
     private let columns = [
         GridItem(.flexible(minimum: 200), spacing: VSpacing.lg, alignment: .top),
@@ -100,13 +103,19 @@ struct AppDirectoryView: View {
             }
         }
         .onAppear { fetchApps() }
+        .onDisappear {
+            for task in previewTasks.values { task.cancel() }
+            previewTasks.removeAll()
+        }
     }
 
     // MARK: - App Card
 
     private func appCard(_ item: DirectoryAppItem) -> some View {
         let isHovered = hoveredAppId == item.id
-        let preview = item.isShared ? item.preview : previewCache[item.localAppId ?? ""]
+        let rawPreview = item.isShared ? item.preview : previewCache[item.localAppId ?? ""]
+        // Empty string is a sentinel for "no preview available" — treat as nil
+        let preview = rawPreview?.isEmpty == true ? nil : rawPreview
 
         return Button {
             openApp(item)
@@ -298,24 +307,44 @@ struct AppDirectoryView: View {
     /// Fetch preview for a local app when its card appears on screen.
     private func fetchPreviewIfNeeded(_ item: DirectoryAppItem) {
         guard let appId = item.localAppId, !item.isShared else { return }
-        guard previewCache[appId] == nil else { return }
+        // Skip if already cached (including empty-string sentinel) or in-flight
+        guard previewCache[appId] == nil, previewTasks[appId] == nil else { return }
 
         let stream = daemonClient.subscribe()
         do {
             try daemonClient.sendAppPreview(appId: appId)
         } catch { return }
 
-        Task { @MainActor in
+        let task = Task { @MainActor in
+            // 10-second timeout to avoid zombie subscribers
+            let timeout = Task { try await Task.sleep(nanoseconds: 10_000_000_000) }
+            defer {
+                timeout.cancel()
+                self.previewTasks.removeValue(forKey: appId)
+            }
+
             for await message in stream {
+                if Task.isCancelled { break }
                 if case .appPreviewResponse(let response) = message,
                    response.appId == appId {
-                    if let preview = response.preview {
-                        self.previewCache[appId] = preview
-                    }
+                    self.previewCache[appId] = response.preview ?? ""
                     return
                 }
             }
+
+            // Stream ended or cancelled — cache empty sentinel to avoid retries
+            if self.previewCache[appId] == nil {
+                self.previewCache[appId] = ""
+            }
         }
+
+        // Cancel after timeout
+        Task {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            if !task.isCancelled { task.cancel() }
+        }
+
+        previewTasks[appId] = task
     }
 
     private func buildDisplayItems() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -45,7 +45,10 @@ struct GeneratedPanel: View {
     @State private var pendingResponses = 0
 
     /// Cache of lazily-loaded preview screenshots keyed by local app ID.
+    /// Empty string is used as a sentinel for "fetched but no preview available".
     @State private var previewCache: [String: String] = [:]
+    /// In-flight preview fetch tasks, keyed by local app ID, so they can be cancelled.
+    @State private var previewTasks: [String: Task<Void, Never>] = [:]
 
     // Slack sharing state
     @State private var slackSharingAppId: String?
@@ -148,7 +151,7 @@ struct GeneratedPanel: View {
                         )
                         .frame(height: 100)
                     } else {
-                        VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
                             // Documents section
                             if !documentItems.isEmpty {
                                 VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -163,7 +166,7 @@ struct GeneratedPanel: View {
                                     }
                                     .padding(.horizontal, VSpacing.xs)
 
-                                    VStack(spacing: VSpacing.md) {
+                                    LazyVStack(spacing: VSpacing.md) {
                                         ForEach(documentItems) { item in
                                             appRow(item)
                                                 .onAppear { fetchPreviewIfNeeded(item) }
@@ -188,7 +191,7 @@ struct GeneratedPanel: View {
                                         .padding(.horizontal, VSpacing.xs)
                                     }
 
-                                    VStack(spacing: VSpacing.md) {
+                                    LazyVStack(spacing: VSpacing.md) {
                                         ForEach(otherItems) { item in
                                             appRow(item)
                                                 .onAppear { fetchPreviewIfNeeded(item) }
@@ -205,6 +208,10 @@ struct GeneratedPanel: View {
         .background(VColor.backgroundSubtle)
         .onAppear {
             fetchApps()
+        }
+        .onDisappear {
+            for task in previewTasks.values { task.cancel() }
+            previewTasks.removeAll()
         }
     }
 
@@ -234,7 +241,9 @@ struct GeneratedPanel: View {
     private func appRow(_ item: DisplayAppItem) -> some View {
         let isHovered = hoveredAppId == item.id
         let isBundlingThis = sharingAppId == item.id && isBundling
-        let preview = item.isShared ? item.preview : previewCache[item.localAppId ?? ""]
+        let rawPreview = item.isShared ? item.preview : previewCache[item.localAppId ?? ""]
+        // Empty string is a sentinel for "no preview available" — treat as nil
+        let preview = rawPreview?.isEmpty == true ? nil : rawPreview
 
         return HStack(spacing: VSpacing.md) {
             // Icon / Preview thumbnail
@@ -581,24 +590,43 @@ struct GeneratedPanel: View {
     /// Fetch preview for a local app when its row appears on screen.
     private func fetchPreviewIfNeeded(_ item: DisplayAppItem) {
         guard let appId = item.localAppId, !item.isShared else { return }
-        guard previewCache[appId] == nil else { return }
+        // Skip if already cached (including empty-string sentinel) or in-flight
+        guard previewCache[appId] == nil, previewTasks[appId] == nil else { return }
 
         let stream = daemonClient.subscribe()
         do {
             try daemonClient.sendAppPreview(appId: appId)
         } catch { return }
 
-        Task { @MainActor in
+        let task = Task { @MainActor in
+            let timeout = Task { try await Task.sleep(nanoseconds: 10_000_000_000) }
+            defer {
+                timeout.cancel()
+                self.previewTasks.removeValue(forKey: appId)
+            }
+
             for await message in stream {
+                if Task.isCancelled { break }
                 if case .appPreviewResponse(let response) = message,
                    response.appId == appId {
-                    if let preview = response.preview {
-                        self.previewCache[appId] = preview
-                    }
+                    self.previewCache[appId] = response.preview ?? ""
                     return
                 }
             }
+
+            // Stream ended or cancelled — cache empty sentinel to avoid retries
+            if self.previewCache[appId] == nil {
+                self.previewCache[appId] = ""
+            }
         }
+
+        // Cancel after timeout
+        Task {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            if !task.isCancelled { task.cancel() }
+        }
+
+        previewTasks[appId] = task
     }
 
     private func buildDisplayItems() {


### PR DESCRIPTION
Address review feedback on PR #4693. Track and cancel preview fetch tasks on disappear with 10s timeouts. Add in-flight deduplication via previewTasks dict. Cache nil preview responses as empty-string sentinel. Switch GeneratedPanel from VStack to LazyVStack for true lazy loading.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
