### PR TITLE
feat: migrate all first-party callers to assistant-less /v1/... routes

### DIFF
--- a/cli/src/adapters/openclaw-http-server.ts
+++ b/cli/src/adapters/openclaw-http-server.ts
@@ -144,12 +144,11 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  const messagesMatch = url.pathname.match(/^\/v1\/assistants\/([^/]+)\/messages$/);
+  const messagesMatch = url.pathname === "/v1/messages";
   if (messagesMatch) {
-    const assistantId = messagesMatch[1];
 
     if (req.method === "GET") {
-      const key = url.searchParams.get("conversationKey") ?? assistantId;
+      const key = url.searchParams.get("conversationKey") ?? "default";
       const msgs = messages[key] ?? [];
       res.writeHead(200);
       res.end(JSON.stringify({ messages: msgs }));
@@ -159,7 +158,7 @@ const server = http.createServer(async (req, res) => {
     if (req.method === "POST") {
       try {
         const parsed = await parseBody(req);
-        const key = (parsed.conversationKey as string) || assistantId;
+        const key = (parsed.conversationKey as string) || "default";
         if (!messages[key]) messages[key] = [];
         const messageId = crypto.randomUUID();
         messages[key].push({

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -81,7 +81,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig();
-    const result = await forwardToRuntime(config, "assistant-a", payload);
+    const result = await forwardToRuntime(config, payload);
     expect(result.accepted).toBe(true);
     expect(result.eventId).toBe("evt-1");
     expect(result.assistantMessage?.content).toBe("Hi there!");
@@ -94,7 +94,7 @@ describe("forwardToRuntime", () => {
 
     const config = makeConfig();
     await expect(
-      forwardToRuntime(config, "assistant-a", payload),
+      forwardToRuntime(config, payload),
     ).rejects.toThrow("Runtime returned 400");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -115,7 +115,7 @@ describe("forwardToRuntime", () => {
     });
 
     const config = makeConfig();
-    const result = await forwardToRuntime(config, "assistant-a", payload);
+    const result = await forwardToRuntime(config, payload);
     expect(result.accepted).toBe(true);
     expect(callCount).toBe(3);
   });
@@ -127,7 +127,7 @@ describe("forwardToRuntime", () => {
 
     const config = makeConfig();
     await expect(
-      forwardToRuntime(config, "assistant-a", payload),
+      forwardToRuntime(config, payload),
     ).rejects.toThrow("Runtime returned 500");
   });
 
@@ -139,7 +139,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig();
-    const result = await forwardToRuntime(config, "assistant-a", payload);
+    const result = await forwardToRuntime(config, payload);
     const attachments = result.assistantMessage?.attachments ?? [];
     expect(attachments).toHaveLength(1);
     expect(attachments[0].id).toBe("att-1");
@@ -147,6 +147,20 @@ describe("forwardToRuntime", () => {
     expect(attachments[0].mimeType).toBe("image/png");
     expect(attachments[0].sizeBytes).toBe(1024);
     expect(attachments[0].kind).toBe("generated_image");
+  });
+
+  test("uses new /v1/channels/inbound URL (no assistantId in path)", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(successBody), { status: 200 }),
+      ),
+    );
+
+    const config = makeConfig();
+    await forwardToRuntime(config, payload);
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toBe("http://localhost:7821/v1/channels/inbound");
   });
 
   test("sends Authorization header when runtimeBearerToken is configured", async () => {
@@ -157,7 +171,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig({ runtimeBearerToken: "my-secret-token" });
-    await forwardToRuntime(config, "assistant-a", payload);
+    await forwardToRuntime(config, payload);
 
     const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
     const headers = calledInit.headers as Record<string, string>;
@@ -172,7 +186,7 @@ describe("forwardToRuntime", () => {
     );
 
     const config = makeConfig();
-    await forwardToRuntime(config, "assistant-a", payload);
+    await forwardToRuntime(config, payload);
 
     const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
     const headers = calledInit.headers as Record<string, string>;
@@ -204,13 +218,13 @@ describe("downloadAttachment", () => {
     );
 
     const config = makeConfig();
-    const result = await downloadAttachment(config, "assistant-a", "att-1");
+    const result = await downloadAttachment(config, "att-1");
     expect(result.id).toBe("att-1");
     expect(result.filename).toBe("chart.png");
     expect(result.data).toBe("iVBORw0KGgo=");
 
     const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(calledUrl).toContain("/attachments/att-1");
+    expect(calledUrl).toBe("http://localhost:7821/v1/attachments/att-1");
   });
 
   test("throws on 404 not found", async () => {
@@ -222,7 +236,7 @@ describe("downloadAttachment", () => {
 
     const config = makeConfig();
     await expect(
-      downloadAttachment(config, "assistant-a", "nonexistent"),
+      downloadAttachment(config, "nonexistent"),
     ).rejects.toThrow("Attachment download failed (404)");
   });
 });

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -77,7 +77,7 @@ describe("sendTelegramAttachments", () => {
       kind: "generated_image",
     };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     // Should have called: 1) runtime download, 2) telegram sendPhoto
     expect(calls).toHaveLength(2);
@@ -114,7 +114,7 @@ describe("sendTelegramAttachments", () => {
       kind: "filesystem",
     };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-2");
@@ -138,7 +138,7 @@ describe("sendTelegramAttachments", () => {
       kind: "filesystem",
     };
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta]);
 
     // Should have sent only the failure notice via sendMessage
     expect(calls).toHaveLength(1);
@@ -176,7 +176,7 @@ describe("sendTelegramAttachments", () => {
       { id: "att-ok", filename: "good.png", mimeType: "image/png", sizeBytes: 50, kind: "generated_image" },
     ];
 
-    await sendTelegramAttachments(config, "chat-1", "assistant-a", attachments);
+    await sendTelegramAttachments(config, "chat-1", attachments);
 
     // Should have: download att-fail (fail), download att-ok, sendPhoto for att-ok, sendMessage for notice
     expect(calls.filter((u) => u.includes("sendPhoto"))).toHaveLength(1);

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -61,7 +61,7 @@ export async function handleInbound(
   const transportUxBrief = options?.transportMetadata?.uxBrief?.trim();
 
   try {
-    const response = await forwardToRuntime(config, routing.assistantId, {
+    const response = await forwardToRuntime(config, {
       sourceChannel: event.sourceChannel,
       externalChatId: event.message.externalChatId,
       externalMessageId: event.message.externalMessageId,

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -31,7 +31,6 @@ export function buildTelegramTransportMetadata(): { hints: string[]; uxBrief: st
 export type OnReply = (
   chatId: string,
   result: InboundResult,
-  assistantId: string,
 ) => Promise<void>;
 
 export function createTelegramWebhookHandler(
@@ -122,7 +121,6 @@ export function createTelegramWebhookHandler(
         try {
           await resetConversation(
             config,
-            routing.assistantId,
             normalized.sourceChannel,
             normalized.message.externalChatId,
           );
@@ -185,7 +183,7 @@ export function createTelegramWebhookHandler(
                 fileName: att.fileName,
                 mimeType: att.mimeType,
               });
-              return uploadAttachment(config, routing.assistantId, downloaded);
+              return uploadAttachment(config, downloaded);
             }),
           );
           for (const result of results) {
@@ -262,7 +260,7 @@ export function createTelegramWebhookHandler(
 
     // Fire reply asynchronously so webhook ack is not blocked by outbound send
     if (onReply && !isRejection(routing) && !result.rejected && result.runtimeResponse?.assistantMessage) {
-      onReply(normalized.message.externalChatId, result, routing.assistantId).catch((err) => {
+      onReply(normalized.message.externalChatId, result).catch((err) => {
         log.error({ err, updateId: payload.update_id }, "Failed to send reply");
       });
     }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -21,7 +21,7 @@ function main() {
   const handleTelegramWebhook = telegramConfigured
     ? createTelegramWebhookHandler(
         config,
-        async (chatId, result, assistantId) => {
+        async (chatId, result) => {
           const msg = result.runtimeResponse?.assistantMessage;
           const content = msg?.content;
           const attachments = msg?.attachments ?? [];
@@ -40,7 +40,7 @@ function main() {
 
           if (attachments.length > 0) {
             try {
-              await sendTelegramAttachments(config, chatId, assistantId, attachments);
+              await sendTelegramAttachments(config, chatId, attachments);
             } catch (err) {
               log.error({ err, chatId }, "Failed to send Telegram attachments");
             }

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -64,17 +64,16 @@ export type RuntimeInboundResponse = {
 
 export async function forwardToRuntime(
   config: GatewayConfig,
-  assistantId: string,
   payload: RuntimeInboundPayload,
 ): Promise<RuntimeInboundResponse> {
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/inbound`;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/channels/inbound`;
 
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt <= config.runtimeMaxRetries; attempt++) {
     if (attempt > 0) {
       const delay = config.runtimeInitialBackoffMs * Math.pow(2, attempt - 1);
-      log.debug({ attempt, delay, assistantId }, "Retrying runtime forward");
+      log.debug({ attempt, delay }, "Retrying runtime forward");
       await new Promise((r) => setTimeout(r, delay));
     }
 
@@ -89,7 +88,7 @@ export async function forwardToRuntime(
       if (response.status >= 400 && response.status < 500) {
         const body = await response.text();
         log.warn(
-          { status: response.status, body, assistantId },
+          { status: response.status, body },
           "Runtime returned client error, not retrying",
         );
         throw new Error(`Runtime returned ${response.status}: ${body}`);
@@ -99,7 +98,7 @@ export async function forwardToRuntime(
         const body = await response.text();
         lastError = new Error(`Runtime returned ${response.status}: ${body}`);
         log.warn(
-          { status: response.status, attempt, assistantId },
+          { status: response.status, attempt },
           "Runtime returned server error",
         );
         continue;
@@ -107,7 +106,7 @@ export async function forwardToRuntime(
 
       const result = (await response.json()) as RuntimeInboundResponse;
       log.debug(
-        { assistantId, eventId: result.eventId, duplicate: result.duplicate },
+        { eventId: result.eventId, duplicate: result.duplicate },
         "Runtime forward succeeded",
       );
       return result;
@@ -120,7 +119,7 @@ export async function forwardToRuntime(
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       log.warn(
-        { err: lastError, attempt, assistantId },
+        { err: lastError, attempt },
         "Runtime forward attempt failed",
       );
     }
@@ -131,11 +130,10 @@ export async function forwardToRuntime(
 
 export async function resetConversation(
   config: GatewayConfig,
-  assistantId: string,
   sourceChannel: string,
   externalChatId: string,
 ): Promise<void> {
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/conversation`;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/channels/conversation`;
 
   const response = await fetch(url, {
     method: "DELETE",
@@ -162,10 +160,9 @@ export type UploadAttachmentResponse = {
 
 export async function downloadAttachment(
   config: GatewayConfig,
-  assistantId: string,
   attachmentId: string,
 ): Promise<RuntimeAttachmentPayload> {
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments/${encodeURIComponent(attachmentId)}`;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`;
 
   const response = await fetch(url, {
     method: "GET",
@@ -183,10 +180,9 @@ export async function downloadAttachment(
 
 export async function uploadAttachment(
   config: GatewayConfig,
-  assistantId: string,
   input: UploadAttachmentInput,
 ): Promise<UploadAttachmentResponse> {
-  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments`;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments`;
 
   const response = await fetch(url, {
     method: "POST",

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -48,7 +48,6 @@ export async function sendTelegramReply(
 export async function sendTelegramAttachments(
   config: GatewayConfig,
   chatId: string,
-  assistantId: string,
   attachments: RuntimeAttachmentMeta[],
 ): Promise<void> {
   const failures: string[] = [];
@@ -61,7 +60,7 @@ export async function sendTelegramAttachments(
     }
 
     try {
-      const payload = await downloadAttachment(config, assistantId, meta.id);
+      const payload = await downloadAttachment(config, meta.id);
       const buffer = Buffer.from(payload.data, "base64");
       const blob = new Blob([buffer], { type: meta.mimeType });
 


### PR DESCRIPTION
## Summary
- Update `gateway/src/runtime/client.ts` to use `/v1/channels/inbound`, `/v1/channels/conversation`, `/v1/attachments`, and `/v1/attachments/:id` URLs; remove `assistantId` parameter from all four functions
- Update all callers (`handle-inbound.ts`, `telegram-webhook.ts`, `telegram/send.ts`, `index.ts`) to pass no `assistantId` to runtime client functions
- Update `cli/src/adapters/openclaw-http-server.ts` to match `/v1/messages` instead of `/v1/assistants/:assistantId/messages`
- Update tests to reflect new URL shapes and removed `assistantId` arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
