### PR TITLE
fix: reset spinner state when IPC stream drops mid-turn

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -463,6 +463,10 @@ public final class ChatViewModel: ObservableObject {
             // task reference, which would cause duplicate subscriptions.
             if self?.messageLoopGeneration == generation {
                 self?.messageLoopTask = nil
+                // Reset spinner state — if IPC drops mid-turn the client
+                // never receives message_complete, leaving the UI stuck.
+                self?.isThinking = false
+                self?.isSending = false
             }
         }
     }


### PR DESCRIPTION
## Summary
- Reset `isThinking` and `isSending` to `false` when the IPC message stream ends unexpectedly in `startMessageLoop()`
- Prevents the chat UI from getting permanently stuck on "Thinking" when the daemon disconnects mid-turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
