### PR TITLE
fix: use monotonic text length for streaming scroll trigger

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -98,9 +98,11 @@ struct ChatView: View {
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     /// Uses utf8.count (O(1) for contiguous strings) instead of String.count (O(n) grapheme
     /// cluster enumeration) to avoid per-delta CPU cost on long streaming responses.
+    /// Uses total message text length (monotonically increasing) rather than the last segment's
+    /// length, which resets when a new text segment starts after a tool call.
     private var streamingScrollTrigger: Int {
         let last = messages.last
-        let textLen = last?.textSegments.last?.utf8.count ?? 0
+        let textLen = last?.text.utf8.count ?? 0
         return textLen + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }
 


### PR DESCRIPTION
Change streamingScrollTrigger to use total message text count instead of last segment byte count, which is non-monotonic across tool call boundaries and could miss scroll updates.

Addresses feedback from PR #4819.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
