### PR TITLE
feat: wire Identity CTA to open avatar customization panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1092,7 +1092,7 @@ struct MainWindowView: View {
         case .threadList:
             sidebarView
         case .identity:
-            IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: {}, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = nil })
         }
@@ -1316,7 +1316,7 @@ struct MainWindowView: View {
             DoctorPanel(onClose: { windowState.dismissOverlay() })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .identity:
-            IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: {}, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.dismissOverlay() })


### PR DESCRIPTION
## Summary
- Connects the "Customize Avatar" button on the Identity panel to the existing avatar customization panel by setting `windowState.selection = .panel(.avatarCustomization)` in both `onCustomizeAvatar` closures.
- Updates both call sites: the side panel (`nativePanelView`) and the full-window overlay (`fullWindowPanel`).

## Test plan
- [ ] Open the Identity panel from the side panel entry point → click "Customize Avatar" → verify the avatar customization panel opens
- [ ] Open the Identity panel from the full-window overlay entry point → click "Customize Avatar" → verify the avatar customization panel opens
- [ ] Verify closing the avatar customization panel returns to expected state in both contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
