### PR TITLE
fix: stop recording after voice transcription completes

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -208,6 +208,9 @@ final class VoiceInputManager {
         recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
             Task { @MainActor in
                 guard let self = self else { return }
+                // Ignore late callbacks delivered after recording was stopped
+                // (e.g. endAudio() triggering a delayed isFinal via Task dispatch).
+                guard self.isRecording else { return }
 
                 if let result = result {
                     let text = result.bestTranscription.formattedString
@@ -226,6 +229,7 @@ final class VoiceInputManager {
                 if let error = error {
                     log.error("Recognition error: \(error.localizedDescription)")
                     self.recognitionTask = nil
+                    self.stopRecording()
                 }
             }
         }
@@ -257,6 +261,8 @@ final class VoiceInputManager {
 
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionTask?.cancel()
+        recognitionTask = nil
         recognitionRequest?.endAudio()
         recognitionRequest = nil
     }

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -217,6 +217,7 @@ final class VoiceInputManager {
                             self.onTranscription?(text)
                         }
                         self.recognitionTask = nil
+                        self.stopRecording()
                     } else {
                         self.onPartialTranscription?(text)
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1606,7 +1606,10 @@ private struct ActiveChatViewWrapper: View {
             onOpenSettings: {
                 windowState.selection = .panel(.settings)
             },
-            onSend: viewModel.sendMessage,
+            onSend: {
+                if viewModel.isRecording { onMicrophoneToggle() }
+                viewModel.sendMessage()
+            },
             onStop: viewModel.stopGenerating,
             onDismissError: viewModel.dismissError,
             isRetryableError: viewModel.isRetryableError,


### PR DESCRIPTION
## Summary
- Sending a message while voice recording was active didn't stop the mic, so partial transcriptions kept filling the input in a loop
- `stopRecording()` calling `endAudio()` could trigger a delayed `isFinal` callback that re-set `inputText` after the user already sent
- Recognition errors left `isRecording=true` with no way to recover

## Changes
- **VoiceInputManager**: Guard recognition callback with `self.isRecording` to ignore late deliveries; cancel recognition task in `stopRecording()`; call `stopRecording()` on errors
- **MainWindowView**: Stop recording before sending when `isRecording` is true

## Test plan
- [ ] Click mic, speak, wait for transcription → verify mic stops and text stays in composer
- [ ] Click mic, speak, hit Send while recording → verify recording stops and no text reappears
- [ ] Click mic, speak, let it auto-finalize, send → verify mic doesn't re-activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)