### PR TITLE
feat: add /commands slash command

### DIFF
--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -249,6 +249,14 @@ export function resolveSlash(content: string): SlashResolution {
   const modelResult = resolveModelCommand(content);
   if (modelResult) return modelResult;
 
+  // Handle /commands command
+  if (content.trim() === '/commands') {
+    return {
+      kind: 'unknown',
+      message: '/commands — List all available commands\n/model — Show or switch the current model\n/models — List all available models',
+    };
+  }
+
   const config = getConfig();
   const catalog = loadSkillCatalog();
   const resolved = resolveSkillStates(catalog, config);

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -579,6 +579,10 @@ struct ChatView: View {
                             modelListView(for: message)
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        } else if message.commandList != nil {
+                            CommandListBubble()
+                                .id(message.id)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
                         } else {
                             // Hide tool call chips when the next message is a pending
                             // confirmation — the tool hasn't been approved yet.

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -10,6 +10,7 @@ struct SlashCommand {
     let icon: String
 
     static let all: [SlashCommand] = [
+        SlashCommand(name: "commands", description: "List all available commands", icon: "terminal"),
         SlashCommand(name: "model", description: "Switch the active model", icon: "cpu"),
         SlashCommand(name: "models", description: "List all available models", icon: "list.bullet"),
     ]
@@ -504,13 +505,8 @@ struct ComposerView: View {
     private func selectSlashCommand(_ command: SlashCommand) {
         withAnimation(VAnimation.fast) { showSlashMenu = false }
         slashSelectedIndex = 0
-        if command.name == "model" {
-            inputText = "/model"
-            onSend()
-        } else if command.name == "models" {
-            inputText = "/models"
-            onSend()
-        }
+        inputText = "/\(command.name)"
+        onSend()
     }
 
     private func handleSlashNavigation(_ action: SlashNavigation) {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -477,6 +477,10 @@ public struct ModelListData: Equatable {
     public init() {}
 }
 
+public struct CommandListData: Equatable {
+    public init() {}
+}
+
 public struct SkillInvocationData: Equatable {
     public let name: String
     public let emoji: String?
@@ -509,6 +513,7 @@ public struct ChatMessage: Identifiable {
     public var skillInvocation: SkillInvocationData?
     public var modelPicker: ModelPickerData?
     public var modelList: ModelListData?
+    public var commandList: CommandListData?
     public var attachments: [ChatAttachment]
     public var toolCalls: [ToolCallData]
     public var inlineSurfaces: [InlineSurfaceData]

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -269,6 +269,8 @@ extension ChatViewModel {
                     msg.modelPicker = ModelPickerData()
                 } else if currentTurnUserText == "/models" {
                     msg.modelList = ModelListData()
+                } else if currentTurnUserText == "/commands" {
+                    msg.commandList = CommandListData()
                 }
                 currentAssistantMessageId = msg.id
                 messages.append(msg)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1113,6 +1113,8 @@ public final class ChatViewModel: ObservableObject {
             } else if userText == "/models" {
                 chatMessages[i + 1].modelList = ModelListData()
                 hasModelCommand = true
+            } else if userText == "/commands" {
+                chatMessages[i + 1].commandList = CommandListData()
             }
         }
         // Refresh model/provider state so the picker/table has correct data on restart

--- a/clients/shared/Features/Chat/CommandListBubble.swift
+++ b/clients/shared/Features/Chat/CommandListBubble.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+public struct CommandListBubble: View {
+    struct CommandEntry: Identifiable {
+        let id: String // slash command
+        let description: String
+    }
+
+    private let commands: [CommandEntry] = [
+        CommandEntry(id: "/commands", description: "Show this list"),
+        CommandEntry(id: "/model", description: "Show or switch the current model"),
+        CommandEntry(id: "/models", description: "List all available models"),
+    ]
+
+    public init() {}
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            Text("COMMANDS")
+                .font(VFont.small)
+                .foregroundColor(VColor.textMuted)
+                .tracking(0.5)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.top, VSpacing.sm)
+                .padding(.bottom, VSpacing.xs)
+
+            // Command rows
+            ForEach(commands) { command in
+                HStack(spacing: VSpacing.sm) {
+                    Text(command.id)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.accent)
+                        .frame(width: 100, alignment: .leading)
+
+                    Text(command.description)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+
+                    Spacer()
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.xs + 2)
+            }
+        }
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .frame(maxWidth: 400)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `/commands` slash command that lists all available commands with a dynamic UI bubble
- Add `CommandListBubble` SwiftUI view matching the existing model list bubble style
- Add `/commands` to the composer autocomplete dropdown
- Generalize `selectSlashCommand` to work for any command instead of hardcoding model/models

## Test plan
- [ ] Type `/` in composer — verify `/commands` appears in autocomplete dropdown
- [ ] Select `/commands` and press Enter — verify it sends and renders the command list bubble
- [ ] Restart the app — verify `/commands` history renders the bubble correctly
- [ ] Verify `/model` and `/models` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
