### PR TITLE
fix: don't cache no-preview sentinel on cancellation/timeout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -331,11 +331,6 @@ struct AppDirectoryView: View {
                     return
                 }
             }
-
-            // Stream ended or cancelled — cache empty sentinel to avoid retries
-            if self.previewCache[appId] == nil {
-                self.previewCache[appId] = ""
-            }
         }
 
         // Cancel after timeout

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -613,11 +613,6 @@ struct GeneratedPanel: View {
                     return
                 }
             }
-
-            // Stream ended or cancelled — cache empty sentinel to avoid retries
-            if self.previewCache[appId] == nil {
-                self.previewCache[appId] = ""
-            }
         }
 
         // Cancel after timeout


### PR DESCRIPTION
Address review feedback on PR #4710. Only cache the empty-string sentinel when the daemon explicitly responds with nil preview, not when the stream is cancelled or times out.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
