### PR TITLE
M3: Guard per-message copy on non-empty text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1034,7 +1034,9 @@ private struct ChatBubble: View {
                 }
 
                 HStack(spacing: VSpacing.xs) {
-                    copyButton
+                    if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        copyButton
+                    }
 
                     if showRegenerate {
                         regenerateButton


### PR DESCRIPTION
Only show the per-message copy button when the message has non-empty text content, so tool-only and surface-only messages don't show an empty copy affordance. Part of #4837.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
