### PR TITLE
chore: custom avatar rollout cleanup and docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3042,6 +3042,8 @@ The avatar evolves during onboarding based on conversation and identity choices.
 - `AvatarEvolutionResolver` — Merges deterministic + model + user layers with strict precedence
 - `AvatarCustomizationPanel` — User override surface with per-field lock/unlock
 
+**Custom avatar storage:** User-uploaded profile pictures are stored at `~/.vellum/workspace/data/avatar/custom-avatar.png`. On first launch after upgrade, any legacy avatar from `~/Library/Application Support/vellum-assistant/` is automatically migrated (copied, not moved). The avatar customization panel is accessible from the Identity panel via a "Customize Avatar" CTA button.
+
 **Precedence:** `user overrides > deterministic constraints > model-driven traits > defaults`
 
 **Persistence:** Evolution state in UserDefaults, resolved appearance in LOOKS.md

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -29,13 +29,13 @@ final class AvatarAppearanceManager {
         NSHomeDirectory() + "/.vellum/workspace/LOOKS.md"
     }
 
-    /// Workspace path for custom avatar (new canonical location, used from PR 02 onward).
+    /// Workspace path for custom avatar — canonical storage location.
     static func workspaceCustomAvatarURL(homeDirectory: String = NSHomeDirectory()) -> URL {
         URL(fileURLWithPath: homeDirectory)
             .appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
     }
 
-    /// Legacy Application Support path for custom avatar (pre-migration location).
+    /// Legacy Application Support path (pre-workspace migration). Retained for one-time migration on first launch after upgrade.
     static func legacyAppSupportCustomAvatarURL() -> URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport


### PR DESCRIPTION
## Summary

Final PR of the custom avatar rollout (PR 06 of 06). Cleans up stale PR-reference comments in AvatarAppearanceManager, documents the new storage location and Identity panel entrypoint in ARCHITECTURE.md, and marks the plan as complete.

- Replaced rollout-internal comment ("used from PR 02 onward") with permanent documentation in `AvatarAppearanceManager.swift`
- Added custom avatar storage and migration details to the Avatar Evolution Pipeline section in `ARCHITECTURE.md`
- No functional changes. Comment and documentation hygiene only.

## Test plan

- [ ] No behavior changes — docs/comments only
- [ ] Verify project builds cleanly (`./build.sh` from `clients/macos`)
- [ ] Confirm no runtime behavior delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
