### PR TITLE
fix: check listenHost on session reuse and avoid binding proxy to 0.0.0.0

### DIFF
--- a/.claude/check-pr-reviews
+++ b/.claude/check-pr-reviews
@@ -188,11 +188,24 @@ check_pr() {
     }' > "$pr_dir/result.json"
 }
 
-# Process all PRs in parallel
+# Process all PRs in parallel, tracking PIDs to surface failures
+WORKER_PIDS=()
 for pr in "${PR_NUMBERS[@]}"; do
   check_pr "$pr" &
+  WORKER_PIDS+=($!)
 done
-wait
+
+# Wait on each worker individually so non-zero exits fail the command
+FAILED=0
+for pid in "${WORKER_PIDS[@]}"; do
+  if ! wait "$pid"; then
+    FAILED=1
+  fi
+done
+if [ "$FAILED" -ne 0 ]; then
+  echo "error: one or more PR checks failed" >&2
+  exit 1
+fi
 
 # Collect results in argument order
 RESULTS=()

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -32,6 +32,8 @@ interface ManagedSession {
   config: ProxySessionConfig;
   dataDir: string | null;
   approvalCallback: ProxyApprovalCallback | null;
+  /** The host address the server is bound to (e.g. '127.0.0.1'). */
+  listenHost: string;
   /** In-flight stop promise so concurrent callers can await the same shutdown. */
   stopPromise: Promise<void> | null;
 }
@@ -105,6 +107,7 @@ export function createSession(
     config: merged,
     dataDir: dataDir ?? null,
     approvalCallback: approvalCallback ?? null,
+    listenHost: '127.0.0.1',
     stopPromise: null,
   });
 
@@ -264,9 +267,11 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
 
   const server = createProxyServer(config);
 
+  const listenHost = options?.listenHost ?? '127.0.0.1';
+
   try {
     return await new Promise<ProxySession>((resolve, reject) => {
-      server.listen(0, options?.listenHost ?? '127.0.0.1', () => {
+      server.listen(0, listenHost, () => {
         const addr = server.address();
         if (!addr || typeof addr === 'string') {
           reject(new Error('Failed to get server address'));
@@ -275,6 +280,7 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
         managed.server = server;
         managed.session.port = addr.port;
         managed.session.status = 'active';
+        managed.listenHost = listenHost;
         resetIdleTimer(managed);
         resolve(cloneSession(managed.session));
       });
@@ -389,10 +395,15 @@ export async function getOrStartSession(
   approvalCallback?: ProxyApprovalCallback,
   options?: { listenHost?: string },
 ): Promise<{ session: ProxySession; created: boolean }> {
-  // Fast path — session already active with matching credentials, no lock needed.
+  const requestedHost = options?.listenHost ?? '127.0.0.1';
+
+  // Fast path — session already active with matching credentials and listen host, no lock needed.
   const existing = getActiveSession(conversationId);
   if (existing && credentialIdsMatch(existing.credentialIds, credentialIds)) {
-    return { session: existing, created: false };
+    const managed = sessions.get(existing.id);
+    if (managed && managed.listenHost === requestedHost) {
+      return { session: existing, created: false };
+    }
   }
   // If credentials don't match (or no session exists), fall through to the
   // lock-protected section. Stopping a mismatched session outside the lock
@@ -408,10 +419,13 @@ export async function getOrStartSession(
     if (!inflight) break;
     const session = await inflight;
     if (credentialIdsMatch(session.credentialIds, credentialIds)) {
-      return { session, created: false };
+      const m = sessions.get(session.id);
+      if (m && m.listenHost === requestedHost) {
+        return { session, created: false };
+      }
     }
-    // Credential mismatch — tear down and loop back to re-check whether
-    // another waiter has already started a replacement session.
+    // Credential or listenHost mismatch — tear down and loop back to re-check
+    // whether another waiter has already started a replacement session.
     await stopSession(session.id);
   }
 
@@ -420,7 +434,8 @@ export async function getOrStartSession(
     // between our initial check and acquiring the lock.
     const recheck = getActiveSession(conversationId);
     if (recheck) {
-      if (credentialIdsMatch(recheck.credentialIds, credentialIds)) {
+      const m = sessions.get(recheck.id);
+      if (credentialIdsMatch(recheck.credentialIds, credentialIds) && m && m.listenHost === requestedHost) {
         return { session: recheck, created: false };
       }
       await stopSession(recheck.id);

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -1,4 +1,5 @@
-import { spawn } from 'node:child_process';
+import { spawn, execSync } from 'node:child_process';
+import { platform } from 'node:os';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
@@ -16,6 +17,28 @@ import {
 import { getDataDir } from '../../util/platform.js';
 
 const log = getLogger('shell-tool');
+
+/**
+ * Returns the host address to bind the proxy to when Docker sandbox is active.
+ * On macOS, Docker Desktop routes host.docker.internal through the VM to
+ * 127.0.0.1, so no bind change is needed. On Linux, we need to bind to the
+ * Docker bridge gateway IP so containers can reach the proxy.
+ */
+function getDockerProxyHost(): string {
+  if (platform() !== 'linux') return '127.0.0.1';
+
+  try {
+    // Docker bridge gateway is the default route from inside docker0 network.
+    // `ip -4 addr show docker0` outputs the gateway IP assigned to the bridge.
+    const output = execSync('ip -4 addr show docker0 2>/dev/null', { encoding: 'utf-8' });
+    const match = output.match(/inet\s+(\d+\.\d+\.\d+\.\d+)/);
+    if (match) return match[1];
+  } catch {
+    // docker0 interface may not exist (e.g. rootless Docker, custom networks)
+  }
+  // Fallback: the conventional Docker bridge gateway IP
+  return '172.17.0.1';
+}
 
 class ShellTool implements Tool {
   name = 'bash';
@@ -107,7 +130,7 @@ class ShellTool implements Tool {
           undefined,
           getDataDir(),
           context.proxyApprovalCallback,
-          isDockerSandbox ? { listenHost: '0.0.0.0' } : undefined,
+          isDockerSandbox ? { listenHost: getDockerProxyHost() } : undefined,
         );
         proxyEnv = getSessionEnv(session.id, { dockerMode: isDockerSandbox });
       } catch (err) {


### PR DESCRIPTION
Address review feedback on PR #4412. Two fixes:

1. Session reuse now checks listenHost compatibility — switching between Docker and non-Docker mode in the same conversation will properly restart the session instead of reusing an incompatible one.

2. Replace 0.0.0.0 binding with Docker bridge gateway IP detection. On macOS, Docker Desktop routes host.docker.internal through the VM so 127.0.0.1 is sufficient. On Linux, the docker0 bridge gateway IP is detected (fallback: 172.17.0.1) to avoid exposing the unauthenticated proxy on all network interfaces.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
