### PR TITLE
fix: await turn commits and initialize git before first turn

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -96,6 +96,7 @@ import {
 import { unregisterSessionSender } from '../tools/browser/browser-screencast.js';
 import { projectSkillTools, resetSkillToolProjection } from './session-skill-tools.js';
 import { commitTurnChanges } from '../workspace/turn-commit.js';
+import { getWorkspaceGitService } from '../workspace/git-service.js';
 
 export interface SessionMemoryPolicy {
   scopeId: string;
@@ -640,6 +641,18 @@ export class Session {
     // from a prior successful run.
     this.lastAssistantAttachments = [];
     this.lastAttachmentWarnings = [];
+
+    // Ensure the workspace git repo is initialized before any tools run.
+    // This must happen before the first turn so the initial commit captures
+    // the pre-turn workspace state; otherwise ensureInitialized() would be
+    // triggered lazily by getStatus() inside commitTurnChanges(), absorbing
+    // the first turn's file changes into the initial commit.
+    try {
+      const gitService = getWorkspaceGitService(this.workingDir);
+      await gitService.ensureInitialized();
+    } catch (err) {
+      rlog.warn({ err }, 'Failed to initialize workspace git repo (non-fatal)');
+    }
 
     this.profiler.startRequest();
 
@@ -1214,10 +1227,11 @@ export class Session {
         sessionId: this.conversationId,
       });
 
-      // Turn-boundary commit: async, fire-and-forget so it never blocks the response.
-      // Increment turn counter and commit any workspace changes from this turn.
+      // Turn-boundary commit: awaited so it completes before the next turn starts.
+      // Without awaiting, the next turn could begin (via drainQueue in finally)
+      // and its file writes could be attributed to this turn's commit.
       this.turnCount++;
-      void commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
+      await commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
 
       // Resolve accumulated attachment directives and tool content blocks
       const attachmentResult = await resolveAssistantAttachments(

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -5,7 +5,8 @@
  * this module checks the workspace for uncommitted changes and creates a
  * single git commit capturing all file modifications from that turn.
  *
- * Commits are performed asynchronously so they do not block the turn response.
+ * Commits are awaited so they complete before the next turn starts,
+ * preventing cross-turn attribution of file changes.
  */
 
 import { getWorkspaceGitService } from './git-service.js';
@@ -70,8 +71,8 @@ function buildChangeSummary(files: string[]): string {
  * Checks the workspace for uncommitted changes. If any are found,
  * creates a single commit with structured metadata.
  *
- * This function is designed to be called fire-and-forget (void) so
- * it never blocks the turn response. All errors are caught and logged.
+ * This function should be awaited so it completes before the next turn
+ * starts. All errors are caught and logged to avoid disrupting the session.
  *
  * @param workspaceDir - Absolute path to the workspace directory
  * @param sessionId - Session/conversation identifier


### PR DESCRIPTION
Addresses review feedback on #4730: (1) Initialize workspace git repo during session setup so first-turn changes aren't absorbed by initial commit. (2) Await commitTurnChanges instead of fire-and-forget to prevent cross-turn attribution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
