### PR TITLE
feat: add view_image tool for filesystem image viewing

### DIFF
--- a/assistant/src/tools/filesystem/view-image.ts
+++ b/assistant/src/tools/filesystem/view-image.ts
@@ -1,0 +1,110 @@
+import { readFileSync, statSync } from 'node:fs';
+import { extname, resolve } from 'node:path';
+import { RiskLevel } from '../../permissions/types.js';
+import type { ImageContent, ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+
+const SUPPORTED_EXTENSIONS: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB
+
+class ViewImageTool implements Tool {
+  name = 'view_image';
+  description =
+    'Read an image file from the filesystem and return it for visual analysis. Supports JPEG, PNG, GIF, and WebP.';
+  category = 'filesystem';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description:
+              'The path to the image file (absolute or relative to working directory)',
+          },
+        },
+        required: ['path'],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const rawPath = input.path as string;
+    if (!rawPath || typeof rawPath !== 'string') {
+      return { content: 'Error: path is required and must be a string', isError: true };
+    }
+
+    const resolved = resolve(context.workingDir, rawPath);
+
+    const ext = extname(resolved).toLowerCase();
+    const mediaType = SUPPORTED_EXTENSIONS[ext];
+    if (!mediaType) {
+      const supported = Object.keys(SUPPORTED_EXTENSIONS).join(', ');
+      return {
+        content: `Error: unsupported image format "${ext}". Supported: ${supported}`,
+        isError: true,
+      };
+    }
+
+    let stat;
+    try {
+      stat = statSync(resolved);
+    } catch {
+      return { content: `Error: file not found: ${resolved}`, isError: true };
+    }
+
+    if (!stat.isFile()) {
+      return { content: `Error: ${resolved} is not a file`, isError: true };
+    }
+
+    if (stat.size > MAX_SIZE_BYTES) {
+      const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
+      return {
+        content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`,
+        isError: true,
+      };
+    }
+
+    let buffer: Buffer;
+    try {
+      buffer = readFileSync(resolved) as Buffer;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error reading file: ${msg}`, isError: true };
+    }
+
+    const base64Data = buffer.toString('base64');
+
+    const imageBlock: ImageContent = {
+      type: 'image' as const,
+      source: {
+        type: 'base64' as const,
+        media_type: mediaType,
+        data: base64Data,
+      },
+    };
+
+    return {
+      content: `Image loaded: ${resolved} (${stat.size} bytes, ${mediaType})`,
+      isError: false,
+      contentBlocks: [imageBlock],
+    };
+  }
+}
+
+registerTool(new ViewImageTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -51,6 +51,7 @@ export const eagerModules: string[] = [
   './contacts/contact-merge.js',
   './assets/search.js',
   './assets/materialize.js',
+  './filesystem/view-image.js',
 ];
 
 // Tool names registered by the eager modules above.  Listed explicitly so
@@ -85,6 +86,7 @@ export const eagerModuleToolNames: string[] = [
   'contact_merge',
   'asset_search',
   'asset_materialize',
+  'view_image',
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `view_image` tool that reads image files from disk and returns them as base64 `ImageContent` blocks for LLM vision analysis
- Supports JPEG, PNG, GIF, and WebP formats with a 20 MB size limit
- Registered as an eager module in the tool manifest with `RiskLevel.Low` (read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
