### PR TITLE
feat: wire macOS client callback for open_tasks_window

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -383,6 +383,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        daemonClient.onOpenTasksWindow = { [weak self] in
+            self?.showTasksWindow()
+        }
+
         // Handle escalation: text_qa -> computer_use via computer_use_request_control
         daemonClient.onTaskRouted = { [weak self] routed in
             guard let self else { return }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -273,6 +273,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
+    /// Called when the daemon wants us to open/focus the tasks window.
+    public var onOpenTasksWindow: (() -> Void)?
+
     /// Called when a subagent is spawned.
     public var onSubagentSpawned: ((IPCSubagentSpawned) -> Void)?
 
@@ -1391,6 +1394,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onWorkItemStatusChanged?(msg)
         case .workItemRunTaskResponse(let msg):
             onWorkItemRunTaskResponse?(msg)
+        case .openTasksWindow:
+            onOpenTasksWindow?()
         case .subagentSpawned(let msg):
             onSubagentSpawned?(msg)
         case .subagentStatusChanged(let msg):


### PR DESCRIPTION
## Summary
- Added `onOpenTasksWindow` callback property to `DaemonClient` that fires when the daemon sends an `open_tasks_window` server message
- Added dispatch case in `DaemonClient`'s server message switch to invoke the callback
- Wired `AppDelegate` to call `showTasksWindow()` (which handles create-or-focus) when the callback fires

## Test plan
- [ ] Verify the macOS app compiles cleanly (`swift build` passes)
- [ ] Trigger an `open_tasks_window` IPC message from the daemon and confirm the tasks window opens
- [ ] If the tasks window is already open, confirm it receives focus instead of creating a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
