### PR TITLE
feat: add shared host-pattern matcher primitive

### DIFF
--- a/assistant/src/__tests__/credential-host-pattern-match.test.ts
+++ b/assistant/src/__tests__/credential-host-pattern-match.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  matchHostPattern,
+  compareMatchSpecificity,
+  type HostMatchKind,
+} from '../tools/credentials/host-pattern-match.js';
+
+describe('matchHostPattern', () => {
+  // -- Exact matches --------------------------------------------------------
+
+  test('exact match returns "exact"', () => {
+    expect(matchHostPattern('api.fal.run', 'api.fal.run')).toBe('exact');
+  });
+
+  test('exact match is case-insensitive', () => {
+    expect(matchHostPattern('API.FAL.RUN', 'api.fal.run')).toBe('exact');
+    expect(matchHostPattern('api.fal.run', 'API.FAL.RUN')).toBe('exact');
+  });
+
+  // -- Wildcard matches (subdomain) ----------------------------------------
+
+  test('*.fal.run matches api.fal.run', () => {
+    expect(matchHostPattern('api.fal.run', '*.fal.run')).toBe('wildcard');
+  });
+
+  test('*.fal.run matches deep.sub.fal.run', () => {
+    expect(matchHostPattern('deep.sub.fal.run', '*.fal.run')).toBe('wildcard');
+  });
+
+  test('wildcard match is case-insensitive', () => {
+    expect(matchHostPattern('API.FAL.RUN', '*.fal.run')).toBe('wildcard');
+  });
+
+  // -- Wildcard does NOT match apex by default ------------------------------
+
+  test('*.fal.run does NOT match fal.run by default', () => {
+    expect(matchHostPattern('fal.run', '*.fal.run')).toBe('none');
+  });
+
+  // -- Wildcard matches apex when includeApexForWildcard = true -------------
+
+  test('*.fal.run matches fal.run when apex inclusion enabled', () => {
+    expect(matchHostPattern('fal.run', '*.fal.run', { includeApexForWildcard: true })).toBe('wildcard');
+  });
+
+  test('apex inclusion is case-insensitive', () => {
+    expect(matchHostPattern('FAL.RUN', '*.fal.run', { includeApexForWildcard: true })).toBe('wildcard');
+  });
+
+  // -- Security: no partial suffix matches ----------------------------------
+
+  test('*.fal.run does NOT match evil.fal.run.attacker.com', () => {
+    expect(matchHostPattern('evil.fal.run.attacker.com', '*.fal.run')).toBe('none');
+  });
+
+  test('*.fal.run does NOT match notfal.run', () => {
+    expect(matchHostPattern('notfal.run', '*.fal.run')).toBe('none');
+    expect(matchHostPattern('notfal.run', '*.fal.run', { includeApexForWildcard: true })).toBe('none');
+  });
+
+  // -- No match -------------------------------------------------------------
+
+  test('returns "none" for completely different hosts', () => {
+    expect(matchHostPattern('api.openai.com', '*.fal.run')).toBe('none');
+  });
+
+  test('returns "none" for non-wildcard pattern that does not match', () => {
+    expect(matchHostPattern('other.fal.run', 'api.fal.run')).toBe('none');
+  });
+});
+
+describe('compareMatchSpecificity', () => {
+  test('exact is more specific than wildcard', () => {
+    expect(compareMatchSpecificity('exact', 'wildcard')).toBeLessThan(0);
+  });
+
+  test('wildcard is more specific than none', () => {
+    expect(compareMatchSpecificity('wildcard', 'none')).toBeLessThan(0);
+  });
+
+  test('exact is more specific than none', () => {
+    expect(compareMatchSpecificity('exact', 'none')).toBeLessThan(0);
+  });
+
+  test('same kind returns 0', () => {
+    expect(compareMatchSpecificity('exact', 'exact')).toBe(0);
+    expect(compareMatchSpecificity('wildcard', 'wildcard')).toBe(0);
+    expect(compareMatchSpecificity('none', 'none')).toBe(0);
+  });
+
+  test('none is less specific than wildcard', () => {
+    expect(compareMatchSpecificity('none', 'wildcard')).toBeGreaterThan(0);
+  });
+
+  test('wildcard is less specific than exact', () => {
+    expect(compareMatchSpecificity('wildcard', 'exact')).toBeGreaterThan(0);
+  });
+
+  test('can be used to sort matches by specificity (most specific first)', () => {
+    const matches: HostMatchKind[] = ['none', 'exact', 'wildcard', 'none', 'exact'];
+    const sorted = [...matches].sort(compareMatchSpecificity);
+    expect(sorted).toEqual(['exact', 'exact', 'wildcard', 'none', 'none']);
+  });
+});

--- a/assistant/src/tools/credentials/host-pattern-match.ts
+++ b/assistant/src/tools/credentials/host-pattern-match.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared host-pattern matching primitive.
+ *
+ * Provides deterministic, case-insensitive hostname matching against
+ * glob-style patterns (e.g. "*.fal.run") with configurable apex inclusion.
+ * Used by the credential selection, proxy router, and policy engines.
+ */
+
+export type HostMatchKind = 'none' | 'wildcard' | 'exact';
+
+export interface MatchHostPatternOptions {
+  /** When true, "*.domain" also matches bare "domain". Defaults to false. */
+  includeApexForWildcard?: boolean;
+}
+
+/**
+ * Match a hostname against a glob-style host pattern.
+ *
+ * Supports:
+ * - Exact match: "api.fal.run" matches "api.fal.run"
+ * - Wildcard match: "*.fal.run" matches "api.fal.run"
+ * - Apex inclusion (opt-in): "*.fal.run" matches "fal.run"
+ *
+ * All comparisons are case-insensitive.
+ */
+export function matchHostPattern(
+  host: string,
+  pattern: string,
+  options?: MatchHostPatternOptions,
+): HostMatchKind {
+  const lHost = host.toLowerCase();
+  const lPattern = pattern.toLowerCase();
+
+  if (lHost === lPattern) return 'exact';
+
+  if (lPattern.startsWith('*.')) {
+    const suffix = lPattern.slice(1); // ".fal.run"
+    // Subdomain match: "api.fal.run".endsWith(".fal.run") and is longer
+    if (lHost.endsWith(suffix) && lHost.length > suffix.length) {
+      return 'wildcard';
+    }
+    // Apex inclusion: "*.fal.run" matches bare "fal.run"
+    if (options?.includeApexForWildcard && lHost === lPattern.slice(2)) {
+      return 'wildcard';
+    }
+  }
+
+  return 'none';
+}
+
+/**
+ * Compare two match results by specificity.
+ * Returns negative if `a` is more specific, positive if `b` is, zero if equal.
+ *
+ * Ordering: exact > wildcard > none
+ */
+export function compareMatchSpecificity(a: HostMatchKind, b: HostMatchKind): number {
+  const rank: Record<HostMatchKind, number> = { exact: 2, wildcard: 1, none: 0 };
+  return rank[b] - rank[a];
+}


### PR DESCRIPTION
## Summary
- Adds `matchHostPattern(host, pattern, options)` with case-insensitive matching, wildcard support, and configurable apex inclusion
- Adds `compareMatchSpecificity(a, b)` for deterministic ordering (exact > wildcard > none)
- Pure, side-effect-free helper — no call sites changed yet

## Test plan
- [x] Unit tests for exact, wildcard, apex-inclusive, and security edge cases
- [x] Specificity comparison tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
