### PR TITLE
fix: reduce gap between microphone and paperclip icons in composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -250,7 +250,7 @@ struct ComposerView: View {
 
     @ViewBuilder
     private var composerActionButtons: some View {
-        HStack(spacing: VSpacing.md) {
+        HStack(spacing: VSpacing.inline) {
             if isSending {
                 Button(action: onStop) {
                     ZStack {


### PR DESCRIPTION
## Summary
- Changed composer action buttons HStack spacing from `VSpacing.md` (12pt) to `VSpacing.inline` (8pt) to tighten the gap between the microphone and paperclip icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
