### PR TITLE
fix: credential proxy injection for curl and trim secret prompt input

### DIFF
--- a/assistant/src/tools/network/script-proxy/certs.ts
+++ b/assistant/src/tools/network/script-proxy/certs.ts
@@ -4,7 +4,16 @@ import { X509Certificate } from 'node:crypto';
 
 const CA_CERT_FILENAME = 'ca.pem';
 const CA_KEY_FILENAME = 'ca-key.pem';
+const COMBINED_CA_FILENAME = 'combined-ca-bundle.pem';
 const ISSUED_DIR = 'issued';
+
+/** Well-known system CA bundle paths by platform. */
+const SYSTEM_CA_PATHS = [
+  '/etc/ssl/cert.pem',                       // macOS
+  '/etc/ssl/certs/ca-certificates.crt',      // Debian/Ubuntu
+  '/etc/pki/tls/certs/ca-bundle.crt',        // RHEL/CentOS/Fedora
+  '/etc/ssl/ca-bundle.pem',                  // openSUSE
+];
 
 // Only allow valid hostname characters: alphanumeric, hyphens, dots, and wildcards
 const HOSTNAME_RE = /^[a-zA-Z0-9.*-]+$/;
@@ -158,6 +167,66 @@ export async function issueLeafCert(
     readFile(leafKeyPath, 'utf-8'),
   ]);
   return { cert, key };
