### PR TITLE
Remove redundant host_file_write/edit skill-dir trust rules

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -933,38 +933,6 @@ describe('Trust Store', () => {
       expect(bundled!.priority).toBe(50);
     });
 
-    test('default rules include ask rules for host_file_write on skill source paths', () => {
-      const rules = getAllRules();
-      const managed = rules.find((r) => r.id === 'default:ask-host_file_write-managed-skills');
-      expect(managed).toBeDefined();
-      expect(managed!.tool).toBe('host_file_write');
-      expect(managed!.decision).toBe('ask');
-      expect(managed!.priority).toBe(50);
-      expect(managed!.pattern).toContain('workspace/skills/**');
-
-      const bundled = rules.find((r) => r.id === 'default:ask-host_file_write-bundled-skills');
-      expect(bundled).toBeDefined();
-      expect(bundled!.tool).toBe('host_file_write');
-      expect(bundled!.decision).toBe('ask');
-      expect(bundled!.priority).toBe(50);
-    });
-
-    test('default rules include ask rules for host_file_edit on skill source paths', () => {
-      const rules = getAllRules();
-      const managed = rules.find((r) => r.id === 'default:ask-host_file_edit-managed-skills');
-      expect(managed).toBeDefined();
-      expect(managed!.tool).toBe('host_file_edit');
-      expect(managed!.decision).toBe('ask');
-      expect(managed!.priority).toBe(50);
-      expect(managed!.pattern).toContain('workspace/skills/**');
-
-      const bundled = rules.find((r) => r.id === 'default:ask-host_file_edit-bundled-skills');
-      expect(bundled).toBeDefined();
-      expect(bundled!.tool).toBe('host_file_edit');
-      expect(bundled!.decision).toBe('ask');
-      expect(bundled!.priority).toBe(50);
-    });
-
     // ── default allow: skill_load ────────────────────────────────
 
     test('skill_load default allow rule exists in templates', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -114,7 +114,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   const managedSkillsDir = join(getRootDir(), 'workspace', 'skills').replaceAll('\\', '/');
   const bundledSkillsDir = getBundledSkillsDir().replaceAll('\\', '/');
   const SKILL_MUTATION_TOOLS = ['file_write', 'file_edit'] as const;
-  const HOST_SKILL_MUTATION_TOOLS = ['host_file_write', 'host_file_edit'] as const;
   const skillDirs: { dir: string; label: string }[] = [
     { dir: managedSkillsDir, label: 'managed' },
     { dir: bundledSkillsDir, label: 'bundled' },
@@ -127,8 +126,8 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     skillDirs.push({ dir: extraDirs[i].replaceAll('\\', '/'), label: `extra-${i}` });
   }
 
-  const skillSourceMutationRules = skillDirs.flatMap(({ dir, label }) => [
-    ...SKILL_MUTATION_TOOLS.map((tool) => ({
+  const skillSourceMutationRules = skillDirs.flatMap(({ dir, label }) =>
+    SKILL_MUTATION_TOOLS.map((tool) => ({
       id: `default:ask-${tool}-${label}-skills`,
       tool,
       pattern: `${tool}:${dir}/**`,
@@ -136,15 +135,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
       decision: 'ask' as const,
       priority: 50,
     })),
-    ...HOST_SKILL_MUTATION_TOOLS.map((tool) => ({
-      id: `default:ask-${tool}-${label}-skills`,
-      tool,
-      pattern: `${tool}:${dir}/**`,
-      scope: 'everywhere',
-      decision: 'ask' as const,
-      priority: 50,
-    })),
-  ]);
+  );
 
   const skillLoadRule: DefaultRuleTemplate = {
     id: 'default:allow-skill_load-global',


### PR DESCRIPTION
## Summary
- Remove `host_file_write`/`host_file_edit` skill-specific ask rules (priority 50) that are shadowed by the global `host_file_*:/**` ask rules at the same priority
- The global rules already match any host file path including skill directories, making the skill-specific host rules redundant
- Sandbox-scoped `file_write`/`file_edit` skill rules are kept — those serve a real purpose for sandbox permission checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
