### PR TITLE
fix: change secret detection default from block to redact

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -98,7 +98,7 @@ describe('AssistantConfigSchema', () => {
       },
     });
     expect(result.rateLimit).toEqual({ maxRequestsPerMinute: 0, maxTokensPerSession: 0 });
-    expect(result.secretDetection).toEqual({ enabled: true, action: 'block', entropyThreshold: 4.0, allowOneTimeSend: false, blockIngress: true });
+    expect(result.secretDetection).toEqual({ enabled: true, action: 'redact', entropyThreshold: 4.0, allowOneTimeSend: false, blockIngress: true });
     expect(result.auditLog).toEqual({ retentionDays: 0 });
   });
 
@@ -617,7 +617,7 @@ describe('loadConfig with schema validation', () => {
   test('falls back for invalid secretDetection.action', () => {
     writeConfig({ secretDetection: { action: 'explode' } });
     const config = loadConfig();
-    expect(config.secretDetection.action).toBe('block');
+    expect(config.secretDetection.action).toBe('redact');
   });
 
   test('falls back for invalid sandbox.enabled', () => {

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -413,10 +413,10 @@ describe('One-time send override', () => {
     expect(DEFAULT_CONFIG.secretDetection.allowOneTimeSend).toBe(false);
   });
 
-  test('default secretDetection.action is block', () => {
+  test('default secretDetection.action is redact', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { DEFAULT_CONFIG } = require('../config/defaults.js');
-    expect(DEFAULT_CONFIG.secretDetection.action).toBe('block');
+    expect(DEFAULT_CONFIG.secretDetection.action).toBe('redact');
   });
 
   test('default secretDetection.blockIngress is true', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -151,7 +151,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   secretDetection: {
     enabled: true,
-    action: 'block',
+    action: 'redact',
     entropyThreshold: 4.0,
     allowOneTimeSend: false,
     blockIngress: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -101,7 +101,7 @@ export const SecretDetectionConfigSchema = z.object({
     .enum(VALID_SECRET_ACTIONS, {
       error: `secretDetection.action must be one of: ${VALID_SECRET_ACTIONS.join(', ')}`,
     })
-    .default('block'),
+    .default('redact'),
   entropyThreshold: z
     .number({ error: 'secretDetection.entropyThreshold must be a number' })
     .finite('secretDetection.entropyThreshold must be finite')
@@ -908,7 +908,7 @@ export const AssistantConfigSchema = z.object({
   }),
   secretDetection: SecretDetectionConfigSchema.default({
     enabled: true,
-    action: 'block',
+    action: 'redact',
     entropyThreshold: 4.0,
     allowOneTimeSend: false,
     blockIngress: true,


### PR DESCRIPTION
## Summary
- Changes `secretDetection.action` default from `"block"` to `"redact"`
- `"block"` replaces the entire tool output with an error on any match — too aggressive for email/messaging tools where normal metadata (tracking tokens, message IDs, DKIM signatures) triggers false positives
- `"redact"` still catches and masks real secrets (AWS keys, GitHub PATs, etc.) but preserves the rest of the content so the model can work with it
- Updates defaults.ts, schema.ts, and corresponding test assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
