### PR TITLE
fix: arm force-exit timer before awaiting heartbeat stop

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -414,16 +414,18 @@ export async function runDaemon(): Promise<void> {
     log.info('Shutting down daemon...');
 
     hookManager.stopWatching();
-    await heartbeat.stop();
 
     // Force exit if graceful shutdown takes too long.
-    // Set this BEFORE triggering daemon-stop hooks so it covers hook execution time.
+    // Set this BEFORE awaiting heartbeat stop and triggering daemon-stop hooks
+    // so it covers all potentially-blocking async shutdown work.
     const forceTimer = setTimeout(() => {
       log.warn('Graceful shutdown timed out, forcing exit');
       cleanupPidFile();
       process.exit(1);
     }, 10_000);
     forceTimer.unref();
+
+    await heartbeat.stop();
 
     try {
       await hookManager.trigger('daemon-stop', { pid: process.pid });


### PR DESCRIPTION
Addresses review feedback on #4748: Move the 10-second force-exit timer setup before await heartbeat.stop() so the timeout covers potentially-blocking heartbeat drain during shutdown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
