### PR TITLE
fix: scrub command clears config.json and LOOKS.md

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -43,9 +43,10 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
    defaults delete com.vellum.vellum-assistant
    ```
 
-7. Remove workspace config (contains model selection that triggers onboarding skip):
+7. Remove workspace config and avatar appearance (contains model selection that triggers onboarding skip, and avatar state from previous sessions):
    ```bash
    rm -f ~/.vellum/workspace/config.json
+   rm -f ~/.vellum/workspace/LOOKS.md
    ```
 
 8. Reset workspace prompt files to templates so the BOOTSTRAP.md onboarding ritual runs again:


### PR DESCRIPTION
## Summary
- Clear `~/.vellum/workspace/config.json` during scrub (contains model selection that causes the app to auto-skip onboarding)
- Clear `~/.vellum/workspace/LOOKS.md` during scrub (carries over avatar appearance from previous sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
