### PR TITLE
fix: emit permission-denied event on secret prompt deny

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -504,7 +504,7 @@ export class ToolExecutor {
               const blockedContent = `Tool output blocked: user denied output containing ${allMatches.length} potential secret(s) (${types}).`;
               const durationMs = Date.now() - startTime;
               emitLifecycleEvent(context, {
-                type: 'executed',
+                type: 'permission_denied',
                 toolName: name,
                 executionTarget,
                 input,
@@ -514,8 +514,8 @@ export class ToolExecutor {
                 requestId: context.requestId,
                 riskLevel,
                 decision: 'deny',
+                reason: `User denied output containing secrets: ${types}`,
                 durationMs,
-                result: { content: blockedContent, isError: true },
               });
 
               void getHookManager().trigger('post-tool-execute', {


### PR DESCRIPTION
Emit a proper permission_denied lifecycle event when the user denies a secret output prompt, so listeners tracking permission outcomes see a complete request/decision cycle.

Addresses feedback from PR #4849.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
