### PR TITLE
fix: bind proxy to localhost instead of all interfaces when docker0 unavailable

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -36,10 +36,12 @@ function getDockerProxyHost(): string {
   } catch {
     // docker0 interface may not exist (e.g. rootless Docker, custom networks)
   }
-  // Fallback: bind to all interfaces when docker0 is unavailable
-  // (e.g. rootless Docker, custom networks). Less restrictive but avoids
-  // EADDRNOTAVAIL failures.
-  return '0.0.0.0';
+  // Fallback: bind to localhost when docker0 is unavailable (e.g. rootless
+  // Docker, custom networks). This avoids EADDRNOTAVAIL from 172.17.0.1 while
+  // keeping the proxy off public interfaces — 0.0.0.0 would expose the
+  // unauthenticated credential proxy to the network. Docker containers won't
+  // be able to reach localhost on the host, but that's a safer failure mode.
+  return '127.0.0.1';
 }
 
 class ShellTool implements Tool {


### PR DESCRIPTION
Address Codex feedback on PR #4742. The 0.0.0.0 fallback exposed the unauthenticated credential proxy on all network interfaces. Use 127.0.0.1 instead for a safer failure mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
