### PR TITLE
feat: specificity-aligned template selection in MITM rewrite

### DIFF
--- a/assistant/src/__tests__/script-proxy-rewrite-specificity.test.ts
+++ b/assistant/src/__tests__/script-proxy-rewrite-specificity.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  matchHostPattern,
+  compareMatchSpecificity,
+  type HostMatchKind,
+} from '../tools/credentials/host-pattern-match.js';
+import type { CredentialInjectionTemplate } from '../tools/credentials/policy-types.js';
+
+/**
+ * Extracted rewrite candidate selection logic — mirrors what session-manager's
+ * rewriteCallback does internally. This allows testing the selection algorithm
+ * without standing up a full MITM proxy server.
+ */
+function selectRewriteCandidate(
+  hostname: string,
+  templates: Map<string, CredentialInjectionTemplate[]>,
+): { credId: string; tpl: CredentialInjectionTemplate } | 'ambiguous' | 'none' {
+  const perCredentialBest: { credId: string; tpl: CredentialInjectionTemplate }[] = [];
+
+  for (const [credId, tpls] of templates) {
+    let bestMatch: HostMatchKind = 'none';
+    let bestCandidates: CredentialInjectionTemplate[] = [];
+
+    for (const tpl of tpls) {
+      if (tpl.injectionType === 'query') continue;
+      const match = matchHostPattern(hostname, tpl.hostPattern, { includeApexForWildcard: true });
+      if (match === 'none') continue;
+
+      const cmp = compareMatchSpecificity(match, bestMatch);
+      if (cmp < 0) {
+        bestMatch = match;
+        bestCandidates = [tpl];
+      } else if (cmp === 0) {
+        bestCandidates.push(tpl);
+      }
+    }
+
+    if (bestCandidates.length === 1) {
+      perCredentialBest.push({ credId, tpl: bestCandidates[0] });
+    } else if (bestCandidates.length > 1) {
+      return 'ambiguous';
+    }
+  }
+
+  if (perCredentialBest.length === 0) return 'none';
+  if (perCredentialBest.length > 1) return 'ambiguous';
+  return perCredentialBest[0];
+}
+
+function headerTemplate(
+  hostPattern: string,
+  headerName = 'Authorization',
+  valuePrefix = 'Key ',
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'header', headerName, valuePrefix };
+}
+
+function queryTemplate(
+  hostPattern: string,
+  queryParamName: string,
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: 'query', queryParamName };
+}
+
+describe('MITM rewrite candidate selection (specificity-aligned)', () => {
+  test('one credential with fal.run + *.fal.run injects exact once', () => {
+    const templates = new Map([
+      ['cred-fal', [
+        headerTemplate('fal.run', 'Authorization', 'Key '),
+        headerTemplate('*.fal.run', 'Authorization', 'Key '),
+      ]],
+    ]);
+    const result = selectRewriteCandidate('fal.run', templates);
+    expect(result).not.toBe('ambiguous');
+    expect(result).not.toBe('none');
+    if (typeof result === 'object') {
+      expect(result.credId).toBe('cred-fal');
+      expect(result.tpl.hostPattern).toBe('fal.run');
+    }
+  });
+
+  test('one credential with only wildcard matches bare domain via apex inclusion', () => {
+    const templates = new Map([
+      ['cred-fal', [headerTemplate('*.fal.run')]],
+    ]);
+    const result = selectRewriteCandidate('fal.run', templates);
+    expect(result).not.toBe('ambiguous');
+    expect(result).not.toBe('none');
+    if (typeof result === 'object') {
+      expect(result.credId).toBe('cred-fal');
+    }
+  });
+
+  test('two credentials matching same host still blocks (ambiguous)', () => {
+    const templates = new Map([
+      ['cred-a', [headerTemplate('*.fal.run', 'Authorization')]],
+      ['cred-b', [headerTemplate('*.fal.run', 'X-Api-Key')]],
+    ]);
+    const result = selectRewriteCandidate('api.fal.run', templates);
+    expect(result).toBe('ambiguous');
+  });
+
+  test('no match returns none', () => {
+    const templates = new Map([
+      ['cred-openai', [headerTemplate('*.openai.com')]],
+    ]);
+    const result = selectRewriteCandidate('api.fal.run', templates);
+    expect(result).toBe('none');
+  });
+
+  test('query templates are excluded from candidate selection', () => {
+    const templates = new Map([
+      ['cred-gcp', [
+        queryTemplate('maps.googleapis.com', 'key'),
+        headerTemplate('maps.googleapis.com'),
+      ]],
+    ]);
+    const result = selectRewriteCandidate('maps.googleapis.com', templates);
+    expect(result).not.toBe('ambiguous');
+    if (typeof result === 'object') {
+      expect(result.tpl.injectionType).toBe('header');
+    }
+  });
+
+  test('same credential equal-specificity tie returns ambiguous', () => {
+    const templates = new Map([
+      ['cred-dual', [
+        headerTemplate('api.fal.run', 'Authorization', 'Key '),
+        headerTemplate('api.fal.run', 'X-Api-Key', 'Bearer '),
+      ]],
+    ]);
+    const result = selectRewriteCandidate('api.fal.run', templates);
+    expect(result).toBe('ambiguous');
+  });
+});

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -14,7 +14,7 @@ import type {
 import type { PolicyCallback } from './http-forwarder.js';
 import { evaluateRequestWithApproval } from './policy.js';
 import { getCAPath, getCombinedCAPath, ensureLocalCA, ensureCombinedCABundle } from './certs.js';
-import { minimatch } from 'minimatch';
+import { matchHostPattern, compareMatchSpecificity, type HostMatchKind } from '../../credentials/host-pattern-match.js';
 import { resolveById } from '../../credentials/resolve.js';
 import { listCredentialMetadata } from '../../credentials/metadata-store.js';
 import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
@@ -162,28 +162,42 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
         shouldIntercept: (hostname: string, port: number) =>
           routeConnection(hostname, port, managed.session.credentialIds, templates),
         rewriteCallback: async (req) => {
-          // Collect matching header-injection candidates to detect ambiguity
-          // before injecting any secrets — mirrors the HTTP policyCallback
-          // guard. Query templates are excluded because the MITM
-          // RewriteCallback can't rewrite URL paths; counting them would
-          // cause false ambiguity when a host has both query and header
-          // templates.
-          const candidates: { credId: string; tpl: CredentialInjectionTemplate }[] = [];
+          // Per-credential best-match selection, mirroring the policy engine's
+          // specificity logic (PR 04). For each credential, pick the single
+          // best header template by specificity (exact > wildcard).
+          const perCredentialBest: { credId: string; tpl: CredentialInjectionTemplate }[] = [];
+
           for (const [credId, tpls] of templates) {
+            let bestMatch: HostMatchKind = 'none';
+            let bestCandidates: CredentialInjectionTemplate[] = [];
+
             for (const tpl of tpls) {
               if (tpl.injectionType === 'query') continue;
-              if (minimatch(req.hostname, tpl.hostPattern, { nocase: true })) {
-                candidates.push({ credId, tpl });
+              const match = matchHostPattern(req.hostname, tpl.hostPattern, { includeApexForWildcard: true });
+              if (match === 'none') continue;
+
+              const cmp = compareMatchSpecificity(match, bestMatch);
+              if (cmp < 0) {
+                bestMatch = match;
+                bestCandidates = [tpl];
+              } else if (cmp === 0) {
+                bestCandidates.push(tpl);
               }
+            }
+
+            if (bestCandidates.length === 1) {
+              perCredentialBest.push({ credId, tpl: bestCandidates[0] });
+            } else if (bestCandidates.length > 1) {
+              // Same credential, same-specificity tie — ambiguous, block
+              return null;
             }
           }
 
-          if (candidates.length === 0) return req.headers;
-          // Ambiguous — multiple templates match; block to avoid injecting
-          // the wrong secret (403 Forbidden via null return).
-          if (candidates.length > 1) return null;
+          if (perCredentialBest.length === 0) return req.headers;
+          // Cross-credential ambiguity — block
+          if (perCredentialBest.length > 1) return null;
 
-          const { credId, tpl } = candidates[0];
+          const { credId, tpl } = perCredentialBest[0];
 
           if (tpl.injectionType === 'header' && tpl.headerName) {
             const resolved = resolveById(credId);


### PR DESCRIPTION
## Summary
- Update MITM rewrite callback to use per-credential specificity selection
- One credential with `fal.run` + `*.fal.run` injects once deterministically
- Two credentials matching same host still blocks (cross-credential ambiguity)
- Same-credential equal-specificity ties remain ambiguous
- Consistent with policy engine behavior from PR 04

## Test plan
- [x] One credential with exact + wildcard templates picks exact
- [x] Wildcard matches bare domain via apex inclusion
- [x] Cross-credential ambiguity still blocks
- [x] Same-credential equal-specificity ties still block
- [x] Query templates excluded from candidate selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
