### PR TITLE
docs: document credential injection semantics + regression sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2673,6 +2673,16 @@ All proxy logging passes through sanitization helpers (`logging.ts`) that redact
 4. **No persistent trust rules for proxied bash** — `persistentDecisionsAllowed: false` prevents saving trust rules that could auto-allow proxied commands across sessions with different credential scopes.
 5. **Auditable routing** — Every CONNECT routing decision carries a deterministic `RouteReason` code (`mitm:credential_injection`, `tunnel:no_rewrite`, `tunnel:no_credentials`) for audit and testing.
 
+### Credential Proxy Injection
+
+The proxy subsystem intercepts outbound HTTPS requests and injects stored credentials via header injection. Key behaviors:
+
+- **Wildcard host patterns** (`*.example.com`) match both subdomains and the bare apex domain (`example.com`)
+- **Specificity selection**: When one credential has both exact and wildcard templates for the same host, the most specific match wins (exact > wildcard)
+- **Cross-credential ambiguity**: When multiple credentials match the same host, injection is blocked (fail-closed)
+- **Credential references**: The shell tool accepts both UUIDs and `service/field` format (e.g., `fal/api_key`); unknown references fail fast before command execution
+- **Diagnostic logging**: Policy and rewrite decisions are logged with structured traces that never include secret values
+
 ### Key Source Files
 
 | File | Role |

--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ The assistant can store and use credentials (API keys, tokens, passwords) withou
 
 See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full security model and data flow diagrams.
 
+#### Credential References
+
+When using `credential_ids` in proxied shell commands, you can use either format:
+- **UUID**: The canonical credential ID (shown in `credential_store list` output and `store`/`prompt` success messages)
+- **service/field**: A human-readable reference like `fal/api_key`
+
+Unknown references fail immediately with a clear error before the command executes.
+
+#### Wildcard Host Matching
+
+Wildcard patterns like `*.fal.run` match:
+- Subdomains: `api.fal.run`, `queue.fal.run`
+- The bare domain: `fal.run`
+
+When one credential has both an exact pattern (`api.fal.run`) and a wildcard pattern (`*.fal.run`), the exact match takes precedence.
+
 ## Dynamic Skill Authoring
 
 The assistant can create, test, and persist new skills at runtime. This is useful when no existing tool or skill covers a user's need.

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -250,10 +250,10 @@ describe('policyCallback credential injection', () => {
 
       const session = createSession(CONV_ID, ['cred-vanish'], undefined, DATA_DIR);
 
+      const started = await startSession(session.id);
+
       // Remove the resolution so the policyCallback's resolveById fails at request time
       resolveByIdResults.delete('cred-vanish');
-
-      const started = await startSession(session.id);
 
       const status = await proxyRequest(
         started.port!,


### PR DESCRIPTION
## Summary
- Document updated wildcard host matching semantics (apex-inclusive)
- Document `credential_ids` accepted formats (UUID and `service/field`)
- Document deterministic same-credential template precedence
- Document cross-credential ambiguity blocking
- Fix test ordering bug in `script-proxy-injection-runtime.test.ts` (resolveById mock was deleted before `startSession` built templates)
- Full regression sweep passed (all test files green)

## Regression sweep results
- credential-host-pattern-match.test.ts (19 tests)
- credential-selection.test.ts (20 tests)
- credential-resolve.test.ts (31 tests)
- script-proxy-router.test.ts (14 tests)
- script-proxy-policy.test.ts (24 tests)
- script-proxy-rewrite-specificity.test.ts (6 tests)
- script-proxy-decision-trace.test.ts (9 tests)
- shell-credential-ref.test.ts (6 tests)
- credential-vault.test.ts (40 tests)
- script-proxy-policy-runtime.test.ts (8 tests)
- script-proxy-injection-runtime.test.ts (9 tests, 1 fixed)

**Total: 186 tests, 0 failures**

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
