### PR TITLE
fix: sidebar polish + disable composer button focus ring

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -938,6 +938,7 @@ private struct ComposerActionButtonStyle: ButtonStyle {
                     )
             )
             .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .focusEffectDisabled()
             .scaleEffect(configuration.isPressed ? 0.97 : 1)
             .animation(VAnimation.fast, value: configuration.isPressed)
             .animation(VAnimation.fast, value: isHovered)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -741,6 +741,7 @@ struct MainWindowView: View {
             ScrollView {
                 VStack(spacing: 0) {
                     // MARK: Nav Items
+                    Spacer().frame(height: VSpacing.md)
                     SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory) {
                         windowState.togglePanel(.directory)
                     }
@@ -749,7 +750,7 @@ struct MainWindowView: View {
                     }
 
                     // MARK: Chats
-                    SidebarSubheader(title: "Chats")
+                    SidebarSubheader(title: "Recent Chats")
 
                     ForEach(displayedThreads) { thread in
                         threadItem(thread)


### PR DESCRIPTION
## Summary
- Disable default macOS blue focus ring on composer action buttons (paperclip, mic) via `.focusEffectDisabled()`
- Add top padding above Home Base in the sidebar for better spacing below traffic lights
- Rename sidebar section header from "Chats" to "Recent Chats"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
