### PR TITLE
fix: preserve turn-boundary commit before attachment resolution

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -669,8 +669,6 @@ export class Session {
 
     // Tracks whether the agent loop started — once true, we guarantee a
     // turn-boundary commit even if post-processing throws.
-    let turnStarted = false;
-    let commitReason: 'turn_complete' | 'post_processing_error' | 'cancelled_turn' = 'turn_complete';
 
     try {
       const preMessageResult = await getHookManager().trigger('pre-message', {
@@ -1062,10 +1060,6 @@ export class Session {
       };
 
       // Mark that the agent loop is about to run — workspace files may be
-      // modified from this point onward, so we must commit at the turn boundary
-      // even if post-processing (e.g. resolveAssistantAttachments) throws.
-      turnStarted = true;
-
       let updatedHistory = await this.agentLoop.run(
         runMessages,
         buildEventHandler(),
@@ -1294,6 +1288,13 @@ export class Session {
         sessionId: this.conversationId,
       });
 
+      // Turn-boundary commit: must run before resolveAssistantAttachments
+      // because that call can rethrow non-upload errors.  Without committing
+      // first, workspace file changes from this turn would be swept into the
+      // next turn's commit, breaking per-turn attribution.
+      this.turnCount++;
+      await commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
+
       // Resolve accumulated attachment directives and tool content blocks
       // BEFORE emitting the completion event so attachments are included.
       const attachmentResult = await resolveAssistantAttachments(
@@ -1361,7 +1362,6 @@ export class Session {
       const errorCtx = { phase: 'agent_loop' as const, aborted: abortController.signal.aborted };
       // AbortError is expected when user cancels — don't treat as an error
       if (isUserCancellation(err, errorCtx)) {
-        commitReason = 'cancelled_turn';
         rlog.info('Generation cancelled by user');
         this.traceEmitter.emit('generation_cancelled', 'Generation cancelled by user', {
           requestId: reqId,
@@ -1369,7 +1369,6 @@ export class Session {
         });
         onEvent({ type: 'generation_cancelled', sessionId: this.conversationId });
       } else {
-        commitReason = 'post_processing_error';
         const message = err instanceof Error ? err.message : String(err);
         const errorClass = err instanceof Error ? err.constructor.name : 'Error';
         rlog.error({ err }, 'Session processing error');
@@ -1389,18 +1388,6 @@ export class Session {
         });
       }
     } finally {
-      // Turn-boundary commit: runs after completion/error events (try or
-      // catch) but before drainQueue.  Guarantees a commit attempt whenever
-      // the agent loop started, even if post-processing threw.
-      if (turnStarted) {
-        this.turnCount++;
-        rlog.info(
-          { reason: commitReason, turnNumber: this.turnCount, conversationId: this.conversationId },
-          'Attempting turn-boundary commit',
-        );
-        await commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
-      }
-
       this.profiler.emitSummary(this.traceEmitter, reqId);
 
       this.abortController = null;


### PR DESCRIPTION
Move commitTurnChanges before resolveAssistantAttachments to ensure per-turn attribution is preserved even if attachment resolution throws.

Addresses feedback from PR #4847.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
