### PR TITLE
fix: show full command text when expanding activity panel entries

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -134,6 +134,22 @@ struct ActivityStepView: View {
             // Expanded details
             if isExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    // Full command / input
+                    if !toolCall.inputSummary.isEmpty {
+                        Text(toolCall.inputSummary)
+                            .font(VFont.monoSmall)
+                            .foregroundColor(VColor.textSecondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(VSpacing.sm)
+                            .background(VColor.background.opacity(0.6))
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                    .stroke(VColor.surfaceBorder, lineWidth: 0.5)
+                            )
+                    }
+
                     // Screenshot
                     if let cachedImage = toolCall.cachedImage {
                         Image(nsImage: cachedImage)
@@ -195,7 +211,7 @@ struct ActivityStepView: View {
     }
 
     private var hasExpandableContent: Bool {
-        (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true)) || toolCall.cachedImage != nil
+        !toolCall.inputSummary.isEmpty || (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true)) || toolCall.cachedImage != nil
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {


### PR DESCRIPTION
## Summary
- Added full `inputSummary` display in the expanded details section of activity entries, styled consistently with the result block (monospace, selectable, bordered)
- Updated `hasExpandableContent` to include entries with non-empty `inputSummary`, so even entries without a result can be expanded to reveal the full command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
