### PR TITLE
fix: fall back to 0.0.0.0 when docker0 is unavailable

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -36,8 +36,10 @@ function getDockerProxyHost(): string {
   } catch {
     // docker0 interface may not exist (e.g. rootless Docker, custom networks)
   }
-  // Fallback: the conventional Docker bridge gateway IP
-  return '172.17.0.1';
+  // Fallback: bind to all interfaces when docker0 is unavailable
+  // (e.g. rootless Docker, custom networks). Less restrictive but avoids
+  // EADDRNOTAVAIL failures.
+  return '0.0.0.0';
 }
 
 class ShellTool implements Tool {


### PR DESCRIPTION
Address review feedback on PR #4713. When docker0 doesn't exist (rootless Docker, custom networks), fall back to 0.0.0.0 instead of 172.17.0.1 to avoid EADDRNOTAVAIL failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
