### PR TITLE
fix: silence unused result warning in AmbientAgent Chrome launch

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -158,7 +158,7 @@ public final class AmbientAgent: ObservableObject {
                 config.arguments = ["--remote-debugging-port=9222", "--force-renderer-accessibility", "--user-data-dir=\(chromeDataDir)"]
             config.activates = true
             if let chromeURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") {
-                try? await NSWorkspace.shared.openApplication(at: chromeURL, configuration: config)
+                _ = try? await NSWorkspace.shared.openApplication(at: chromeURL, configuration: config)
                 // Wait for CDP to come up
                 for _ in 0..<30 {
                     try? await Task.sleep(nanoseconds: 500_000_000)


### PR DESCRIPTION
## Summary
- Assign `_ =` to the result of `try? await NSWorkspace.shared.openApplication(...)` to silence the Swift "result of 'try?' is unused" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
