### PR TITLE
fix: show native confirmation for non-active threads even when window is visible

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -591,11 +591,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     return
                 }
 
-                // When the chat window is visible, the inline ToolConfirmationBubble
-                // handles the confirmation UX — skip the native notification to avoid
-                // showing a duplicate prompt.
+                // When the chat window is visible AND the confirmation belongs to the
+                // active thread, the inline ToolConfirmationBubble handles the
+                // confirmation UX — skip the native notification to avoid showing a
+                // duplicate prompt.  If the confirmation is for a background thread,
+                // the inline bubble won't be visible, so we must still fire the
+                // native notification.
                 if NSApp.isActive, let mainWindow = self.mainWindow, mainWindow.isVisible {
-                    return
+                    let activeSessionId = mainWindow.threadManager.activeViewModel?.sessionId
+                    let confirmationIsForActiveThread = msg.sessionId == nil || msg.sessionId == activeSessionId
+                    if confirmationIsForActiveThread {
+                        return
+                    }
                 }
 
                 let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)


### PR DESCRIPTION
Addresses review feedback from #4801.

## Changes
- Check if confirmation belongs to active thread before suppressing native notification
- Native notification still fires for confirmations on background threads
- Prevents blocked tool calls with no visible prompt in multi-thread scenarios
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
