### PR TITLE
fix: cap fallback image height in AnimatedImageView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -49,7 +49,7 @@ struct AnimatedImageView: View {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: maxDimension)
+                    .frame(maxWidth: maxDimension, maxHeight: maxDimension)
             } else {
                 Image(systemName: "photo")
                     .font(.system(size: 24))


### PR DESCRIPTION
Add maxHeight constraint to the fallback image rendering path (when cgImage is nil) to prevent oversized chat bubbles, matching the CGImage path's height cap.

Addresses feedback from PR #4856.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
