### PR TITLE
feat: render session errors inside a red box in chat

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -96,10 +96,8 @@ struct ChatContentView: View {
             }
             } // end else (messages non-empty)
 
-            // Session error banner
-            if let sessionError = viewModel.sessionError {
-                sessionErrorBanner(sessionError)
-            } else if let errorText = viewModel.errorText {
+            // Generic error banner (session errors are shown inline in messages)
+            if viewModel.sessionError == nil, let errorText = viewModel.errorText {
                 genericErrorBanner(errorText)
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -342,7 +342,7 @@ struct ChatView: View {
         let buttonRow: CGFloat = expanded ? 34 + VSpacing.xs : 0
         let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
-        let error: CGFloat = sessionError != nil ? 60 : (errorText != nil ? 36 : 0)
+        let error: CGFloat = (sessionError == nil && errorText != nil) ? 36 : 0
         let queueCount = CGFloat(queuedMessages.count)
         let queue: CGFloat = queueCount > 0 ? (28 + (isQueueExpanded ? queueCount * 24 : 0) + VSpacing.xs) : 0
         return base + attachments + error + queue
@@ -373,9 +373,7 @@ struct ChatView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
-            if let sessionError {
-                sessionErrorToast(sessionError)
-            } else if let errorText {
+            if let errorText, sessionError == nil {
                 errorBanner(errorText)
             }
             queueSummary
@@ -1019,6 +1017,8 @@ private struct ChatBubble: View {
     private var bubbleFill: AnyShapeStyle {
         if isUser {
             AnyShapeStyle(VColor.userBubble)
+        } else if message.isError {
+            AnyShapeStyle(VColor.error.opacity(0.1))
         } else {
             AnyShapeStyle(Color.clear)
         }
@@ -1820,7 +1820,19 @@ private struct ChatBubble: View {
                 SkillInvocationChip(data: skillInvocation)
             }
 
-            if hasText {
+            if message.isError && hasText {
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(VColor.error)
+                        .padding(.top, 1)
+                    Text(message.text)
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textPrimary)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else if hasText {
                 let segments = Self.cachedSegments(for: message.text)
                 let hasRichContent = segments.contains(where: {
                     switch $0 {
@@ -1954,11 +1966,17 @@ private struct ChatBubble: View {
                 }
             }
         }
-        .padding(.horizontal, isUser ? VSpacing.lg : 0)
-        .padding(.vertical, isUser ? VSpacing.md : 0)
+        .padding(.horizontal, isUser || message.isError ? VSpacing.lg : 0)
+        .padding(.vertical, isUser || message.isError ? VSpacing.md : 0)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(bubbleFill)
+        )
+        .overlay(
+            message.isError
+                ? RoundedRectangle(cornerRadius: VRadius.lg)
+                    .strokeBorder(VColor.error.opacity(0.3), lineWidth: 1)
+                : nil
         )
         .frame(maxWidth: 520, alignment: isUser ? .trailing : .leading)
     }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -844,6 +844,9 @@ public struct ChatMessage: Identifiable {
     public var streamingCodePreview: String?
     /// Tool name associated with the streaming code preview.
     public var streamingCodeToolName: String?
+    /// When true, this message represents a session error (rate limit, network failure, etc.)
+    /// and should be rendered with distinct error styling (red box) instead of a normal bubble.
+    public var isError: Bool
     /// The daemon's persisted message ID, populated from history responses.
     /// Nil for freshly streamed messages that haven't been loaded from history.
     /// Used for anchoring diagnostics exports so the daemon can locate the message.
@@ -854,7 +857,7 @@ public struct ChatMessage: Identifiable {
         textSegments.joined()
     }
 
-    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = []) {
+    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false) {
         self.id = id
         self.role = role
         self.textSegments = text.isEmpty ? [] : [text]
@@ -867,6 +870,7 @@ public struct ChatMessage: Identifiable {
         self.attachments = attachments
         self.toolCalls = toolCalls
         self.inlineSurfaces = inlineSurfaces
+        self.isError = isError
     }
 
     /// Build a default content order from the legacy `arrivedBeforeText` flag.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -946,12 +946,21 @@ extension ChatViewModel {
             currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
-            // When the user intentionally cancelled, suppress both the typed
-            // session error and the errorText so no toast appears.
+            // When the user intentionally cancelled, suppress the error.
+            // Otherwise, insert an inline error message so errors are visually
+            // distinct from normal assistant replies (rendered with a red box).
             if !wasCancelling {
                 let typedError = SessionError(from: msg)
                 sessionError = typedError
-                errorText = msg.userMessage
+                // Remove empty assistant message left over from the interrupted stream
+                if let existingId = messages.last?.id,
+                   messages.last?.role == .assistant,
+                   messages.last?.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true,
+                   messages.last?.toolCalls.isEmpty == true {
+                    messages.removeAll(where: { $0.id == existingId })
+                }
+                let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true)
+                messages.append(errorMsg)
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -700,6 +700,11 @@ public final class ChatViewModel: ObservableObject {
             return
         }
 
+        // Remove inline error messages before regenerating so they don't
+        // linger above the new response.
+        while messages.last?.isError == true {
+            messages.removeLast()
+        }
         errorText = nil
         sessionError = nil
         isSending = true

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -189,6 +189,25 @@ public struct MessageBubbleView: View {
                 .background(VColor.userBubble)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .textSelection(.enabled)
+        } else if message.isError {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(VColor.error)
+                    .padding(.top, 1)
+                Text(text)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(VSpacing.md)
+            .background(VColor.error.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .strokeBorder(VColor.error.opacity(0.3), lineWidth: 1)
+            )
         } else {
             MarkdownRenderer(text: text)
                 .padding(VSpacing.md)


### PR DESCRIPTION
## Summary
- Session errors (rate limits, network failures, API errors) are now rendered as inline chat messages inside a visually distinct red box with a warning icon, instead of as toast banners above the composer
- Error messages are automatically removed when the user regenerates a response
- Both macOS and iOS platforms updated

## Test plan
- [ ] Trigger a rate limit error and verify it appears as a red-boxed message in the chat (not as a toast)
- [ ] Verify the error message has a warning triangle icon, red-tinted background, and red border
- [ ] Click "Regenerate" on the error message and verify the error is removed and a new response streams in
- [ ] Cancel a request and verify no error message appears (cancellation suppression still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
