### PR TITLE
fix: editable document title in toolbar and initialize word count on load

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -51,6 +51,7 @@ final class DocumentManager: ObservableObject {
         self.sessionId = sessionId
         self.title = title
         self.initialContent = initialContent
+        self.wordCount = initialContent.split(whereSeparator: \.isWhitespace).count
         self.hasActiveDocument = true
 
         // Initialize editor with content (or store as pending if coordinator not ready)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -10,10 +10,11 @@ struct DocumentEditorPanelView: View {
         VStack(spacing: 0) {
             // Header toolbar
             HStack {
-                Text(documentManager.title)
+                TextField("Document title", text: $documentManager.title)
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(1)
+                    .textFieldStyle(.plain)
                 Spacer()
                 if documentManager.wordCount > 0 {
                     Text("\(documentManager.wordCount) words")


### PR DESCRIPTION
## Summary
- Makes document title editable directly in the panel toolbar via a SwiftUI TextField (replaces non-editable Text view) — users can now rename documents without needing the hidden WebView header
- Seeds wordCount from initialContent in createDocument() so the toolbar shows correct word count immediately when a document loads, not just after the first edit

Addresses Codex feedback from https://github.com/vellum-ai/vellum-assistant/pull/4594
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
