### PR TITLE
feat: add CDP network recording and cookie extraction

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -4,6 +4,7 @@ import { getDataDir } from '../../util/platform.js';
 import { getLogger } from '../../util/logger.js';
 import { checkBrowserRuntime } from './runtime-check.js';
 import { authSessionCache } from './auth-cache.js';
+import type { ExtractedCredential } from './network-recording-types.js';
 
 const log = getLogger('browser-manager');
 
@@ -623,6 +624,66 @@ class BrowserManager {
 
       this.handoffResolvers.set(sessionId, resolver);
     });
+  }
+
+  /**
+   * Get the raw Playwright page for a session (for CDP session creation).
+   * Used by NetworkRecorder to create its own CDP session.
+   */
+  getRawPage(sessionId: string): unknown | undefined {
+    return this.rawPages.get(sessionId);
+  }
+
+  /**
+   * Get any available raw page (for network recording when we don't care which page).
+   */
+  getAnyRawPage(): unknown | undefined {
+    for (const page of this.rawPages.values()) {
+      return page;
+    }
+    return undefined;
+  }
+
+  /**
+   * Extract cookies from the browser via CDP, optionally filtered by domain.
+   */
+  async extractCookies(domain?: string): Promise<ExtractedCredential[]> {
+    if (!this.browserCdpSession) return [];
+    try {
+      const result = await this.browserCdpSession.send('Network.getAllCookies') as {
+        cookies: Array<{
+          name: string;
+          value: string;
+          domain: string;
+          path: string;
+          httpOnly: boolean;
+          secure: boolean;
+          expires: number;
+        }>;
+      };
+
+      let cookies = result.cookies ?? [];
+      if (domain) {
+        cookies = cookies.filter(c =>
+          c.domain === domain ||
+          c.domain === `.${domain}` ||
+          c.domain.endsWith(`.${domain}`),
+        );
+      }
+
+      return cookies.map(c => ({
+        name: c.name,
+        value: c.value,
+        domain: c.domain,
+        path: c.path,
+        httpOnly: c.httpOnly,
+        secure: c.secure,
+        expires: c.expires > 0 ? c.expires : undefined,
+      }));
+    } catch (err) {
+      log.warn({ err }, 'Failed to extract cookies via CDP');
+      return [];
+    }
   }
 
   hasContext(): boolean {

--- a/assistant/src/tools/browser/network-recorder.ts
+++ b/assistant/src/tools/browser/network-recorder.ts
@@ -82,6 +82,9 @@ class DirectCDPClient {
       this.ws.close();
       this.ws = null;
     }
+    for (const cb of this.callbacks.values()) {
+      cb.reject(new Error('CDP client closed'));
+    }
     this.callbacks.clear();
     this.eventHandlers.clear();
   }
@@ -96,8 +99,11 @@ export class NetworkRecorder {
   private attachedTargetIds = new Set<string>();
   private targetPollTimer?: ReturnType<typeof setInterval>;
 
-  /** Called when a successful postLoginQuery response is detected. */
+  /** Called when a successful login-indicating response is detected. */
   onLoginDetected?: () => void;
+
+  /** URL patterns that indicate a successful login (checked via `includes`). */
+  loginSignals: string[] = [];
 
   constructor(targetDomain?: string) {
     this.targetDomain = targetDomain;
@@ -151,6 +157,7 @@ export class NetworkRecorder {
             await this.attachToTarget(page.webSocketDebuggerUrl);
             log.info({ targetId: page.id }, 'Attached to new tab');
           } catch (err) {
+            this.attachedTargetIds.delete(page.id);
             log.warn({ err, targetId: page.id }, 'Failed to attach to page target');
           }
         }
@@ -202,6 +209,7 @@ export class NetworkRecorder {
     const result = Array.from(this.entries.values());
     this.entries.clear();
     this.attachedTargetIds.clear();
+    this.loginDetectedFired = false;
     log.info({ entryCount: result.length }, 'Network recording stopped');
     return result;
   }
@@ -250,13 +258,6 @@ export class NetworkRecorder {
     }
   }
 
