### PR TITLE
fix: add AbortSignal integration to shell tools for cooperative cancellation

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -123,6 +123,18 @@ class HostShellTool implements Tool {
         child.kill('SIGKILL');
       }, timeoutMs);
 
+      // Cooperative cancellation via AbortSignal
+      const onAbort = () => {
+        child.kill('SIGKILL');
+      };
+      if (context.signal) {
+        if (context.signal.aborted) {
+          child.kill('SIGKILL');
+        } else {
+          context.signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+
       child.stdout.on('data', (data: Buffer) => {
         stdoutChunks.push(data);
         context.onOutput?.(data.toString());
@@ -135,6 +147,7 @@ class HostShellTool implements Tool {
 
       child.on('close', (code) => {
         clearTimeout(timer);
+        context.signal?.removeEventListener('abort', onAbort);
 
         const stdout = Buffer.concat(stdoutChunks).toString();
         const stderr = Buffer.concat(stderrChunks).toString();
@@ -149,6 +162,7 @@ class HostShellTool implements Tool {
 
       child.on('error', (err) => {
         clearTimeout(timer);
+        context.signal?.removeEventListener('abort', onAbort);
         let hint = '';
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
           hint = !existsSync(workingDir)

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -172,6 +172,18 @@ class ShellTool implements Tool {
         child.kill('SIGKILL');
       }, timeoutMs);
 
+      // Cooperative cancellation via AbortSignal
+      const onAbort = () => {
+        child.kill('SIGKILL');
+      };
+      if (context.signal) {
+        if (context.signal.aborted) {
+          child.kill('SIGKILL');
+        } else {
+          context.signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+
       child.stdout.on('data', (data: Buffer) => {
         stdoutChunks.push(data);
         context.onOutput?.(data.toString());
@@ -184,6 +196,7 @@ class ShellTool implements Tool {
 
       child.on('close', (code) => {
         clearTimeout(timer);
+        context.signal?.removeEventListener('abort', onAbort);
 
         const stdout = Buffer.concat(stdoutChunks).toString();
         const stderr = Buffer.concat(stderrChunks).toString();
@@ -198,6 +211,7 @@ class ShellTool implements Tool {
 
       child.on('error', (err) => {
         clearTimeout(timer);
+        context.signal?.removeEventListener('abort', onAbort);
         resolve({
           content: `Error spawning command: ${err.message}${(err as NodeJS.ErrnoException).code === 'ENOENT' ? '. The command was not found — check that it is installed and in PATH.' : ''}`,
           isError: true,


### PR DESCRIPTION
## Summary
- Adds `context.signal` abort listener to both `ShellTool` (bash) and `HostShellTool` (host_bash) child processes
- When the session is cancelled, running shell commands are now killed immediately via SIGKILL instead of running until their own timeout expires
- Follows the established `sandbox-runner.ts` pattern: register abort handler, check pre-aborted state, clean up in both close and error handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
