### PR TITLE
fix: add transient error handling to rev-parse HEAD check

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -171,9 +171,28 @@ export class WorkspaceGitService {
             // HEAD resolves — repo is fully initialized
             this.initialized = true;
             return;
-          } catch {
-            // HEAD doesn't resolve — no commits yet.
-            // Fall through to create the initial commit.
+          } catch (err: unknown) {
+            // Distinguish transient failures from genuine "no commits".
+            // Transient errors (timeouts, permissions, missing git binary)
+            // should NOT fall through to re-initialization — they will
+            // resolve on retry via the initPromise clearing logic.
+            const errMsg = err instanceof Error ? err.message : String(err);
+            const errAny = err as any;
+            const isTimeout = errAny.killed === true
+              || errAny.signal === 'SIGTERM'
+              || errMsg.includes('SIGTERM')
+              || errMsg.includes('timed out');
+            const isPermission = errAny.code === 'EACCES'
+              || errMsg.includes('EACCES')
+              || errMsg.toLowerCase().includes('permission denied');
+            const isMissingBinary = errAny.code === 'ENOENT'
+              || errMsg.includes('ENOENT');
+
+            if (isTimeout || isPermission || isMissingBinary) {
+              throw err;
+            }
+            // Genuine "no commits" (unborn HEAD) — fall through to
+            // create the initial commit.
           }
         }
         // Otherwise fall through to reinitialize / create initial commit


### PR DESCRIPTION
Addresses review feedback on #4751: Mirror the transient-error detection pattern from rev-parse --git-dir in the rev-parse HEAD catch block. Re-throw timeout, permission, and missing-binary errors instead of falling through to re-initialization.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
