### PR TITLE
UI polish: sidebar drawer overlay, editor theming, split view handle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -225,29 +225,34 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
   <style>
     :root {
       --v-bg: #FFFFFF;
-      --v-surface: #F5F5F7;
-      --v-surface-border: #D2D2D7;
-      --v-text: #1D1D1F;
-      --v-text-secondary: #86868B;
-      --v-text-muted: #AEAEB2;
-      --v-accent: #8A5BE0;
+      --v-surface: #FFFFFF;
+      --v-surface-border: #E7E5E4;
+      --v-text: #292524;
+      --v-text-secondary: #78716C;
+      --v-text-muted: #97918B;
+      --v-accent: #262624;
     }
     @media (prefers-color-scheme: dark) {
       :root {
-        --v-bg: #070D19;
-        --v-surface: #1E293B;
-        --v-surface-border: #334155;
-        --v-text: #F8FAFC;
-        --v-text-secondary: #94A3B8;
-        --v-text-muted: #64748B;
-        --v-accent: #8A5BE0;
+        --v-bg: #262624;
+        --v-surface: #2F2F2D;
+        --v-surface-border: #3A3A37;
+        --v-text: #F5F3EB;
+        --v-text-secondary: #A1A096;
+        --v-text-muted: #6B6B65;
+        --v-accent: #216C37;
       }
+    }
+    /* Invert toolbar icons in dark mode — target both the JS-applied class and the media query */
+    .toastui-editor-dark .toastui-editor-toolbar-icons { filter: invert(1) brightness(0.85) !important; }
+    @media (prefers-color-scheme: dark) {
+      .toastui-editor-toolbar-icons { filter: invert(1) brightness(0.85) !important; }
     }
 
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+      font-family: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
       background: var(--v-bg);
       color: var(--v-text);
       height: 100vh;
@@ -259,6 +264,7 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
     .header { display: none; }
 
     .title-input {
+      font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
       font-size: 20px;
       font-weight: 600;
       background: transparent;
@@ -288,24 +294,37 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
     }
 
     /* Override Toast UI Editor theme colors to match Vellum */
-    .toastui-editor-defaultUI { border: none !important; }
-    .toastui-editor-toolbar { background: var(--v-surface) !important; border-bottom: 1px solid var(--v-surface-border) !important; }
-    .toastui-editor-toolbar-icons { color: var(--v-text-secondary) !important; }
-    .toastui-editor-toolbar-icons:hover { background: var(--v-surface-border) !important; }
+    .toastui-editor-defaultUI { border: none !important; background: var(--v-bg) !important; }
+    .toastui-editor-defaultUI-toolbar { background: var(--v-surface) !important; border-bottom: 1px solid var(--v-surface-border) !important; }
+    .toastui-editor-toolbar { background: var(--v-surface) !important; border-top: 1px solid var(--v-surface-border) !important; border-bottom: 1px solid var(--v-surface-border) !important; }
+    .toastui-editor-toolbar-icons { color: var(--v-text) !important; background-color: transparent !important; border: none !important; }
+    .toastui-editor-toolbar-icons:hover { background-color: var(--v-surface-border) !important; }
+    .toastui-editor-toolbar-icons.active { background-color: var(--v-surface-border) !important; }
+    .toastui-editor-toolbar-divider { background: var(--v-surface-border) !important; }
+    .toastui-editor-toolbar-group { border-right-color: var(--v-surface-border) !important; }
+    .toastui-editor-popup { background: var(--v-surface) !important; border-color: var(--v-surface-border) !important; }
+    .toastui-editor-popup-body { background: var(--v-surface) !important; }
     .toastui-editor-md-container,
     .toastui-editor-ww-container { background: var(--v-bg) !important; color: var(--v-text) !important; }
