### PR TITLE
fix: include inputFull in ToolCallData Equatable conformance

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -346,6 +346,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.isError == rhs.isError
             && lhs.isComplete == rhs.isComplete
             && lhs.arrivedBeforeText == rhs.arrivedBeforeText
+            && lhs.inputFull == rhs.inputFull
             && lhs.imageData == rhs.imageData
             && lhs.buildingStatus == rhs.buildingStatus
     }


### PR DESCRIPTION
Add inputFull to the custom == operator in ToolCallData so SwiftUI correctly diffs and re-renders when inputFull changes.

Addresses feedback from PR #4763.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
