### PR TITLE
fix: stop LLM from polling subagent_status after spawn

### DIFF
--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -73,7 +73,7 @@ export const subagentSpawnTool: Tool = {
           subagentId,
           label,
           status: 'pending',
-          message: `Subagent "${label}" spawned. It will work autonomously and report back when complete.`,
+          message: `Subagent "${label}" spawned. You will be notified automatically when it completes or fails — do NOT poll subagent_status. Continue the conversation normally.`,
         }),
         isError: false,
       };

--- a/assistant/src/tools/subagent/status.ts
+++ b/assistant/src/tools/subagent/status.ts
@@ -9,7 +9,7 @@ import { getSubagentManager } from '../../subagent/index.js';
 
 const definition: ToolDefinition = {
   name: 'subagent_status',
-  description: 'Get the status of a specific subagent or list all subagents for the current session.',
+  description: 'Get the status of a specific subagent or list all subagents for the current session. Only use this when the user explicitly asks about subagent status — do NOT poll automatically, as you will be notified when subagents complete.',
   input_schema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary
- Updated `subagent_spawn` tool response to explicitly tell the LLM not to poll and to continue the conversation normally
- Updated `subagent_status` tool description to say "only use when user explicitly asks"
- The notification system already auto-injects a message into the parent session when subagents complete, so polling is unnecessary

## Test plan
- [ ] Spawn a subagent and verify the LLM continues chatting instead of immediately calling `subagent_status`
- [ ] Verify subagent completion notification still arrives and triggers `subagent_read`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
