### PR TITLE
fix: prevent daemon restart race that deletes new socket

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -213,6 +213,20 @@ export async function stopDaemon(): Promise<{ stopped: boolean }> {
   } catch (err) {
     log.debug({ err, pid }, 'SIGKILL failed, process already exited');
   }
+
+  // Wait for the process to actually die after SIGKILL. Without this,
+  // startDaemon() can race with the dying process's shutdown handler,
+  // which removes the socket file and bricks the new daemon.
+  const killMaxWait = 2000;
+  let killWaited = 0;
+  while (killWaited < killMaxWait && isProcessRunning(pid)) {
+    await new Promise((r) => setTimeout(r, 100));
+    killWaited += 100;
+  }
+
+  // Clean up socket file — the old daemon's shutdown handler may have
+  // already removed it, or it may still point to the old process.
+  removeSocketFile(getSocketPath());
   cleanupPidFile();
   return { stopped: true };
 }


### PR DESCRIPTION
## Summary
- After SIGKILL in `stopDaemon()`, wait up to 2s for the old process to actually die before returning
- Explicitly clean up the socket file after the old process is confirmed dead, preventing the old daemon's shutdown handler from deleting the new daemon's socket
- Fixes a race condition where restarting a bloated daemon would brick the chat UI (socket deleted, client gets ENOENT, UI stuck on "Thinking")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
