### PR TITLE
fix: release heavy session data on dispose to prevent memory leak

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -480,6 +480,18 @@ export class Session {
     unregisterSessionSender(this.conversationId);
     resetSkillToolProjection(this.skillProjectionState);
     this.eventBus.dispose();
+
+    // Release heavy in-memory data so GC can reclaim it even if stale
+    // closure references (e.g. from buildEventHandler / onCheckpoint)
+    // keep this Session object reachable.
+    this.messages = [];
+    this.profiler.clear();
+    this.surfaceUndoStacks.clear();
+    this.currentTurnSurfaces = [];
+    this.pendingSurfaceActions.clear();
+    this.surfaceState.clear();
+    this.lastSurfaceAction.clear();
+    this.workspaceTopLevelContext = null;
   }
 
   /**

--- a/assistant/src/events/tool-profiling-listener.ts
+++ b/assistant/src/events/tool-profiling-listener.ts
@@ -78,6 +78,14 @@ export class ToolProfiler {
     };
   }
 
+  /** Release all accumulated stats. */
+  clear(): void {
+    this.tools.clear();
+    this.requestStartMs = 0;
+    this.rssStartBytes = 0;
+    this.peakRssBytes = 0;
+  }
+
   emitSummary(traceEmitter: TraceEmitter, requestId?: string): void {
     const summary = this.getSummary();
     if (summary.toolCount === 0) return;


### PR DESCRIPTION
## Summary
- Clear `messages[]` (can be 500+ MB for large conversations), profiler stats, surface undo stacks, surface state maps, and workspace context in `Session.dispose()`
- Add `ToolProfiler.clear()` method to release accumulated per-tool timing data
- Prevents memory leaks when stale closure references keep evicted Session objects reachable by GC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
