### PR TITLE
fix: restore conditional NSPopUpButton rendering to prevent scroll crash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1057,50 +1057,58 @@ private struct ChatBubble: View {
                     }
 
                     if canReportMessage {
-                        Menu {
-                            if let onReportMessage {
-                                Button("Export response for diagnostics") {
-                                    onReportMessage(message.daemonMessageId)
+                        // Use ZStack + conditional rendering so the NSPopUpButton is only
+                        // in the view hierarchy while hovered — avoiding per-message SF
+                        // Symbol and accessibility-string lookups on every scroll frame
+                        // that cause the scroll crash (see #4809).
+                        ZStack {
+                            Color.clear.frame(width: 24, height: 24)
+                            if isHovered {
+                                Menu {
+                                    if let onReportMessage {
+                                        Button("Export response for diagnostics") {
+                                            onReportMessage(message.daemonMessageId)
+                                        }
+                                    }
+                                } label: {
+                                    Image(systemName: "ellipsis")
+                                        .font(.system(size: 11, weight: .medium))
+                                        .foregroundColor(VColor.textMuted)
+                                        .frame(width: 24, height: 24)
+                                        .contentShape(Rectangle())
                                 }
-                            }
-                        } label: {
-                            Image(systemName: "ellipsis")
-                                .font(.system(size: 11, weight: .medium))
-                                .foregroundColor(VColor.textMuted)
+                                .menuStyle(.borderlessButton)
+                                .menuIndicator(.hidden)
+                                .tint(VColor.textMuted)
                                 .frame(width: 24, height: 24)
-                                .contentShape(Rectangle())
-                        }
-                        .menuStyle(.borderlessButton)
-                        .menuIndicator(.hidden)
-                        .tint(VColor.textMuted)
-                        .frame(width: 24, height: 24)
-                        .opacity(isUser ? (isHovered ? 1 : 0) : 1)
-                        .allowsHitTesting(isUser ? isHovered : true)
-                        .accessibilityLabel("Message actions")
-                        .onHover { isMoreHovered = $0 }
-                        .overlay(alignment: .bottom) {
-                            if isMoreHovered {
-                                Text("More")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textPrimary)
-                                    .padding(.horizontal, VSpacing.sm)
-                                    .padding(.vertical, VSpacing.xs)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: VRadius.sm)
-                                            .fill(VColor.surface)
-                                    )
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: VRadius.sm)
-                                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                                    )
-                                    .vShadow(VShadow.sm)
-                                    .fixedSize()
-                                    .offset(y: 28)
-                                    .transition(.opacity)
-                                    .allowsHitTesting(false)
+                                .accessibilityLabel("Message actions")
+                                .onHover { isMoreHovered = $0 }
+                                .overlay(alignment: .bottom) {
+                                    if isMoreHovered {
+                                        Text("More")
+                                            .font(VFont.caption)
+                                            .foregroundColor(VColor.textPrimary)
+                                            .padding(.horizontal, VSpacing.sm)
+                                            .padding(.vertical, VSpacing.xs)
+                                            .background(
+                                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                                    .fill(VColor.surface)
+                                            )
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                            )
+                                            .vShadow(VShadow.sm)
+                                            .fixedSize()
+                                            .offset(y: 28)
+                                            .transition(.opacity)
+                                            .allowsHitTesting(false)
+                                    }
+                                }
+                                .animation(VAnimation.fast, value: isMoreHovered)
+                                .transition(.opacity.animation(VAnimation.fast))
                             }
                         }
-                        .animation(VAnimation.fast, value: isMoreHovered)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

PR #4823 removed the `if isHovered` guard around the three-dot `Menu` that PR #4809 specifically added to prevent scroll crashes. With the NSPopUpButton (`.menuStyle(.borderlessButton)`) always in the view hierarchy for every assistant message, AppKit triggers SF Symbol loading and accessibility-string lookups on every scroll frame — causing the app to crash on scroll.

**Fix:** Restore the ZStack + `if isHovered` conditional rendering pattern from #4809 for the `Menu` button. A `Color.clear` 24×24 placeholder keeps the layout stable (no visual shift when hover state changes). Copy and regenerate buttons remain always visible since they're plain SwiftUI Buttons with no NSPopUpButton overhead.

Note: this means the three-dot button is hover-visible only (not always-visible), which partially reverts the UX intent of #4823 — but that's required to avoid the crash.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
