### PR TITLE
Fix CAPTCHA detection: hCaptcha fallback and post-handoff auth re-check

### DIFF
--- a/assistant/src/tools/browser/auth-detector.ts
+++ b/assistant/src/tools/browser/auth-detector.ts
@@ -240,6 +240,14 @@ const CAPTCHA_DETECT_EXPRESSION = `(() => {
     if (rect.width > 0 && rect.height > 0) return true;
   }
 
+  // hCaptcha fallback — catch custom-rendered hCaptcha in arbitrary host elements
+  // by looking for a visible hCaptcha iframe directly
+  const hcaptchaIframe = document.querySelector('iframe[src*="hcaptcha"]');
+  if (hcaptchaIframe) {
+    const rect = hcaptchaIframe.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) return true;
+  }
+
   return false;
 })()`;
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -319,6 +319,19 @@ export async function executeBrowserNavigate(
             const newTitle = await page.title();
             lines.push('');
             lines.push(`CAPTCHA solved by user. Current page: ${newTitle} (${newUrl})`);
+
+            // Re-check for auth challenges — the page behind the CAPTCHA may have a login form
+            const postCaptchaAuth = await detectAuthChallenge(page);
+            if (postCaptchaAuth) {
+              lines.push('');
+              lines.push(formatAuthChallenge(postCaptchaAuth));
+              lines.push('');
+              lines.push('Handle this by using browser tools to interact with the login form:');
+              lines.push('1. Use browser_snapshot to find the sign-in form elements');
+              lines.push('2. Use browser_fill_credential to fill email/password from credential_store');
+              lines.push('3. For SMS/email verification codes, use ui_show with a form to ask the user for the code mid-turn');
+              lines.push('4. Do NOT give up or tell the user to sign in manually — handle the login flow yourself');
+            }
           } else {
             lines.push('');
             lines.push('⚠️ CAPTCHA/Cloudflare verification detected on this page.');


### PR DESCRIPTION
Address Codex P2 feedback from #4728: add visible iframe fallback for hCaptcha in custom containers, and re-check for auth challenges after CAPTCHA handoff completes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
