### PR TITLE
feat: show queued messages above composer instead of inline

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -341,7 +341,9 @@ struct ChatView: View {
         let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = sessionError != nil ? 60 : (errorText != nil ? 36 : 0)
-        let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0
+        // Queue container: header (~28pt) + per-message row (~24pt each) + padding
+        let queueCount = CGFloat(queuedMessages.count)
+        let queue: CGFloat = queueCount > 0 ? (28 + (isQueueExpanded ? queueCount * 24 : 0) + VSpacing.xs) : 0
         return base + attachments + error + queue
     }
 
@@ -498,10 +500,10 @@ struct ChatView: View {
 
     // MARK: - Message List
 
-    private func shouldShowTimestamp(at index: Int) -> Bool {
+    private func shouldShowTimestamp(at index: Int, in list: [ChatMessage]) -> Bool {
         if index == 0 { return true }
-        let current = messages[index].timestamp
-        let previous = messages[index - 1].timestamp
+        let current = list[index].timestamp
+        let previous = list[index - 1].timestamp
         // Always show a divider when crossing a calendar-day boundary (in local timezone)
         var calendar = Calendar.current
         calendar.timeZone = ChatTimestampTimeZone.resolve()
@@ -514,8 +516,13 @@ struct ChatView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
-                    ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
-                        if shouldShowTimestamp(at: index) {
+                    // Filter out queued messages — they're shown above the composer instead
+                    let displayMessages = messages.filter { msg in
+                        if case .queued = msg.status { return false }
+                        return true
+                    }
+                    ForEach(Array(displayMessages.enumerated()), id: \.element.id) { index, message in
+                        if shouldShowTimestamp(at: index, in: displayMessages) {
                             TimestampDivider(date: message.timestamp)
                         }
 
@@ -538,7 +545,7 @@ struct ChatView: View {
                             else {
                                 let hasPrecedingAssistant: Bool = {
                                     guard index > 0 else { return false }
-                                    return messages[index - 1].role == .assistant
+                                    return displayMessages[index - 1].role == .assistant
                                 }()
 
                                 if !hasPrecedingAssistant {
@@ -569,23 +576,23 @@ struct ChatView: View {
                         } else {
                             // Hide tool call chips when the next message is a pending
                             // confirmation — the tool hasn't been approved yet.
-                            let nextIsPendingConfirmation = index + 1 < messages.count
-                                && messages[index + 1].confirmation?.state == .pending
+                            let nextIsPendingConfirmation = index + 1 < displayMessages.count
+                                && displayMessages[index + 1].confirmation?.state == .pending
 
                             // Pass decided confirmation from the next message so it
                             // renders as a compact chip at the bottom of this bubble.
                             let nextDecidedConfirmation: ToolConfirmationData? = {
-                                guard index + 1 < messages.count,
-                                      let conf = messages[index + 1].confirmation,
+                                guard index + 1 < displayMessages.count,
+                                      let conf = displayMessages[index + 1].confirmation,
                                       conf.state != .pending else { return nil }
                                 return conf
                             }()
 
                             let isLastAssistant = message.role == .assistant
                                 && !message.isStreaming
-                                && (index == messages.count - 1
-                                    || (index == messages.count - 2
-                                        && messages[messages.count - 1].confirmation != nil && messages[messages.count - 1].confirmation?.state != .pending))
+                                && (index == displayMessages.count - 1
+                                    || (index == displayMessages.count - 2
+                                        && displayMessages[displayMessages.count - 1].confirmation != nil && displayMessages[displayMessages.count - 1].confirmation?.state != .pending))
                                 && !isSending
                                 && !isThinking
 
@@ -597,7 +604,6 @@ struct ChatView: View {
                                 onRegenerate: onRegenerate,
                                 onSurfaceAction: onSurfaceAction,
                                 onReportMessage: onReportMessage,
-                                onDeleteQueuedMessage: onDeleteQueuedMessage,
                                 mediaEmbedSettings: mediaEmbedSettings
                             )
                                 .id(message.id)
@@ -850,23 +856,79 @@ struct ChatView: View {
         }
     }
 
-    // MARK: - Queue Summary
+    // MARK: - Queued Messages (above composer)
+
+    /// Messages waiting in the queue, shown stacked above the input field
+    /// so they don't break chronological order in the chat feed.
+    private var queuedMessages: [ChatMessage] {
+        messages.filter { msg in
+            if case .queued = msg.status { return true }
+            return false
+        }
+    }
+
+    @State private var isQueueExpanded = true
 
     @ViewBuilder
     private var queueSummary: some View {
-        if pendingQueuedCount > 0 {
-            HStack(spacing: VSpacing.xs) {
-                Image(systemName: "text.line.first.and.arrowtriangle.forward")
-                    .font(VFont.caption)
-                Text(pendingQueuedCount == 1
-                     ? "1 message queued, sending automatically"
-                     : "\(pendingQueuedCount) messages queued, sending automatically")
-                    .font(VFont.caption)
+        let queued = queuedMessages
+        if !queued.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                Button {
+                    withAnimation(VAnimation.fast) {
+                        isQueueExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: isQueueExpanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(VColor.textMuted)
+                        Text("\(queued.count) Queued")
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.sm)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                // Message list
+                if isQueueExpanded {
+                    VStack(spacing: VSpacing.xs) {
+                        ForEach(queued, id: \.id) { message in
+                            HStack(spacing: VSpacing.sm) {
+                                Circle()
+                                    .fill(VColor.textMuted)
+                                    .frame(width: 5, height: 5)
+                                Text(message.text)
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textSecondary)
+                                    .lineLimit(1)
+                                Spacer()
+                            }
+                            .padding(.horizontal, VSpacing.lg)
+                        }
+                    }
+                    .padding(.bottom, VSpacing.sm)
+                    .transition(.opacity)
+                }
             }
-            .foregroundColor(VColor.textSecondary)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(VColor.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
             .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.xs)
-            .transition(.opacity)
+            .padding(.bottom, VSpacing.xs)
+            .frame(maxWidth: 700)
+            .frame(maxWidth: .infinity)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
         }
     }
 
@@ -904,7 +966,6 @@ private struct ChatBubble: View {
     let onRegenerate: () -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     var onReportMessage: ((String?) -> Void)?
-    var onDeleteQueuedMessage: ((UUID) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
 
     @State private var appearance = AvatarAppearanceManager.shared
@@ -931,25 +992,6 @@ private struct ChatBubble: View {
         if message.isStreaming { return "streaming-\(message.id)" }
         let s = mediaEmbedSettings
         return "\(message.text)|\(s?.enabled ?? false)|\(s?.enabledSince?.timeIntervalSince1970 ?? 0)|\(s?.allowedDomains ?? [])"
-    }
-
-    private var statusLabel: String? {
-        switch message.status {
-        case .queued(let position):
-            return position > 0 ? "Queued (\(ordinal(position)) in line)" : "Queued"
-        case .processing:
-            return "Sending\u{2026}"
-        case .sent:
-            return nil
-        }
-    }
-
-    private var bubbleOpacity: Double {
-        switch message.status {
-        case .queued: return 0.7
-        case .processing: return 0.85
-        case .sent: return 1.0
-        }
     }
 
     private var bubbleFill: AnyShapeStyle {
@@ -1046,25 +1088,6 @@ private struct ChatBubble: View {
                 // - Complete: shows compact chips ("Ran a terminal command" + "Permission granted")
                 if !isUser {
                     trailingStatus
-                }
-
-                if let label = statusLabel {
-                    HStack(spacing: VSpacing.xs) {
-                        Text(label)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                        if case .queued = message.status, let onDelete = onDeleteQueuedMessage {
-                            Button {
-                                onDelete(message.id)
-                            } label: {
-                                Image(systemName: "xmark.circle.fill")
-                                    .font(.system(size: 12))
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Delete queued message")
-                        }
-                    }
                 }
 
                 HStack(spacing: VSpacing.xs) {
@@ -1940,7 +1963,6 @@ private struct ChatBubble: View {
                 .fill(bubbleFill)
         )
         .frame(maxWidth: 520, alignment: isUser ? .trailing : .leading)
-        .opacity(bubbleOpacity)
     }
 
     @ViewBuilder
@@ -2114,22 +2136,6 @@ private struct ChatBubble: View {
         return parsed
     }
 
-    private func ordinal(_ n: Int) -> String {
-        let suffix: String
-        let ones = n % 10
-        let tens = (n / 10) % 10
-        if tens == 1 {
-            suffix = "th"
-        } else {
-            switch ones {
-            case 1: suffix = "st"
-            case 2: suffix = "nd"
-            case 3: suffix = "rd"
-            default: suffix = "th"
-            }
-        }
-        return "\(n)\(suffix)"
-    }
 }
 
 // MARK: - Markdown Table Support

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -341,7 +341,6 @@ struct ChatView: View {
         let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = sessionError != nil ? 60 : (errorText != nil ? 36 : 0)
-        // Queue container: header (~28pt) + per-message row (~24pt each) + padding
         let queueCount = CGFloat(queuedMessages.count)
         let queue: CGFloat = queueCount > 0 ? (28 + (isQueueExpanded ? queueCount * 24 : 0) + VSpacing.xs) : 0
         return base + attachments + error + queue

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -626,11 +626,12 @@ struct ChatView: View {
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
 
-                    let hasPendingConfirmation = messages.last?.confirmation?.state == .pending
-                    let hasActiveToolCall = messages.last?.toolCalls.contains(where: { !$0.isComplete }) == true
-                    if isSending && !(messages.last?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {
+                    let lastVisible = displayMessages.last
+                    let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
+                    let hasActiveToolCall = lastVisible?.toolCalls.contains(where: { !$0.isComplete }) == true
+                    if isSending && !(lastVisible?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {
                         RunningIndicator(
-                            label: !hasEverSentMessage && messages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
+                            label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
                             showIcon: false
                         )
                         .frame(maxWidth: 520, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -908,6 +908,17 @@ struct ChatView: View {
                                     .foregroundColor(VColor.textSecondary)
                                     .lineLimit(1)
                                 Spacer()
+                                if let onDelete = onDeleteQueuedMessage {
+                                    Button {
+                                        onDelete(message.id)
+                                    } label: {
+                                        Image(systemName: "trash")
+                                            .font(.system(size: 11))
+                                            .foregroundColor(VColor.textMuted)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("Delete queued message")
+                                }
                             }
                             .padding(.horizontal, VSpacing.lg)
                         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -902,10 +902,19 @@ struct ChatView: View {
                                 Circle()
                                     .fill(VColor.textMuted)
                                     .frame(width: 5, height: 5)
-                                Text(message.text)
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                    .lineLimit(1)
+                                if message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                    // Attachment-only message — show filenames
+                                    let names = message.attachments.map(\.filename).joined(separator: ", ")
+                                    Label(names.isEmpty ? "Attachment" : names, systemImage: "paperclip")
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.textMuted)
+                                        .lineLimit(1)
+                                } else {
+                                    Text(message.text)
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.textSecondary)
+                                        .lineLimit(1)
+                                }
                                 Spacer()
                                 if let onDelete = onDeleteQueuedMessage {
                                     Button {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -101,7 +101,9 @@ struct ChatView: View {
     /// Uses total message text length (monotonically increasing) rather than the last segment's
     /// length, which resets when a new text segment starts after a tool call.
     private var streamingScrollTrigger: Int {
-        let last = messages.last
+        // Use last non-queued message so streaming deltas still trigger
+        // auto-scroll even when queued user messages sit at the array tail.
+        let last = messages.last(where: { if case .queued = $0.status { return false }; return true })
         let textLen = last?.text.utf8.count ?? 0
         return textLen + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -828,7 +828,7 @@ public struct ChatMessage: Identifiable {
     public let role: ChatRole
     public var textSegments: [String]
     public var contentOrder: [ContentBlockRef]
-    public let timestamp: Date
+    public var timestamp: Date
     public var isStreaming: Bool
     public var status: ChatMessageStatus
     /// Non-nil when this message is an inline tool confirmation request.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -542,8 +542,12 @@ extension ChatViewModel {
             // so assistantTextDelta tags the response correctly.
             if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId),
                let index = messages.firstIndex(where: { $0.id == messageId }) {
-                messages[index].status = .processing
-                currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Move the dequeued message to the end so it appears after the
+                // agent's response to the previous message, preserving chronological order.
+                var message = messages.remove(at: index)
+                message.status = .processing
+                messages.append(message)
+                currentTurnUserText = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
             }
             // Recompute positions for remaining queued messages
             for i in messages.indices {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -546,6 +546,7 @@ extension ChatViewModel {
                 // agent's response to the previous message, preserving chronological order.
                 var message = messages.remove(at: index)
                 message.status = .processing
+                message.timestamp = Date()
                 messages.append(message)
                 currentTurnUserText = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
             }


### PR DESCRIPTION
## Summary
- Queued messages now appear in a collapsible container above the input bar instead of as dimmed bubbles inline in the chat feed, preventing chronological order breakage
- When a message is dequeued, it's moved to the end of the messages array so it appears after the agent's response to the previous message
- Removed dead code: `statusLabel`, `bubbleOpacity`, and `ordinal` helper

## Test plan
- [ ] Send multiple messages while agent is processing — verify they appear in the queue container above the composer
- [ ] Verify the queue container has a "N Queued" header with chevron toggle
- [ ] Verify clicking the chevron collapses/expands the message list
- [ ] Verify dequeued messages appear in correct chronological order (after agent response, not at original position)
- [ ] Verify no "Sending..." or "Queued" labels appear on messages in the chat feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
