### PR TITLE
feat: add daemon emit support for open_tasks_window

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -176,6 +176,11 @@ export function createToolExecutor(
       }
     }
 
+    // Tell the client to open/focus the tasks window when the model lists tasks
+    if (name === 'task_list_show' && !result.isError) {
+      ctx.sendToClient({ type: 'open_tasks_window' });
+    }
+
     // Auto-refresh workspace surfaces when app files are edited
     if ((name === 'app_file_edit' || name === 'app_file_write') && !result.isError) {
       const appId = input.app_id as string | undefined;


### PR DESCRIPTION
## Summary
- Added daemon-side emit for `open_tasks_window` server message in `session-tool-setup.ts`
- When `task_list_show` tool executes successfully, sends `{ type: 'open_tasks_window' }` to the connected client
- Follows the existing post-execution side-effect pattern used by `app_update` and `app_file_edit` hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
