### PR TITLE
fix: suppress memory pressure warning when no sessions to evict

### DIFF
--- a/assistant/src/daemon/session-evictor.ts
+++ b/assistant/src/daemon/session-evictor.ts
@@ -139,15 +139,17 @@ export class SessionEvictor {
     // no more idle sessions remain.
     const rss = process.memoryUsage.rss();
     if (rss > this.memoryThresholdBytes) {
-      log.warn(
-        { rssBytes: rss, thresholdBytes: this.memoryThresholdBytes, sessionCount: this.sessions.size },
-        'Memory pressure detected, evicting idle sessions',
-      );
       const sorted = this.idleSessionsByLru();
-      for (const [id, session] of sorted) {
-        if (process.memoryUsage.rss() <= this.memoryThresholdBytes) break;
-        this.evict(id, session);
-        result.memoryEvicted++;
+      if (sorted.length > 0) {
+        log.warn(
+          { rssBytes: rss, thresholdBytes: this.memoryThresholdBytes, sessionCount: this.sessions.size },
+          'Memory pressure detected, evicting idle sessions',
+        );
+        for (const [id, session] of sorted) {
+          if (process.memoryUsage.rss() <= this.memoryThresholdBytes) break;
+          this.evict(id, session);
+          result.memoryEvicted++;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- The session evictor's Phase 3 (memory pressure) logged a warn every 60s sweep whenever RSS exceeded the threshold — even when there were zero sessions to evict
- Moved the idle-session sort before the log and skip the warning entirely when there are no idle sessions, eliminating non-actionable log spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
