### PR TITLE
Show all tool call arguments in expanded details

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -162,18 +162,15 @@ private struct UsedToolsRow: View {
                             .foregroundColor(VColor.textMuted)
                             .textCase(.uppercase)
 
-                        HStack(spacing: VSpacing.xs) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text(toolCall.friendlyName)
                                 .font(VFont.captionMedium)
                                 .foregroundColor(VColor.textSecondary)
-                            if !toolCall.inputSummary.isEmpty {
-                                Text("·")
-                                    .foregroundColor(VColor.textMuted)
-                                Text(toolCall.inputSummary)
+                            if !toolCall.inputFull.isEmpty {
+                                Text(toolCall.inputFull)
                                     .font(VFont.monoSmall)
                                     .foregroundColor(VColor.textSecondary)
                                     .textSelection(.enabled)
-                                    .lineLimit(3)
                             }
                         }
                     }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -60,6 +60,46 @@ extension ChatViewModel {
         return str.count > 80 ? String(str.prefix(77)) + "..." : str
     }
 
+    /// Format all tool input arguments for display in expanded details.
+    /// The primary value comes first, then remaining keys as `key: value` lines.
+    func formatAllToolInput(_ input: [String: AnyCodable]) -> String {
+        guard !input.isEmpty else { return "" }
+
+        // Find the primary key (same logic as extractToolInput)
+        let primaryKey = Self.toolInputPriorityKeys.first(where: { input[$0] != nil })
+            ?? input.keys.sorted().first
+
+        var lines: [String] = []
+
+        // Primary value first (undecorated)
+        if let key = primaryKey, let value = input[key] {
+            lines.append(stringifyValue(value))
+        }
+
+        // Remaining keys sorted alphabetically
+        let otherKeys = input.keys
+            .filter { $0 != primaryKey }
+            .sorted()
+        for key in otherKeys {
+            guard let value = input[key] else { continue }
+            lines.append("\(key): \(stringifyValue(value))")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func stringifyValue(_ value: AnyCodable) -> String {
+        if let s = value.value as? String { return s }
+        if let b = value.value as? Bool { return b ? "true" : "false" }
+        if let n = value.value as? Int { return String(n) }
+        if let n = value.value as? Double { return String(n) }
+        if let encoder = try? JSONEncoder().encode(value),
+           let json = String(data: encoder, encoding: .utf8) {
+            return json
+        }
+        return String(describing: value.value ?? "")
+    }
+
     func toolDisplayName(_ name: String) -> String {
         switch name {
         case "file_write": return "Write File"
@@ -647,7 +687,7 @@ extension ChatViewModel {
             var toolCall = ToolCallData(
                 toolName: msg.toolName,
                 inputSummary: summarizeToolInput(msg.input),
-                inputFull: extractToolInput(msg.input),
+                inputFull: formatAllToolInput(msg.input),
                 arrivedBeforeText: !currentAssistantHasText,
                 startedAt: Date()
             )

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -64,19 +64,15 @@ public struct ToolCallChip: View {
                             .foregroundColor(VColor.textMuted)
                             .textCase(.uppercase)
 
-                        HStack(alignment: .top, spacing: VSpacing.xs) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text(toolCall.friendlyName)
                                 .font(VFont.captionMedium)
                                 .foregroundColor(VColor.textSecondary)
-                            if !toolCall.inputSummary.isEmpty {
-                                Text("·")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                                Text(toolCall.inputSummary)
+                            if !toolCall.inputFull.isEmpty {
+                                Text(toolCall.inputFull)
                                     .font(VFont.monoSmall)
                                     .foregroundColor(VColor.textSecondary)
                                     .textSelection(.enabled)
-                                    .lineLimit(3)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Add `formatAllToolInput()` to format all tool call parameters (not just the primary value)
- Expanded technical details now show all args: primary value first, then remaining key-value pairs
- Both `ToolCallChip` and `UsedToolsRow` updated to display `inputFull` instead of truncated `inputSummary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
