### PR TITLE
feat: wire decision trace logging in shell + session manager

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -19,6 +19,10 @@ import { resolveById } from '../../credentials/resolve.js';
 import { listCredentialMetadata } from '../../credentials/metadata-store.js';
 import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
+import { buildDecisionTrace } from './logging.js';
+import { getLogger } from '../../../util/logger.js';
+
+const log = getLogger('proxy-session');
 
 const DEFAULT_CONFIG: ProxySessionConfig = {
   idleTimeoutMs: 5 * 60 * 1000, // 5 minutes
@@ -201,6 +205,7 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
           if (perCredentialBest.length > 1) return null;
 
           const { credId, tpl } = perCredentialBest[0];
+          log.debug({ host: req.hostname, pattern: tpl.hostPattern, credentialId: credId }, 'MITM rewrite: injecting credential');
 
           if (tpl.injectionType === 'header' && tpl.headerName) {
             const resolved = resolveById(credId);
@@ -248,6 +253,8 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
       hostname, port, reqPath,
       managed.session.credentialIds, templates, getAllKnown(), scheme,
     );
+
+    log.debug({ trace: buildDecisionTrace(hostname, port, reqPath, scheme, decision) }, 'Policy decision');
 
     switch (decision.kind) {
       case 'matched': {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -16,6 +16,7 @@ import {
 } from '../network/script-proxy/index.js';
 import { getDataDir } from '../../util/platform.js';
 import { resolveCredentialRef } from '../credentials/resolve.js';
+import { buildCredentialRefTrace } from '../network/script-proxy/logging.js';
 
 const log = getLogger('shell-tool');
 
@@ -127,11 +128,13 @@ class ShellTool implements Tool {
         }
       }
       if (unresolvedRefs.length > 0) {
+        log.warn({ trace: buildCredentialRefTrace(rawCredentialRefs, credentialIds, unresolvedRefs) }, 'Credential ref resolution failed');
         return {
           content: `Error: unknown credential reference(s): ${unresolvedRefs.join(', ')}. Use credential_store list to see available credentials.`,
           isError: true,
         };
       }
+      log.debug({ trace: buildCredentialRefTrace(rawCredentialRefs, credentialIds, []) }, 'Credential refs resolved');
     } else {
       credentialIds.push(...rawCredentialRefs);
     }


### PR DESCRIPTION
## Summary
- Log credential ref resolution traces (success and failure) in shell tool
- Log policy decision traces in session manager's policyCallback
- Log MITM rewrite injection decisions in session manager's rewriteCallback
- All traces use safe builders that never include secret values
- Logging at debug/warn level according to existing conventions

## Test plan
- [x] Shell credential ref tests pass (logging is passive)
- [x] Decision trace tests pass
- [x] No secret values in log output by construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
