### PR TITLE
fix: route homebase relay_prompt actions as chat messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1120,6 +1120,18 @@ struct MainWindowView: View {
                             windowState.setAppEditing(appId: appId, threadId: threadId)
                         }
                     }
+                    // Route relay_prompt actions directly as chat messages so they
+                    // reach the active session instead of being lost when the surface
+                    // was opened outside a session context (e.g. home base via app_open).
+                    if actionId == "relay_prompt" || actionId == "agent_prompt",
+                       let dataDict = actionData as? [String: Any],
+                       let prompt = dataDict["prompt"] as? String,
+                       !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                       let vm = threadManager.activeViewModel {
+                        vm.inputText = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                        vm.sendMessage()
+                        return
+                    }
                     surfaceManager.onAction?(surface.sessionId, surface.id, actionId, actionData as? [String: Any])
                 },
                 onLinkOpen: { url, metadata in
@@ -1746,6 +1758,17 @@ private struct DynamicWorkspaceWrapper: View {
                 onAction: { actionId, actionData in
                     if !isChatDockOpen {
                         onToggleChatDock()
+                    }
+                    // Route relay_prompt actions directly as chat messages so they
+                    // reach the active session instead of being lost when the surface
+                    // was opened outside a session context (e.g. home base via app_open).
+                    if actionId == "relay_prompt" || actionId == "agent_prompt",
+                       let dataDict = actionData as? [String: Any],
+                       let prompt = dataDict["prompt"] as? String,
+                       !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        viewModel.inputText = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                        viewModel.sendMessage()
+                        return
                     }
                     surfaceManager.onAction?(surface.sessionId, surface.id, actionId, actionData as? [String: Any])
                 },


### PR DESCRIPTION
## Summary
- Home base action buttons (Research, Build, Customize, Voice, etc.) were silently failing because the surface was created with `sessionId: 'app-panel'` which has no matching daemon session
- Daemon logs showed repeated `"No session found for surface action"` warnings on every button click
- Fix: intercept `relay_prompt`/`agent_prompt` actions in both `DynamicWorkspaceWrapper` and `surfaceSlotView`, routing them directly through `ChatViewModel.sendMessage()` instead of the broken surface action IPC path

## Test plan
- [ ] Scrub and relaunch the app
- [ ] Complete onboarding flow
- [ ] Click any home base action button (e.g. "Start research")
- [ ] Verify the prompt appears in the chat and the assistant responds
- [ ] Verify non-relay actions (like content_changed) still flow through surfaceManager.onAction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
