### PR TITLE
M4: Polish, Testing & Documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1019,6 +1019,70 @@ The Anthropic provider places `cache_control: { type: 'ephemeral' }` on the **la
 
 ---
 
+## Workspace Git Tracking — Change Management
+
+The workspace sandbox (`~/.vellum/workspace`) is automatically tracked by a per-workspace git repository. Every file change made by the assistant is captured in structured commits, providing a full audit trail and natural undo/history exploration via standard git commands.
+
+### Architecture overview
+
+```mermaid
+graph TB
+    subgraph "Turn-boundary commits (primary)"
+        SESSION["Session.processMessage()"]
+        TURN_COMMIT["commitTurnChanges()<br/>fire-and-forget"]
+        GIT_SERVICE["WorkspaceGitService<br/>mutex-protected"]
+    end
+
+    subgraph "Heartbeat safety net (secondary)"
+        HEARTBEAT["HeartbeatService<br/>setInterval every 5 min"]
+        CHECK["check(): age > 5 min<br/>OR files > 20"]
+    end
+
+    subgraph "Lifecycle"
+        STARTUP["Daemon startup<br/>lifecycle.ts"]
+        SHUTDOWN["Graceful shutdown<br/>commitAllPending()"]
+    end
+
+    SESSION -->|"void (non-blocking)"| TURN_COMMIT
+    TURN_COMMIT --> GIT_SERVICE
+    HEARTBEAT --> CHECK
+    CHECK --> GIT_SERVICE
+    STARTUP --> HEARTBEAT
+    SHUTDOWN -->|"await"| HEARTBEAT
+```
+
+### How it works
+
+1. **Lazy initialization**: The git repository is created on first use, not at workspace creation. When `ensureInitialized()` is called, it checks for a `.git` directory. If absent, it runs `git init`, creates a `.gitignore` (excluding `data/`, `logs/`, `*.log`, `*.sock`, `*.pid`, `session-token`, `http-token`), sets the git identity to "Vellum Assistant", and creates an initial commit capturing any pre-existing files. This handles migration of existing workspaces transparently.
+
+2. **Turn-boundary commits**: After each conversation turn (user message + assistant response cycle), `session.ts` calls `void commitTurnChanges(workspaceDir, sessionId, turnNumber)` in a fire-and-forget pattern. This checks for uncommitted changes and, if any exist, creates a single commit with structured metadata (session ID, turn number, timestamp, file count). The `void` prefix ensures the commit never blocks the turn response.
+
+3. **Heartbeat safety net**: A `HeartbeatService` runs on a 5-minute interval, checking all tracked workspaces for uncommitted changes. It auto-commits when changes exceed either an age threshold (5 minutes since first detected) or a file count threshold (20+ files). This catches changes from long-running bash scripts, background processes, or crashed sessions that miss turn-boundary commits.
+
+4. **Shutdown safety net**: During graceful daemon shutdown, `commitAllPending()` is called to commit any remaining uncommitted changes across all workspaces, ensuring no workspace state is lost.
+
+5. **Corrupted repo recovery**: If a `.git` directory exists but is corrupted (e.g. missing HEAD), the service detects this via `git rev-parse --git-dir`, removes the corrupted directory, and reinitializes cleanly.
+
+### Design decisions
+
+- **Commit at turn boundaries, not per-tool-call**: A single commit per turn captures all file mutations from that turn atomically. This avoids noisy per-file commits and keeps the history meaningful.
+- **Lazy init for migration**: Existing workspaces get their files captured in an "Initial commit: migrated existing workspace" on first use, rather than requiring an explicit migration step.
+- **Mutex serialization**: All git operations go through a per-workspace `Mutex` to prevent concurrent `git add`/`git commit` from corrupting the index. The mutex uses a FIFO wait queue.
+- **Fire-and-forget in session.ts**: Turn commits use `void commitTurnChanges(...)` so they never block the assistant response. All errors are caught and logged as warnings.
+- **We intentionally don't provide custom history APIs** -- assistants should use git commands naturally via Bash (e.g. `git log`, `git diff`, `git show`). The workspace git repo is a standard git repository that any tool can interact with.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `assistant/src/workspace/git-service.ts` | `WorkspaceGitService`: lazy init, mutex, `commitChanges()`, `getStatus()`, singleton registry |
+| `assistant/src/workspace/turn-commit.ts` | `commitTurnChanges()`: turn-boundary commit with structured metadata |
+| `assistant/src/workspace/heartbeat-service.ts` | `HeartbeatService`: periodic safety-net auto-commits and shutdown commits |
+| `assistant/src/daemon/session.ts` | Integration: `void commitTurnChanges(...)` at turn boundary (line ~1220) |
+| `assistant/src/daemon/lifecycle.ts` | Integration: `HeartbeatService` start/stop and shutdown commit |
+
+---
+
 ## Web Server — Connection Modes
 
 ```mermaid

--- a/assistant/src/__tests__/workspace-lifecycle.test.ts
+++ b/assistant/src/__tests__/workspace-lifecycle.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Integration-style test that exercises the full git workspace lifecycle:
+ *   lazy init → turn-boundary commits → heartbeat safety net → commit history verification.
+ *
+ * This test wires together WorkspaceGitService, commitTurnChanges, and HeartbeatService
+ * in the same flow a real daemon session would follow.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import {
+  WorkspaceGitService,
+  getWorkspaceGitService,
+  _resetGitServiceRegistry,
+} from '../workspace/git-service.js';
+import { commitTurnChanges } from '../workspace/turn-commit.js';
+import {
+  HeartbeatService,
+  _resetHeartbeatState,
+} from '../workspace/heartbeat-service.js';
+
+describe('Workspace git lifecycle (integration)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(
+      tmpdir(),
+      `vellum-lifecycle-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+    _resetGitServiceRegistry();
+    _resetHeartbeatState();
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // Helper to read git log output
+  function gitLog(cwd: string, format = '--oneline'): string {
+    return execFileSync('git', ['log', format], { cwd, encoding: 'utf-8' }).trim();
+  }
+
+  function commitCount(cwd: string): number {
+    return parseInt(
+      execFileSync('git', ['rev-list', '--count', 'HEAD'], { cwd, encoding: 'utf-8' }).trim(),
+      10,
+    );
+  }
+
+  function lastCommitMessage(cwd: string): string {
+    return execFileSync('git', ['log', '-1', '--pretty=%B'], { cwd, encoding: 'utf-8' }).trim();
+  }
+
+  function lastCommitFiles(cwd: string): string[] {
+    return execFileSync('git', ['diff', '--name-only', 'HEAD~1', 'HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+    })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+  }
+
+  test('full lifecycle: init → turns → heartbeat → history', async () => {
+    const sessionId = 'sess_lifecycle_test';
+
+    // ----------------------------------------------------------------
+    // Step 1: Lazy initialization — workspace starts without a git repo
+    // ----------------------------------------------------------------
+    expect(existsSync(join(testDir, '.git'))).toBe(false);
+
+    // Pre-populate workspace with files (simulates existing workspace)
+    writeFileSync(join(testDir, 'README.md'), '# My Project');
+    writeFileSync(join(testDir, 'config.json'), '{"version": 1}');
+
+    // Getting the service via the singleton registry is how session.ts does it
+    const service = getWorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Verify lazy init created the repo and the initial commit
+    expect(existsSync(join(testDir, '.git'))).toBe(true);
+    expect(commitCount(testDir)).toBe(1);
+    expect(lastCommitMessage(testDir)).toContain('Initial commit: migrated existing workspace');
+
+    // ----------------------------------------------------------------
+    // Step 2: Turn 1 — assistant edits files, turn-boundary commit fires
+    // ----------------------------------------------------------------
+    writeFileSync(join(testDir, 'hello.ts'), 'export const greeting = "hello";');
+    writeFileSync(join(testDir, 'config.json'), '{"version": 2}');
+
+    await commitTurnChanges(testDir, sessionId, 1);
+
+    expect(commitCount(testDir)).toBe(2);
+    const turn1Msg = lastCommitMessage(testDir);
+    expect(turn1Msg).toContain('Turn:');
+    expect(turn1Msg).toContain('Session: sess_lifecycle_test');
+    expect(turn1Msg).toContain('Turn: 1');
+    expect(turn1Msg).toContain('Files: 2 changed');
+    expect(turn1Msg).toMatch(/Timestamp: \d{4}-\d{2}-\d{2}T/);
+
+    const turn1Files = lastCommitFiles(testDir);
+    expect(turn1Files).toContain('hello.ts');
+    expect(turn1Files).toContain('config.json');
+
+    // ----------------------------------------------------------------
+    // Step 3: Turn 2 — more edits
+    // ----------------------------------------------------------------
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'index.ts'), 'console.log("hello");');
+
+    await commitTurnChanges(testDir, sessionId, 2);
+
+    expect(commitCount(testDir)).toBe(3);
+    const turn2Msg = lastCommitMessage(testDir);
+    expect(turn2Msg).toContain('Turn: 2');
+    expect(turn2Msg).toContain('Files: 1 changed');
+
+    // ----------------------------------------------------------------
+    // Step 4: Turn 3 — no changes (should NOT create a commit)
+    // ----------------------------------------------------------------
+    await commitTurnChanges(testDir, sessionId, 3);
+    expect(commitCount(testDir)).toBe(3); // Still 3
+
+    // ----------------------------------------------------------------
+    // Step 5: Heartbeat safety net — simulate uncommitted changes
+    //         that linger past the age threshold
+    // ----------------------------------------------------------------
+    writeFileSync(join(testDir, 'background-output.log.txt'), 'background process output');
+
+    // Build a services map the way the heartbeat does at runtime
+    const services = new Map<string, WorkspaceGitService>();
+    services.set(testDir, service);
+
+    let fakeTime = 2_000_000;
+    const heartbeat = new HeartbeatService({
+      ageThresholdMs: 5 * 60 * 1000,
+      fileThreshold: 100,
+      getServices: () => services,
+      now: () => fakeTime,
+    });
+
+    // First heartbeat: records the dirty timestamp
+    const firstCheck = await heartbeat.check();
+    expect(firstCheck.committed).toBe(0);
+    expect(firstCheck.skipped).toBe(1); // Below threshold
+
+    // Advance time past 5-minute threshold
+    fakeTime += 6 * 60 * 1000;
+
+    const secondCheck = await heartbeat.check();
+    expect(secondCheck.committed).toBe(1);
+    expect(commitCount(testDir)).toBe(4);
+
+    const heartbeatMsg = lastCommitMessage(testDir);
+    expect(heartbeatMsg).toContain('auto-commit');
+    expect(heartbeatMsg).toContain('heartbeat');
+    expect(heartbeatMsg).toContain('safety net');
+
+    // ----------------------------------------------------------------
+    // Step 6: Verify full commit history has correct ordering/metadata
+    // ----------------------------------------------------------------
+    const fullLog = gitLog(testDir, '--oneline');
+    const lines = fullLog.split('\n');
+    expect(lines.length).toBe(4);
+
+    // Most recent first
+    expect(lines[0]).toContain('auto-commit');
+    expect(lines[1]).toContain('Turn:');
+    expect(lines[2]).toContain('Turn:');
+    expect(lines[3]).toContain('Initial commit');
+
+    // ----------------------------------------------------------------
+    // Step 7: Shutdown commit — one more file, then graceful shutdown
+    // ----------------------------------------------------------------
+    writeFileSync(join(testDir, 'unsaved-work.txt'), 'important unsaved data');
+
+    const shutdownResult = await heartbeat.commitAllPending();
+    expect(shutdownResult.committed).toBe(1);
+    expect(commitCount(testDir)).toBe(5);
+    expect(lastCommitMessage(testDir)).toContain('shutdown');
+  });
+
+  test('workspace recovers from corrupted .git directory', async () => {
+    // Create a directory that looks like .git but is corrupted
+    mkdirSync(join(testDir, '.git'), { recursive: true });
+    // No HEAD, no objects, no refs — git will fail on this
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Should have recovered: reinitialize a proper repo
+    expect(service.isInitialized()).toBe(true);
+    expect(commitCount(testDir)).toBe(1);
+    expect(lastCommitMessage(testDir)).toContain('Initial commit');
+  });
+
+  test('concurrent turn commits and heartbeats do not conflict', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Simulate concurrent turn commits and heartbeat checks
+    const services = new Map<string, WorkspaceGitService>();
+    services.set(testDir, service);
+
+    const heartbeat = new HeartbeatService({
+      ageThresholdMs: 0,
+      fileThreshold: 1,
+      getServices: () => services,
+    });
+
+    // Create files and fire turn commits + heartbeat checks concurrently
+    const operations: Promise<unknown>[] = [];
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(testDir, `concurrent-${i}.txt`), `content ${i}`);
+      operations.push(commitTurnChanges(testDir, 'sess_concurrent', i + 1));
+      operations.push(heartbeat.check());
+    }
+
+    // None of these should throw (mutex serialization prevents conflicts)
+    await Promise.all(operations);
+
+    // Verify the repo is in a consistent state
+    const status = await service.getStatus();
+    expect(status.clean).toBe(true);
+  });
+
+  test('fire-and-forget pattern does not lose commits', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Simulate the session.ts fire-and-forget pattern:
+    // `void commitTurnChanges(...)` -- the void discards the promise
+    writeFileSync(join(testDir, 'fire-forget-1.txt'), 'content 1');
+    const p1 = commitTurnChanges(testDir, 'sess_ff', 1);
+
+    writeFileSync(join(testDir, 'fire-forget-2.txt'), 'content 2');
+    const p2 = commitTurnChanges(testDir, 'sess_ff', 2);
+
+    // Even though session.ts doesn't await these, they should eventually complete
+    await Promise.all([p1, p2]);
+
+    // Both commits should exist
+    const count = commitCount(testDir);
+    // At least 2 turn commits + 1 initial = 3
+    // (exact count may vary due to --allow-empty behavior)
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  test('getWorkspaceGitService returns same instance across turn commits and heartbeat', async () => {
+    // Verify the singleton registry is coherent across all modules
+    const fromTurnCommitPath = getWorkspaceGitService(testDir);
+    const fromHeartbeatPath = getWorkspaceGitService(testDir);
+    const fromDirectCall = getWorkspaceGitService(testDir);
+
+    expect(fromTurnCommitPath).toBe(fromHeartbeatPath);
+    expect(fromHeartbeatPath).toBe(fromDirectCall);
+  });
+});

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -2,8 +2,10 @@ import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { getLogger } from '../util/logger.js';
 
 const execFileAsync = promisify(execFile);
