### PR TITLE
feat: add credential reference resolver (UUID or service/field)

### DIFF
--- a/assistant/src/__tests__/credential-resolve.test.ts
+++ b/assistant/src/__tests__/credential-resolve.test.ts
@@ -19,6 +19,7 @@ import {
   resolveByServiceField,
   resolveById,
   resolveForDomain,
+  resolveCredentialRef,
 } from '../tools/credentials/resolve.js';
 
 const TEST_DIR = join(tmpdir(), `vellum-credresolve-test-${randomBytes(4).toString('hex')}`);
@@ -264,6 +265,64 @@ describe('credential resolver', () => {
       expect(resolveForDomain('api.example.com')).toHaveLength(1);
       expect(resolveForDomain('API.EXAMPLE.COM')).toHaveLength(1);
       expect(resolveForDomain('Api.Example.Com')).toHaveLength(1);
+    });
+  });
+
+  describe('resolveCredentialRef', () => {
+    test('resolves by UUID', () => {
+      const created = upsertCredentialMetadata('github', 'token');
+      const result = resolveCredentialRef(created.credentialId);
+      expect(result).toBeDefined();
+      expect(result!.credentialId).toBe(created.credentialId);
+      expect(result!.service).toBe('github');
+    });
+
+    test('resolves by service/field', () => {
+      upsertCredentialMetadata('fal', 'api_key');
+      const result = resolveCredentialRef('fal/api_key');
+      expect(result).toBeDefined();
+      expect(result!.service).toBe('fal');
+      expect(result!.field).toBe('api_key');
+    });
+
+    test('returns undefined for unknown UUID', () => {
+      expect(resolveCredentialRef('00000000-0000-0000-0000-000000000000')).toBeUndefined();
+    });
+
+    test('returns undefined for unknown service/field', () => {
+      expect(resolveCredentialRef('nonexistent/field')).toBeUndefined();
+    });
+
+    test('returns undefined for empty string', () => {
+      expect(resolveCredentialRef('')).toBeUndefined();
+    });
+
+    test('returns undefined for whitespace-only string', () => {
+      expect(resolveCredentialRef('   ')).toBeUndefined();
+    });
+
+    test('returns undefined for malformed ref with no slash', () => {
+      expect(resolveCredentialRef('fal')).toBeUndefined();
+    });
+
+    test('returns undefined for malformed ref with too many slashes', () => {
+      expect(resolveCredentialRef('fal/api/key')).toBeUndefined();
+    });
+
+    test('returns undefined for ref with empty service segment', () => {
+      expect(resolveCredentialRef('/api_key')).toBeUndefined();
+    });
+
+    test('returns undefined for ref with empty field segment', () => {
+      expect(resolveCredentialRef('fal/')).toBeUndefined();
+    });
+
+    test('UUID takes precedence when both UUID and service/field would match', () => {
+      const created = upsertCredentialMetadata('github', 'token');
+      // The credentialId is a UUID, not a service/field, so resolveById finds it first
+      const result = resolveCredentialRef(created.credentialId);
+      expect(result).toBeDefined();
+      expect(result!.credentialId).toBe(created.credentialId);
     });
   });
 });

--- a/assistant/src/tools/credentials/resolve.ts
+++ b/assistant/src/tools/credentials/resolve.ts
@@ -66,6 +66,36 @@ export function resolveById(
 }
 
 /**
+ * Resolve a credential reference that may be either a UUID or a "service/field" string.
+ *
+ * Resolution order:
+ * 1. Try as UUID via resolveById
+ * 2. If not found, try parsing as "service/field" via resolveByServiceField
+ *
+ * Returns undefined for malformed refs (e.g. no slash, too many slashes, empty segments)
+ * and for refs that don't match any stored credential.
+ */
+export function resolveCredentialRef(
+  ref: string,
+): ResolvedCredential | undefined {
+  if (!ref || ref.trim().length === 0) return undefined;
+
+  // Try as UUID first
+  const byId = resolveById(ref);
+  if (byId) return byId;
+
+  // Try as service/field
+  const slashIndex = ref.indexOf('/');
+  if (slashIndex <= 0 || slashIndex >= ref.length - 1) return undefined;
+  // Reject refs with more than one slash (e.g. "fal/api/key")
+  if (ref.indexOf('/', slashIndex + 1) !== -1) return undefined;
+
+  const service = ref.slice(0, slashIndex);
+  const field = ref.slice(slashIndex + 1);
+  return resolveByServiceField(service, field);
+}
+
+/**
  * Find all credentials whose injection templates match a given hostname.
  * Returns resolved credentials with their `injectionTemplates` filtered
  * to only the matching entries.


### PR DESCRIPTION
## Summary
- Adds `resolveCredentialRef(ref)` that accepts both UUID and `service/field` format strings
- Malformed refs (empty, no slash, too many slashes, empty segments) return undefined
- UUID resolution takes precedence over service/field parsing

## Test plan
- [x] UUID resolution works
- [x] service/field resolution works
- [x] Malformed refs (empty, no slash, too many slashes, empty segments) return undefined
- [x] Existing resolver tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
