### PR TITLE
fix: stop greetings parsing at all markdown heading levels

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -46,7 +46,7 @@ struct IdentityInfo {
 
         for line in content.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("## ") || trimmed.hasPrefix("# ") {
+            if trimmed.hasPrefix("#") && trimmed.drop(while: { $0 == "#" }).first == " " {
                 inGreetingsSection = trimmed.lowercased().contains("greetings")
                 continue
             }


### PR DESCRIPTION
## Summary
- Changed section boundary detection from only `#` and `##` to any markdown heading level (e.g. `###`, `####`)
- Prevents deeper headings after `## Greetings` from failing to end the greetings section, which would misclassify later bullet lists as greeting prompts

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3513
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
