### PR TITLE
M2: Hide Thinking indicator during pending confirmation

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -60,7 +60,8 @@ struct ChatContentView: View {
                         }
 
                         // Current step indicator shown while generating
-                        if viewModel.isSending {
+                        let hasPendingConfirmation = viewModel.messages.last?.confirmation?.state == .pending
+                        if viewModel.isSending && !hasPendingConfirmation {
                             let allToolCalls = viewModel.messages.last?.toolCalls ?? []
                             CurrentStepIndicator(
                                 toolCalls: allToolCalls,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -623,7 +623,8 @@ struct ChatView: View {
                         }
                     }
 
-                    if isSending && !(messages.last?.isStreaming == true) {
+                    let hasPendingConfirmation = messages.last?.confirmation?.state == .pending
+                    if isSending && !(messages.last?.isStreaming == true) && !hasPendingConfirmation {
                         RunningIndicator(
                             label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
                             showIcon: false


### PR DESCRIPTION
Fixes #4799. Part of #4797.

## Changes
- Add hasPendingConfirmation check to RunningIndicator display condition
- Fixed in both macOS ChatView.swift and iOS ChatContentView.swift
- Thinking indicator now correctly hidden when waiting for user to approve/deny a tool
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
