### PR TITLE
Wire Control Center Tasks entry to open standalone Tasks window

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -350,7 +350,7 @@ struct MainWindowView: View {
                             },
                             onTaskQueue: {
                                 showControlCenterDrawer = false
-                                windowState.togglePanel(.taskQueue)
+                                (NSApp.delegate as? AppDelegate)?.showTasksWindow()
                             },
                             onSettings: {
                                 showControlCenterDrawer = false


### PR DESCRIPTION
## Summary
- The Control Center drawer menu's "Tasks" entry now opens the dedicated `TasksWindow` via `AppDelegate.showTasksWindow()` instead of toggling the `.taskQueue` side panel.
- Uses the established `NSApp.delegate as? AppDelegate` pattern already used elsewhere in the codebase (e.g., `SettingsPanel.swift`).
- The `.taskQueue` side panel code remains intact as a fallback — no panel or panel-routing code was removed.

## Test plan
- [ ] Open the app, click Control Center in the sidebar, click "Tasks" — verify the standalone Tasks window opens
- [ ] Verify the drawer closes after clicking "Tasks"
- [ ] Verify the TaskQueue side panel still works if opened programmatically (e.g., via layout config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
