### PR TITLE
fix: defer daemon-side queue cancellation until requestId is available

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -503,7 +503,15 @@ extension ChatViewModel {
             if let messageId = pendingMessageIds.first {
                 pendingMessageIds.removeFirst()
                 requestIdToMessageId[queued.requestId] = messageId
-                if let index = messages.firstIndex(where: { $0.id == messageId }) {
+                // If the user deleted this message before the ack arrived,
+                // forward the deletion to the daemon now that we have the requestId.
+                if pendingLocalDeletions.remove(messageId) != nil {
+                    do {
+                        try daemonClient.send(DeleteQueuedMessageMessage(sessionId: queued.sessionId, requestId: queued.requestId))
+                    } catch {
+                        log.error("Failed to send deferred delete_queued_message: \(error.localizedDescription)")
+                    }
+                } else if let index = messages.firstIndex(where: { $0.id == messageId }) {
                     messages[index].status = .queued(position: queued.position)
                 }
             }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -117,6 +117,9 @@ public final class ChatViewModel: ObservableObject {
     var requestIdToMessageId: [String: UUID] = [:]
     /// FIFO queue of user message UUIDs awaiting requestId assignment from the daemon.
     var pendingMessageIds: [UUID] = []
+    /// Messages deleted locally before the daemon's `message_queued` ack arrived.
+    /// Once the ack provides the requestId, the deletion is forwarded to the daemon.
+    var pendingLocalDeletions: Set<UUID> = []
     /// Tracks the current in-flight suggestion request so stale responses are ignored.
     var pendingSuggestionRequestId: String?
     /// Safety timer that force-resets the UI if the daemon never acknowledges
@@ -191,6 +194,7 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingQueuedCount = 0
                 self?.pendingMessageIds.removeAll()
                 self?.requestIdToMessageId.removeAll()
+                self?.pendingLocalDeletions.removeAll()
             }
         }
     }
@@ -572,6 +576,7 @@ public final class ChatViewModel: ObservableObject {
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
+            pendingLocalDeletions.removeAll()
             for i in messages.indices {
                 if case .queued = messages[i].status, messages[i].role == .user {
                     messages[i].status = .sent
@@ -614,6 +619,7 @@ public final class ChatViewModel: ObservableObject {
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
+            pendingLocalDeletions.removeAll()
             // Reset processing/queued messages to sent
             for i in messages.indices {
                 if case .queued = messages[i].status, messages[i].role == .user {
@@ -669,6 +675,7 @@ public final class ChatViewModel: ObservableObject {
             self.pendingQueuedCount = 0
             self.pendingMessageIds = []
             self.requestIdToMessageId = [:]
+            self.pendingLocalDeletions.removeAll()
             // Reset queued/processing messages to sent (matches other cancel-failure paths)
             for i in self.messages.indices {
                 if case .queued = self.messages[i].status, self.messages[i].role == .user {
@@ -729,7 +736,9 @@ public final class ChatViewModel: ObservableObject {
 
         // Find the requestId for this message
         guard let entry = requestIdToMessageId.first(where: { $0.value == messageId }) else {
-            // Message hasn't been assigned a requestId yet — remove it locally
+            // Message hasn't been assigned a requestId yet — remove it from the UI
+            // and defer the daemon-side cancellation until the ack arrives.
+            pendingLocalDeletions.insert(messageId)
             removeQueuedMessageLocally(messageId: messageId)
             return
         }
@@ -810,6 +819,7 @@ public final class ChatViewModel: ObservableObject {
         pendingQueuedCount = 0
         pendingMessageIds = []
         requestIdToMessageId = [:]
+        pendingLocalDeletions.removeAll()
         for i in messages.indices {
             if case .queued = messages[i].status, messages[i].role == .user {
                 messages[i].status = .sent


### PR DESCRIPTION
Track pending local deletions so that when a queued message is deleted before the daemon ack arrives, the deletion is sent to the daemon as soon as the requestId becomes known via the message_queued event. Prevents ghost processing and FIFO mapping corruption.

Addresses feedback from PR #4881.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
