### PR TITLE
test: add tests for work_item_list, work_item_enqueue, and task_delete tools

### DIFF
--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -35,10 +35,14 @@ mock.module('./indexer.js', () => ({
 
 import type { Database } from 'bun:sqlite';
 import { initializeDb, getDb } from '../memory/db.js';
-import { createTask } from '../tasks/task-store.js';
+import { createTask, createTaskRun } from '../tasks/task-store.js';
+import { createWorkItem } from '../work-items/work-item-store.js';
 import { taskSaveTool } from '../tools/tasks/task-save.js';
 import { taskRunTool } from '../tools/tasks/task-run.js';
 import { taskListTool } from '../tools/tasks/task-list.js';
+import { workItemListTool } from '../tools/tasks/work-item-list.js';
+import { workItemEnqueueTool } from '../tools/tasks/work-item-enqueue.js';
+import { taskDeleteTool } from '../tools/tasks/task-delete.js';
 import type { ToolContext } from '../tools/types.js';
 
 initializeDb();
@@ -354,5 +358,201 @@ describe('task_list tool', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Status: active');
     expect(result.content).toContain('Created:');
+  });
+});
+
+// ── work_item_list ───────────────────────────────────────────────────
+
+describe('work_item_list tool', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM work_items');
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+  });
+
+  test('lists work items when they exist', async () => {
+    const task = createTask({ title: 'My Task', template: 'Do it' });
+    createWorkItem({ taskId: task.id, title: 'Work Item Alpha', priorityTier: 1 });
+    createWorkItem({ taskId: task.id, title: 'Work Item Beta', notes: 'some notes', priorityTier: 2 });
+
+    const result = await workItemListTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Found 2 work item(s)');
+    expect(result.content).toContain('Work Item Alpha');
+    expect(result.content).toContain('Work Item Beta');
+    expect(result.content).toContain('Status: queued');
+    expect(result.content).toContain('Notes: some notes');
+  });
+
+  test('returns empty message when no work items', async () => {
+    const result = await workItemListTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No Tasks found');
+  });
+
+  test('filters by status when status param is provided', async () => {
+    const task = createTask({ title: 'Filter Task', template: 'Do it' });
+    createWorkItem({ taskId: task.id, title: 'Queued Item', priorityTier: 2 });
+    const raw = getRawDb();
+    // Create a second work item and manually set its status to 'done'
+    const doneItem = createWorkItem({ taskId: task.id, title: 'Done Item', priorityTier: 2 });
+    raw.query('UPDATE work_items SET status = ? WHERE id = ?').run('done', doneItem.id);
+
+    const resultQueued = await workItemListTool.execute({ status: 'queued' }, stubContext);
+    expect(resultQueued.isError).toBe(false);
+    expect(resultQueued.content).toContain('Found 1 work item(s)');
+    expect(resultQueued.content).toContain('Queued Item');
+    expect(resultQueued.content).not.toContain('Done Item');
+
+    const resultDone = await workItemListTool.execute({ status: 'done' }, stubContext);
+    expect(resultDone.isError).toBe(false);
+    expect(resultDone.content).toContain('Found 1 work item(s)');
+    expect(resultDone.content).toContain('Done Item');
+    expect(resultDone.content).not.toContain('Queued Item');
+  });
+});
+
+// ── work_item_enqueue ────────────────────────────────────────────────
+
+describe('work_item_enqueue tool', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM work_items');
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+  });
+
+  test('successfully enqueues by task_id', async () => {
+    const task = createTask({ title: 'Deploy Service', template: 'deploy it' });
+
+    const result = await workItemEnqueueTool.execute({ task_id: task.id }, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Enqueued work item');
+    expect(result.content).toContain('Deploy Service');
+    expect(result.content).toContain('Status: queued');
+  });
+
+  test('successfully enqueues by task_name (case-insensitive match)', async () => {
+    createTask({ title: 'Run Database Migration', template: 'migrate' });
+
+    const result = await workItemEnqueueTool.execute({ task_name: 'database migration' }, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Enqueued work item');
+    expect(result.content).toContain('Run Database Migration');
+  });
+
+  test('returns disambiguation when multiple name matches', async () => {
+    createTask({ title: 'Deploy Frontend', template: 'deploy fe' });
+    createTask({ title: 'Deploy Backend', template: 'deploy be' });
+
+    const result = await workItemEnqueueTool.execute({ task_name: 'deploy' }, stubContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Multiple task definitions match');
+    expect(result.content).toContain('Deploy Frontend');
+    expect(result.content).toContain('Deploy Backend');
+  });
+
+  test('returns error when no matching task found', async () => {
+    createTask({ title: 'Existing Task', template: 'do something' });
+
+    const result = await workItemEnqueueTool.execute({ task_name: 'nonexistent' }, stubContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No task definition found matching "nonexistent"');
+  });
+
+  test('returns error when neither task_id nor task_name provided', async () => {
+    const result = await workItemEnqueueTool.execute({}, stubContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('You must provide either task_id or task_name');
+  });
+
+  test('applies optional overrides (title, notes, priority_tier)', async () => {
+    const task = createTask({ title: 'Generic Task', template: 'do it' });
+
+    const result = await workItemEnqueueTool.execute(
+      {
+        task_id: task.id,
+        title: 'Custom Title Override',
+        notes: 'Important context here',
+        priority_tier: 0,
+      },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Custom Title Override');
+    expect(result.content).toContain('Notes: Important context here');
+    expect(result.content).toContain('Priority: urgent');
+  });
+});
+
+// ── task_delete ──────────────────────────────────────────────────────
+
+describe('task_delete tool', () => {
+  beforeEach(() => {
+    const raw = getRawDb();
+    raw.run('DELETE FROM work_items');
+    raw.run('DELETE FROM task_runs');
+    raw.run('DELETE FROM tasks');
+  });
+
+  test('successfully deletes a single task', async () => {
+    const task = createTask({ title: 'Doomed Task', template: 'bye' });
+
+    const result = await taskDeleteTool.execute({ task_ids: [task.id] }, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Deleted task: Doomed Task');
+  });
+
+  test('successfully deletes multiple tasks', async () => {
+    const t1 = createTask({ title: 'Task One', template: 'one' });
+    const t2 = createTask({ title: 'Task Two', template: 'two' });
+
+    const result = await taskDeleteTool.execute({ task_ids: [t1.id, t2.id] }, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Deleted 2 task(s)');
+    expect(result.content).toContain('Task One');
+    expect(result.content).toContain('Task Two');
+  });
+
+  test('returns error for non-existent task ID', async () => {
+    const result = await taskDeleteTool.execute({ task_ids: ['nonexistent-id'] }, stubContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No task found with ID nonexistent-id');
+  });
+
+  test('cascades deletion to associated task runs and work items', async () => {
+    const task = createTask({ title: 'Parent Task', template: 'parent' });
+    createTaskRun(task.id);
+    createWorkItem({ taskId: task.id, title: 'Child Work Item' });
+
+    const raw = getRawDb();
+    // Verify the associated records exist before deletion
+    const runsBefore = raw.query('SELECT COUNT(*) as count FROM task_runs WHERE task_id = ?').get(task.id) as { count: number };
+    const itemsBefore = raw.query('SELECT COUNT(*) as count FROM work_items WHERE task_id = ?').get(task.id) as { count: number };
+    expect(runsBefore.count).toBe(1);
+    expect(itemsBefore.count).toBe(1);
+
+    const result = await taskDeleteTool.execute({ task_ids: [task.id] }, stubContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Deleted task: Parent Task');
+
+    // Verify cascade: associated records should be gone
+    const runsAfter = raw.query('SELECT COUNT(*) as count FROM task_runs WHERE task_id = ?').get(task.id) as { count: number };
+    const itemsAfter = raw.query('SELECT COUNT(*) as count FROM work_items WHERE task_id = ?').get(task.id) as { count: number };
+    expect(runsAfter.count).toBe(0);
+    expect(itemsAfter.count).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Added 13 new test cases covering the `work_item_list`, `work_item_enqueue`, and `task_delete` tools
- `work_item_list`: tests for listing items, empty state, and status filtering
- `work_item_enqueue`: tests for enqueue by task ID, by name (case-insensitive), disambiguation on multiple matches, error when no match, error when neither ID nor name provided, and optional overrides (title, notes, priority_tier)
- `task_delete`: tests for single delete, multi-delete, non-existent ID error, and cascade deletion of associated task runs and work items
- All 29 tests pass (16 existing + 13 new), type-check clean

## Test plan
- [x] `bun test src/__tests__/task-tools.test.ts` — 29 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
