### PR TITLE
chore: upgrade Sonnet model from 4.5 to 4.6

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -10,7 +10,7 @@ let _lastStreamOptions: Record<string, unknown> | null = null;
 
 const fakeResponse = {
   content: [{ type: 'text', text: 'Hello' }],
-  model: 'claude-sonnet-4-5-20250929',
+  model: 'claude-sonnet-4-6',
   usage: {
     input_tokens: 100,
     output_tokens: 20,
@@ -99,7 +99,7 @@ describe('AnthropicProvider — Cache-Control Characterization', () => {
   beforeEach(() => {
     lastStreamParams = null;
     _lastStreamOptions = null;
-    provider = new AnthropicProvider('sk-ant-test', 'claude-sonnet-4-5-20250929');
+    provider = new AnthropicProvider('sk-ant-test', 'claude-sonnet-4-6');
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/key-migration.test.ts
+++ b/assistant/src/__tests__/key-migration.test.ts
@@ -95,7 +95,7 @@ describe('key migration', () => {
     const configPath = CONFIG_PATH;
     writeFileSync(configPath, JSON.stringify({
       provider: 'anthropic',
-      model: 'claude-sonnet-4-5-20250929',
+      model: 'claude-sonnet-4-6',
     }));
 
     const config = loadConfig();
@@ -104,7 +104,7 @@ describe('key migration', () => {
     // Config file should be unchanged
     const rawJson = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(rawJson.provider).toBe('anthropic');
-    expect(rawJson.model).toBe('claude-sonnet-4-5-20250929');
+    expect(rawJson.model).toBe('claude-sonnet-4-6');
   });
 
   test('does not migrate empty apiKeys object', () => {

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -104,8 +104,8 @@ describe('resolvePricing', () => {
   });
 
   describe('prefix matching', () => {
-    test('matches claude-sonnet-4-5-20250929 via claude-sonnet-4 prefix', () => {
-      const result = resolvePricing('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000);
+    test('matches claude-sonnet-4-6 via claude-sonnet-4 prefix', () => {
+      const result = resolvePricing('anthropic', 'claude-sonnet-4-6', 1_000_000, 1_000_000);
       expect(result.pricingStatus).toBe('priced');
       expect(result.estimatedCostUsd).toBe(3 + 15);
     });
@@ -159,7 +159,7 @@ describe('resolvePricingWithOverrides', () => {
     const overrides: ModelPricingOverride[] = [
       { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 5, outputPer1M: 25 },
     ];
-    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000, overrides);
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-6', 1_000_000, 1_000_000, overrides);
     expect(result.pricingStatus).toBe('priced');
     expect(result.estimatedCostUsd).toBe(5 + 25);
   });
@@ -200,7 +200,7 @@ describe('resolvePricingWithOverrides', () => {
       { provider: 'anthropic', modelPattern: 'claude-sonnet', inputPer1M: 1, outputPer1M: 1 },
       { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 99, outputPer1M: 99 },
     ];
-    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000, overrides);
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-6', 1_000_000, 1_000_000, overrides);
     expect(result.pricingStatus).toBe('priced');
     expect(result.estimatedCostUsd).toBe(99 + 99);
   });
@@ -208,7 +208,7 @@ describe('resolvePricingWithOverrides', () => {
 
 describe('estimateCost', () => {
   test('returns a number for known Anthropic model', () => {
-    const cost = estimateCost(1_000_000, 1_000_000, 'claude-sonnet-4-5-20250929', 'anthropic');
+    const cost = estimateCost(1_000_000, 1_000_000, 'claude-sonnet-4-6', 'anthropic');
     expect(typeof cost).toBe('number');
     expect(cost).toBe(3 + 15);
   });

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -40,7 +40,7 @@ mock.module('../config/loader.js', () => ({
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
       plannerModel: 'claude-haiku-4-5-20251001',
-      synthesizerModel: 'claude-sonnet-4-5-20250929',
+      synthesizerModel: 'claude-sonnet-4-6',
     },
   }),
 }));

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -31,7 +31,7 @@ mock.module('../config/loader.js', () => ({
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
       plannerModel: 'claude-haiku-4-5-20251001',
-      synthesizerModel: 'claude-sonnet-4-5-20250929',
+      synthesizerModel: 'claude-sonnet-4-6',
     },
   }),
 }));

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -22,7 +22,7 @@ mock.module('../config/loader.js', () => ({
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
       plannerModel: 'claude-haiku-4-5-20251001',
-      synthesizerModel: 'claude-sonnet-4-5-20250929',
+      synthesizerModel: 'claude-sonnet-4-6',
     },
   }),
   getSwarmDisabledConfig: () => ({

--- a/assistant/src/config/bundled-skills/claude-code/TOOLS.json
+++ b/assistant/src/config/bundled-skills/claude-code/TOOLS.json
@@ -23,7 +23,7 @@
           },
           "model": {
             "type": "string",
-            "description": "Model to use (defaults to claude-sonnet-4-5-20250929)"
+            "description": "Model to use (defaults to claude-sonnet-4-6)"
           },
           "profile": {
             "type": "string",

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -175,7 +175,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     maxRetriesPerTask: 1,
     workerTimeoutSec: 900,
     plannerModel: 'claude-haiku-4-5-20251001',
-    synthesizerModel: 'claude-sonnet-4-5-20250929',
+    synthesizerModel: 'claude-sonnet-4-6',
   },
   skills: {
     entries: {},

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -735,7 +735,7 @@ export const SwarmConfigSchema = z.object({
     .default('claude-haiku-4-5-20251001'),
   synthesizerModel: z
     .string({ error: 'swarm.synthesizerModel must be a string' })
-    .default('claude-sonnet-4-5-20250929'),
+    .default('claude-sonnet-4-6'),
 });
 
 export const SkillsConfigSchema = z.object({
@@ -939,7 +939,7 @@ export const AssistantConfigSchema = z.object({
     maxRetriesPerTask: 1,
     workerTimeoutSec: 900,
     plannerModel: 'claude-haiku-4-5-20251001',
-    synthesizerModel: 'claude-sonnet-4-5-20250929',
+    synthesizerModel: 'claude-sonnet-4-6',
   }),
   skills: SkillsConfigSchema.default({
     entries: {},

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -19,20 +19,20 @@ export type SlashResolution =
 
 const AVAILABLE_MODELS = [
   'claude-opus-4-6',
-  'claude-sonnet-4-5-20250929',
+  'claude-sonnet-4-6',
   'claude-haiku-4-5-20251001',
 ] as const;
 
 const MODEL_DISPLAY_NAMES: Record<string, string> = {
   'claude-opus-4-6': 'Claude Opus 4.6',
-  'claude-sonnet-4-5-20250929': 'Claude Sonnet 4.5',
+  'claude-sonnet-4-6': 'Claude Sonnet 4.6',
   'claude-haiku-4-5-20251001': 'Claude Haiku 4.5',
 };
 
 const PROVIDER_MODEL_SHORTCUTS: Record<string, { provider: string; model: string; displayName: string }> = {
   // Anthropic
   'opus': { provider: 'anthropic', model: 'claude-opus-4-6', displayName: 'Claude Opus 4.6' },
-  'sonnet': { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929', displayName: 'Claude Sonnet 4.5' },
+  'sonnet': { provider: 'anthropic', model: 'claude-sonnet-4-6', displayName: 'Claude Sonnet 4.6' },
   'haiku': { provider: 'anthropic', model: 'claude-haiku-4-5-20251001', displayName: 'Claude Haiku 4.5' },
 
   // OpenAI

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -239,7 +239,7 @@ export async function generateSummary(session: WatchSession): Promise<void> {
     ].join('\n');
 
     const response = await client.messages.create({
-      model: 'claude-sonnet-4-5-20250929',
+      model: 'claude-sonnet-4-6',
       max_tokens: 2000,
       system: systemPrompt,
       messages: [{ role: 'user', content: userContent }],

--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -53,7 +53,7 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
           prompt: input.prompt,
           options: {
             cwd: input.workingDir,
-            model: input.model ?? 'claude-sonnet-4-5-20250929',
+            model: input.model ?? 'claude-sonnet-4-6',
             canUseTool,
             permissionMode: 'default',
             maxTurns: 30,

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -213,7 +213,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       objective: plan.objective,
       results: allResults,
       provider: opts.synthesisProvider,
-      model: opts.synthesisModel ?? 'claude-sonnet-4-5-20250929',
+      model: opts.synthesisModel ?? 'claude-sonnet-4-6',
     });
   } else {
     if (!signal?.aborted) onStatus?.({ kind: 'synthesis_started' });

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -49,7 +49,7 @@ export const claudeCodeTool: Tool = {
           },
           model: {
             type: 'string',
-            description: 'Model to use (defaults to claude-sonnet-4-5-20250929)',
+            description: 'Model to use (defaults to claude-sonnet-4-6)',
           },
           profile: {
             type: 'string',
@@ -70,7 +70,7 @@ export const claudeCodeTool: Tool = {
     const prompt = input.prompt as string;
     const workingDir = (input.working_dir as string) || context.workingDir;
     const resumeSessionId = input.resume as string | undefined;
-    const model = (input.model as string) || 'claude-sonnet-4-5-20250929';
+    const model = (input.model as string) || 'claude-sonnet-4-6';
     const profileName = (input.profile as WorkerProfile | undefined) ?? 'general';
 
     // Validate profile

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -11,11 +11,11 @@ struct ModelSelectionStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
-    @State private var selectedModel = "claude-sonnet-4-5-20250929"
+    @State private var selectedModel = "claude-sonnet-4-6"
 
     private static let models: [(id: String, name: String, detail: String)] = [
         ("claude-opus-4-6", "Opus 4.6", "Most capable"),
-        ("claude-sonnet-4-5-20250929", "Sonnet 4.5", "Balanced"),
+        ("claude-sonnet-4-6", "Sonnet 4.6", "Balanced"),
         ("claude-haiku-4-5-20251001", "Haiku 4.5", "Fastest"),
     ]
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -23,13 +23,13 @@ public final class SettingsStore: ObservableObject {
 
     static let availableModels: [String] = [
         "claude-opus-4-6",
-        "claude-sonnet-4-5-20250929",
+        "claude-sonnet-4-6",
         "claude-haiku-4-5-20251001",
     ]
 
     static let modelDisplayNames: [String: String] = [
         "claude-opus-4-6": "Claude Opus 4.6",
-        "claude-sonnet-4-5-20250929": "Claude Sonnet 4.5",
+        "claude-sonnet-4-6": "Claude Sonnet 4.6",
         "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
     ]
 

--- a/clients/macos/vellum-assistant/Inference/AnthropicClient.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicClient.swift
@@ -52,7 +52,7 @@ final class AnthropicClient {
     /// with exponential backoff. Client errors (400, 401, 403, etc.) are thrown immediately.
     ///
     /// - Parameters:
-    ///   - model: The model identifier (e.g. "claude-sonnet-4-5-20250929").
+    ///   - model: The model identifier (e.g. "claude-sonnet-4-6").
     ///   - maxTokens: Maximum tokens for the response.
     ///   - system: The system prompt string.
     ///   - tools: Array of tool definition dictionaries.

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -20,7 +20,7 @@ public struct ModelListBubble: View {
     private static let providerGroups: [(key: String, name: String, models: [(cmd: String, model: String, display: String)])] = [
         ("anthropic", "Anthropic", [
             ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
-            ("sonnet", "claude-sonnet-4-5-20250929", "Claude Sonnet 4.5"),
+            ("sonnet", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
             ("haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
         ]),
         ("openai", "OpenAI", [


### PR DESCRIPTION
## Summary
- Updated all model ID references from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6` across backend, macOS clients, configs, and tests
- Updated display names from "Sonnet 4.5" to "Sonnet 4.6" in all UI-facing strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
