### PR TITLE
docs: fix stale JSDoc for memoryThresholdBytes default

### DIFF
--- a/assistant/src/daemon/session-evictor.ts
+++ b/assistant/src/daemon/session-evictor.ts
@@ -13,7 +13,7 @@ export interface EvictorOptions {
   ttlMs?: number;
   /** Max number of in-memory sessions before LRU eviction kicks in. Default: 100. */
   maxSessions?: number;
-  /** RSS threshold (bytes) above which idle sessions are aggressively evicted. Default: 512 MB. */
+  /** RSS threshold (bytes) above which idle sessions are aggressively evicted. Default: 1.5 GB. */
   memoryThresholdBytes?: number;
   /** Interval between periodic sweeps (ms). Default: 60 s. */
   sweepIntervalMs?: number;


### PR DESCRIPTION
Update JSDoc comment on memoryThresholdBytes from 'Default: 512 MB' to 'Default: 1.5 GB' to match the actual default value.

Addresses feedback from PR #4885.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
