### PR TITLE
fix: prevent document editor panel closing on second show; close document on panel dismiss

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -168,7 +168,7 @@ final class MainWindow {
             initialContent: msg.initialContent
         )
         show()
-        windowState.togglePanel(.documentEditor)
+        windowState.selection = .panel(.documentEditor)
     }
 
     func handleDocumentEditorUpdate(_ msg: DocumentEditorUpdateMessage) {
@@ -189,7 +189,7 @@ final class MainWindow {
             initialContent: content
         )
         show()
-        windowState.togglePanel(.documentEditor)
+        windowState.selection = .panel(.documentEditor)
     }
 
     func show() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1171,7 +1171,7 @@ struct MainWindowView: View {
                         DocumentEditorPanelView(
                             documentManager: documentManager,
                             daemonClient: daemonClient,
-                            onClose: { windowState.selection = nil }
+                            onClose: { windowState.selection = nil; documentManager.closeDocument() }
                         )
                     }
                 )


### PR DESCRIPTION
## Summary

Addresses review feedback on https://github.com/vellum-ai/vellum-assistant/pull/4502

- **Fix 1** (`MainWindow.swift`): Replace `togglePanel(.documentEditor)` with `windowState.selection = .panel(.documentEditor)` in both `handleDocumentEditorShow` and `handleDocumentLoadResponse`. The previous `togglePanel` call would accidentally close the panel if a second `document_editor_show` or `document_load_response` message arrived while the panel was already open (because `togglePanel` checks if the panel is already selected and closes it if so).

- **Fix 2** (`MainWindowView.swift`): Call `documentManager.closeDocument()` in the `onClose` handler for `DocumentEditorPanelView`. When the user closes the document editor panel, the document manager state (including `editorCoordinator`) was not being reset. This stale state meant that on the next `document_editor_show`, `createDocument` might try to use the old coordinator (which no longer has a live web view), causing documents to appear without their initial content.

## Test plan

- [ ] Open document editor via daemon message
- [ ] Close and reopen: verify content is restored correctly
- [ ] Send second `document_editor_show` while panel is open: verify panel stays open with new content
- [ ] Send `document_load_response` while panel is open: verify panel stays open with new content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
