### PR TITLE
Reorder sidebar nav and add active state to nav items

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -679,17 +679,17 @@ struct MainWindowView: View {
 
             ScrollView {
                 VStack(spacing: 0) {
-                    // MARK: New Chat Button
-                    NewChatButton(action: { windowState.selection = nil; threadManager.createThread() })
-                        .padding(.bottom, VSpacing.sm)
-
                     // MARK: Nav Items
-                    SidebarNavRow(icon: "house.fill", label: "Home Base") {
+                    SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory) {
                         windowState.togglePanel(.directory)
                     }
-                    SidebarNavRow(icon: "person.crop.circle", label: "Identity") {
+                    SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
                         windowState.togglePanel(.identity)
                     }
+
+                    // MARK: New Chat Button
+                    NewChatButton(action: { windowState.selection = nil; threadManager.createThread() })
+                        .padding(.vertical, VSpacing.sm)
 
                     // MARK: Recents
                     SidebarSubheader(title: "Recents")
@@ -1395,6 +1395,7 @@ private struct NewChatButton: View {
 private struct SidebarNavRow: View {
     let icon: String
     let label: String
+    var isActive: Bool = false
     let action: () -> Void
     @State private var isHovered = false
 
@@ -1403,17 +1404,17 @@ private struct SidebarNavRow: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: icon)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
+                    .foregroundColor(isActive || isHovered ? VColor.textPrimary : VColor.textSecondary)
                     .frame(width: 18)
                 Text(label)
-                    .font(VFont.body)
+                    .font(isActive ? VFont.bodyMedium : VFont.body)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
             }
             .padding(.leading, 20)
             .padding(.trailing, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : .clear)
+            .background(isActive ? VColor.hoverOverlay.opacity(0.08) : (isHovered ? VColor.hoverOverlay.opacity(0.06) : .clear))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Moved "New Chat" button below "Identity" and above "Recents" in the sidebar
- Added active/selected state to `SidebarNavRow` — the currently active panel gets a bolder font, highlighted icon, and subtle background
- Active state is driven by `windowState.activePanel` matching the panel type

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
