### PR TITLE
feat: add Identity panel Customize Avatar CTA

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1092,7 +1092,7 @@ struct MainWindowView: View {
         case .threadList:
             sidebarView
         case .identity:
-            IdentityPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: {}, daemonClient: daemonClient)
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = nil })
         }
@@ -1316,7 +1316,7 @@ struct MainWindowView: View {
             DoctorPanel(onClose: { windowState.dismissOverlay() })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .identity:
-            IdentityPanel(onClose: { windowState.dismissOverlay() }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: {}, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.dismissOverlay() })

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -3,6 +3,7 @@ import VellumAssistantShared
 
 struct IdentityPanel: View {
     let onClose: () -> Void
+    let onCustomizeAvatar: () -> Void
     let daemonClient: DaemonClient
     @State private var appearance = AvatarAppearanceManager.shared
 
@@ -46,6 +47,25 @@ struct IdentityPanel: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.lg)
+
+            // Customize Avatar CTA
+            Button(action: onCustomizeAvatar) {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "paintpalette")
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Customize Avatar")
+                        .font(VFont.bodyMedium)
+                }
+                .foregroundColor(VColor.accent)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, VSpacing.lg)
 
             // Constellation fills remaining space
             ConstellationView(


### PR DESCRIPTION
## Summary
- Adds a `onCustomizeAvatar` callback closure to `IdentityPanel`, positioned after `onClose` and before `daemonClient` in the struct signature.
- Renders a "Customize Avatar" button (with paintpalette icon) below the avatar + ID card HStack and above the ConstellationView, styled with design system tokens (`VColor.accent`, `VFont.bodyMedium`, `VSpacing`, `VRadius`).
- Both call sites in `MainWindowView.swift` (side panel in `nativePanelView` and full-window overlay in `fullWindowPanel`) pass an empty closure `{}` as a no-op placeholder — wiring to the avatar customization panel happens in a follow-up PR.

## Test plan
- [ ] Visual verification that the "Customize Avatar" button appears on the Identity panel below the avatar area
- [ ] Button uses accent color and has a subtle bordered outline
- [ ] Tapping the button does nothing (no-op closure) — no crash or navigation
- [ ] Callback contract compiles correctly at both call sites (side panel and full-window overlay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
