### PR TITLE
fix: handle unsupported file/image MIME types and prevent scroll freeze

### DIFF
--- a/assistant/src/config/bundled-skills/weather/icon.svg
+++ b/assistant/src/config/bundled-skills/weather/icon.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="16" height="16" fill="#87CEEB"/>
+  <rect x="3" y="2" width="10" height="1" fill="#FFFFFF"/>
+  <rect x="2" y="3" width="12" height="1" fill="#FFFFFF"/>
+  <rect x="1" y="4" width="14" height="2" fill="#FFFFFF"/>
+  <rect x="2" y="6" width="12" height="1" fill="#FFFFFF"/>
+  <rect x="3" y="7" width="10" height="1" fill="#FFFFFF"/>
+  <rect x="4" y="8" width="8" height="1" fill="#87CEEB"/>
+  <rect x="2" y="9" width="3" height="1" fill="#4A90E2"/>
+  <rect x="6" y="9" width="1" height="1" fill="#4A90E2"/>
+  <rect x="9" y="9" width="1" height="1" fill="#4A90E2"/>
+  <rect x="12" y="9" width="2" height="1" fill="#4A90E2"/>
+  <rect x="1" y="10" width="4" height="1" fill="#4A90E2"/>
+  <rect x="6" y="10" width="1" height="1" fill="#4A90E2"/>
+  <rect x="9" y="10" width="1" height="1" fill="#4A90E2"/>
+  <rect x="12" y="10" width="3" height="1" fill="#4A90E2"/>
+  <rect x="2" y="11" width="3" height="1" fill="#4A90E2"/>
+  <rect x="6" y="11" width="1" height="1" fill="#4A90E2"/>
+  <rect x="9" y="11" width="1" height="1" fill="#4A90E2"/>
+  <rect x="12" y="11" width="2" height="1" fill="#4A90E2"/>
+  <rect x="3" y="12" width="2" height="1" fill="#4A90E2"/>
+  <rect x="7" y="12" width="1" height="1" fill="#4A90E2"/>
+  <rect x="11" y="12" width="2" height="1" fill="#4A90E2"/>
+</svg>

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -14,6 +14,19 @@ const log = getLogger('anthropic-client');
 
 const TOOL_ID_RE = /[^a-wyzA-Z0-9_-]/g;
 
