### PR TITLE
fix: use direct panel selection for document editor to prevent toggle-close

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -168,7 +168,7 @@ final class MainWindow {
             initialContent: msg.initialContent
         )
         show()
-        windowState.togglePanel(.documentEditor)
+        windowState.selection = .panel(.documentEditor)
     }
 
     func handleDocumentEditorUpdate(_ msg: DocumentEditorUpdateMessage) {
@@ -189,7 +189,7 @@ final class MainWindow {
             initialContent: content
         )
         show()
-        windowState.togglePanel(.documentEditor)
+        windowState.selection = .panel(.documentEditor)
     }
 
     func show() {


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #4512 (document preview widget in chat).

The P1 review comment noted that tapping a document preview widget when
the editor panel is already open with a different document could accidentally
close the panel (since `togglePanel` acts as a toggle). This fix replaces
`togglePanel(.documentEditor)` with `windowState.selection = .panel(.documentEditor)`
in both `handleDocumentEditorShow` and `handleDocumentLoadResponse` so that opening
the document editor is always an open operation, never a close.

### Changes

- `clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift`: Replace
  `windowState.togglePanel(.documentEditor)` with `windowState.selection = .panel(.documentEditor)`
  in `handleDocumentEditorShow` and `handleDocumentLoadResponse` to prevent accidentally
  closing the panel when a second show message arrives while the panel is already open
  (e.g. when multiple document preview widgets are present in chat).

### Context

The P2 fix (persisting document preview surfaces across app restarts) was addressed
in PR #4639 by auto-tracking `ui_surface_show` messages from tools in
`currentTurnSurfaces` so they are serialised into the assistant message at
`message_complete` and survive thread reloads.

## Test plan

- [ ] Open a document with `document_create`
- [ ] Verify the document editor panel opens
- [ ] Click the inline document preview widget again
- [ ] Verify the panel stays open (does not toggle-close)
- [ ] With multiple document previews, click each to verify the correct document loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
