### PR TITLE
fix: move copy and retry tooltips below buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1140,7 +1140,7 @@ private struct ChatBubble: View {
                 NSCursor.arrow.set()
             }
         }
-        .overlay(alignment: .top) {
+        .overlay(alignment: .bottom) {
             if isCopyHovered && !showCopyConfirmation {
                 Text("Copy")
                     .font(VFont.caption)
@@ -1157,7 +1157,7 @@ private struct ChatBubble: View {
                     )
                     .vShadow(VShadow.sm)
                     .fixedSize()
-                    .offset(y: -28)
+                    .offset(y: 28)
                     .transition(.opacity)
                     .allowsHitTesting(false)
             }
@@ -1178,7 +1178,7 @@ private struct ChatBubble: View {
         .buttonStyle(.plain)
         .accessibilityLabel("Try again")
         .onHover { isRegenerateHovered = $0 }
-        .overlay(alignment: .top) {
+        .overlay(alignment: .bottom) {
             if isRegenerateHovered {
                 Text("Try again")
                     .font(VFont.caption)
@@ -1195,7 +1195,7 @@ private struct ChatBubble: View {
                     )
                     .vShadow(VShadow.sm)
                     .fixedSize()
-                    .offset(y: -28)
+                    .offset(y: 28)
                     .transition(.opacity)
                     .allowsHitTesting(false)
             }


### PR DESCRIPTION
## Summary
- Move copy and retry tooltip overlays from above to below the buttons
- Tooltips now appear underneath instead of overlapping message content above

## Test plan
- [ ] Hover copy button — tooltip appears below
- [ ] Hover retry button — tooltip appears below

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
