### PR TITLE
fix: keep sidebar open when clicking main canvas

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -415,15 +415,6 @@ struct MainWindowView: View {
 
                         // Sidebar drawer overlay
                         if sidebarOpen && windowState.layoutConfig.left.visible {
-                            // Scrim — click to dismiss
-                            Color.black.opacity(0.15)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    withAnimation(.easeInOut(duration: 0.35)) {
-                                        sidebarOpen = false
-                                    }
-                                }
-
                             // Sidebar panel + resize handle
                             HStack(spacing: 0) {
                                 sidebarView


### PR DESCRIPTION
## Summary
- Removed the semi-transparent scrim overlay on the main canvas that dismissed the sidebar on tap
- The sidebar now stays open when interacting with the main content area; use the sidebar toggle button to close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)