### PR TITLE
feat: detect merged-PR CI failures in check-reviews and swarm

### DIFF
--- a/.claude/commands/check-reviews-and-swarm.md
+++ b/.claude/commands/check-reviews-and-swarm.md
@@ -9,9 +9,9 @@ Parse positional arguments (these are passed through to `/swarm`):
 
 ## Phase 1: Check reviews
 
-Run the `/check-reviews` skill. Wait for it to complete and note how many "Address the feedback" items were added to `.private/TODO.md`.
+Run the `/check-reviews` skill. Wait for it to complete and note how many "Address the feedback" items and "Fix CI failures" items were added to `.private/TODO.md`.
 
-If no feedback items were added (all PRs were approved or still pending), report the results and stop — there's nothing to swarm on.
+If no items were added (all PRs were approved or still pending, and no CI failures on main), report the results and stop — there's nothing to swarm on.
 
 ## Phase 2: Swarm on feedback
 
@@ -23,5 +23,5 @@ After both phases complete, print a combined summary:
 
 | Phase         | Result                                      |
 | ------------- | ------------------------------------------- |
-| Check Reviews | _e.g., "3 PRs reviewed, 2 had feedback"_    |
-| Swarm         | _e.g., "2 feedback items addressed, 0 failed"_ |
+| Check Reviews | _e.g., "3 PRs reviewed, 2 had feedback, 1 CI failure on main"_ |
+| Swarm         | _e.g., "3 items addressed, 0 failed"_                          |

--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -95,4 +95,35 @@ Do NOT continue processing remaining PRs until the user responds.
 
 </instructions>
 
+## Phase 2: Check for merged PRs with CI failures
+
+After processing all items in UNREVIEWED_PRS.md, check for recently merged PRs where CI failed on the main branch.
+
+### How to detect CI failures
+
+Run: `gh run list --branch main --status failure --limit 10 --json databaseId,headSha,displayTitle,url,conclusion,createdAt,event`
+
+This returns failed workflow runs on main. For each failed run:
+
+1. **Find the associated PR**: Use `gh pr list --state merged --search "<headSha>" --json number,url,title,mergedAt --limit 1` or cross-reference the run's `displayTitle` / `headSha` with merged PRs. If you can't find a matching PR, use the run URL directly.
+2. **Skip if already in TODO**: Read .private/TODO.md and check if there's already a `Fix CI failures` entry for that PR or run. Don't add duplicates.
+3. **Add to TODO**: For each new CI failure, add `- Fix CI failures from merged PR <link to PR> (run: <link to failed run>)` to the **top** of .private/TODO.md (after any "Address the feedback" items, but before other tasks).
+
+### Output
+
+Append a second table to the output:
+
+**CI Failures on main:**
+
+| Run | PR | Title | Age | Added to TODO |
+| --- | --- | ----- | --- | ------------- |
+
+- **Run**: Link to the failed GitHub Actions run
+- **PR**: Link to the PR that introduced the failure (if identifiable), or "—"
+- **Title**: The run's display title
+- **Age**: How long ago the run was created
+- **Added to TODO**: ✅ if added, `dup` if already in TODO, — if skipped for other reasons
+
+If there are no CI failures on main, print: "No CI failures on main. ✅"
+
 IMPORTANT: .private/TODO.md and .private/UNREVIEWED_PRS.md are written to by other processes so make sure you read them before writing to them and after writing to them. Don't be alarmed if you see changes that you didn't make, but make sure your changes are persisted and you're not overwriting other changes. .private/TODO.md and .private/UNREVIEWED_PRS.md are gitignored.

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -83,6 +83,14 @@ For "Address the feedback on <PR URL>" tasks:
 - After creating the followup PR, leave a paper trail on the original PR:
   1. Comment on the original PR: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
   2. Resolve all bot review threads: `.claude/gh-review resolve-threads <original-PR-number> "Addressed in <new-PR-URL>"`
+
+For "Fix CI failures from merged PR <PR URL> (run: <run URL>)" tasks:
+- Open the failed run URL and read the logs to understand what failed.
+- Read the referenced PR's diff (`gh pr diff <number>`) to understand what changes were introduced.
+- Diagnose the root cause of the CI failure.
+- Implement the fix in your worktree (on a new branch — this will become a new PR).
+- Follow the same PR creation and merge workflow above.
+- In the new PR body, reference the original PR and the failed run.
 ```
 
 ## Phase 4: When an agent finishes


### PR DESCRIPTION
## Summary
- Adds a Phase 2 to `/check-reviews` that queries failed GitHub Actions runs on `main`, cross-references them with merged PRs, and adds "Fix CI failures" items to `TODO.md`
- Updates `/check-reviews-and-swarm` to trigger swarming on CI failure items alongside review feedback
- Adds swarm agent instructions for diagnosing and fixing CI failures from merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
