### PR TITLE
fix: check listenHost compatibility on session reuse and restrict proxy binding

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -32,6 +32,8 @@ interface ManagedSession {
   config: ProxySessionConfig;
   dataDir: string | null;
   approvalCallback: ProxyApprovalCallback | null;
+  /** The host address the proxy server is bound to (e.g. '127.0.0.1'). */
+  listenHost: string;
   /** In-flight stop promise so concurrent callers can await the same shutdown. */
   stopPromise: Promise<void> | null;
 }
@@ -105,6 +107,7 @@ export function createSession(
     config: merged,
     dataDir: dataDir ?? null,
     approvalCallback: approvalCallback ?? null,
+    listenHost: '127.0.0.1',
     stopPromise: null,
   });
 
@@ -264,7 +267,8 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
 
   try {
     return await new Promise<ProxySession>((resolve, reject) => {
-      server.listen(0, options?.listenHost ?? '127.0.0.1', () => {
+      const bindHost = options?.listenHost ?? '127.0.0.1';
+      server.listen(0, bindHost, () => {
         const addr = server.address();
         if (!addr || typeof addr === 'string') {
           reject(new Error('Failed to get server address'));
@@ -273,6 +277,7 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
         managed.server = server;
         managed.session.port = addr.port;
         managed.session.status = 'active';
+        managed.listenHost = bindHost;
         resetIdleTimer(managed);
         resolve(cloneSession(managed.session));
       });
@@ -359,6 +364,11 @@ export function getSessionEnv(
   return env;
 }
 
+/** Return the listen host of a managed session, or undefined if not found. */
+function getListenHost(sessionId: ProxySessionId): string | undefined {
+  return sessions.get(sessionId)?.listenHost;
+}
+
 /** Sorted comparison so order doesn't matter. */
 function credentialIdsMatch(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false;
@@ -372,9 +382,10 @@ function credentialIdsMatch(a: string[], b: string[]): boolean {
  * session or creates + starts a new one. Serialized per conversation so
  * concurrent callers share the same session instead of each spawning one.
  *
- * If the active session was created with different `credentialIds`, it is
- * stopped and a fresh session is created so callers always get a session
- * bound to the requested credentials.
+ * If the active session was created with different `credentialIds` or a
+ * different `listenHost`, it is stopped and a fresh session is created so
+ * callers always get a session bound to the requested credentials and
+ * network interface.
  *
  * Returns `{ session, created }` so the caller knows whether it owns the
  * session lifecycle (and should stop it) or is borrowing a shared one.
@@ -387,14 +398,17 @@ export async function getOrStartSession(
   approvalCallback?: ProxyApprovalCallback,
   options?: { listenHost?: string },
 ): Promise<{ session: ProxySession; created: boolean }> {
+  const requestedHost = options?.listenHost ?? '127.0.0.1';
+
   // Fast path — session already active, no lock needed.
   const existing = getActiveSession(conversationId);
   if (existing) {
-    if (credentialIdsMatch(existing.credentialIds, credentialIds)) {
+    const existingHost = getListenHost(existing.id);
+    if (credentialIdsMatch(existing.credentialIds, credentialIds) && existingHost === requestedHost) {
       return { session: existing, created: false };
     }
-    // Credential mismatch — tear down the stale session so we can create
-    // one with the correct bindings.
+    // Credential or listenHost mismatch — tear down the stale session so
+    // we can create one with the correct bindings.
     await stopSession(existing.id);
   }
 
@@ -407,11 +421,12 @@ export async function getOrStartSession(
     const inflight = acquireLocks.get(conversationId);
     if (!inflight) break;
     const session = await inflight;
-    if (credentialIdsMatch(session.credentialIds, credentialIds)) {
+    const inflightHost = getListenHost(session.id);
+    if (credentialIdsMatch(session.credentialIds, credentialIds) && inflightHost === requestedHost) {
       return { session, created: false };
     }
-    // Credential mismatch — tear down and loop back to re-check whether
-    // another waiter has already started a replacement session.
+    // Credential or listenHost mismatch — tear down and loop back to
+    // re-check whether another waiter has already started a replacement.
     await stopSession(session.id);
   }
 
@@ -420,7 +435,8 @@ export async function getOrStartSession(
     // between our initial check and acquiring the lock.
     const recheck = getActiveSession(conversationId);
     if (recheck) {
-      if (credentialIdsMatch(recheck.credentialIds, credentialIds)) {
+      const recheckHost = getListenHost(recheck.id);
+      if (credentialIdsMatch(recheck.credentialIds, credentialIds) && recheckHost === requestedHost) {
         return { session: recheck, created: false };
       }
       await stopSession(recheck.id);

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
@@ -16,6 +16,28 @@ import {
 import { getDataDir } from '../../util/platform.js';
 
 const log = getLogger('shell-tool');
+
+/**
+ * Resolve the Docker bridge gateway IP so the proxy can bind to only that
+ * interface instead of 0.0.0.0. Containers on the bridge network reach
+ * the host via this address (mapped by --add-host=host.docker.internal:host-gateway).
+ * Falls back to 127.0.0.1 if the bridge IP cannot be determined.
+ */
+function getDockerBridgeGateway(): string {
+  try {
+    const out = execFileSync(
+      'docker',
+      ['network', 'inspect', 'bridge', '--format', '{{(index .IPAM.Config 0).Gateway}}'],
+      { timeout: 5000, encoding: 'utf-8' },
+    );
+    const ip = out.trim();
+    // Basic validation: must look like an IPv4 address.
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(ip)) return ip;
+  } catch {
+    // Docker CLI unavailable or bridge network not found — fall back.
+  }
+  return '127.0.0.1';
+}
 
 class ShellTool implements Tool {
   name = 'bash';
@@ -107,7 +129,7 @@ class ShellTool implements Tool {
           undefined,
           getDataDir(),
           context.proxyApprovalCallback,
-          isDockerSandbox ? { listenHost: '0.0.0.0' } : undefined,
+          isDockerSandbox ? { listenHost: getDockerBridgeGateway() } : undefined,
         );
         proxyEnv = getSessionEnv(session.id, { dockerMode: isDockerSandbox });
       } catch (err) {


### PR DESCRIPTION
Address review feedback on PR #4412. Add listenHost to session reuse compatibility check so mismatched sessions are recreated. Restrict proxy binding for Docker to Docker bridge interface instead of 0.0.0.0.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
