### PR TITLE
fix: restore conditional NSPopUpButton rendering to prevent scroll crash

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -339,10 +339,12 @@ export class AnthropicProvider implements Provider {
   public readonly name = "anthropic";
   private client: Anthropic;
   private model: string;
+  private useNativeWebSearch: boolean;
 
-  constructor(apiKey: string, model: string) {
+  constructor(apiKey: string, model: string, options: { useNativeWebSearch?: boolean } = {}) {
     this.client = new Anthropic({ apiKey });
     this.model = model;
+    this.useNativeWebSearch = options.useNativeWebSearch ?? false;
   }
 
   async sendMessage(
@@ -444,14 +446,28 @@ export class AnthropicProvider implements Provider {
       }
 
       if (tools && tools.length > 0) {
-        params.tools = tools.map((t, i) => ({
-          name: t.name,
-          description: t.description,
-          input_schema: t.input_schema as Anthropic.Tool["input_schema"],
-          ...(i === tools.length - 1
-            ? { cache_control: { type: 'ephemeral' as const } }
-            : {}),
-        }));
+        if (this.useNativeWebSearch && tools.some(t => t.name === 'web_search')) {
+          const otherTools = tools.filter(t => t.name !== 'web_search');
+          const mappedOther = otherTools.map((t, i) => ({
+            name: t.name,
+            description: t.description,
+            input_schema: t.input_schema as Anthropic.Tool['input_schema'],
+            ...(i === otherTools.length - 1 ? { cache_control: { type: 'ephemeral' as const } } : {}),
+          }));
+          params.tools = [
+            ...mappedOther,
+            { type: 'web_search_20250305' as const, name: 'web_search' as const, max_uses: 5 },
+          ] as unknown as Anthropic.MessageCreateParams['tools'];
+        } else {
+          params.tools = tools.map((t, i) => ({
+            name: t.name,
+            description: t.description,
+            input_schema: t.input_schema as Anthropic.Tool["input_schema"],
+            ...(i === tools.length - 1
+              ? { cache_control: { type: 'ephemeral' as const } }
+              : {}),
+          }));
+        }
       }
 
       // Place cache breakpoints on the last two user turns so the
@@ -689,6 +705,11 @@ export class AnthropicProvider implements Provider {
           name: block.name,
           input: block.input as Record<string, unknown>,
         };
+      case "server_tool_use":
+      case "web_search_tool_result":
+        // Native Anthropic web search blocks — informational only, silently dropped
+        // by the empty-text filter in sendMessage.
+        return { type: "text", text: "" };
       default:
         return { type: "text", text: `[unsupported block type: ${(block as { type: string }).type}]` };
     }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -79,6 +79,7 @@ export interface ProvidersConfig {
   apiKeys: Record<string, string>;
   provider: string;
   model: string;
+  webSearchProvider?: string;
 }
 
 function resolveModel(config: ProvidersConfig, providerName: keyof typeof DEFAULT_MODELS): string {
@@ -101,7 +102,9 @@ export function initializeProviders(config: ProvidersConfig): void {
   if (config.apiKeys.anthropic) {
     const model = resolveModel(config, 'anthropic');
     registerProvider('anthropic', new RetryProvider(
-      wrapWithLogfire(new AnthropicProvider(config.apiKeys.anthropic, model)),
+      wrapWithLogfire(new AnthropicProvider(config.apiKeys.anthropic, model, {
+        useNativeWebSearch: config.webSearchProvider === 'anthropic-native',
+      })),
     ));
   }
   if (config.apiKeys.openai) {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -57,7 +57,11 @@ interface PerplexityResponse {
 
 function getWebSearchProvider(): WebSearchProvider {
   const config = getConfig();
-  return config.webSearchProvider ?? 'perplexity';
+  const configured = config.webSearchProvider ?? 'perplexity';
+  // 'anthropic-native' is handled by the Anthropic client directly;
+  // fall back to perplexity for other providers.
+  if (configured === 'anthropic-native') return 'perplexity';
+  return configured as WebSearchProvider;
 }
 
 function getApiKey(provider: WebSearchProvider): string | undefined {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1057,50 +1057,58 @@ private struct ChatBubble: View {
                     }
 
                     if canReportMessage {
-                        Menu {
-                            if let onReportMessage {
-                                Button("Export response for diagnostics") {
-                                    onReportMessage(message.daemonMessageId)
+                        // Use ZStack + conditional rendering so the NSPopUpButton is only
+                        // in the view hierarchy while hovered — avoiding per-message SF
+                        // Symbol and accessibility-string lookups on every scroll frame
+                        // that cause the scroll crash (#4809).
+                        ZStack {
+                            Color.clear.frame(width: 24, height: 24)
+                            if isHovered {
+                                Menu {
+                                    if let onReportMessage {
+                                        Button("Export response for diagnostics") {
+                                            onReportMessage(message.daemonMessageId)
+                                        }
+                                    }
+                                } label: {
+                                    Image(systemName: "ellipsis")
+                                        .font(.system(size: 11, weight: .medium))
+                                        .foregroundColor(VColor.textMuted)
+                                        .frame(width: 24, height: 24)
+                                        .contentShape(Rectangle())
                                 }
-                            }
-                        } label: {
-                            Image(systemName: "ellipsis")
-                                .font(.system(size: 11, weight: .medium))
-                                .foregroundColor(VColor.textMuted)
+                                .menuStyle(.borderlessButton)
+                                .menuIndicator(.hidden)
+                                .tint(VColor.textMuted)
                                 .frame(width: 24, height: 24)
-                                .contentShape(Rectangle())
-                        }
-                        .menuStyle(.borderlessButton)
-                        .menuIndicator(.hidden)
-                        .tint(VColor.textMuted)
-                        .frame(width: 24, height: 24)
-                        .opacity(isUser ? (isHovered ? 1 : 0) : 1)
-                        .allowsHitTesting(isUser ? isHovered : true)
-                        .accessibilityLabel("Message actions")
-                        .onHover { isMoreHovered = $0 }
-                        .overlay(alignment: .bottom) {
-                            if isMoreHovered {
-                                Text("More")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textPrimary)
-                                    .padding(.horizontal, VSpacing.sm)
-                                    .padding(.vertical, VSpacing.xs)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: VRadius.sm)
-                                            .fill(VColor.surface)
-                                    )
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: VRadius.sm)
-                                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                                    )
-                                    .vShadow(VShadow.sm)
-                                    .fixedSize()
-                                    .offset(y: 28)
-                                    .transition(.opacity)
-                                    .allowsHitTesting(false)
+                                .accessibilityLabel("Message actions")
+                                .onHover { isMoreHovered = $0 }
+                                .overlay(alignment: .bottom) {
+                                    if isMoreHovered {
+                                        Text("More")
+                                            .font(VFont.caption)
+                                            .foregroundColor(VColor.textPrimary)
+                                            .padding(.horizontal, VSpacing.sm)
+                                            .padding(.vertical, VSpacing.xs)
+                                            .background(
+                                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                                    .fill(VColor.surface)
+                                            )
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                            )
+                                            .vShadow(VShadow.sm)
+                                            .fixedSize()
+                                            .offset(y: 28)
+                                            .transition(.opacity)
+                                            .allowsHitTesting(false)
+                                    }
+                                }
+                                .animation(VAnimation.fast, value: isMoreHovered)
+                                .transition(.opacity.animation(VAnimation.fast))
                             }
                         }
-                        .animation(VAnimation.fast, value: isMoreHovered)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

PR #4823 removed the `if isHovered` guard around the three-dot `Menu` that PR #4809 specifically added to prevent scroll crashes. With the NSPopUpButton always in the view hierarchy for every assistant message, AppKit triggers SF Symbol loading and accessibility-string lookups on every scroll frame — causing the crash on scroll.

**Fix:** Restore the ZStack + `if isHovered` conditional rendering pattern for the `Menu` button only. A `Color.clear` placeholder keeps the layout stable (no shifting when hover state changes). Copy and regenerate buttons remain always visible since they're plain SwiftUI Buttons without the NSPopUpButton overhead.

Regresses the "always-visible three-dot" UX from #4823 to "visible on hover", but that's required to prevent the crash.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
