### PR TITLE
fix: apply query template filtering to HTTP policy path

### DIFF
--- a/assistant/src/__tests__/script-proxy-policy.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy.test.ts
@@ -104,13 +104,28 @@ describe('evaluateRequest', () => {
     }
   });
 
-  test('works with query injection templates', () => {
+  test('excludes query templates from candidate matching', () => {
+    // Query templates are handled via URL rewriting in the MITM path and
+    // can't be injected by the HTTP forwarder, so they are excluded from
+    // candidate selection to avoid false ambiguity.
     const tpl = queryTemplate('maps.googleapis.com', 'key');
     const templates = new Map<string, CredentialInjectionTemplate[]>([
       ['cred-gcp', [tpl]],
     ]);
     const result = evaluateRequest('maps.googleapis.com', '/api/geocode', ['cred-gcp'], templates);
-    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-gcp', template: tpl });
+    expect(result).toEqual({ kind: 'missing' });
+  });
+
+  test('query template alongside header template does not cause ambiguity', () => {
+    // A host with both a query template and a header template should
+    // resolve to matched (header only), not ambiguous.
+    const headerTpl = headerTemplate('maps.googleapis.com');
+    const qTpl = queryTemplate('maps.googleapis.com', 'key');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-gcp', [headerTpl, qTpl]],
+    ]);
+    const result = evaluateRequest('maps.googleapis.com', '/api/geocode', ['cred-gcp'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-gcp', template: headerTpl });
   });
 
   test('matches hostnames case-insensitively', () => {

--- a/assistant/src/tools/network/script-proxy/policy.ts
+++ b/assistant/src/tools/network/script-proxy/policy.ts
@@ -37,6 +37,11 @@ export function evaluateRequest(
     if (!tpls) continue;
 
     for (const tpl of tpls) {
+      // Query templates are handled via URL rewriting in the MITM path
+      // and can't be injected by the HTTP forwarder. Exclude them so
+      // a host with both query and header templates doesn't appear
+      // ambiguous — consistent with the MITM rewriteCallback filtering.
+      if (tpl.injectionType === 'query') continue;
       if (minimatch(hostname, tpl.hostPattern, { nocase: true })) {
         candidates.push({ credentialId: id, template: tpl });
       }


### PR DESCRIPTION
Address review feedback on PR #4700. Apply the same query template filtering in the shared evaluateRequest policy function that was already done in the MITM rewriteCallback, ensuring consistent behavior between HTTP and HTTPS paths. Query templates are excluded from candidate matching since they can only be injected via URL rewriting in the MITM path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
