### PR TITLE
fix: redact sensitive tool inputs and fix hasDetails/history consistency

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -94,7 +94,7 @@ private struct UsedToolsRow: View {
     @Environment(\.displayScale) private var displayScale
 
     private var hasDetails: Bool {
-        !toolCall.inputSummary.isEmpty ||
+        !toolCall.inputFull.isEmpty ||
         (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true)) ||
         toolCall.cachedImage != nil
     }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -60,8 +60,14 @@ extension ChatViewModel {
         return str.count > 80 ? String(str.prefix(77)) + "..." : str
     }
 
+    /// Argument keys whose values may contain credentials and must be redacted.
+    private static let sensitiveKeys: Set<String> = [
+        "value", "secret", "password", "token", "client_secret", "api_key"
+    ]
+
     /// Format all tool input arguments for display in expanded details.
     /// The primary value comes first, then remaining keys as `key: value` lines.
+    /// Sensitive keys (passwords, tokens, etc.) are redacted to prevent credential exposure.
     func formatAllToolInput(_ input: [String: AnyCodable]) -> String {
         guard !input.isEmpty else { return "" }
 
@@ -73,16 +79,24 @@ extension ChatViewModel {
 
         // Primary value first (undecorated)
         if let key = primaryKey, let value = input[key] {
-            lines.append(stringifyValue(value))
+            if Self.sensitiveKeys.contains(key) {
+                lines.append("[redacted]")
+            } else {
+                lines.append(stringifyValue(value))
+            }
         }
 
-        // Remaining keys sorted alphabetically
+        // Remaining keys sorted alphabetically, skipping sensitive values
         let otherKeys = input.keys
             .filter { $0 != primaryKey }
             .sorted()
         for key in otherKeys {
             guard let value = input[key] else { continue }
-            lines.append("\(key): \(stringifyValue(value))")
+            if Self.sensitiveKeys.contains(key) {
+                lines.append("\(key): [redacted]")
+            } else {
+                lines.append("\(key): \(stringifyValue(value))")
+            }
         }
 
         return lines.joined(separator: "\n")

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1034,7 +1034,7 @@ public final class ChatViewModel: ObservableObject {
                     ToolCallData(
                         toolName: tc.name,
                         inputSummary: summarizeToolInput(tc.input),
-                        inputFull: extractToolInput(tc.input),
+                        inputFull: formatAllToolInput(tc.input),
                         result: tc.result,
                         isError: tc.isError ?? false,
                         isComplete: true,


### PR DESCRIPTION
Three fixes:
1. Redact sensitive argument keys (value, secret, password, token, etc.) in formatAllToolInput to prevent credential exposure.
2. Change hasDetails to check inputFull instead of inputSummary so expand chevron shows when there's content to display.
3. Use formatAllToolInput in history population path for consistency with live streaming.

Addresses feedback from PR #4877.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
