### PR TITLE
view_image: enforce sandbox paths and add default allow rule

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -196,6 +196,17 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   }));
 
+  // view_image is a read-only sandbox tool — always allow without prompting.
+  // Candidates contain "/" (absolute paths), so use "/**" globstar.
+  const viewImageRule: DefaultRuleTemplate = {
+    id: 'default:allow-view_image-global',
+    tool: 'view_image',
+    pattern: 'view_image:/**',
+    scope: 'everywhere',
+    decision: 'allow',
+    priority: 100,
+  };
+
   return [
     ...hostFileRules,
     hostShellRule,
@@ -208,5 +219,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     browserNavigateRule,
     ...browserToolRules,
     ...uiSurfaceRules,
+    viewImageRule,
   ];
 }

--- a/assistant/src/tools/filesystem/view-image.ts
+++ b/assistant/src/tools/filesystem/view-image.ts
@@ -1,10 +1,11 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, statSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { extname, join, resolve } from 'node:path';
+import { extname, join } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
 import type { ImageContent, ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
+import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 
 const SUPPORTED_EXTENSIONS = new Set([
@@ -100,7 +101,11 @@ class ViewImageTool implements Tool {
       return { content: 'Error: path is required and must be a string', isError: true };
     }
 
-    const resolved = resolve(context.workingDir, rawPath);
+    const pathCheck = sandboxPolicy(rawPath, context.workingDir);
+    if (!pathCheck.ok) {
+      return { content: `Error: ${pathCheck.error}`, isError: true };
+    }
+    const resolved = pathCheck.resolved;
 
     const ext = extname(resolved).toLowerCase();
     if (!SUPPORTED_EXTENSIONS.has(ext)) {


### PR DESCRIPTION
## Summary
- Replace raw `resolve()` in `view_image` with `sandboxPolicy()` to enforce sandbox boundary (prevents symlink escape and `../` traversal)
- Add a default allow rule for `view_image` in `defaults.ts` so it never triggers permission prompts (read-only, sandbox-bounded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
