### PR TITLE
fix: handle dirty workspace branch switch and narrow unborn-HEAD catch

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -517,6 +517,43 @@ describe('WorkspaceGitService', () => {
       expect(branchAfter).toBe('main');
     });
 
+    test('existing repo on feature branch with dirty working tree switches to main', async () => {
+      // Set up a pre-existing git repo on a feature branch with uncommitted changes.
+      // This exercises the --discard-changes fallback in ensureOnMainLocked().
+      execFileSync('git', ['init', '-b', 'main'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: testDir });
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: testDir });
+      writeFileSync(join(testDir, 'file.txt'), 'original content');
+      execFileSync('git', ['add', '-A'], { cwd: testDir });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: testDir });
+      execFileSync('git', ['checkout', '-b', 'feature-branch'], { cwd: testDir });
+
+      // Create uncommitted changes that would block a normal `git switch main`
+      writeFileSync(join(testDir, 'file.txt'), 'modified on feature branch');
+
+      // Verify we're on feature-branch with dirty working tree
+      const branchBefore = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(branchBefore).toBe('feature-branch');
+      const statusBefore = execFileSync('git', ['status', '--porcelain'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(statusBefore).toContain('file.txt');
+
+      // Initialize the service — should auto-switch to main despite dirty tree
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const branchAfter = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(branchAfter).toBe('main');
+    });
+
     test('existing repo gets .gitignore rules appended on init', async () => {
       // Set up a pre-existing git repo without our gitignore rules
       execFileSync('git', ['init', '-b', 'main'], { cwd: testDir });

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -215,16 +215,10 @@ export class WorkspaceGitService {
           // init (e.g. git init succeeded but the initial commit failed)
           // leaves .git present with an undefined HEAD. In that case,
           // fall through to the initial commit logic below.
+          let headExists = false;
           try {
             await this.execGit(['rev-parse', 'HEAD']);
-            // HEAD resolves — repo is fully initialized.
-            // Run normalization for existing repos that may have been
-            // created before these helpers existed, or by external tools.
-            this.ensureGitignoreRulesLocked();
-            await this.ensureCommitIdentityLocked();
-            await this.ensureOnMainLocked();
-            this.initialized = true;
-            return;
+            headExists = true;
           } catch (err: unknown) {
             // Distinguish transient failures from genuine "no commits".
             // Transient errors (timeouts, permissions, missing git binary)
@@ -247,6 +241,19 @@ export class WorkspaceGitService {
             }
             // Genuine "no commits" (unborn HEAD) — fall through to
             // create the initial commit.
+          }
+
+          if (headExists) {
+            // HEAD resolves — repo is fully initialized.
+            // Run normalization for existing repos that may have been
+            // created before these helpers existed, or by external tools.
+            // These calls are OUTSIDE the rev-parse try/catch so that
+            // normalization errors are not misclassified as "no commits".
+            this.ensureGitignoreRulesLocked();
+            await this.ensureCommitIdentityLocked();
+            await this.ensureOnMainLocked();
+            this.initialized = true;
+            return;
           }
         }
         // Otherwise fall through to reinitialize / create initial commit
@@ -474,11 +481,30 @@ export class WorkspaceGitService {
       `Workspace repo is on ${state}; auto-switching to main`,
     );
 
-    // Try switching to existing main branch first, fall back to creating it
+    // Try switching to existing main branch first.
+    // If the switch fails, distinguish "main doesn't exist" from
+    // "local changes would be overwritten" to pick the right recovery.
     try {
       await this.execGit(['switch', 'main']);
     } catch {
-      await this.execGit(['switch', '-c', 'main']);
+      // Check whether `main` already exists as a branch.
+      let mainExists = false;
+      try {
+        await this.execGit(['rev-parse', '--verify', 'main']);
+        mainExists = true;
+      } catch {
+        // main branch does not exist
+      }
+
+      if (mainExists) {
+        // `main` exists but switch failed — likely due to uncommitted
+        // local changes that would be overwritten. Discard them so we
+        // can land on main.
+        await this.execGit(['switch', 'main', '--discard-changes']);
+      } else {
+        // `main` doesn't exist yet — create it.
+        await this.execGit(['switch', '-c', 'main']);
+      }
     }
   }
 


### PR DESCRIPTION
Addresses review feedback from #4793.

## Changes
- ensureOnMainLocked(): distinguish 'main missing' from 'local changes conflict' when git switch fails
- ensureInitialized(): move normalization calls outside rev-parse HEAD try/catch to prevent misclassifying normalization errors as 'no commits'
- Add test for dirty workspace branch switch scenario
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
