### PR TITLE
fix: use refs/heads/main for branch existence check

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -490,7 +490,7 @@ export class WorkspaceGitService {
       // Check whether `main` already exists as a branch.
       let mainExists = false;
       try {
-        await this.execGit(['rev-parse', '--verify', 'main']);
+        await this.execGit(['rev-parse', '--verify', 'refs/heads/main']);
         mainExists = true;
       } catch {
         // main branch does not exist


### PR DESCRIPTION
Addresses review feedback from #4795.

## Changes
- Changed rev-parse --verify main to rev-parse --verify refs/heads/main in ensureOnMainLocked()
- Ensures only local branches are matched, not tags or other refs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
