### PR TITLE
feat: add safe proxy decision trace builder

### DIFF
--- a/assistant/src/__tests__/script-proxy-decision-trace.test.ts
+++ b/assistant/src/__tests__/script-proxy-decision-trace.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  buildDecisionTrace,
+  buildCredentialRefTrace,
+  type ProxyDecisionTrace,
+  type CredentialRefTrace,
+} from '../tools/network/script-proxy/logging.js';
+import type { PolicyDecision } from '../tools/network/script-proxy/types.js';
+
+describe('buildDecisionTrace', () => {
+  test('matched decision includes selected pattern and credential', () => {
+    const decision: PolicyDecision = {
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: {
+        hostPattern: '*.fal.ai',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Key ',
+      },
+    };
+    const trace = buildDecisionTrace('api.fal.ai', 443, '/v1/run', 'https', decision);
+    expect(trace).toEqual<ProxyDecisionTrace>({
+      host: 'api.fal.ai',
+      port: 443,
+      path: '/v1/run',
+      scheme: 'https',
+      decisionKind: 'matched',
+      candidateCount: 1,
+      selectedPattern: '*.fal.ai',
+      selectedCredentialId: 'cred-fal',
+    });
+  });
+
+  test('ambiguous decision includes candidate count but no selection', () => {
+    const decision: PolicyDecision = {
+      kind: 'ambiguous',
+      candidates: [
+        { credentialId: 'cred-a', template: { hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'Authorization' } },
+        { credentialId: 'cred-b', template: { hostPattern: '*.fal.ai', injectionType: 'header', headerName: 'X-Key' } },
+      ],
+    };
+    const trace = buildDecisionTrace('api.fal.ai', null, '/', 'https', decision);
+    expect(trace.decisionKind).toBe('ambiguous');
+    expect(trace.candidateCount).toBe(2);
+    expect(trace.selectedPattern).toBeNull();
+    expect(trace.selectedCredentialId).toBeNull();
+  });
+
+  test('missing decision has zero candidates', () => {
+    const decision: PolicyDecision = { kind: 'missing' };
+    const trace = buildDecisionTrace('unknown.com', 443, '/', 'https', decision);
+    expect(trace.decisionKind).toBe('missing');
+    expect(trace.candidateCount).toBe(0);
+    expect(trace.selectedPattern).toBeNull();
+  });
+
+  test('unauthenticated decision has zero candidates', () => {
+    const decision: PolicyDecision = { kind: 'unauthenticated' };
+    const trace = buildDecisionTrace('example.com', null, '/', 'http', decision);
+    expect(trace.decisionKind).toBe('unauthenticated');
+    expect(trace.candidateCount).toBe(0);
+  });
+
+  test('ask_missing_credential includes matching pattern count', () => {
+    const decision: PolicyDecision = {
+      kind: 'ask_missing_credential',
+      target: { hostname: 'api.fal.ai', port: 443, path: '/v1', scheme: 'https' },
+      matchingPatterns: ['*.fal.ai', 'api.fal.ai'],
+    };
+    const trace = buildDecisionTrace('api.fal.ai', 443, '/v1', 'https', decision);
+    expect(trace.decisionKind).toBe('ask_missing_credential');
+    expect(trace.candidateCount).toBe(2);
+  });
+
+  test('ask_unauthenticated has zero candidates', () => {
+    const decision: PolicyDecision = {
+      kind: 'ask_unauthenticated',
+      target: { hostname: 'example.com', port: null, path: '/', scheme: 'https' },
+    };
+    const trace = buildDecisionTrace('example.com', null, '/', 'https', decision);
+    expect(trace.decisionKind).toBe('ask_unauthenticated');
+    expect(trace.candidateCount).toBe(0);
+  });
+
+  test('trace never contains secret values', () => {
+    const decision: PolicyDecision = {
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: {
+        hostPattern: '*.fal.ai',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Key ',
+      },
+    };
+    const trace = buildDecisionTrace('api.fal.ai', 443, '/', 'https', decision);
+    const serialized = JSON.stringify(trace);
+    // Should not contain any typical secret patterns
+    expect(serialized).not.toContain('Bearer ');
+    expect(serialized).not.toContain('Key ');
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('token');
+    // Should only contain expected fields
+    const keys = Object.keys(trace);
+    expect(keys).toEqual([
+      'host', 'port', 'path', 'scheme',
+      'decisionKind', 'candidateCount',
+      'selectedPattern', 'selectedCredentialId',
+    ]);
+  });
+});
+
+describe('buildCredentialRefTrace', () => {
+  test('builds trace with all fields', () => {
+    const trace = buildCredentialRefTrace(
+      ['fal/api_key', 'unknown/ref'],
+      ['uuid-123'],
+      ['unknown/ref'],
+    );
+    expect(trace).toEqual<CredentialRefTrace>({
+      rawRefs: ['fal/api_key', 'unknown/ref'],
+      resolvedIds: ['uuid-123'],
+      unresolvedRefs: ['unknown/ref'],
+    });
+  });
+
+  test('empty arrays for clean resolution', () => {
+    const trace = buildCredentialRefTrace(['uuid-abc'], ['uuid-abc'], []);
+    expect(trace.unresolvedRefs).toEqual([]);
+    expect(trace.resolvedIds).toEqual(['uuid-abc']);
+  });
+});

