### PR TITLE
fix: resolve CI type check failures

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -84,6 +84,7 @@ describe('AssistantConfigSchema', () => {
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
       toolExecutionTimeoutSec: 120,
+      providerStreamTimeoutSec: 300,
     });
     expect(result.sandbox).toEqual({
       enabled: true,

--- a/assistant/src/__tests__/shell-credential-ref.test.ts
+++ b/assistant/src/__tests__/shell-credential-ref.test.ts
@@ -46,7 +46,7 @@ mock.module('../util/platform.js', () => ({
 }));
 
 // Mock proxy session manager
-const mockGetOrStartSession = mock(() => Promise.resolve({
+const mockGetOrStartSession = mock((_convId: string, _credIds: string[]) => Promise.resolve({
   session: { id: 'test-session-id', port: 8080, status: 'active' },
   created: true,
 }));

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -729,27 +729,30 @@ export class AnthropicProvider implements Provider {
   private fromAnthropicBlock(
     block: Anthropic.ContentBlock,
   ): ContentBlock {
-    switch (block.type) {
+    const blockType = block.type as string;
+    switch (blockType) {
       case "text":
-        return { type: "text", text: block.text };
+        return { type: "text", text: (block as Anthropic.TextBlock).text };
       case "thinking":
-        return { type: "thinking", thinking: block.thinking, signature: block.signature };
+        return { type: "thinking", thinking: (block as Anthropic.ThinkingBlock).thinking, signature: (block as Anthropic.ThinkingBlock).signature };
       case "redacted_thinking":
-        return { type: "redacted_thinking", data: block.data };
-      case "tool_use":
+        return { type: "redacted_thinking", data: (block as Anthropic.RedactedThinkingBlock).data };
+      case "tool_use": {
+        const tu = block as Anthropic.ToolUseBlock;
         return {
           type: "tool_use",
-          id: block.id,
-          name: block.name,
-          input: block.input as Record<string, unknown>,
+          id: tu.id,
+          name: tu.name,
+          input: tu.input as Record<string, unknown>,
         };
+      }
       case "server_tool_use":
       case "web_search_tool_result":
         // Native Anthropic web search blocks — informational only, silently dropped
         // by the empty-text filter in sendMessage.
         return { type: "text", text: "" };
       default:
-        return { type: "text", text: `[unsupported block type: ${(block as { type: string }).type}]` };
+        return { type: "text", text: `[unsupported block type: ${blockType}]` };
     }
   }
 


### PR DESCRIPTION
## Summary
- Add missing `providerStreamTimeoutSec` to config-schema test's expected timeouts object
- Type mock function parameters in shell-credential-ref test to fix tuple access errors
- Cast `block.type` to `string` in anthropic client to handle `server_tool_use`/`web_search_tool_result` block types not present in SDK type union

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
