### PR TITLE
fix: address PR #4639 review feedback - seed currentContent and fix auto-save scheduling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -51,6 +51,7 @@ final class DocumentManager: ObservableObject {
         self.sessionId = sessionId
         self.title = title
         self.initialContent = initialContent
+        self.currentContent = initialContent
         self.wordCount = initialContent.split(whereSeparator: \.isWhitespace).count
         self.hasActiveDocument = true
 
@@ -85,6 +86,7 @@ final class DocumentManager: ObservableObject {
             currentContent = existing + sep + markdown
         }
 
+        scheduleAutoSave()
         guard let coordinator = editorCoordinator else {
             log.warning("Cannot update document: editor coordinator not ready, content tracked for later")
             print("Cannot update document: editor coordinator not ready, content tracked for later")


### PR DESCRIPTION
## Summary

Addresses review feedback on #4639 (feat: persist document widget in chat after app reload).

### Fix 1: Seed `currentContent` in `createDocument`

`createDocument` now sets `self.currentContent = initialContent` before marking the document active. Previously, when a document was opened via `document_load_response` (with existing content) and a subsequent `append`-mode streaming update arrived, `currentContent` was `nil`, causing the buffer to drop the original text and lose data on reload.

### Fix 2: Schedule auto-save before the coordinator guard

Moved `scheduleAutoSave()` to before the `guard let coordinator = editorCoordinator else { return }` block in `updateDocument`. Previously, if all streaming updates completed before the WebView coordinator finished loading, `scheduleAutoSave()` was never called and the document was never persisted. The auto-save now fires regardless of coordinator readiness.

## Files Modified

- `clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift`

## Notes

Fix 3 from the review (use `selection = .panel(.documentEditor)` instead of `togglePanel`) was already applied in commit `d3f80158` ("fix: prevent document editor panel closing on second show") and is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
