### PR TITLE
fix: stop global hotkey from stealing keyboard shortcuts from other apps

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -26,7 +26,6 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/soffes/HotKey", from: "0.2.1"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
     ],
     targets: [
@@ -46,7 +45,7 @@ let package = Package(
         // iOS apps should depend only on VellumAssistantShared, not this target.
         .target(
             name: "VellumAssistantLib",
-            dependencies: ["VellumAssistantShared", "HotKey", "Sparkle"],
+            dependencies: ["VellumAssistantShared", "Sparkle"],
             path: "macos/vellum-assistant",
             exclude: ["Resources/Info.plist", "Resources/bg.png"],
             resources: [

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2,7 +2,6 @@ import AppKit
 import VellumAssistantShared
 import Combine
 import CoreText
-import HotKey
 import SwiftUI
 import UserNotifications
 import os
@@ -74,7 +73,7 @@ enum InteractionType {
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
-    private var hotKey: HotKey?
+    private var hotKeyMonitor: Any?
     private var escapeMonitor: Any?
     var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
@@ -259,7 +258,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             settingsWindow?.close()
             settingsWindow = nil
 
-            hotKey = nil
+            if let hotKeyMonitor {
+                NSEvent.removeMonitor(hotKeyMonitor)
+                self.hotKeyMonitor = nil
+            }
             if let escapeMonitor {
                 NSEvent.removeMonitor(escapeMonitor)
                 self.escapeMonitor = nil
@@ -674,9 +676,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Hotkey
 
     private func setupHotKey() {
-        hotKey = HotKey(key: .g, modifiers: [.command, .shift])
-        hotKey?.keyDownHandler = { [weak self] in
-            self?.showMainWindow()
+        // Use NSEvent global monitor instead of Carbon RegisterEventHotKey (HotKey package).
+        // Carbon hotkeys consume the event globally, preventing other apps from seeing the
+        // keystroke. NSEvent.addGlobalMonitorForEvents observes without consuming, so Cmd+Shift+G
+        // still reaches the frontmost app.
+        hotKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
+                  event.charactersIgnoringModifiers == "g" else { return }
+            Task { @MainActor in
+                self?.showMainWindow()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaced the `HotKey` Swift package (Carbon-based `RegisterEventHotKey`) with `NSEvent.addGlobalMonitorForEvents` for the Cmd+Shift+G show-window hotkey
- Carbon hotkeys consume keyboard events globally, preventing other apps from ever seeing the keystroke. `NSEvent.addGlobalMonitorForEvents` observes without consuming, so the shortcut now passes through to the frontmost app
- Removed the `HotKey` package dependency from `Package.swift` entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
