### PR TITLE
feat: policy engine apex matching + specificity selection

### DIFF
--- a/assistant/src/__tests__/script-proxy-policy.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy.test.ts
@@ -91,17 +91,15 @@ describe('evaluateRequest', () => {
     expect(result).toEqual({ kind: 'matched', credentialId: 'cred-multi', template: tpl2 });
   });
 
-  test('returns ambiguous when one credential matches multiple templates', () => {
+  test('single credential with exact + wildcard templates picks exact', () => {
     const tpl1 = headerTemplate('*.fal.ai', 'Authorization', 'Key ');
     const tpl2 = headerTemplate('api.fal.ai', 'Authorization', 'Bearer ');
     const templates = new Map<string, CredentialInjectionTemplate[]>([
       ['cred-dual', [tpl1, tpl2]],
     ]);
     const result = evaluateRequest('api.fal.ai', '/', ['cred-dual'], templates);
-    expect(result.kind).toBe('ambiguous');
-    if (result.kind === 'ambiguous') {
-      expect(result.candidates).toHaveLength(2);
-    }
+    // Specificity selection: exact (api.fal.ai) wins over wildcard (*.fal.ai)
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-dual', template: tpl2 });
   });
 
   test('excludes query templates from candidate matching', () => {
@@ -137,13 +135,36 @@ describe('evaluateRequest', () => {
     expect(result).toEqual({ kind: 'matched', credentialId: 'cred-fal', template: tpl });
   });
 
-  test('non-matching hostname with glob returns missing', () => {
+  test('bare domain matches wildcard with apex-inclusive matching', () => {
+    const tpl = headerTemplate('*.fal.ai');
     const templates = new Map<string, CredentialInjectionTemplate[]>([
-      ['cred-1', [headerTemplate('*.fal.ai')]],
+      ['cred-1', [tpl]],
     ]);
     const result = evaluateRequest('fal.ai', '/', ['cred-1'], templates);
-    // "*.fal.ai" does not match bare "fal.ai" with minimatch
-    expect(result).toEqual({ kind: 'missing' });
+    // Apex-inclusive: "*.fal.ai" now matches bare "fal.ai"
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-1', template: tpl });
+  });
+
+  test('same-credential equal-specificity ties remain ambiguous', () => {
+    const tpl1 = headerTemplate('api.fal.ai', 'Authorization', 'Key ');
+    const tpl2 = headerTemplate('api.fal.ai', 'X-Api-Key', 'Bearer ');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-dual', [tpl1, tpl2]],
+    ]);
+    const result = evaluateRequest('api.fal.ai', '/', ['cred-dual'], templates);
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+
+  test('evaluateRequest with apex-inclusive fal.run matches *.fal.run', () => {
+    const tpl = headerTemplate('*.fal.run');
+    const templates = new Map<string, CredentialInjectionTemplate[]>([
+      ['cred-fal', [tpl]],
+    ]);
+    const result = evaluateRequest('fal.run', '/', ['cred-fal'], templates);
+    expect(result).toEqual({ kind: 'matched', credentialId: 'cred-fal', template: tpl });
   });
 });
 

--- a/assistant/src/tools/network/script-proxy/policy.ts
+++ b/assistant/src/tools/network/script-proxy/policy.ts
@@ -3,7 +3,7 @@
  * injection templates and emits deterministic policy decisions.
  */
 
-import { minimatch } from 'minimatch';
+import { matchHostPattern, compareMatchSpecificity, type HostMatchKind } from '../../credentials/host-pattern-match.js';
 import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
 import type { PolicyDecision, RequestTargetContext } from './types.js';
 
@@ -30,37 +30,60 @@ export function evaluateRequest(
     return { kind: 'unauthenticated' };
   }
 
-  const candidates: MatchCandidate[] = [];
+  // For each credential, find the best matching header template by specificity.
+  // Query templates are excluded — they're handled via URL rewriting in the
+  // MITM path and can't be injected by the HTTP forwarder.
+  const perCredentialBest: MatchCandidate[] = [];
 
   for (const id of credentialIds) {
     const tpls = templates.get(id);
     if (!tpls) continue;
 
+    let bestMatch: HostMatchKind = 'none';
+    let bestCandidates: CredentialInjectionTemplate[] = [];
+
     for (const tpl of tpls) {
-      // Query templates are handled via URL rewriting in the MITM path
-      // and can't be injected by the HTTP forwarder. Exclude them so
-      // a host with both query and header templates doesn't appear
-      // ambiguous — consistent with the MITM rewriteCallback filtering.
       if (tpl.injectionType === 'query') continue;
-      if (minimatch(hostname, tpl.hostPattern, { nocase: true })) {
-        candidates.push({ credentialId: id, template: tpl });
+      const match = matchHostPattern(hostname, tpl.hostPattern, { includeApexForWildcard: true });
+      if (match === 'none') continue;
+
+      const cmp = compareMatchSpecificity(match, bestMatch);
+      if (cmp < 0) {
+        // Strictly more specific — replace
+        bestMatch = match;
+        bestCandidates = [tpl];
+      } else if (cmp === 0) {
+        // Same specificity — accumulate (potential intra-credential tie)
+        bestCandidates.push(tpl);
       }
+      // cmp > 0 means less specific — skip
+    }
+
+    if (bestCandidates.length === 1) {
+      perCredentialBest.push({ credentialId: id, template: bestCandidates[0] });
+    } else if (bestCandidates.length > 1) {
+      // Same credential has multiple templates at the same specificity — ambiguous
+      return {
+        kind: 'ambiguous',
+        candidates: bestCandidates.map((tpl) => ({ credentialId: id, template: tpl })),
+      };
     }
   }
 
-  if (candidates.length === 0) {
+  if (perCredentialBest.length === 0) {
     return { kind: 'missing' };
   }
 
-  if (candidates.length === 1) {
+  if (perCredentialBest.length === 1) {
     return {
       kind: 'matched',
-      credentialId: candidates[0].credentialId,
-      template: candidates[0].template,
+      credentialId: perCredentialBest[0].credentialId,
+      template: perCredentialBest[0].template,
     };
   }
 
-  return { kind: 'ambiguous', candidates };
+  // Multiple credentials match — cross-credential ambiguity
+  return { kind: 'ambiguous', candidates: perCredentialBest };
 }
 
 /**
@@ -112,7 +135,7 @@ export function evaluateRequestWithApproval(
   const matchingPatterns: string[] = [];
   for (const tpl of allKnownTemplates) {
     if (tpl.injectionType === 'query') continue;
-    if (minimatch(hostname, tpl.hostPattern, { nocase: true })) {
+    if (matchHostPattern(hostname, tpl.hostPattern, { includeApexForWildcard: true }) !== 'none') {
       matchingPatterns.push(tpl.hostPattern);
     }
   }


### PR DESCRIPTION
## Summary
- Replace `minimatch` with shared `matchHostPattern` (apex-inclusive) in policy engine
- Per-credential specificity selection: exact > wildcard — prevents false ambiguity
- Same-credential equal-specificity ties remain ambiguous
- Cross-credential ambiguity remains fail-closed
- `evaluateRequestWithApproval` uses apex-inclusive matching for known-pattern checks

## Test plan
- [x] `evaluateRequest('fal.run', tpl='*.fal.run')` returns matched
- [x] Single credential with exact + wildcard templates picks exact
- [x] Same-credential equal-specificity ties remain ambiguous
- [x] `ask_missing_credential`/`ask_unauthenticated` behavior stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
