### PR TITLE
fix: simplify task priority to high/medium/low

### DIFF
--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -375,8 +375,8 @@ describe('task_list_show tool', () => {
 
   test('lists work items when they exist', async () => {
     const task = createTask({ title: 'My Task', template: 'Do it' });
-    createWorkItem({ taskId: task.id, title: 'Work Item Alpha', priorityTier: 1 });
-    createWorkItem({ taskId: task.id, title: 'Work Item Beta', notes: 'some notes', priorityTier: 2 });
+    createWorkItem({ taskId: task.id, title: 'Work Item Alpha', priorityTier: 0 });
+    createWorkItem({ taskId: task.id, title: 'Work Item Beta', notes: 'some notes', priorityTier: 1 });
 
     const result = await taskListShowTool.execute({}, stubContext);
 
@@ -397,10 +397,10 @@ describe('task_list_show tool', () => {
 
   test('filters by status when status param is provided', async () => {
     const task = createTask({ title: 'Filter Task', template: 'Do it' });
-    createWorkItem({ taskId: task.id, title: 'Queued Item', priorityTier: 2 });
+    createWorkItem({ taskId: task.id, title: 'Queued Item', priorityTier: 1 });
     const raw = getRawDb();
     // Create a second work item and manually set its status to 'done'
-    const doneItem = createWorkItem({ taskId: task.id, title: 'Done Item', priorityTier: 2 });
+    const doneItem = createWorkItem({ taskId: task.id, title: 'Done Item', priorityTier: 1 });
     raw.query('UPDATE work_items SET status = ? WHERE id = ?').run('done', doneItem.id);
 
     const resultQueued = await taskListShowTool.execute({ status: 'queued' }, stubContext);
@@ -503,7 +503,7 @@ describe('task_list_add tool', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Buy groceries');
     expect(result.content).toContain('Notes: Milk, eggs, bread');
-    expect(result.content).toContain('Priority: high');
+    expect(result.content).toContain('Priority: medium');
   });
 
   test('ad-hoc work item shows up in task_list_show', async () => {
@@ -534,7 +534,7 @@ describe('task_list_add tool', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Custom Title Override');
     expect(result.content).toContain('Notes: Important context here');
-    expect(result.content).toContain('Priority: urgent');
+    expect(result.content).toContain('Priority: high');
   });
 });
 

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -433,7 +433,7 @@ export const workItems = sqliteTable('work_items', {
   title: text('title').notNull(),
   notes: text('notes'),
   status: text('status').notNull().default('queued'),  // queued | running | awaiting_review | failed | done | archived
-  priorityTier: integer('priority_tier').notNull().default(1), // 0=urgent, 1=high, 2=normal, 3=low
+  priorityTier: integer('priority_tier').notNull().default(1), // 0=high, 1=medium, 2=low
   sortIndex: integer('sort_index'),  // manual ordering within same priority tier; null = fall back to updated_at
   lastRunId: text('last_run_id'),
   lastRunConversationId: text('last_run_conversation_id'),

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -5,10 +5,9 @@ import { getTask, listTasks, createTask } from '../../tasks/task-store.js';
 import { createWorkItem } from '../../work-items/work-item-store.js';
 
 const PRIORITY_LABELS: Record<number, string> = {
-  0: 'urgent',
-  1: 'high',
-  2: 'normal',
-  3: 'low',
+  0: 'high',
+  1: 'medium',
+  2: 'low',
 };
 
 const definition: ToolDefinition = {
@@ -38,7 +37,7 @@ const definition: ToolDefinition = {
       },
       priority_tier: {
         type: 'number',
-        description: '0 = urgent, 1 = high, 2 = normal (default), 3 = low.',
+        description: '0 = high, 1 = medium (default), 2 = low.',
       },
       sort_index: {
         type: 'number',
@@ -86,7 +85,7 @@ class TaskListAddTool implements Tool {
           taskId: adHocTask.id,
           title: titleOverride,
           notes,
-          priorityTier: priorityTier ?? 2,
+          priorityTier: priorityTier ?? 1,
           sortIndex,
         });
 
@@ -146,7 +145,7 @@ class TaskListAddTool implements Tool {
         taskId: resolvedTask.id,
         title: titleOverride ?? resolvedTask.title,
         notes,
-        priorityTier: priorityTier ?? 2,
+        priorityTier: priorityTier ?? 1,
         sortIndex,
       });
 

--- a/assistant/src/tools/tasks/work-item-list.ts
+++ b/assistant/src/tools/tasks/work-item-list.ts
@@ -4,10 +4,9 @@ import type { ToolDefinition } from '../../providers/types.js';
 import { listWorkItems, type WorkItemStatus } from '../../work-items/work-item-store.js';
 
 const PRIORITY_LABELS: Record<number, string> = {
-  0: 'urgent',
-  1: 'high',
-  2: 'normal',
-  3: 'low',
+  0: 'high',
+  1: 'medium',
+  2: 'low',
 };
 
 const definition: ToolDefinition = {

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -235,10 +235,9 @@ private struct TasksWindowRow: View {
 
     private func priorityColor(tier: Double) -> Color {
         switch tier {
-        case 0: return VColor.error
-        case 1: return VColor.warning
-        case 2: return VColor.accent
-        default: return VColor.textMuted
+        case 0: return VColor.error      // high
+        case 1: return VColor.accent     // medium
+        default: return VColor.textMuted // low
         }
     }
 


### PR DESCRIPTION
## Summary
- Simplified priority tiers from 4 (urgent/high/normal/low) to 3 (high/medium/low)
- Default priority is now "medium" (tier 1) instead of "normal" (tier 2)
- Updated tool descriptions, labels, schema comments, Swift UI colors, and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
