### PR TITLE
Fix duplicate permission prompts and false Thinking indicator

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -60,7 +60,8 @@ struct ChatContentView: View {
                         }
 
                         // Current step indicator shown while generating
-                        if viewModel.isSending {
+                        let hasPendingConfirmation = viewModel.messages.last?.confirmation?.state == .pending
+                        if viewModel.isSending && !hasPendingConfirmation {
                             let allToolCalls = viewModel.messages.last?.toolCalls ?? []
                             CurrentStepIndicator(
                                 toolCalls: allToolCalls,

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -591,6 +591,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     return
                 }
 
+                // When the chat window is visible the inline ToolConfirmationBubble
+                // already provides the approval UI — skip the native notification
+                // to avoid showing a duplicate prompt.
+                if self.mainWindow?.isVisible == true {
+                    return
+                }
+
                 let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)
                 // If the inline chat path already forwarded the response, skip
                 // the duplicate IPC send and state update.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -623,7 +623,8 @@ struct ChatView: View {
                         }
                     }
 
-                    if isSending && !(messages.last?.isStreaming == true) {
+                    let hasPendingConfirmation = messages.last?.confirmation?.state == .pending
+                    if isSending && !(messages.last?.isStreaming == true) && !hasPendingConfirmation {
                         RunningIndicator(
                             label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
                             showIcon: false


### PR DESCRIPTION
## Summary
Fixes two bugs in the tool confirmation flow: duplicate permission prompts appearing simultaneously, and a false "Thinking..." indicator showing while waiting for user approval.

## Changes
- Suppress native macOS notification for tool confirmations when the chat window is visible (the inline ToolConfirmationBubble already provides the UX). Native notifications still fire when the app is in the background.
- Hide the "Thinking" RunningIndicator when a tool confirmation prompt is pending, since the assistant is waiting for user approval rather than thinking. Fixed on both macOS and iOS.

## Milestone PRs (merged into feature branch)
- #4804: M1: Suppress duplicate confirmation prompt
- #4805: M2: Hide Thinking indicator during pending confirmation

## Project issue
Closes #4797

## Test plan
- [ ] Send a message that triggers a tool confirmation (e.g., web search) with the chat window visible — verify only ONE inline confirmation card appears (no native notification)
- [ ] Minimize/hide the chat window, then trigger a tool confirmation — verify the native macOS notification still appears
- [ ] When a confirmation prompt is pending, verify "Thinking..." does NOT show below it
- [ ] After approving/denying a confirmation, verify normal "Thinking..." behavior resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
