### PR TITLE
fix: compute app panel default width from content area, not full window

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1109,8 +1109,12 @@ struct MainWindowView: View {
             // VSplitView: ChatView (left) + workspace (right)
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
+                // Compute content area width accounting for sidebar, divider, padding, and zoom
+                let sidebarVisible = sidebarOpen && windowState.layoutConfig.left.visible
+                let sidebarW = sidebarVisible ? threadDrawerWidth + Double(VSpacing.xs) : 0
+                let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - sidebarW - Double(VSpacing.sm)
                 let effectiveWidth = Binding<Double>(
-                    get: { appPanelWidth > 0 ? appPanelWidth : geometry.size.width * 0.7 },
+                    get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
                     set: { appPanelWidth = $0 }
                 )
                 VSplitView(


### PR DESCRIPTION
## Summary
- Fix app panel default width calculation to account for sidebar, divider, padding, and zoom level
- Previously used `geometry.size.width * 0.7` which is the full window width
- Now computes the actual content area width by subtracting sidebar width, divider, leading padding, and dividing by zoom level

Addresses feedback on #4765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
