### PR TITLE
fix: validate HEAD exists during init to handle partial git setup

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -161,11 +161,22 @@ export class WorkspaceGitService {
         }
 
         if (existsSync(gitDir)) {
-          // Repo is healthy
-          this.initialized = true;
-          return;
+          // .git exists and passed the corruption check, but we still
+          // need to verify that at least one commit exists. A partial
+          // init (e.g. git init succeeded but the initial commit failed)
+          // leaves .git present with an undefined HEAD. In that case,
+          // fall through to the initial commit logic below.
+          try {
+            await this.execGit(['rev-parse', 'HEAD']);
+            // HEAD resolves — repo is fully initialized
+            this.initialized = true;
+            return;
+          } catch {
+            // HEAD doesn't resolve — no commits yet.
+            // Fall through to create the initial commit.
+          }
         }
-        // Otherwise fall through to reinitialize
+        // Otherwise fall through to reinitialize / create initial commit
       }
 
       // Initialize new git repository


### PR DESCRIPTION
Addresses review feedback on #4724: When .git directory exists but has no commits (partial init from a previously failed attempt), create the initial commit instead of marking as initialized with undefined HEAD.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
