### PR TITLE
fix: conditionally show pointer cursor and double-click on valid image paths

### DIFF
--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -84,22 +84,30 @@ public struct ToolCallChip: View {
                     // Image preview (for browser_screenshot etc.)
                     if let cachedImage = toolCall.cachedImage {
                         #if os(macOS)
-                        Image(nsImage: cachedImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxWidth: .infinity)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                            .padding(.horizontal, VSpacing.sm)
-                            .onTapGesture(count: 2) {
-                                let path = toolCall.inputFull
-                                guard !path.isEmpty,
-                                      FileManager.default.fileExists(atPath: path) else { return }
-                                NSWorkspace.shared.open(URL(fileURLWithPath: path))
-                            }
-                            .onHover { hovering in
-                                if hovering { NSCursor.pointingHand.push() }
-                                else { NSCursor.pop() }
-                            }
+                        let canOpenImage = !toolCall.inputFull.isEmpty
+                            && FileManager.default.fileExists(atPath: toolCall.inputFull)
+                        if canOpenImage {
+                            Image(nsImage: cachedImage)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: .infinity)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                                .padding(.horizontal, VSpacing.sm)
+                                .onTapGesture(count: 2) {
+                                    NSWorkspace.shared.open(URL(fileURLWithPath: toolCall.inputFull))
+                                }
+                                .onHover { hovering in
+                                    if hovering { NSCursor.pointingHand.push() }
+                                    else { NSCursor.pop() }
+                                }
+                        } else {
+                            Image(nsImage: cachedImage)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: .infinity)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                                .padding(.horizontal, VSpacing.sm)
+                        }
                         #elseif os(iOS)
                         Image(uiImage: cachedImage)
                             .resizable()


### PR DESCRIPTION
Only show the pointing hand cursor and enable double-click-to-open when the tool call's inputFull is a valid file path on disk. Prevents misleading cursor on browser_screenshot images and silent failures on relative paths.

Addresses feedback from PR #4876.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
