### PR TITLE
fix: remove "More" tooltip from ellipsis menu button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -994,7 +994,7 @@ private struct ChatBubble: View {
     @State private var isHovered = false
     @State private var isRegenerateHovered = false
     @State private var isCopyHovered = false
-    @State private var isMoreHovered = false
+
     @State private var showCopyConfirmation = false
     @State private var copyConfirmationTimer: DispatchWorkItem?
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
@@ -1147,30 +1147,6 @@ private struct ChatBubble: View {
                                 .tint(VColor.textMuted)
                                 .frame(width: 24, height: 24)
                                 .accessibilityLabel("Message actions")
-                                .onHover { isMoreHovered = $0 }
-                                .overlay(alignment: .bottom) {
-                                    if isMoreHovered {
-                                        Text("More")
-                                            .font(VFont.caption)
-                                            .foregroundColor(VColor.textPrimary)
-                                            .padding(.horizontal, VSpacing.sm)
-                                            .padding(.vertical, VSpacing.xs)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: VRadius.sm)
-                                                    .fill(VColor.surface)
-                                            )
-                                            .overlay(
-                                                RoundedRectangle(cornerRadius: VRadius.sm)
-                                                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-                                            )
-                                            .vShadow(VShadow.sm)
-                                            .fixedSize()
-                                            .offset(y: 28)
-                                            .transition(.opacity)
-                                            .allowsHitTesting(false)
-                                    }
-                                }
-                                .animation(VAnimation.fast, value: isMoreHovered)
                                 .transition(.opacity.animation(VAnimation.fast))
                             }
                         }


### PR DESCRIPTION
## Summary
- Removed the custom "More" tooltip overlay that appeared on hover over the ellipsis (⋯) menu button in chat messages
- Cleaned up the associated `isMoreHovered` state variable and hover/animation handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
