### PR TITLE
fix: resolve Dockerfile.sandbox in compiled builds and improve error messages

### DIFF
--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, realpathSync } from 'node:fs';
-import { resolve, relative, posix } from 'node:path';
+import { dirname, resolve, relative, posix } from 'node:path';
 import { ToolError } from '../../../util/errors.js';
 import { getLogger } from '../../../util/logger.js';
 import type { DockerConfig } from '../../../config/types.js';
@@ -81,10 +81,22 @@ function checkDockerDaemon(): void {
 /**
  * Resolve the path to Dockerfile.sandbox relative to this source file.
  * Works in both development (source layout) and bundled environments.
+ *
+ * In compiled Bun binaries, import.meta.dirname resolves into the virtual
+ * $bunfs filesystem, so the Dockerfile won't exist there. Fall back to
+ * looking next to the compiled binary (process.execPath) in that case.
  */
 function getSandboxDockerfilePath(): string {
   const dir = import.meta.dirname ?? __dirname;
-  return resolve(dir, '../../../../Dockerfile.sandbox');
+  const sourcePath = resolve(dir, '../../../../Dockerfile.sandbox');
+
+  // In compiled Bun binaries, dir points into /$bunfs/ which is virtual.
+  // Fall back to looking next to the compiled binary itself.
+  if (!existsSync(sourcePath) && dir.startsWith('/$bunfs/')) {
+    return resolve(dirname(process.execPath), 'Dockerfile.sandbox');
+  }
+
+  return sourcePath;
 }
 
 function checkImageAvailable(image: string): void {
@@ -126,6 +138,16 @@ function checkImageAvailable(image: string): void {
         );
       }
     }
+
+    // Dockerfile not found — can't build the local-only image and pulling won't work.
+    throw new ToolError(
+      `Cannot find Dockerfile.sandbox to build "${image}". ` +
+      'This image is built locally and is not available from a registry. ' +
+      'If you have the Vellum source tree, build it manually:\n' +
+      '  docker build --no-cache -t vellum-sandbox:latest -f Dockerfile.sandbox .\n' +
+      'Or set sandbox.docker.image to a different image in your config.',
+      'bash',
+    );
   }
 
   log.info(`Docker image "${image}" not found locally, pulling...`);

--- a/assistant/src/tools/terminal/sandbox-diagnostics.ts
+++ b/assistant/src/tools/terminal/sandbox-diagnostics.ts
@@ -2,6 +2,7 @@ import { execSync, execFileSync } from 'node:child_process';
 import { isMacOS, isLinux, getSandboxWorkingDir } from '../../util/platform.js';
 import { getConfig } from '../../config/loader.js';
 import type { SandboxConfig } from '../../config/schema.js';
+import { DEFAULT_SANDBOX_IMAGE } from './backends/docker.js';
 
 export interface SandboxCheckResult {
   label: string;
@@ -43,7 +44,11 @@ function checkDockerImage(image: string): SandboxCheckResult {
     execFileSync('docker', ['image', 'inspect', image], { stdio: 'pipe', timeout: 10000 });
     return { label: `Docker image available (${image})`, ok: true };
   } catch {
-    return { label: `Docker image available (${image})`, ok: false, detail: `pull with: docker pull ${image}` };
+    // The default sandbox image is built locally from Dockerfile.sandbox — docker pull won't work.
+    const remediation = image === DEFAULT_SANDBOX_IMAGE
+      ? 'build with: docker build --no-cache -t vellum-sandbox:latest -f Dockerfile.sandbox .'
+      : `pull with: docker pull ${image}`;
+    return { label: `Docker image available (${image})`, ok: false, detail: remediation };
   }
 }
 


### PR DESCRIPTION
Address Codex and Devin feedback on PR #4745. Fixes: (1) handle compiled Bun binary path resolution for Dockerfile.sandbox, (2) update sandbox diagnostics to suggest docker build instead of docker pull for vellum-sandbox:latest, (3) throw actionable error instead of falling through to impossible docker pull.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
