### PR TITLE
Add copy-to-clipboard icon to assistant responses

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1041,9 +1041,7 @@ private struct ChatBubble: View {
                         .foregroundColor(VColor.textMuted)
                 }
 
-                if isUser {
-                    copyButton
-                }
+                copyButton
             }
             // Prevent LazyVStack from compressing the bubble height, which causes the
             // trailing tool-chip to overlap long text content.
@@ -1083,11 +1081,7 @@ private struct ChatBubble: View {
         }
         .contentShape(Rectangle())
         .onHover { hovering in
-            if canReportMessage || isUser {
-                isHovered = hovering
-            } else if isHovered {
-                isHovered = false
-            }
+            isHovered = hovering
         }
         .task(id: mediaEmbedTaskID) {
             guard let settings = mediaEmbedSettings else {


### PR DESCRIPTION
## Summary
- Show the existing copy icon on assistant message bubbles (previously only on user messages)
- Enable hover tracking on all messages so the icon appears on hover
- Reuses the existing `copyButton` view with tooltip and checkmark confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
