### PR TITLE
refactor: extract migration resolver for direct testability

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -69,24 +69,34 @@ final class AvatarAppearanceManager {
 
     // MARK: - Custom Avatar
 
-    private func loadCustomAvatar() {
-        let workspaceURL = customAvatarURL
-        let legacyURL = Self.legacyAppSupportCustomAvatarURL()
-        let fm = FileManager.default
-
+    /// Resolves which avatar URL to load from, performing one-time migration if needed.
+    /// Extracted as a static helper so migration logic is directly testable.
+    nonisolated static func resolveCustomAvatarURL(
+        workspaceURL: URL,
+        legacyURL: URL,
+        fileManager: FileManager = .default
+    ) -> URL? {
         // One-time migration: copy legacy avatar to workspace if workspace copy doesn't exist
-        if !fm.fileExists(atPath: workspaceURL.path), fm.fileExists(atPath: legacyURL.path) {
+        if !fileManager.fileExists(atPath: workspaceURL.path), fileManager.fileExists(atPath: legacyURL.path) {
             let dir = workspaceURL.deletingLastPathComponent()
-            try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
-            try? fm.copyItem(at: legacyURL, to: workspaceURL)
+            try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+            try? fileManager.copyItem(at: legacyURL, to: workspaceURL)
         }
 
-        // Load from workspace (primary) or fall back to legacy for current session
-        if fm.fileExists(atPath: workspaceURL.path) {
-            customAvatarImage = NSImage(contentsOf: workspaceURL)
-        } else if fm.fileExists(atPath: legacyURL.path) {
-            customAvatarImage = NSImage(contentsOf: legacyURL)
+        if fileManager.fileExists(atPath: workspaceURL.path) {
+            return workspaceURL
+        } else if fileManager.fileExists(atPath: legacyURL.path) {
+            return legacyURL
         }
+        return nil
+    }
+
+    private func loadCustomAvatar() {
+        guard let url = Self.resolveCustomAvatarURL(
+            workspaceURL: customAvatarURL,
+            legacyURL: Self.legacyAppSupportCustomAvatarURL()
+        ) else { return }
+        customAvatarImage = NSImage(contentsOf: url)
     }
 
     func setCustomAvatar(_ image: NSImage) {

--- a/clients/macos/vellum-assistantTests/AvatarAppearanceManagerMigrationTests.swift
+++ b/clients/macos/vellum-assistantTests/AvatarAppearanceManagerMigrationTests.swift
@@ -3,25 +3,6 @@ import XCTest
 
 final class AvatarAppearanceManagerMigrationTests: XCTestCase {
 
-    /// Replicates the migration logic from `loadCustomAvatar()` for testability.
-    /// Uses the same conditional structure: copy legacy -> workspace if workspace absent.
-    private func runMigrationLogic(workspaceURL: URL, legacyURL: URL) -> URL? {
-        let fm = FileManager.default
-
-        if !fm.fileExists(atPath: workspaceURL.path), fm.fileExists(atPath: legacyURL.path) {
-            let dir = workspaceURL.deletingLastPathComponent()
-            try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
-            try? fm.copyItem(at: legacyURL, to: workspaceURL)
-        }
-
-        if fm.fileExists(atPath: workspaceURL.path) {
-            return workspaceURL
-        } else if fm.fileExists(atPath: legacyURL.path) {
-            return legacyURL
-        }
-        return nil
-    }
-
     func testMigrationCopiesLegacyToWorkspaceWhenWorkspaceAbsent() throws {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tmp) }
@@ -29,14 +10,15 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
         let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
 
-        // Set up legacy file only
         try FileManager.default.createDirectory(at: legacyURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        let testData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) // PNG header
+        let testData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
         try testData.write(to: legacyURL)
 
-        let result = runMigrationLogic(workspaceURL: workspaceURL, legacyURL: legacyURL)
+        let result = AvatarAppearanceManager.resolveCustomAvatarURL(
+            workspaceURL: workspaceURL,
+            legacyURL: legacyURL
+        )
 
-        // Migration should have copied to workspace and returned workspace URL
         XCTAssertEqual(result, workspaceURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: workspaceURL.path))
         XCTAssertEqual(try Data(contentsOf: workspaceURL), testData)
@@ -51,36 +33,51 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
         let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
 
-        // Set up both files with different content
         try FileManager.default.createDirectory(at: legacyURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data([0x01]).write(to: legacyURL)
         try FileManager.default.createDirectory(at: workspaceURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data([0x02]).write(to: workspaceURL)
 
-        let result = runMigrationLogic(workspaceURL: workspaceURL, legacyURL: legacyURL)
+        let result = AvatarAppearanceManager.resolveCustomAvatarURL(
+            workspaceURL: workspaceURL,
+            legacyURL: legacyURL
+        )
 
-        // Workspace takes precedence
         XCTAssertEqual(result, workspaceURL)
-        // Workspace content unchanged (no overwrite from legacy)
         XCTAssertEqual(try Data(contentsOf: workspaceURL), Data([0x02]))
     }
 
-    func testFallsBackToLegacyWhenMigrationFails() throws {
+    func testFallsBackToLegacyWhenCopyFails() throws {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: tmp) }
+        defer {
+            // Remove read-only attr before cleanup
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: tmp.appendingPathComponent(".vellum/workspace/data/avatar").path
+            )
+            try? FileManager.default.removeItem(at: tmp)
+        }
 
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
-        // Point workspace to a path where parent dir creation will succeed but
-        // we can verify the fallback behavior when workspace doesn't end up existing
         let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
 
-        // Only legacy exists
+        // Set up legacy file
         try FileManager.default.createDirectory(at: legacyURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data([0x03]).write(to: legacyURL)
 
-        // Run migration — it should copy successfully and return workspace
-        let result = runMigrationLogic(workspaceURL: workspaceURL, legacyURL: legacyURL)
-        XCTAssertEqual(result, workspaceURL)
+        // Create workspace parent dir as read-only so copyItem fails
+        let workspaceDir = workspaceURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: workspaceDir, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: workspaceDir.path)
+
+        let result = AvatarAppearanceManager.resolveCustomAvatarURL(
+            workspaceURL: workspaceURL,
+            legacyURL: legacyURL
+        )
+
+        // Copy should have failed; resolver should fall back to legacy
+        XCTAssertEqual(result, legacyURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: workspaceURL.path))
     }
 
     func testReturnsNilWhenNeitherFileExists() {
@@ -88,12 +85,14 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
         let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
 
-        let result = runMigrationLogic(workspaceURL: workspaceURL, legacyURL: legacyURL)
+        let result = AvatarAppearanceManager.resolveCustomAvatarURL(
+            workspaceURL: workspaceURL,
+            legacyURL: legacyURL
+        )
         XCTAssertNil(result)
     }
 
     func testPathHelpersProduceCorrectURLsForMigration() {
-        // Verify the path helpers used by loadCustomAvatar produce the expected paths
         let workspace = AvatarAppearanceManager.workspaceCustomAvatarURL(homeDirectory: "/Users/test")
         XCTAssertEqual(workspace.path, "/Users/test/.vellum/workspace/data/avatar/custom-avatar.png")
 


### PR DESCRIPTION
## Summary
- Extracts the migration/selection logic from `loadCustomAvatar()` into a `nonisolated static func resolveCustomAvatarURL(workspaceURL:legacyURL:fileManager:)` helper on `AvatarAppearanceManager`.
- `loadCustomAvatar()` now delegates to the extracted helper — zero behavior change.
- Migration tests now call the **real** `resolveCustomAvatarURL` instead of duplicating the logic in a test-only helper.
- Fixes `testFallsBackToLegacyWhenMigrationFails` which previously didn't induce a failure — now makes the workspace directory read-only so `copyItem` fails, verifying the legacy fallback path.

## Test plan
- [x] `AvatarAppearanceManagerMigrationTests` — all 5 tests call the real `resolveCustomAvatarURL`
- [x] `testFallsBackToLegacyWhenCopyFails` — induces actual copy failure via read-only dir
- [x] No behavior change to production code (same logic, just extracted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