+const ANTHROPIC_SUPPORTED_IMAGE_TYPES = new Set([
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+]);
+
+function isTextBasedMimeType(mediaType: string): boolean {
+  return (
+    mediaType.startsWith('text/') ||
+    mediaType === 'application/json' ||
+    mediaType === 'application/xml' ||
+    mediaType === 'application/javascript'
+  );
+}
+
 /** Anthropic requires tool_use IDs to match ^[a-zA-Z0-9_-]+$ */
 function sanitizeToolId(id: string): string {
   if (!id) return 'empty';
@@ -571,6 +584,10 @@ export class AnthropicProvider implements Provider {
       case "redacted_thinking":
         return { type: "redacted_thinking", data: block.data };
       case "image":
+        if (!ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(block.source.media_type)) {
+          log.warn(`Unsupported image MIME type for Anthropic: ${block.source.media_type}; replacing with text placeholder`);
+          return { type: "text", text: `[Image: ${block.source.media_type} — format not supported by this provider]` };
+        }
         return {
           type: "image",
           source: {
@@ -580,16 +597,32 @@ export class AnthropicProvider implements Provider {
             data: block.source.data,
           },
         };
-      case "file":
-        return {
-          type: "document",
-          source: {
-            type: "base64",
-            media_type: block.source.media_type,
-            data: block.source.data,
-          },
-          ...(block.source.filename ? { title: block.source.filename } : {}),
-        } as unknown as Anthropic.ContentBlockParam;
+      case "file": {
+        const { media_type, data, filename } = block.source;
+        if (media_type === 'application/pdf') {
+          // Only valid base64 document source for Anthropic
+          return {
+            type: "document",
+            source: { type: "base64", media_type: "application/pdf", data },
+            ...(filename ? { title: filename } : {}),
+          } as unknown as Anthropic.ContentBlockParam;
+        }
+        if (isTextBasedMimeType(media_type)) {
+          // Decode base64 to UTF-8 text and send as PlainTextSource
+          const decodedText = Buffer.from(data, 'base64').toString('utf-8');
+          return {
+            type: "document",
+            source: { type: "text", media_type: "text/plain", data: decodedText },
+            ...(filename ? { title: filename } : {}),
+          } as unknown as Anthropic.ContentBlockParam;
+        }
+        // Binary non-text file: use extracted_text if available, otherwise a placeholder
+        log.warn(`Binary file type not natively supported by Anthropic: ${media_type}; falling back to text`);
+        const fallbackText = block.extracted_text?.trim()
+          ? block.extracted_text
+          : `[File: ${filename ?? 'unknown'} (${media_type}) — binary file]`;
+        return { type: "text", text: fallbackText };
+      }
       case "tool_use":
         return {
           type: "tool_use",

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -16,6 +16,10 @@ export interface OpenAICompatibleProviderOptions {
   providerLabel?: string;
 }
 
+const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+]);
+
 export class OpenAIProvider implements Provider {
   public readonly name: string;
   private readonly providerLabel: string;
@@ -268,12 +272,16 @@ export class OpenAIProvider implements Provider {
           parts.push({ type: 'text', text: block.text });
           break;
         case 'image':
-          parts.push({
-            type: 'image_url',
-            image_url: {
-              url: `data:${block.source.media_type};base64,${block.source.data}`,
-            },
-          });
+          if (!OPENAI_SUPPORTED_IMAGE_TYPES.has(block.source.media_type)) {
+            parts.push({ type: 'text', text: `[Image: ${block.source.media_type} — format not supported by this provider]` });
+          } else {
+            parts.push({
+              type: 'image_url',
+              image_url: {
+                url: `data:${block.source.media_type};base64,${block.source.data}`,
+              },
+            });
+          }
           break;
         case 'file':
           parts.push({

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1055,27 +1055,33 @@ private struct ChatBubble: View {
 
             if canReportMessage {
                 VStack {
-                    Menu {
-                        if let onReportMessage {
-                            Button("Export response for diagnostics") {
-                                onReportMessage(message.daemonMessageId)
+                    // Use conditional rendering instead of opacity(0) so the NSPopUpButton
+                    // is only in the view hierarchy while hovered — avoiding per-message
+                    // SF Symbol and accessibility-string lookups on every scroll update.
+                    ZStack {
+                        Color.clear.frame(width: 24, height: 24)
+                        if isHovered {
+                            Menu {
+                                if let onReportMessage {
+                                    Button("Export response for diagnostics") {
+                                        onReportMessage(message.daemonMessageId)
+                                    }
+                                }
+                            } label: {
+                                Image(systemName: "ellipsis")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(VColor.textSecondary)
+                                    .rotationEffect(.degrees(90))
+                                    .frame(width: 24, height: 24)
+                                    .contentShape(Rectangle())
                             }
-                        }
-                    } label: {
-                        Image(systemName: "ellipsis")
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .rotationEffect(.degrees(90))
+                            .menuStyle(.borderlessButton)
+                            .menuIndicator(.hidden)
                             .frame(width: 24, height: 24)
-                            .contentShape(Rectangle())
+                            .accessibilityLabel("Message actions")
+                            .transition(.opacity.animation(VAnimation.fast))
+                        }
                     }
-                    .menuStyle(.borderlessButton)
-                    .menuIndicator(.hidden)
-                    .frame(width: 24, height: 24)
-                    .opacity(isHovered ? 1 : 0)
-                    .allowsHitTesting(isHovered)
-                    .accessibilityLabel("Message actions")
-                    .animation(VAnimation.fast, value: isHovered)
 
                     Spacer(minLength: 0)
                 }
@@ -1629,7 +1635,7 @@ private struct ChatBubble: View {
     /// Render a single text segment as a styled bubble, with table and image support.
     @ViewBuilder
     private func textBubble(for segmentText: String) -> some View {
-        let segments = parseMarkdownSegments(segmentText)
+        let segments = Self.cachedSegments(for: segmentText)
         let hasRichContent = segments.contains(where: {
             switch $0 {
             case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
@@ -1789,7 +1795,7 @@ private struct ChatBubble: View {
             }
 
             if hasText {
-                let segments = parseMarkdownSegments(message.text)
+                let segments = Self.cachedSegments(for: message.text)
                 let hasRichContent = segments.contains(where: {
                     switch $0 {
                     case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
@@ -2004,6 +2010,11 @@ private struct ChatBubble: View {
     }
 
     private func nsImage(for attachment: ChatAttachment) -> NSImage? {
+        // Use pre-decoded thumbnail image — avoids NSImage(data:) during layout, which
+        // can trigger re-entrant AppKit constraint invalidation and crash on scroll.
+        if let img = attachment.thumbnailImage {
+            return img
+        }
         if let thumbnailData = attachment.thumbnailData, let img = NSImage(data: thumbnailData) {
             return img
         }
@@ -2040,6 +2051,20 @@ private struct ChatBubble: View {
         if kb < 1024 { return String(format: "%.1f KB", kb) }
         let mb = kb / 1024
         return String(format: "%.1f MB", mb)
+    }
+
+    /// Cached markdown segment parser to avoid re-parsing on every render.
+    private static var segmentCache = [Int: [MarkdownSegment]]()
+
+    private static func cachedSegments(for text: String) -> [MarkdownSegment] {
+        let key = text.hashValue
+        if let cached = segmentCache[key] { return cached }
+        let result = parseMarkdownSegments(text)
+        if segmentCache.count >= maxCacheSize {
+            if let first = segmentCache.keys.first { segmentCache.removeValue(forKey: first) }
+        }
+        segmentCache[key] = result
+        return result
     }
 
     /// Cached markdown parser to avoid re-parsing on every render.


### PR DESCRIPTION
## Summary
- Fix Anthropic provider rejecting non-PDF file uploads by routing text-based MIME types to `PlainTextSource` (decoded UTF-8) and binary types to text placeholders; fix unsupported image MIME types similarly
- Fix OpenAI provider rejecting unsupported image MIME types with a text placeholder instead of sending an invalid `image_url`
- Fix scroll freeze in ChatView by caching `parseMarkdownSegments` results (new `segmentCache`), making `nsImage(for:)` use pre-decoded `thumbnailImage`, and conditionally rendering the report-message `Menu` only on hover to eliminate per-message NSPopUpButton overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
