### PR TITLE
fix: resolve Swift build error and deprecation warning

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/SubagentStatusChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/SubagentStatusChip.swift
@@ -67,8 +67,8 @@ struct SubagentStatusChip: View {
         )
         .onAppear { startDotAnimation() }
         .onDisappear { timer?.invalidate() }
-        .onChange(of: subagent.status) { newStatus in
-            if newStatus.isTerminal {
+        .onChange(of: subagent.status) {
+            if subagent.status.isTerminal {
                 timer?.invalidate()
                 timer = nil
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1669,12 +1669,12 @@ private struct ActiveChatViewWrapper: View {
                     )
                 }
             },
+            onDeleteQueuedMessage: { messageId in viewModel.deleteQueuedMessage(messageId: messageId) },
             mediaEmbedSettings: MediaEmbedResolverSettings(
                 enabled: settingsStore.mediaEmbedsEnabled,
                 enabledSince: settingsStore.mediaEmbedsEnabledSince,
                 allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
             ),
-            onDeleteQueuedMessage: { messageId in viewModel.deleteQueuedMessage(messageId: messageId) },
             isTemporaryChat: isTemporaryChat,
             activeSubagents: viewModel.activeSubagents
         )


### PR DESCRIPTION
## Summary
- Fix argument ordering error in MainWindowView: `onDeleteQueuedMessage` must precede `mediaEmbedSettings` in the ChatView initializer
- Fix deprecated `onChange(of:perform:)` warning in SubagentStatusChip by using the zero-parameter closure variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
