### PR TITLE
fix: add timeout to Anthropic provider stream to prevent indefinite hangs

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -128,6 +128,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
     toolExecutionTimeoutSec: 120,
+    providerStreamTimeoutSec: 300,
   },
   sandbox: {
     enabled: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -30,6 +30,11 @@ export const TimeoutConfigSchema = z.object({
     .finite('timeouts.toolExecutionTimeoutSec must be finite')
     .positive('timeouts.toolExecutionTimeoutSec must be a positive number')
     .default(120),
+  providerStreamTimeoutSec: z
+    .number({ error: 'timeouts.providerStreamTimeoutSec must be a number' })
+    .finite('timeouts.providerStreamTimeoutSec must be finite')
+    .positive('timeouts.providerStreamTimeoutSec must be a positive number')
+    .default(300),
 });
 
 export const DockerConfigSchema = z.object({
@@ -889,6 +894,7 @@ export const AssistantConfigSchema = z.object({
     shellDefaultTimeoutSec: 120,
     permissionTimeoutSec: 300,
     toolExecutionTimeoutSec: 120,
+    providerStreamTimeoutSec: 300,
   }),
   sandbox: SandboxConfigSchema.default({
     enabled: true,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -340,11 +340,13 @@ export class AnthropicProvider implements Provider {
   private client: Anthropic;
   private model: string;
   private useNativeWebSearch: boolean;
+  private streamTimeoutMs: number;
 
-  constructor(apiKey: string, model: string, options: { useNativeWebSearch?: boolean } = {}) {
+  constructor(apiKey: string, model: string, options: { useNativeWebSearch?: boolean; streamTimeoutMs?: number } = {}) {
     this.client = new Anthropic({ apiKey });
     this.model = model;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
   }
 
   async sendMessage(
@@ -484,7 +486,27 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      const stream = this.client.messages.stream(params, { signal });
+      // Create a local AbortController that aborts after streamTimeoutMs.
+      // If the caller already provided a signal, link it so external
+      // cancellation also aborts the stream.
+      const timeoutController = new AbortController();
+      const timeoutHandle = setTimeout(() => {
+        timeoutController.abort(new Error(`Provider stream timed out after ${this.streamTimeoutMs / 1000}s`));
+      }, this.streamTimeoutMs);
+
+      const onExternalAbort = () => {
+        timeoutController.abort(signal!.reason);
+      };
+      if (signal) {
+        if (signal.aborted) {
+          clearTimeout(timeoutHandle);
+          timeoutController.abort(signal.reason);
+        } else {
+          signal.addEventListener('abort', onExternalAbort, { once: true });
+        }
+      }
+
+      const stream = this.client.messages.stream(params, { signal: timeoutController.signal });
 
       stream.on("text", (text) => {
         onEvent?.({ type: "text_delta", text });
@@ -542,7 +564,13 @@ export class AnthropicProvider implements Provider {
         }
       });
 
-      const response = await stream.finalMessage();
+      let response: Anthropic.Message;
+      try {
+        response = await stream.finalMessage();
+      } finally {
+        clearTimeout(timeoutHandle);
+        signal?.removeEventListener('abort', onExternalAbort);
+      }
 
       return {
         content: response.content.map((block) =>

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -80,6 +80,7 @@ export interface ProvidersConfig {
   provider: string;
   model: string;
   webSearchProvider?: string;
+  timeouts?: { providerStreamTimeoutSec?: number };
 }
 
 function resolveModel(config: ProvidersConfig, providerName: keyof typeof DEFAULT_MODELS): string {
@@ -104,6 +105,7 @@ export function initializeProviders(config: ProvidersConfig): void {
     registerProvider('anthropic', new RetryProvider(
       wrapWithLogfire(new AnthropicProvider(config.apiKeys.anthropic, model, {
         useNativeWebSearch: config.webSearchProvider === 'anthropic-native',
+        streamTimeoutMs: (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000,
       })),
     ));
   }


### PR DESCRIPTION
## Summary
- Adds `providerStreamTimeoutSec` config field (default 300s) to `TimeoutConfigSchema`
- Wraps the Anthropic `stream.finalMessage()` call with an AbortController + setTimeout that aborts the stream after the configured timeout
- Links the external abort signal (user cancellation) to the same timeout controller so both cancellation and timeout are handled uniformly

## Context
The Anthropic API streaming call has no timeout — when the connection stalls after tool execution, `stream.finalMessage()` hangs forever. No terminal event (`message_complete`, `error`) reaches the client, leaving the UI stuck in a "Thinking" state indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
