### PR TITLE
fix: correct mock signature and restore deny-rule URL coverage

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3825,10 +3825,8 @@ describe('bash network_mode=proxied force prompt (PR 14)', () => {
   });
 
   test('deny rule still blocks proxied host_bash command', async () => {
-    addRule('host_bash', 'curl *', 'everywhere', 'deny');
-    // Use a command without URL slashes so minimatch's '*' (which doesn't
-    // cross '/') can match the argument.
-    const result = await check('host_bash', { command: 'curl evil.com', network_mode: 'proxied' }, '/tmp');
+    addRule('host_bash', 'curl https://**', 'everywhere', 'deny');
+    const result = await check('host_bash', { command: 'curl https://evil.com', network_mode: 'proxied' }, '/tmp');
     expect(result.decision).toBe('deny');
     expect(result.reason).toContain('deny rule');
   });

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -45,12 +45,12 @@ mock.module('../security/secure-keys.js', () => ({
 const metadataStore = new Map<string, { credentialId: string; service: string; field: string }>();
 
 mock.module('../tools/credentials/metadata-store.js', () => ({
-  upsertCredentialMetadata: (meta: { credentialId?: string; service: string; field: string }) => {
-    const key = `${meta.service}:${meta.field}`;
+  upsertCredentialMetadata: (service: string, field: string, _policy?: Record<string, unknown>) => {
+    const key = `${service}:${field}`;
     metadataStore.set(key, {
-      credentialId: meta.credentialId ?? `cred-${meta.service}-${meta.field}`,
-      service: meta.service,
-      field: meta.field,
+      credentialId: `cred-${service}-${field}`,
+      service,
+      field,
     });
   },
   deleteCredentialMetadata: (service: string, field: string) => {


### PR DESCRIPTION
Address review feedback on PR #4394. Fix upsertCredentialMetadata mock to use positional args matching production signature. Restore deny-rule test to use URL with slashes for proper coverage by using a globstar pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
