### PR TITLE
fix: address review feedback on WorkspaceGitService

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -102,9 +102,6 @@ describe('WorkspaceGitService', () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
 
-      // Wait a bit for async initial commit to complete
-      await new Promise(resolve => setTimeout(resolve, 100));
-
       const log = execFileSync('git', ['log', '--oneline'], {
         cwd: testDir,
         encoding: 'utf-8',
@@ -122,9 +119,6 @@ describe('WorkspaceGitService', () => {
 
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-
-      // Wait for async initial commit
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       const log = execFileSync('git', ['log', '--oneline'], {
         cwd: testDir,
@@ -145,20 +139,58 @@ describe('WorkspaceGitService', () => {
       expect(files).toContain('subdir/file.txt');
     });
 
-    test('initial commit is async and non-blocking', async () => {
-      // Create many files to make commit slow
-      for (let i = 0; i < 100; i++) {
+    test('initial commit completes within ensureInitialized', async () => {
+      // Create some files before initializing git
+      for (let i = 0; i < 10; i++) {
         writeFileSync(join(testDir, `file${i}.txt`), 'content');
       }
 
       const service = new WorkspaceGitService(testDir);
-      const start = Date.now();
       await service.ensureInitialized();
-      const duration = Date.now() - start;
 
-      // ensureInitialized should return quickly (< 1s)
-      // even with 100 files, as the commit is async
-      expect(duration).toBeLessThan(1000);
+      // Initial commit should already be done - no need to wait
+      const log = execFileSync('git', ['log', '--oneline'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+
+      expect(log).toContain('Initial commit: migrated existing workspace');
+    });
+
+    test('initial commit does not race with first commitChanges', async () => {
+      // Pre-populate workspace with files (simulating a migrated workspace)
+      writeFileSync(join(testDir, 'existing.txt'), 'pre-existing content');
+
+      const service = new WorkspaceGitService(testDir);
+
+      // Initialize - the initial commit now happens synchronously within
+      // ensureInitialized, so it completes before we can write new files.
+      await service.ensureInitialized();
+
+      // Now write a file AFTER init and commit it
+      writeFileSync(join(testDir, 'user-edit.txt'), 'user content');
+      await service.commitChanges('User turn 1');
+
+      // The user's commit (HEAD) should contain user-edit.txt
+      const userCommitFiles = execFileSync(
+        'git', ['diff', '--name-only', 'HEAD~1', 'HEAD'],
+        { cwd: testDir, encoding: 'utf-8' },
+      ).trim();
+
+      expect(userCommitFiles).toContain('user-edit.txt');
+      // user-edit.txt should NOT appear in the initial commit
+      expect(userCommitFiles).not.toContain('existing.txt');
+
+      // The initial commit (HEAD~1) should contain existing.txt and .gitignore
+      const initialCommitFiles = execFileSync(
+        'git', ['show', '--name-only', '--pretty=format:', 'HEAD~1'],
+        { cwd: testDir, encoding: 'utf-8' },
+      ).trim();
+
+      expect(initialCommitFiles).toContain('existing.txt');
+      expect(initialCommitFiles).toContain('.gitignore');
+      // The initial commit should NOT contain user-edit.txt
+      expect(initialCommitFiles).not.toContain('user-edit.txt');
     });
   });
 
@@ -166,7 +198,6 @@ describe('WorkspaceGitService', () => {
     test('commits changes with message', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100)); // Wait for initial commit
 
       writeFileSync(join(testDir, 'test.txt'), 'hello world');
       await service.commitChanges('Add test file');
@@ -182,7 +213,6 @@ describe('WorkspaceGitService', () => {
     test('commits with metadata', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       writeFileSync(join(testDir, 'test.txt'), 'content');
       await service.commitChanges('Add file', {
@@ -205,7 +235,6 @@ describe('WorkspaceGitService', () => {
     test('commits multiple files at once', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       writeFileSync(join(testDir, 'file1.txt'), 'content1');
       writeFileSync(join(testDir, 'file2.txt'), 'content2');
@@ -226,7 +255,6 @@ describe('WorkspaceGitService', () => {
     test('allows empty commits', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       // Commit without any changes
       await service.commitChanges('Empty commit for checkpoint');
@@ -244,7 +272,6 @@ describe('WorkspaceGitService', () => {
     test('returns clean status for new workspace', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100)); // Wait for initial commit
 
       const status = await service.getStatus();
 
@@ -257,7 +284,6 @@ describe('WorkspaceGitService', () => {
     test('detects untracked files', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       writeFileSync(join(testDir, 'new-file.txt'), 'content');
 
@@ -270,7 +296,6 @@ describe('WorkspaceGitService', () => {
     test('detects modified files', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       writeFileSync(join(testDir, 'file.txt'), 'original');
       await service.commitChanges('Add file');
@@ -286,7 +311,6 @@ describe('WorkspaceGitService', () => {
     test('detects staged files', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       writeFileSync(join(testDir, 'file.txt'), 'content');
 
@@ -304,7 +328,6 @@ describe('WorkspaceGitService', () => {
     test('serializes concurrent commit operations', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       // Start multiple concurrent commits
       const commits = [];
@@ -337,7 +360,6 @@ describe('WorkspaceGitService', () => {
     test('serializes concurrent status checks', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       // Start multiple concurrent status checks
       const checks = [];
@@ -388,10 +410,37 @@ describe('WorkspaceGitService', () => {
       await expect(service.ensureInitialized()).rejects.toThrow();
     });
 
+    test('failed initialization can be retried', async () => {
+      // Create a service pointing to a directory that doesn't exist yet
+      const retryDir = join(tmpdir(), `vellum-retry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      const service = new WorkspaceGitService(retryDir);
+
+      // First attempt: directory doesn't exist, should fail
+      await expect(service.ensureInitialized()).rejects.toThrow();
+
+      // Create the directory so the retry can succeed
+      mkdirSync(retryDir, { recursive: true });
+
+      try {
+        // Second attempt: directory now exists, should succeed because
+        // the .catch handler cleared initPromise after the first failure
+        await service.ensureInitialized();
+        expect(service.isInitialized()).toBe(true);
+
+        // Verify the repo was actually initialized
+        const log = execFileSync('git', ['log', '--oneline'], {
+          cwd: retryDir,
+          encoding: 'utf-8',
+        });
+        expect(log).toContain('Initial commit');
+      } finally {
+        rmSync(retryDir, { recursive: true, force: true });
+      }
+    });
+
     test('continues to work after failed operation', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       // Try to commit without any changes and without allow-empty
       // (This should succeed with --allow-empty, but let's test recovery)
@@ -408,7 +457,6 @@ describe('WorkspaceGitService', () => {
     test('respects .gitignore for data directory', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       // Create files in data directory
       mkdirSync(join(testDir, 'data'));
@@ -423,7 +471,6 @@ describe('WorkspaceGitService', () => {
     test('respects .gitignore for log files', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       writeFileSync(join(testDir, 'test.log'), 'log content');
 
@@ -436,7 +483,6 @@ describe('WorkspaceGitService', () => {
     test('tracks non-ignored files', async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       writeFileSync(join(testDir, 'config.json'), '{}');
       writeFileSync(join(testDir, 'README.md'), '# Test');

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -73,7 +73,7 @@ interface GitStatus {
  * - Lazy initialization: git repo created only when needed
  * - Mutex-protected operations: prevents concurrent git command conflicts
  * - Handles both new and existing workspaces transparently
- * - Async initial commit to avoid blocking on large workspaces
+ * - Synchronous initial commit within mutex to prevent races
  */
 export class WorkspaceGitService {
   private readonly workspaceDir: string;
@@ -94,8 +94,10 @@ export class WorkspaceGitService {
    * 1. Run git init -b main
    * 2. Create .gitignore
    * 3. Set git identity
-   * 4. Stage all files
-   * 5. Create initial commit (async, returns immediately)
+   * 4. Stage all files and create initial commit
+   *
+   * The initial commit is created synchronously within the mutex lock
+   * to prevent races with the first commitChanges() call.
    */
   async ensureInitialized(): Promise<void> {
     // Fast path: already initialized
@@ -148,45 +150,32 @@ export class WorkspaceGitService {
       await this.execGit(['config', 'user.name', 'Vellum Assistant']);
       await this.execGit(['config', 'user.email', 'assistant@vellum.ai']);
 
-      this.initialized = true;
-
-      // Create initial commit asynchronously to avoid blocking
-      // This runs in the background after ensureInitialized returns
-      this.createInitialCommitAsync().catch(() => {
-        // Silently ignore errors - repo is still usable
-        // (errors expected during tests when directories are cleaned up)
-      });
-    });
-
-    return this.initPromise;
-  }
-
-  /**
-   * Create the initial commit asynchronously.
-   * Determines if this is a new or migrated workspace and commits accordingly.
-   */
-  private async createInitialCommitAsync(): Promise<void> {
-    await this.mutex.withLock(async () => {
-      // Check if workspace directory still exists (may have been deleted in tests)
-      if (!existsSync(this.workspaceDir)) {
-        return;
-      }
-
-      // Check if there are any existing files (excluding .git and .gitignore)
+      // Create initial commit synchronously within the lock to prevent
+      // races with the first commitChanges() call. Without this, the
+      // initial commit could run concurrently and consume edits meant
+      // for the first user-requested commit.
       const status = await this.getStatusInternal();
       const hasExistingFiles = status.untracked.length > 1 || // More than just .gitignore
         status.untracked.some(f => f !== '.gitignore');
 
-      // Stage all files
       await this.execGit(['add', '-A']);
 
-      // Create initial commit with appropriate message
       const message = hasExistingFiles
         ? 'Initial commit: migrated existing workspace'
         : 'Initial commit: new workspace';
 
       await this.execGit(['commit', '-m', message, '--allow-empty']);
+
+      this.initialized = true;
     });
+
+    // If initialization fails, clear the cached promise so subsequent
+    // calls can retry instead of permanently returning the rejected promise.
+    this.initPromise.catch(() => {
+      this.initPromise = null;
+    });
+
+    return this.initPromise;
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Fix cached rejected promise**: Added a `.catch` handler on `initPromise` that resets it to `null` when initialization fails, allowing subsequent calls to retry instead of permanently returning the cached rejection.
- **Fix initial commit race condition**: Moved the initial commit from an async fire-and-forget (`createInitialCommitAsync()`) into the synchronous mutex lock within `ensureInitialized()`. This ensures the baseline commit completes before any `commitChanges()` calls can proceed, preventing the initial commit from consuming edits meant for the first user-requested commit.
- **Remove setTimeout waits from tests**: Since the initial commit now completes synchronously within `ensureInitialized()`, removed all `await new Promise(resolve => setTimeout(resolve, 100))` waits that were previously needed.
- **Add new tests**: Added test verifying failed initialization can be retried, and test verifying initial commit doesn't race with first `commitChanges()` call.

## Test plan
- [x] Verify failed initialization can be retried (new test)
- [x] Verify initial commit does not race with first `commitChanges()` call (new test)
- [x] All 27 existing tests pass
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
