### PR TITLE
feat: add standalone Tasks window

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -117,6 +117,11 @@ extension AppDelegate {
         newChatItem.image = NSImage(systemSymbolName: "plus.message", accessibilityDescription: nil)
         menu.addItem(newChatItem)
 
+        let tasksItem = NSMenuItem(title: "Tasks", action: #selector(showTasksWindow), keyEquivalent: "t")
+        tasksItem.target = self
+        tasksItem.image = NSImage(systemSymbolName: "list.bullet.clipboard", accessibilityDescription: nil)
+        menu.addItem(tasksItem)
+
         // My Apps submenu
         let myAppsItem = NSMenuItem(title: "My Apps", action: nil, keyEquivalent: "")
         myAppsItem.image = NSImage(systemSymbolName: "square.grid.2x2", accessibilityDescription: nil)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -106,6 +106,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var mainWindow: MainWindow?
     private var settingsWindow: NSWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
+    private var tasksWindow: TasksWindow?
     /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
     /// Each call to sendOpenBundle appends a path; handleOpenBundleResponse
     /// pops the first entry so concurrent opens are correctly paired.
@@ -1016,6 +1017,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         settingsWindow = window
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    // MARK: - Tasks Window
+
+    @objc func showTasksWindow() {
+        NSApp.setActivationPolicy(.regular)
+        if tasksWindow == nil {
+            tasksWindow = TasksWindow(daemonClient: daemonClient)
+        }
+        tasksWindow?.show()
     }
 
     // MARK: - Application Lifecycle

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
@@ -1,0 +1,53 @@
+import AppKit
+import VellumAssistantShared
+import SwiftUI
+
+/// Standalone window that displays the task queue independently of the main window.
+/// Follows the same pattern as ComponentGalleryWindow and OnboardingWindow.
+@MainActor
+final class TasksWindow {
+    private var window: NSWindow?
+    private let daemonClient: DaemonClient
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    func show() {
+        if let existing = window {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hostingController = NSHostingController(
+            rootView: TasksWindowView(daemonClient: daemonClient)
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 550),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.title = "Tasks"
+        window.backgroundColor = NSColor(VColor.background)
+        window.isReleasedWhenClosed = false
+        window.contentMinSize = NSSize(width: 320, height: 400)
+
+        window.setContentSize(NSSize(width: 420, height: 550))
+        window.center()
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -1,0 +1,298 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Standalone window view that displays the task queue.
+/// Reuses the same data-fetching and row rendering as TaskQueuePanel
+/// but presented as a full window rather than a side panel.
+struct TasksWindowView: View {
+    @ObservedObject var daemonClient: DaemonClient
+
+    @State private var items: [IPCWorkItemsListResponseItem] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("TASKS")
+                    .font(VFont.display)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                Text("\(items.count)")
+                    .font(VFont.monoSmall)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.top, VSpacing.lg)
+            .padding(.bottom, VSpacing.sm)
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Content
+            if isLoading {
+                VStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                VStack(spacing: VSpacing.md) {
+                    Spacer()
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 24))
+                        .foregroundColor(VColor.warning)
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .multilineTextAlignment(.center)
+                    Button("Retry") {
+                        fetchWorkItems()
+                    }
+                    .font(VFont.caption)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(VSpacing.lg)
+            } else if items.isEmpty {
+                VEmptyState(
+                    title: "No tasks",
+                    subtitle: "Your tasks will appear here",
+                    icon: "list.bullet.clipboard"
+                )
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: VSpacing.xs) {
+                        ForEach(items, id: \.id) { item in
+                            TasksWindowRow(
+                                item: item,
+                                onRun: { runTask(id: item.id) },
+                                onComplete: { completeTask(id: item.id) }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.sm)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.background)
+        .onAppear {
+            fetchWorkItems()
+            listenForStatusChanges()
+        }
+    }
+
+    // MARK: - Data Fetching
+
+    private func fetchWorkItems() {
+        isLoading = true
+        errorMessage = nil
+
+        daemonClient.onWorkItemsListResponse = { response in
+            self.items = response.items
+            self.isLoading = false
+        }
+
+        do {
+            try daemonClient.sendWorkItemsList()
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    private func listenForStatusChanges() {
+        daemonClient.onWorkItemStatusChanged = { _ in
+            do {
+                try daemonClient.sendWorkItemsList()
+            } catch {
+                // Silently ignore; the list will refresh on next status change
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func runTask(id: String) {
+        do {
+            try daemonClient.sendWorkItemRunTask(id: id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func completeTask(id: String) {
+        do {
+            try daemonClient.sendWorkItemComplete(id: id)
+            items.removeAll { $0.id == id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Row View
+
+/// Row view for the standalone Tasks window. Mirrors the side-panel
+/// TaskQueueRow but lives in the Tasks feature module.
+private struct TasksWindowRow: View {
+    let item: IPCWorkItemsListResponseItem
+    let onRun: () -> Void
+    let onComplete: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(alignment: .center, spacing: VSpacing.sm) {
+                priorityIndicator
+                Text(item.title)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                Spacer()
+                statusBadge
+            }
+
+            if let notes = item.notes, !notes.isEmpty {
+                Text(notes)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(2)
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                if item.status == "queued" {
+                    Button(action: onRun) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "play.fill")
+                                .font(.system(size: 10))
+                            Text("Run")
+                                .font(VFont.caption)
+                        }
+                        .foregroundColor(VColor.accent)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.accent.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if item.status == "awaiting_review" {
+                    Button(action: onComplete) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 10))
+                            Text("Mark Reviewed")
+                                .font(VFont.caption)
+                        }
+                        .foregroundColor(VColor.success)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.success.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+
+                if let lastRunStatus = item.lastRunStatus {
+                    Text("Last run: \(lastRunStatus)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .background(isHovered ? VColor.surface.opacity(0.8) : VColor.surface.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+        )
+        .onHover { hovering in
+            isHovered = hovering
+        }
+    }
+
+    // MARK: - Priority Indicator
+
+    @ViewBuilder
+    private var priorityIndicator: some View {
+        let tier = item.priorityTier
+        Circle()
+            .fill(priorityColor(tier: tier))
+            .frame(width: 8, height: 8)
+            .accessibilityLabel("Priority \(Int(tier))")
+    }
+
+    private func priorityColor(tier: Double) -> Color {
+        switch tier {
+        case 0: return VColor.error
+        case 1: return VColor.warning
+        case 2: return VColor.accent
+        default: return VColor.textMuted
+        }
+    }
+
+    // MARK: - Status Badge
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        let (label, color, showSpinner) = statusInfo(item.status)
+        HStack(spacing: VSpacing.xs) {
+            if showSpinner {
+                ProgressView()
+                    .controlSize(.mini)
+            }
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(color)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, 2)
+        .background(color.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+    }
+
+    private func statusInfo(_ status: String) -> (String, Color, Bool) {
+        switch status {
+        case "queued":
+            return ("Queued", VColor.textSecondary, false)
+        case "running":
+            return ("Running", VColor.accent, true)
+        case "awaiting_review":
+            return ("Awaiting Review", VColor.warning, false)
+        case "failed":
+            return ("Failed", VColor.error, false)
+        case "done":
+            return ("Done", VColor.success, false)
+        default:
+            return (status, VColor.textMuted, false)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct TasksWindowViewPreview: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            TasksWindowView(daemonClient: DaemonClient())
+                .frame(width: 420, height: 550)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Introduces a dedicated Tasks window (`TasksWindow` + `TasksWindowView`) in `Features/Tasks/` that displays the task queue as a standalone macOS window
- Adds a "Tasks" menu item (Cmd+T) to the status bar menu for quick access
- Reuses the same DaemonClient work items API and row rendering as the existing `TaskQueuePanel` side panel, adapted for a standalone window context
- Follows the established window patterns (similar to `ComponentGalleryWindow` and `OnboardingWindow`)

## Test plan
- [ ] Build compiles: `cd clients/macos && swift build`
- [ ] Open the Tasks window via the status bar menu "Tasks" item
- [ ] Verify the window displays the task queue list (or empty state if no tasks)
- [ ] Verify the window can be opened/closed independently of the main window
- [ ] Verify bringing the window to front if already open works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
