### PR TITLE
M1: ChatTranscriptFormatter shared utility + unit tests

### DIFF
--- a/clients/shared/Features/Chat/ChatTranscriptFormatter.swift
+++ b/clients/shared/Features/Chat/ChatTranscriptFormatter.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Formats chat messages for clipboard export. Shared across platforms.
+public enum ChatTranscriptFormatter {
+
+    public struct ParticipantNames {
+        public let assistantName: String
+        public let userName: String
+
+        public init(assistantName: String, userName: String) {
+            self.assistantName = assistantName
+            self.userName = userName
+        }
+    }
+
+    /// Render an entire thread as lightweight Markdown.
+    /// - Parameters:
+    ///   - messages: All messages in the thread.
+    ///   - threadTitle: Optional thread title (rendered as `# title`).
+    ///   - participantNames: Display names for assistant and user.
+    /// - Returns: Markdown string, or empty string if no text messages exist.
+    public static func threadMarkdown(
+        messages: [ChatMessage],
+        threadTitle: String?,
+        participantNames: ParticipantNames
+    ) -> String {
+        let textMessages = messages.filter {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard !textMessages.isEmpty else { return "" }
+
+        var parts: [String] = []
+
+        if let title = threadTitle, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            parts.append("# \(title)")
+        }
+
+        let messageParts = textMessages.map { message -> String in
+            let sender = message.role == .assistant
+                ? participantNames.assistantName
+                : participantNames.userName
+            return "### \(sender)\n\(message.text)"
+        }
+
+        parts.append(messageParts.joined(separator: "\n\n---\n\n"))
+
+        return parts.joined(separator: "\n\n")
+    }
+
+    /// Plain text content of a single message for per-message copy.
+    /// Returns the trimmed text, or empty string if the message has no text content.
+    public static func messagePlainText(_ message: ChatMessage) -> String {
+        message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/clients/shared/Tests/ChatTranscriptFormatterTests.swift
+++ b/clients/shared/Tests/ChatTranscriptFormatterTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatTranscriptFormatterTests: XCTestCase {
+
+    private let names = ChatTranscriptFormatter.ParticipantNames(
+        assistantName: "Aria",
+        userName: "Noa"
+    )
+
+    // MARK: - threadMarkdown
+
+    func testThreadMarkdownWithTitleAndMessages() {
+        let messages = [
+            ChatMessage(role: .user, text: "Hello!"),
+            ChatMessage(role: .assistant, text: "Hi there!")
+        ]
+
+        let result = ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: "Test Thread",
+            participantNames: names
+        )
+
+        XCTAssertTrue(result.hasPrefix("# Test Thread"))
+        XCTAssertTrue(result.contains("### Noa"))
+        XCTAssertTrue(result.contains("Hello!"))
+        XCTAssertTrue(result.contains("### Aria"))
+        XCTAssertTrue(result.contains("Hi there!"))
+        XCTAssertTrue(result.contains("---"))
+    }
+
+    func testThreadMarkdownWithoutTitle() {
+        let messages = [
+            ChatMessage(role: .user, text: "Hello!")
+        ]
+
+        let result = ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: nil,
+            participantNames: names
+        )
+
+        XCTAssertFalse(result.hasPrefix("# "))
+        XCTAssertTrue(result.contains("### Noa"))
+        XCTAssertTrue(result.contains("Hello!"))
+    }
+
+    func testThreadMarkdownSkipsEmptyTextMessages() {
+        let messages = [
+            ChatMessage(role: .assistant, text: ""),
+            ChatMessage(role: .user, text: "Real message"),
+            ChatMessage(role: .assistant, text: "   "),
+        ]
+
+        let result = ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: nil,
+            participantNames: names
+        )
+
+        XCTAssertFalse(result.contains("### Aria"))
+        XCTAssertTrue(result.contains("### Noa"))
+        XCTAssertTrue(result.contains("Real message"))
+        XCTAssertFalse(result.contains("---"))
+    }
+
+    func testThreadMarkdownEmptyInputReturnsEmptyString() {
+        let result = ChatTranscriptFormatter.threadMarkdown(
+            messages: [],
+            threadTitle: "Empty Thread",
+            participantNames: names
+        )
+
+        XCTAssertEqual(result, "")
+    }
+
+    func testThreadMarkdownAllEmptyTextReturnsEmptyString() {
+        let messages = [
+            ChatMessage(role: .assistant, text: ""),
+            ChatMessage(role: .user, text: "  \n  "),
+        ]
+
+        let result = ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: "Thread",
+            participantNames: names
+        )
+
+        XCTAssertEqual(result, "")
+    }
+
+    func testThreadMarkdownSeparatorsBetweenMessages() {
+        let messages = [
+            ChatMessage(role: .user, text: "First"),
+            ChatMessage(role: .assistant, text: "Second"),
+            ChatMessage(role: .user, text: "Third"),
+        ]
+
+        let result = ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: nil,
+            participantNames: names
+        )
+
+        let separatorCount = result.components(separatedBy: "\n\n---\n\n").count - 1
+        XCTAssertEqual(separatorCount, 2)
+    }
+
+    func testThreadMarkdownUsesParticipantNames() {
+        let customNames = ChatTranscriptFormatter.ParticipantNames(
+            assistantName: "Bot",
+            userName: "Human"
+        )
+        let messages = [
+            ChatMessage(role: .user, text: "Hi"),
+            ChatMessage(role: .assistant, text: "Hello")
+        ]
+
+        let result = ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: nil,
+            participantNames: customNames
+        )
+
+        XCTAssertTrue(result.contains("### Human"))
+        XCTAssertTrue(result.contains("### Bot"))
+        XCTAssertFalse(result.contains("Aria"))
+        XCTAssertFalse(result.contains("Noa"))
+    }
+
+    // MARK: - messagePlainText
+
+    func testMessagePlainTextReturnsTrimmedText() {
+        let message = ChatMessage(role: .assistant, text: "  Hello world  ")
+        XCTAssertEqual(ChatTranscriptFormatter.messagePlainText(message), "Hello world")
+    }
+
+    func testMessagePlainTextReturnsEmptyForBlankMessage() {
+        let message = ChatMessage(role: .user, text: "   ")
+        XCTAssertEqual(ChatTranscriptFormatter.messagePlainText(message), "")
+    }
+
+    func testMessagePlainTextReturnsEmptyForEmptyMessage() {
+        let message = ChatMessage(role: .user, text: "")
+        XCTAssertEqual(ChatTranscriptFormatter.messagePlainText(message), "")
+    }
+}


### PR DESCRIPTION
Add ChatTranscriptFormatter to VellumAssistantShared with threadMarkdown() and messagePlainText() methods. Includes comprehensive unit tests. Part of #4837.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
