### PR TITLE
fix: hide Thinking indicator during active tool invocations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -624,7 +624,8 @@ struct ChatView: View {
                     }
 
                     let hasPendingConfirmation = messages.last?.confirmation?.state == .pending
-                    if isSending && !(messages.last?.isStreaming == true) && !hasPendingConfirmation {
+                    let hasActiveToolCall = messages.last?.toolCalls.contains(where: { !$0.isComplete }) == true
+                    if isSending && !(messages.last?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {
                         RunningIndicator(
                             label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
                             showIcon: false


### PR DESCRIPTION
## Summary
- Hide the "Thinking..." indicator on macOS when there are active (incomplete) tool calls
- Prevents showing both "Taking a screenshot..." and "Thinking..." simultaneously
- Adds `hasActiveToolCall` check alongside existing `hasPendingConfirmation` and `isStreaming` checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
