### PR TITLE
feat: router apex-inclusive wildcard matching

### DIFF
--- a/assistant/src/__tests__/script-proxy-router.test.ts
+++ b/assistant/src/__tests__/script-proxy-router.test.ts
@@ -60,15 +60,15 @@ describe('routeConnection', () => {
     });
   });
 
-  test('returns tunnel:no_rewrite for bare domain when pattern requires subdomain', () => {
+  test('returns mitm for bare domain when wildcard pattern exists (apex-inclusive)', () => {
     const templates = new Map<string, CredentialInjectionTemplate[]>([
       ['cred-1', [headerTemplate('*.fal.ai')]],
     ]);
-    // minimatch: "*.fal.ai" does not match bare "fal.ai"
+    // Apex-inclusive: "*.fal.ai" now matches bare "fal.ai"
     const result = routeConnection('fal.ai', 443, ['cred-1'], templates);
     expect(result).toEqual<RouteDecision>({
-      action: 'tunnel',
-      reason: 'tunnel:no_rewrite',
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
     });
   });
 
@@ -164,6 +164,17 @@ describe('routeConnection', () => {
     expect(result).toEqual<RouteDecision>({
       action: 'tunnel',
       reason: 'tunnel:no_rewrite',
+    });
+  });
+
+  test('regression: routeConnection fal.run with *.fal.run template => mitm', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [headerTemplate('*.fal.run')]],
+    ]);
+    const result = routeConnection('fal.run', 443, ['cred-fal'], templates);
+    expect(result).toEqual<RouteDecision>({
+      action: 'mitm',
+      reason: 'mitm:credential_injection',
     });
   });
 });

--- a/assistant/src/tools/network/script-proxy/router.ts
+++ b/assistant/src/tools/network/script-proxy/router.ts
@@ -7,7 +7,7 @@
  * pay the cost of TLS termination, cert issuance, and request rewriting.
  */
 
-import { minimatch } from 'minimatch';
+import { matchHostPattern } from '../../credentials/host-pattern-match.js';
 import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
 
 // ---- Public types ----------------------------------------------------------
@@ -49,7 +49,7 @@ export function routeConnection(
     if (!tpls) continue;
 
     for (const tpl of tpls) {
-      if (minimatch(hostname, tpl.hostPattern, { nocase: true })) {
+      if (matchHostPattern(hostname, tpl.hostPattern, { includeApexForWildcard: true }) !== 'none') {
         return { action: 'mitm', reason: 'mitm:credential_injection' };
       }
     }


### PR DESCRIPTION
## Summary
- Replace `minimatch` with shared `matchHostPattern` in the proxy router
- Enable apex-inclusive wildcard behavior: `*.fal.run` now matches bare `fal.run`
- CONNECT routing now MITMs bare domain when wildcard template exists

## Test plan
- [x] Updated bare domain test from tunnel→mitm
- [x] Regression test: `fal.run` with `*.fal.run` template → mitm
- [x] All existing router tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
