### PR TITLE
fix: remap container-scoped /workspace paths in sandboxPolicy

### DIFF
--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -148,6 +148,37 @@ describe('sandboxPolicy', () => {
       expect(result.resolved).toBe(join(boundary, 'subdir', 'new-file.txt'));
     }
   });
+
+  test('remaps /workspace/ paths to boundary dir', () => {
+    const boundary = makeTempDir();
+    mkdirSync(join(boundary, 'scratch'));
+
+    const result = sandboxPolicy('/workspace/scratch/file.png', boundary);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(boundary, 'scratch', 'file.png'));
+    }
+  });
+
+  test('remaps bare /workspace to boundary root', () => {
+    const boundary = makeTempDir();
+
+    const result = sandboxPolicy('/workspace', boundary);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(boundary);
+    }
+  });
+
+  test('remapped /workspace path still rejects traversal escapes', () => {
+    const boundary = makeTempDir();
+
+    const result = sandboxPolicy('/workspace/../../../etc/passwd', boundary);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('out_of_bounds');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -10,6 +10,13 @@ export type PathResult =
   | { ok: true; resolved: string }
   | { ok: false; reason: PathFailureReason; error: string };
 
+// The Docker sandbox mounts the host workspace at /workspace inside the
+// container. The model generates container-scoped paths (e.g.
+// "/workspace/scratch/file.png") that need to be remapped to the host
+// boundary directory before validation.
+const CONTAINER_WORKSPACE_PREFIX = '/workspace/';
+const CONTAINER_WORKSPACE_EXACT = '/workspace';
+
 // ---------------------------------------------------------------------------
 // Sandbox policy
 // ---------------------------------------------------------------------------
@@ -22,6 +29,10 @@ export type PathResult =
  * pointing outside the boundary is caught. For new paths (e.g. file_write),
  * pass `mustExist: false` — the nearest existing ancestor directory is
  * resolved via realpathSync to catch symlinks in parent dirs.
+ *
+ * Paths starting with `/workspace/` are treated as container-scoped and
+ * remapped relative to the boundary directory (the Docker sandbox mounts
+ * the host workspace at /workspace).
  */
 export function sandboxPolicy(
   rawPath: string,
@@ -30,7 +41,15 @@ export function sandboxPolicy(
 ): PathResult {
   const mustExist = options?.mustExist ?? true;
 
-  const resolved = resolve(boundaryDir, rawPath);
+  // Remap container-scoped /workspace paths to the host boundary dir.
+  let effectivePath = rawPath;
+  if (rawPath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
+    effectivePath = rawPath.slice(CONTAINER_WORKSPACE_PREFIX.length);
+  } else if (rawPath === CONTAINER_WORKSPACE_EXACT) {
+    effectivePath = '.';
+  }
+
+  const resolved = resolve(boundaryDir, effectivePath);
 
   // Resolve symlinks to catch symlink-based escapes.
   // For mustExist=false, walk up to the nearest existing ancestor and


### PR DESCRIPTION
## Summary
- `sandboxPolicy` now remaps `/workspace/`-prefixed paths to be relative to the boundary directory, matching the Docker sandbox mount convention
- Fixes `view_image` (and all sandbox-scoped filesystem tools) rejecting container-scoped paths like `/workspace/scratch/file.png`
- Adds tests for remapping, bare `/workspace`, and traversal escape through remapped paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
