### PR TITLE
fix: normalize learn domain input and conditional save summary

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -43,7 +43,9 @@ async function completeSession(session: WatchSession): Promise<void> {
   // In learn mode, stop recording and save — skip the LLM summary (not needed)
   if (session.isLearnMode && session.recordingId) {
     session.savedRecordingPath = await finalizeLearnRecording(watchId, session, session.recordingId);
-    lastSummaryBySession.set(sessionId, 'Learn session completed — recording saved.');
+    lastSummaryBySession.set(sessionId, session.savedRecordingPath
+      ? 'Learn session completed — recording saved.'
+      : 'Learn session completed — recording failed to save.');
     session.status = 'completed';
     log.info({ watchId, sessionId }, 'Learn session complete — firing completion notifier');
     fireWatchCompletionNotifier(sessionId, session);

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -294,7 +294,19 @@ extension AppDelegate {
         alert.window.initialFirstResponder = input
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        let domain = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        var domain = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        // Strip URL scheme if user entered a full URL
+        if let url = URL(string: domain), let host = url.host {
+            domain = host
+        } else if domain.hasPrefix("https://") {
+            domain = String(domain.dropFirst("https://".count))
+        } else if domain.hasPrefix("http://") {
+            domain = String(domain.dropFirst("http://".count))
+        }
+        // Strip trailing slash/path
+        if let slashIdx = domain.firstIndex(of: "/") {
+            domain = String(domain[domain.startIndex..<slashIdx])
+        }
         guard !domain.isEmpty else { return }
 
         ambientAgent.startLearnSession(targetDomain: domain, durationSeconds: 300)


### PR DESCRIPTION
## Summary
- Normalize domain input in Learn menu: strip URL scheme (`https://`), lowercase, remove trailing paths so `NetworkRecorder.matchesDomain` works even if user enters a full URL like `https://doordash.com/`
- Make learn session summary conditional: show "recording failed to save" when `finalizeLearnRecording` returns `undefined`

## Addresses feedback from
- #4946

## Files modified
- `assistant/src/daemon/ride-shotgun-handler.ts` — conditional summary message
- `clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift` — domain normalization

## Test plan
- [ ] Enter `https://doordash.com` in Learn prompt — domain should be normalized to `doordash.com`
- [ ] Enter `DOORDASH.COM` — should be lowercased
- [ ] Summary says "recording saved" on success, "failed to save" on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
