### PR TITLE
fix: refresh constellation skills after install/uninstall in IdentityPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -7,6 +7,7 @@ import VellumAssistantShared
 /// or wrapped in a VSidePanel via AgentPanel.
 struct AgentPanelContent: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
+    var onSkillsChanged: (() -> Void)?
     let daemonClient: DaemonClient
 
     @StateObject private var skillsManager: SkillsManager
@@ -18,8 +19,9 @@ struct AgentPanelContent: View {
     @State private var hoveredDetailInstall = false
     @State private var skillToDelete: SkillInfo?
 
-    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient) {
+    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, daemonClient: DaemonClient) {
         self.onInvokeSkill = onInvokeSkill
+        self.onSkillsChanged = onSkillsChanged
         self.daemonClient = daemonClient
         _skillsManager = StateObject(wrappedValue: SkillsManager(daemonClient: daemonClient))
     }
@@ -38,6 +40,9 @@ struct AgentPanelContent: View {
         }
         .onAppear {
             skillsManager.fetchSkills()
+        }
+        .onChange(of: skillsManager.skills.map(\.id)) {
+            onSkillsChanged?()
         }
         .alert("Delete Skill", isPresented: Binding(
             get: { skillToDelete != nil },

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -63,6 +63,7 @@ struct IdentityPanel: View {
                     // Skills management
                     AgentPanelContent(
                         onInvokeSkill: onInvokeSkill,
+                        onSkillsChanged: { fetchSkills() },
                         daemonClient: daemonClient
                     )
                     .padding(.horizontal, VSpacing.lg)


### PR DESCRIPTION
Addresses review feedback from #4800.

## Changes
- Refresh ConstellationView skills when skills are installed/uninstalled in the embedded AgentPanelContent
- Prevents stale constellation visualization after skill operations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
