### PR TITLE
Remove redundant protected-dir trust rules for file_read/write/edit

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -791,34 +791,12 @@ describe('Trust Store', () => {
       // Remove one default rule by editing trust.json directly on disk
       // (removeRule() throws for default rules, so we simulate external editing)
       const raw = JSON.parse(readFileSync(trustPath, 'utf-8'));
-      raw.rules = raw.rules.filter((r: { id: string }) => r.id !== 'default:ask-file_read-protected');
+      raw.rules = raw.rules.filter((r: { id: string }) => r.id !== 'default:ask-host_file_read-global');
       writeFileSync(trustPath, JSON.stringify(raw, null, 2));
       // After reload, the rule is re-backfilled (defaults are always present)
       clearCache();
       const rules = getAllRules();
-      expect(rules.find((r) => r.id === 'default:ask-file_read-protected')).toBeDefined();
-    });
-
-    test('findHighestPriorityRule matches default ask for protected file_read', () => {
-      const protectedPath = join(testDir, 'protected', 'trust.json');
-      const match = findHighestPriorityRule('file_read', [`file_read:${protectedPath}`], '/tmp');
-      expect(match).not.toBeNull();
-      expect(match!.decision).toBe('ask');
-      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-file_read-protected')!);
-    });
-
-    test('findHighestPriorityRule matches default ask for protected file_write', () => {
-      const protectedPath = join(testDir, 'protected', 'keys.enc');
-      const match = findHighestPriorityRule('file_write', [`file_write:${protectedPath}`], '/tmp');
-      expect(match).not.toBeNull();
-      expect(match!.decision).toBe('ask');
-    });
-
-    test('findHighestPriorityRule matches default ask for protected file_edit', () => {
-      const protectedPath = join(testDir, 'protected', 'secret-allowlist.json');
-      const match = findHighestPriorityRule('file_edit', [`file_edit:${protectedPath}`], '/tmp');
-      expect(match).not.toBeNull();
-      expect(match!.decision).toBe('ask');
+      expect(rules.find((r) => r.id === 'default:ask-host_file_read-global')).toBeDefined();
     });
 
     test('findHighestPriorityRule matches default ask for host_file_read', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -12,8 +12,6 @@ export interface DefaultRuleTemplate {
   priority: number;
 }
 
-/** Tools that directly access the filesystem by path. */
-const FILE_TOOLS = ['file_read', 'file_write', 'file_edit'] as const;
 const HOST_FILE_TOOLS = ['host_file_read', 'host_file_write', 'host_file_edit'] as const;
 const COMPUTER_USE_TOOLS = [
   'computer_use_click',
@@ -37,19 +35,6 @@ const COMPUTER_USE_TOOLS = [
  * Computed at runtime so paths reflect the configured root directory.
  */
 export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
-  // Use forward slashes so minimatch patterns work on all platforms
-  // (path.join produces backslashes on Windows, which minimatch treats as escapes).
-  const protectedDir = join(getRootDir(), 'protected').replaceAll('\\', '/');
-
-  const protectedFileRules = FILE_TOOLS.map((tool) => ({
-    id: `default:ask-${tool}-protected`,
-    tool,
-    pattern: `${tool}:${protectedDir}/**`,
-    scope: 'everywhere',
-    decision: 'ask' as const,
-    priority: 1000,
-  }));
-
   const hostFileRules = HOST_FILE_TOOLS.map((tool) => ({
     id: `default:ask-${tool}-global`,
     tool,
@@ -221,7 +206,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   }));
 
   return [
-    ...protectedFileRules,
     ...hostFileRules,
     hostShellRule,
     ...computerUseRules,


### PR DESCRIPTION
## Summary
- Remove default `ask` trust rules for `file_read`, `file_write`, and `file_edit` targeting `~/.vellum/protected/**`
- These rules were unreachable: sandbox-scoped file tools use `sandboxPolicy()` which restricts them to the workspace directory, so they can never access the protected directory
- Host file tools (`host_file_read/write/edit`) still have their global `ask` rules and are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
