### PR TITLE
feat: native Anthropic web search support

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { getDataDir } from '../util/platform.js';
 
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks'] as const;
-const VALID_WEB_SEARCH_PROVIDERS = ['perplexity', 'brave'] as const;
+const VALID_WEB_SEARCH_PROVIDERS = ['perplexity', 'brave', 'anthropic-native'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block', 'prompt'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
 const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
@@ -756,7 +756,7 @@ export const AssistantConfigSchema = z.object({
     .enum(VALID_WEB_SEARCH_PROVIDERS, {
       error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(', ')}`,
     })
-    .default('perplexity'),
+    .default('anthropic-native'),
   providerOrder: z
     .array(z.enum(VALID_PROVIDERS, {
       error: `Each providerOrder entry must be one of: ${VALID_PROVIDERS.join(', ')}`,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -339,10 +339,12 @@ export class AnthropicProvider implements Provider {
   public readonly name = "anthropic";
   private client: Anthropic;
   private model: string;
+  private useNativeWebSearch: boolean;
 
-  constructor(apiKey: string, model: string) {
+  constructor(apiKey: string, model: string, options: { useNativeWebSearch?: boolean } = {}) {
     this.client = new Anthropic({ apiKey });
     this.model = model;
+    this.useNativeWebSearch = options.useNativeWebSearch ?? false;
   }
 
   async sendMessage(
@@ -444,14 +446,28 @@ export class AnthropicProvider implements Provider {
       }
 
       if (tools && tools.length > 0) {
-        params.tools = tools.map((t, i) => ({
-          name: t.name,
-          description: t.description,
-          input_schema: t.input_schema as Anthropic.Tool["input_schema"],
-          ...(i === tools.length - 1
-            ? { cache_control: { type: 'ephemeral' as const } }
-            : {}),
-        }));
+        if (this.useNativeWebSearch && tools.some(t => t.name === 'web_search')) {
+          const otherTools = tools.filter(t => t.name !== 'web_search');
+          const mappedOther = otherTools.map((t, i) => ({
+            name: t.name,
+            description: t.description,
+            input_schema: t.input_schema as Anthropic.Tool['input_schema'],
+            ...(i === otherTools.length - 1 ? { cache_control: { type: 'ephemeral' as const } } : {}),
+          }));
+          params.tools = [
+            ...mappedOther,
+            { type: 'web_search_20250305' as const, name: 'web_search' as const, max_uses: 5 },
+          ] as unknown as Anthropic.MessageCreateParams['tools'];
+        } else {
+          params.tools = tools.map((t, i) => ({
+            name: t.name,
+            description: t.description,
+            input_schema: t.input_schema as Anthropic.Tool["input_schema"],
+            ...(i === tools.length - 1
+              ? { cache_control: { type: 'ephemeral' as const } }
+              : {}),
+          }));
+        }
       }
 
       // Place cache breakpoints on the last two user turns so the
@@ -689,6 +705,11 @@ export class AnthropicProvider implements Provider {
           name: block.name,
           input: block.input as Record<string, unknown>,
         };
+      case "server_tool_use":
+      case "web_search_tool_result":
+        // Native Anthropic web search blocks — informational only, silently dropped
+        // by the empty-text filter in sendMessage.
+        return { type: "text", text: "" };
       default:
         return { type: "text", text: `[unsupported block type: ${(block as { type: string }).type}]` };
     }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -79,6 +79,7 @@ export interface ProvidersConfig {
   apiKeys: Record<string, string>;
   provider: string;
   model: string;
+  webSearchProvider?: string;
 }
 
 function resolveModel(config: ProvidersConfig, providerName: keyof typeof DEFAULT_MODELS): string {
@@ -101,7 +102,9 @@ export function initializeProviders(config: ProvidersConfig): void {
   if (config.apiKeys.anthropic) {
     const model = resolveModel(config, 'anthropic');
     registerProvider('anthropic', new RetryProvider(
-      wrapWithLogfire(new AnthropicProvider(config.apiKeys.anthropic, model)),
+      wrapWithLogfire(new AnthropicProvider(config.apiKeys.anthropic, model, {
+        useNativeWebSearch: config.webSearchProvider === 'anthropic-native',
+      })),
     ));
   }
   if (config.apiKeys.openai) {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -57,7 +57,11 @@ interface PerplexityResponse {
 
 function getWebSearchProvider(): WebSearchProvider {
   const config = getConfig();
-  return config.webSearchProvider ?? 'perplexity';
+  const configured = config.webSearchProvider ?? 'perplexity';
+  // 'anthropic-native' is handled by the Anthropic client directly;
+  // fall back to perplexity for other providers.
+  if (configured === 'anthropic-native') return 'perplexity';
+  return configured as WebSearchProvider;
 }
 
 function getApiKey(provider: WebSearchProvider): string | undefined {


### PR DESCRIPTION
## Summary
- Adds `'anthropic-native'` as a valid `webSearchProvider` option and makes it the new default for Claude users — no Perplexity/Brave API key required
- When active, `AnthropicProvider` substitutes the custom `web_search` tool with Anthropic's server-side `web_search_20250305` tool; `server_tool_use` and `web_search_tool_result` response blocks are silently dropped by the existing empty-text filter
- Non-Anthropic providers (OpenAI, Gemini, etc.) with `anthropic-native` set automatically fall back to Perplexity in `getWebSearchProvider()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
