### PR TITLE
feat: resolve credential_ids and fail fast on unknown refs

### DIFF
--- a/assistant/src/__tests__/shell-credential-ref.test.ts
+++ b/assistant/src/__tests__/shell-credential-ref.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+// Mock logger
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Mock registry
+mock.module('../tools/registry.js', () => ({
+  registerTool: () => {},
+}));
+
+// Mock config
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600 },
+    sandbox: { enabled: false, backend: 'none' },
+    secretDetection: { allowOneTimeSend: false },
+  }),
+}));
+
+// Mock secret scanner
+mock.module('../security/secret-scanner.js', () => ({
+  redactSecrets: (s: string) => s,
+}));
+
+// Mock sandbox
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: (cmd: string, cwd: string) => ({ command: '/bin/sh', args: ['-c', cmd] }),
+}));
+
+// Mock safe-env
+mock.module('../tools/terminal/safe-env.js', () => ({
+  buildSanitizedEnv: () => ({ PATH: '/usr/bin' }),
+}));
+
+// Mock platform
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => '/tmp/test-data',
+}));
+
+// Mock proxy session manager
+const mockGetOrStartSession = mock(() => Promise.resolve({
+  session: { id: 'test-session-id', port: 8080, status: 'active' },
+  created: true,
+}));
+const mockGetSessionEnv = mock(() => ({
+  HTTP_PROXY: 'http://127.0.0.1:8080',
+  HTTPS_PROXY: 'http://127.0.0.1:8080',
+  NO_PROXY: 'localhost',
+}));
+mock.module('../tools/network/script-proxy/index.js', () => ({
+  getOrStartSession: mockGetOrStartSession,
+  getSessionEnv: mockGetSessionEnv,
+}));
+
+// Set up metadata store for credential resolution
+import { _setMetadataPath, upsertCredentialMetadata } from '../tools/credentials/metadata-store.js';
+
+const TEST_DIR = join(tmpdir(), `vellum-shell-cred-ref-test-${randomBytes(4).toString('hex')}`);
+const META_PATH = join(TEST_DIR, 'metadata.json');
+
+// Import the shell tool after mocks
+import { shellTool } from '../tools/terminal/shell.js';
+import type { ToolContext } from '../tools/types.js';
+
+const ctx: ToolContext = {
+  workingDir: '/tmp',
+  sessionId: 'test-session',
+  conversationId: 'test-conv',
+};
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  _setMetadataPath(META_PATH);
+  mockGetOrStartSession.mockClear();
+  mockGetSessionEnv.mockClear();
+});
+
+afterAll(() => {
+  _setMetadataPath(null);
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mock.restore();
+});
+
+describe('shell tool credential ref resolution', () => {
+  test('service/field ref resolves to UUID and reaches session creation', async () => {
+    const meta = upsertCredentialMetadata('fal', 'api_key', {
+      injectionTemplates: [{ hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization', valuePrefix: 'Key ' }],
+    });
+
+    const result = await shellTool.execute({
+      command: 'echo hello',
+      reason: 'test',
+      network_mode: 'proxied',
+      credential_ids: ['fal/api_key'],
+    }, ctx);
+
+    // Should have called getOrStartSession with the resolved UUID
+    expect(mockGetOrStartSession).toHaveBeenCalledTimes(1);
+    const callArgs = mockGetOrStartSession.mock.calls[0];
+    expect(callArgs[1]).toEqual([meta.credentialId]);
+  });
+
+  test('UUID ref remains supported', async () => {
+    const meta = upsertCredentialMetadata('github', 'token');
+
+    const result = await shellTool.execute({
+      command: 'echo hello',
+      reason: 'test',
+      network_mode: 'proxied',
+      credential_ids: [meta.credentialId],
+    }, ctx);
+
+    expect(mockGetOrStartSession).toHaveBeenCalledTimes(1);
+    const callArgs = mockGetOrStartSession.mock.calls[0];
+    expect(callArgs[1]).toEqual([meta.credentialId]);
+  });
+
+  test('unknown ref fails fast before spawning', async () => {
+    const result = await shellTool.execute({
+      command: 'echo hello',
+      reason: 'test',
+      network_mode: 'proxied',
+      credential_ids: ['nonexistent/key'],
+    }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('unknown credential reference');
+    expect(result.content).toContain('nonexistent/key');
+    // Session should NOT have been created
+    expect(mockGetOrStartSession).not.toHaveBeenCalled();
+  });
+
+  test('mixed known+unknown refs fails fast (no partial execution)', async () => {
+    upsertCredentialMetadata('fal', 'api_key');
+
+    const result = await shellTool.execute({
+      command: 'echo hello',
+      reason: 'test',
+      network_mode: 'proxied',
+      credential_ids: ['fal/api_key', 'unknown/ref'],
+    }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('unknown credential reference');
+    expect(result.content).toContain('unknown/ref');
+    expect(mockGetOrStartSession).not.toHaveBeenCalled();
+  });
+
+  test('duplicate refs are deduped', async () => {
+    const meta = upsertCredentialMetadata('fal', 'api_key');
+
+    await shellTool.execute({
+      command: 'echo hello',
+      reason: 'test',
+      network_mode: 'proxied',
+      credential_ids: ['fal/api_key', meta.credentialId],
+    }, ctx);
+
+    expect(mockGetOrStartSession).toHaveBeenCalledTimes(1);
+    const callArgs = mockGetOrStartSession.mock.calls[0];
+    // Should be deduped to a single UUID
+    expect(callArgs[1]).toEqual([meta.credentialId]);
+  });
+
+  test('non-proxied mode passes refs through without resolution', async () => {
+    // In non-proxied mode, credential_ids are ignored for proxy but still collected
+    const result = await shellTool.execute({
+      command: 'echo hello',
+      reason: 'test',
+      network_mode: 'off',
+      credential_ids: ['unknown/ref'],
+    }, ctx);
+
+    // Should not fail — credential resolution only happens in proxied mode
+    expect(result.isError).toBeFalsy();
+    expect(mockGetOrStartSession).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -15,6 +15,7 @@ import {
   getSessionEnv,
 } from '../network/script-proxy/index.js';
 import { getDataDir } from '../../util/platform.js';
+import { resolveCredentialRef } from '../credentials/resolve.js';
 
 const log = getLogger('shell-tool');
 
@@ -100,13 +101,39 @@ class ShellTool implements Tool {
     const networkMode: 'off' | 'proxied' =
       input.network_mode === 'proxied' ? 'proxied' : 'off';
 
-    const credentialIds: string[] = [];
+    const rawCredentialRefs: string[] = [];
     if (Array.isArray(input.credential_ids)) {
       for (const id of input.credential_ids) {
         if (typeof id === 'string' && id.length > 0) {
-          credentialIds.push(id);
+          rawCredentialRefs.push(id);
         }
       }
+    }
+
+    // Resolve credential refs (UUID or service/field) to canonical UUIDs.
+    // Fail fast if any ref is unresolvable — partial execution with missing
+    // credentials is worse than a clear error.
+    const credentialIds: string[] = [];
+    if (networkMode === 'proxied' && rawCredentialRefs.length > 0) {
+      const unresolvedRefs: string[] = [];
+      const seenIds = new Set<string>();
+      for (const ref of rawCredentialRefs) {
+        const resolved = resolveCredentialRef(ref);
+        if (!resolved) {
+          unresolvedRefs.push(ref);
+        } else if (!seenIds.has(resolved.credentialId)) {
+          seenIds.add(resolved.credentialId);
+          credentialIds.push(resolved.credentialId);
+        }
+      }
+      if (unresolvedRefs.length > 0) {
+        return {
+          content: `Error: unknown credential reference(s): ${unresolvedRefs.join(', ')}. Use credential_store list to see available credentials.`,
+          isError: true,
+        };
+      }
+    } else {
+      credentialIds.push(...rawCredentialRefs);
     }
 
     const config = getConfig();
@@ -115,7 +142,7 @@ class ShellTool implements Tool {
     const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
     const timeoutMs = timeoutSec * 1000;
 
-    log.info({ command: redactSecrets(command), cwd: context.workingDir, timeoutSec, networkMode, credentialIds }, 'Executing shell command');
+    log.info({ command: redactSecrets(command), cwd: context.workingDir, timeoutSec, networkMode, rawRefs: rawCredentialRefs, credentialIds }, 'Executing shell command');
 
     // Resolve sandbox config early — needed both for proxy env and command wrapping.
     const sandboxConfig = context.sandboxOverride != null


### PR DESCRIPTION
## Summary
- Normalize `credential_ids` through `resolveCredentialRef` in proxied mode
- Support both UUID and `service/field` format (e.g. `fal/api_key`)
- Fail fast with explicit error when any ref is unresolvable
- Deduplicate resolved UUIDs
- Non-proxied mode passes refs through unchanged

## Test plan
- [x] `service/field` ref resolves to UUID and reaches session creation
- [x] UUID refs remain supported
- [x] Unknown ref fails fast, `spawn` is not called
- [x] Mixed known+unknown refs fails fast (no partial execution)
- [x] Duplicate refs are deduped
- [x] Non-proxied mode ignores resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