--- a/assistant/src/tools/network/script-proxy/logging.ts
+++ b/assistant/src/tools/network/script-proxy/logging.ts
@@ -1,9 +1,10 @@
 /**
- * Sanitization utilities for proxy log entries.
+ * Safe diagnostic logging helpers for the proxy subsystem.
  *
- * All proxy logging must pass through these helpers so that secrets
- * injected via credential templates (Authorization headers, API key
- * query params, etc.) are never persisted or printed in plaintext.
+ * All sanitizers and trace builders are designed to NEVER include secret
+ * values by construction — sanitizers redact sensitive header/query values,
+ * and trace builders only reference host patterns, decision kinds, and
+ * candidate counts.
  */
 
 const REDACTED = '[REDACTED]';
@@ -88,4 +89,98 @@ export function createSafeLogEntry(
     url: sanitizeUrl(req.url, sensitiveKeys),
     headers: sanitizeHeaders(req.headers, sensitiveKeys),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Policy/rewrite decision trace
+// ---------------------------------------------------------------------------
+
+import type { PolicyDecision } from './types.js';
+
+export interface ProxyDecisionTrace {
+  /** Target hostname. */
+  host: string;
+  /** Target port (null = default for scheme). */
+  port: number | null;
+  /** Request path. */
+  path: string;
+  /** Protocol scheme. */
+  scheme: 'http' | 'https';
+  /** The decision kind emitted by the policy engine. */
+  decisionKind: PolicyDecision['kind'];
+  /** Number of candidate templates that matched before disambiguation. */
+  candidateCount: number;
+  /** The host pattern of the selected template, if any. */
+  selectedPattern: string | null;
+  /** The credential ID of the selected credential, if any. */
+  selectedCredentialId: string | null;
+}
+
+/**
+ * Build a structured trace record from a policy decision.
+ *
+ * Intentionally excludes all secret-bearing fields (header values,
+ * storage keys, injected tokens) — only patterns, counts, and
+ * decision metadata are included.
+ */
+export function buildDecisionTrace(
+  host: string,
+  port: number | null,
+  path: string,
+  scheme: 'http' | 'https',
+  decision: PolicyDecision,
+): ProxyDecisionTrace {
+  let candidateCount = 0;
+  let selectedPattern: string | null = null;
+  let selectedCredentialId: string | null = null;
+
+  switch (decision.kind) {
+    case 'matched':
+      candidateCount = 1;
+      selectedPattern = decision.template.hostPattern;
+      selectedCredentialId = decision.credentialId;
+      break;
+    case 'ambiguous':
+      candidateCount = decision.candidates.length;
+      break;
+    case 'ask_missing_credential':
+      candidateCount = decision.matchingPatterns.length;
+      break;
+    // 'missing', 'unauthenticated', 'ask_unauthenticated' — no candidates
+  }
+
+  return {
+    host,
+    port,
+    path,
+    scheme,
+    decisionKind: decision.kind,
+    candidateCount,
+    selectedPattern,
+    selectedCredentialId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Credential ref resolution trace
+// ---------------------------------------------------------------------------
+
+export interface CredentialRefTrace {
+  /** The raw refs provided by the caller. */
+  rawRefs: string[];
+  /** The resolved canonical UUIDs. */
+  resolvedIds: string[];
+  /** Any refs that could not be resolved. */
+  unresolvedRefs: string[];
+}
+
+/**
+ * Build a credential ref resolution trace for diagnostic logging.
+ */
+export function buildCredentialRefTrace(
+  rawRefs: string[],
+  resolvedIds: string[],
+  unresolvedRefs: string[],
+): CredentialRefTrace {
+  return { rawRefs, resolvedIds, unresolvedRefs };
 }


### PR DESCRIPTION
## Summary
- Add `buildDecisionTrace()` for structured policy/rewrite decision logging
- Add `buildCredentialRefTrace()` for credential resolution logging
- All traces are safe by construction — never include secret values
- Pure helpers, no call sites wired yet (done in PR 10)

## Test plan
- [x] Matched/ambiguous/missing/unauthenticated decisions produce correct traces
- [x] ask_missing_credential and ask_unauthenticated include pattern counts
- [x] Trace serialization never contains secret values
- [x] Credential ref trace builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
