### PR TITLE
feat: auto-allow all sandbox bash commands without prompting

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -348,20 +348,30 @@ describe('Permission Checker', () => {
   // ── check (decision logic) ─────────────────────────────────────
 
   describe('check', () => {
-    test('high risk → always prompt', async () => {
-      const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
+    test('sandbox bash auto-allows all risk levels via default rule', async () => {
+      // High risk
+      const high = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
+      expect(high.decision).toBe('allow');
+      expect(high.matchedRule?.id).toBe('default:allow-bash-global');
+
+      // Medium risk
+      const med = await check('bash', { command: 'rm file.txt' }, '/tmp');
+      expect(med.decision).toBe('allow');
+      expect(med.matchedRule?.id).toBe('default:allow-bash-global');
+
+      // Low risk
+      const low = await check('bash', { command: 'ls' }, '/tmp');
+      expect(low.decision).toBe('allow');
+      expect(low.matchedRule?.id).toBe('default:allow-bash-global');
+    });
+
+    test('host_bash high risk → always prompt', async () => {
+      const result = await check('host_bash', { command: 'sudo rm -rf /' }, '/tmp');
       expect(result.decision).toBe('prompt');
-      expect(result.reason).toContain('High risk');
     });
 
-    test('low risk → auto-allow', async () => {
-      const result = await check('bash', { command: 'ls' }, '/tmp');
-      expect(result.decision).toBe('allow');
-      expect(result.reason).toContain('Low risk');
-    });
-
-    test('medium risk with no matching rule → prompt', async () => {
-      const result = await check('bash', { command: 'rm file.txt' }, '/tmp');
+    test('host_bash medium risk with no matching rule → prompt', async () => {
+      const result = await check('host_bash', { command: 'rm file.txt' }, '/tmp');
       expect(result.decision).toBe('prompt');
     });
 
@@ -1596,33 +1606,29 @@ describe('Permission Checker', () => {
   // ── strict mode: no implicit allow (PR 21) ───────────────────
 
   describe('strict mode — no implicit allow (PR 21)', () => {
-    test('low-risk tool with no matching rule returns prompt in strict mode', async () => {
+    test('sandbox bash auto-allows in strict mode (default rule is a matching rule)', async () => {
       testConfig.permissions.mode = 'strict';
-      const result = await check('bash', { command: 'ls' }, '/tmp');
-      expect(result.decision).toBe('prompt');
-      expect(result.reason).toContain('Strict mode');
-    });
-
-    test('medium-risk tool with no matching rule returns prompt in strict mode', async () => {
-      testConfig.permissions.mode = 'strict';
-      const result = await check('bash', { command: 'rm file.txt' }, '/tmp');
-      expect(result.decision).toBe('prompt');
-      expect(result.reason).toContain('Strict mode');
-    });
-
-    test('high-risk tool with no matching rule returns prompt in strict mode', async () => {
-      testConfig.permissions.mode = 'strict';
-      const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
-      expect(result.decision).toBe('prompt');
-      // High risk prompts via the existing high-risk path, not strict mode
-      expect(result.reason).toContain('requires approval');
-    });
-
-    test('low-risk tool still auto-allows in legacy mode (backward compat)', async () => {
-      testConfig.permissions.mode = 'legacy';
       const result = await check('bash', { command: 'ls' }, '/tmp');
       expect(result.decision).toBe('allow');
-      expect(result.reason).toContain('Low risk');
+      expect(result.matchedRule?.id).toBe('default:allow-bash-global');
+    });
+
+    test('host_bash with no user rule returns prompt in strict mode', async () => {
+      testConfig.permissions.mode = 'strict';
+      const result = await check('host_bash', { command: 'ls' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+    });
+
+    test('medium-risk host_bash with no matching rule returns prompt in strict mode', async () => {
+      testConfig.permissions.mode = 'strict';
+      const result = await check('host_bash', { command: 'rm file.txt' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+    });
+
+    test('high-risk host_bash with no matching rule returns prompt in strict mode', async () => {
+      testConfig.permissions.mode = 'strict';
+      const result = await check('host_bash', { command: 'sudo rm -rf /' }, '/tmp');
+      expect(result.decision).toBe('prompt');
     });
 
     test('explicit allow rule still returns allow in strict mode', async () => {
@@ -1698,16 +1704,15 @@ describe('Permission Checker', () => {
       expect(result.reason).toContain('High risk');
     });
 
-    test('high-risk tool with no matching rule returns prompt', async () => {
-      const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
+    test('high-risk host_bash with no matching user rule returns prompt', async () => {
+      const result = await check('host_bash', { command: 'sudo rm -rf /' }, '/tmp');
       expect(result.decision).toBe('prompt');
-      expect(result.reason).toContain('High risk');
     });
 
-    test('low-risk tool is NOT affected by allowHighRisk (still auto-allows without it)', async () => {
-      const result = await check('bash', { command: 'ls' }, '/tmp');
+    test('sandbox bash auto-allows high-risk via default allowHighRisk rule', async () => {
+      const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
       expect(result.decision).toBe('allow');
-      expect(result.reason).toContain('Low risk');
+      expect(result.matchedRule?.id).toBe('default:allow-bash-global');
     });
 
     test('medium-risk tool with allow rule is NOT affected by allowHighRisk', async () => {
@@ -1832,11 +1837,13 @@ describe('Permission Checker', () => {
       const trustDir = dirname(trustPath);
       if (!existsSync(trustDir)) mkdirSync(trustDir, { recursive: true });
 
+      // Use host_bash — sandbox bash has a default allow rule that would match
+      // as a wildcard regardless of principal.
       writeFileSync(trustPath, JSON.stringify({
         version: 3,
         rules: [{
           id: 'test-strict-principal-mismatch',
-          tool: 'bash',
+          tool: 'host_bash',
           pattern: 'echo *',
           scope: 'everywhere',
           decision: 'allow',
@@ -1848,14 +1855,13 @@ describe('Permission Checker', () => {
       }, null, 2));
       clearCache();
 
-      // Wrong principal — rule should not match. In strict mode, bash 'echo' is
-      // low risk but has no matching rule → prompt with "Strict mode" reason.
+      // Wrong principal — rule should not match. The default ask rule for
+      // host_bash matches but is a prompt, so the result should be prompt.
       const ctx: PolicyContext = {
         principal: { kind: 'skill', id: 'attacker-skill' },
       };
-      const result = await check('bash', { command: 'echo hello' }, '/tmp', ctx);
+      const result = await check('host_bash', { command: 'echo hello' }, '/tmp', ctx);
       expect(result.decision).toBe('prompt');
-      expect(result.reason).toContain('Strict mode');
     });
 
     test('strict mode: high-risk allowHighRisk rule with version-bound principal auto-allows', async () => {
@@ -1905,11 +1911,13 @@ describe('Permission Checker', () => {
       const trustDir = dirname(trustPath);
       if (!existsSync(trustDir)) mkdirSync(trustDir, { recursive: true });
 
+      // Use host_bash — sandbox bash has a default allowHighRisk rule that
+      // would match as a wildcard regardless of principal version.
       writeFileSync(trustPath, JSON.stringify({
         version: 3,
         rules: [{
           id: 'test-strict-hr-version-mismatch',
-          tool: 'bash',
+          tool: 'host_bash',
           pattern: 'sudo *',
           scope: 'everywhere',
           decision: 'allow',
@@ -1924,12 +1932,12 @@ describe('Permission Checker', () => {
       clearCache();
 
       // Same principal but different version — rule should not match.
+      // The default host_bash ask rule matches instead → prompt.
       const ctx: PolicyContext = {
         principal: { kind: 'skill', id: 'admin-skill', version: 'v2:different' },
       };
-      const result = await check('bash', { command: 'sudo apt update' }, '/tmp', ctx);
+      const result = await check('host_bash', { command: 'sudo apt update' }, '/tmp', ctx);
       expect(result.decision).toBe('prompt');
-      expect(result.reason).toContain('requires approval');
     });
 
     test('strict mode: deny rule overrides allowHighRisk rule even in strict mode', async () => {
@@ -2906,10 +2914,12 @@ describe('Permission Checker', () => {
 
     // ── high-risk: version-bound allowHighRisk rule stops matching after edit ──
 
-    test('high-risk bash: version-bound allowHighRisk rule stops matching after skill edit', async () => {
+    test('high-risk host_bash: version-bound allowHighRisk rule stops matching after skill edit', async () => {
+      // Use host_bash — sandbox bash has a default allowHighRisk rule that
+      // would match as a wildcard regardless of principal version.
       await addVersionBoundRule({
         id: 'pr35-hr-version-drift',
-        tool: 'bash',
+        tool: 'host_bash',
         pattern: 'sudo *',
         scope: 'everywhere',
         decision: 'allow',
@@ -2924,7 +2934,7 @@ describe('Permission Checker', () => {
       const ctxV1: PolicyContext = {
         principal: { kind: 'skill', id: 'pr35-admin-skill', version: 'v1:trusted-hash' },
       };
-      const r1 = await check('bash', { command: 'sudo apt update' }, '/tmp', ctxV1);
+      const r1 = await check('host_bash', { command: 'sudo apt update' }, '/tmp', ctxV1);
       expect(r1.decision).toBe('allow');
       expect(r1.reason).toContain('high-risk trust rule');
       expect(r1.matchedRule?.id).toBe('pr35-hr-version-drift');
@@ -2933,7 +2943,7 @@ describe('Permission Checker', () => {
       const ctxV2: PolicyContext = {
         principal: { kind: 'skill', id: 'pr35-admin-skill', version: 'v2:modified-hash' },
       };
-      const r2 = await check('bash', { command: 'sudo apt update' }, '/tmp', ctxV2);
+      const r2 = await check('host_bash', { command: 'sudo apt update' }, '/tmp', ctxV2);
       expect(r2.decision).toBe('prompt');
       expect(r2.matchedRule?.id).not.toBe('pr35-hr-version-drift');
     });
@@ -3060,11 +3070,17 @@ describe('Permission Checker', () => {
     //    explicit matching rule. ──────────────────────────────────────
 
     describe('Invariant 1: strict mode requires explicit matching rule for every tool', () => {
-      test('low-risk bash with no rule prompts in strict mode', async () => {
+      test('sandbox bash auto-allows in strict mode (default rule matches)', async () => {
         testConfig.permissions.mode = 'strict';
         const result = await check('bash', { command: 'echo hello' }, '/tmp');
+        expect(result.decision).toBe('allow');
+        expect(result.matchedRule?.id).toBe('default:allow-bash-global');
+      });
+
+      test('low-risk host_bash with no user rule prompts in strict mode', async () => {
+        testConfig.permissions.mode = 'strict';
+        const result = await check('host_bash', { command: 'echo hello' }, '/tmp');
         expect(result.decision).toBe('prompt');
-        expect(result.reason).toContain('Strict mode');
       });
 
       test('low-risk file_read with no rule prompts in strict mode', async () => {
@@ -3088,11 +3104,17 @@ describe('Permission Checker', () => {
         expect(result.reason).toContain('Strict mode');
       });
 
-      test('high-risk command with no rule prompts in strict mode', async () => {
+      test('high-risk sandbox bash auto-allows in strict mode (default allowHighRisk rule)', async () => {
         testConfig.permissions.mode = 'strict';
         const result = await check('bash', { command: 'sudo apt update' }, '/tmp');
+        expect(result.decision).toBe('allow');
+        expect(result.matchedRule?.id).toBe('default:allow-bash-global');
+      });
+
+      test('high-risk host_bash command with no user rule prompts in strict mode', async () => {
+        testConfig.permissions.mode = 'strict';
+        const result = await check('host_bash', { command: 'sudo apt update' }, '/tmp');
         expect(result.decision).toBe('prompt');
-        expect(result.reason).toContain('requires approval');
       });
 
       test('skill-origin tool with no rule prompts in strict mode', async () => {

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -321,13 +321,14 @@ describe('Trust Store', () => {
 
     test('returns null when tool does not match', () => {
       addRule('file_write', 'git *', '/tmp');
-      const match = findMatchingRule('bash', 'git push', '/tmp');
+      // host_bash default is 'ask' so findMatchingRule (allow-only) won't find it
+      const match = findMatchingRule('host_bash', 'git push', '/tmp');
       expect(match).toBeNull();
     });
 
     test('returns null when pattern does not match', () => {
-      addRule('bash', 'git *', '/tmp');
-      const match = findMatchingRule('bash', 'npm install', '/tmp');
+      addRule('host_bash', 'git *', '/tmp');
+      const match = findMatchingRule('host_bash', 'npm install', '/tmp');
       expect(match).toBeNull();
     });
 
@@ -346,8 +347,8 @@ describe('Trust Store', () => {
       });
 
       test('does not match when scope is outside rule scope', () => {
-        addRule('bash', 'npm *', '/home/user/project');
-        const match = findMatchingRule('bash', 'npm install', '/home/other');
+        addRule('host_bash', 'npm *', '/home/user/project');
+        const match = findMatchingRule('host_bash', 'npm install', '/home/other');
         expect(match).toBeNull();
       });
 
@@ -364,8 +365,8 @@ describe('Trust Store', () => {
       });
 
       test('does not match sibling path with shared prefix', () => {
-        addRule('bash', 'npm *', '/home/user/project');
-        const match = findMatchingRule('bash', 'npm install', '/home/user/project-evil');
+        addRule('host_bash', 'npm *', '/home/user/project');
+        const match = findMatchingRule('host_bash', 'npm install', '/home/user/project-evil');
         expect(match).toBeNull();
       });
 
@@ -382,8 +383,8 @@ describe('Trust Store', () => {
       });
 
       test('does not match sibling with glob-suffixed scope', () => {
-        addRule('bash', 'npm *', '/home/user/project*');
-        const match = findMatchingRule('bash', 'npm install', '/home/user/project-evil');
+        addRule('host_bash', 'npm *', '/home/user/project*');
+        const match = findMatchingRule('host_bash', 'npm install', '/home/user/project-evil');
         expect(match).toBeNull();
       });
     });
@@ -397,9 +398,9 @@ describe('Trust Store', () => {
       });
 
       test('matches exact string', () => {
-        addRule('bash', 'git status', '/tmp');
-        expect(findMatchingRule('bash', 'git status', '/tmp')).not.toBeNull();
-        expect(findMatchingRule('bash', 'git push', '/tmp')).toBeNull();
+        addRule('host_bash', 'git status', '/tmp');
+        expect(findMatchingRule('host_bash', 'git status', '/tmp')).not.toBeNull();
+        expect(findMatchingRule('host_bash', 'git push', '/tmp')).toBeNull();
       });
 
       test('matches file path pattern', () => {
@@ -460,15 +461,18 @@ describe('Trust Store', () => {
     });
 
     test('returns null when no rule matches', () => {
-      addRule('bash', 'git *', '/tmp', 'allow');
-      const match = findHighestPriorityRule('bash', ['npm install'], '/tmp');
+      // Use file_read with a non-workspace path — file_read defaults only
+      // cover specific workspace files, so /tmp paths won't match any default.
+      addRule('file_read', 'file_read:/specific/*', '/tmp', 'allow');
+      const match = findHighestPriorityRule('file_read', ['file_read:/other/path'], '/tmp');
       expect(match).toBeNull();
     });
 
     test('respects scope matching', () => {
-      addRule('bash', 'rm *', '/home/user/project', 'deny');
-      expect(findHighestPriorityRule('bash', ['rm file.txt'], '/home/user/project/sub')).not.toBeNull();
-      expect(findHighestPriorityRule('bash', ['rm file.txt'], '/home/other')).toBeNull();
+      // Use file_read — bash has a global default allow rule that matches everywhere.
+      addRule('file_read', 'file_read:/home/user/project/*', '/home/user/project', 'deny');
+      expect(findHighestPriorityRule('file_read', ['file_read:/home/user/project/file.txt'], '/home/user/project/sub')).not.toBeNull();
+      expect(findHighestPriorityRule('file_read', ['file_read:/home/user/project/file.txt'], '/home/other')).toBeNull();
     });
 
     test('everywhere scope matches any directory', () => {
@@ -564,8 +568,9 @@ describe('Trust Store', () => {
     });
 
     test('findMatchingRule ignores deny rules', () => {
-      addRule('bash', 'rm *', '/tmp', 'deny');
-      const match = findMatchingRule('bash', 'rm file.txt', '/tmp');
+      // Use host_bash — bash has a default allow rule that would match.
+      addRule('host_bash', 'rm *', '/tmp', 'deny');
+      const match = findMatchingRule('host_bash', 'rm file.txt', '/tmp');
       expect(match).toBeNull();
     });
 
@@ -845,14 +850,18 @@ describe('Trust Store', () => {
 
     test('bootstrap delete rule matches only when workingDir is the workspace dir', () => {
       const workspaceDir = join(testDir, 'workspace');
-      // Should match when workingDir is the workspace directory
+      // Should match when workingDir is the workspace directory — the bootstrap
+      // rule (priority 100) outranks the global default allow (priority 50).
       const match = findHighestPriorityRule('bash', ['rm BOOTSTRAP.md'], workspaceDir);
       expect(match).not.toBeNull();
       expect(match!.id).toBe('default:allow-bash-rm-bootstrap');
       expect(match!.decision).toBe('allow');
-      // Should NOT match when workingDir is somewhere else
-      const noMatch = findHighestPriorityRule('bash', ['rm BOOTSTRAP.md'], '/tmp/other-project');
-      expect(noMatch).toBeNull();
+      // Outside workspace, the bootstrap rule doesn't match — the global
+      // default:allow-bash-global rule matches instead (not the bootstrap rule).
+      const other = findHighestPriorityRule('bash', ['rm BOOTSTRAP.md'], '/tmp/other-project');
+      expect(other).not.toBeNull();
+      expect(other!.id).not.toBe('default:allow-bash-rm-bootstrap');
+      expect(other!.id).toBe('default:allow-bash-global');
     });
 
     test('default ask does not affect files outside protected directory', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -10,6 +10,7 @@ export interface DefaultRuleTemplate {
   scope: string;
   decision: 'allow' | 'deny' | 'ask';
   priority: number;
+  allowHighRisk?: boolean;
 }
 
 const HOST_FILE_TOOLS = ['host_file_read', 'host_file_write', 'host_file_edit'] as const;
@@ -54,6 +55,18 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     scope: 'everywhere',
     decision: 'ask',
     priority: 50,
+  };
+
+  // Sandboxed bash commands run in an isolated container — auto-allow all of
+  // them (including high-risk) so the user is never prompted for sandbox work.
+  const sandboxShellRule: DefaultRuleTemplate = {
+    id: 'default:allow-bash-global',
+    tool: 'bash',
+    pattern: '**',
+    scope: 'everywhere',
+    decision: 'allow',
+    priority: 50,
+    allowHighRisk: true,
   };
 
   // Standalone "**" globstar — minimatch only treats ** as globstar when it is
@@ -210,6 +223,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   return [
     ...hostFileRules,
     hostShellRule,
+    sandboxShellRule,
     ...computerUseRules,
     ...managedSkillRules,
     ...workspacePromptRules,

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -76,19 +76,30 @@ function backfillDefaults(rules: TrustRule[]): boolean {
     }
   }
 
-  // Migrate existing default rules whose priority or pattern has changed
-  // in the template (e.g. host_bash pattern changed from '*' to '**',
-  // host tool priorities changed from 1000 to 50).
+  // Migrate existing default rules whose priority, pattern, decision, or
+  // allowHighRisk has changed in the template (e.g. host_bash pattern changed
+  // from '*' to '**', host tool priorities changed from 1000 to 50).
   for (const template of getDefaultRuleTemplates()) {
     if (existingIds.has(template.id)) {
       const rule = rules.find((r) => r.id === template.id);
-      if (rule && (rule.priority !== template.priority || rule.pattern !== template.pattern)) {
+      if (rule && (
+        rule.priority !== template.priority
+        || rule.pattern !== template.pattern
+        || rule.decision !== template.decision
+        || rule.allowHighRisk !== template.allowHighRisk
+      )) {
         log.info(
           { ruleId: rule.id, oldPriority: rule.priority, newPriority: template.priority, oldPattern: rule.pattern, newPattern: template.pattern },
           'Migrated default rule to updated template values',
         );
         rule.priority = template.priority;
         rule.pattern = template.pattern;
+        rule.decision = template.decision;
+        if (template.allowHighRisk != null) {
+          rule.allowHighRisk = template.allowHighRisk;
+        } else {
+          delete rule.allowHighRisk;
+        }
         changed = true;
       }
     }
@@ -96,7 +107,7 @@ function backfillDefaults(rules: TrustRule[]): boolean {
 
   for (const template of getDefaultRuleTemplates()) {
     if (!existingIds.has(template.id)) {
-      rules.push({
+      const rule: TrustRule = {
         id: template.id,
         tool: template.tool,
         pattern: template.pattern,
@@ -104,7 +115,11 @@ function backfillDefaults(rules: TrustRule[]): boolean {
         decision: template.decision,
         priority: template.priority,
         createdAt: Date.now(),
-      });
+      };
+      if (template.allowHighRisk != null) {
+        rule.allowHighRisk = template.allowHighRisk;
+      }
+      rules.push(rule);
       changed = true;
       log.info({ ruleId: template.id }, 'Backfilled default trust rule');
     }


### PR DESCRIPTION
## Summary
- Adds a default `allow` rule with `allowHighRisk: true` for sandboxed `bash` commands, so they never trigger permission prompts
- The sandbox (Docker) provides sufficient isolation that all commands are safe — users shouldn't need to approve them
- `host_bash` commands remain unchanged (still prompt via default `ask` rule)
- Proxied network mode still forces prompts (checked before rule matching)

## Test plan
- [x] All 323 checker tests pass (updated affected tests to reflect new behavior)
- [x] All 144 trust-store tests pass (updated generic matching tests to avoid default rule interference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
