### PR TITLE
fix: stop auto-closing threads panel when activity panel opens

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -242,9 +242,9 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = nil
                 }
 
-                // Close the left sidebar when the activity or document editor panel opens to avoid crowding
+                // Close the left sidebar when the document editor panel opens to avoid crowding
                 if case .panel(let panel) = newSelection,
-                   (panel == .activity || panel == .documentEditor),
+                   panel == .documentEditor,
                    sidebarOpen {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         sidebarOpen = false


### PR DESCRIPTION
## Summary
- Removed the activity panel from the auto-close trigger that closes the left sidebar (threads panel)
- The document editor panel still auto-closes the sidebar since it takes more horizontal space
- Opening the activity panel on the right no longer forces the threads panel on the left to collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
