### PR TITLE
fix: gate SSL_CERT_FILE on bundle existence and fix button disabled state

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -1,5 +1,6 @@
 import type { Server } from 'node:http';
 import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { createProxyServer } from './server.js';
 import type { ProxyServerConfig } from './server.js';
@@ -372,7 +373,13 @@ export function getSessionEnv(
     env.NODE_EXTRA_CA_CERTS = getCAPath(managed.dataDir);
     // Combined bundle lets non-Node clients (curl, Python, Go) trust
     // the proxy CA alongside system roots via SSL_CERT_FILE.
-    env.SSL_CERT_FILE = getCombinedCAPath(managed.dataDir);
+    // Only set when the bundle file actually exists — it's created by
+    // ensureCombinedCABundle() during MITM setup, and pointing
+    // SSL_CERT_FILE at a missing file would break trust roots.
+    const combinedPath = getCombinedCAPath(managed.dataDir);
+    if (existsSync(combinedPath)) {
+      env.SSL_CERT_FILE = combinedPath;
+    }
   }
 
   return env;

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -227,7 +227,7 @@ struct SecretPromptView: View {
                                 withAnimation(VAnimation.standard) { saved = true }
                             }
                         }
-                        .disabled(secretValue.isEmpty)
+                        .disabled(secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
 
                     if allowOneTimeSend {
@@ -240,7 +240,7 @@ struct SecretPromptView: View {
                                 guard !trimmed.isEmpty else { return }
                                 _ = onSendOnce(trimmed)
                             }
-                            .disabled(secretValue.isEmpty)
+                            .disabled(secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         }
                     }
                 }


### PR DESCRIPTION
Two fixes:
1. Only set SSL_CERT_FILE in getSessionEnv when the combined CA bundle file actually exists, preventing HTTPS failures for non-Node clients.
2. Fix Save/Send Once button disabled state to use trimmed value check, matching the action's guard.

Addresses feedback from PR #4775.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
