### PR TITLE
feat: add workspace avatar path constants + tests

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -29,6 +29,20 @@ final class AvatarAppearanceManager {
         NSHomeDirectory() + "/.vellum/workspace/LOOKS.md"
     }
 
+    /// Workspace path for custom avatar (new canonical location, used from PR 02 onward).
+    static func workspaceCustomAvatarURL(homeDirectory: String = NSHomeDirectory()) -> URL {
+        URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
+    }
+
+    /// Legacy Application Support path for custom avatar (pre-migration location).
+    static func legacyAppSupportCustomAvatarURL() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("vellum-assistant", isDirectory: true)
+            .appendingPathComponent("custom-avatar.png")
+    }
+
     private var customAvatarURL: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let dir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)

--- a/clients/macos/vellum-assistantTests/AvatarAppearanceManagerPathTests.swift
+++ b/clients/macos/vellum-assistantTests/AvatarAppearanceManagerPathTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class AvatarAppearanceManagerPathTests: XCTestCase {
+
+    func testWorkspacePathUsesVellumWorkspaceDirectory() {
+        let url = AvatarAppearanceManager.workspaceCustomAvatarURL(homeDirectory: "/Users/testuser")
+        XCTAssertEqual(url.path, "/Users/testuser/.vellum/workspace/data/avatar/custom-avatar.png")
+    }
+
+    func testWorkspacePathDefaultsToRealHomeDirectory() {
+        let url = AvatarAppearanceManager.workspaceCustomAvatarURL()
+        XCTAssertTrue(url.path.hasSuffix("/.vellum/workspace/data/avatar/custom-avatar.png"))
+        XCTAssertFalse(url.path.isEmpty)
+    }
+
+    func testLegacyPathUsesApplicationSupport() {
+        let url = AvatarAppearanceManager.legacyAppSupportCustomAvatarURL()
+        XCTAssertTrue(url.path.contains("Application Support/vellum-assistant"))
+        XCTAssertTrue(url.path.hasSuffix("/custom-avatar.png"))
+    }
+
+    func testWorkspaceAndLegacyPathsAreDifferent() {
+        let workspace = AvatarAppearanceManager.workspaceCustomAvatarURL()
+        let legacy = AvatarAppearanceManager.legacyAppSupportCustomAvatarURL()
+        XCTAssertNotEqual(workspace.path, legacy.path)
+    }
+
+    func testWorkspacePathIsDeterministicForSameInput() {
+        let url1 = AvatarAppearanceManager.workspaceCustomAvatarURL(homeDirectory: "/tmp/test")
+        let url2 = AvatarAppearanceManager.workspaceCustomAvatarURL(homeDirectory: "/tmp/test")
+        XCTAssertEqual(url1, url2)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces two static path helpers on `AvatarAppearanceManager`: `workspaceCustomAvatarURL(homeDirectory:)` for the new canonical `~/.vellum/workspace/data/avatar/` location and `legacyAppSupportCustomAvatarURL()` for the existing Application Support path.
- The existing `customAvatarURL` instance property is unchanged — runtime behavior is identical to before this PR.
- Adds `AvatarAppearanceManagerPathTests` with five unit tests covering path composition, determinism, and differentiation between workspace and legacy locations.

## Test plan
- [x] `testWorkspacePathUsesVellumWorkspaceDirectory` — verifies injected home directory produces the expected full path
- [x] `testWorkspacePathDefaultsToRealHomeDirectory` — verifies the default parameter resolves to the real home and has the correct suffix
- [x] `testLegacyPathUsesApplicationSupport` — verifies the legacy helper points into Application Support
- [x] `testWorkspaceAndLegacyPathsAreDifferent` — confirms the two locations are distinct
- [x] `testWorkspacePathIsDeterministicForSameInput` — same input yields identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
