### PR TITLE
feat: default app panel width to 70% of available space

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -35,6 +35,7 @@ struct MainWindowView: View {
     @State private var systemIsDark: Bool = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     @AppStorage("threadDrawerWidth") private var threadDrawerWidth: Double = 240
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
+    @AppStorage("appPanelWidth") private var appPanelWidth: Double = -1
     @AppStorage("homeBaseDashboardDefaultEnabled") private var homeBaseDashboardDefaultEnabled: Bool = false
     @AppStorage("homeBaseDashboardAutoEnabled") private var homeBaseDashboardAutoEnabled: Bool = false
     @State private var drawerDragStartWidth: Double?
@@ -1108,8 +1109,12 @@ struct MainWindowView: View {
             // VSplitView: ChatView (left) + workspace (right)
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
+                let effectiveWidth = Binding<Double>(
+                    get: { appPanelWidth > 0 ? appPanelWidth : geometry.size.width * 0.7 },
+                    set: { appPanelWidth = $0 }
+                )
                 VSplitView(
-                    panelWidth: $sidePanelWidth,
+                    panelWidth: effectiveWidth,
                     showPanel: true,
                     main: {
                         chatView


### PR DESCRIPTION
## Summary
- Apps (including Home Base) now default to 70% of the window width when shown with chat docked, instead of the fixed 400pt side panel width
- Uses a separate `appPanelWidth` AppStorage so dragging to resize persists independently from regular side panels
- Falls back to 70% of geometry width until the user manually resizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
