### PR TITLE
M3: Heartbeat Safety Net

### DIFF
--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -1,0 +1,347 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import {
+  WorkspaceGitService,
+  _resetGitServiceRegistry,
+} from '../workspace/git-service.js';
+import {
+  HeartbeatService,
+  _resetHeartbeatState,
+} from '../workspace/heartbeat-service.js';
+
+describe('HeartbeatService', () => {
+  let testDir: string;
+  let service: WorkspaceGitService;
+  let services: Map<string, WorkspaceGitService>;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `vellum-heartbeat-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    _resetGitServiceRegistry();
+    _resetHeartbeatState();
+
+    service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    services = new Map();
+    services.set(testDir, service);
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('heartbeat check with age threshold', () => {
+    test('does not commit when workspace is clean', async () => {
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 0, // Immediate
+        fileThreshold: 1,
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.check();
+
+      expect(result.checked).toBe(1);
+      expect(result.committed).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    test('does not commit when changes are below age and file thresholds', async () => {
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 10 * 60 * 1000, // 10 minutes
+        fileThreshold: 100,
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.check();
+
+      expect(result.checked).toBe(1);
+      expect(result.committed).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    test('commits when changes exceed age threshold', async () => {
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+
+      let currentTime = 1000000;
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 5 * 60 * 1000, // 5 minutes
+        fileThreshold: 100,
+        getServices: () => services,
+        now: () => currentTime,
+      });
+
+      // First check: records dirty time but doesn't commit (too recent)
+      const firstResult = await heartbeat.check();
+      expect(firstResult.committed).toBe(0);
+
+      // Advance time past threshold
+      currentTime += 6 * 60 * 1000; // 6 minutes later
+
+      const secondResult = await heartbeat.check();
+      expect(secondResult.committed).toBe(1);
+
+      // Verify commit message
+      const commitMsg = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+      expect(commitMsg).toContain('auto-commit');
+      expect(commitMsg).toContain('heartbeat');
+      expect(commitMsg).toContain('safety net');
+    });
+
+    test('commits when file count exceeds threshold', async () => {
+      // Create enough files to exceed the threshold
+      for (let i = 0; i < 25; i++) {
+        writeFileSync(join(testDir, `file${i}.txt`), `content ${i}`);
+      }
+
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 10 * 60 * 1000, // 10 minutes (not yet)
+        fileThreshold: 20,
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.check();
+
+      expect(result.committed).toBe(1);
+
+      // Verify commit message mentions file count
+      const commitMsg = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+      expect(commitMsg).toContain('25 files changed');
+    });
+  });
+
+  describe('normal operation does not create spurious commits', () => {
+    test('clean workspace produces no heartbeat commits', async () => {
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 0,
+        fileThreshold: 1,
+        getServices: () => services,
+      });
+
+      // Run check multiple times on clean workspace
+      for (let i = 0; i < 5; i++) {
+        const result = await heartbeat.check();
+        expect(result.committed).toBe(0);
+      }
+
+      // Only the initial commit should exist
+      const commitCount = execFileSync('git', ['rev-list', '--count', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(parseInt(commitCount, 10)).toBe(1);
+    });
+
+    test('changes below both thresholds do not trigger heartbeat commit', async () => {
+      // Create a small number of files (below file threshold)
+      writeFileSync(join(testDir, 'small-change.txt'), 'content');
+
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 10 * 60 * 1000, // 10 minutes
+        fileThreshold: 100, // Very high
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.check();
+      expect(result.committed).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    test('does not double-commit after turn-boundary commit clears changes', async () => {
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+
+      let currentTime = 1000000;
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 5 * 60 * 1000,
+        fileThreshold: 100,
+        getServices: () => services,
+        now: () => currentTime,
+      });
+
+      // First check: records dirty state
+      await heartbeat.check();
+
+      // Simulate a turn-boundary commit that clears the changes
+      await service.commitChanges('Turn-boundary commit');
+
+      // Advance time past the threshold
+      currentTime += 6 * 60 * 1000;
+
+      // Heartbeat should see clean workspace and skip
+      const result = await heartbeat.check();
+      expect(result.committed).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('shutdown commits', () => {
+    test('commits pending changes on shutdown', async () => {
+      writeFileSync(join(testDir, 'unsaved.txt'), 'uncommitted content');
+
+      const heartbeat = new HeartbeatService({
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.commitAllPending();
+
+      expect(result.checked).toBe(1);
+      expect(result.committed).toBe(1);
+
+      // Verify commit message
+      const commitMsg = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+      expect(commitMsg).toContain('auto-commit');
+      expect(commitMsg).toContain('shutdown');
+      expect(commitMsg).toContain('safety net');
+    });
+
+    test('does not commit on shutdown when workspace is clean', async () => {
+      const heartbeat = new HeartbeatService({
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.commitAllPending();
+
+      expect(result.checked).toBe(1);
+      expect(result.committed).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    test('shutdown commits multiple workspaces', async () => {
+      const testDir2 = join(tmpdir(), `vellum-heartbeat-test2-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      mkdirSync(testDir2, { recursive: true });
+      const service2 = new WorkspaceGitService(testDir2);
+      await service2.ensureInitialized();
+      services.set(testDir2, service2);
+
+      writeFileSync(join(testDir, 'file1.txt'), 'content1');
+      writeFileSync(join(testDir2, 'file2.txt'), 'content2');
+
+      const heartbeat = new HeartbeatService({
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.commitAllPending();
+
+      expect(result.checked).toBe(2);
+      expect(result.committed).toBe(2);
+
+      // Clean up second test dir
+      rmSync(testDir2, { recursive: true, force: true });
+    });
+  });
+
+  describe('uninitialized workspaces', () => {
+    test('skips uninitialized workspaces', async () => {
+      const uninitDir = join(tmpdir(), `vellum-uninit-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      mkdirSync(uninitDir, { recursive: true });
+
+      const uninitService = new WorkspaceGitService(uninitDir);
+      const mixedServices = new Map<string, WorkspaceGitService>();
+      mixedServices.set(uninitDir, uninitService);
+      mixedServices.set(testDir, service);
+
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 0,
+        fileThreshold: 1,
+        getServices: () => mixedServices,
+        now: () => Date.now(),
+      });
+
+      // First check to register dirty state, then immediate second check
+      await heartbeat.check();
+
+      const result = await heartbeat.check();
+      // Only initialized workspace should be checked
+      // The first check committed the file, so the second check sees it clean
+      expect(result.checked).toBe(1);
+
+      rmSync(uninitDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('threshold behavior', () => {
+    test('resets dirty tracking after successful commit', async () => {
+      let currentTime = 1000000;
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 5 * 60 * 1000,
+        fileThreshold: 100,
+        getServices: () => services,
+        now: () => currentTime,
+      });
+
+      // Create changes and register dirty state
+      writeFileSync(join(testDir, 'file1.txt'), 'content');
+      await heartbeat.check(); // Records first-seen time
+
+      // Advance past threshold and commit
+      currentTime += 6 * 60 * 1000;
+      const firstResult = await heartbeat.check();
+      expect(firstResult.committed).toBe(1);
+
+      // Create new changes after the commit
+      writeFileSync(join(testDir, 'file2.txt'), 'more content');
+
+      // Check again immediately -- should not commit (dirty timer was reset)
+      const secondResult = await heartbeat.check();
+      expect(secondResult.committed).toBe(0);
+
+      // Advance past threshold again
+      currentTime += 6 * 60 * 1000;
+      const thirdResult = await heartbeat.check();
+      expect(thirdResult.committed).toBe(1);
+    });
+
+    test('commit message includes trigger metadata', async () => {
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 0,
+        fileThreshold: 1,
+        getServices: () => services,
+      });
+
+      // Two checks: first registers, second commits (age 0 means immediate on re-check)
+      await heartbeat.check();
+      await heartbeat.check();
+
+      const commitMsg = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+      expect(commitMsg).toContain('trigger: "heartbeat"');
+    });
+  });
+
+  describe('start and stop', () => {
+    test('start and stop are idempotent', () => {
+      const heartbeat = new HeartbeatService({
+        intervalMs: 60000,
+        getServices: () => services,
+      });
+
+      // Should not throw
+      heartbeat.start();
+      heartbeat.start(); // Idempotent
+      heartbeat.stop();
+      heartbeat.stop(); // Idempotent
+    });
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -42,6 +42,7 @@ import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { getHookManager } from '../hooks/manager.js';
 import { installTemplates } from '../hooks/templates.js';
+import { HeartbeatService } from '../workspace/heartbeat-service.js';
 
 const log = getLogger('lifecycle');
 
@@ -397,6 +398,14 @@ export async function runDaemon(): Promise<void> {
     }
   }
 
+  // Start workspace heartbeat service. This periodically checks all
+  // tracked workspaces for uncommitted changes and auto-commits when
+  // thresholds are exceeded (age > 5 min OR > 20 files changed).
+  // Acts as a safety net for long-running operations or background
+  // processes that modify workspace files between turn-boundary commits.
+  const heartbeat = new HeartbeatService();
+  heartbeat.start();
+
   // Graceful shutdown
   let shuttingDown = false;
   const shutdown = async () => {
@@ -405,6 +414,7 @@ export async function runDaemon(): Promise<void> {
     log.info('Shutting down daemon...');
 
     hookManager.stopWatching();
+    heartbeat.stop();
 
     // Force exit if graceful shutdown takes too long.
     // Set this BEFORE triggering daemon-stop hooks so it covers hook execution time.
@@ -419,6 +429,14 @@ export async function runDaemon(): Promise<void> {
       await hookManager.trigger('daemon-stop', { pid: process.pid });
     } catch {
       // Don't let hook failures block shutdown
+    }
+
+    // Commit any uncommitted workspace changes before stopping the server.
+    // This ensures no workspace state is lost during graceful shutdown.
+    try {
+      await heartbeat.commitAllPending();
+    } catch (err) {
+      log.warn({ err }, 'Shutdown workspace commit failed');
     }
 
     await server.stop();

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -312,6 +312,14 @@ export function getWorkspaceGitService(workspaceDir: string): WorkspaceGitServic
 }
 
 /**
+ * Returns all currently registered WorkspaceGitService instances.
+ * Used by the heartbeat service to check all tracked workspaces for uncommitted changes.
+ */
+export function getAllWorkspaceGitServices(): ReadonlyMap<string, WorkspaceGitService> {
+  return serviceRegistry;
+}
+
+/**
  * @internal Test-only: clear the service registry
  */
 export function _resetGitServiceRegistry(): void {

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -1,0 +1,263 @@
+import { getLogger } from '../util/logger.js';
+import { getAllWorkspaceGitServices, type WorkspaceGitService } from './git-service.js';
+
+const log = getLogger('heartbeat');
+
+/** Threshold: commit if changes are older than this (ms). Default: 5 minutes. */
+const DEFAULT_AGE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/** Threshold: commit if more than this many files have changed. Default: 20. */
+const DEFAULT_FILE_THRESHOLD = 20;
+
+/** How often the heartbeat runs (ms). Default: 5 minutes. */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface HeartbeatServiceOptions {
+  /** Maximum age of uncommitted changes before auto-commit (ms). */
+  ageThresholdMs?: number;
+  /** Maximum number of changed files before auto-commit. */
+  fileThreshold?: number;
+  /** Interval between heartbeat checks (ms). */
+  intervalMs?: number;
+  /** Override for getting workspace git services (for testing). */
+  getServices?: () => ReadonlyMap<string, WorkspaceGitService>;
+  /** Override for getting the current timestamp (for testing). */
+  now?: () => number;
+}
+
+/**
+ * Result of a single heartbeat check cycle.
+ */
+export interface HeartbeatCheckResult {
+  /** Number of workspaces checked. */
+  checked: number;
+  /** Number of workspaces that had commits created. */
+  committed: number;
+  /** Number of workspaces skipped (clean or below thresholds). */
+  skipped: number;
+  /** Number of workspaces that failed during check. */
+  failed: number;
+}
+
+/**
+ * Tracks when changes were first detected in each workspace, so the heartbeat
+ * can determine whether changes are "old enough" to warrant an auto-commit.
+ */
+const firstSeenDirty = new Map<string, number>();
+
+/**
+ * Heartbeat service that periodically checks all tracked workspaces for
+ * uncommitted changes and auto-commits them when thresholds are met.
+ *
+ * This is a SAFETY NET -- turn-boundary commits (M2) handle the primary case.
+ * The heartbeat catches:
+ * - Long-running bash scripts that modify files without returning to the agent loop
+ * - Background processes that write to the workspace
+ * - Forgotten state from crashed or interrupted sessions
+ */
+export class HeartbeatService {
+  private readonly ageThresholdMs: number;
+  private readonly fileThreshold: number;
+  private readonly intervalMs: number;
+  private readonly getServices: () => ReadonlyMap<string, WorkspaceGitService>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options?: HeartbeatServiceOptions) {
+    this.ageThresholdMs = options?.ageThresholdMs ?? DEFAULT_AGE_THRESHOLD_MS;
+    this.fileThreshold = options?.fileThreshold ?? DEFAULT_FILE_THRESHOLD;
+    this.intervalMs = options?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.getServices = options?.getServices ?? getAllWorkspaceGitServices;
+    this.now = options?.now ?? Date.now;
+  }
+
+  /**
+   * Start the periodic heartbeat timer.
+   * Idempotent -- calling start() when already running is a no-op.
+   */
+  start(): void {
+    if (this.timer) return;
+    log.info(
+      { intervalMs: this.intervalMs, ageThresholdMs: this.ageThresholdMs, fileThreshold: this.fileThreshold },
+      'Heartbeat service started',
+    );
+    this.timer = setInterval(() => {
+      this.check().catch((err) => {
+        log.error({ err }, 'Heartbeat check failed');
+      });
+    }, this.intervalMs);
+  }
+
+  /**
+   * Stop the periodic heartbeat timer.
+   */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      log.info('Heartbeat service stopped');
+    }
+  }
+
+  /**
+   * Run a single heartbeat check across all tracked workspaces.
+   * For each workspace with uncommitted changes that exceed the age or file
+   * threshold, an auto-commit is created.
+   */
+  async check(): Promise<HeartbeatCheckResult> {
+    const result: HeartbeatCheckResult = {
+      checked: 0,
+      committed: 0,
+      skipped: 0,
+      failed: 0,
+    };
+
+    const services = this.getServices();
+
+    for (const [workspaceDir, service] of services) {
+      // Only check workspaces that have been initialized (have a .git dir).
+      // Skip workspaces that haven't been used yet to avoid spurious init.
+      if (!service.isInitialized()) {
+        continue;
+      }
+
+      result.checked++;
+
+      try {
+        const committed = await this.checkWorkspace(workspaceDir, service, 'heartbeat');
+        if (committed) {
+          result.committed++;
+        } else {
+          result.skipped++;
+        }
+      } catch (err) {
+        log.warn({ err, workspaceDir }, 'Heartbeat check failed for workspace');
+        result.failed++;
+      }
+    }
+
+    if (result.committed > 0) {
+      log.info(result, 'Heartbeat check completed with commits');
+    }
+
+    return result;
+  }
+
+  /**
+   * Commit any pending changes in all tracked workspaces as a shutdown safety net.
+   * Called during graceful daemon shutdown to ensure no workspace state is lost.
+   */
+  async commitAllPending(): Promise<HeartbeatCheckResult> {
+    const result: HeartbeatCheckResult = {
+      checked: 0,
+      committed: 0,
+      skipped: 0,
+      failed: 0,
+    };
+
+    const services = this.getServices();
+
+    for (const [workspaceDir, service] of services) {
+      if (!service.isInitialized()) {
+        continue;
+      }
+
+      result.checked++;
+
+      try {
+        const status = await service.getStatus();
+        if (status.clean) {
+          result.skipped++;
+          continue;
+        }
+
+        const totalChanges = status.staged.length + status.modified.length + status.untracked.length;
+        log.info({ workspaceDir, totalChanges }, 'Committing pending changes on shutdown');
+
+        await service.commitChanges(
+          `auto-commit: shutdown safety net (${totalChanges} files)`,
+          { trigger: 'shutdown', timestamp: this.now() },
+        );
+
+        // Clean up tracking state
+        firstSeenDirty.delete(workspaceDir);
+        result.committed++;
+      } catch (err) {
+        log.warn({ err, workspaceDir }, 'Shutdown commit failed for workspace');
+        result.failed++;
+      }
+    }
+
+    if (result.committed > 0) {
+      log.info(result, 'Shutdown commits completed');
+    }
+
+    return result;
+  }
+
+  /**
+   * Check a single workspace and commit if thresholds are exceeded.
+   *
+   * @returns true if a commit was created
+   */
+  private async checkWorkspace(
+    workspaceDir: string,
+    service: WorkspaceGitService,
+    trigger: string,
+  ): Promise<boolean> {
+    const status = await service.getStatus();
+
+    if (status.clean) {
+      // Workspace is clean -- clear any dirty tracking
+      firstSeenDirty.delete(workspaceDir);
+      return false;
+    }
+
+    const totalChanges = status.staged.length + status.modified.length + status.untracked.length;
+    const now = this.now();
+
+    // Track when we first saw this workspace as dirty
+    if (!firstSeenDirty.has(workspaceDir)) {
+      firstSeenDirty.set(workspaceDir, now);
+    }
+
+    const dirtyAge = now - firstSeenDirty.get(workspaceDir)!;
+
+    // Check thresholds: commit if changes are old enough OR if too many files changed
+    const ageExceeded = dirtyAge >= this.ageThresholdMs;
+    const fileCountExceeded = totalChanges >= this.fileThreshold;
+
+    if (!ageExceeded && !fileCountExceeded) {
+      log.debug(
+        { workspaceDir, totalChanges, dirtyAgeMs: dirtyAge },
+        'Changes below threshold, skipping heartbeat commit',
+      );
+      return false;
+    }
+
+    const reason = ageExceeded
+      ? `changes older than ${Math.round(dirtyAge / 1000)}s`
+      : `${totalChanges} files changed (threshold: ${this.fileThreshold})`;
+
+    log.info(
+      { workspaceDir, totalChanges, dirtyAgeMs: dirtyAge, reason },
+      'Heartbeat auto-committing workspace changes',
+    );
+
+    await service.commitChanges(
+      `auto-commit: ${trigger} safety net (${totalChanges} files, ${reason})`,
+      { trigger, timestamp: now },
+    );
+
+    // Reset dirty tracking after successful commit
+    firstSeenDirty.delete(workspaceDir);
+    return true;
+  }
+}
+
+/**
+ * @internal Test-only: clear the dirty tracking state
+ */
+export function _resetHeartbeatState(): void {
+  firstSeenDirty.clear();
+}


### PR DESCRIPTION
## Summary

- Add `HeartbeatService` that periodically checks all tracked workspaces for uncommitted changes and auto-commits when thresholds are exceeded (>5 min old OR >20 files changed)
- Hook graceful daemon shutdown to commit any pending workspace changes before exit
- Export `getAllWorkspaceGitServices()` from git-service to allow heartbeat iteration over tracked workspaces

## Design

This is a **safety net** -- turn-boundary commits (M2) handle the primary case. The heartbeat catches:
- Long-running bash scripts that modify files without returning to the agent loop
- Background processes that write to the workspace
- Forgotten state from crashed or interrupted sessions

Commit messages include the trigger source (`heartbeat` or `shutdown`) and metadata for debugging.

## Test plan

- [x] Clean workspace produces no heartbeat commits (no spurious commits)
- [x] Changes below both age and file thresholds are not committed
- [x] Changes exceeding age threshold (>5 min) trigger auto-commit
- [x] Changes exceeding file threshold (>20 files) trigger auto-commit
- [x] Turn-boundary commits that clear changes prevent heartbeat double-commits
- [x] Graceful shutdown commits pending changes
- [x] Shutdown skips clean workspaces
- [x] Uninitialized workspaces are skipped
- [x] Dirty tracking resets after successful commit
- [x] Start/stop are idempotent
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 14 new tests pass, all 27 existing git-service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
