### PR TITLE
Fix hCaptcha detection: check all iframes

### DIFF
--- a/assistant/src/tools/browser/auth-detector.ts
+++ b/assistant/src/tools/browser/auth-detector.ts
@@ -241,10 +241,10 @@ const CAPTCHA_DETECT_EXPRESSION = `(() => {
   }
 
   // hCaptcha fallback — catch custom-rendered hCaptcha in arbitrary host elements
-  // by looking for a visible hCaptcha iframe directly
-  const hcaptchaIframe = document.querySelector('iframe[src*="hcaptcha"]');
-  if (hcaptchaIframe) {
-    const rect = hcaptchaIframe.getBoundingClientRect();
+  // by looking for any visible hCaptcha iframe (check all, not just the first)
+  const hcaptchaIframes = document.querySelectorAll('iframe[src*="hcaptcha"]');
+  for (const iframe of hcaptchaIframes) {
+    const rect = iframe.getBoundingClientRect();
     if (rect.width > 0 && rect.height > 0) return true;
   }
 


### PR DESCRIPTION
Address Codex P2 feedback from #4736: use querySelectorAll instead of querySelector for hCaptcha iframe fallback so pages with multiple iframes (first hidden, later visible) are correctly detected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
