### PR TITLE
fix: prevent stale Docker cache from breaking sandbox image build

### DIFF
--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -104,18 +104,24 @@ function checkImageAvailable(image: string): void {
     if (existsSync(dockerfile)) {
       log.info(`Building sandbox image "${image}" from ${dockerfile}...`);
       try {
-        execFileSync('docker', ['build', '-t', image, '-f', dockerfile, '.'], {
-          stdio: 'ignore',
+        // --no-cache avoids stale apt-get layers with expired GPG signatures.
+        execFileSync('docker', ['build', '--no-cache', '-t', image, '-f', dockerfile, '.'], {
+          stdio: ['ignore', 'ignore', 'pipe'],
           timeout: 120000,
           cwd: resolve(dockerfile, '..'),
         });
         imageAvailableCache.add(image);
         return;
-      } catch {
+      } catch (err: unknown) {
+        const stderr = err instanceof Error && 'stderr' in err
+          ? String((err as { stderr: unknown }).stderr).trim()
+          : '';
+        const detail = stderr ? `\n\nBuild output:\n${stderr}` : '';
         throw new ToolError(
           `Failed to build sandbox image "${image}" from ${dockerfile}. ` +
           'Check Docker is running and try building manually: ' +
-          `docker build -t ${image} -f ${dockerfile} ${resolve(dockerfile, '..')}`,
+          `docker build --no-cache -t ${image} -f ${dockerfile} ${resolve(dockerfile, '..')}` +
+          detail,
           'bash',
         );
       }


### PR DESCRIPTION
## Summary
- Add `--no-cache` flag to sandbox image `docker build` to prevent stale apt-get layers with expired/corrupt GPG signatures from failing the build
- Capture stderr from failed builds and include it in the error message so users see the actual Docker error instead of a generic "check Docker is running" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
