### PR TITLE
refactor: use shared host-pattern matcher in credential selection

### DIFF
--- a/assistant/src/tools/credentials/selection.ts
+++ b/assistant/src/tools/credentials/selection.ts
@@ -9,6 +9,7 @@
 import type { CredentialMetadata } from './metadata-store.js';
 import type { CredentialInjectionTemplate } from './policy-types.js';
 import { isDomainAllowed } from './domain-policy.js';
+import { matchHostPattern } from './host-pattern-match.js';
 
 export interface CredentialCandidate {
   credentialId: string;
@@ -35,24 +36,7 @@ const SCORE_ALIAS_SET = 10;
  * Supports leading wildcard like "*.example.com".
  */
 function hostMatchesPattern(host: string, pattern: string): 'exact' | 'wildcard' | 'none' {
-  const lHost = host.toLowerCase();
-  const lPattern = pattern.toLowerCase();
-
-  if (lHost === lPattern) return 'exact';
-
-  // Wildcard patterns like "*.fal.ai"
-  if (lPattern.startsWith('*.')) {
-    const suffix = lPattern.slice(1); // ".fal.ai"
-    if (lHost.endsWith(suffix) && lHost.length > suffix.length) {
-      return 'wildcard';
-    }
-    // Also match the bare domain: "*.fal.ai" should match "fal.ai"
-    if (lHost === lPattern.slice(2)) {
-      return 'wildcard';
-    }
-  }
-
-  return 'none';
+  return matchHostPattern(host, pattern, { includeApexForWildcard: true });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace local `hostMatchesPattern` in `selection.ts` with shared `matchHostPattern` from `host-pattern-match.ts`
- Pure refactor with no externally visible behavior change
- Removes ~15 lines of duplicated matching logic

## Test plan
- [x] All existing credential-selection tests pass unchanged
- [x] Host pattern matcher tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
