### PR TITLE
test: fix trust-store default rules assertion for ui_dismiss/ui_update

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -743,6 +743,8 @@ describe('Trust Store', () => {
         'host_file_write',
         'scaffold_managed_skill',
         'skill_load',
+        'ui_dismiss',
+        'ui_update',
       ]);
     });
 


### PR DESCRIPTION
## Summary
- Add `ui_dismiss` and `ui_update` to the expected default trust rules list in `trust-store.test.ts`
- These tools were added to default rules upstream but the test wasn't updated

## Test plan
- [x] `bun test src/__tests__/trust-store.test.ts` passes (149/149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
