### PR TITLE
fix: use case-insensitive hotkey comparison and clean up monitor on terminate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -682,7 +682,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // still reaches the frontmost app.
         hotKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
-                  event.charactersIgnoringModifiers == "g" else { return }
+                  event.charactersIgnoringModifiers?.lowercased() == "g" else { return }
             Task { @MainActor in
                 self?.showMainWindow()
             }
@@ -1041,6 +1041,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Application Lifecycle
 
     public func applicationWillTerminate(_ notification: Notification) {
+        if let monitor = hotKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
         }


### PR DESCRIPTION
Address Codex and Devin feedback on PR #4759. Uses .lowercased() for hotkey character comparison so Cmd+Shift+G actually fires, and adds hotKeyMonitor cleanup in applicationWillTerminate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
