### PR TITLE
feat: include raw LLM request/response payloads in diagnostics export

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -32,7 +32,7 @@ export type AgentEvent =
   | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }
   | { type: 'input_json_delta'; toolName: string; accumulatedJson: string }
   | { type: 'error'; error: Error }
-  | { type: 'usage'; inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; model: string; providerDurationMs: number };
+  | { type: 'usage'; inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; model: string; providerDurationMs: number; rawRequest?: unknown; rawResponse?: unknown };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 64000,
@@ -186,6 +186,8 @@ export class AgentLoop {
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
           model: response.model,
           providerDurationMs,
+          rawRequest: response.rawRequest,
+          rawResponse: response.rawResponse,
         });
 
         void getHookManager().trigger('post-llm-call', {

--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -7,7 +7,7 @@ import { randomBytes } from 'node:crypto';
 import { eq, and, desc, gte, lte } from 'drizzle-orm';
 import archiver from 'archiver';
 import { getDb } from '../../memory/db.js';
-import { messages, toolInvocations, llmUsageEvents } from '../../memory/schema.js';
+import { messages, toolInvocations, llmUsageEvents, llmRequestLogs } from '../../memory/schema.js';
 import type { DiagnosticsExportRequest } from '../ipc-protocol.js';
 import { log, type HandlerContext } from './shared.js';
 
@@ -159,6 +159,20 @@ export async function handleDiagnosticsExport(
       .orderBy(llmUsageEvents.createdAt)
       .all();
 
+    // 5b. Query raw LLM request/response logs in the range
+    const rangeRequestLogs = db
+      .select()
+      .from(llmRequestLogs)
+      .where(
+        and(
+          eq(llmRequestLogs.conversationId, conversationId),
+          gte(llmRequestLogs.createdAt, rangeStart),
+          lte(llmRequestLogs.createdAt, usageRangeEnd),
+        ),
+      )
+      .orderBy(llmRequestLogs.createdAt)
+      .all();
+
     // 6. Write export files to a temp directory
     const exportId = `diagnostics-${new Date().toISOString().replace(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
     const tempDir = join(tmpdir(), exportId);
@@ -167,7 +181,7 @@ export async function handleDiagnosticsExport(
     try {
       // manifest.json
       const manifest = {
-        version: '1.0',
+        version: '1.1',
         exportedAt: new Date().toISOString(),
         conversationId,
         messageId: anchorMessage.id,
@@ -220,6 +234,18 @@ export async function handleDiagnosticsExport(
         }),
       );
       writeFileSync(join(tempDir, 'usage.jsonl'), usageLines.join('\n') + (usageLines.length > 0 ? '\n' : ''));
+
+      // llm_requests.jsonl — raw request/response payloads sent to the LLM provider
+      const requestLogLines = rangeRequestLogs.map((r) =>
+        JSON.stringify({
+          id: r.id,
+          conversationId: r.conversationId,
+          request: JSON.parse(r.requestPayload),
+          response: JSON.parse(r.responsePayload),
+          createdAt: r.createdAt,
+        }),
+      );
+      writeFileSync(join(tempDir, 'llm_requests.jsonl'), requestLogLines.join('\n') + (requestLogLines.length > 0 ? '\n' : ''));
 
       // 7. Zip the temp directory
       const downloadsDir = join(homedir(), 'Downloads');

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -81,6 +81,7 @@ import {
   type HistorySessionContext,
 } from './session-history.js';
 import { recordUsage } from './session-usage.js';
+import { recordRequestLog } from '../memory/llm-request-log-store.js';
 import { isProviderOrderingError } from './session-slash.js';
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from './session-workspace.js';
 import type { UsageActor } from '../usage/actors.js';
@@ -1016,6 +1017,19 @@ export class Session {
             exchangeInputTokens += event.inputTokens;
             exchangeOutputTokens += event.outputTokens;
             model = event.model;
+
+            // Persist raw LLM request/response payloads for diagnostics export
+            if (event.rawRequest && event.rawResponse) {
+              try {
+                recordRequestLog(
+                  this.conversationId,
+                  JSON.stringify(event.rawRequest),
+                  JSON.stringify(event.rawResponse),
+                );
+              } catch (err) {
+                rlog.warn({ err }, 'Failed to persist LLM request log (non-fatal)');
+              }
+            }
 
             // Ensure llm_call_started is emitted even for tool-only turns
             // (where no text_delta or thinking_delta events fire)

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -404,6 +404,16 @@ export function initializeDb(): void {
   `);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS llm_request_logs (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      request_payload TEXT NOT NULL,
+      response_payload TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS llm_usage_events (
       id TEXT PRIMARY KEY,
       created_at INTEGER NOT NULL,
@@ -536,6 +546,7 @@ export function initializeDb(): void {
   migrateMemoryItemsScopeSaltedFingerprints(database);
 
   // Indexes for query performance on large datasets
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_request_logs_conv_created ON llm_request_logs(conversation_id, created_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_tool_invocations_conversation_id ON tool_invocations(conversation_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at)`);

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -1,0 +1,45 @@
+import { and, gte, lte, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { llmRequestLogs } from './schema.js';
+
+export function recordRequestLog(
+  conversationId: string,
+  requestPayload: string,
+  responsePayload: string,
+): void {
+  const db = getDb();
+  db.insert(llmRequestLogs).values({
+    id: uuid(),
+    conversationId,
+    requestPayload,
+    responsePayload,
+    createdAt: Date.now(),
+  }).run();
+}
+
+export function queryRequestLogs(
+  conversationId: string,
+  startTime: number,
+  endTime: number,
+): Array<{
+  id: string;
+  conversationId: string;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt: number;
+}> {
+  const db = getDb();
+  return db
+    .select()
+    .from(llmRequestLogs)
+    .where(
+      and(
+        eq(llmRequestLogs.conversationId, conversationId),
+        gte(llmRequestLogs.createdAt, startTime),
+        lte(llmRequestLogs.createdAt, endTime),
+      ),
+    )
+    .orderBy(llmRequestLogs.createdAt)
+    .all();
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -501,6 +501,14 @@ export const watcherEvents = sqliteTable('watcher_events', {
   createdAt: integer('created_at').notNull(),
 });
 
+export const llmRequestLogs = sqliteTable('llm_request_logs', {
+  id: text('id').primaryKey(),
+  conversationId: text('conversation_id').notNull(),
+  requestPayload: text('request_payload').notNull(),
+  responsePayload: text('response_payload').notNull(),
+  createdAt: integer('created_at').notNull(),
+});
+
 export const llmUsageEvents = sqliteTable('llm_usage_events', {
   id: text('id').primaryKey(),
   createdAt: integer('created_at').notNull(),

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -594,6 +594,8 @@ export class AnthropicProvider implements Provider {
           cacheReadInputTokens: response.usage.cache_read_input_tokens ?? undefined,
         },
         stopReason: response.stop_reason ?? "unknown",
+        rawRequest: params,
+        rawResponse: response,
       };
     } catch (error) {
       if (error instanceof Anthropic.APIError) {

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -120,11 +120,26 @@ export class GeminiProvider implements Provider {
         });
       }
 
+      const rawRequest = {
+        model: modelOverride ?? this.model,
+        contents: geminiContents,
+        config: geminiConfig,
+      };
+      const rawResponse = {
+        model: responseModel,
+        text: fullText || null,
+        functionCalls: functionCalls.length > 0 ? functionCalls : undefined,
+        finishReason,
+        usageMetadata: { promptTokenCount: promptTokens, candidatesTokenCount: outputTokens },
+      };
+
       return {
         content,
         model: responseModel,
         usage: { inputTokens: promptTokens, outputTokens },
         stopReason: finishReason,
+        rawRequest,
+        rawResponse,
       };
     } catch (error) {
       if (error instanceof ApiError) {

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -135,11 +135,33 @@ export class OpenAIProvider implements Provider {
         });
       }
 
+      // Build a synthetic response object from accumulated streaming data
+      const rawResponse = {
+        model: responseModel,
+        choices: [{
+          message: {
+            role: 'assistant',
+            content: contentText || null,
+            tool_calls: toolCallMap.size > 0
+              ? Array.from(toolCallMap.values()).map((tc) => ({
+                  id: tc.id,
+                  type: 'function',
+                  function: { name: tc.name, arguments: tc.args },
+                }))
+              : undefined,
+          },
+          finish_reason: finishReason,
+        }],
+        usage: { prompt_tokens: promptTokens, completion_tokens: completionTokens },
+      };
+
       return {
         content,
         model: responseModel,
         usage: { inputTokens: promptTokens, outputTokens: completionTokens },
         stopReason: finishReason,
+        rawRequest: params,
+        rawResponse,
       };
     } catch (error) {
       if (error instanceof OpenAI.APIError) {

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -81,6 +81,10 @@ export interface ProviderResponse {
     cacheReadInputTokens?: number;
   };
   stopReason: string;
+  /** Raw JSON request body sent to the provider (for diagnostics logging). */
+  rawRequest?: unknown;
+  /** Raw JSON response body received from the provider (for diagnostics logging). */
+  rawResponse?: unknown;
 }
 
 export type ProviderEvent =


### PR DESCRIPTION
## Summary
- Add `llm_request_logs` table to store raw JSON request/response payloads per LLM call
- Capture raw payloads from all three providers (Anthropic, OpenAI, Gemini) via new `rawRequest`/`rawResponse` fields on `ProviderResponse`
- Thread payloads through AgentLoop → Session → DB storage on each provider call
- Include `llm_requests.jsonl` in the diagnostics zip export with full request/response pairs

## Test plan
- [ ] Trigger a conversation, then export diagnostics — verify `llm_requests.jsonl` is present in the zip
- [ ] Inspect `llm_requests.jsonl` — confirm it contains the exact request params (model, messages, system, tools) and response (content, usage, stop_reason)
- [ ] Verify existing diagnostics files (messages.jsonl, tool_invocations.jsonl, usage.jsonl) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
