### PR TITLE
feat: add jq to Docker sandbox image

### DIFF
--- a/assistant/Dockerfile.sandbox
+++ b/assistant/Dockerfile.sandbox
@@ -1,5 +1,5 @@
 FROM node:20-slim
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates bash \
+ && apt-get install -y --no-install-recommends curl ca-certificates bash jq \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Add `jq` to the `apt-get install` line in `Dockerfile.sandbox` so it's available inside the Docker sandbox environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
