### PR TITLE
fix: emit message_complete before git commit to prevent stuck thinking indicator

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1276,13 +1276,8 @@ export class Session {
         sessionId: this.conversationId,
       });
 
-      // Turn-boundary commit: awaited so it completes before the next turn starts.
-      // Without awaiting, the next turn could begin (via drainQueue in finally)
-      // and its file writes could be attributed to this turn's commit.
-      this.turnCount++;
-      await commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
-
       // Resolve accumulated attachment directives and tool content blocks
+      // BEFORE emitting the completion event so attachments are included.
       const attachmentResult = await resolveAssistantAttachments(
         accumulatedDirectives,
         accumulatedToolContentBlocks,
@@ -1302,6 +1297,11 @@ export class Session {
         onEvent({ type: 'assistant_text_delta', text: warningText, sessionId: this.conversationId });
       }
 
+      // Emit the completion event BEFORE the turn-boundary commit so the
+      // client's thinking/streaming indicators clear immediately.  The git
+      // commit can take 0.5–2 s on large workspaces and has no dependency
+      // on the completion signal — it only needs to finish before
+      // drainQueue (which runs in `finally`).
       if (yieldedForHandoff) {
         this.traceEmitter.emit('generation_handoff', 'Handing off to next queued message', {
           requestId: reqId,
@@ -1332,6 +1332,12 @@ export class Session {
           ...(emittedAttachments.length > 0 ? { attachments: emittedAttachments } : {}),
         });
       }
+
+      // Turn-boundary commit: awaited so it completes before the next turn
+      // starts (drainQueue runs in `finally`).  Runs after the completion
+      // event so the client isn't blocked on git operations.
+      this.turnCount++;
+      await commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
 
       // Auto-generate conversation title after first exchange
       if (isFirstMessage) {


### PR DESCRIPTION
## Summary
- Reorder session post-processing so `message_complete` is emitted before `commitTurnChanges`
- The git commit (0.5–2s on large workspaces) was blocking the completion signal, leaving the inline 'Thinking' indicator stuck after all tools finished
- No behavior change — commit still completes before `drainQueue` in the `finally` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
