### PR TITLE
fix: raise memory pressure threshold from 1.5 GB to 3 GB

### DIFF
--- a/assistant/src/daemon/session-evictor.ts
+++ b/assistant/src/daemon/session-evictor.ts
@@ -13,7 +13,7 @@ export interface EvictorOptions {
   ttlMs?: number;
   /** Max number of in-memory sessions before LRU eviction kicks in. Default: 100. */
   maxSessions?: number;
-  /** RSS threshold (bytes) above which idle sessions are aggressively evicted. Default: 1.5 GB. */
+  /** RSS threshold (bytes) above which idle sessions are aggressively evicted. Default: 3 GB. */
   memoryThresholdBytes?: number;
   /** Interval between periodic sweeps (ms). Default: 60 s. */
   sweepIntervalMs?: number;
@@ -32,7 +32,7 @@ export interface EvictionResult {
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_MAX_SESSIONS = 100;
-const DEFAULT_MEMORY_THRESHOLD_BYTES = 1536 * 1024 * 1024; // 1.5 GB
+const DEFAULT_MEMORY_THRESHOLD_BYTES = 3072 * 1024 * 1024; // 3 GB
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000; // 60 seconds
 
 export class SessionEvictor {


### PR DESCRIPTION
## Summary
- Daemon baseline RSS (~1.72 GB with 0 sessions) already exceeded the old 1.5 GB threshold
- Raised to 3 GB so memory-pressure eviction only triggers when sessions actually contribute to memory growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
