### PR TITLE
fix: correct Dockerfile path in build hint and update test assertion

### DIFF
--- a/assistant/src/__tests__/sandbox-diagnostics.test.ts
+++ b/assistant/src/__tests__/sandbox-diagnostics.test.ts
@@ -287,7 +287,7 @@ describe('runSandboxDiagnostics — Docker image check', () => {
     const imageCheck = result.checks.find((c) => c.label.includes('Docker image available'));
     expect(imageCheck).toBeDefined();
     expect(imageCheck!.ok).toBe(false);
-    expect(imageCheck!.detail).toContain('docker pull');
+    expect(imageCheck!.detail).toContain('docker build');
   });
 
   test('includes configured image name in label', () => {

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -144,7 +144,7 @@ function checkImageAvailable(image: string): void {
       `Cannot find Dockerfile.sandbox to build "${image}". ` +
       'This image is built locally and is not available from a registry. ' +
       'If you have the Vellum source tree, build it manually:\n' +
-      '  docker build --no-cache -t vellum-sandbox:latest -f Dockerfile.sandbox .\n' +
+      '  docker build --no-cache -t vellum-sandbox:latest -f assistant/Dockerfile.sandbox assistant\n' +
       'Or set sandbox.docker.image to a different image in your config.',
       'bash',
     );

--- a/assistant/src/tools/terminal/sandbox-diagnostics.ts
+++ b/assistant/src/tools/terminal/sandbox-diagnostics.ts
@@ -46,7 +46,7 @@ function checkDockerImage(image: string): SandboxCheckResult {
   } catch {
     // The default sandbox image is built locally from Dockerfile.sandbox — docker pull won't work.
     const remediation = image === DEFAULT_SANDBOX_IMAGE
-      ? 'build with: docker build --no-cache -t vellum-sandbox:latest -f Dockerfile.sandbox .'
+      ? 'build with: docker build --no-cache -t vellum-sandbox:latest -f assistant/Dockerfile.sandbox assistant'
       : `pull with: docker pull ${image}`;
     return { label: `Docker image available (${image})`, ok: false, detail: remediation };
   }


### PR DESCRIPTION
Address Codex and Devin feedback on PR #4757. Fixes repo-relative Dockerfile path in docker build hint and updates sandbox diagnostics test to expect docker build instead of docker pull for the default image.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
