### PR TITLE
Increase log truncation limit for content blocks by 1000 chars

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -172,8 +172,8 @@ export class AgentLoop {
             cacheReadInputTokens: response.usage.cacheReadInputTokens,
             contentBlocks: response.content.map((b) => ({
               type: b.type,
-              ...(b.type === 'text' ? { text: truncateForLog(b.text, 200) } : {}),
-              ...(b.type === 'tool_use' ? { name: b.name, input: truncateForLog(JSON.stringify(b.input), 200) } : {}),
+              ...(b.type === 'text' ? { text: truncateForLog(b.text, 1200) } : {}),
+              ...(b.type === 'tool_use' ? { name: b.name, input: truncateForLog(JSON.stringify(b.input), 1200) } : {}),
             })),
           }, 'Provider response received');
         }


### PR DESCRIPTION
## Summary
- Increased `truncateForLog` limit for text and tool_use content blocks in the "Provider response received" debug log from 200 to 1200 characters
- This prevents useful content from being cut off too aggressively in debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
