### PR TITLE
fix: prevent shell injection in sips by using execFileSync

### DIFF
--- a/assistant/src/tools/filesystem/view-image.ts
+++ b/assistant/src/tools/filesystem/view-image.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync, statSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { extname, join } from 'node:path';
@@ -57,10 +57,13 @@ function detectMediaType(buf: Buffer): string | null {
 function optimizeWithSips(srcPath: string): string | null {
   const tmpPath = join(tmpdir(), `vellum-view-image-${Date.now()}.jpg`);
   try {
-    execSync(
-      `sips --resampleHeightWidthMax ${OPTIMIZE_MAX_DIMENSION} -s format jpeg -s formatOptions ${OPTIMIZE_JPEG_QUALITY} ${JSON.stringify(srcPath)} --out ${JSON.stringify(tmpPath)}`,
-      { stdio: 'pipe', timeout: 15_000 },
-    );
+    execFileSync('sips', [
+      '--resampleHeightWidthMax', String(OPTIMIZE_MAX_DIMENSION),
+      '-s', 'format', 'jpeg',
+      '-s', 'formatOptions', String(OPTIMIZE_JPEG_QUALITY),
+      srcPath,
+      '--out', tmpPath,
+    ], { stdio: 'pipe', timeout: 15_000 });
     return tmpPath;
   } catch {
     return null;


### PR DESCRIPTION
Replace `execSync` with `execFileSync` and argument array in `optimizeWithSips` to prevent command injection via crafted filenames containing shell metacharacters like `$()` or backticks.

Addresses feedback from PR #4820.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