-    .toastui-editor-contents { color: var(--v-text) !important; padding: 0 !important; }
-    .toastui-editor-ww-content { padding: 0 !important; }
-    .ProseMirror { padding: 0 !important; }
-    .toastui-editor-md-container .toastui-editor { padding: 0 !important; }
-    .toastui-editor-contents h1,
-    .toastui-editor-contents h2,
-    .toastui-editor-contents h3 { color: var(--v-text) !important; border-bottom-color: var(--v-surface-border) !important; }
-    .toastui-editor-contents pre { background: var(--v-surface) !important; }
-    .toastui-editor-contents code { background: var(--v-surface) !important; color: var(--v-text) !important; }
+    .toastui-editor-contents { color: var(--v-text) !important; font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 14px !important; line-height: 1.7 !important; padding: 24px 32px !important; }
+    .toastui-editor-ww-content { padding: 24px 32px !important; }
+    .ProseMirror { padding: 24px 32px !important; }
+    .toastui-editor-md-container .toastui-editor { padding: 24px 32px !important; }
+    .toastui-editor-contents h1 { font-family: "Fraunces", Georgia, serif !important; font-size: 28px !important; font-weight: 400 !important; color: var(--v-text) !important; border-bottom: none !important; margin-top: 32px !important; margin-bottom: 12px !important; }
+    .toastui-editor-contents h2 { font-family: "Fraunces", Georgia, serif !important; font-size: 22px !important; font-weight: 400 !important; color: var(--v-text) !important; border-bottom: none !important; margin-top: 28px !important; margin-bottom: 10px !important; }
+    .toastui-editor-contents h3 { font-family: "Fraunces", Georgia, serif !important; font-size: 18px !important; font-weight: 400 !important; color: var(--v-text) !important; border-bottom: none !important; margin-top: 24px !important; margin-bottom: 8px !important; }
+    .toastui-editor-contents p { margin-bottom: 12px !important; }
+    .toastui-editor-contents pre { background: var(--v-surface) !important; border-radius: 8px !important; padding: 12px 16px !important; }
+    .toastui-editor-contents code { background: var(--v-surface) !important; color: var(--v-text) !important; font-family: "DMMono-Regular", "SF Mono", monospace !important; border-radius: 4px !important; padding: 2px 5px !important; font-size: 13px !important; }
     .toastui-editor-contents blockquote { border-left-color: var(--v-accent) !important; color: var(--v-text-secondary) !important; }
     .toastui-editor-contents table td,
     .toastui-editor-contents table th { border-color: var(--v-surface-border) !important; }
+    /* Hide mode switch (Markdown / WYSIWYG toggle) */
+    .toastui-editor-mode-switch { display: none !important; }
+    /* Scrollbar styling */
+    .toastui-editor-contents::-webkit-scrollbar { width: 6px; }
+    .toastui-editor-contents::-webkit-scrollbar-track { background: transparent; }
+    .toastui-editor-contents::-webkit-scrollbar-thumb { background: var(--v-surface-border); border-radius: 3px; }
   </style>
 </head>
 <body>

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -322,7 +322,7 @@ struct MainWindowView: View {
                         }
                     }()
                     if shouldClose {
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        withAnimation(.easeInOut(duration: 0.35)) {
                             sidebarOpen = false
                         }
                     }
