### PR TITLE
Update tool descriptions for task/queue intent routing

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -109,6 +109,7 @@ export function buildSystemPrompt(): string {
   }
   parts.push(buildConfigSection());
   parts.push(buildToolRoutingSection());
+  parts.push(buildTaskScheduleReminderRoutingSection());
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
   parts.push(buildActionableUiSection());
@@ -189,6 +190,37 @@ function buildToolRoutingSection(): string {
     '- "Make a countdown timer" → `app_create` (interactive, dynamic)',
     '',
     '**All three tools are equally important — use the right one for the task.**',
+  ].join('\n');
+}
+
+function buildTaskScheduleReminderRoutingSection(): string {
+  return [
+    '## Tool Routing: Tasks vs Schedules vs Reminders',
+    '',
+    'These three systems serve different purposes. Choose the right one based on user intent:',
+    '',
+    '### Task Queue (work_item_enqueue / work_item_list)',
+    'For tracking things the user wants to do or remember. Use when the user says:',
+    '- "Add to my tasks", "add to my queue", "put this on my task list"',
+    '- "Track this", "I need to do X", "queue this up"',
+    '- Any request to add a one-off item to their personal to-do list',
+    '',
+    '### Schedules (schedule_create / schedule_list / schedule_update / schedule_delete)',
+    'For recurring automated jobs that run on a cron schedule. Use ONLY when the user explicitly wants:',
+    '- Recurring automation: "every day at 9am", "weekly on Mondays", "every hour"',
+    '- Periodic background tasks: "check my email every morning", "run this report weekly"',
+    '',
+    '### Reminders (reminder)',
+    'For one-time time-triggered notifications. Use ONLY when the user wants:',
+    '- A notification at a specific future time: "remind me at 3pm", "remind me in 2 hours"',
+    '- A timed alert, not a tracked task',
+    '',
+    '### Common mistakes to avoid',
+    '- "Add this to my tasks" → work_item_enqueue (NOT schedule_create or reminder)',
+    '- "What\'s on my task list?" → work_item_list (NOT schedule_list)',
+    '- "Remind me to buy groceries" without a time → work_item_enqueue (it\'s a task, not a timed reminder)',
+    '- "Remind me at 5pm to buy groceries" → reminder (explicit time trigger)',
+    '- "Check my inbox every morning at 8am" → schedule_create (recurring automation)',
   ].join('\n');
 }
 

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -102,7 +102,7 @@ function cancelAction(input: Record<string, unknown>): ToolExecutionResult {
 
 class ReminderTool implements Tool {
   name = 'reminder';
-  description = 'Create, list, or cancel one-time reminders. Reminders fire at a specific time and either notify the user or execute a message through the assistant.';
+  description = 'Create, list, or cancel one-time time-based reminders. Reminders fire at a specific future time and either notify the user or execute a message through the assistant. Use this ONLY when the user wants a time-triggered notification (e.g. "remind me at 3pm", "remind me in 2 hours"). Do NOT use this for "add to my tasks" or "add to my queue" — use work_item_enqueue for those requests.';
   category = 'reminder';
   defaultRiskLevel = RiskLevel.Low;
 

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -6,7 +6,7 @@ import { createSchedule, isValidCronExpression, formatLocalDate, describeCronExp
 
 class ScheduleCreateTool implements Tool {
   name = 'schedule_create';
-  description = 'Create a scheduled task that sends a message at a recurring interval';
+  description = 'Create a recurring scheduled automation that sends a message at a cron interval. ONLY use this when the user explicitly wants something to run on a schedule (e.g. "every day at 9am", "weekly on Mondays", "every hour"). Do NOT use this for "add to my tasks" or "add to my queue" — use work_item_enqueue for those requests instead.';
   category = 'schedule';
   defaultRiskLevel = RiskLevel.Medium;
 

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -6,7 +6,7 @@ import { deleteSchedule, getSchedule } from '../../schedule/schedule-store.js';
 
 class ScheduleDeleteTool implements Tool {
   name = 'schedule_delete';
-  description = 'Delete a scheduled task and all its run history';
+  description = 'Delete a recurring scheduled automation and all its run history';
   category = 'schedule';
   defaultRiskLevel = RiskLevel.High;
 

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -6,7 +6,7 @@ import { listSchedules, getSchedule, getScheduleRuns, formatLocalDate, describeC
 
 class ScheduleListTool implements Tool {
   name = 'schedule_list';
-  description = 'List scheduled tasks, or show details and recent runs for a specific task';
+  description = 'List recurring scheduled automations (cron jobs), or show details and recent runs for a specific one. For the user\'s task queue, use work_item_list instead.';
   category = 'schedule';
   defaultRiskLevel = RiskLevel.Low;
 

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -6,7 +6,7 @@ import { updateSchedule, formatLocalDate, describeCronExpression } from '../../s
 
 class ScheduleUpdateTool implements Tool {
   name = 'schedule_update';
-  description = 'Update an existing scheduled task (schedule, message, name, or enabled state)';
+  description = 'Update an existing recurring scheduled automation (cron expression, message, name, or enabled state)';
   category = 'schedule';
   defaultRiskLevel = RiskLevel.Medium;
 

--- a/assistant/src/tools/tasks/task-save.ts
+++ b/assistant/src/tools/tasks/task-save.ts
@@ -6,7 +6,7 @@ import { compileTaskFromConversation, saveCompiledTask } from '../../tasks/task-
 const definition: ToolDefinition = {
   name: 'task_save',
   description:
-    'Save the current conversation as a task template. Extracts the conversation pattern into a reusable definition with placeholders that can be run later with different inputs to create Tasks (work items).',
+    'Save the current conversation as a reusable task template (definition). This is NOT for adding items to the user\'s task queue — use work_item_enqueue for that. task_save extracts the conversation pattern into a reusable definition with placeholders that can be run later with different inputs.',
   input_schema: {
     type: 'object',
     properties: {

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -14,7 +14,7 @@ const PRIORITY_LABELS: Record<number, string> = {
 const definition: ToolDefinition = {
   name: 'work_item_enqueue',
   description:
-    'Add a task to the Task Queue. Creates a work item from a task definition (template) by name or ID.',
+    'Add a task to the user\'s Task Queue. Use this when the user says "add to my tasks", "add to my queue", "put this on my task list", "track this task", or any variation of adding a one-off item they want to remember or work on. This creates a work item from a task definition (template) by name or ID. Do NOT use schedule_create or reminder for simple "add to tasks" requests — those are for timed/recurring automation only.',
   input_schema: {
     type: 'object',
     properties: {

--- a/assistant/src/tools/tasks/work-item-list.ts
+++ b/assistant/src/tools/tasks/work-item-list.ts
@@ -12,7 +12,7 @@ const PRIORITY_LABELS: Record<number, string> = {
 
 const definition: ToolDefinition = {
   name: 'work_item_list',
-  description: 'List all Tasks (work items) with their status, priority, and last run info.',
+  description: 'List the user\'s Task Queue (work items) with their status, priority, and last run info. Use this when the user says "show my tasks", "what\'s in my queue", "what\'s on my task list", or similar.',
   input_schema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

- Updated tool descriptions across 8 files to make intent routing between Tasks, Schedules, and Reminders unambiguous
- `work_item_enqueue` and `work_item_list` now explicitly list the natural-language phrases they handle ("add to my tasks", "what's in my queue", etc.)
- `schedule_create`, `schedule_list`, `schedule_update`, `schedule_delete` descriptions now say "recurring scheduled automation" instead of "scheduled task" to avoid confusion with task queue items, and include explicit "do NOT use for add to tasks" guidance
- `reminder` tool description clarifies it's only for time-triggered notifications, not task tracking
- `task_save` description clarifies it saves reusable templates, not individual queue items
- Added a new "Tool Routing: Tasks vs Schedules vs Reminders" section to the system prompt with decision rules and common-mistake examples

## Why

The model was misrouting "add to my tasks" / "add to my queue" requests to `schedule_create` or the reminder tool instead of `work_item_enqueue`. This was caused by ambiguous tool descriptions (e.g. schedule_create said "Create a scheduled task") and no system-prompt guidance distinguishing the three systems.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [ ] Verify in conversation that "add this to my tasks" triggers `work_item_enqueue`
- [ ] Verify "remind me at 3pm" still triggers `reminder`
- [ ] Verify "check my email every morning at 8am" still triggers `schedule_create`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
