### PR TITLE
fix: use optional currentContent to distinguish uninitialized vs empty document state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -55,10 +55,10 @@ struct DocumentEditorView: NSViewRepresentable {
 
         // Register coordinator with DocumentManager (after loading so no double-load)
         documentManager.editorCoordinator = context.coordinator
-        print("🔧 Coordinator registered with DocumentManager")
+        print("\u{1F527} Coordinator registered with DocumentManager")
 
         log.info("DocumentEditorView created")
-        print("📄 DocumentEditorView created, loading HTML...")
+        print("\u{1F4C4} DocumentEditorView created, loading HTML...")
         return webView
     }
 
@@ -121,11 +121,11 @@ struct DocumentEditorView: NSViewRepresentable {
 
         func sendContentUpdate(markdown: String, mode: String) {
             guard let webView = webView, isInitialized else {
-                log.warning("⚠️ Cannot send content update: editor not initialized (isInitialized=\(self.isInitialized))")
-                print("⚠️ Cannot send content update: editor not initialized (isInitialized=\(self.isInitialized))")
+                log.warning("\u{26A0}\u{FE0F} Cannot send content update: editor not initialized (isInitialized=\(self.isInitialized))")
+                print("\u{26A0}\u{FE0F} Cannot send content update: editor not initialized (isInitialized=\(self.isInitialized))")
                 return
             }
-            print("✅ Sending content update to WebView: mode=\(mode), length=\(markdown.count)")
+            print("\u{2705} Sending content update to WebView: mode=\(mode), length=\(markdown.count)")
 
             let escapedMarkdown = escapeForJS(markdown)
             let js: String
@@ -179,11 +179,10 @@ struct DocumentEditorView: NSViewRepresentable {
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             isInitialized = true
             log.info("Document editor loaded")
-            print("✅ WebView finished loading - editor initialized!")
+            print("\u{2705} WebView finished loading - editor initialized!")
             // Apply any content that accumulated while the WebView was loading
             // (document_editor_update messages that arrived before isInitialized was set)
-            let tracked = documentManager.currentContent
-            if !tracked.isEmpty {
+            if let tracked = documentManager.currentContent, !tracked.isEmpty {
                 setInitialContent(title: documentManager.title, markdown: tracked)
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -15,17 +15,19 @@ final class DocumentManager: ObservableObject {
     @Published var isSaving: Bool = false
     @Published var lastSaveError: String?
 
-    /// Current document content and metadata
-    private(set) var currentContent: String = ""
+    /// Current document content and metadata.
+    /// `nil` means the editor has not yet received any content (uninitialized).
+    /// `""` means the user intentionally deleted all text.
+    private(set) var currentContent: String? = nil
     @Published var wordCount: Int = 0
 
-    /// Initial content from daemon — persisted for panel reopen after the coordinator consumes pendingInitialContent
+    /// Initial content from daemon persisted for panel reopen after the coordinator consumes pendingInitialContent
     private(set) var initialContent: String = ""
 
     /// Pending initial content to be set when coordinator becomes ready
     private var pendingInitialContent: String?
 
-    /// Debounced auto-save task — cancelled and rescheduled on every content update
+    /// Debounced auto-save task cancelled and rescheduled on every content update
     private var autoSaveTask: Task<Void, Never>?
 
     /// Reference to daemon client for saving documents
@@ -62,10 +64,12 @@ final class DocumentManager: ObservableObject {
     }
 
     /// Returns the content the editor WebView should load when (re)created.
+    /// Uses `currentContent` when it has been initialized (including intentionally empty),
+    /// falling back to `initialContent` only when `currentContent` is `nil` (never set).
     /// Clears pendingInitialContent so the coordinator didSet won't double-load.
     func contentForEditorView() -> (title: String, content: String)? {
         guard hasActiveDocument else { return nil }
-        let content = currentContent.isEmpty ? initialContent : currentContent
+        let content = currentContent ?? initialContent
         pendingInitialContent = nil
         return (title: title, content: content)
     }
@@ -75,17 +79,18 @@ final class DocumentManager: ObservableObject {
         if mode == "replace" {
             currentContent = markdown
         } else {
-            let sep = currentContent.isEmpty ? "" : "\n\n"
-            currentContent += sep + markdown
+            let existing = currentContent ?? ""
+            let sep = existing.isEmpty ? "" : "\n\n"
+            currentContent = existing + sep + markdown
         }
 
         guard let coordinator = editorCoordinator else {
-            log.warning("⚠️ Cannot update document: editor coordinator not ready, content tracked for later")
-            print("⚠️ Cannot update document: editor coordinator not ready, content tracked for later")
+            log.warning("Cannot update document: editor coordinator not ready, content tracked for later")
+            print("Cannot update document: editor coordinator not ready, content tracked for later")
             return
         }
 
-        print("📝 Sending update to coordinator: mode=\(mode), length=\(markdown.count)")
+        print("Sending update to coordinator: mode=\(mode), length=\(markdown.count)")
         coordinator.sendContentUpdate(markdown: markdown, mode: mode)
         log.info("Document updated: mode=\(mode), length=\(markdown.count)")
 
@@ -116,7 +121,7 @@ final class DocumentManager: ObservableObject {
         surfaceId = nil
         sessionId = nil
         title = "Untitled Document"
-        currentContent = ""
+        currentContent = nil
         wordCount = 0
         initialContent = ""
         pendingInitialContent = nil
@@ -124,18 +129,19 @@ final class DocumentManager: ObservableObject {
     }
 
     func save() {
-        print("💾 save() called - surfaceId: \(surfaceId ?? "nil"), sessionId: \(sessionId ?? "nil"), daemonClient: \(daemonClient != nil)")
+        print("save() called - surfaceId: \(surfaceId ?? "nil"), sessionId: \(sessionId ?? "nil"), daemonClient: \(daemonClient != nil)")
 
         guard let surfaceId = surfaceId,
               let sessionId = sessionId,
               let daemonClient = daemonClient else {
             log.warning("Cannot save: missing surfaceId, sessionId, or daemonClient")
             lastSaveError = "Cannot save: missing document information"
-            print("💾 ❌ Save failed: missing information")
+            print("Save failed: missing information")
             return
         }
 
-        print("💾 Starting save: title=\(title), contentLength=\(currentContent.count), wordCount=\(wordCount)")
+        let contentToSave = currentContent ?? ""
+        print("Starting save: title=\(title), contentLength=\(contentToSave.count), wordCount=\(wordCount)")
         isSaving = true
         lastSaveError = nil
 
@@ -144,11 +150,11 @@ final class DocumentManager: ObservableObject {
                 surfaceId: surfaceId,
                 conversationId: sessionId,
                 title: title,
-                content: currentContent,
+                content: contentToSave,
                 wordCount: wordCount
             )
             log.info("Document save requested: \(surfaceId) - \(self.wordCount) words")
-            print("💾 ✅ IPC message sent successfully")
+            print("IPC message sent successfully")
         } catch {
             log.error("Failed to send document save: \(error.localizedDescription)")
             lastSaveError = error.localizedDescription


### PR DESCRIPTION
## Summary
- Changes contentForEditorView() to distinguish between uninitialized content (nil) and intentionally empty content ("")
- Prevents deleted content from reappearing when the editor panel is reopened
- Addresses Codex feedback on #4541

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4541
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