+const log = getLogger('workspace-git');
 
 /**
  * Simple mutex implementation for per-workspace git operation serialization.
@@ -120,9 +122,27 @@ export class WorkspaceGitService {
       const gitDir = join(this.workspaceDir, '.git');
 
       if (existsSync(gitDir)) {
-        // Already initialized by another process or previous run
-        this.initialized = true;
-        return;
+        // Validate existing repo is not corrupted before marking as ready.
+        // A corrupted .git directory (e.g. missing HEAD) would cause all
+        // subsequent git operations to fail with confusing errors.
+        try {
+          await this.execGit(['rev-parse', '--git-dir']);
+        } catch {
+          log.warn(
+            { workspaceDir: this.workspaceDir },
+            'Corrupted .git directory detected; reinitializing',
+          );
+          // Remove corrupted .git and fall through to full init below
+          const { rmSync } = await import('node:fs');
+          rmSync(gitDir, { recursive: true, force: true });
+        }
+
+        if (existsSync(gitDir)) {
+          // Repo is healthy
+          this.initialized = true;
+          return;
+        }
+        // Otherwise fall through to reinitialize
       }
 
       // Initialize new git repository
@@ -255,19 +275,24 @@ export class WorkspaceGitService {
 
   /**
    * Execute a git command in the workspace directory.
+   * Includes a 30-second timeout to prevent hung operations
+   * (e.g. stale git lock files).
    */
   private async execGit(args: string[]): Promise<{ stdout: string; stderr: string }> {
     try {
       const { stdout, stderr } = await execFileAsync('git', args, {
         cwd: this.workspaceDir,
         encoding: 'utf-8',
+        timeout: 30_000,
       });
       return { stdout, stderr };
     } catch (err) {
       // Enhance error with git command details
-      const gitErr = err as Error & { stdout?: string; stderr?: string };
+      const gitErr = err as Error & { stdout?: string; stderr?: string; code?: string };
+      const isPermissionError = gitErr.code === 'EACCES' || gitErr.stderr?.includes('Permission denied');
+      const prefix = isPermissionError ? 'Git permission error' : 'Git command failed';
       throw new Error(
-        `Git command failed: git ${args.join(' ')}\n` +
+        `${prefix}: git ${args.join(' ')}\n` +
         `Error: ${gitErr.message}\n` +
         `Stderr: ${gitErr.stderr || ''}`,
       );


### PR DESCRIPTION
## Summary
- **Error handling hardening**: Added corrupted `.git` directory detection with auto-recovery (removes corrupted `.git` and reinitializes), 30-second timeout on all git commands to prevent hung operations from stale lock files, and improved error messages that distinguish permission errors from other git failures.
- **Integration test**: Added `workspace-lifecycle.test.ts` with 5 tests covering the full lifecycle: lazy init with pre-existing files, turn-boundary commits with metadata, heartbeat safety net with age threshold, shutdown commits, corrupted repo recovery, concurrent operations, and fire-and-forget pattern verification.
- **Documentation**: Added "Workspace Git Tracking -- Change Management" section to `ARCHITECTURE.md` with Mermaid architecture diagram, detailed how-it-works flow, design decisions (including the explicit note that we don't provide custom history APIs), and key files table.

All 54 workspace tests pass (27 git-service + 8 turn-commit + 14 heartbeat + 5 lifecycle). Lint and type check pass cleanly.

## Test plan
- [x] `bun test workspace-git-service.test.ts` -- 27 tests pass
- [x] `bun test turn-commit.test.ts` -- 8 tests pass
- [x] `bun test workspace-heartbeat-service.test.ts` -- 14 tests pass
- [x] `bun test workspace-lifecycle.test.ts` -- 5 tests pass (new)
- [x] `bunx tsc --noEmit` -- passes
- [x] `bun run lint` -- passes

## Files changed
- `assistant/src/workspace/git-service.ts` -- corrupted repo detection, timeout, permission error handling
- `assistant/src/__tests__/workspace-lifecycle.test.ts` -- new integration test (5 tests)
- `ARCHITECTURE.md` -- workspace git tracking documentation section
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
