### PR TITLE
M1: Suppress duplicate confirmation prompt

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -591,6 +591,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     return
                 }
 
+                // When the chat window is visible, the inline ToolConfirmationBubble
+                // handles the confirmation UX — skip the native notification to avoid
+                // showing a duplicate prompt.
+                if NSApp.isActive, let mainWindow = self.mainWindow, mainWindow.isVisible {
+                    return
+                }
+
                 let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)
                 // If the inline chat path already forwarded the response, skip
                 // the duplicate IPC send and state update.


### PR DESCRIPTION
Fixes #4798. Part of #4797.

## Changes
- Skip native macOS notification for tool confirmations when chat window is visible
- Inline ToolConfirmationBubble handles the UX when user is looking at the chat
- Native notification still fires when app is in background
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
