### PR TITLE
fix: restore document state cleanup and use direct panel selection on document show

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -168,7 +168,7 @@ final class MainWindow {
             initialContent: msg.initialContent
         )
         show()
-        windowState.togglePanel(.documentEditor)
+        windowState.selection = .panel(.documentEditor)
     }
 
     func handleDocumentEditorUpdate(_ msg: DocumentEditorUpdateMessage) {
@@ -189,7 +189,7 @@ final class MainWindow {
             initialContent: content
         )
         show()
-        windowState.togglePanel(.documentEditor)
+        windowState.selection = .panel(.documentEditor)
     }
 
     func show() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1171,7 +1171,7 @@ struct MainWindowView: View {
                         DocumentEditorPanelView(
                             documentManager: documentManager,
                             daemonClient: daemonClient,
-                            onClose: { windowState.selection = nil }
+                            onClose: { windowState.selection = nil; documentManager.closeDocument() }
                         )
                     }
                 )


### PR DESCRIPTION
## Summary

Addresses review feedback on https://github.com/vellum-ai/vellum-assistant/pull/4585

- **Fix 1** (`MainWindow.swift`): Replace `windowState.togglePanel(.documentEditor)` with `windowState.selection = .panel(.documentEditor)` in both `handleDocumentEditorShow` and `handleDocumentLoadResponse`. Using `togglePanel` would accidentally close the panel if a second show message arrived while the panel was already open.

- **Fix 2** (`MainWindowView.swift`): Restore `documentManager.closeDocument()` in the `onClose` handler for `DocumentEditorPanelView`. Without this call, document state (surfaceId, sessionId, currentContent, etc.) was never cleared when the panel was dismissed, leading to stale state on the next document open.

## Test plan

- [ ] Open document editor via daemon message
- [ ] Close and reopen: verify content loads correctly with no stale state
- [ ] Send second `document_editor_show` while panel is open: verify panel stays open with new content
- [ ] Send `document_load_response` while panel is open: verify panel stays open with new content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
