### PR TITLE
fix: handle query-template-only hosts in evaluateRequestWithApproval

### DIFF
--- a/assistant/src/tools/network/script-proxy/policy.ts
+++ b/assistant/src/tools/network/script-proxy/policy.ts
@@ -105,9 +105,13 @@ export function evaluateRequestWithApproval(
 
   const target: RequestTargetContext = { hostname, port, path, scheme };
 
-  // Check whether any template in the full registry covers this host.
+  // Check whether any non-query template in the full registry covers this
+  // host. Query templates are excluded for consistency with evaluateRequest
+  // — they're handled via URL rewriting in the MITM path and shouldn't
+  // cause a false ask_missing_credential on the HTTP forwarder path.
   const matchingPatterns: string[] = [];
   for (const tpl of allKnownTemplates) {
+    if (tpl.injectionType === 'query') continue;
     if (minimatch(hostname, tpl.hostPattern, { nocase: true })) {
       matchingPatterns.push(tpl.hostPattern);
     }


### PR DESCRIPTION
Address Codex feedback on PR #4741. Query-template-only hosts were getting a false ask_missing_credential decision in the non-MITM path because evaluateRequest now returns missing for query templates. Fix evaluateRequestWithApproval to handle this case gracefully by also filtering out query templates when scanning allKnownTemplates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
