### PR TITLE
feat: add work_item_enqueue chat tool

### DIFF
--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -3,3 +3,4 @@ export { taskRunTool } from './task-run.js';
 export { taskListTool } from './task-list.js';
 export { taskDeleteTool } from './task-delete.js';
 export { workItemListTool } from './work-item-list.js';
+export { workItemEnqueueTool } from './work-item-enqueue.js';

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -1,0 +1,143 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { getTask, listTasks } from '../../tasks/task-store.js';
+import { createWorkItem } from '../../work-items/work-item-store.js';
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'urgent',
+  1: 'high',
+  2: 'normal',
+  3: 'low',
+};
+
+const definition: ToolDefinition = {
+  name: 'work_item_enqueue',
+  description:
+    'Add a task to the Task Queue. Creates a work item from a task definition (template) by name or ID.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      task_id: {
+        type: 'string',
+        description: 'ID of the task definition to enqueue. Provide this or task_name.',
+      },
+      task_name: {
+        type: 'string',
+        description:
+          'Title/name of the task definition to search for (case-insensitive substring match). Provide this or task_id.',
+      },
+      title: {
+        type: 'string',
+        description:
+          'Override title for the work item. Defaults to the task definition title if omitted.',
+      },
+      notes: {
+        type: 'string',
+        description: 'Notes to attach to the work item.',
+      },
+      priority_tier: {
+        type: 'number',
+        description: '0 = urgent, 1 = high, 2 = normal (default), 3 = low.',
+      },
+      sort_index: {
+        type: 'number',
+        description: 'Manual sort order within the priority tier.',
+      },
+    },
+  },
+};
+
+class WorkItemEnqueueTool implements Tool {
+  name = 'work_item_enqueue';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    try {
+      const taskId = input.task_id as string | undefined;
+      const taskName = input.task_name as string | undefined;
+      const titleOverride = input.title as string | undefined;
+      const notes = input.notes as string | undefined;
+      const priorityTier = input.priority_tier as number | undefined;
+      const sortIndex = input.sort_index as number | undefined;
+
+      if (!taskId && !taskName) {
+        return {
+          content: 'Error: You must provide either task_id or task_name to identify the task definition.',
+          isError: true,
+        };
+      }
+
+      let resolvedTask;
+
+      if (taskId) {
+        resolvedTask = getTask(taskId);
+        if (!resolvedTask) {
+          return { content: `Error: No task definition found with ID "${taskId}".`, isError: true };
+        }
+      } else {
+        // Search by name (case-insensitive substring match)
+        const needle = taskName!.toLowerCase();
+        const allTasks = listTasks();
+        const matches = allTasks.filter((t) => t.title.toLowerCase().includes(needle));
+
+        if (matches.length === 0) {
+          return {
+            content: `Error: No task definition found matching "${taskName}". Use task_list to see available tasks.`,
+            isError: true,
+          };
+        }
+
+        if (matches.length > 1) {
+          const lines = [
+            `Multiple task definitions match "${taskName}". Please specify by ID:`,
+            '',
+          ];
+          for (const m of matches) {
+            lines.push(`- ${m.title}  (ID: ${m.id})`);
+          }
+          return { content: lines.join('\n'), isError: true };
+        }
+
+        resolvedTask = matches[0];
+      }
+
+      const workItem = createWorkItem({
+        taskId: resolvedTask.id,
+        title: titleOverride ?? resolvedTask.title,
+        notes,
+        priorityTier: priorityTier ?? 2,
+        sortIndex,
+      });
+
+      const priority = PRIORITY_LABELS[workItem.priorityTier] ?? `tier ${workItem.priorityTier}`;
+      const lines = [
+        `Enqueued work item:`,
+        `  Title: ${workItem.title}`,
+        `  ID: ${workItem.id}`,
+        `  Task definition: ${resolvedTask.title} (${resolvedTask.id})`,
+        `  Priority: ${priority}`,
+        `  Status: ${workItem.status}`,
+      ];
+      if (workItem.notes) {
+        lines.push(`  Notes: ${workItem.notes}`);
+      }
+      if (workItem.sortIndex !== null) {
+        lines.push(`  Sort index: ${workItem.sortIndex}`);
+      }
+
+      return { content: lines.join('\n'), isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const workItemEnqueueTool = new WorkItemEnqueueTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,7 +18,7 @@ import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 import { followupCreateTool, followupListTool, followupResolveTool } from './followups/index.js';
-import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, workItemListTool } from './tasks/index.js';
+import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, workItemListTool, workItemEnqueueTool } from './tasks/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -111,6 +111,7 @@ export const explicitTools: Tool[] = [
   taskListTool,
   taskDeleteTool,
   workItemListTool,
+  workItemEnqueueTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a `work_item_enqueue` tool that creates work items from existing task definitions (templates)
- Supports lookup by task ID or case-insensitive name search with disambiguation for multiple matches
- Accepts optional overrides: title, notes, priority_tier (0-3), and sort_index
- Registered in the tool manifest as an explicit tool with `RiskLevel.Low` in the `tasks` category

## Files changed
- `assistant/src/tools/tasks/work-item-enqueue.ts` — new tool implementation
- `assistant/src/tools/tasks/index.ts` — export the new tool
- `assistant/src/tools/tool-manifest.ts` — import and register in `explicitTools`

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`) ✅
- [ ] Tool appears in tool registry when daemon starts
- [ ] Enqueue by task ID creates a work item with correct fields
- [ ] Enqueue by name with single match creates work item
- [ ] Enqueue by name with multiple matches returns disambiguation list
- [ ] Enqueue with no matching name returns helpful error
- [ ] Missing both task_id and task_name returns validation error
- [ ] Optional overrides (title, notes, priority, sort) are applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
