### PR TITLE
feat: add 'prompt' secret detection action to ask user instead of blocking

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -3,7 +3,7 @@ import { getDataDir } from '../util/platform.js';
 
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks'] as const;
 const VALID_WEB_SEARCH_PROVIDERS = ['perplexity', 'brave'] as const;
-const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
+const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block', 'prompt'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
 const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1152,7 +1152,7 @@ export interface SecretDetected {
   type: 'secret_detected';
   toolName: string;
   matches: Array<{ type: string; redactedValue: string }>;
-  action: 'redact' | 'warn' | 'block';
+  action: 'redact' | 'warn' | 'block' | 'prompt';
 }
 
 export interface MemoryRecalledCandidateDebug {

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -29,7 +29,7 @@ export interface ToolDomainEvents {
     sessionId: string;
     requestId?: string;
     toolName: string;
-    action: 'redact' | 'warn' | 'block';
+    action: 'redact' | 'warn' | 'block' | 'prompt';
     matches: Array<{ type: string; redactedValue: string }>;
     detectedAtMs: number;
   };

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -425,7 +425,7 @@ export class ToolExecutor {
             }
           } else if (sdConfig.action === 'block') {
             const types = [...new Set(allMatches.map((m) => m.type))].join(', ');
-            const blockedContent = `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Configure secretDetection.action to "redact" or "warn" to allow output.`;
+            const blockedContent = `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Configure secretDetection.action to "redact" or "prompt" to allow output.`;
             const durationMs = Date.now() - startTime;
             const blockedResult = {
               content: blockedContent,
@@ -456,6 +456,75 @@ export class ToolExecutor {
             });
 
             return blockedResult;
+          } else if (sdConfig.action === 'prompt') {
+            // Ask the user whether to allow tool output containing secrets
+            const types = [...new Set(allMatches.map((m) => m.type))].join(', ');
+            const promptInput = {
+              _secretDetection: true,
+              summary: `Tool output contains ${allMatches.length} potential secret(s): ${types}`,
+              tool: name,
+            };
+
+            emitLifecycleEvent(context, {
+              type: 'permission_prompt',
+              toolName: name,
+              executionTarget,
+              input: promptInput,
+              workingDir: context.workingDir,
+              sessionId: context.sessionId,
+              conversationId: context.conversationId,
+              requestId: context.requestId,
+              riskLevel: RiskLevel.High,
+              reason: `Secret detected in tool output: ${types}`,
+              allowlistOptions: [],
+              scopeOptions: [],
+              persistentDecisionsAllowed: false,
+            });
+
+            const response = await this.prompter.prompt(
+              name,
+              promptInput,
+              RiskLevel.High,
+              [],   // no allowlist options
+              [],   // no scope options
+              undefined, // no diff
+              undefined, // not sandboxed
+              context.conversationId,
+              executionTarget,
+              undefined, // no principal
+              false, // no persistent decisions
+            );
+
+            if (response.decision === 'deny' || response.decision === 'always_deny') {
+              const blockedContent = `Tool output blocked: user denied output containing ${allMatches.length} potential secret(s) (${types}).`;
+              const durationMs = Date.now() - startTime;
+              emitLifecycleEvent(context, {
+                type: 'executed',
+                toolName: name,
+                executionTarget,
+                input,
+                workingDir: context.workingDir,
+                sessionId: context.sessionId,
+                conversationId: context.conversationId,
+                requestId: context.requestId,
+                riskLevel,
+                decision: 'deny',
+                durationMs,
+                result: { content: blockedContent, isError: true },
+              });
+
+              void getHookManager().trigger('post-tool-execute', {
+                toolName: name,
+                input: sanitizeToolInput(name, input),
+                riskLevel,
+                isError: true,
+                durationMs,
+                sessionId: context.sessionId,
+              });
+
+              return { content: blockedContent, isError: true };
+            }
+            // User allowed — pass content through unchanged
           }
         }
       }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -66,7 +66,7 @@ export interface ToolExecutionErrorEvent extends ToolLifecycleEventBase {
 export interface ToolSecretDetectedEvent extends ToolLifecycleEventBase {
   type: 'secret_detected';
   matches: Array<{ type: string; redactedValue: string }>;
-  action: 'redact' | 'warn' | 'block';
+  action: 'redact' | 'warn' | 'block' | 'prompt';
   detectedAtMs: number;
 }
 


### PR DESCRIPTION
## Summary
- Adds `'prompt'` as a new `secretDetection.action` option alongside `redact`, `warn`, and `block`
- When set to `prompt`, detected secrets in tool output trigger the standard Allow/Deny confirmation dialog instead of silently blocking
- If the user allows, the output passes through unchanged; if denied, it's blocked with an error message
- Updated the action type across all type definitions (config schema, tool types, domain events, IPC contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
