### PR TITLE
fix: show full untruncated command in expanded activity panel entries

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ActivityPanel.swift
@@ -134,9 +134,9 @@ struct ActivityStepView: View {
             // Expanded details
             if isExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    // Full command / input
-                    if !toolCall.inputSummary.isEmpty {
-                        Text(toolCall.inputSummary)
+                    // Full command / input (untruncated)
+                    if !toolCall.inputFull.isEmpty {
+                        Text(toolCall.inputFull)
                             .font(VFont.monoSmall)
                             .foregroundColor(VColor.textSecondary)
                             .textSelection(.enabled)

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -315,6 +315,8 @@ public struct ToolCallData: Identifiable, Equatable {
     public let id: UUID
     public let toolName: String
     public let inputSummary: String
+    /// Full (untruncated) input text for display in expanded views.
+    public let inputFull: String
     public var result: String?
     public var isError: Bool
     public var isComplete: Bool
@@ -348,10 +350,11 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.buildingStatus == rhs.buildingStatus
     }
 
-    public init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
+        self.inputFull = inputFull ?? inputSummary
         self.result = result
         self.isError = isError
         self.isComplete = isComplete

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -32,8 +32,8 @@ extension ChatViewModel {
         "command", "file_path", "path", "query", "url", "pattern", "glob"
     ]
 
-    /// Summarize tool input for display, picking the most relevant value truncated to 80 chars.
-    func summarizeToolInput(_ input: [String: AnyCodable]) -> String {
+    /// Extract the most relevant tool input value as a full string (no truncation).
+    func extractToolInput(_ input: [String: AnyCodable]) -> String {
         // Pick the first matching priority key, falling back to the first sorted key.
         let value: AnyCodable
         if let match = Self.toolInputPriorityKeys.first(where: { input[$0] != nil }),
@@ -44,15 +44,19 @@ extension ChatViewModel {
         } else {
             return ""
         }
-        let str: String
         if let s = value.value as? String {
-            str = s
+            return s
         } else if let encoder = try? JSONEncoder().encode(value),
                   let json = String(data: encoder, encoding: .utf8) {
-            str = json
+            return json
         } else {
-            str = String(describing: value.value ?? "")
+            return String(describing: value.value ?? "")
         }
+    }
+
+    /// Summarize tool input for display, picking the most relevant value truncated to 80 chars.
+    func summarizeToolInput(_ input: [String: AnyCodable]) -> String {
+        let str = extractToolInput(input)
         return str.count > 80 ? String(str.prefix(77)) + "..." : str
     }
 
@@ -641,6 +645,7 @@ extension ChatViewModel {
             var toolCall = ToolCallData(
                 toolName: toolDisplayName(msg.toolName),
                 inputSummary: summarizeToolInput(msg.input),
+                inputFull: extractToolInput(msg.input),
                 arrivedBeforeText: !currentAssistantHasText,
                 startedAt: Date()
             )

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1003,6 +1003,7 @@ public final class ChatViewModel: ObservableObject {
                     ToolCallData(
                         toolName: toolDisplayName(tc.name),
                         inputSummary: summarizeToolInput(tc.input),
+                        inputFull: extractToolInput(tc.input),
                         result: tc.result,
                         isError: tc.isError ?? false,
                         isComplete: true,


### PR DESCRIPTION
## Summary
- Added `inputFull` field to `ToolCallData` to store the full (untruncated) tool input text
- Extracted `extractToolInput()` from `summarizeToolInput()` so both truncated and full values can be produced from the same logic
- Updated the expanded activity panel view to display `inputFull` instead of the 80-char truncated `inputSummary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
