### PR TITLE
docs: fix secretDetection docs to match code — blockIngress gates ingress, action defaults to redact

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2434,7 +2434,7 @@ sequenceDiagram
 
 ```mermaid
 graph TB
-    MSG["Inbound user_message / task_submit"] --> CHECK{"secretDetection.enabled<br/>+ action == 'block'?"}
+    MSG["Inbound user_message / task_submit"] --> CHECK{"secretDetection.enabled<br/>+ blockIngress == true?"}
     CHECK -->|no| PASS["Pass through to session"]
     CHECK -->|yes| SCAN["scanText(content)<br/>regex + entropy detection"]
     SCAN --> MATCH{"Matches found?"}

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The assistant can store and use credentials (API keys, tokens, passwords) withou
 
 - **Storage**: Secret values are stored in the macOS Keychain via `secure-keys.ts`, with an encrypted file fallback for Linux/headless environments or degraded Keychain sessions. Metadata (service, field, label, usage policy) is stored in a JSON file at `~/.vellum/workspace/data/credentials/metadata.json`.
 - **Secret prompt**: When a credential is needed, a floating `SecretPromptView` panel appears. The user enters the value in a `SecureField` — the LLM never sees it.
-- **Ingress blocking**: Inbound user messages are scanned for secrets (regex + entropy). If `secretDetection.action` is `block` (the default), messages containing secrets are rejected with a notice to use the secure prompt instead.
+- **Ingress blocking**: Inbound user messages are scanned for secrets (regex + entropy). When `secretDetection.blockIngress` is `true` (the default), messages containing secrets are rejected with a notice to use the secure prompt instead. The `secretDetection.action` setting (default: `redact`) separately controls how secrets in tool *output* are handled.
 - **Usage policy**: Each credential can specify `allowedTools` and `allowedDomains`. The `CredentialBroker` enforces these policies at use time.
 - **One-time send**: When `secretDetection.allowOneTimeSend` is enabled (default: `false`), a "Send Once" button lets users provide a value for immediate use without persisting it.
 - **No plaintext read API**: There is no tool-layer function that returns a stored secret as plaintext. Secrets are only consumed by the broker for scoped tool execution.


### PR DESCRIPTION
Update README.md and ARCHITECTURE.md to accurately reflect the secret detection implementation:

- README: Ingress blocking is controlled by `secretDetection.blockIngress` (not `action`), and the default `action` is `redact` (not `block`)
- ARCHITECTURE: Fix Mermaid diagram decision node from `action == 'block'?` to `blockIngress == true?`

These docs were out of sync with the actual code in `secret-ingress.ts` and `schema.ts`.

Addresses feedback from PR #4833.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
