### PR TITLE
fix: reset pendingVoiceMessage on error and sessionError paths

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -472,6 +472,7 @@ extension ChatViewModel {
             refinementStreamingText = nil
             cancelledDuringRefinement = false
             isThinking = false
+            pendingVoiceMessage = false
             let wasCancelling = isCancelling
             isCancelling = false
             // Mark current assistant message as no longer streaming
@@ -756,6 +757,7 @@ extension ChatViewModel {
             refinementStreamingText = nil
             cancelledDuringRefinement = false
             isThinking = false
+            pendingVoiceMessage = false
             let wasCancelling = isCancelling
             isCancelling = false
             if let existingId = currentAssistantMessageId,


### PR DESCRIPTION
## Summary
- Added `pendingVoiceMessage = false` to both `.error` and `.sessionError` handlers
- Prevents stale voice message flag from triggering incorrect push notifications on the next successful non-voice message

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3516
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
