### PR TITLE
fix: export all LLM request logs in diagnostics

### DIFF
--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -159,17 +159,12 @@ export async function handleDiagnosticsExport(
       .orderBy(llmUsageEvents.createdAt)
       .all();
 
-    // 5b. Query raw LLM request/response logs in the range
+    // 5b. Query ALL raw LLM request/response logs for the conversation
+    // (not time-scoped — we want the full request history for debugging)
     const rangeRequestLogs = db
       .select()
       .from(llmRequestLogs)
-      .where(
-        and(
-          eq(llmRequestLogs.conversationId, conversationId),
-          gte(llmRequestLogs.createdAt, rangeStart),
-          lte(llmRequestLogs.createdAt, usageRangeEnd),
-        ),
-      )
+      .where(eq(llmRequestLogs.conversationId, conversationId))
       .orderBy(llmRequestLogs.createdAt)
       .all();
 


### PR DESCRIPTION
## Summary
- Removed time-range filter from the LLM request logs query in diagnostics export
- Now queries all request/response pairs for the entire conversation instead of only those from the last user→assistant turn
- Other diagnostics data (messages, tool invocations, usage events) remain turn-scoped as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
