### PR TITLE
fix: prevent Chrome process leak and restore SSRF protection

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -93,6 +93,13 @@ class MockSession {
   }
 }
 
+// Mock child_process to prevent getScreenDimensions() from running Swift on Linux CI
+// where CoreGraphics is not available and the execSync call hangs for 10s.
+mock.module('node:child_process', () => ({
+  execSync: () => '1920x1080',
+  execFileSync: () => '',
+}));
+
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
     get: () => () => {},

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -31,6 +31,7 @@ mock.module('../tools/browser/browser-manager.js', () => {
     browserManager: {
       getOrCreateSessionPage: getOrCreateSessionPageMock,
       clearSnapshotMap: mock(() => {}),
+      supportsRouteInterception: true,
     },
   };
 });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -143,8 +143,8 @@ export async function executeBrowserNavigate(
     // Install request interception to block redirects/sub-requests to private networks.
     // This prevents SSRF bypass via server-side redirects and DNS rebinding attacks,
     // since Playwright follows redirects internally and performs its own DNS resolution.
-    // CDP mode skips route interception since page.route() may not work with connectOverCDP.
-    if (!allowPrivateNetwork && browserManager.browserMode !== 'cdp') {
+    // Only skip for connectOverCDP browsers where page.route() is unreliable.
+    if (!allowPrivateNetwork && browserManager.supportsRouteInterception) {
       // Cache DNS results per-hostname to avoid redundant lookups on subrequests
       // (heavy sites like DoorDash fire hundreds of requests to the same CDN hostnames).
       // Use a short TTL to mitigate DNS rebinding attacks where a hostname first

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -101,6 +101,7 @@ class BrowserManager {
   private _browserMode: 'headless' | 'cdp' = 'headless';
   private cdpUrl: string = 'http://localhost:9222';
   private cdpBrowser: unknown = null; // Store CDP browser reference separately
+  private _browserLaunched = false; // true when browser was launched (vs connected via CDP)
   private browserCdpSession: CDPSession | null = null;
   private browserWindowId: number | null = null;
   private cdpRequestResolvers = new Map<string, (response: { success: boolean; declined?: boolean }) => void>();
@@ -110,6 +111,11 @@ class BrowserManager {
 
   get browserMode(): 'headless' | 'cdp' {
     return this._browserMode;
+  }
+
+  /** Whether page.route() is supported. False only for connectOverCDP browsers. */
+  get supportsRouteInterception(): boolean {
+    return this._browserMode !== 'cdp' || this._browserLaunched;
   }
 
   registerSender(sessionId: string, sendToClient: (msg: { type: string; sessionId: string }) => void): void {
@@ -215,6 +221,7 @@ class BrowserManager {
           const pw = await import('playwright');
           const browser = await pw.chromium.connectOverCDP(this.cdpUrl, { timeout: 10_000 });
           this.cdpBrowser = browser;
+          this._browserLaunched = false;
           const contexts = browser.contexts();
           const ctx = contexts[0] || await browser.newContext();
           this.setBrowserMode('cdp');
@@ -245,6 +252,7 @@ class BrowserManager {
           });
           const ctx = headedBrowser.contexts()[0] || await headedBrowser.newContext();
           this.cdpBrowser = headedBrowser as unknown as typeof this.cdpBrowser;
+          this._browserLaunched = true;
           this.setBrowserMode('cdp');
           await this.initBrowserCdpSession();
           log.info('Launched headed Chromium (minimized) for interactive handoff support');
@@ -313,6 +321,7 @@ class BrowserManager {
           this.browserCdpSession = null;
           this.browserWindowId = null;
           this.cdpBrowser = null;
+          this._browserLaunched = false;
           // Resolve any pending handoffs before clearing state
           for (const resolver of this.handoffResolvers.values()) {
             resolver();
@@ -429,14 +438,22 @@ class BrowserManager {
       this.browserWindowId = null;
     }
 
-    // Disconnect CDP browser connection if present
+    // Close or disconnect CDP browser connection if present
     if (this.cdpBrowser) {
-      const b = this.cdpBrowser as { disconnect?: () => Promise<void> };
+      const b = this.cdpBrowser as { close?: () => Promise<void>; disconnect?: () => Promise<void> };
+      const wasLaunched = this._browserLaunched;
       this.cdpBrowser = null;
+      this._browserLaunched = false;
       try {
-        await b.disconnect?.();
+        if (wasLaunched) {
+          // Launched browsers must be closed to terminate the process
+          await b.close?.();
+        } else {
+          // CDP-connected browsers should be disconnected, not closed
+          await b.disconnect?.();
+        }
       } catch (err) {
-        log.warn({ err }, 'Failed to disconnect CDP browser');
+        log.warn({ err }, 'Failed to close/disconnect CDP browser');
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Chrome process leak fixed** — `closeAllPages()` now calls `browser.close()` for browsers launched via `chromium.launch()` (headed fallback), instead of the no-op `disconnect()` which only works for `connectOverCDP` browsers. Prevents orphaned Chrome processes on cleanup.
- **SSRF route interception restored** — Added `supportsRouteInterception` getter that returns `true` for all browsers except actual `connectOverCDP` connections. The headed browser fallback now correctly gets SSRF protection via `page.route()`.
- **Test updated** — Added `supportsRouteInterception: true` to the mocked `browserManager` in navigate tests.

Addresses review feedback from #4784.

## Test plan
- [x] All 27 browser tests pass (browser-manager + headless-browser-navigate)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
