### PR TITLE
fix: mock resolveCredentialRef in shell proxy mode tests

### DIFF
--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -110,6 +110,14 @@ mock.module('../tools/network/script-proxy/index.js', () => ({
   stopAllSessions: async () => {},
 }));
 
+mock.module('../tools/credentials/resolve.js', () => ({
+  resolveCredentialRef: (ref: string) => ({ credentialId: ref }),
+}));
+
+mock.module('../tools/network/script-proxy/logging.js', () => ({
+  buildCredentialRefTrace: (rawRefs: string[], resolvedIds: string[], unresolvedRefs: string[]) => ({ rawRefs, resolvedIds, unresolvedRefs }),
+}));
+
 import { shellTool } from '../tools/terminal/shell.js';
 import type { ToolContext } from '../tools/types.js';
 


### PR DESCRIPTION
## Summary
- Adds `resolveCredentialRef` and `buildCredentialRefTrace` mocks to `shell-tool-proxy-mode.test.ts`
- Fixes 2 test failures caused by the MITM fix series adding fail-fast credential resolution

## Test plan
- [x] `bun test shell-tool-proxy-mode.test.ts` — 9 pass, 0 fail
- [x] `bun test shell-credential-ref.test.ts` — 6 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
