### PR TITLE
M2: Turn-Boundary Commits

### DIFF
--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { commitTurnChanges } from '../workspace/turn-commit.js';
+import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
+
+describe('commitTurnChanges', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `vellum-turn-commit-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    _resetGitServiceRegistry();
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('turn with file edits creates a commit', async () => {
+    // Initialize workspace git
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Simulate file edits during a turn
+    writeFileSync(join(testDir, 'hello.txt'), 'hello world');
+    writeFileSync(join(testDir, 'config.json'), '{"key": "value"}');
+
+    await commitTurnChanges(testDir, 'sess_abc123', 1);
+
+    // Verify a commit was created
+    const log = execFileSync('git', ['log', '--oneline'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(log).toContain('Turn:');
+
+    // Verify commit message format
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(fullMessage).toContain('Turn:');
+    expect(fullMessage).toContain('Session: sess_abc123');
+    expect(fullMessage).toContain('Turn: 1');
+    expect(fullMessage).toContain('Timestamp:');
+    expect(fullMessage).toContain('Files: 2 changed');
+  });
+
+  test('turn with no changes creates no commit', async () => {
+    // Initialize workspace git
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Count commits before
+    const logBefore = execFileSync('git', ['log', '--oneline'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    }).trim();
+    const commitCountBefore = logBefore.split('\n').length;
+
+    // No file changes — just call commitTurnChanges
+    await commitTurnChanges(testDir, 'sess_xyz', 3);
+
+    // Count commits after
+    const logAfter = execFileSync('git', ['log', '--oneline'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    }).trim();
+    const commitCountAfter = logAfter.split('\n').length;
+
+    // No new commits should have been created
+    expect(commitCountAfter).toBe(commitCountBefore);
+  });
+
+  test('multiple tool calls in one turn result in single commit at end', async () => {
+    // Initialize workspace git
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Simulate multiple tool call outputs (file writes) within a single turn
+    writeFileSync(join(testDir, 'file1.txt'), 'content from tool call 1');
+    writeFileSync(join(testDir, 'file2.txt'), 'content from tool call 2');
+    writeFileSync(join(testDir, 'file3.txt'), 'content from tool call 3');
+    mkdirSync(join(testDir, 'subdir'), { recursive: true });
+    writeFileSync(join(testDir, 'subdir', 'nested.txt'), 'nested content');
+
+    // Single call to commitTurnChanges (as happens at turn boundary)
+    await commitTurnChanges(testDir, 'sess_multi', 2);
+
+    // There should be exactly 2 commits: initial + turn
+    const log = execFileSync('git', ['log', '--oneline'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    }).trim();
+    const commitCount = log.split('\n').length;
+    expect(commitCount).toBe(2);
+
+    // The single turn commit should include all 4 files
+    const changedFiles = execFileSync(
+      'git', ['diff', '--name-only', 'HEAD~1', 'HEAD'],
+      { cwd: testDir, encoding: 'utf-8' },
+    ).trim();
+
+    expect(changedFiles).toContain('file1.txt');
+    expect(changedFiles).toContain('file2.txt');
+    expect(changedFiles).toContain('file3.txt');
+    expect(changedFiles).toContain('subdir/nested.txt');
+  });
+
+  test('commit message includes correct metadata', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'doc.md'), '# Document');
+    writeFileSync(join(testDir, 'style.css'), 'body {}');
+    writeFileSync(join(testDir, 'app.js'), 'console.log("hello")');
+
+    await commitTurnChanges(testDir, 'sess_meta_test', 5);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    // Verify structured metadata
+    expect(fullMessage).toContain('Session: sess_meta_test');
+    expect(fullMessage).toContain('Turn: 5');
+    expect(fullMessage).toContain('Files: 3 changed');
+    // Timestamp should be ISO 8601 format
+    expect(fullMessage).toMatch(/Timestamp: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  test('commit summary shows single file name for one change', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'only-file.txt'), 'content');
+
+    await commitTurnChanges(testDir, 'sess_single', 1);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(fullMessage).toContain('Turn: only-file.txt');
+    expect(fullMessage).toContain('Files: 1 changed');
+  });
+
+  test('commit summary shows "and N more" for many changes', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(testDir, `file${i}.txt`), `content ${i}`);
+    }
+
+    await commitTurnChanges(testDir, 'sess_many', 1);
+
+    const firstLine = execFileSync('git', ['log', '-1', '--pretty=%s'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    }).trim();
+
+    // Should show first 2 files "and 3 more"
+    expect(firstLine).toContain('and 3 more');
+  });
+
+  test('handles errors gracefully without throwing', async () => {
+    // Call with a nonexistent workspace — should NOT throw
+    await commitTurnChanges('/nonexistent/workspace/path', 'sess_err', 1);
+    // If we get here, the test passes (no exception bubbled up)
+  });
+
+  test('successive turns produce separate commits', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Turn 1
+    writeFileSync(join(testDir, 'turn1.txt'), 'turn 1 content');
+    await commitTurnChanges(testDir, 'sess_successive', 1);
+
+    // Turn 2
+    writeFileSync(join(testDir, 'turn2.txt'), 'turn 2 content');
+    await commitTurnChanges(testDir, 'sess_successive', 2);
+
+    // Turn 3 — no changes
+    await commitTurnChanges(testDir, 'sess_successive', 3);
+
+    // Should have 3 total commits: initial + turn 1 + turn 2
+    // Turn 3 had no changes so no commit
+    const log = execFileSync('git', ['log', '--oneline'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    }).trim();
+    const commitCount = log.split('\n').length;
+    expect(commitCount).toBe(3);
+
+    // Verify turn metadata in the commits
+    const turn2Msg = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+    expect(turn2Msg).toContain('Turn: 2');
+
+    const turn1Msg = execFileSync('git', ['log', '-1', '--skip=1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+    expect(turn1Msg).toContain('Turn: 1');
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -95,6 +95,7 @@ import {
 } from './session-tool-setup.js';
 import { unregisterSessionSender } from '../tools/browser/browser-screencast.js';
 import { projectSkillTools, resetSkillToolProjection } from './session-skill-tools.js';
+import { commitTurnChanges } from '../workspace/turn-commit.js';
 
 export interface SessionMemoryPolicy {
   scopeId: string;
@@ -182,6 +183,8 @@ export class Session {
   workspaceTopLevelDirty = true;
   public readonly traceEmitter: TraceEmitter;
   public memoryPolicy: SessionMemoryPolicy;
+  /** Monotonically increasing turn counter for turn-boundary commits. */
+  private turnCount = 0;
 
   /** Resolved assistant attachment drafts from the most recent exchange. */
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
@@ -1210,6 +1213,11 @@ export class Session {
       void getHookManager().trigger('post-message', {
         sessionId: this.conversationId,
       });
+
+      // Turn-boundary commit: async, fire-and-forget so it never blocks the response.
+      // Increment turn counter and commit any workspace changes from this turn.
+      this.turnCount++;
+      void commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
 
       // Resolve accumulated attachment directives and tool content blocks
       const attachmentResult = await resolveAssistantAttachments(

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -1,0 +1,129 @@
+/**
+ * Turn-boundary commit logic for workspace git tracking.
+ *
+ * After each conversation turn (user message -> assistant response cycle),
+ * this module checks the workspace for uncommitted changes and creates a
+ * single git commit capturing all file modifications from that turn.
+ *
+ * Commits are performed asynchronously so they do not block the turn response.
+ */
+
+import { getWorkspaceGitService } from './git-service.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('turn-commit');
+
+export interface TurnCommitMetadata {
+  /** Session/conversation identifier */
+  sessionId: string;
+  /** 1-based turn number within the session */
+  turnNumber: number;
+  /** ISO 8601 timestamp of when the turn completed */
+  timestamp: string;
+  /** Number of files changed in this turn */
+  filesChanged: number;
+}
+
+/**
+ * Build a commit message with structured metadata for a turn boundary commit.
+ *
+ * Format:
+ * ```
+ * Turn: <summary>
+ *
+ * Session: sess_xyz
+ * Turn: 5
+ * Timestamp: 2026-02-18T15:30:00Z
+ * Files: 3 changed
+ * ```
+ */
+function buildCommitMessage(summary: string, metadata: TurnCommitMetadata): string {
+  return [
+    `Turn: ${summary}`,
+    '',
+    `Session: ${metadata.sessionId}`,
+    `Turn: ${metadata.turnNumber}`,
+    `Timestamp: ${metadata.timestamp}`,
+    `Files: ${metadata.filesChanged} changed`,
+  ].join('\n');
+}
+
+/**
+ * Build a short summary of what changed from a list of file paths.
+ */
+function buildChangeSummary(files: string[]): string {
+  if (files.length === 0) {
+    return 'workspace changes';
+  }
+  if (files.length === 1) {
+    return files[0];
+  }
+  if (files.length <= 3) {
+    return files.join(', ');
+  }
+  return `${files.slice(0, 2).join(', ')} and ${files.length - 2} more`;
+}
+
+/**
+ * Attempt a turn-boundary commit for the workspace.
+ *
+ * Checks the workspace for uncommitted changes. If any are found,
+ * creates a single commit with structured metadata.
+ *
+ * This function is designed to be called fire-and-forget (void) so
+ * it never blocks the turn response. All errors are caught and logged.
+ *
+ * @param workspaceDir - Absolute path to the workspace directory
+ * @param sessionId - Session/conversation identifier
+ * @param turnNumber - 1-based turn number within the session
+ */
+export async function commitTurnChanges(
+  workspaceDir: string,
+  sessionId: string,
+  turnNumber: number,
+): Promise<void> {
+  try {
+    const gitService = getWorkspaceGitService(workspaceDir);
+
+    // Check if there are any uncommitted changes
+    const status = await gitService.getStatus();
+    if (status.clean) {
+      log.debug({ sessionId, turnNumber }, 'No workspace changes to commit for turn');
+      return;
+    }
+
+    // Gather all changed files for the summary and metadata
+    const allChangedFiles = [
+      ...status.staged,
+      ...status.modified,
+      ...status.untracked,
+    ];
+    // Deduplicate (a file could appear in both staged and modified)
+    const uniqueFiles = [...new Set(allChangedFiles)];
+
+    const timestamp = new Date().toISOString();
+    const summary = buildChangeSummary(uniqueFiles);
+
+    const metadata: TurnCommitMetadata = {
+      sessionId,
+      turnNumber,
+      timestamp,
+      filesChanged: uniqueFiles.length,
+    };
+
+    const message = buildCommitMessage(summary, metadata);
+
+    await gitService.commitChanges(message);
+
+    log.info(
+      { sessionId, turnNumber, filesChanged: uniqueFiles.length },
+      'Turn-boundary commit created',
+    );
+  } catch (err) {
+    // Never let commit failures propagate — they must not affect the turn
+    log.warn(
+      { err, sessionId, turnNumber },
+      'Failed to create turn-boundary commit (non-fatal)',
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Added `assistant/src/workspace/turn-commit.ts` — a module that checks the workspace for uncommitted changes at turn boundaries and creates a single commit with structured metadata (session ID, turn number, timestamp, file count)
- Integrated turn-boundary commits into `Session.runAgentLoop()` in `assistant/src/daemon/session.ts` — after all tool results are processed and the post-message hook fires, the commit is triggered as a fire-and-forget async operation so it never blocks the turn response
- Added a `turnCount` field to the `Session` class to track monotonically increasing turn numbers per session

### Commit message format
```
Turn: <short summary of what changed>

Session: sess_xyz
Turn: 5
Timestamp: 2026-02-18T15:30:00Z
Files: 3 changed
```

## Test plan
- [x] Turn with file edits creates a commit (with correct metadata)
- [x] Turn with no changes creates no commit
- [x] Multiple tool calls in one turn result in single commit at end
- [x] Commit message includes correct metadata (session ID, turn number, timestamp, file count)
- [x] Single file change shows filename in summary
- [x] Many file changes show "and N more" in summary
- [x] Errors are handled gracefully without throwing
- [x] Successive turns produce separate commits
- [x] All 8 new tests pass, all 27 existing git-service tests pass
- [x] Type check passes with `bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
