### PR TITLE
fix: show full command in permission prompt technical details

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -12,10 +12,6 @@ public struct ToolConfirmationBubble: View {
     @State private var showDiff = false
     @State private var showAlwaysAllowMenu = false
     @State private var showTechnicalDetails = false
-    @State private var isPreviewExpanded = false
-    @State private var isTruncated = false
-    @State private var fullTextHeight: CGFloat = 0
-    @State private var truncatedTextHeight: CGFloat = 0
 
     public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
         self.confirmation = confirmation
@@ -240,55 +236,17 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private func inlinePreview(_ preview: String) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.xxs) {
-            Text(preview)
-                .font(VFont.monoSmall)
-                .foregroundColor(VColor.textSecondary)
-                .lineLimit(isPreviewExpanded ? nil : 3)
-                .textSelection(.enabled)
-                .background(
-                    // Hidden full-height text to detect truncation
-                    Text(preview)
-                        .font(VFont.monoSmall)
-                        .lineLimit(nil)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .hidden()
-                        .background(GeometryReader { fullGeometry in
-                            Color.clear.preference(key: FullTextHeightKey.self, value: fullGeometry.size.height)
-                        })
-                )
-                .background(GeometryReader { visibleGeometry in
-                    Color.clear.preference(key: TruncatedTextHeightKey.self, value: visibleGeometry.size.height)
-                })
-                .onPreferenceChange(FullTextHeightKey.self) { fullHeight in
-                    updateTruncation(fullHeight: fullHeight)
-                }
-                .onPreferenceChange(TruncatedTextHeightKey.self) { truncatedHeight in
-                    updateTruncation(truncatedHeight: truncatedHeight)
-                }
-
-            if isTruncated {
-                HStack(spacing: 2) {
-                    Image(systemName: isPreviewExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 8, weight: .semibold))
-                    Text(isPreviewExpanded ? "Show less" : "Show more")
-                        .font(.system(size: 10))
-                }
-                .foregroundColor(VColor.textMuted)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    withAnimation(VAnimation.fast) {
-                        isPreviewExpanded.toggle()
-                    }
-                }
-            }
-        }
-        .padding(VSpacing.sm)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.sm)
-                .fill(VColor.backgroundSubtle)
-        )
+        Text(preview)
+            .font(VFont.monoSmall)
+            .foregroundColor(VColor.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .textSelection(.enabled)
+            .padding(VSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(VColor.backgroundSubtle)
+            )
     }
 
     // MARK: - Description Text
@@ -464,34 +422,6 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
-    // MARK: - Truncation Detection
-
-    private func updateTruncation(fullHeight: CGFloat? = nil, truncatedHeight: CGFloat? = nil) {
-        if let h = fullHeight { self.fullTextHeight = h }
-        if let h = truncatedHeight { self.truncatedTextHeight = h }
-        let full = fullHeight ?? self.fullTextHeight
-        let truncated = truncatedHeight ?? self.truncatedTextHeight
-        guard full > 0, truncated > 0 else { return }
-        // Skip recalculating when expanded — the truncated height equals
-        // full height with no line limit, which would reset isTruncated to false
-        // and hide the "Show less" button.
-        guard !isPreviewExpanded else { return }
-        isTruncated = full > truncated + 1
-    }
-}
-
-private struct FullTextHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
-private struct TruncatedTextHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
 }
 
 // MARK: - Always Allow Row


### PR DESCRIPTION
## Summary
- Remove 3-line truncation from the technical details command preview in permission prompts
- Users need to see the full command text to make informed allow/deny decisions
- Removes unused truncation detection machinery (PreferenceKeys, state vars, Show more/less toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
