### PR TITLE
feat: add Image Studio skill for AI image generation via Gemini

### DIFF
--- a/assistant/src/__tests__/gemini-image-service.test.ts
+++ b/assistant/src/__tests__/gemini-image-service.test.ts
@@ -1,0 +1,261 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mock @google/genai module — must be before importing the service
+// ---------------------------------------------------------------------------
+
+interface FakeResponse {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+        inlineData?: { mimeType?: string; data?: string };
+      }>;
+    };
+  }>;
+}
+
+let lastGenerateParams: Record<string, unknown> | null = null;
+let fakeResponse: FakeResponse = {};
+let shouldThrow: Error | null = null;
+let generateCallCount = 0;
+
+class FakeApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'ApiError';
+  }
+}
+
+mock.module('@google/genai', () => ({
+  GoogleGenAI: class MockGoogleGenAI {
+    constructor(_opts: Record<string, unknown>) {}
+    models = {
+      generateContent: async (params: Record<string, unknown>) => {
+        lastGenerateParams = params;
+        generateCallCount++;
+        if (shouldThrow) throw shouldThrow;
+        return fakeResponse;
+      },
+    };
+  },
+  ApiError: FakeApiError,
+}));
+
+// Import after mocking
+import { generateImage, mapGeminiError } from '../media/gemini-image-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function imageResponse(mimeType = 'image/png', data = 'base64data'): FakeResponse {
+  return {
+    candidates: [{
+      content: {
+        parts: [
+          { inlineData: { mimeType, data } },
+        ],
+      },
+    }],
+  };
+}
+
+function imageWithTextResponse(text: string, mimeType = 'image/png', data = 'base64data'): FakeResponse {
+  return {
+    candidates: [{
+      content: {
+        parts: [
+          { text },
+          { inlineData: { mimeType, data } },
+        ],
+      },
+    }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastGenerateParams = null;
+  fakeResponse = imageResponse();
+  shouldThrow = null;
+  generateCallCount = 0;
+});
+
+describe('generateImage', () => {
+  test('generate mode returns images from response parts', async () => {
+    fakeResponse = imageResponse('image/png', 'abc123');
+
+    const result = await generateImage('test-key', {
+      prompt: 'a cat',
+      mode: 'generate',
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].mimeType).toBe('image/png');
+    expect(result.images[0].dataBase64).toBe('abc123');
+    expect(result.resolvedModel).toBe('gemini-2.5-flash-image');
+  });
+
+  test('generate mode collects text commentary from response', async () => {
+    fakeResponse = imageWithTextResponse('Here is your image');
+
+    const result = await generateImage('test-key', {
+      prompt: 'a dog',
+      mode: 'generate',
+    });
+
+    expect(result.text).toBe('Here is your image');
+    expect(result.images).toHaveLength(1);
+  });
+
+  test('edit mode passes source images as inline data', async () => {
+    fakeResponse = imageResponse();
+
+    await generateImage('test-key', {
+      prompt: 'remove background',
+      mode: 'edit',
+      sourceImages: [
+        { mimeType: 'image/jpeg', dataBase64: 'srcdata' },
+      ],
+    });
+
+    expect(lastGenerateParams).not.toBeNull();
+    const contents = (lastGenerateParams as Record<string, unknown>).contents as Array<Record<string, unknown>>;
+    const parts = contents[0].parts as Array<Record<string, unknown>>;
+
+    // First part is the text prompt
+    expect(parts[0]).toEqual({ text: 'remove background' });
+    // Second part is the source image
+    expect(parts[1]).toEqual({
+      inlineData: { mimeType: 'image/jpeg', data: 'srcdata' },
+    });
+  });
+
+  test('model validation rejects unknown models and defaults', async () => {
+    fakeResponse = imageResponse();
+
+    await generateImage('test-key', {
+      prompt: 'test',
+      mode: 'generate',
+      model: 'invalid-model',
+    });
+
+    expect(lastGenerateParams).not.toBeNull();
+    expect((lastGenerateParams as Record<string, unknown>).model).toBe('gemini-2.5-flash-image');
+  });
+
+  test('model validation accepts allowed models', async () => {
+    fakeResponse = imageResponse();
+
+    await generateImage('test-key', {
+      prompt: 'test',
+      mode: 'generate',
+      model: 'gemini-3-pro-image',
+    });
+
+    expect((lastGenerateParams as Record<string, unknown>).model).toBe('gemini-3-pro-image');
+  });
+
+  test('variants makes parallel calls', async () => {
+    fakeResponse = imageResponse();
+
+    const result = await generateImage('test-key', {
+      prompt: 'test',
+      mode: 'generate',
+      variants: 3,
+    });
+
+    expect(generateCallCount).toBe(3);
+    expect(result.images).toHaveLength(3);
+  });
+
+  test('variants are clamped to 1-4', async () => {
+    fakeResponse = imageResponse();
+
+    await generateImage('test-key', {
+      prompt: 'test',
+      mode: 'generate',
+      variants: 10,
+    });
+
+    expect(generateCallCount).toBe(4);
+  });
+
+  test('variants defaults to 1', async () => {
+    fakeResponse = imageResponse();
+
+    await generateImage('test-key', {
+      prompt: 'test',
+      mode: 'generate',
+    });
+
+    expect(generateCallCount).toBe(1);
+  });
+
+  test('handles empty candidates gracefully', async () => {
+    fakeResponse = { candidates: [] };
+
+    const result = await generateImage('test-key', {
+      prompt: 'test',
+      mode: 'generate',
+    });
+
+    expect(result.images).toHaveLength(0);
+    expect(result.text).toBeUndefined();
+  });
+
+  test('response config includes TEXT and IMAGE modalities', async () => {
+    fakeResponse = imageResponse();
+
+    await generateImage('test-key', {
+      prompt: 'test',
+      mode: 'generate',
+    });
+
+    const config = (lastGenerateParams as Record<string, unknown>).config as Record<string, unknown>;
+    expect(config.responseModalities).toEqual(['TEXT', 'IMAGE']);
+  });
+});
+
+describe('mapGeminiError', () => {
+  test('maps 400 status to bad request message', () => {
+    const msg = mapGeminiError(new FakeApiError(400, 'bad'));
+    expect(msg).toContain('invalid');
+  });
+
+  test('maps 401 status to auth message', () => {
+    const msg = mapGeminiError(new FakeApiError(401, 'unauth'));
+    expect(msg).toContain('Authentication');
+  });
+
+  test('maps 403 status to auth message', () => {
+    const msg = mapGeminiError(new FakeApiError(403, 'forbidden'));
+    expect(msg).toContain('Authentication');
+  });
+
+  test('maps 429 status to rate limit message', () => {
+    const msg = mapGeminiError(new FakeApiError(429, 'limit'));
+    expect(msg).toContain('Rate limit');
+  });
+
+  test('maps 500 status to server error message', () => {
+    const msg = mapGeminiError(new FakeApiError(500, 'internal'));
+    expect(msg).toContain('temporarily unavailable');
+  });
+
+  test('maps generic Error to message', () => {
+    const msg = mapGeminiError(new Error('network fail'));
+    expect(msg).toContain('network fail');
+  });
+
+  test('maps unknown error to generic message', () => {
+    const msg = mapGeminiError('something');
+    expect(msg).toContain('unexpected error');
+  });
+});

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -76,6 +76,10 @@ mock.module('../daemon/media-visibility-policy.js', () => ({
   isAttachmentVisible: () => true,
 }));
 
+mock.module('../tools/assets/search.js', () => ({
+  getAttachmentSourceConversations: () => [],
+}));
+
 // Import after mocking
 import { run } from '../config/bundled-skills/image-studio/tools/media-generate-image.js';
 

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -1,0 +1,234 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { getTool, __resetRegistryForTesting } from '../tools/registry.js';
+import type { ToolContext } from '../tools/types.js';
+
+// ---------------------------------------------------------------------------
+// Mock dependencies for the tool wrapper
+// ---------------------------------------------------------------------------
+
+let mockApiKey: string | undefined = 'test-gemini-key';
+let mockGenerateResult = {
+  images: [{ mimeType: 'image/png', dataBase64: 'generated-data' }],
+  text: 'A beautiful image',
+  resolvedModel: 'gemini-2.5-flash-image',
+};
+let mockGenerateError: Error | null = null;
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    apiKeys: { gemini: mockApiKey },
+  }),
+}));
+
+mock.module('../media/gemini-image-service.js', () => ({
+  generateImage: async (_apiKey: string, _request: Record<string, unknown>) => {
+    if (mockGenerateError) throw mockGenerateError;
+    return mockGenerateResult;
+  },
+  mapGeminiError: (error: unknown) => {
+    if (error instanceof Error) return `Mock error: ${error.message}`;
+    return 'Mock unknown error';
+  },
+}));
+
+let mockAttachments: Array<{
+  id: string;
+  assistantId: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+  createdAt: number;
+  dataBase64: string;
+}> = [];
+
+mock.module('../memory/attachments-store.js', () => ({
+  getAttachmentsByIds: (_assistantId: string, _ids: string[]) => mockAttachments,
+}));
+
+mock.module('../memory/db.js', () => ({
+  getDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          get: () => ({ assistantId: 'test-assistant' }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+mock.module('../memory/schema.js', () => ({
+  conversationKeys: { assistantId: 'assistantId', conversationId: 'conversationId' },
+}));
+
+mock.module('drizzle-orm', () => ({
+  eq: () => true,
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getConversationThreadType: () => 'standard',
+}));
+
+mock.module('../daemon/media-visibility-policy.js', () => ({
+  isAttachmentVisible: () => true,
+}));
+
+// Import after mocking
+import { run } from '../config/bundled-skills/image-studio/tools/media-generate-image.js';
+
+// Clean up after this file to prevent contamination of later test files.
+afterAll(() => { __resetRegistryForTesting(); });
+
+const CONFIG_DIR = join(dirname(import.meta.dirname!), 'config', 'bundled-skills', 'image-studio');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockApiKey = 'test-gemini-key';
+  mockGenerateResult = {
+    images: [{ mimeType: 'image/png', dataBase64: 'generated-data' }],
+    text: 'A beautiful image',
+    resolvedModel: 'gemini-2.5-flash-image',
+  };
+  mockGenerateError = null;
+  mockAttachments = [];
+});
+
+const fakeContext = {
+  conversationId: 'conv-123',
+  sessionId: 'sess-123',
+  workingDir: '/tmp',
+} as unknown as ToolContext;
+
+describe('image-studio skill script wrapper', () => {
+  test('exports a run function without registering media_generate_image in the tool registry', async () => {
+    expect(getTool('media_generate_image')).toBeUndefined();
+    expect(typeof run).toBe('function');
+    expect(getTool('media_generate_image')).toBeUndefined();
+  });
+
+  test('returns error when no API key is configured', async () => {
+    mockApiKey = undefined;
+
+    const result = await run({ prompt: 'a cat' }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No Gemini API key');
+  });
+
+  test('returns generated image with contentBlocks', async () => {
+    const result = await run({ prompt: 'a sunset' }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Generated 1 image');
+    expect(result.content).toContain('gemini-2.5-flash-image');
+    expect(result.content).toContain('A beautiful image');
+    expect(result.contentBlocks).toHaveLength(1);
+    expect(result.contentBlocks![0]).toEqual({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: 'generated-data',
+      },
+    });
+  });
+
+  test('handles multiple images in result', async () => {
+    mockGenerateResult = {
+      images: [
+        { mimeType: 'image/png', dataBase64: 'img1' },
+        { mimeType: 'image/png', dataBase64: 'img2' },
+      ],
+      text: undefined as unknown as string,
+      resolvedModel: 'gemini-2.5-flash-image',
+    };
+
+    const result = await run({ prompt: 'test', variants: 2 }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Generated 2 images');
+    expect(result.contentBlocks).toHaveLength(2);
+  });
+
+  test('handles generation error gracefully', async () => {
+    mockGenerateError = new Error('API failure');
+
+    const result = await run({ prompt: 'a cat' }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Mock error: API failure');
+  });
+
+  test('passes attachment data as sourceImages for edit mode', async () => {
+    mockAttachments = [{
+      id: 'att-1',
+      assistantId: 'test-assistant',
+      originalFilename: 'photo.jpg',
+      mimeType: 'image/jpeg',
+      sizeBytes: 1000,
+      kind: 'image',
+      createdAt: Date.now(),
+      dataBase64: 'attachment-data',
+    }];
+
+    const result = await run(
+      { prompt: 'remove bg', mode: 'edit', attachment_ids: ['att-1'] },
+      fakeContext,
+    );
+
+    expect(result.isError).toBe(false);
+  });
+});
+
+describe('image-studio TOOLS.json manifest', () => {
+  const manifest = JSON.parse(readFileSync(join(CONFIG_DIR, 'TOOLS.json'), 'utf-8'));
+
+  test('has version 1', () => {
+    expect(manifest.version).toBe(1);
+  });
+
+  test('declares exactly one tool', () => {
+    expect(manifest.tools).toHaveLength(1);
+  });
+
+  test('tool is named media_generate_image', () => {
+    expect(manifest.tools[0].name).toBe('media_generate_image');
+  });
+
+  test('tool executor points to the skill script wrapper', () => {
+    expect(manifest.tools[0].executor).toBe('tools/media-generate-image.ts');
+  });
+
+  test('tool execution_target is host', () => {
+    expect(manifest.tools[0].execution_target).toBe('host');
+  });
+
+  test('tool risk is low', () => {
+    expect(manifest.tools[0].risk).toBe('low');
+  });
+
+  test('tool category is media', () => {
+    expect(manifest.tools[0].category).toBe('media');
+  });
+
+  test('input schema requires prompt', () => {
+    const schema = manifest.tools[0].input_schema;
+    expect(schema.type).toBe('object');
+    expect(schema.required).toEqual(['prompt']);
+    expect(schema.properties.prompt.type).toBe('string');
+  });
+
+  test('input schema has optional mode, attachment_ids, model, variants', () => {
+    const props = manifest.tools[0].input_schema.properties;
+    expect(props.mode.enum).toEqual(['generate', 'edit']);
+    expect(props.attachment_ids.type).toBe('array');
+    expect(props.model.enum).toEqual(['gemini-2.5-flash-image', 'gemini-3-pro-image']);
+    expect(props.variants.type).toBe('number');
+  });
+});

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: "Image Studio"
+description: "Generate and edit images using AI"
+user-invocable: true
+disable-model-invocation: false
+metadata: {"vellum": {"emoji": "🎨"}}
+---
+
+You are an image generation assistant. When the user asks you to create or edit images, use the `media_generate_image` tool.
+
+## Usage
+
+- **Text-to-image**: "Generate an image of a sunset over the ocean"
+- **Image editing**: "Remove the background from this image" (requires attaching an image)
+- **Multiple variants**: "Generate 3 variations of a logo for a coffee shop"
+
+## Modes
+
+- **generate** (default): Create a new image from a text prompt.
+- **edit**: Modify an existing image based on a text prompt. Requires one or more attached source images via `attachment_ids`.
+
+## Models
+
+- `gemini-2.5-flash-image` (default) — fast, good quality
+- `gemini-3-pro-image` — higher quality, slower
+
+## Tips
+
+- Be descriptive in your prompts for better results. Include details about style, composition, lighting, and mood.
+- When editing images, clearly describe what changes you want made to the source image.
+- Use the `variants` parameter (1-4) to generate multiple options and pick the best one.
+- If no Gemini API key is configured, the tool will return an error — ask the user to set one up.

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "media_generate_image",
+      "description": "Generate or edit images using AI. Supports text-to-image generation and image editing with source images.",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "A text description of the image to generate or the edits to apply"
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["generate", "edit"],
+            "description": "Whether to generate a new image or edit an existing one (default: generate)"
+          },
+          "attachment_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "IDs of attached source images to edit (required for edit mode)"
+          },
+          "model": {
+            "type": "string",
+            "enum": ["gemini-2.5-flash-image", "gemini-3-pro-image"],
+            "description": "Which model to use for generation (default: gemini-2.5-flash-image)"
+          },
+          "variants": {
+            "type": "number",
+            "description": "Number of image variants to generate (1-4, default: 1)"
+          }
+        },
+        "required": ["prompt"]
+      },
+      "executor": "tools/media-generate-image.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -8,6 +8,26 @@ import { getDb } from '../../../../memory/db.js';
 import { conversationKeys } from '../../../../memory/schema.js';
 import { isAttachmentVisible, type AttachmentContext } from '../../../../daemon/media-visibility-policy.js';
 import { getConversationThreadType } from '../../../../memory/conversation-store.js';
+import { getAttachmentSourceConversations } from '../../../../tools/assets/search.js';
+
+/**
+ * Check whether an attachment is visible from the given context.
+ * Mirrors the logic in tools/assets/search.ts:isAttachmentVisibleFromContext.
+ */
+function isAttachmentAccessible(attachmentId: string, currentContext: AttachmentContext): boolean {
+  const sources = getAttachmentSourceConversations(attachmentId);
+  if (sources.length === 0) {
+    return true; // orphan attachments are universally visible
+  }
+  const hasStandard = sources.some((s) => s.threadType !== 'private');
+  if (hasStandard) {
+    return true;
+  }
+  // All sources are private — visible only if the caller is in one of those threads
+  return sources.some(
+    (s) => isAttachmentVisible({ conversationId: s.conversationId, isPrivate: true }, currentContext),
+  );
+}
 
 /** Resolve the assistantId for the current conversation. */
 function getAssistantIdForConversation(conversationId: string): string | null {
@@ -61,12 +81,9 @@ export async function run(
       isPrivate: threadType === 'private',
     };
 
-    // Filter to only visible attachments
+    // Filter to only visible attachments using their originating context
     const visibleAttachments = attachments.filter((att) =>
-      isAttachmentVisible(
-        { conversationId: context.conversationId, isPrivate: threadType === 'private' },
-        currentContext,
-      ),
+      isAttachmentAccessible(att.id, currentContext),
     );
 
     if (visibleAttachments.length === 0 && attachmentIds.length > 0) {

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,0 +1,120 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import type { ImageContent } from '../../../../providers/types.js';
+import { eq } from 'drizzle-orm';
+import { getConfig } from '../../../../config/loader.js';
+import { generateImage, mapGeminiError } from '../../../../media/gemini-image-service.js';
+import { getAttachmentsByIds } from '../../../../memory/attachments-store.js';
+import { getDb } from '../../../../memory/db.js';
+import { conversationKeys } from '../../../../memory/schema.js';
+import { isAttachmentVisible, type AttachmentContext } from '../../../../daemon/media-visibility-policy.js';
+import { getConversationThreadType } from '../../../../memory/conversation-store.js';
+
+/** Resolve the assistantId for the current conversation. */
+function getAssistantIdForConversation(conversationId: string): string | null {
+  const db = getDb();
+  const row = db
+    .select({ assistantId: conversationKeys.assistantId })
+    .from(conversationKeys)
+    .where(eq(conversationKeys.conversationId, conversationId))
+    .get();
+  return row?.assistantId ?? null;
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const config = getConfig();
+  const apiKey = config.apiKeys.gemini;
+
+  if (!apiKey) {
+    return {
+      content: 'No Gemini API key configured. Please set your Gemini API key to use image generation.',
+      isError: true,
+    };
+  }
+
+  const prompt = input.prompt as string;
+  const mode = (input.mode as 'generate' | 'edit') ?? 'generate';
+  const attachmentIds = input.attachment_ids as string[] | undefined;
+  const model = input.model as string | undefined;
+  const variants = input.variants as number | undefined;
+
+  // Resolve source images from attachments for edit mode
+  let sourceImages: Array<{ mimeType: string; dataBase64: string }> | undefined;
+
+  if (attachmentIds && attachmentIds.length > 0) {
+    const assistantId = getAssistantIdForConversation(context.conversationId);
+    if (!assistantId) {
+      return {
+        content: 'Could not resolve assistant context for attachment lookup.',
+        isError: true,
+      };
+    }
+
+    const attachments = getAttachmentsByIds(assistantId, attachmentIds);
+
+    // Build visibility context for the current conversation
+    const threadType = getConversationThreadType(context.conversationId);
+    const currentContext: AttachmentContext = {
+      conversationId: context.conversationId,
+      isPrivate: threadType === 'private',
+    };
+
+    // Filter to only visible attachments
+    const visibleAttachments = attachments.filter((att) =>
+      isAttachmentVisible(
+        { conversationId: context.conversationId, isPrivate: threadType === 'private' },
+        currentContext,
+      ),
+    );
+
+    if (visibleAttachments.length === 0 && attachmentIds.length > 0) {
+      return {
+        content: 'None of the specified attachments could be found or are accessible.',
+        isError: true,
+      };
+    }
+
+    sourceImages = visibleAttachments.map((att) => ({
+      mimeType: att.mimeType,
+      dataBase64: att.dataBase64,
+    }));
+  }
+
+  try {
+    const result = await generateImage(apiKey, {
+      prompt,
+      mode,
+      sourceImages,
+      model,
+      variants,
+    });
+
+    const imageCount = result.images.length;
+    let content = `Generated ${imageCount} image${imageCount !== 1 ? 's' : ''} using ${result.resolvedModel}.`;
+    if (result.text) {
+      content += `\n\n${result.text}`;
+    }
+
+    const contentBlocks: ImageContent[] = result.images.map((img) => ({
+      type: 'image' as const,
+      source: {
+        type: 'base64' as const,
+        media_type: img.mimeType,
+        data: img.dataBase64,
+      },
+    }));
+
+    return {
+      content,
+      isError: false,
+      contentBlocks,
+    };
+  } catch (error) {
+    return {
+      content: mapGeminiError(error),
+      isError: true,
+    };
+  }
+}

--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -1,0 +1,136 @@
+import { GoogleGenAI, ApiError } from '@google/genai';
+
+// --- Request / Response types ---
+
+export interface ImageGenerationRequest {
+  prompt: string;
+  mode: 'generate' | 'edit';
+  /** Base64-encoded source images for edit mode */
+  sourceImages?: Array<{ mimeType: string; dataBase64: string }>;
+  /** Model override; defaults to 'gemini-2.5-flash-image' */
+  model?: string;
+  /** Number of output variants (1-4, default 1) */
+  variants?: number;
+}
+
+export interface GeneratedImage {
+  mimeType: string;
+  dataBase64: string;
+}
+
+export interface ImageGenerationResult {
+  images: GeneratedImage[];
+  text?: string;
+  resolvedModel: string;
+}
+
+// --- Constants ---
+
+const DEFAULT_MODEL = 'gemini-2.5-flash-image';
+const ALLOWED_MODELS = new Set(['gemini-2.5-flash-image', 'gemini-3-pro-image']);
+const MAX_VARIANTS = 4;
+
+// --- Error mapping ---
+
+export function mapGeminiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    const status = error.status;
+    if (status === 400) {
+      return 'The image request was invalid. Please check your prompt and try again.';
+    }
+    if (status === 401 || status === 403) {
+      return 'Authentication failed. Please check your Gemini API key.';
+    }
+    if (status === 429) {
+      return 'Rate limit exceeded. Please wait a moment and try again.';
+    }
+    if (status !== undefined && status >= 500) {
+      return 'The Gemini service is temporarily unavailable. Please try again later.';
+    }
+    return `Gemini API error (status ${status}). Please try again.`;
+  }
+  if (error instanceof Error) {
+    return `Image generation failed: ${error.message}`;
+  }
+  return 'An unexpected error occurred during image generation.';
+}
+
+// --- Core function ---
+
+export async function generateImage(
+  apiKey: string,
+  request: ImageGenerationRequest,
+): Promise<ImageGenerationResult> {
+  const model = request.model && ALLOWED_MODELS.has(request.model)
+    ? request.model
+    : DEFAULT_MODEL;
+
+  const variants = Math.max(1, Math.min(request.variants ?? 1, MAX_VARIANTS));
+
+  const client = new GoogleGenAI({ apiKey });
+
+  // Build contents array
+  const parts: Array<{ text: string } | { inlineData: { mimeType: string; data: string } }> = [
+    { text: request.prompt },
+  ];
+
+  if (request.mode === 'edit' && request.sourceImages) {
+    for (const img of request.sourceImages) {
+      parts.push({
+        inlineData: { mimeType: img.mimeType, data: img.dataBase64 },
+      });
+    }
+  }
+
+  const config = { responseModalities: ['TEXT', 'IMAGE'] as string[] };
+
+  const makeSingleCall = async () => {
+    const response = await client.models.generateContent({
+      model,
+      contents: [{ role: 'user' as const, parts }],
+      config,
+    });
+
+    const images: GeneratedImage[] = [];
+    let text: string | undefined;
+
+    const responseParts = response.candidates?.[0]?.content?.parts;
+    if (responseParts) {
+      for (const part of responseParts) {
+        if (part.inlineData) {
+          images.push({
+            mimeType: part.inlineData.mimeType ?? 'image/png',
+            dataBase64: part.inlineData.data ?? '',
+          });
+        }
+        if (part.text) {
+          text = text ? `${text}\n${part.text}` : part.text;
+        }
+      }
+    }
+
+    return { images, text };
+  };
+
+  if (variants === 1) {
+    const result = await makeSingleCall();
+    return { ...result, resolvedModel: model };
+  }
+
+  // Parallel calls for multiple variants
+  const results = await Promise.all(
+    Array.from({ length: variants }, () => makeSingleCall()),
+  );
+
+  const allImages: GeneratedImage[] = [];
+  let combinedText: string | undefined;
+
+  for (const result of results) {
+    allImages.push(...result.images);
+    if (result.text) {
+      combinedText = combinedText ? `${combinedText}\n${result.text}` : result.text;
+    }
+  }
+
+  return { images: allImages, text: combinedText, resolvedModel: model };
+}


### PR DESCRIPTION
## Summary

- Adds a bundled **Image Studio** skill (`media_generate_image` tool) for AI-powered image generation and editing via Google Gemini
- Introduces a reusable `gemini-image-service` module with support for text-to-image generation, image editing with source attachments, model selection (`gemini-2.5-flash-image`, `gemini-3-pro-image`), and 1-4 variant generation via parallel API calls
- Includes deterministic error mapping (rate limits, auth failures, bad requests) for user-safe error messages

## Test plan

- [x] 17 unit tests for the Gemini image service (generate/edit modes, model validation, variants, error mapping)
- [x] 15 unit tests for the tool wrapper (API key checks, content block structure, attachment handling, manifest validation)
- [x] TypeScript build passes (`tsc --noEmit`)
- [x] Manual E2E: activated skill, generated retro-futuristic cityscape images with 2 variants — images rendered correctly in conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
