### PR TITLE
UI polish: centered layouts, consistent styling, onboarding fonts

### DIFF
--- a/assistant/src/config/bundled-skills/agentmail/icon.svg
+++ b/assistant/src/config/bundled-skills/agentmail/icon.svg
@@ -1,0 +1,21 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect width="16" height="16" fill="#0a0e27"/>
+  <rect x="2" y="3" width="12" height="8" fill="#1e40af" stroke="#60a5fa" stroke-width="1"/>
+  <rect x="2" y="3" width="12" height="2" fill="#3b82f6"/>
+  <rect x="3" y="4" width="10" height="1" fill="#0a0e27"/>
+  <rect x="3" y="5" width="5" height="1" fill="#93c5fd"/>
+  <rect x="3" y="6" width="5" height="1" fill="#bfdbfe"/>
+  <rect x="9" y="5" width="3" height="1" fill="#bfdbfe"/>
+  <rect x="9" y="6" width="3" height="1" fill="#93c5fd"/>
+  <rect x="2" y="12" width="3" height="1" fill="#059669"/>
+  <rect x="3" y="13" width="2" height="1" fill="#10b981"/>
+  <rect x="2" y="14" width="1" height="1" fill="#10b981"/>
+  <rect x="3" y="14" width="1" height="1" fill="#34d399"/>
+  <rect x="6" y="12" width="8" height="1" fill="#1f2937"/>
+  <rect x="6" y="13" width="8" height="1" fill="#374151"/>
+  <rect x="6" y="14" width="8" height="1" fill="#1f2937"/>
+  <rect x="7" y="13" width="1" height="1" fill="#60a5fa"/>
+  <rect x="9" y="13" width="1" height="1" fill="#60a5fa"/>
+  <rect x="11" y="13" width="1" height="1" fill="#60a5fa"/>
+  <rect x="13" y="13" width="1" height="1" fill="#60a5fa"/>
+</svg>

--- a/assistant/src/config/bundled-skills/app-builder/icon.svg
+++ b/assistant/src/config/bundled-skills/app-builder/icon.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<rect width="16" height="16" fill="#f0f0f0"/>
+<rect x="2" y="2" width="12" height="12" fill="#4a90e2" stroke="#2c5aa0" stroke-width="1"/>
+<rect x="3" y="3" width="10" height="2" fill="#2c5aa0"/>
+<rect x="3" y="6" width="2" height="6" fill="#e8a83d"/>
+<rect x="6" y="6" width="2" height="6" fill="#5db854"/>
+<rect x="9" y="6" width="2" height="6" fill="#e74c3c"/>
+<rect x="12" y="6" width="1" height="6" fill="#9b59b6"/>
+</svg>

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -116,7 +116,6 @@ struct AvatarCustomizationPanel: View {
             Text("Profile Picture")
                 .font(VFont.headline)
                 .foregroundColor(VColor.textSecondary)
-                .textCase(.uppercase)
 
             if let customImage = appearance.customAvatarImage {
                 HStack(spacing: VSpacing.md) {
@@ -227,7 +226,6 @@ struct AvatarCustomizationPanel: View {
             Text("Outfit")
                 .font(VFont.headline)
                 .foregroundColor(VColor.textSecondary)
-                .textCase(.uppercase)
 
             outfitPicker(title: "Hat", field: .hat, options: hatOptions,
                          current: evolutionState.userOverrides[.hat] ?? appearance.config.hat)
@@ -276,7 +274,6 @@ struct AvatarCustomizationPanel: View {
             Text(title)
                 .font(VFont.headline)
                 .foregroundColor(VColor.textSecondary)
-                .textCase(.uppercase)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -313,12 +313,18 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = nil
                 }
 
-                // Close the left sidebar when the document editor panel opens to avoid crowding
-                if case .panel(let panel) = newSelection,
-                   panel == .documentEditor,
-                   sidebarOpen {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        sidebarOpen = false
+                // Close the left sidebar when any right-side content opens to avoid crowding
+                if sidebarOpen {
+                    let shouldClose: Bool = {
+                        switch newSelection {
+                        case .panel, .app, .appEditing: return true
+                        default: return false
+                        }
+                    }()
+                    if shouldClose {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                            sidebarOpen = false
+                        }
                     }
                 }
             }
@@ -763,7 +769,7 @@ struct MainWindowView: View {
     @ViewBuilder
     private var sidebarView: some View {
         VStack(spacing: 0) {
-            // Top bar: sidebar toggle + new chat
+            // Top bar: sidebar toggle
             HStack {
                 Spacer()
                 VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true) {
@@ -771,23 +777,30 @@ struct MainWindowView: View {
                         sidebarOpen.toggle()
                     }
                 }
-                VIconButton(label: "New chat", icon: "square.and.pencil", iconOnly: true) {
-                    windowState.selection = nil
-                    threadManager.createThread()
-                }
             }
             .padding(.trailing, VSpacing.sm)
             .frame(height: 36)
 
             ScrollView {
                 VStack(spacing: 0) {
-                    // MARK: Nav Items
+                    // MARK: New Chat
                     Spacer().frame(height: VSpacing.md)
+                    SidebarNavRow(icon: "plus.circle", label: "New chat") {
+                        windowState.selection = nil
+                        threadManager.createThread()
+                    }
+
+                    Spacer().frame(height: VSpacing.lg)
+
+                    // MARK: Nav Items
                     SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory) {
                         windowState.togglePanel(.directory)
                     }
                     SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
                         windowState.togglePanel(.identity)
+                    }
+                    SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
+                        windowState.togglePanel(.agent)
                     }
 
                     // MARK: Chats
@@ -1095,22 +1108,7 @@ struct MainWindowView: View {
         case .threadList:
             sidebarView
         case .identity:
-            IdentityPanel(onClose: { windowState.selection = nil }, onInvokeSkill: { skill in
-                if threadManager.activeViewModel == nil {
-                    threadManager.createThread()
-                }
-                if let viewModel = threadManager.activeViewModel {
-                    viewModel.pendingSkillInvocation = SkillInvocationData(
-                        name: skill.name,
-                        emoji: skill.emoji,
-                        description: skill.description
-                    )
-                    viewModel.inputText = "Use the \(skill.name) skill"
-                    viewModel.sendMessage()
-                    viewModel.pendingSkillInvocation = nil
-                }
-                windowState.selection = nil
-            }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = nil })
         }
@@ -1324,22 +1322,7 @@ struct MainWindowView: View {
             DoctorPanel(onClose: { windowState.dismissOverlay() })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .identity:
-            IdentityPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
-                if threadManager.activeViewModel == nil {
-                    threadManager.createThread()
-                }
-                if let viewModel = threadManager.activeViewModel {
-                    viewModel.pendingSkillInvocation = SkillInvocationData(
-                        name: skill.name,
-                        emoji: skill.emoji,
-                        description: skill.description
-                    )
-                    viewModel.inputText = "Use the \(skill.name) skill"
-                    viewModel.sendMessage()
-                    viewModel.pendingSkillInvocation = nil
-                }
-                windowState.dismissOverlay()
-            }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.dismissOverlay() }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.dismissOverlay() })
@@ -1454,15 +1437,19 @@ private struct SidebarNavRow: View {
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
             }
