### PR TITLE
fix: composer text clipping when deleting from second line back to first

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -245,6 +245,8 @@ struct ComposerView: View {
         .onChange(of: editorContentHeight) {
             if editorContentHeight > composerCompactHeight && !isComposerExpanded {
                 withAnimation(VAnimation.fast) { isComposerExpanded = true }
+            } else if editorContentHeight <= composerCompactHeight && isComposerExpanded {
+                withAnimation(VAnimation.fast) { isComposerExpanded = false }
             }
         }
     }
@@ -696,6 +698,11 @@ private struct ComposerTextView: NSViewRepresentable {
             parent.onOverflowChange?(rawHeight > parent.maxHeight)
 
             if abs(lastReportedHeight - clampedHeight) > 0.5 {
+                // When content shrinks (e.g. deleting from 2 lines back to 1),
+                // reset the scroll position so text isn't clipped at the top.
+                if clampedHeight < lastReportedHeight {
+                    textView.scrollToBeginningOfDocument(nil)
+                }
                 lastReportedHeight = clampedHeight
                 parent.onHeightChange(clampedHeight)
             }


### PR DESCRIPTION
## Summary
- Fixed text being cut off at the top of the composer when typing past one line then deleting back to a single line
- Collapse `isComposerExpanded` when content height drops back to single-line height (was only resetting when text was completely empty)
- Reset scroll position via `scrollToBeginningOfDocument` when content height shrinks, preventing stale scroll offset from clipping text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
