### PR TITLE
feat: support ad-hoc work items in work_item_enqueue

### DIFF
--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -469,11 +469,53 @@ describe('work_item_enqueue tool', () => {
     expect(result.content).toContain('No task definition found matching "nonexistent"');
   });
 
-  test('returns error when neither task_id nor task_name provided', async () => {
+  test('returns error when no identifiers provided at all', async () => {
     const result = await workItemEnqueueTool.execute({}, stubContext);
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain('You must provide either task_id or task_name');
+    expect(result.content).toContain('You must provide either task_id, task_name, or title');
+  });
+
+  test('creates ad-hoc work item with just title (no task_id or task_name)', async () => {
+    const result = await workItemEnqueueTool.execute(
+      { title: 'Check Gmail' },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Enqueued work item');
+    expect(result.content).toContain('Check Gmail');
+    expect(result.content).toContain('Status: queued');
+    // Ad-hoc items should not show "Task definition:" line
+    expect(result.content).not.toContain('Task definition:');
+  });
+
+  test('ad-hoc work item with notes and priority', async () => {
+    const result = await workItemEnqueueTool.execute(
+      {
+        title: 'Buy groceries',
+        notes: 'Milk, eggs, bread',
+        priority_tier: 1,
+      },
+      stubContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Buy groceries');
+    expect(result.content).toContain('Notes: Milk, eggs, bread');
+    expect(result.content).toContain('Priority: high');
+  });
+
+  test('ad-hoc work item shows up in work_item_list', async () => {
+    await workItemEnqueueTool.execute(
+      { title: 'Call dentist' },
+      stubContext,
+    );
+
+    const listResult = await workItemListTool.execute({}, stubContext);
+
+    expect(listResult.isError).toBe(false);
+    expect(listResult.content).toContain('Call dentist');
   });
 
   test('applies optional overrides (title, notes, priority_tier)', async () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -205,6 +205,8 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '- "Track this", "I need to do X", "queue this up"',
     '- Any request to add a one-off item to their personal to-do list',
     '',
+    'You can create ad-hoc work items by providing just a `title` to `work_item_enqueue` — no existing task template is needed. A lightweight template is auto-created behind the scenes. For reusable task definitions with templates and input schemas, use `task_save` first.',
+    '',
     '### Schedules (schedule_create / schedule_list / schedule_update / schedule_delete)',
     'For recurring automated jobs that run on a cron schedule. Use ONLY when the user explicitly wants:',
     '- Recurring automation: "every day at 9am", "weekly on Mondays", "every hour"',

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -1,7 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { getTask, listTasks } from '../../tasks/task-store.js';
+import { getTask, listTasks, createTask } from '../../tasks/task-store.js';
 import { createWorkItem } from '../../work-items/work-item-store.js';
 
 const PRIORITY_LABELS: Record<number, string> = {
@@ -14,23 +14,23 @@ const PRIORITY_LABELS: Record<number, string> = {
 const definition: ToolDefinition = {
   name: 'work_item_enqueue',
   description:
-    'Add a task to the user\'s Task Queue. Use this when the user says "add to my tasks", "add to my queue", "put this on my task list", "track this task", or any variation of adding a one-off item they want to remember or work on. This creates a work item from a task definition (template) by name or ID. Do NOT use schedule_create or reminder for simple "add to tasks" requests — those are for timed/recurring automation only.',
+    'Add a task to the user\'s Task Queue. Use this when the user says "add to my tasks", "add to my queue", "put this on my task list", "track this task", or any variation of adding a one-off item they want to remember or work on. You can provide just a title for ad-hoc items, or reference an existing task definition by name or ID. Do NOT use schedule_create or reminder for simple "add to tasks" requests — those are for timed/recurring automation only.',
   input_schema: {
     type: 'object',
     properties: {
       task_id: {
         type: 'string',
-        description: 'ID of the task definition to enqueue. Provide this or task_name.',
+        description: 'ID of an existing task definition to enqueue. Provide this, task_name, or just title.',
       },
       task_name: {
         type: 'string',
         description:
-          'Title/name of the task definition to search for (case-insensitive substring match). Provide this or task_id.',
+          'Title/name of an existing task definition to search for (case-insensitive substring match). Provide this, task_id, or just title.',
       },
       title: {
         type: 'string',
         description:
-          'Override title for the work item. Defaults to the task definition title if omitted.',
+          'Title for the work item. When provided WITHOUT task_id or task_name, creates an ad-hoc work item directly (a lightweight task template is auto-created behind the scenes). When provided WITH task_id or task_name, overrides the task definition title.',
       },
       notes: {
         type: 'string',
@@ -67,11 +67,45 @@ class WorkItemEnqueueTool implements Tool {
       const priorityTier = input.priority_tier as number | undefined;
       const sortIndex = input.sort_index as number | undefined;
 
+      // Ad-hoc mode: title provided without task_id or task_name
       if (!taskId && !taskName) {
-        return {
-          content: 'Error: You must provide either task_id or task_name to identify the task definition.',
-          isError: true,
-        };
+        if (!titleOverride) {
+          return {
+            content: 'Error: You must provide either task_id, task_name, or title to create a work item.',
+            isError: true,
+          };
+        }
+
+        // Auto-create a lightweight task template for the ad-hoc item
+        const adHocTask = createTask({
+          title: titleOverride,
+          template: titleOverride,
+        });
+
+        const workItem = createWorkItem({
+          taskId: adHocTask.id,
+          title: titleOverride,
+          notes,
+          priorityTier: priorityTier ?? 2,
+          sortIndex,
+        });
+
+        const priority = PRIORITY_LABELS[workItem.priorityTier] ?? `tier ${workItem.priorityTier}`;
+        const lines = [
+          `Enqueued work item:`,
+          `  Title: ${workItem.title}`,
+          `  ID: ${workItem.id}`,
+          `  Priority: ${priority}`,
+          `  Status: ${workItem.status}`,
+        ];
+        if (workItem.notes) {
+          lines.push(`  Notes: ${workItem.notes}`);
+        }
+        if (workItem.sortIndex !== null) {
+          lines.push(`  Sort index: ${workItem.sortIndex}`);
+        }
+
+        return { content: lines.join('\n'), isError: false };
       }
 
       let resolvedTask;


### PR DESCRIPTION
## Summary

- `work_item_enqueue` now accepts a `title` parameter without requiring `task_id` or `task_name`, enabling ad-hoc work item creation in a single step
- When only `title` is provided, a lightweight task template is auto-created behind the scenes so the existing schema (NOT NULL FK on taskId) remains unchanged
- Updated tool description and parameter docs to guide the model toward using the ad-hoc flow
- Added system prompt guidance in the Task Queue routing section explaining the ad-hoc capability
- Added 4 new tests covering ad-hoc creation, notes/priority, list visibility, and the updated error message

## Why

Previously, if a user said "add check gmail to my tasks" and no "check gmail" task template existed, the model had to perform a two-step flow: `task_save` first to create a template, then `work_item_enqueue` to create the work item. This was error-prone and unintuitive. Now the model can do it in one call.

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 32 task-tools tests pass (`bun test src/__tests__/task-tools.test.ts`)
- [ ] Verify ad-hoc work items appear correctly in the Tasks window UI
- [ ] Verify existing task_id/task_name flows remain unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
