### PR TITLE
M1: Existing repo normalization + branch enforcement

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -453,6 +453,162 @@ describe('WorkspaceGitService', () => {
     });
   });
 
+  describe('existing repo normalization', () => {
+    test('existing repo on feature branch auto-switches to main on init', async () => {
+      // Set up a pre-existing git repo on a feature branch
+      execFileSync('git', ['init', '-b', 'main'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: testDir });
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+      execFileSync('git', ['add', '-A'], { cwd: testDir });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: testDir });
+      execFileSync('git', ['checkout', '-b', 'feature-branch'], { cwd: testDir });
+
+      // Verify we're on feature-branch
+      const branchBefore = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(branchBefore).toBe('feature-branch');
+
+      // Initialize the service — should auto-switch to main
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const branchAfter = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(branchAfter).toBe('main');
+    });
+
+    test('detached HEAD recovers to main on init', async () => {
+      // Set up a pre-existing git repo then detach HEAD
+      execFileSync('git', ['init', '-b', 'main'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: testDir });
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+      execFileSync('git', ['add', '-A'], { cwd: testDir });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: testDir });
+      // Detach HEAD by checking out the commit hash
+      const commitHash = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      execFileSync('git', ['checkout', commitHash], { cwd: testDir });
+
+      // Verify we're in detached HEAD
+      let isDetached = false;
+      try {
+        execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], { cwd: testDir });
+      } catch {
+        isDetached = true;
+      }
+      expect(isDetached).toBe(true);
+
+      // Initialize the service — should recover to main
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const branchAfter = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(branchAfter).toBe('main');
+    });
+
+    test('existing repo gets .gitignore rules appended on init', async () => {
+      // Set up a pre-existing git repo without our gitignore rules
+      execFileSync('git', ['init', '-b', 'main'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: testDir });
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules/\n');
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+      execFileSync('git', ['add', '-A'], { cwd: testDir });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: testDir });
+
+      // Verify .gitignore does NOT have our rules yet
+      const contentBefore = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(contentBefore).not.toContain('data/');
+      expect(contentBefore).not.toContain('vellum.sock');
+
+      // Initialize the service — should append rules
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const contentAfter = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(contentAfter).toContain('node_modules/');  // original rule preserved
+      expect(contentAfter).toContain('data/');
+      expect(contentAfter).toContain('*.log');
+      expect(contentAfter).toContain('vellum.sock');
+      expect(contentAfter).toContain('session-token');
+    });
+
+    test('existing repo gets local identity set on init', async () => {
+      // Set up a pre-existing git repo with a different identity
+      execFileSync('git', ['init', '-b', 'main'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.name', 'Old Name'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.email', 'old@example.com'], { cwd: testDir });
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+      execFileSync('git', ['add', '-A'], { cwd: testDir });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: testDir });
+
+      // Initialize the service — should set identity
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const userName = execFileSync('git', ['config', 'user.name'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      const userEmail = execFileSync('git', ['config', 'user.email'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+
+      expect(userName).toBe('Vellum Assistant');
+      expect(userEmail).toBe('assistant@vellum.ai');
+    });
+
+    test('existing repo with correct config is idempotent', async () => {
+      // Set up a repo that already has everything configured correctly
+      execFileSync('git', ['init', '-b', 'main'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.name', 'Vellum Assistant'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.email', 'assistant@vellum.ai'], { cwd: testDir });
+      const gitignoreContent = '# Runtime state - excluded from git tracking\ndata/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.sock\nvellum.pid\nsession-token\nhttp-token\n';
+      writeFileSync(join(testDir, '.gitignore'), gitignoreContent);
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+      execFileSync('git', ['add', '-A'], { cwd: testDir });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: testDir });
+
+      const gitignoreBefore = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+
+      // Initialize the service — should be a no-op
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      // Verify nothing changed
+      const gitignoreAfter = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(gitignoreAfter).toBe(gitignoreBefore);
+
+      const userName = execFileSync('git', ['config', 'user.name'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(userName).toBe('Vellum Assistant');
+
+      const branch = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(branch).toBe('main');
+
+      // No errors, no duplicate rules
+      const ruleCount = (gitignoreAfter.match(/data\//g) || []).length;
+      expect(ruleCount).toBe(1);
+    });
+  });
+
   describe('gitignore behavior', () => {
     test('respects .gitignore for data directory', async () => {
       const service = new WorkspaceGitService(testDir);

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -217,7 +217,12 @@ export class WorkspaceGitService {
           // fall through to the initial commit logic below.
           try {
             await this.execGit(['rev-parse', 'HEAD']);
-            // HEAD resolves — repo is fully initialized
+            // HEAD resolves — repo is fully initialized.
+            // Run normalization for existing repos that may have been
+            // created before these helpers existed, or by external tools.
+            this.ensureGitignoreRulesLocked();
+            await this.ensureCommitIdentityLocked();
+            await this.ensureOnMainLocked();
             this.initialized = true;
             return;
           } catch (err: unknown) {
@@ -250,24 +255,13 @@ export class WorkspaceGitService {
       // Initialize new git repository
       await this.execGit(['init', '-b', 'main']);
 
-      // Ensure .gitignore contains runtime exclusions.
-      // Preserve any existing rules the workspace already had.
-      const gitignorePath = join(this.workspaceDir, '.gitignore');
-      if (existsSync(gitignorePath)) {
-        const existing = readFileSync(gitignorePath, 'utf-8');
-        const missingRules = WORKSPACE_GITIGNORE_RULES.filter(rule => !existing.includes(rule));
-        if (missingRules.length > 0) {
-          const section = '\n# Vellum runtime state (auto-added)\n' + missingRules.join('\n') + '\n';
-          writeFileSync(gitignorePath, existing + section, 'utf-8');
-        }
-      } else {
-        const gitignore = '# Runtime state - excluded from git tracking\n' + WORKSPACE_GITIGNORE_RULES.join('\n') + '\n';
-        writeFileSync(gitignorePath, gitignore, 'utf-8');
-      }
-
-      // Set git identity for automated commits
-      await this.execGit(['config', 'user.name', 'Vellum Assistant']);
-      await this.execGit(['config', 'user.email', 'assistant@vellum.ai']);
+      // Run normalization (gitignore + identity + branch enforcement).
+      // For fresh `git init -b main` the branch is already main, but
+      // in the corruption-recovery path we fall through here after
+      // removing .git, so branch enforcement is still useful.
+      this.ensureGitignoreRulesLocked();
+      await this.ensureCommitIdentityLocked();
+      await this.ensureOnMainLocked();
 
       // Create initial commit synchronously within the lock to prevent
       // races with the first commitChanges() call. Without this, the
@@ -422,6 +416,70 @@ export class WorkspaceGitService {
       untracked,
       clean: staged.length === 0 && modified.length === 0 && untracked.length === 0,
     };
+  }
+
+  /**
+   * Ensure .gitignore contains all required workspace exclusion rules.
+   * Idempotent: checks for missing rules and only appends what's needed.
+   * Must be called with the mutex lock held.
+   */
+  private ensureGitignoreRulesLocked(): void {
+    const gitignorePath = join(this.workspaceDir, '.gitignore');
+    if (existsSync(gitignorePath)) {
+      const existing = readFileSync(gitignorePath, 'utf-8');
+      const missingRules = WORKSPACE_GITIGNORE_RULES.filter(rule => !existing.includes(rule));
+      if (missingRules.length > 0) {
+        const section = '\n# Vellum runtime state (auto-added)\n' + missingRules.join('\n') + '\n';
+        writeFileSync(gitignorePath, existing + section, 'utf-8');
+      }
+    } else {
+      const gitignore = '# Runtime state - excluded from git tracking\n' + WORKSPACE_GITIGNORE_RULES.join('\n') + '\n';
+      writeFileSync(gitignorePath, gitignore, 'utf-8');
+    }
+  }
+
+  /**
+   * Ensure local git identity is configured for automated commits.
+   * Idempotent: git config set is a no-op if the value is already correct.
+   * Must be called with the mutex lock held.
+   */
+  private async ensureCommitIdentityLocked(): Promise<void> {
+    await this.execGit(['config', 'user.name', 'Vellum Assistant']);
+    await this.execGit(['config', 'user.email', 'assistant@vellum.ai']);
+  }
+
+  /**
+   * Ensure the workspace repo is on the `main` branch.
+   * If on a different branch or in detached HEAD state, switches to main
+   * (creating it if it doesn't exist).
+   * Must be called with the mutex lock held.
+   */
+  private async ensureOnMainLocked(): Promise<void> {
+    let currentBranch: string | null = null;
+    try {
+      const { stdout } = await this.execGit(['symbolic-ref', '--short', 'HEAD']);
+      currentBranch = stdout.trim();
+    } catch {
+      // symbolic-ref fails in detached HEAD state
+      currentBranch = null;
+    }
+
+    if (currentBranch === 'main') {
+      return;
+    }
+
+    const state = currentBranch === null ? 'detached HEAD' : `branch '${currentBranch}'`;
+    log.warn(
+      { workspaceDir: this.workspaceDir, currentBranch },
+      `Workspace repo is on ${state}; auto-switching to main`,
+    );
+
+    // Try switching to existing main branch first, fall back to creating it
+    try {
+      await this.execGit(['switch', 'main']);
+    } catch {
+      await this.execGit(['switch', '-c', 'main']);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #4790. Part of #4789.

## Changes
- Extract .gitignore and identity setup into idempotent helpers
- Call normalization for existing repos (fixes bug where early return skipped setup)
- Add ensureOnMainLocked() branch enforcement at init time
- Add tests for branch correction, detached HEAD recovery, and existing repo normalization
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
