### PR TITLE
Move Skills into Identity panel, rename App Directory to Home Base

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -684,14 +684,11 @@ struct MainWindowView: View {
                         .padding(.bottom, VSpacing.sm)
 
                     // MARK: Nav Items
-                    SidebarNavRow(icon: "square.grid.2x2", label: "App Directory") {
+                    SidebarNavRow(icon: "house.fill", label: "Home Base") {
                         windowState.togglePanel(.directory)
                     }
                     SidebarNavRow(icon: "person.crop.circle", label: "Identity") {
                         windowState.togglePanel(.identity)
-                    }
-                    SidebarNavRow(icon: "wand.and.stars", label: "Skills") {
-                        windowState.togglePanel(.agent)
                     }
 
                     // MARK: Recents
@@ -1006,7 +1003,22 @@ struct MainWindowView: View {
         case .threadList:
             sidebarView
         case .identity:
-            IdentityPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.selection = nil }, onInvokeSkill: { skill in
+                if threadManager.activeViewModel == nil {
+                    threadManager.createThread()
+                }
+                if let viewModel = threadManager.activeViewModel {
+                    viewModel.pendingSkillInvocation = SkillInvocationData(
+                        name: skill.name,
+                        emoji: skill.emoji,
+                        description: skill.description
+                    )
+                    viewModel.inputText = "Use the \(skill.name) skill"
+                    viewModel.sendMessage()
+                    viewModel.pendingSkillInvocation = nil
+                }
+                windowState.selection = nil
+            }, daemonClient: daemonClient)
         }
     }
 
@@ -1164,7 +1176,7 @@ struct MainWindowView: View {
                     }
                 )
             } else {
-                // Full-window panels: settings, skills, debug, doctor, identity
+                // Full-window panels: settings, debug, doctor, identity
                 fullWindowPanel(panelType)
             }
         case nil:
@@ -1243,7 +1255,22 @@ struct MainWindowView: View {
             DoctorPanel(onClose: { windowState.dismissOverlay() })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .identity:
-            IdentityPanel(onClose: { windowState.dismissOverlay() }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
+                if threadManager.activeViewModel == nil {
+                    threadManager.createThread()
+                }
+                if let viewModel = threadManager.activeViewModel {
+                    viewModel.pendingSkillInvocation = SkillInvocationData(
+                        name: skill.name,
+                        emoji: skill.emoji,
+                        description: skill.description
+                    )
+                    viewModel.inputText = "Use the \(skill.name) skill"
+                    viewModel.sendMessage()
+                    viewModel.pendingSkillInvocation = nil
+                }
+                windowState.dismissOverlay()
+            }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - Agent Panel
+// MARK: - Agent Panel Content (embeddable)
 
-struct AgentPanel: View {
-    var onClose: () -> Void
+/// The skills management content, usable standalone (e.g. inside IdentityPanel)
+/// or wrapped in a VSidePanel via AgentPanel.
+struct AgentPanelContent: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
 
@@ -17,15 +18,14 @@ struct AgentPanel: View {
     @State private var hoveredDetailInstall = false
     @State private var skillToDelete: SkillInfo?
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient) {
-        self.onClose = onClose
+    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient) {
         self.onInvokeSkill = onInvokeSkill
         self.daemonClient = daemonClient
         _skillsManager = StateObject(wrappedValue: SkillsManager(daemonClient: daemonClient))
     }
 
     var body: some View {
-        VSidePanel(title: "Skills", onClose: onClose) {
+        VStack(alignment: .leading, spacing: 0) {
             // Installed skills section
             sectionHeader("Installed", count: userSkills.count)
 
@@ -998,6 +998,20 @@ struct AgentPanel: View {
                 .font(.system(size: 13))
                 .foregroundColor(VColor.textMuted)
                 .frame(width: 24, height: 24)
+        }
+    }
+}
+
+// MARK: - Agent Panel (standalone, wrapped in VSidePanel)
+
+struct AgentPanel: View {
+    var onClose: () -> Void
+    var onInvokeSkill: ((SkillInfo) -> Void)?
+    let daemonClient: DaemonClient
+
+    var body: some View {
+        VSidePanel(title: "Skills", onClose: onClose) {
+            AgentPanelContent(onInvokeSkill: onInvokeSkill, daemonClient: daemonClient)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -3,6 +3,7 @@ import VellumAssistantShared
 
 struct IdentityPanel: View {
     let onClose: () -> Void
+    var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
     private let appearance = AvatarAppearanceManager.shared
 
@@ -35,26 +36,39 @@ struct IdentityPanel: View {
             Divider()
                 .background(VColor.surfaceBorder)
 
-            // Avatar + ID card side by side
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
-                    .frame(width: 180, height: 200)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    // Avatar + ID card side by side
+                    HStack(alignment: .center, spacing: VSpacing.lg) {
+                        DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                            .frame(width: 180, height: 200)
 
-                if let identity {
-                    idCardSection(identity: identity)
+                        if let identity {
+                            idCardSection(identity: identity)
+                        }
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.lg)
+
+                    // Constellation
+                    ConstellationView(
+                        identity: identity,
+                        skills: skills,
+                        workspaceFiles: workspaceFiles
+                    )
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 300)
+                    .background(VColor.background)
+
+                    // Skills management
+                    AgentPanelContent(
+                        onInvokeSkill: onInvokeSkill,
+                        daemonClient: daemonClient
+                    )
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.lg)
                 }
             }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.lg)
-
-            // Constellation — full width, fills remaining space
-            ConstellationView(
-                identity: identity,
-                skills: skills,
-                workspaceFiles: workspaceFiles
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.background)
         }
         .background(VColor.backgroundSubtle)
         .onAppear {


### PR DESCRIPTION
## Summary
- Removed "Skills" as its own sidebar nav item; its content (installed/available skills management) is now embedded at the bottom of the Identity panel
- Renamed "App Directory" to "Home Base" with a `house.fill` icon in the sidebar
- Extracted `AgentPanelContent` as a reusable view so it can be embedded in IdentityPanel while keeping the standalone `AgentPanel` wrapper intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
