### PR TITLE
fix: vertically center composer placeholder text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -734,10 +734,15 @@ private final class ComposerNativeTextView: NSTextView {
 
         let linePadding = textContainer?.lineFragmentPadding ?? 0
         let x = textContainerInset.width + linePadding
-        let y = textContainerInset.height + placeholderVerticalOffset
         let width = max(0, bounds.width - x - textContainerInset.width - linePadding)
-        let height = max(0, bounds.height - (textContainerInset.height * 2))
-        let rect = NSRect(x: x, y: y, width: width, height: height)
+
+        // Measure placeholder height to vertically center it
+        let measureSize = NSSize(width: width, height: .greatestFiniteMagnitude)
+        let placeholderSize = (placeholderText as NSString).boundingRect(
+            with: measureSize, options: .usesLineFragmentOrigin, attributes: attributes
+        ).size
+        let y = max(0, (bounds.height - placeholderSize.height) / 2)
+        let rect = NSRect(x: x, y: y, width: width, height: placeholderSize.height)
 
         (placeholderText as NSString).draw(in: rect, withAttributes: attributes)
     }


### PR DESCRIPTION
## Summary
- Center placeholder text vertically within the composer text field instead of top-aligning it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
