### PR TITLE
refactor: deprecate task_list in favor of work_item_list for listing tasks

### DIFF
--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -334,6 +334,7 @@ describe('task_list tool', () => {
     expect(result.content).toContain('file_read');
     expect(result.content).toContain('file_write');
     expect(result.content).toContain('file_path');
+    expect(result.content).toContain('Tip: To see your active Tasks (work items in the queue), use the work_item_list tool.');
   });
 
   test('returns empty message when no tasks exist', async () => {
@@ -341,6 +342,7 @@ describe('task_list tool', () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('No task templates found');
+    expect(result.content).toContain('Tip: To see your active Tasks (work items in the queue), use the work_item_list tool.');
   });
 
   test('shows task status and creation date', async () => {

--- a/assistant/src/tools/tasks/task-list.ts
+++ b/assistant/src/tools/tasks/task-list.ts
@@ -5,7 +5,7 @@ import { listTasks } from '../../tasks/task-store.js';
 
 const definition: ToolDefinition = {
   name: 'task_list',
-  description: 'List all task templates. Shows each template\'s ID, title, required tools, and creation date. These are reusable definitions that can be run to create Tasks (work items).',
+  description: 'List saved task templates (reusable definitions). To see your active Tasks (work items), use work_item_list instead.',
   input_schema: {
     type: 'object',
     properties: {},
@@ -27,7 +27,7 @@ class TaskListTool implements Tool {
       const tasks = listTasks();
 
       if (tasks.length === 0) {
-        return { content: 'No task templates found. Use task_save to create one from a conversation.', isError: false };
+        return { content: 'No task templates found. Use task_save to create one from a conversation.\n\nTip: To see your active Tasks (work items in the queue), use the work_item_list tool.', isError: false };
       }
 
       const lines = [`Found ${tasks.length} task template(s):`, ''];
@@ -51,6 +51,8 @@ class TaskListTool implements Tool {
         }
         lines.push('');
       }
+
+      lines.push('Tip: To see your active Tasks (work items in the queue), use the work_item_list tool.');
 
       return { content: lines.join('\n'), isError: false };
     } catch (err) {


### PR DESCRIPTION
## Summary

- Updated `task_list` tool description to clarify it lists "saved task templates (reusable definitions)" and directs users to `work_item_list` for active work items
- Added a tip to both empty and non-empty output: "Tip: To see your active Tasks (work items in the queue), use the work_item_list tool."
- Updated test expectations to verify the new tip appears in output

## Why

When users say "list my tasks", they typically mean their active task queue (work items), not reusable task templates. This change reframes `task_list` as a secondary/internal tool and guides users toward `work_item_list` for their actual task queue.

## Files changed

- `assistant/src/tools/tasks/task-list.ts` — updated description and output
- `assistant/src/__tests__/task-tools.test.ts` — added assertions for tip text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
