### PR TITLE
M1: Suppress duplicate confirmation prompt

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -591,6 +591,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     return
                 }
 
+                // When the chat window is visible the inline ToolConfirmationBubble
+                // already provides the approval UI — skip the native notification
+                // to avoid showing a duplicate prompt.
+                if self.mainWindow?.isVisible == true {
+                    return
+                }
+
                 let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)
                 // If the inline chat path already forwarded the response, skip
                 // the duplicate IPC send and state update.


### PR DESCRIPTION
When the chat window is visible, skip the native macOS notification for tool confirmations since the inline ToolConfirmationBubble already provides the UX. Native notifications still fire when the app is in the background. Fixes #4798
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
