### PR TITLE
fix: prevent EPIPE error when client disconnects during streaming

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -721,7 +721,7 @@ export class DaemonServer {
   }
 
   private send(socket: net.Socket, msg: ServerMessage): void {
-    if (!socket.destroyed) {
+    if (!socket.destroyed && socket.writable) {
       socket.write(serialize(msg));
     }
   }


### PR DESCRIPTION
## Summary
- Added `socket.writable` check in `server.send()` alongside the existing `!socket.destroyed` guard
- Prevents EPIPE errors when the daemon tries to send events to a client that has already disconnected (e.g., during an active Anthropic stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
