### PR TITLE
feat: double-click image in tool call chip to open in Preview

### DIFF
--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 public struct ToolCallChip: View {
     public let toolCall: ToolCallData
@@ -91,6 +94,16 @@ public struct ToolCallChip: View {
                             .frame(maxWidth: .infinity)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                             .padding(.horizontal, VSpacing.sm)
+                            .onTapGesture(count: 2) {
+                                let path = toolCall.inputFull
+                                guard !path.isEmpty,
+                                      FileManager.default.fileExists(atPath: path) else { return }
+                                NSWorkspace.shared.open(URL(fileURLWithPath: path))
+                            }
+                            .onHover { hovering in
+                                if hovering { NSCursor.pointingHand.push() }
+                                else { NSCursor.pop() }
+                            }
                         #elseif os(iOS)
                         Image(uiImage: cachedImage)
                             .resizable()


### PR DESCRIPTION
## Summary
- Added double-click gesture on images in ToolCallChip (macOS) that opens the source file in Preview (or the default image viewer)
- Uses the tool call's `inputFull` path (e.g. from `view_image`) to locate the file on disk, with a guard for file existence
- Added pointer cursor on hover to indicate the image is interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
