### PR TITLE
fix: remove forced prompt for proxied network mode

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3732,63 +3732,22 @@ describe('Permission Checker', () => {
   });
 });
 
-describe('bash network_mode=proxied force prompt (PR 14)', () => {
+describe('bash network_mode=proxied follows normal rules (no force prompt)', () => {
   beforeEach(() => {
     clearCache();
     testConfig.permissions = { mode: 'legacy' };
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
-  test('proxied bash always prompts even when trust rules would allow', async () => {
-    // Add a trust rule that would normally auto-allow any bash command
-    addRule('bash', '*', 'everywhere');
+  test('proxied bash auto-allows via default sandbox rule', async () => {
     const result = await check('bash', { command: 'curl https://api.example.com', network_mode: 'proxied' }, '/tmp');
-    expect(result.decision).toBe('prompt');
-    expect(result.reason).toContain('Proxied network mode');
-  });
-
-  test('host_bash with network_mode=proxied follows normal flow (not force-prompted)', async () => {
-    // host_bash does not support network_mode — proxied-mode force-prompt
-    // applies only to sandboxed bash, not host_bash. The decision may still
-    // be prompt/allow based on normal risk+trust-rule evaluation, but the
-    // reason must NOT be the proxied-mode bypass.
-    addRule('host_bash', '**', 'everywhere');
-    const result = await check('host_bash', { command: 'curl https://api.example.com', network_mode: 'proxied' }, '/tmp');
     expect(result.decision).toBe('allow');
-    expect(result.reason).not.toContain('Proxied network mode');
-  });
-
-  test('non-proxied bash follows normal flow (auto-allowed)', async () => {
-    const result = await check('bash', { command: 'ls' }, '/tmp');
-    expect(result.decision).toBe('allow');
-    // Should NOT contain the proxied reason
-    expect(result.reason).not.toContain('Proxied network mode');
-  });
-
-  test('non-proxied bash with trust rule follows normal flow', async () => {
-    addRule('bash', 'rm *', '/tmp');
-    const result = await check('bash', { command: 'rm file.txt' }, '/tmp');
-    expect(result.decision).toBe('allow');
-    expect(result.reason).not.toContain('Proxied network mode');
-  });
-
-  test('proxied bash prompt reason is descriptive', async () => {
-    const result = await check('bash', { command: 'wget http://example.com', network_mode: 'proxied' }, '/tmp');
-    expect(result.decision).toBe('prompt');
-    expect(result.reason).toBe('Proxied network mode requires explicit approval for each invocation.');
+    expect(result.matchedRule?.id).toBe('default:allow-bash-global');
   });
 
   test('proxied bash with network_mode=off follows normal flow', async () => {
     const result = await check('bash', { command: 'ls', network_mode: 'off' }, '/tmp');
     expect(result.decision).toBe('allow');
-  });
-
-  test('proxied bash prompts even in strict mode with matching rule', async () => {
-    testConfig.permissions = { mode: 'strict' };
-    addRule('bash', '*', 'everywhere');
-    const result = await check('bash', { command: 'curl https://api.example.com', network_mode: 'proxied' }, '/tmp');
-    expect(result.decision).toBe('prompt');
-    expect(result.reason).toContain('Proxied network mode');
   });
 
   test('deny rule still blocks proxied bash command', async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -355,15 +355,6 @@ export async function check(
     return { decision: 'deny', reason: `Blocked by deny rule: ${matchedRule.pattern}`, matchedRule };
   }
 
-  // Proxied network mode requires explicit user approval for every
-  // invocation because the command routes through an authenticated
-  // proxy with injected credentials. This runs after deny rules but
-  // before allow/ask rules so that trust rules cannot auto-approve
-  // proxied commands.
-  if (toolName === 'bash' && input.network_mode === 'proxied') {
-    return { decision: 'prompt', reason: 'Proxied network mode requires explicit approval for each invocation.' };
-  }
-
   if (matchedRule) {
     if (matchedRule.decision === 'ask') {
       // Ask rules always prompt — never auto-allow or auto-deny


### PR DESCRIPTION
## Summary
- Removes the special-case force-prompt for `network_mode: 'proxied'` bash commands
- Proxied sandbox commands now follow normal trust rule evaluation (auto-allowed by the default sandbox bash rule)
- Deny rules still block proxied commands as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
