### PR TITLE
Fix navigation timeout: preserve fallback for same-URL refreshes

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -224,7 +224,7 @@ export async function executeBrowserNavigate(
       if (navMsg.includes('Timeout') || navMsg.includes('timeout')) {
         // If the page URL never changed from before navigation, the page
         // never actually loaded — re-throw instead of reporting success.
-        if (page.url() === urlBeforeNav) {
+        if (page.url() === urlBeforeNav && urlBeforeNav !== parsedUrl.href) {
           throw navErr;
         }
         navigationTimedOut = true;


### PR DESCRIPTION
Address Codex P2 + Devin feedback from #4727: only throw on timeout when the page URL didn't change AND the target URL is different (new navigation). Same-URL refreshes that timeout now gracefully fall back instead of hard-failing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
