### PR TITLE
fix: prevent recorder leak, surface save failures, parameterize learn domain

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -11,9 +11,7 @@ import {
 } from '../tools/watch/watch-state.js';
 import type { WatchSession } from '../tools/watch/watch-state.js';
 import { lastSummaryBySession, generateSummary } from './watch-handler.js';
-import { join } from 'node:path';
 import { getLogger } from '../util/logger.js';
-import { getDataDir } from '../util/platform.js';
 import { NetworkRecorder } from '../tools/browser/network-recorder.js';
 import { saveRecording } from '../tools/browser/recording-store.js';
 import type { SessionRecording } from '../tools/browser/network-recording-types.js';
@@ -44,7 +42,7 @@ async function completeSession(session: WatchSession): Promise<void> {
 
   // In learn mode, stop recording and save — skip the LLM summary (not needed)
   if (session.isLearnMode && session.recordingId) {
-    await finalizeLearnRecording(watchId, session, session.recordingId);
+    session.savedRecordingPath = await finalizeLearnRecording(watchId, session, session.recordingId);
     lastSummaryBySession.set(sessionId, 'Learn session completed — recording saved.');
     session.status = 'completed';
     log.info({ watchId, sessionId }, 'Learn session complete — firing completion notifier');
@@ -99,6 +97,11 @@ export async function handleRideShotgunStart(
   if (isLearnMode) {
     const startRecording = async () => {
       for (let attempt = 0; attempt < 10; attempt++) {
+        // Check if session is still active before each attempt
+        if (session.status !== 'active') {
+          log.info({ watchId, attempt, status: session.status }, 'Session no longer active — aborting recording start');
+          return;
+        }
         try {
           const recorder = new NetworkRecorder(targetDomain);
           recorder.loginSignals = [
@@ -107,6 +110,12 @@ export async function handleRideShotgunStart(
             '/graphql/getConsumerOrdersWithDetails',
           ];
           await recorder.startDirect();
+          // If session completed while we were connecting, stop immediately to avoid leak
+          if (session.status !== 'active') {
+            log.info({ watchId, attempt }, 'Session completed during CDP connect — stopping recorder to prevent leak');
+            await recorder.stop();
+            return;
+          }
           // Auto-stop when login is detected
           recorder.onLoginDetected = () => {
             log.info({ watchId }, 'Login detected — auto-stopping learn session');
@@ -142,11 +151,6 @@ export async function handleRideShotgunStart(
       'Completion notifier firing — sending ride_shotgun_result to client',
     );
 
-    let recordingPath: string | undefined;
-    if (isLearnMode && recordingId) {
-      recordingPath = join(getDataDir(), 'recordings', `${recordingId}.json`);
-    }
-
     ctx.send(socket, {
       type: 'ride_shotgun_result',
       sessionId,
@@ -154,7 +158,7 @@ export async function handleRideShotgunStart(
       summary,
       observationCount,
       recordingId,
-      recordingPath,
+      recordingPath: _completedSession.savedRecordingPath,
     });
 
     unregisterWatchCompletionNotifier(sessionId);

--- a/assistant/src/tools/watch/watch-state.ts
+++ b/assistant/src/tools/watch/watch-state.ts
@@ -32,6 +32,8 @@ export interface WatchSession {
   targetDomain?: string;
   /** Recording ID for learn mode sessions */
   recordingId?: string;
+  /** Path where the learn recording was successfully saved (undefined if save failed) */
+  savedRecordingPath?: string;
 }
 
 /** Module-level map of watch sessions keyed by watchId. */

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -280,7 +280,24 @@ extension AppDelegate {
     }
 
     @objc func startRideShotgunLearn() {
-        ambientAgent.startLearnSession(targetDomain: "doordash.com", durationSeconds: 300)
+        let alert = NSAlert()
+        alert.messageText = "Learn Session"
+        alert.informativeText = "Enter the target domain to record:"
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Start")
+        alert.addButton(withTitle: "Cancel")
+
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+        input.stringValue = "doordash.com"
+        input.placeholderString = "example.com"
+        alert.accessoryView = input
+        alert.window.initialFirstResponder = input
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let domain = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !domain.isEmpty else { return }
+
+        ambientAgent.startLearnSession(targetDomain: domain, durationSeconds: 300)
     }
 
     @objc func stopRideShotgun() {


### PR DESCRIPTION
Addresses review feedback from #4930:
- Check session status in startRecording retry loop to prevent leaked NetworkRecorders
- Capture and propagate actual save path from finalizeLearnRecording instead of computing it independently
- Prompt user for target domain in Learn menu item instead of hardcoding doordash.com
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
