### PR TITLE
fix: show 'Hide' label when technical details are expanded

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -167,7 +167,7 @@ public struct ToolConfirmationBubble: View {
                             .font(.system(size: 9, weight: .semibold))
                             .foregroundColor(VColor.textMuted)
                             .rotationEffect(.degrees(showTechnicalDetails ? 90 : 0))
-                        Text("More details")
+                        Text(showTechnicalDetails ? "Hide" : "More details")
                             .font(VFont.captionMedium)
                             .foregroundColor(VColor.textMuted)
                     }


### PR DESCRIPTION
## Summary
- Change the "More details" label to "Hide" when the section is expanded in permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
