### PR TITLE
raise session evictor memory threshold from 512 MB to 1.5 GB

### DIFF
--- a/assistant/src/daemon/session-evictor.ts
+++ b/assistant/src/daemon/session-evictor.ts
@@ -32,7 +32,7 @@ export interface EvictionResult {
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_MAX_SESSIONS = 100;
-const DEFAULT_MEMORY_THRESHOLD_BYTES = 512 * 1024 * 1024; // 512 MB
+const DEFAULT_MEMORY_THRESHOLD_BYTES = 1536 * 1024 * 1024; // 1.5 GB
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000; // 60 seconds
 
 export class SessionEvictor {


### PR DESCRIPTION
## Summary
- Raise default memory pressure threshold from 512 MB to 1.5 GB
- The daemon regularly sits at ~1 GB RSS with a loaded session, so the old threshold triggered on every sweep (every 60s) producing noisy warning logs with no actual evictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