-            .padding(.leading, 20)
-            .padding(.trailing, VSpacing.md)
+            .padding(.leading, VSpacing.md)
+            .padding(.trailing, VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
             .background(isActive || isHovered ? VColor.hoverOverlay.opacity(0.08) : .clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
+        .padding(.horizontal, VSpacing.sm)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -11,13 +11,14 @@ struct AgentPanelContent: View {
     let daemonClient: DaemonClient
 
     @StateObject private var skillsManager: SkillsManager
+    @State private var selectedTab: SkillsTab = .installed
     @State private var expandedSkillId: String?
-    @State private var hoveredInstalledUseSkillId: String?
-    @State private var hoveredInstalledViewSkillId: String?
-    @State private var hoveredInstalledDeleteSkillId: String?
     @State private var selectedSkillSlug: String?
-    @State private var hoveredDetailInstall = false
     @State private var skillToDelete: SkillInfo?
+
+    private enum SkillsTab {
+        case installed, available
+    }
 
     init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, daemonClient: DaemonClient) {
         self.onInvokeSkill = onInvokeSkill
@@ -28,15 +29,25 @@ struct AgentPanelContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Installed skills section
-            sectionHeader("Installed", count: userSkills.count)
+            // Tab bar
+            VStack(spacing: 0) {
+                HStack(spacing: VSpacing.xl) {
+                    tabButton("Installed", tab: .installed)
+                    tabButton("Available", tab: .available)
+                    Spacer()
+                }
 
-            skillsContent
+                Divider().background(VColor.surfaceBorder)
+            }
+            .padding(.bottom, VSpacing.lg)
 
-            // Available skills section
-            sectionHeader("Available")
-
-            availableSkillsContent
+            // Tab content
+            switch selectedTab {
+            case .installed:
+                skillsContent
+            case .available:
+                availableSkillsContent
+            }
         }
         .onAppear {
             skillsManager.fetchSkills()
@@ -63,29 +74,27 @@ struct AgentPanelContent: View {
     }
 
     @ViewBuilder
-    private func sectionHeader(_ title: String, count: Int? = nil) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            Text(title)
-                .font(VFont.captionMedium)
-                .foregroundColor(VColor.textMuted)
+    private func tabButton(_ label: String, tab: SkillsTab) -> some View {
+        let isActive = selectedTab == tab
+        Button {
+            withAnimation(VAnimation.fast) { selectedTab = tab }
+        } label: {
+            VStack(spacing: VSpacing.sm) {
+                Text(label)
+                    .font(VFont.body)
+                    .foregroundColor(isActive ? VColor.textPrimary : VColor.textMuted)
+                    .padding(.bottom, VSpacing.xs)
 
-            if let count {
-                Text("\(count)")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xxs)
-                    .background(VColor.backgroundSubtle)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                Rectangle()
+                    .fill(isActive ? VColor.textPrimary : Color.clear)
+                    .frame(height: 2)
             }
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
+            .fixedSize()
+            .contentShape(Rectangle())
         }
-        .padding(.top, VSpacing.lg)
-        .padding(.bottom, VSpacing.sm)
+        .buttonStyle(.plain)
     }
+
 
     // MARK: - Available Skills Tab
 
@@ -202,10 +211,10 @@ struct AgentPanelContent: View {
                     Button(action: { skillSortOrder = order }) {
                         Text(order.rawValue)
                             .font(VFont.caption)
-                            .foregroundColor(skillSortOrder == order ? Emerald._400 : VColor.textMuted)
+                            .foregroundColor(skillSortOrder == order ? VColor.accent : VColor.textMuted)
                             .padding(.horizontal, VSpacing.sm)
                             .padding(.vertical, VSpacing.xs)
-                            .background(skillSortOrder == order ? Emerald._400.opacity(0.15) : Color.clear)
+                            .background(skillSortOrder == order ? VColor.accent.opacity(0.15) : Color.clear)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                     }
                     .buttonStyle(.plain)
@@ -250,7 +259,7 @@ struct AgentPanelContent: View {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "sparkles")
                         .font(.system(size: 10))
-                        .foregroundColor(Emerald._400)
+                        .foregroundColor(VColor.accent)
                     Text("Browse more on ClawhHub")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
@@ -264,7 +273,6 @@ struct AgentPanelContent: View {
 
     @State private var installingSlug: String?
     @State private var installAttemptId: UUID?
-    @State private var hoveredStarterInstall: String?
     @State private var skillSearchQuery = ""
     @State private var skillSortOrder: SkillSortOrder = .installs
 
@@ -281,7 +289,7 @@ struct AgentPanelContent: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(starter.name)
-                    .font(VFont.mono)
+                    .font(VFont.bodyBold)
                     .foregroundColor(VColor.textPrimary)
 
                 Text(starter.description)
@@ -294,15 +302,10 @@ struct AgentPanelContent: View {
 
             Text("Included")
                 .font(VFont.caption)
-                .foregroundColor(Emerald._400)
+                .foregroundColor(VColor.success)
         }
         .padding(VSpacing.lg)
-        .background(VColor.surfaceSubtle)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
-        )
+        .vCard(background: VColor.surfaceSubtle)
     }
 
     /// How long ago a skill was published, as a human-readable string.
@@ -320,7 +323,6 @@ struct AgentPanelContent: View {
 
     private func clawhubSkillCard(_ skill: ClawhubSkillItem) -> some View {
         let isInstalling = installingSlug == skill.slug
-        let isHovered = hoveredStarterInstall == skill.slug
         let isNew = skill.createdAt > 0 && Date().timeIntervalSince(
             Date(timeIntervalSince1970: Double(skill.createdAt) / 1000)
         ) < 7 * 86400
@@ -337,7 +339,7 @@ struct AgentPanelContent: View {
                     VStack(alignment: .leading, spacing: 2) {
                         HStack(spacing: VSpacing.sm) {
                             Text(skill.name)
-                                .font(VFont.mono)
+                                .font(VFont.bodyBold)
                                 .foregroundColor(VColor.textPrimary)
 
                             if isNew {
@@ -363,7 +365,12 @@ struct AgentPanelContent: View {
 
                 Spacer()
 
-                Button(action: {
+                VButton(
+                    label: isInstalling ? "Installing..." : "Install",
+                    icon: isInstalling ? nil : "arrow.down.circle.fill",
+                    style: .primary,
+                    isDisabled: installingSlug != nil
+                ) {
                     guard installingSlug == nil else { return }
                     let attemptId = UUID()
                     installingSlug = skill.slug
@@ -374,34 +381,6 @@ struct AgentPanelContent: View {
                             installingSlug = nil
                             installAttemptId = nil
                         }
-                    }
-                }) {
-                    HStack(spacing: VSpacing.sm) {
-                        if isInstalling {
-                            ProgressView()
-                                .controlSize(.mini)
-                        } else {
-                            Image(systemName: "arrow.down.circle.fill")
-                                .font(.system(size: 12))
-                        }
-                        Text(isInstalling ? "Installing..." : "Install")
-                            .font(VFont.mono)
-                    }
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.sm)
-                    .foregroundColor(isHovered ? Slate._900 : Emerald._400)
-                    .background(isHovered ? Emerald._400 : VColor.backgroundSubtle)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(Emerald._500.opacity(0.6), lineWidth: 1.5)
-                    )
-                }
-                .buttonStyle(.plain)
-                .disabled(installingSlug != nil)
-                .onHover { hovering in
-                    withAnimation(VAnimation.fast) {
-                        hoveredStarterInstall = hovering ? skill.slug : nil
                     }
                 }
             }
@@ -441,12 +420,7 @@ struct AgentPanelContent: View {
             .padding(.leading, 24 + VSpacing.md)
         }
         .padding(VSpacing.lg)
-        .background(VColor.surfaceSubtle)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(isNew ? Amber._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
-        )
+        .vCard(background: VColor.surfaceSubtle)
     }
 
     // MARK: - Skill Detail View
@@ -596,7 +570,7 @@ struct AgentPanelContent: View {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("v\(version.version)")
                     .font(VFont.mono)
-                    .foregroundColor(Emerald._400)
+                    .foregroundColor(VColor.success)
                 if let changelog = version.changelog, !changelog.isEmpty {
                     Text(changelog)
                         .font(VFont.caption)
@@ -685,7 +659,13 @@ struct AgentPanelContent: View {
         let isError = result?.slug == slug && result?.success == false
         let errorMessage = result?.error
 
-        Button(action: {
+        VButton(
+            label: isSuccess ? "Installed!" : (isInstalling ? "Installing..." : "Install"),
+            icon: isSuccess ? "checkmark.circle.fill" : (isInstalling ? nil : "arrow.down.circle.fill"),
+            style: .primary,
+            isFullWidth: true,
+            isDisabled: isInstalling || isSuccess
+        ) {
             guard installingSlug == nil, !isSuccess else { return }
             let attemptId = UUID()
             installingSlug = slug
@@ -696,39 +676,6 @@ struct AgentPanelContent: View {
                     installingSlug = nil
                     installAttemptId = nil
                 }
-            }
-        }) {
-            HStack(spacing: VSpacing.sm) {
-                if isSuccess {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 14))
-                    Text("Installed!")
-                } else if isInstalling {
-                    ProgressView()
-                        .controlSize(.mini)
-                    Text("Installing...")
-                } else {
-                    Image(systemName: "arrow.down.circle.fill")
-                        .font(.system(size: 14))
-                    Text("Install")
-                }
-            }
-            .font(VFont.mono)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, VSpacing.md)
-            .foregroundColor(isSuccess ? Emerald._400 : (hoveredDetailInstall && !isInstalling ? Slate._900 : Emerald._400))
-            .background(isSuccess ? Emerald._400.opacity(0.15) : (hoveredDetailInstall && !isInstalling ? Emerald._400 : VColor.backgroundSubtle))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(isSuccess ? Emerald._500 : Emerald._500.opacity(0.6), lineWidth: 1.5)
-            )
-        }
-        .buttonStyle(.plain)
-        .disabled(isInstalling || isSuccess)
-        .onHover { hovering in
-            withAnimation(VAnimation.fast) {
-                hoveredDetailInstall = hovering
             }
         }
 
@@ -779,9 +726,6 @@ struct AgentPanelContent: View {
 
     private func skillCard(_ skill: SkillInfo) -> some View {
         let isExpanded = expandedSkillId == skill.id
-        let useHovered = hoveredInstalledUseSkillId == skill.id
-        let viewHovered = hoveredInstalledViewSkillId == skill.id
-        let borderColor = skill.updateAvailable ? Amber._700.opacity(0.45) : Emerald._700.opacity(0.4)
 
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(alignment: .top, spacing: VSpacing.md) {
@@ -791,7 +735,7 @@ struct AgentPanelContent: View {
                     VStack(alignment: .leading, spacing: 2) {
                         HStack(spacing: VSpacing.sm) {
                             Text(skill.name)
-                                .font(VFont.mono)
+                                .font(VFont.bodyBold)
                                 .foregroundColor(VColor.textPrimary)
 
                             if skill.updateAvailable {
@@ -811,34 +755,12 @@ struct AgentPanelContent: View {
                 Spacer(minLength: VSpacing.lg)
 
                 VStack(alignment: .trailing, spacing: VSpacing.sm) {
-                    Button(action: {
+                    VButton(label: "Use", icon: "bolt.fill", style: .primary) {
                         onInvokeSkill?(skill)
-                    }) {
-                        HStack(spacing: VSpacing.sm) {
-                            Image(systemName: "bolt.fill")
-                                .font(.system(size: 10))
-                            Text("Use")
-                                .font(VFont.mono)
-                        }
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.vertical, VSpacing.sm)
-                        .foregroundColor(useHovered ? Slate._900 : Emerald._400)
-                        .background(useHovered ? Emerald._400 : VColor.backgroundSubtle)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(Emerald._500.opacity(0.6), lineWidth: 1.5)
-                        )
-                    }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        withAnimation(VAnimation.fast) {
-                            hoveredInstalledUseSkillId = hovering ? skill.id : nil
-                        }
                     }
 
                     HStack(spacing: VSpacing.sm) {
-                        Button(action: {
+                        VButton(label: isExpanded ? "Hide" : "View", icon: isExpanded ? "chevron.up" : "chevron.down", style: .ghost) {
                             withAnimation(VAnimation.standard) {
                                 if isExpanded {
                                     expandedSkillId = nil
@@ -847,53 +769,11 @@ struct AgentPanelContent: View {
                                     skillsManager.fetchSkillBody(skillId: skill.id)
                                 }
                             }
-                        }) {
-                            HStack(spacing: VSpacing.sm) {
-                                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                                    .font(.system(size: 9, weight: .semibold))
-                                Text(isExpanded ? "Hide" : "View")
-                                    .font(VFont.captionMedium)
-                            }
-                            .padding(.horizontal, VSpacing.md)
-                            .padding(.vertical, VSpacing.xs)
-                            .foregroundColor(viewHovered ? VColor.textPrimary : VColor.textMuted)
-                            .background(viewHovered ? VColor.ghostHover : VColor.backgroundSubtle)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.7), lineWidth: 1)
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .onHover { hovering in
-                            withAnimation(VAnimation.fast) {
-                                hoveredInstalledViewSkillId = hovering ? skill.id : nil
-                            }
                         }
 
                         if skill.source == "managed" {
-                            let deleteHovered = hoveredInstalledDeleteSkillId == skill.id
-                            Button(action: {
+                            VButton(label: "Delete", icon: "trash", style: .danger) {
                                 skillToDelete = skill
-                            }) {
-                                Image(systemName: "trash")
-                                    .font(.system(size: 10))
-                                    .padding(.horizontal, VSpacing.sm)
-                                    .padding(.vertical, VSpacing.xs)
-                                    .foregroundColor(deleteHovered ? Rose._400 : VColor.textMuted)
-                                    .background(deleteHovered ? Rose._400.opacity(0.15) : VColor.backgroundSubtle)
-                                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: VRadius.md)
-                                            .stroke(deleteHovered ? Rose._500.opacity(0.6) : VColor.surfaceBorder.opacity(0.7), lineWidth: 1)
-                                    )
-                            }
-                            .buttonStyle(.plain)
-                            .help("Delete managed skill")
-                            .onHover { hovering in
-                                withAnimation(VAnimation.fast) {
-                                    hoveredInstalledDeleteSkillId = hovering ? skill.id : nil
-                                }
                             }
                         }
                     }
@@ -901,7 +781,7 @@ struct AgentPanelContent: View {
             }
 
             HStack(spacing: VSpacing.lg) {
-                skillMetaItem(icon: "checkmark.circle.fill", value: "Installed", color: Emerald._400)
+                skillMetaItem(icon: "checkmark.circle.fill", value: "Installed", color: VColor.success)
                 skillMetaItem(icon: "shippingbox", value: sourceLabel(skill.source))
 
                 if let installedVersion = skill.installedVersion, !installedVersion.isEmpty {
@@ -943,12 +823,7 @@ struct AgentPanelContent: View {
             }
         }
         .padding(VSpacing.lg)
-        .background(VColor.surfaceSubtle)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(borderColor, lineWidth: 1)
-        )
+        .vCard(background: VColor.surfaceSubtle)
     }
 
     private func sourceLabel(_ source: String) -> String {
@@ -1014,10 +889,32 @@ struct AgentPanel: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
 
+    /// Maximum width of the centered content area.
+    private let maxContentWidth: CGFloat = 1100
+
     var body: some View {
-        VSidePanel(title: "Skills", onClose: onClose) {
-            AgentPanelContent(onInvokeSkill: onInvokeSkill, daemonClient: daemonClient)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack(alignment: .center) {
+                    Text("Skills")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
+                }
+                .padding(.top, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xl)
+
+                Divider().background(VColor.surfaceBorder)
+                    .padding(.bottom, VSpacing.md)
+
+                AgentPanelContent(onInvokeSkill: onInvokeSkill, daemonClient: daemonClient)
+            }
+            .frame(maxWidth: maxContentWidth)
+            .padding(.horizontal, VSpacing.xxl)
+            .frame(maxWidth: .infinity)
         }
+        .background(VColor.backgroundSubtle)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -27,81 +27,103 @@ struct AppDirectoryView: View {
     @State private var previewTasks: [String: Task<Void, Never>] = [:]
 
     private let columns = [
-        GridItem(.flexible(minimum: 200), spacing: VSpacing.lg, alignment: .top),
-        GridItem(.flexible(minimum: 200), spacing: VSpacing.lg, alignment: .top),
+        GridItem(.flexible(minimum: 160), spacing: VSpacing.lg, alignment: .top),
+        GridItem(.flexible(minimum: 160), spacing: VSpacing.lg, alignment: .top),
+        GridItem(.flexible(minimum: 160), spacing: VSpacing.lg, alignment: .top),
     ]
 
-    var body: some View {
-        VSidePanel(title: "Directory", onClose: onBack, pinnedContent: {
-            // Search bar (only when there are items to search)
-            if !displayItems.isEmpty || !searchText.isEmpty {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
+    /// Maximum width of the centered content area.
+    private let maxContentWidth: CGFloat = 1100
 
-                    TextField("Search apps...", text: $searchText)
-                        .textFieldStyle(.plain)
-                        .font(VFont.body)
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header row: title + search
+                HStack(alignment: .center) {
+                    Text("Directory")
+                        .font(VFont.panelTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    if !searchText.isEmpty {
-                        Button(action: { searchText = "" }) {
-                            Image(systemName: "xmark.circle.fill")
-                                .font(.system(size: 12))
+                    Spacer()
+
+                    // Search bar
+                    if !displayItems.isEmpty || !searchText.isEmpty {
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "magnifyingglass")
+                                .font(.system(size: 12, weight: .medium))
                                 .foregroundColor(VColor.textMuted)
+
+                            TextField("Search apps...", text: $searchText)
+                                .textFieldStyle(.plain)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+
+                            if !searchText.isEmpty {
+                                Button(action: { searchText = "" }) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(VColor.textMuted)
+                                }
+                                .buttonStyle(.plain)
+                            }
                         }
-                        .buttonStyle(.plain)
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                        .frame(maxWidth: 260)
                     }
                 }
-                .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.sm)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder, lineWidth: 1)
-                )
-                .padding(.horizontal, VSpacing.lg)
-                .padding(.vertical, VSpacing.md)
+                .padding(.top, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xl)
 
                 Divider().background(VColor.surfaceBorder)
-            }
-        }) {
-            if isLoading {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                        .controlSize(.regular)
-                    Spacer()
-                }
-                .frame(height: 300)
-            } else if displayItems.isEmpty {
-                VEmptyState(
-                    title: "No apps yet",
-                    subtitle: "Apps built with your assistant will appear here",
-                    icon: "square.grid.2x2"
-                )
-                .frame(maxWidth: .infinity)
-                .padding(.top, VSpacing.xxxl)
-            } else if filteredItems.isEmpty {
-                VEmptyState(
-                    title: "No results",
-                    subtitle: "No apps matched \"\(searchText)\"",
-                    icon: "magnifyingglass"
-                )
-                .frame(maxWidth: .infinity)
-                .padding(.top, VSpacing.xxxl)
-            } else {
-                LazyVGrid(columns: columns, spacing: VSpacing.lg) {
-                    ForEach(filteredItems) { item in
-                        appCard(item)
-                            .onAppear { fetchPreviewIfNeeded(item) }
+                    .padding(.bottom, VSpacing.xl)
+
+                // Content
+                if isLoading {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                            .controlSize(.regular)
+                        Spacer()
                     }
+                    .frame(height: 300)
+                } else if displayItems.isEmpty {
+                    VEmptyState(
+                        title: "No apps yet",
+                        subtitle: "Apps built with your assistant will appear here",
+                        icon: "square.grid.2x2"
+                    )
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, VSpacing.xxxl)
+                } else if filteredItems.isEmpty {
+                    VEmptyState(
+                        title: "No results",
+                        subtitle: "No apps matched \"\(searchText)\"",
+                        icon: "magnifyingglass"
+                    )
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, VSpacing.xxxl)
+                } else {
+                    LazyVGrid(columns: columns, spacing: VSpacing.lg) {
+                        ForEach(filteredItems) { item in
+                            appCard(item)
+                                .onAppear { fetchPreviewIfNeeded(item) }
+                        }
+                    }
+                    .padding(.bottom, VSpacing.xxl)
                 }
-                .padding(.bottom, VSpacing.md)
             }
+            .frame(maxWidth: maxContentWidth)
+            .padding(.horizontal, VSpacing.xxl)
+            .frame(maxWidth: .infinity)
         }
+        .background(VColor.backgroundSubtle)
         .onAppear { fetchApps() }
         .onDisappear {
             for task in previewTasks.values { task.cancel() }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -175,10 +175,13 @@ private struct CategoryHubLabel: View {
 
 private struct DraggableNode<Content: View>: View {
     let nodeKey: String
+    /// Additional node keys that move together with this node (e.g. child leaves of a hub).
+    var childKeys: [String] = []
     @Binding var offsets: [String: CGSize]
     @ViewBuilder let content: () -> Content
 
     @State private var dragStartOffset: CGSize?
+    @State private var childStartOffsets: [String: CGSize] = [:]
 
     var body: some View {
         content()
@@ -188,15 +191,26 @@ private struct DraggableNode<Content: View>: View {
                     .onChanged { value in
                         if dragStartOffset == nil {
                             dragStartOffset = offsets[nodeKey] ?? .zero
+                            for key in childKeys {
+                                childStartOffsets[key] = offsets[key] ?? .zero
+                            }
                         }
                         let start = dragStartOffset ?? .zero
                         offsets[nodeKey] = CGSize(
                             width: start.width + value.translation.width,
                             height: start.height + value.translation.height
                         )
+                        for key in childKeys {
+                            let childStart = childStartOffsets[key] ?? .zero
+                            offsets[key] = CGSize(
+                                width: childStart.width + value.translation.width,
+                                height: childStart.height + value.translation.height
+                            )
+                        }
                     }
                     .onEnded { _ in
                         dragStartOffset = nil
+                        childStartOffsets.removeAll()
                     }
             )
     }
@@ -389,7 +403,8 @@ struct ConstellationView: View {
     private func canvasHubs(hubBasePositions: [CGPoint], layoutGroups: [CategoryGroup]) -> some View {
         ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
             let hubKey = "hub-\(group.category.rawValue)"
-            DraggableNode(nodeKey: hubKey, offsets: $nodeOffsets) {
+            let leafKeys = group.items.map(\.id)
+            DraggableNode(nodeKey: hubKey, childKeys: leafKeys, offsets: $nodeOffsets) {
                 CategoryHubLabel(category: group.category, itemCount: group.items.count)
             }
             .position(hubBasePositions[groupIdx])

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -76,7 +76,7 @@ struct GeneratedPanel: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel(isExpanded ? "Exit full screen" : "Enter full screen")
 
-                Text("DYNAMIC")
+                Text("Dynamic")
                     .font(VFont.panelTitle)
                     .foregroundColor(VColor.textPrimary)
 
@@ -156,7 +156,7 @@ struct GeneratedPanel: View {
                             if !documentItems.isEmpty {
                                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                                     HStack {
-                                        Text("DOCUMENTS")
+                                        Text("Documents")
                                             .font(VFont.display)
                                             .foregroundColor(VColor.textMuted)
                                         Spacer()
@@ -180,7 +180,7 @@ struct GeneratedPanel: View {
                                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                                     if !documentItems.isEmpty {
                                         HStack {
-                                            Text("PAGES")
+                                            Text("Pages")
                                                 .font(VFont.display)
                                                 .foregroundColor(VColor.textMuted)
                                             Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -3,7 +3,6 @@ import VellumAssistantShared
 
 struct IdentityPanel: View {
     let onClose: () -> Void
-    var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
     @State private var appearance = AvatarAppearanceManager.shared
 
@@ -36,40 +35,26 @@ struct IdentityPanel: View {
             Divider()
                 .background(VColor.surfaceBorder)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Avatar + ID card side by side
-                    HStack(alignment: .center, spacing: VSpacing.lg) {
-                        DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
-                            .frame(width: 180, height: 200)
+            // Avatar + ID card side by side
+            HStack(alignment: .center, spacing: VSpacing.lg) {
+                DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                    .frame(width: 180, height: 200)
 
-                        if let identity {
-                            idCardSection(identity: identity)
-                        }
-                    }
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.lg)
-
-                    // Constellation
-                    ConstellationView(
-                        identity: identity,
-                        skills: skills,
-                        workspaceFiles: workspaceFiles
-                    )
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 300)
-                    .background(VColor.background)
-
-                    // Skills management
-                    AgentPanelContent(
-                        onInvokeSkill: onInvokeSkill,
-                        onSkillsChanged: { fetchSkills() },
-                        daemonClient: daemonClient
-                    )
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.lg)
+                if let identity {
+                    idCardSection(identity: identity)
                 }
             }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.lg)
+
+            // Constellation fills remaining space
+            ConstellationView(
+                identity: identity,
+                skills: skills,
+                workspaceFiles: workspaceFiles
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(VColor.background)
         }
         .background(VColor.backgroundSubtle)
         .onAppear {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1,6 +1,15 @@
 import SwiftUI
 import VellumAssistantShared
 
+enum SettingsTab: String, CaseIterable {
+    case integrations = "Integrations"
+    case trust = "Trust"
+    case tasks = "Tasks"
+    case reminders = "Reminders"
+    case appearance = "Appearance"
+    case advanced = "Advanced"
+}
+
 @MainActor
 struct SettingsPanel: View {
     var onClose: () -> Void
@@ -29,6 +38,7 @@ struct SettingsPanel: View {
     @State private var newAllowlistDomain = ""
     @State private var sessionToken: String = ""
     @State private var tokenCopied: Bool = false
+    @State private var selectedTab: SettingsTab = .integrations
     #if DEBUG
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
@@ -36,665 +46,46 @@ struct SettingsPanel: View {
     #endif
 
     var body: some View {
-        VSidePanel(title: "Settings", onClose: onClose) {
-            VStack(alignment: .leading, spacing: VSpacing.xl) {
-                // ANTHROPIC section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("ANTHROPIC")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    if store.hasKey {
-                        HStack(spacing: VSpacing.sm) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(VColor.success)
-                                .font(.system(size: 14))
-                            Text(store.maskedKey)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Spacer()
-                            VButton(label: "Clear", style: .danger) {
-                                store.clearAPIKey()
-                                apiKeyText = ""
-                            }
-                        }
-                    } else {
-                        HStack(spacing: VSpacing.xs) {
-                            Text("Enter API Key")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textSecondary)
-                            Image(systemName: "info.circle")
-                                .font(.system(size: 12))
-                                .foregroundColor(VColor.textMuted)
-                        }
-
-                        SecureField("This is your private generated key", text: $apiKeyText)
-                            .textFieldStyle(.plain)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
-
-                        Text("Get your API key at console.anthropic.com")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-
-                        VButton(label: "Save", style: .primary) {
-                            store.saveAPIKey(apiKeyText)
-                            apiKeyText = ""
-                        }
-                    }
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                // MODEL section (only when API key is configured)
-                if store.hasKey {
-                    VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("MODEL")
-                            .font(VFont.sectionTitle)
-                            .foregroundColor(VColor.textPrimary)
-
-                        HStack {
-                            Text("Active Model")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Spacer()
-                            ModelPickerButton(
-                                store: store,
-                                isOpen: $showModelDropdown
-                            )
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                    .overlay(alignment: .bottomTrailing) {
-                        if showModelDropdown {
-                            VStack(alignment: .leading, spacing: 0) {
-                                ForEach(SettingsStore.availableModels, id: \.self) { model in
-                                    ModelPickerItem(
-                                        name: SettingsStore.modelDisplayNames[model] ?? model,
-                                        isSelected: model == store.selectedModel
-                                    ) {
-                                        store.selectedModel = model
-                                        store.setModel(model)
-                                        withAnimation(VAnimation.fast) { showModelDropdown = false }
-                                    }
-                                }
-                            }
-                            .padding(.vertical, VSpacing.xs)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.lg)
-                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-                            )
-                            .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
-                            .fixedSize(horizontal: true, vertical: true)
-                            .alignmentGuide(.bottom) { d in d[.top] }
-                            .padding(.trailing, VSpacing.lg)
-                            .transition(.opacity)
-                            .background(
-                                GeometryReader { geo in
-                                    Color.clear.onAppear {
-                                        modelDropdownFrame = geo.frame(in: .global)
-                                    }
-                                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
-                                        modelDropdownFrame = newFrame
-                                    }
-                                }
-                            )
-                        }
-                    }
-                    .animation(VAnimation.fast, value: showModelDropdown)
-                    .zIndex(showModelDropdown ? 1 : 0)
-                }
-
-                // PERPLEXITY SEARCH section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("PERPLEXITY SEARCH")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    if store.hasPerplexityKey {
-                        HStack(spacing: VSpacing.sm) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(VColor.success)
-                                .font(.system(size: 14))
-                            Text(store.maskedPerplexityKey)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Spacer()
-                            VButton(label: "Clear", style: .danger) {
-                                store.clearPerplexityKey()
-                                perplexityKeyText = ""
-                            }
-                        }
-                    } else {
-                        HStack(spacing: VSpacing.xs) {
-                            Text("Enter Perplexity API Key")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textSecondary)
-                            Image(systemName: "info.circle")
-                                .font(.system(size: 12))
-                                .foregroundColor(VColor.textMuted)
-                        }
-
-                        SecureField("Your Perplexity API key", text: $perplexityKeyText)
-                            .textFieldStyle(.plain)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
-
-                        Text("Get your API key at perplexity.ai/settings/api")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-
-                        VButton(label: "Save", style: .primary) {
-                            store.savePerplexityKey(perplexityKeyText)
-                            perplexityKeyText = ""
-                        }
-                    }
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                // BRAVE SEARCH section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("BRAVE SEARCH")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    if store.hasBraveKey {
-                        HStack(spacing: VSpacing.sm) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(VColor.success)
-                                .font(.system(size: 14))
-                            Text(store.maskedBraveKey)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Spacer()
-                            VButton(label: "Clear", style: .danger) {
-                                store.clearBraveKey()
-                                braveKeyText = ""
-                            }
-                        }
-                    } else {
-                        HStack(spacing: VSpacing.xs) {
-                            Text("Enter Brave Search API Key")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textSecondary)
-                            Image(systemName: "info.circle")
-                                .font(.system(size: 12))
-                                .foregroundColor(VColor.textMuted)
-                        }
-
-                        SecureField("Your Brave Search API key", text: $braveKeyText)
-                            .textFieldStyle(.plain)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
-
-                        Text("Get your API key at brave.com/search/api")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-
-                        VButton(label: "Save", style: .primary) {
-                            store.saveBraveKey(braveKeyText)
-                            braveKeyText = ""
-                        }
-                    }
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                // INTEGRATIONS section
-                if daemonClient != nil {
-                    VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("INTEGRATIONS")
-                            .font(VFont.sectionTitle)
-                            .foregroundColor(VColor.textPrimary)
-
-                        if integrations.isEmpty {
-                            Text("No integrations available")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        } else {
-                            ForEach(integrations, id: \.id) { integration in
-                                integrationRow(integration)
-                            }
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                }
-
-                // COMPUTER USAGE section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("COMPUTER USAGE")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    HStack {
-                        Text("Max Steps per Session")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 12))
-                            .foregroundColor(VColor.textMuted)
-                        Spacer()
-                        Text("\(Int(store.maxSteps))")
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textSecondary)
-                    }
-
-                    VSlider(value: $store.maxSteps, range: 1...100, step: 10, showTickMarks: true)
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                // DISPLAY section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("DISPLAY")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    HStack {
-                        Text("Theme")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                        Picker("", selection: Binding(
-                            get: { themePreference },
-                            set: { newValue in
-                                themePreference = newValue
-                                if let delegate = NSApp.delegate as? AppDelegate {
-                                    delegate.applyThemePreference()
-                                }
-                            }
-                        )) {
-                            Text("System").tag("system")
-                            Text("Light").tag("light")
-                            Text("Dark").tag("dark")
-                        }
-                        .pickerStyle(.segmented)
-                        .frame(width: 200)
-                    }
-
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                // MEDIA EMBEDS section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("MEDIA EMBEDS")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    HStack {
-                        Text("Auto media embeds")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                        Toggle("", isOn: Binding(
-                            get: { store.mediaEmbedsEnabled },
-                            set: { store.setMediaEmbedsEnabled($0) }
-                        ))
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                    }
-
-                    Text("Automatically embed images, videos, and other media shared in chat messages.")
-                        .font(VFont.caption)
+        VStack(alignment: .leading, spacing: 0) {
+            // Header (matches VSidePanel style)
+            HStack {
+                Text("Settings")
+                    .font(VFont.panelTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(VColor.textMuted)
-
-                    if store.mediaEmbedsEnabled {
-                        Divider()
-                            .background(VColor.surfaceBorder)
-
-                        Text("Video Domain Allowlist")
-                            .font(VFont.bodyBold)
-                            .foregroundColor(VColor.textSecondary)
-
-                        HStack(spacing: VSpacing.sm) {
-                            TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
-                                .textFieldStyle(.plain)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textPrimary)
-                                .padding(VSpacing.md)
-                                .background(VColor.surface)
-                                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: VRadius.md)
-                                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                                )
-
-                            VButton(label: "Add", style: .primary) {
-                                let domain = newAllowlistDomain
-                                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                                guard !domain.isEmpty else { return }
-                                var domains = store.mediaEmbedVideoAllowlistDomains
-                                domains.append(domain)
-                                store.setMediaEmbedVideoAllowlistDomains(domains)
-                                newAllowlistDomain = ""
-                            }
-                        }
-
-                        ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in
-                            HStack {
-                                Text(domain)
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                Spacer()
-                                Button {
-                                    var domains = store.mediaEmbedVideoAllowlistDomains
-                                    domains.removeAll { $0 == domain }
-                                    store.setMediaEmbedVideoAllowlistDomains(domains)
-                                } label: {
-                                    Image(systemName: "trash")
-                                        .foregroundColor(VColor.error)
-                                }
-                                .buttonStyle(.plain)
-                            }
-                            .padding(.vertical, VSpacing.xs)
-                        }
-
-                        HStack {
-                            Spacer()
-                            VButton(label: "Reset to Defaults", style: .ghost) {
-                                store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
-                            }
-                        }
-                    }
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
                 }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close Settings")
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.lg)
 
-                // PRIVATE THREAD section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("PRIVATE THREAD")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
+            Divider()
+                .background(VColor.surfaceBorder)
 
-                    HStack {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("New Private Thread")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Text("Private threads have isolated memory — facts learned in private threads stay private and won't appear in other conversations.")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        Spacer()
-                        VButton(label: "New Private Thread", style: .primary) {
-                            threadManager.createPrivateThread()
-                            onClose()
-                        }
-                    }
+            // Two-column layout
+            HStack(spacing: 0) {
+                // Left: nav sidebar
+                settingsNav
+                    .frame(width: 160)
+
+                Divider()
+
+                // Right: content for selected tab
+                ScrollView {
+                    selectedTabContent
+                        .padding(VSpacing.lg)
+                        .frame(maxWidth: .infinity, alignment: .top)
                 }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                // ARCHIVED THREADS section
-                if !threadManager.archivedThreads.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("ARCHIVED THREADS")
-                            .font(VFont.sectionTitle)
-                            .foregroundColor(VColor.textPrimary)
-
-                        ForEach(threadManager.archivedThreads) { thread in
-                            HStack {
-                                Text(thread.title)
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                    .lineLimit(1)
-                                Spacer()
-                                Button(action: { threadManager.unarchiveThread(id: thread.id) }) {
-                                    Text("Unarchive")
-                                        .font(VFont.caption)
-                                        .foregroundColor(VColor.accent)
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel("Unarchive \(thread.title)")
-                            }
-                            .padding(.vertical, VSpacing.xs)
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                }
-
-                // iOS DEVICE section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("IOS DEVICE")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        Text("Session Token")
-                            .font(VFont.bodyMedium)
-                            .foregroundColor(VColor.textPrimary)
-                        Text("Paste this into the Vellum iOS app to connect it to this Mac.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-
-                        HStack(spacing: VSpacing.sm) {
-                            if sessionToken.isEmpty {
-                                Text("Token not found")
-                                    .font(VFont.mono)
-                                    .foregroundColor(VColor.textMuted)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            } else {
-                                Text(String(sessionToken.prefix(16)) + "...")
-                                    .font(VFont.mono)
-                                    .foregroundColor(VColor.textSecondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-
-                            Button(tokenCopied ? "Copied!" : "Copy") {
-                                NSPasteboard.general.clearContents()
-                                NSPasteboard.general.setString(sessionToken, forType: .string)
-                                tokenCopied = true
-                                Task {
-                                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                                    tokenCopied = false
-                                }
-                            }
-                            .disabled(sessionToken.isEmpty)
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                }
-
-                // PERMISSIONS section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("PERMISSIONS")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    permissionRow(
-                        emoji: "\u{1F47B}",
-                        label: "Accessibility",
-                        granted: accessibilityGranted,
-                        action: {
-                            // Request accessibility permission (opens System Settings)
-                            _ = PermissionManager.accessibilityStatus(prompt: true)
-                            startPermissionPolling()
-                        }
-                    )
-
-                    permissionRow(
-                        emoji: "\u{1F355}",
-                        label: "Screen Recording",
-                        granted: screenRecordingGranted,
-                        action: {
-                            // Request screen recording permission (opens System Settings)
-                            PermissionManager.requestScreenRecordingAccess()
-                            startPermissionPolling()
-                        }
-                    )
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                // SCHEDULED TASKS section
-                if daemonClient != nil {
-                    VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("SCHEDULED TASKS")
-                            .font(VFont.sectionTitle)
-                            .foregroundColor(VColor.textPrimary)
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                                Text("Manage Scheduled Tasks")
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                Text("View and manage recurring tasks created by the assistant")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            Spacer()
-                            VButton(label: "Manage...", style: .ghost) {
-                                showingScheduledTasks = true
-                            }
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                }
-
-                // REMINDERS section
-                if daemonClient != nil {
-                    VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("REMINDERS")
-                            .font(VFont.sectionTitle)
-                            .foregroundColor(VColor.textPrimary)
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                                Text("Manage Reminders")
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                Text("View and manage one-shot reminders created by the assistant")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            Spacer()
-                            VButton(label: "Manage...", style: .ghost) {
-                                showingReminders = true
-                            }
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                }
-
-                // TRUST RULES section
-                if daemonClient != nil {
-                    VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("TRUST RULES")
-                            .font(VFont.sectionTitle)
-                            .foregroundColor(VColor.textPrimary)
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                                Text("Manage Trust Rules")
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                Text("Control which tool actions are automatically allowed or denied")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            Spacer()
-                            VButton(label: "Manage...", style: .ghost) {
-                                daemonClient?.isTrustRulesSheetOpen = true
-                                showingTrustRules = true
-                            }
-                            .disabled(store.isAnyTrustRulesSheetOpen)
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                }
-
-                // PRIVACY & SECURITY section
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("PRIVACY & SECURITY")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    VStack(alignment: .leading, spacing: 0) {
-                        privacyBullet(icon: "eye.slash", text: "AI only runs when you explicitly trigger it")
-                        Divider().background(VColor.surfaceBorder)
-                        privacyBullet(icon: "lock.shield", text: "API key stored in macOS Keychain")
-                        Divider().background(VColor.surfaceBorder)
-                        privacyBullet(icon: "xmark.shield", text: "Your data is not used to train AI models")
-                        Divider().background(VColor.surfaceBorder)
-                        privacyBullet(icon: "internaldrive", text: "Session logs and knowledge stored locally on your Mac")
-                    }
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                #if DEBUG
-                // DEVELOPER section (debug builds only)
-                if daemonClient != nil {
-                    VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("DEVELOPER")
-                            .font(VFont.sectionTitle)
-                            .foregroundColor(VColor.textPrimary)
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                                Text("Environment Variables")
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                Text("View env vars for both the app and daemon processes")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            Spacer()
-                            VButton(label: "View...", style: .ghost) {
-                                appEnvVars = ProcessInfo.processInfo.environment
-                                    .sorted(by: { $0.key < $1.key })
-                                    .map { ($0.key, $0.value) }
-                                daemonEnvVars = []
-                                daemonClient?.onEnvVarsResponse = { response in
-                                    Task { @MainActor in
-                                        self.daemonEnvVars = response.vars
-                                            .sorted(by: { $0.key < $1.key })
-                                            .map { ($0.key, $0.value) }
-                                    }
-                                }
-                                try? daemonClient?.sendEnvVarsRequest()
-                                showingEnvVars = true
-                            }
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .vCard(background: VColor.surfaceSubtle)
-                }
-                #endif
             }
         }
+        .background(VColor.backgroundSubtle)
         .task {
             // Refresh permission status when the view appears
             refreshPermissionStatus()
@@ -775,6 +166,730 @@ struct SettingsPanel: View {
             SettingsPanelEnvVarsSheet(appEnvVars: appEnvVars, daemonEnvVars: daemonEnvVars)
         }
         #endif
+    }
+
+    // MARK: - Nav Sidebar
+
+    private var settingsNav: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            ForEach(SettingsTab.allCases, id: \.self) { tab in
+                SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
+                    selectedTab = tab
+                }
+            }
+            Spacer()
+        }
+        .padding(VSpacing.lg)
+    }
+
+    // MARK: - Tab Content Router
+
+    @ViewBuilder
+    private var selectedTabContent: some View {
+        switch selectedTab {
+        case .integrations:
+            integrationsContent
+        case .trust:
+            trustContent
+        case .tasks:
+            tasksContent
+        case .reminders:
+            remindersContent
+        case .appearance:
+            appearanceContent
+        case .advanced:
+            advancedContent
+        }
+    }
+
+    // MARK: - Integrations Tab
+
+    private var integrationsContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            // ANTHROPIC section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Anthropic")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                if store.hasKey {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 14))
+                        Text(store.maskedKey)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        VButton(label: "Clear", style: .danger) {
+                            store.clearAPIKey()
+                            apiKeyText = ""
+                        }
+                    }
+                } else {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Enter API Key")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.textMuted)
+                    }
+
+                    SecureField("This is your private generated key", text: $apiKeyText)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(VSpacing.md)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                        )
+
+                    Text("Get your API key at console.anthropic.com")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    VButton(label: "Save", style: .primary) {
+                        store.saveAPIKey(apiKeyText)
+                        apiKeyText = ""
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // MODEL section (only when API key is configured)
+            if store.hasKey {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Model")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        Text("Active Model")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        ModelPickerButton(
+                            store: store,
+                            isOpen: $showModelDropdown
+                        )
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+                .overlay(alignment: .bottomTrailing) {
+                    if showModelDropdown {
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(SettingsStore.availableModels, id: \.self) { model in
+                                ModelPickerItem(
+                                    name: SettingsStore.modelDisplayNames[model] ?? model,
+                                    isSelected: model == store.selectedModel
+                                ) {
+                                    store.selectedModel = model
+                                    store.setModel(model)
+                                    withAnimation(VAnimation.fast) { showModelDropdown = false }
+                                }
+                            }
+                        }
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                        .shadow(color: .black.opacity(0.3), radius: 12, y: 4)
+                        .fixedSize(horizontal: true, vertical: true)
+                        .alignmentGuide(.bottom) { d in d[.top] }
+                        .padding(.trailing, VSpacing.lg)
+                        .transition(.opacity)
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.onAppear {
+                                    modelDropdownFrame = geo.frame(in: .global)
+                                }
+                                .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                                    modelDropdownFrame = newFrame
+                                }
+                            }
+                        )
+                    }
+                }
+                .animation(VAnimation.fast, value: showModelDropdown)
+                .zIndex(showModelDropdown ? 1 : 0)
+            }
+
+            // PERPLEXITY SEARCH section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Perplexity Search")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                if store.hasPerplexityKey {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 14))
+                        Text(store.maskedPerplexityKey)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        VButton(label: "Clear", style: .danger) {
+                            store.clearPerplexityKey()
+                            perplexityKeyText = ""
+                        }
+                    }
+                } else {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Enter Perplexity API Key")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.textMuted)
+                    }
+
+                    SecureField("Your Perplexity API key", text: $perplexityKeyText)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(VSpacing.md)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                        )
+
+                    Text("Get your API key at perplexity.ai/settings/api")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    VButton(label: "Save", style: .primary) {
+                        store.savePerplexityKey(perplexityKeyText)
+                        perplexityKeyText = ""
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // BRAVE SEARCH section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Brave Search")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                if store.hasBraveKey {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 14))
+                        Text(store.maskedBraveKey)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        VButton(label: "Clear", style: .danger) {
+                            store.clearBraveKey()
+                            braveKeyText = ""
+                        }
+                    }
+                } else {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Enter Brave Search API Key")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.textMuted)
+                    }
+
+                    SecureField("Your Brave Search API key", text: $braveKeyText)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(VSpacing.md)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                        )
+
+                    Text("Get your API key at brave.com/search/api")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    VButton(label: "Save", style: .primary) {
+                        store.saveBraveKey(braveKeyText)
+                        braveKeyText = ""
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // INTEGRATIONS section
+            if daemonClient != nil {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Integrations")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    if integrations.isEmpty {
+                        Text("No integrations available")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    } else {
+                        ForEach(integrations, id: \.id) { integration in
+                            integrationRow(integration)
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+        }
+    }
+
+    // MARK: - Trust Tab
+
+    private var trustContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            // PERMISSIONS section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Permissions")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                permissionRow(
+                    emoji: "\u{1F47B}",
+                    label: "Accessibility",
+                    granted: accessibilityGranted,
+                    action: {
+                        // Request accessibility permission (opens System Settings)
+                        _ = PermissionManager.accessibilityStatus(prompt: true)
+                        startPermissionPolling()
+                    }
+                )
+
+                permissionRow(
+                    emoji: "\u{1F355}",
+                    label: "Screen Recording",
+                    granted: screenRecordingGranted,
+                    action: {
+                        // Request screen recording permission (opens System Settings)
+                        PermissionManager.requestScreenRecordingAccess()
+                        startPermissionPolling()
+                    }
+                )
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // TRUST RULES section
+            if daemonClient != nil {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Trust Rules")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Manage Trust Rules")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("Control which tool actions are automatically allowed or denied")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Manage...", style: .ghost) {
+                            daemonClient?.isTrustRulesSheetOpen = true
+                            showingTrustRules = true
+                        }
+                        .disabled(store.isAnyTrustRulesSheetOpen)
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+
+            // PRIVACY & SECURITY section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("PRIVACY & SECURITY")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                VStack(alignment: .leading, spacing: 0) {
+                    privacyBullet(icon: "eye.slash", text: "AI only runs when you explicitly trigger it")
+                    Divider().background(VColor.surfaceBorder)
+                    privacyBullet(icon: "lock.shield", text: "API key stored in macOS Keychain")
+                    Divider().background(VColor.surfaceBorder)
+                    privacyBullet(icon: "xmark.shield", text: "Your data is not used to train AI models")
+                    Divider().background(VColor.surfaceBorder)
+                    privacyBullet(icon: "internaldrive", text: "Session logs and knowledge stored locally on your Mac")
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+        }
+    }
+
+    // MARK: - Tasks Tab
+
+    private var tasksContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            if daemonClient != nil {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Scheduled Tasks")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Manage Scheduled Tasks")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("View and manage recurring tasks created by the assistant")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Manage...", style: .ghost) {
+                            showingScheduledTasks = true
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+        }
+    }
+
+    // MARK: - Reminders Tab
+
+    private var remindersContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            if daemonClient != nil {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Reminders")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Manage Reminders")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("View and manage one-shot reminders created by the assistant")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Manage...", style: .ghost) {
+                            showingReminders = true
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+        }
+    }
+
+    // MARK: - Appearance Tab
+
+    private var appearanceContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            // DISPLAY section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Display")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack {
+                    Text("Theme")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Picker("", selection: Binding(
+                        get: { themePreference },
+                        set: { newValue in
+                            themePreference = newValue
+                            if let delegate = NSApp.delegate as? AppDelegate {
+                                delegate.applyThemePreference()
+                            }
+                        }
+                    )) {
+                        Text("System").tag("system")
+                        Text("Light").tag("light")
+                        Text("Dark").tag("dark")
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 200)
+                }
+
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // MEDIA EMBEDS section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Media Embeds")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack {
+                    Text("Auto media embeds")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { store.mediaEmbedsEnabled },
+                        set: { store.setMediaEmbedsEnabled($0) }
+                    ))
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+                }
+
+                Text("Automatically embed images, videos, and other media shared in chat messages.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+
+                if store.mediaEmbedsEnabled {
+                    Divider()
+                        .background(VColor.surfaceBorder)
+
+                    Text("Video Domain Allowlist")
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.textSecondary)
+
+                    HStack(spacing: VSpacing.sm) {
+                        TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+
+                        VButton(label: "Add", style: .primary) {
+                            let domain = newAllowlistDomain
+                                .trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !domain.isEmpty else { return }
+                            var domains = store.mediaEmbedVideoAllowlistDomains
+                            domains.append(domain)
+                            store.setMediaEmbedVideoAllowlistDomains(domains)
+                            newAllowlistDomain = ""
+                        }
+                    }
+
+                    ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in
+                        HStack {
+                            Text(domain)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Spacer()
+                            Button {
+                                var domains = store.mediaEmbedVideoAllowlistDomains
+                                domains.removeAll { $0 == domain }
+                                store.setMediaEmbedVideoAllowlistDomains(domains)
+                            } label: {
+                                Image(systemName: "trash")
+                                    .foregroundColor(VColor.error)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.vertical, VSpacing.xs)
+                    }
+
+                    HStack {
+                        Spacer()
+                        VButton(label: "Reset to Defaults", style: .ghost) {
+                            store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
+                        }
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+        }
+    }
+
+    // MARK: - Advanced Tab
+
+    private var advancedContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            // COMPUTER USAGE section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Computer Usage")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack {
+                    Text("Max Steps per Session")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.textMuted)
+                    Spacer()
+                    Text("\(Int(store.maxSteps))")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                VSlider(value: $store.maxSteps, range: 1...100, step: 10, showTickMarks: true)
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // PRIVATE THREAD section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Private Thread")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("New Private Thread")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Private threads have isolated memory — facts learned in private threads stay private and won't appear in other conversations.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                    VButton(label: "New Private Thread", style: .primary) {
+                        threadManager.createPrivateThread()
+                        onClose()
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // ARCHIVED THREADS section
+            if !threadManager.archivedThreads.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Archived Threads")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    ForEach(threadManager.archivedThreads) { thread in
+                        HStack {
+                            Text(thread.title)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                                .lineLimit(1)
+                            Spacer()
+                            Button(action: { threadManager.unarchiveThread(id: thread.id) }) {
+                                Text("Unarchive")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.accent)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Unarchive \(thread.title)")
+                        }
+                        .padding(.vertical, VSpacing.xs)
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+
+            // iOS DEVICE section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("iOS Device")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Session Token")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+                    Text("Paste this into the Vellum iOS app to connect it to this Mac.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+
+                    HStack(spacing: VSpacing.sm) {
+                        if sessionToken.isEmpty {
+                            Text("Token not found")
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textMuted)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        } else {
+                            Text(String(sessionToken.prefix(16)) + "...")
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textSecondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+
+                        Button(tokenCopied ? "Copied!" : "Copy") {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(sessionToken, forType: .string)
+                            tokenCopied = true
+                            Task {
+                                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                tokenCopied = false
+                            }
+                        }
+                        .disabled(sessionToken.isEmpty)
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+
+            #if DEBUG
+            // DEVELOPER section (debug builds only)
+            if daemonClient != nil {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Developer")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Environment Variables")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("View env vars for both the app and daemon processes")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "View...", style: .ghost) {
+                            appEnvVars = ProcessInfo.processInfo.environment
+                                .sorted(by: { $0.key < $1.key })
+                                .map { ($0.key, $0.value) }
+                            daemonEnvVars = []
+                            daemonClient?.onEnvVarsResponse = { response in
+                                Task { @MainActor in
+                                    self.daemonEnvVars = response.vars
+                                        .sorted(by: { $0.key < $1.key })
+                                        .map { ($0.key, $0.value) }
+                                }
+                            }
+                            try? daemonClient?.sendEnvVarsRequest()
+                            showingEnvVars = true
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+            #endif
+        }
     }
 
     // MARK: - Integration Row
