### PR TITLE
chore: bump assistant version to 0.1.28

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vellum-assistant",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "type": "module",
   "bin": {
     "vellum": "./src/index.ts"


### PR DESCRIPTION
## Summary
- Bump assistant/package.json version from 0.1.27 to 0.1.28 to trigger an e2e release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
