### PR TITLE
fix: skip batch secret verification in downgraded keychain mode

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -7,6 +7,7 @@ import {
   deleteSecureKey,
   getBackendType,
   listSecureKeys,
+  isDowngradedFromKeychain,
 } from '../../security/secure-keys.js';
 import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata, listCredentialMetadata, assertMetadataWritable } from './metadata-store.js';
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
@@ -333,14 +334,15 @@ class CredentialStoreTool implements Tool {
         }
 
         const allMetadata = listCredentialMetadata();
-        // On the encrypted backend (including downgraded mode where keychain
-        // failed at runtime), verify secrets still exist by reading all key
-        // names once via listSecureKeys(). This avoids per-entry getSecureKey
-        // calls that would fall back to keychain probes (execFileSync with 5s
-        // timeout each), which hangs the list operation in downgraded mode.
-        // On keychain we trust metadata since the OS keychain has no batch
-        // list API.
-        const verifySecrets = getBackendType() === 'encrypted';
+        // On the encrypted backend we can verify secrets still exist by reading
+        // all key names once (instead of per-entry getSecureKey calls that each
+        // re-read/re-derive the store). On keychain we trust metadata since the
+        // OS keychain has no batch list API.
+        // In downgraded mode (keychain failed, switched to encrypted), skip
+        // batch verification because listSecureKeys() only returns keys from
+        // the encrypted store — keychain-only credentials would be hidden.
+        const downgraded = isDowngradedFromKeychain();
+        const verifySecrets = getBackendType() === 'encrypted' && !downgraded;
         let secureKeySet: Set<string> | undefined;
         if (verifySecrets) {
           try {


### PR DESCRIPTION
Address review feedback on PR #4706. In downgraded mode, skip batch verification via listSecureKeys() since it only checks the encrypted store and would hide keychain-only credentials. Trust metadata alone in this case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