@@ -1000,6 +1115,34 @@ struct SettingsPanel: View {
 
 }
 
+// MARK: - Settings Nav Row
+
+private struct SettingsNavRow: View {
+    let tab: SettingsTab
+    let isSelected: Bool
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(tab.rawValue)
+                .font(isSelected ? VFont.bodyMedium : VFont.body)
+                .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(isSelected ? VColor.hoverOverlay.opacity(0.08) : (isHovered ? VColor.hoverOverlay.opacity(0.04) : Color.clear))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+}
+
 // MARK: - Custom Model Picker
 
 private struct ModelPickerButton: View {
@@ -1090,8 +1233,8 @@ private struct SettingsPanelEnvVarsSheet: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: VSpacing.xl) {
-                    envVarsSection(title: "APP PROCESS", vars: appEnvVars)
-                    envVarsSection(title: "DAEMON PROCESS", vars: daemonEnvVars)
+                    envVarsSection(title: "App Process", vars: appEnvVars)
+                    envVarsSection(title: "Daemon Process", vars: daemonEnvVars)
                 }
                 .padding(VSpacing.lg)
             }

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -13,7 +13,7 @@ struct TasksWindowView: View {
         VStack(spacing: 0) {
             // Header
             HStack {
-                Text("TASKS")
+                Text("Tasks")
                     .font(VFont.display)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()

--- a/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
+++ b/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
@@ -22,7 +22,6 @@ public struct VEmptyState: View {
             Text(title)
                 .font(VFont.mono)
                 .foregroundColor(VColor.textMuted)
-                .textCase(.uppercase)
             if let subtitle = subtitle {
                 Text(subtitle)
                     .font(VFont.body)

--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -8,7 +8,7 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
     @ViewBuilder public let pinnedContent: () -> PinnedContent
     @ViewBuilder public let content: () -> Content
 
-    public init(title: String, titleFont: Font = VFont.panelTitle, uppercased: Bool = true, onClose: (() -> Void)? = nil, @ViewBuilder pinnedContent: @escaping () -> PinnedContent, @ViewBuilder content: @escaping () -> Content) {
+    public init(title: String, titleFont: Font = VFont.panelTitle, uppercased: Bool = false, onClose: (() -> Void)? = nil, @ViewBuilder pinnedContent: @escaping () -> PinnedContent, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.titleFont = titleFont
         self.uppercased = uppercased
@@ -61,7 +61,7 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
 
 // Backward-compatible init (no pinnedContent)
 public extension VSidePanel where PinnedContent == EmptyView {
-    init(title: String, titleFont: Font = VFont.panelTitle, uppercased: Bool = true, onClose: (() -> Void)? = nil,
+    init(title: String, titleFont: Font = VFont.panelTitle, uppercased: Bool = false, onClose: (() -> Void)? = nil,
          @ViewBuilder content: @escaping () -> Content) {
         self.init(title: title, titleFont: titleFont, uppercased: uppercased, onClose: onClose,
                   pinnedContent: { EmptyView() }, content: content)

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -7,8 +7,9 @@ import UIKit
 
 /// Font presets for the app. Always use these instead of raw Font.system() calls.
 ///
-/// **Silkscreen** — pixelated bitmap font for headings and display text.
-/// **DM Mono** — monospaced font for body/UI text.
+/// **Inter** — humanist sans-serif for headings, body, and UI text.
+/// **DM Mono** — monospaced font for code and debug views.
+/// **Silkscreen** — pixelated bitmap font, used sparingly for buttons.
 public enum VFont {
 
     /// DM Mono's default "f" has an exaggerated italic-style hook.
@@ -42,16 +43,16 @@ public enum VFont {
         return Font.custom(name, size: size)
         #endif
     }
-    // MARK: - Onboarding (Silkscreen pixel font)
+    // MARK: - Onboarding
 
-    public static let onboardingTitle = Font.custom("Silkscreen-Regular", size: 28)
-    public static let onboardingSubtitle = Font.custom("Silkscreen-Regular", size: 15)
+    public static let onboardingTitle = Font.custom("Fraunces", size: 28).weight(.semibold)
+    public static let onboardingSubtitle = Font.system(size: 15)
 
-    // MARK: - Headings (Silkscreen)
-    // TODO: Clean up typography once we solidify the design system - we dont seem to use Bold
-    public static let largeTitle = Font.custom("Silkscreen-Bold", size: 26)
-    public static let title      = Font.custom("Silkscreen-Bold", size: 22)
-    public static let headline   = Font.custom("Silkscreen-Bold", size: 13)
+    // MARK: - Headings (Inter)
+
+    public static let largeTitle = Font.custom("Inter-SemiBold", size: 26)
+    public static let title      = Font.custom("Inter-SemiBold", size: 22)
+    public static let headline   = Font.custom("Inter-SemiBold", size: 13)
 
     // MARK: - Body / UI (Inter)
 
@@ -70,11 +71,16 @@ public enum VFont {
     public static let monoSmall  = dmMono("DMMono-Regular", size: 11)
     public static let monoMedium = dmMono("DMMono-Medium", size: 16)
 
-    /// All-caps pixel display font (used for panel headers like "AGENT", "GENERATED CONTENT")
-    public static let display    = Font.custom("Silkscreen-Bold", size: 18)
-    public static let panelTitle   = Font.custom("Silkscreen-Regular", size: 24)
-    public static let sectionTitle   = Font.custom("Silkscreen-Regular", size: 18)
+    /// Display font (used for panel headers like "AGENT", "GENERATED CONTENT")
+    public static let display    = Font.custom("Inter-SemiBold", size: 18)
+    public static let panelTitle   = Font.custom("Inter-Medium", size: 24)
+    public static let sectionTitle   = Font.custom("Inter-Medium", size: 18)
 
-    /// Small Silkscreen label (used for thread tab names)
-    public static let tabLabel   = Font.custom("Silkscreen-Regular", size: 11)
+    /// Small label (used for thread tab names)
+    public static let tabLabel   = Font.custom("Inter", size: 11)
+
+    // MARK: - Pixel (Silkscreen — use sparingly, e.g. buttons)
+
+    public static let pixel      = Font.custom("Silkscreen-Regular", size: 13)
+    public static let pixelSmall = Font.custom("Silkscreen-Regular", size: 11)
 }

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -63,7 +63,7 @@ public struct ModelListBubble: View {
             ForEach(groups) { group in
                 // Provider header
                 HStack(spacing: VSpacing.sm) {
-                    Text(group.name.uppercased())
+                    Text(group.name)
                         .font(VFont.small)
                         .foregroundColor(VColor.textMuted)
                         .tracking(0.5)


### PR DESCRIPTION
## Summary
- Replace VSidePanel with centered max-width layouts for directory and skills pages (matching Claude Artifacts style)
- Add Installed/Available tabs to skills page, replace teal/emerald colors with design system tokens, use VButton component
- Sidebar: full-row New chat button with matching hover, group-dragging in constellation view
- Onboarding fonts: Fraunces for titles, SF system font for body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
