### PR TITLE
Fix sidebar active state consistency between nav rows and threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -527,6 +527,11 @@ struct MainWindowView: View {
     @ViewBuilder
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected: Bool = {
+            // Top-level nav panels deselect all threads
+            if case .panel(let panel) = windowState.selection,
+               panel == .directory || panel == .identity {
+                return false
+            }
             if thread.id == windowState.persistentThreadId { return true }
             if case .thread(let id) = windowState.selection, id == thread.id { return true }
             if case .appEditing(_, let threadId) = windowState.selection, threadId == thread.id { return true }
@@ -1375,17 +1380,18 @@ private struct SidebarNavRow: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: icon)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(isActive || isHovered ? VColor.textPrimary : VColor.textSecondary)
+                    .foregroundColor(VColor.textPrimary)
                     .frame(width: 18)
                 Text(label)
-                    .font(isActive ? VFont.bodyMedium : VFont.body)
+                    .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
             }
             .padding(.leading, 20)
             .padding(.trailing, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(isActive ? VColor.hoverOverlay.opacity(0.08) : (isHovered ? VColor.hoverOverlay.opacity(0.06) : .clear))
+            .background(isActive || isHovered ? VColor.hoverOverlay.opacity(0.08) : .clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Made Home Base/Identity nav rows use the same active style as chat threads (rounded background highlight only — no bold font or icon color changes)
- Threads are now visually deselected when Home Base or Identity is active, so only one sidebar item appears selected at a time
- Other panels (activity, debug, etc.) still keep the thread highlighted since they show alongside chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
