### PR TITLE
Fix permission denial retry behavior with better model guidance

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -576,6 +576,19 @@ function buildToolPermissionSection(): string {
     '- Calling a tool with no preceding text at all',
     '',
     'Be conversational and transparent. Your user is granting access to their machine, so acknowledge their request, explain what you need in plain language, and ask them to allow it.',
+    '',
+    '### Handling Permission Denials',
+    '',
+    'When your user denies a tool permission (clicks "Don\'t Allow"), you will receive an error indicating the denial. Follow these rules:',
+    '',
+    '1. **Do NOT immediately retry the tool call.** Retrying without waiting creates another permission prompt, which is annoying and disrespectful of the user\'s decision.',
+    '2. **Acknowledge the denial.** Tell the user that the action was not performed because they chose not to allow it.',
+    '3. **Ask before retrying.** Ask if they would like you to try again, or if they would prefer a different approach.',
+    '4. **Wait for an explicit response.** Only retry the tool call after the user explicitly confirms they want you to try again.',
+    '5. **Offer alternatives.** If possible, suggest alternative approaches that might not require the denied permission.',
+    '',
+    'Example:',
+    '- Tool denied → "No problem! I wasn\'t able to access your Downloads folder since you chose not to allow it. Would you like me to try again, or is there another way I can help?"',
   ].join('\n');
 }
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -213,6 +213,7 @@ export class ToolExecutor {
         });
 
         if (response.decision === 'deny') {
+          const denialMessage = `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
           const durationMs = Date.now() - startTime;
           emitLifecycleEvent(context, {
             type: 'permission_denied',
@@ -228,7 +229,7 @@ export class ToolExecutor {
             reason: 'Permission denied by user',
             durationMs,
           });
-          return { content: 'Permission denied by user', isError: true };
+          return { content: denialMessage, isError: true };
         }
 
         if (response.decision === 'always_deny') {
@@ -236,6 +237,10 @@ export class ToolExecutor {
           if (ruleSaved) {
             addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
           }
+          const denialReason = ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user';
+          const denialMessage = ruleSaved
+            ? `Permission denied by user, and a rule was saved to always deny the "${name}" tool for this pattern. Do NOT retry this tool call. Inform the user that this action has been permanently blocked by their preference. If the user wants to allow it in the future, they can update their permission rules.`
+            : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
           const durationMs = Date.now() - startTime;
           emitLifecycleEvent(context, {
             type: 'permission_denied',
@@ -248,10 +253,10 @@ export class ToolExecutor {
             requestId: context.requestId,
             riskLevel,
             decision: 'always_deny',
-            reason: ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user',
+            reason: denialReason,
             durationMs,
           });
-          return { content: ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user', isError: true };
+          return { content: denialMessage, isError: true };
         }
 
         if (


### PR DESCRIPTION
## Summary
- Updated permission denial error messages in `executor.ts` to include explicit instructions telling the model not to retry the tool call immediately, to explain the denial to the user, and to wait for user confirmation before retrying
- Added distinct messaging for `always_deny` with saved rules, informing the model the action is permanently blocked
- Added a "Handling Permission Denials" subsection to the system prompt's Tool Permissions section with 5 clear rules for handling denials gracefully

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All system-prompt tests pass (44/44)
- [x] No executor-specific tests exist; changes are text/prompt-only with no logic changes
- [ ] Manual verification: deny a tool permission and observe the model acknowledges the denial and asks before retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
