### PR TITLE
fix: use monotonic text length sum for streaming scroll trigger

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -96,11 +96,11 @@ struct ChatView: View {
     var activeSubagents: [SubagentInfo] = []
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
-    /// Uses utf8.count (O(1) for contiguous strings) instead of String.count (O(n) grapheme
-    /// cluster enumeration) to avoid per-delta CPU cost on long streaming responses.
+    /// Sums utf8.count across all text segments so the value is monotonic even when new segments
+    /// are appended after tool calls. Each utf8.count is O(1) for contiguous Swift strings.
     private var streamingScrollTrigger: Int {
         let last = messages.last
-        let textLen = last?.textSegments.last?.utf8.count ?? 0
+        let textLen = last?.textSegments.reduce(0) { $0 + $1.utf8.count } ?? 0
         return textLen + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }
 


### PR DESCRIPTION
Sum utf8.count across all textSegments instead of only the last segment. The last-segment-only approach was non-monotonic: when a new text segment starts after a tool call, the length resets and can collide with the previous segment's length, causing missed auto-scroll updates.

Addresses feedback from PR #4819.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
