### PR TITLE
Fix blurry chat image rendering on Retina displays

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -16,19 +16,40 @@ struct AnimatedImageView: View {
     @State private var loadedImage: NSImage?
     @State private var imageData: Data?
     @State private var isLoading = true
+    @Environment(\.displayScale) private var displayScale
+
+    /// Maximum display dimension in points (matches text bubble maxWidth).
+    private let maxDimension: CGFloat = 520
 
     var body: some View {
         Group {
             if let data = imageData, isAnimatedGIF(data) {
                 GIFView(data: data)
                     .frame(
-                        width: min(imageSize.width, 280),
-                        height: min(imageSize.height, 280)
+                        width: min(gifSize.width, maxDimension),
+                        height: min(gifSize.height, maxDimension)
+                    )
+            } else if let image = loadedImage,
+                      let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+                // Use CGImage with the display's scale factor so each source pixel
+                // maps to exactly one backing-store pixel on Retina displays,
+                // preventing the upscale blur that Image(nsImage:) causes.
+                let nativeWidth = CGFloat(cgImage.width) / displayScale
+                let nativeHeight = CGFloat(cgImage.height) / displayScale
+                Image(decorative: cgImage, scale: displayScale)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(
+                        maxWidth: min(nativeWidth, maxDimension),
+                        maxHeight: min(nativeHeight, maxDimension)
                     )
             } else if let image = loadedImage {
+                // Fallback when CGImage extraction fails
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: maxDimension)
             } else {
                 Image(systemName: "photo")
                     .font(.system(size: 24))
@@ -41,11 +62,11 @@ struct AnimatedImageView: View {
         }
     }
 
-    private var imageSize: CGSize {
-        guard let image = loadedImage else { return CGSize(width: 280, height: 280) }
+    private var gifSize: CGSize {
+        guard let image = loadedImage else { return CGSize(width: maxDimension, height: maxDimension) }
         let size = image.size
-        guard size.width > 0, size.height > 0 else { return CGSize(width: 280, height: 280) }
-        let scale = min(280 / size.width, 280 / size.height, 1.0)
+        guard size.width > 0, size.height > 0 else { return CGSize(width: maxDimension, height: maxDimension) }
+        let scale = min(maxDimension / size.width, maxDimension / size.height, 1.0)
         return CGSize(width: size.width * scale, height: size.height * scale)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1652,7 +1652,6 @@ private struct ChatBubble: View {
                         MarkdownTableView(headers: headers, rows: rows)
                     case .image(let alt, let url):
                         AnimatedImageView(urlString: url)
-                            .frame(maxWidth: 280, maxHeight: 280)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                             .accessibilityLabel(alt.isEmpty ? "Image" : alt)
 
@@ -1811,7 +1810,6 @@ private struct ChatBubble: View {
                                 MarkdownTableView(headers: headers, rows: rows)
                             case .image(let alt, let url):
                                 AnimatedImageView(urlString: url)
-                                    .frame(maxWidth: 280, maxHeight: 280)
                                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                     .accessibilityLabel(alt.isEmpty ? "Image" : alt)
                             case .heading(let level, let headingText):

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -91,6 +91,7 @@ private struct UsedToolsRow: View {
 
     @State private var isExpanded = false
     @State private var isHovered = false
+    @Environment(\.displayScale) private var displayScale
 
     private var hasDetails: Bool {
         !toolCall.inputSummary.isEmpty ||
@@ -178,8 +179,17 @@ private struct UsedToolsRow: View {
                     }
                     .padding(.horizontal, VSpacing.md)
 
-                    // Screenshot
-                    if let img = toolCall.cachedImage {
+                    // Screenshot — use CGImage + displayScale for pixel-perfect Retina rendering
+                    if let img = toolCall.cachedImage,
+                       let cgImage = img.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+                        Image(decorative: cgImage, scale: displayScale)
+                            .resizable()
+                            .interpolation(.high)
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .padding(.horizontal, VSpacing.md)
+                    } else if let img = toolCall.cachedImage {
                         Image(nsImage: img)
                             .resizable()
                             .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
## Summary
- Use `Image(decorative: cgImage, scale: displayScale)` instead of `Image(nsImage:)` so source pixels map 1:1 to backing-store pixels on Retina — prevents upscale blur
- Increase max image dimension from 280pt to 520pt (matching text bubble `maxWidth`) so photos display larger and sharper
- Add `.interpolation(.high)` for best-quality downscaling
- Apply the same fix to tool result screenshots in `UsedToolsList`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