-  /** Patterns that indicate a successful login. */
-  private static readonly LOGIN_SIGNALS = [
-    '/graphql/postLoginQuery',
-    '/graphql/homePageFacetFeed',
-    '/graphql/getConsumerOrdersWithDetails',
-  ];
-
   private loginDetectedFired = false;
 
   private handleRequestWillBeSent(params: Record<string, unknown>): void {
@@ -302,7 +303,8 @@ export class NetworkRecorder {
       status === 200 &&
       this.onLoginDetected &&
       !this.loginDetectedFired &&
-      NetworkRecorder.LOGIN_SIGNALS.some(sig => entry.request.url.includes(sig))
+      this.loginSignals.length > 0 &&
+      this.loginSignals.some(sig => entry.request.url.includes(sig))
     ) {
       this.loginDetectedFired = true;
       log.info({ url: entry.request.url.slice(0, 120) }, 'Login detected — will auto-stop in 5s');

--- a/assistant/src/tools/browser/network-recorder.ts
+++ b/assistant/src/tools/browser/network-recorder.ts
@@ -1,0 +1,346 @@
+/**
+ * CDP Network recorder for Ride Shotgun "learn" mode.
+ *
+ * Connects directly to Chrome's CDP WebSocket endpoint to record
+ * Network.* events across all tabs the user browses.
+ */
+
+import { getLogger } from '../../util/logger.js';
+import type { NetworkRecordedEntry, NetworkRecordedRequest, ExtractedCredential } from './network-recording-types.js';
+
+const log = getLogger('network-recorder');
+
+/** Max response body size to capture (64 KB). */
+const MAX_BODY_SIZE = 64 * 1024;
+
+/** CDP endpoint to discover targets. */
+const CDP_BASE = 'http://localhost:9222';
+
+/**
+ * Minimal CDP client over WebSocket — talks the Chrome DevTools Protocol directly
+ * without needing Playwright, so it can attach to the user's real browsing session.
+ */
+class DirectCDPClient {
+  private ws: WebSocket | null = null;
+  private nextId = 1;
+  private callbacks = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private eventHandlers = new Map<string, Array<(params: Record<string, unknown>) => void>>();
+
+  async connect(wsUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(wsUrl);
+      ws.onopen = () => {
+        this.ws = ws;
+        resolve();
+      };
+      ws.onerror = (e) => reject(new Error(`CDP WebSocket error: ${e}`));
+      ws.onclose = () => { this.ws = null; };
+      ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(typeof event.data === 'string' ? event.data : '');
+          if (msg.id != null) {
+            const cb = this.callbacks.get(msg.id);
+            if (cb) {
+              this.callbacks.delete(msg.id);
+              if (msg.error) {
+                cb.reject(new Error(msg.error.message));
+              } else {
+                cb.resolve(msg.result);
+              }
+            }
+          } else if (msg.method) {
+            const handlers = this.eventHandlers.get(msg.method);
+            if (handlers) {
+              for (const h of handlers) h(msg.params ?? {});
+            }
+          }
+        } catch {}
+      };
+    });
+  }
+
+  async send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    if (!this.ws) throw new Error('Not connected');
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.callbacks.set(id, { resolve, reject });
+      this.ws!.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  on(event: string, handler: (params: Record<string, unknown>) => void): void {
+    let handlers = this.eventHandlers.get(event);
+    if (!handlers) {
+      handlers = [];
+      this.eventHandlers.set(event, handlers);
+    }
+    handlers.push(handler);
+  }
+
+  close(): void {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.callbacks.clear();
+    this.eventHandlers.clear();
+  }
+}
+
+export class NetworkRecorder {
+  private cdp: DirectCDPClient | null = null;
+  private entries = new Map<string, NetworkRecordedEntry>();
+  private targetDomain?: string;
+  private running = false;
+  private cdpBaseUrl = CDP_BASE;
+  private attachedTargetIds = new Set<string>();
+  private targetPollTimer?: ReturnType<typeof setInterval>;
+
+  /** Called when a successful postLoginQuery response is detected. */
+  onLoginDetected?: () => void;
+
+  constructor(targetDomain?: string) {
+    this.targetDomain = targetDomain;
+  }
+
+  /**
+   * Connect directly to Chrome's CDP endpoint and start recording network events.
+   * Attaches to the browser-level target so events from all tabs are captured.
+   */
+  async startDirect(cdpBaseUrl: string = CDP_BASE): Promise<void> {
+    if (this.running) return;
+    this.cdpBaseUrl = cdpBaseUrl;
+
+    // Discover the browser's WebSocket debugger URL
+    const versionRes = await fetch(`${cdpBaseUrl}/json/version`);
+    const version = await versionRes.json() as { webSocketDebuggerUrl: string };
+    const wsUrl = version.webSocketDebuggerUrl;
+
+    if (!wsUrl) {
+      throw new Error('Chrome CDP: no webSocketDebuggerUrl found');
+    }
+
+    log.info({ wsUrl }, 'Connecting to Chrome CDP');
+    this.cdp = new DirectCDPClient();
+    await this.cdp.connect(wsUrl);
+    this.running = true;
+
+    // Attach to all existing page targets
+    await this.discoverAndAttachTargets();
+
+    // Poll for new tabs every 2 seconds so we catch tabs opened after recording starts
+    this.targetPollTimer = setInterval(() => {
+      this.discoverAndAttachTargets().catch(err => {
+        log.debug({ err }, 'Target discovery poll failed');
+      });
+    }, 2000);
+
+    log.info({ targetDomain: this.targetDomain, attachedCount: this.attachedTargetIds.size }, 'Network recording started');
+  }
+
+  private async discoverAndAttachTargets(): Promise<void> {
+    if (!this.running) return;
+    try {
+      const res = await fetch(`${this.cdpBaseUrl}/json`);
+      const pages = await res.json() as Array<{ id: string; type: string; webSocketDebuggerUrl: string }>;
+
+      for (const page of pages) {
+        if (page.type === 'page' && page.webSocketDebuggerUrl && !this.attachedTargetIds.has(page.id)) {
+          try {
+            this.attachedTargetIds.add(page.id);
+            await this.attachToTarget(page.webSocketDebuggerUrl);
+            log.info({ targetId: page.id }, 'Attached to new tab');
+          } catch (err) {
+            log.warn({ err, targetId: page.id }, 'Failed to attach to page target');
+          }
+        }
+      }
+    } catch {
+      // CDP endpoint may be temporarily unavailable
+    }
+  }
+
+  private pageClients: DirectCDPClient[] = [];
+
+  private async attachToTarget(wsUrl: string): Promise<void> {
+    const client = new DirectCDPClient();
+    await client.connect(wsUrl);
+
+    client.on('Network.requestWillBeSent', (params) => this.handleRequestWillBeSent(params));
+    client.on('Network.responseReceived', (params) => this.handleResponseReceived(params));
+    client.on('Network.loadingFinished', (params) => this.handleLoadingFinished(params, client));
+
+    await client.send('Network.enable');
+    this.pageClients.push(client);
+  }
+
+  async stop(): Promise<NetworkRecordedEntry[]> {
+    if (!this.running) return [];
+    this.running = false;
+
+    // Stop polling for new tabs
+    if (this.targetPollTimer) {
+      clearInterval(this.targetPollTimer);
+      this.targetPollTimer = undefined;
+    }
+
+    // Close all page-level CDP connections
+    for (const client of this.pageClients) {
+      try {
+        await client.send('Network.disable');
+      } catch {}
+      client.close();
+    }
+    this.pageClients = [];
+
+    // Close browser-level connection
+    if (this.cdp) {
+      this.cdp.close();
+      this.cdp = null;
+    }
+
+    const result = Array.from(this.entries.values());
+    this.entries.clear();
+    this.attachedTargetIds.clear();
+    log.info({ entryCount: result.length }, 'Network recording stopped');
+    return result;
+  }
+
+  /**
+   * Extract cookies via CDP Network.getAllCookies on the first page client.
+   */
+  async extractCookies(domain?: string): Promise<ExtractedCredential[]> {
+    const client = this.pageClients[0];
+    if (!client) return [];
+    try {
+      const result = await client.send('Network.getAllCookies') as {
+        cookies: Array<{
+          name: string; value: string; domain: string; path: string;
+          httpOnly: boolean; secure: boolean; expires: number;
+        }>;
+      };
+      let cookies = result.cookies ?? [];
+      if (domain) {
+        cookies = cookies.filter(c =>
+          c.domain === domain || c.domain === `.${domain}` || c.domain.endsWith(`.${domain}`),
+        );
+      }
+      return cookies.map(c => ({
+        name: c.name, value: c.value, domain: c.domain, path: c.path,
+        httpOnly: c.httpOnly, secure: c.secure,
+        expires: c.expires > 0 ? c.expires : undefined,
+      }));
+    } catch (err) {
+      log.warn({ err }, 'Failed to extract cookies');
+      return [];
+    }
+  }
+
+  getEntries(): NetworkRecordedEntry[] {
+    return Array.from(this.entries.values());
+  }
+
+  private matchesDomain(url: string): boolean {
+    if (!this.targetDomain) return true;
+    try {
+      const hostname = new URL(url).hostname;
+      return hostname === this.targetDomain || hostname.endsWith(`.${this.targetDomain}`);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Patterns that indicate a successful login. */
+  private static readonly LOGIN_SIGNALS = [
+    '/graphql/postLoginQuery',
+    '/graphql/homePageFacetFeed',
+    '/graphql/getConsumerOrdersWithDetails',
+  ];
+
+  private loginDetectedFired = false;
+
+  private handleRequestWillBeSent(params: Record<string, unknown>): void {
+    const resourceType = params.type as string;
+    if (resourceType !== 'XHR' && resourceType !== 'Fetch') return;
+
+    const request = params.request as Record<string, unknown>;
+    const url = request.url as string;
+    if (!this.matchesDomain(url)) return;
+
+    const requestId = params.requestId as string;
+    const headers = (request.headers as Record<string, string>) ?? {};
+    const method = (request.method as string) ?? 'GET';
+    const postData = request.postData as string | undefined;
+
+    log.debug({ url: url.slice(0, 120), method, requestId }, 'Request captured');
+
+    const recordedRequest: NetworkRecordedRequest = { method, url, headers, postData };
+    const entry: NetworkRecordedEntry = {
+      requestId,
+      resourceType,
+      timestamp: (params.timestamp as number) ?? Date.now() / 1000,
+      request: recordedRequest,
+    };
+    this.entries.set(requestId, entry);
+  }
+
+  private handleResponseReceived(params: Record<string, unknown>): void {
+    const requestId = params.requestId as string;
+    const entry = this.entries.get(requestId);
+    if (!entry) return;
+
+    const response = params.response as Record<string, unknown>;
+    const status = (response.status as number) ?? 0;
+    entry.response = {
+      status,
+      headers: (response.headers as Record<string, string>) ?? {},
+      mimeType: (response.mimeType as string) ?? '',
+    };
+
+    // Auto-detect login: check for any of the login signal URLs
+    if (
+      status === 200 &&
+      this.onLoginDetected &&
+      !this.loginDetectedFired &&
+      NetworkRecorder.LOGIN_SIGNALS.some(sig => entry.request.url.includes(sig))
+    ) {
+      this.loginDetectedFired = true;
+      log.info({ url: entry.request.url.slice(0, 120) }, 'Login detected — will auto-stop in 5s');
+      // Delay to let remaining network requests (cookies, session data) settle
+      setTimeout(() => this.onLoginDetected?.(), 5000);
+    }
+  }
+
+  private handleLoadingFinished(params: Record<string, unknown>, client: DirectCDPClient): void {
+    const requestId = params.requestId as string;
+    const entry = this.entries.get(requestId);
+    if (!entry || !entry.response) return;
+
+    const mimeType = entry.response.mimeType;
+    if (!mimeType.includes('json') && !mimeType.includes('text')) return;
+
+    this.fetchResponseBody(requestId, entry, client);
+  }
+
+  private async fetchResponseBody(requestId: string, entry: NetworkRecordedEntry, client: DirectCDPClient): Promise<void> {
+    if (!this.running) return;
+    try {
+      const result = await client.send('Network.getResponseBody', { requestId }) as {
+        body: string;
+        base64Encoded: boolean;
+      };
+
+      if (result.body && entry.response) {
+        const body = result.base64Encoded
+          ? Buffer.from(result.body, 'base64').toString('utf-8')
+          : result.body;
+
+        entry.response.body = body.length > MAX_BODY_SIZE
+          ? body.slice(0, MAX_BODY_SIZE) + '...[truncated]'
+          : body;
+      }
+    } catch {
+      // Response body may not be available
+    }
+  }
+}

--- a/assistant/src/tools/browser/network-recording-types.ts
+++ b/assistant/src/tools/browser/network-recording-types.ts
@@ -1,0 +1,49 @@
+/** Types for CDP network recording used by Ride Shotgun "learn" mode. */
+
+export interface NetworkRecordedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  postData?: string;
+}
+
+export interface NetworkRecordedResponse {
+  status: number;
+  headers: Record<string, string>;
+  mimeType: string;
+  body?: string;
+}
+
+export interface NetworkRecordedEntry {
+  requestId: string;
+  resourceType: string;
+  timestamp: number;
+  request: NetworkRecordedRequest;
+  response?: NetworkRecordedResponse;
+}
+
+export interface ExtractedCredential {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  httpOnly: boolean;
+  secure: boolean;
+  expires?: number;
+}
+
+export interface SessionRecording {
+  id: string;
+  startedAt: number;
+  endedAt: number;
+  targetDomain?: string;
+  networkEntries: NetworkRecordedEntry[];
+  cookies: ExtractedCredential[];
+  observations: Array<{
+    ocrText: string;
+    appName?: string;
+    windowTitle?: string;
+    timestamp: number;
+    captureIndex: number;
+  }>;
+}

--- a/assistant/src/tools/browser/recording-store.ts
+++ b/assistant/src/tools/browser/recording-store.ts
@@ -1,0 +1,41 @@
+/**
+ * Simple read/write for session recording JSON files.
+ * Stores recordings at ~/.vellum/workspace/data/recordings/<id>.json
+ */
+
+import { join } from 'node:path';
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { getDataDir } from '../../util/platform.js';
+import { getLogger } from '../../util/logger.js';
+import type { SessionRecording } from './network-recording-types.js';
+
+const log = getLogger('recording-store');
+
+function getRecordingsDir(): string {
+  return join(getDataDir(), 'recordings');
+}
+
+export function saveRecording(recording: SessionRecording): string {
+  const dir = getRecordingsDir();
+  mkdirSync(dir, { recursive: true });
+
+  const filePath = join(dir, `${recording.id}.json`);
+  writeFileSync(filePath, JSON.stringify(recording, null, 2), 'utf-8');
+  log.info({ recordingId: recording.id, path: filePath, entries: recording.networkEntries.length }, 'Recording saved');
+  return filePath;
+}
+
+export function loadRecording(recordingId: string): SessionRecording | null {
+  const filePath = join(getRecordingsDir(), `${recordingId}.json`);
+  if (!existsSync(filePath)) {
+    log.warn({ recordingId, path: filePath }, 'Recording file not found');
+    return null;
+  }
+  try {
+    const data = readFileSync(filePath, 'utf-8');
+    return JSON.parse(data) as SessionRecording;
+  } catch (err) {
+    log.warn({ err, recordingId }, 'Failed to load recording');
+    return null;
+  }
+}

--- a/assistant/src/tools/browser/recording-store.ts
+++ b/assistant/src/tools/browser/recording-store.ts
@@ -3,7 +3,7 @@
  * Stores recordings at ~/.vellum/workspace/data/recordings/<id>.json
  */
 
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { getDataDir } from '../../util/platform.js';
 import { getLogger } from '../../util/logger.js';
@@ -19,14 +19,22 @@ export function saveRecording(recording: SessionRecording): string {
   const dir = getRecordingsDir();
   mkdirSync(dir, { recursive: true });
 
-  const filePath = join(dir, `${recording.id}.json`);
+  const filePath = resolve(dir, `${recording.id}.json`);
+  if (!filePath.startsWith(resolve(dir) + '/')) {
+    throw new Error(`Invalid recording ID: ${recording.id}`);
+  }
   writeFileSync(filePath, JSON.stringify(recording, null, 2), 'utf-8');
   log.info({ recordingId: recording.id, path: filePath, entries: recording.networkEntries.length }, 'Recording saved');
   return filePath;
 }
 
 export function loadRecording(recordingId: string): SessionRecording | null {
-  const filePath = join(getRecordingsDir(), `${recordingId}.json`);
+  const dir = getRecordingsDir();
+  const filePath = resolve(dir, `${recordingId}.json`);
+  if (!filePath.startsWith(resolve(dir) + '/')) {
+    log.warn({ recordingId }, 'Invalid recording ID');
+    return null;
+  }
   if (!existsSync(filePath)) {
     log.warn({ recordingId, path: filePath }, 'Recording file not found');
     return null;


### PR DESCRIPTION
## Summary
- Adds `NetworkRecorder` class for capturing HTTP request/response pairs via Chrome DevTools Protocol (CDP) Network domain events, with domain filtering and multi-tab support
- Adds recording store for saving/loading session recordings as JSON to `~/.vellum/workspace/data/`
- Adds shared type definitions for recorded network entries, sessions, and extracted credentials
- Extends `BrowserManager` with `getRawPage()`, `getAnyRawPage()` for CDP session access, and `extractCookies()` for domain-filtered cookie extraction

## Context
Foundation layer for the DoorDash CLI integration and ride-shotgun learn mode. These browser recording tools are generic and not specific to any particular service.

## Test plan
- [ ] Verify `BrowserManager.extractCookies()` returns cookies filtered by domain
- [ ] Verify `NetworkRecorder` captures request/response pairs when attached to a CDP session
- [ ] Verify `saveRecording`/`loadRecording` round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
