### PR TITLE
fix: update trust-store tests for removed protected file rules

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -696,11 +696,6 @@ describe('Trust Store', () => {
         }
       }
 
-      const protectedDefaults = defaults.filter((rule) => rule.id.endsWith('-protected'));
-      expect(protectedDefaults).toHaveLength(3);
-      for (const rule of protectedDefaults) {
-        expect(rule.pattern).toContain(`${testDir}/protected/`);
-      }
     });
 
     test('default rules cover file, host file, host shell, and workspace prompt tools', () => {
@@ -745,6 +740,7 @@ describe('Trust Store', () => {
         'skill_load',
         'ui_dismiss',
         'ui_update',
+        'view_image',
       ]);
     });
 
@@ -1843,11 +1839,11 @@ describe('Trust Store', () => {
       });
 
       test('existing default rules (no principal fields) match with any context', () => {
-        // Default rules have no principal fields and should match regardless of context
-        const protectedPath = join(testDir, 'protected', 'trust.json');
+        // Default rules have no principal fields and should match regardless of context.
+        // Use host_file_read which has a default ask rule (default:ask-host_file_read-global).
         const match = findHighestPriorityRule(
-          'file_read',
-          [`file_read:${protectedPath}`],
+          'host_file_read',
+          ['host_file_read:/etc/hosts'],
           '/tmp',
           { principal: { kind: 'skill', id: 'random-skill', version: 'v99' } },
         );


### PR DESCRIPTION
Fix test assertions in trust-store.test.ts that referenced the removed protectedFileRules:
1. Remove the assertion checking for 3 rules with IDs ending in '-protected'.
2. Update the 'existing default rules match with any context' test to use host_file_read instead of the removed file_read protected rule.
3. Add view_image to the expected default tools list.

Addresses feedback from PR #4851.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
