### PR TITLE
fix: match three-dot menu icon color with copy/retry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1077,6 +1077,7 @@ private struct ChatBubble: View {
                         }
                         .menuStyle(.borderlessButton)
                         .menuIndicator(.hidden)
+                        .tint(VColor.textMuted)
                         .frame(width: 24, height: 24)
                         .opacity(isUser ? (isHovered ? 1 : 0) : 1)
                         .allowsHitTesting(isUser ? isHovered : true)


### PR DESCRIPTION
## Summary
- Add `.tint(VColor.textMuted)` to the ellipsis menu so it matches the copy and retry button colors
- The `.borderlessButton` menu style ignores `.foregroundColor` on the label and uses tint instead

## Test plan
- [ ] Three-dot menu icon now matches the muted color of copy and retry buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