+}
+
+/**
+ * Create a combined CA bundle that includes both system root CAs and the
+ * proxy CA cert. This is needed for non-Node clients (curl, Python, Go)
+ * that don't honor NODE_EXTRA_CA_CERTS — they use SSL_CERT_FILE instead,
+ * which replaces (rather than supplements) the default CA bundle.
+ *
+ * Idempotent: skips regeneration if the combined bundle is newer than
+ * both the system bundle and the proxy CA cert.
+ */
+export async function ensureCombinedCABundle(dataDir: string): Promise<string | null> {
+  const caDir = join(dataDir, 'proxy-ca');
+  const caCertPath = join(caDir, CA_CERT_FILENAME);
+  const combinedPath = join(caDir, COMBINED_CA_FILENAME);
+
+  // Find the system CA bundle
+  let systemBundlePath: string | null = null;
+  for (const p of SYSTEM_CA_PATHS) {
+    try {
+      await stat(p);
+      systemBundlePath = p;
+      break;
+    } catch {
+      // not found, try next
+    }
+  }
+  if (!systemBundlePath) return null;
+
+  // Check if combined bundle already exists and is newer than both sources
+  try {
+    const [combinedSt, caSt, systemSt] = await Promise.all([
+      stat(combinedPath),
+      stat(caCertPath),
+      stat(systemBundlePath),
+    ]);
+    if (combinedSt.mtimeMs > caSt.mtimeMs && combinedSt.mtimeMs > systemSt.mtimeMs) {
+      return combinedPath;
+    }
+  } catch {
+    // One or more files missing — fall through to create
+  }
+
+  try {
+    const [systemCAs, proxyCACert] = await Promise.all([
+      readFile(systemBundlePath, 'utf-8'),
+      readFile(caCertPath, 'utf-8'),
+    ]);
+    await writeFile(combinedPath, systemCAs + '\n' + proxyCACert);
+    return combinedPath;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the path to the combined CA bundle for use as SSL_CERT_FILE.
+ */
+export function getCombinedCAPath(dataDir: string): string {
+  return join(dataDir, 'proxy-ca', COMBINED_CA_FILENAME);
 }
 
 /**

--- a/assistant/src/tools/network/script-proxy/index.ts
+++ b/assistant/src/tools/network/script-proxy/index.ts
@@ -21,6 +21,8 @@ export {
 
 export {
   ensureLocalCA,
+  ensureCombinedCABundle,
   issueLeafCert,
   getCAPath,
+  getCombinedCAPath,
 } from './certs.js';

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -13,7 +13,7 @@ import type {
 } from './types.js';
 import type { PolicyCallback } from './http-forwarder.js';
 import { evaluateRequestWithApproval } from './policy.js';
-import { getCAPath, ensureLocalCA } from './certs.js';
+import { getCAPath, getCombinedCAPath, ensureLocalCA, ensureCombinedCABundle } from './certs.js';
 import { minimatch } from 'minimatch';
 import { resolveById } from '../../credentials/resolve.js';
 import { listCredentialMetadata } from '../../credentials/metadata-store.js';
@@ -149,17 +149,14 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
       // per-conversation limit.
       try {
         await ensureLocalCA(managed.dataDir);
+        // Build a combined CA bundle (system roots + proxy CA) so
+        // non-Node clients like curl, Python, and Go trust the proxy's
+        // leaf certs via SSL_CERT_FILE (see getSessionEnv).
+        await ensureCombinedCABundle(managed.dataDir);
       } catch (err) {
         sessions.delete(sessionId);
         throw err;
       }
-
-      // MITM interception relies on NODE_EXTRA_CA_CERTS to make the
-      // generated CA trusted by child processes. This only works for
-      // Node/Bun runtimes — non-Node clients (curl, Python, Go) will
-      // reject the proxy's TLS certificates. For now, MITM is only
-      // enabled when credential injection templates require it, and the
-      // primary use case is Node/Bun subprocesses launched by the agent.
       config.mitmHandler = {
         caDir,
         shouldIntercept: (hostname: string, port: number) =>
@@ -373,6 +370,9 @@ export function getSessionEnv(
 
   if (managed.dataDir) {
     env.NODE_EXTRA_CA_CERTS = getCAPath(managed.dataDir);
+    // Combined bundle lets non-Node clients (curl, Python, Go) trust
+    // the proxy CA alongside system roots via SSL_CERT_FILE.
+    env.SSL_CERT_FILE = getCombinedCAPath(managed.dataDir);
   }
 
   return env;

--- a/assistant/src/tools/network/script-proxy/types.ts
+++ b/assistant/src/tools/network/script-proxy/types.ts
@@ -25,6 +25,8 @@ export interface ProxyEnvVars {
   HTTPS_PROXY: string;
   NO_PROXY: string;
   NODE_EXTRA_CA_CERTS?: string;
+  /** Combined CA bundle (system roots + proxy CA) for non-Node TLS clients (curl, Python, etc.). */
+  SSL_CERT_FILE?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -221,8 +221,9 @@ struct SecretPromptView: View {
                             onCancel()
                         }
                         VButton(label: "Save", style: .primary) {
-                            guard !secretValue.isEmpty else { return }
-                            if onSave(secretValue) {
+                            let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            if onSave(trimmed) {
                                 withAnimation(VAnimation.standard) { saved = true }
                             }
                         }
@@ -235,8 +236,9 @@ struct SecretPromptView: View {
                                 .font(.system(size: 10))
                                 .foregroundColor(VColor.warning)
                             VButton(label: "Send Once (not saved)", style: .ghost) {
-                                guard !secretValue.isEmpty else { return }
-                                _ = onSendOnce(secretValue)
+                                let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                guard !trimmed.isEmpty else { return }
+                                _ = onSendOnce(trimmed)
                             }
                             .disabled(secretValue.isEmpty)
                         }


### PR DESCRIPTION
## Summary
- **Combined CA bundle**: `ensureCombinedCABundle()` creates a PEM file merging system root CAs with the proxy CA, exported as `SSL_CERT_FILE` so curl/Python/Go trust MITM leaf certs (previously only `NODE_EXTRA_CA_CERTS` was set, which only Node/Bun honor)
- **Secret prompt trimming**: `SecretPromptManager.swift` now trims whitespace and newlines from pasted secrets before saving, preventing macOS Keychain from hex-encoding values with trailing `\n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
