### PR TITLE
feat: add Opus 4.6 Fast mode support

### DIFF
--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -19,12 +19,14 @@ export type SlashResolution =
 
 const AVAILABLE_MODELS = [
   'claude-opus-4-6',
+  'claude-opus-4-6-fast',
   'claude-sonnet-4-6',
   'claude-haiku-4-5-20251001',
 ] as const;
 
 const MODEL_DISPLAY_NAMES: Record<string, string> = {
   'claude-opus-4-6': 'Claude Opus 4.6',
+  'claude-opus-4-6-fast': 'Claude Opus 4.6 Fast',
   'claude-sonnet-4-6': 'Claude Sonnet 4.6',
   'claude-haiku-4-5-20251001': 'Claude Haiku 4.5',
 };
@@ -32,6 +34,7 @@ const MODEL_DISPLAY_NAMES: Record<string, string> = {
 const PROVIDER_MODEL_SHORTCUTS: Record<string, { provider: string; model: string; displayName: string }> = {
   // Anthropic
   'opus': { provider: 'anthropic', model: 'claude-opus-4-6', displayName: 'Claude Opus 4.6' },
+  'opus-fast': { provider: 'anthropic', model: 'claude-opus-4-6-fast', displayName: 'Claude Opus 4.6 Fast' },
   'sonnet': { provider: 'anthropic', model: 'claude-sonnet-4-6', displayName: 'Claude Sonnet 4.6' },
   'haiku': { provider: 'anthropic', model: 'claude-haiku-4-5-20251001', displayName: 'Claude Haiku 4.5' },
 

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -341,10 +341,13 @@ export class AnthropicProvider implements Provider {
   private model: string;
   private useNativeWebSearch: boolean;
   private streamTimeoutMs: number;
+  private fastMode: boolean;
 
   constructor(apiKey: string, model: string, options: { useNativeWebSearch?: boolean; streamTimeoutMs?: number } = {}) {
     this.client = new Anthropic({ apiKey });
-    this.model = model;
+    // Models ending in "-fast" use the beta fast-mode API
+    this.fastMode = model.endsWith('-fast');
+    this.model = this.fastMode ? model.slice(0, -'-fast'.length) : model;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
     this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
   }
@@ -506,7 +509,12 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      const stream = this.client.messages.stream(params, { signal: timeoutController.signal });
+      const stream = this.fastMode
+        ? this.client.beta.messages.stream(
+            { ...params, betas: ['fast-mode-2026-02-01'], speed: 'fast' } as Parameters<typeof this.client.beta.messages.stream>[0],
+            { signal: timeoutController.signal },
+          )
+        : this.client.messages.stream(params, { signal: timeoutController.signal });
 
       stream.on("text", (text) => {
         onEvent?.({ type: "text_delta", text });

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -13,6 +13,7 @@ interface ModelPricing {
 const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   anthropic: {
     'claude-opus-4': { inputPer1M: 15, outputPer1M: 75 },
+    'claude-opus-4-6-fast': { inputPer1M: 30, outputPer1M: 150 },
     'claude-sonnet-4': { inputPer1M: 3, outputPer1M: 15 },
     'claude-haiku-4': { inputPer1M: 0.80, outputPer1M: 4 },
   },

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -15,6 +15,7 @@ struct ModelSelectionStepView: View {
 
     private static let models: [(id: String, name: String, detail: String)] = [
         ("claude-opus-4-6", "Opus 4.6", "Most capable"),
+        ("claude-opus-4-6-fast", "Opus 4.6 Fast", "Fastest Opus"),
         ("claude-sonnet-4-6", "Sonnet 4.6", "Balanced"),
         ("claude-haiku-4-5-20251001", "Haiku 4.5", "Fastest"),
     ]

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -23,12 +23,14 @@ public final class SettingsStore: ObservableObject {
 
     static let availableModels: [String] = [
         "claude-opus-4-6",
+        "claude-opus-4-6-fast",
         "claude-sonnet-4-6",
         "claude-haiku-4-5-20251001",
     ]
 
     static let modelDisplayNames: [String: String] = [
         "claude-opus-4-6": "Claude Opus 4.6",
+        "claude-opus-4-6-fast": "Claude Opus 4.6 Fast",
         "claude-sonnet-4-6": "Claude Sonnet 4.6",
         "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
     ]

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -20,6 +20,7 @@ public struct ModelListBubble: View {
     private static let providerGroups: [(key: String, name: String, models: [(cmd: String, model: String, display: String)])] = [
         ("anthropic", "Anthropic", [
             ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
+            ("opus-fast", "claude-opus-4-6-fast", "Claude Opus 4.6 Fast"),
             ("sonnet", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
             ("haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
         ]),


### PR DESCRIPTION
## Summary
- Added `claude-opus-4-6-fast` model variant that uses Anthropic's beta fast-mode API (`speed: "fast"`) for up to 2.5x faster output token generation
- Detects `-fast` suffix in the Anthropic provider, strips it for the real model ID, and switches to `client.beta.messages.stream()` with `betas: ["fast-mode-2026-02-01"]`
- Added `/opus-fast` shortcut, pricing ($30/$150 per MTok), and model entries across Settings, Onboarding, and ModelListBubble UIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
