### PR TITLE
feat: add copy button to user messages on hover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -913,6 +913,9 @@ private struct ChatBubble: View {
 
     @State private var isHovered = false
     @State private var isRegenerateHovered = false
+    @State private var isCopyHovered = false
+    @State private var showCopyConfirmation = false
+    @State private var copyConfirmationTimer: DispatchWorkItem?
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
 
     private var isUser: Bool { message.role == .user }
@@ -1037,6 +1040,10 @@ private struct ChatBubble: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                 }
+
+                if isUser {
+                    copyButton
+                }
             }
             // Prevent LazyVStack from compressing the bubble height, which causes the
             // trailing tool-chip to overlap long text content.
@@ -1076,7 +1083,7 @@ private struct ChatBubble: View {
         }
         .contentShape(Rectangle())
         .onHover { hovering in
-            if canReportMessage {
+            if canReportMessage || isUser {
                 isHovered = hovering
             } else if isHovered {
                 isHovered = false
@@ -1098,6 +1105,59 @@ private struct ChatBubble: View {
     /// Whether all tool calls are complete and the message is done streaming.
     private var allToolCallsComplete: Bool {
         !message.toolCalls.isEmpty && message.toolCalls.allSatisfy { $0.isComplete } && !message.isStreaming
+    }
+
+    private var copyButton: some View {
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(message.text, forType: .string)
+            copyConfirmationTimer?.cancel()
+            showCopyConfirmation = true
+            let timer = DispatchWorkItem { showCopyConfirmation = false }
+            copyConfirmationTimer = timer
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+        } label: {
+            Image(systemName: showCopyConfirmation ? "checkmark" : "doc.on.doc")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(showCopyConfirmation ? VColor.success : VColor.textMuted)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Copy message")
+        .onHover { hovering in
+            isCopyHovered = hovering
+            if hovering {
+                NSCursor.pointingHand.set()
+            } else {
+                NSCursor.arrow.set()
+            }
+        }
+        .overlay(alignment: .top) {
+            if isCopyHovered && !showCopyConfirmation {
+                Text("Copy")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill(VColor.surface)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                    .vShadow(VShadow.sm)
+                    .fixedSize()
+                    .offset(y: -28)
+                    .transition(.opacity)
+                    .allowsHitTesting(false)
+            }
+        }
+        .opacity(isHovered ? 1 : 0)
+        .allowsHitTesting(isHovered)
+        .animation(VAnimation.fast, value: isHovered)
     }
 
     private var regenerateButton: some View {


### PR DESCRIPTION
## Summary
- Adds a copy-to-clipboard button below user message bubbles that fades in on hover
- Shows a checkmark confirmation icon (green) for 1.5s after copying
- Includes tooltip on hover and pointer cursor feedback
- Matches existing hover pattern styling (ellipsis menu on assistant messages)

## Test plan
- [ ] Hover over a user message — copy button fades in below the bubble
- [ ] Click the copy button — icon changes to checkmark, message text is in clipboard
- [ ] Hover the copy button — pointer cursor appears, "Copy" tooltip shows
- [ ] Verify assistant messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