@@ -354,83 +354,88 @@ struct MainWindowView: View {
     private var coreLayoutView: some View {
         GeometryReader { geometry in
             Group {
-                HStack(spacing: 0) {
-                    // Left: Full-height sidebar (extends behind traffic lights)
-                    sidebarView
-                        .frame(width: sidebarOpen && windowState.layoutConfig.left.visible ? threadDrawerWidth : 0, alignment: .leading)
-                        .clipped()
-                        .allowsHitTesting(sidebarOpen && windowState.layoutConfig.left.visible)
-                        .animation(isDrawerDragging ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: sidebarOpen)
-                        .animation(nil, value: threadDrawerWidth)
-
-                    if sidebarOpen && windowState.layoutConfig.left.visible {
-                        drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
-                    }
-
-                    // Right: Top bar + main content
-                    VStack(spacing: 0) {
-                        // Top bar — sidebar toggle always visible when sidebar is closed;
-                        // TemporaryChatToggle only shown on chat views.
-                        if !(sidebarOpen && windowState.layoutConfig.left.visible) || windowState.isShowingChat {
-                            HStack(spacing: 0) {
-                                if !(sidebarOpen && windowState.layoutConfig.left.visible) {
-                                    VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true) {
-                                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                                            sidebarOpen.toggle()
-                                        }
-                                    }
-                                }
-                                Spacer()
-                                if windowState.isShowingChat {
-                                    // Copy Thread button
-                                    Button {
-                                        let messages = threadManager.activeViewModel?.messages ?? []
-                                        let title = threadManager.activeThread?.title
-                                        let names = resolveParticipantNames()
-                                        let markdown = ChatTranscriptFormatter.threadMarkdown(
-                                            messages: messages,
-                                            threadTitle: title,
-                                            participantNames: names
-                                        )
-                                        guard !markdown.isEmpty else { return }
-                                        NSPasteboard.general.clearContents()
-                                        NSPasteboard.general.setString(markdown, forType: .string)
-                                        copyThreadConfirmationTimer?.cancel()
-                                        showCopyThreadConfirmation = true
-                                        let timer = DispatchWorkItem { showCopyThreadConfirmation = false }
-                                        copyThreadConfirmationTimer = timer
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
-                                    } label: {
-                                        Image(systemName: showCopyThreadConfirmation ? "checkmark" : "list.clipboard")
-                                            .font(.system(size: 12, weight: .medium))
-                                            .foregroundColor(showCopyThreadConfirmation ? VColor.success : VColor.textMuted)
-                                            .frame(width: 28, height: 28)
-                                            .contentShape(Rectangle())
-                                    }
-                                    .buttonStyle(.plain)
-                                    .accessibilityLabel("Copy thread")
-                                    .disabled({
-                                        let messages = threadManager.activeViewModel?.messages ?? []
-                                        return !messages.contains { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-                                    }())
-                                    .help(showCopyThreadConfirmation ? "Copied!" : "Copy thread")
-
-                                    TemporaryChatToggle(
-                                        isActive: threadManager.activeThread?.kind == .private,
-                                        onToggle: { toggleTemporaryChat() }
-                                    )
-                                }
+                VStack(spacing: 0) {
+                    // Top bar (always visible, above sidebar)
+                    HStack(spacing: 0) {
+                        VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true) {
+                            withAnimation(.easeInOut(duration: 0.35)) {
+                                sidebarOpen.toggle()
                             }
-                            .padding(.leading, (sidebarOpen && windowState.layoutConfig.left.visible) ? VSpacing.sm : trafficLightPadding)
-                            .padding(.trailing, VSpacing.lg)
-                            .frame(height: 36)
                         }
+                        Spacer()
+                        if windowState.isShowingChat {
+                            // Copy Thread button
+                            Button {
+                                let messages = threadManager.activeViewModel?.messages ?? []
+                                let title = threadManager.activeThread?.title
+                                let names = resolveParticipantNames()
+                                let markdown = ChatTranscriptFormatter.threadMarkdown(
+                                    messages: messages,
+                                    threadTitle: title,
+                                    participantNames: names
+                                )
+                                guard !markdown.isEmpty else { return }
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(markdown, forType: .string)
+                                copyThreadConfirmationTimer?.cancel()
+                                showCopyThreadConfirmation = true
+                                let timer = DispatchWorkItem { showCopyThreadConfirmation = false }
+                                copyThreadConfirmationTimer = timer
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+                            } label: {
+                                Image(systemName: showCopyThreadConfirmation ? "checkmark" : "list.clipboard")
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundColor(showCopyThreadConfirmation ? VColor.success : VColor.textMuted)
+                                    .frame(width: 28, height: 28)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Copy thread")
+                            .disabled({
+                                let messages = threadManager.activeViewModel?.messages ?? []
+                                return !messages.contains { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                            }())
+                            .help(showCopyThreadConfirmation ? "Copied!" : "Copy thread")
 
-                        // Main content
-                        chatContentView(geometry: geometry)
+                            TemporaryChatToggle(
+                                isActive: threadManager.activeThread?.kind == .private,
+                                onToggle: { toggleTemporaryChat() }
+                            )
+                        }
                     }
+                    .padding(.leading, trafficLightPadding)
+                    .padding(.trailing, VSpacing.lg)
+                    .frame(height: 36)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    // Content area with sidebar drawer overlay
+                    ZStack(alignment: .leading) {
+                        chatContentView(geometry: geometry)
+
+                        // Sidebar drawer overlay
+                        if sidebarOpen && windowState.layoutConfig.left.visible {
+                            // Scrim — click to dismiss
+                            Color.black.opacity(0.15)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    withAnimation(.easeInOut(duration: 0.35)) {
+                                        sidebarOpen = false
+                                    }
+                                }
+
+                            // Sidebar panel + resize handle
+                            HStack(spacing: 0) {
+                                sidebarView
+                                drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
+                            }
+                            .shadow(color: .black.opacity(0.2), radius: 8, x: 2, y: 0)
+                            .transition(.move(edge: .leading))
+                            .animation(nil, value: threadDrawerWidth)
+                        }
+                    }
+                    .coordinateSpace(name: drawerDragCoordinateSpaceName)
                 }
-                .coordinateSpace(name: drawerDragCoordinateSpaceName)
                 .overlay {
                     // Click-outside-to-dismiss background for control center drawer
                     if showControlCenterDrawer {
@@ -769,18 +774,6 @@ struct MainWindowView: View {
     @ViewBuilder
     private var sidebarView: some View {
         VStack(spacing: 0) {
-            // Top bar: sidebar toggle
-            HStack {
-                Spacer()
-                VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true) {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        sidebarOpen.toggle()
-                    }
-                }
-            }
-            .padding(.trailing, VSpacing.sm)
-            .frame(height: 36)
-
             ScrollView {
                 VStack(spacing: 0) {
                     // MARK: New Chat
@@ -1182,10 +1175,8 @@ struct MainWindowView: View {
             // VSplitView: ChatView (left) + workspace (right)
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
-                // Compute content area width accounting for sidebar, divider, padding, and zoom
-                let sidebarVisible = sidebarOpen && windowState.layoutConfig.left.visible
-                let sidebarW = sidebarVisible ? threadDrawerWidth + Double(VSpacing.xs) : 0
-                let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - sidebarW - Double(VSpacing.sm)
+                // Compute content area width (sidebar is an overlay, doesn't reduce content width)
+                let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
                 let effectiveWidth = Binding<Double>(
                     get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
                     set: { appPanelWidth = $0 }
@@ -1840,7 +1831,7 @@ private struct DynamicWorkspaceWrapper: View {
                         .accessibilityLabel("Close workspace")
                     }
                 }
-                .padding(.leading, (isSidebarOpen || isChatDockOpen) ? VSpacing.lg : trafficLightPadding)
+                .padding(.leading, isChatDockOpen ? VSpacing.lg : trafficLightPadding)
                 .padding(.trailing, VSpacing.xl)
                 .padding(.top, VSpacing.md)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -10,11 +10,11 @@ struct DocumentEditorPanelView: View {
         VStack(spacing: 0) {
             // Header toolbar
             HStack {
-                TextField("Document title", text: $documentManager.title)
+                Text(documentManager.title)
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(1)
-                    .textFieldStyle(.plain)
+                    .truncationMode(.tail)
                 Spacer()
                 if documentManager.wordCount > 0 {
                     Text("\(documentManager.wordCount) words")

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -13,6 +13,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
     @State private var dragStartWidth: Double?
     @State private var dragStartAvailableWidth: CGFloat?
     @State private var isDragging: Bool = false
+    @State private var isDividerHovered: Bool = false
     private let dragCoordinateSpaceName = "VSplitViewDragCoordinateSpace"
 
     // MARK: - Body
@@ -25,7 +26,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .padding([.bottom, .leading, .trailing], VSpacing.xs)
+                    .padding([.bottom, .leading], VSpacing.xs)
+                    .padding(.trailing, showPanel ? 0 : VSpacing.xs)
 
                 // Panel slides in from right, pushing content
                 if showPanel, let panel = panel {
@@ -36,8 +38,10 @@ public struct VSplitView<Main: View, Panel: View>: View {
                         .frame(width: panelWidth)
                         .animation(nil, value: panelWidth)  // Disable animation on width changes
                         .background(VColor.backgroundSubtle)
-                        .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.lg))
-                        .padding([.bottom, .trailing], VSpacing.xs)
+                        .overlay(alignment: .top) {
+                            VColor.surfaceBorder.frame(height: 1)
+                        }
+                        .padding(.bottom, VSpacing.xs)
                         .transition(.move(edge: .trailing))
                 }
             }
@@ -47,31 +51,47 @@ public struct VSplitView<Main: View, Panel: View>: View {
     }
 
     private func dragDivider(availableWidth: CGFloat) -> some View {
-        Rectangle()
-            .fill(Color.clear)
-            .frame(width: VSpacing.xs)
-            .contentShape(Rectangle())
-            #if os(macOS)
-            .onHover { hovering in
-                if hovering {
-                    NSCursor.resizeLeftRight.set()
-                } else {
-                    NSCursor.arrow.set()
+        ZStack {
+            // Thin vertical line
+            Rectangle()
+                .fill(isDividerHovered || isDragging ? VColor.accent : VColor.surfaceBorder)
+                .frame(width: 1)
+
+            // Pill handle centered vertically
+            Capsule()
+                .fill(isDividerHovered || isDragging ? VColor.accent : VColor.surfaceBorder)
+                .frame(width: 6, height: 48)
+                .overlay(
+                    Capsule()
+                        .stroke(isDividerHovered || isDragging ? VColor.accent : VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
+        }
+        .frame(width: 12)
+        .contentShape(Rectangle())
+        .animation(VAnimation.fast, value: isDividerHovered)
+        .animation(VAnimation.fast, value: isDragging)
+        #if os(macOS)
+        .onHover { hovering in
+            isDividerHovered = hovering
+            if hovering {
+                NSCursor.pointingHand.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
+        #endif
+        .gesture(
+            DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
+                .onChanged { value in
+                    self.handleDragChanged(value, availableWidth: availableWidth)
                 }
-            }
-            #endif
-            .gesture(
-                DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
-                    .onChanged { value in
-                        self.handleDragChanged(value, availableWidth: availableWidth)
-                    }
-                    .onEnded { _ in
-                        self.resetDragState()
-                    }
-            )
-            .onDisappear {
-                self.resetDragState()
-            }
+                .onEnded { _ in
+                    self.resetDragState()
+                }
+        )
+        .onDisappear {
+            self.resetDragState()
+        }
     }
 
     // MARK: - Drag Helpers
@@ -98,8 +118,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
         // Calculate constraints
         let minPanelWidth: CGFloat = 300
         let minMainContentWidth: CGFloat = 300
-        // main leading + main trailing + divider + panel trailing
-        let dividerAndPadding = VSpacing.xs * 4
+        // main leading + divider (no trailing padding on main or panel when panel is shown)
+        let dividerAndPadding = VSpacing.xs + 12
         let maxAllowed = initialAvailableWidth - minMainContentWidth - dividerAndPadding
 
         // Update width without animation to prevent jitter

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -188,7 +188,7 @@ public enum VColor {
     public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)
 
     // Text
-    public static let textPrimary = adaptiveColor(light: Stone._900, dark: Moss._200)
+    public static let textPrimary = adaptiveColor(light: Stone._900, dark: Moss._50)
     public static let textSecondary = adaptiveColor(light: Stone._600, dark: Moss._400)
     public static let textMuted = adaptiveColor(light: Stone._500, dark: Moss._500)
 


### PR DESCRIPTION
## Summary
- **Sidebar drawer**: converted from push layout to overlay drawer that opens below the top bar with a click-to-dismiss scrim, drop shadow, and smooth easeInOut animation
- **Document editor theming**: fixed invisible toolbar icons (background shorthand was clearing SVG background-images), applied Moss/Stone/Forest theme colors, Fraunces headings, Inter body font, hidden Markdown/WYSIWYG toggle
- **VSplitView handle**: added visible pill/capsule drag divider with green accent on hover, removed right padding when panel is shown
- **Dark mode text**: brightened VColor.textPrimary to Moss._50 for better contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
