### PR TITLE
feat: add inline video attachment playback

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -106,7 +106,13 @@ describe('classifyKind', () => {
     expect(classifyKind('image/webp')).toBe('image');
   });
 
-  test('classifies non-image mime types as document', () => {
+  test('classifies video mime types as video', () => {
+    expect(classifyKind('video/mp4')).toBe('video');
+    expect(classifyKind('video/webm')).toBe('video');
+    expect(classifyKind('video/quicktime')).toBe('video');
+  });
+
+  test('classifies non-image non-video mime types as document', () => {
     expect(classifyKind('application/pdf')).toBe('document');
     expect(classifyKind('text/plain')).toBe('document');
     expect(classifyKind('application/octet-stream')).toBe('document');

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -31,7 +31,7 @@ export interface AssistantAttachmentDraft {
   mimeType: string;
   dataBase64: string;
   sizeBytes: number;
-  kind: 'image' | 'document';
+  kind: 'image' | 'video' | 'document';
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +75,12 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
   js: 'text/javascript',
   ts: 'text/typescript',
 
+  // Video
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  mpeg: 'video/mpeg',
+
   // Archives
   zip: 'application/zip',
   gz: 'application/gzip',
@@ -96,8 +102,10 @@ export function inferMimeType(filename: string): string {
 // Kind classification
 // ---------------------------------------------------------------------------
 
-export function classifyKind(mimeType: string): 'image' | 'document' {
-  return mimeType.startsWith('image/') ? 'image' : 'document';
+export function classifyKind(mimeType: string): 'image' | 'video' | 'document' {
+  if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('video/')) return 'video';
+  return 'document';
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -22,6 +22,7 @@ export interface StoredAttachment {
 
 function classifyKind(mimeType: string): string {
   if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('video/')) return 'video';
   return 'document';
 }
 

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -69,6 +69,7 @@ let package = Package(
                 .linkedFramework("Vision"),
                 .linkedFramework("Network"),
                 .linkedFramework("SpriteKit"),
+                .linkedFramework("AVKit"),
                 .linkedFramework("AuthenticationServices"),
             ]
         ),

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1798,19 +1798,22 @@ private struct ChatBubble: View {
         return "Sent \(count) attachments"
     }
 
-    /// Partitions attachments into decoded images and non-image files in a single pass,
+    /// Partitions attachments into decoded images, videos, and non-media files in a single pass,
     /// avoiding redundant base64 decoding and NSImage construction across render calls.
-    private var partitionedAttachments: (images: [(ChatAttachment, NSImage)], files: [ChatAttachment]) {
+    private var partitionedAttachments: (images: [(ChatAttachment, NSImage)], videos: [ChatAttachment], files: [ChatAttachment]) {
         var images: [(ChatAttachment, NSImage)] = []
+        var videos: [ChatAttachment] = []
         var files: [ChatAttachment] = []
         for attachment in message.attachments {
             if attachment.mimeType.hasPrefix("image/"), let img = nsImage(for: attachment) {
                 images.append((attachment, img))
+            } else if attachment.mimeType.hasPrefix("video/") {
+                videos.append(attachment)
             } else {
                 files.append(attachment)
             }
         }
-        return (images, files)
+        return (images, videos, files)
     }
 
     private var bubbleContent: some View {
@@ -1949,6 +1952,14 @@ private struct ChatBubble: View {
                 attachmentImageGrid(partitioned.images)
             }
 
+            if !partitioned.videos.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(partitioned.videos) { attachment in
+                        InlineVideoAttachmentView(attachment: attachment)
+                    }
+                }
+            }
+
             if !partitioned.files.isEmpty {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     ForEach(partitioned.files) { attachment in
@@ -2079,6 +2090,8 @@ private struct ChatBubble: View {
     }
 
     private func fileIcon(for mimeType: String) -> String {
+        if mimeType.hasPrefix("video/") { return "film" }
+        if mimeType.hasPrefix("audio/") { return "waveform" }
         if mimeType.hasPrefix("text/") { return "doc.text.fill" }
         if mimeType == "application/pdf" { return "doc.fill" }
         if mimeType.contains("zip") || mimeType.contains("archive") { return "doc.zipper" }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -1,0 +1,124 @@
+import AVKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Inline video player for file-based video attachments (e.g. video/mp4).
+///
+/// Decodes base64 attachment data to a temp file and plays it with native
+/// AVPlayerView. Uses a click-to-play pattern to avoid auto-playing videos
+/// on scroll.
+struct InlineVideoAttachmentView: View {
+    let attachment: ChatAttachment
+
+    @State private var player: AVPlayer?
+    @State private var isPlaying = false
+    @State private var failed = false
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 0.5)
+                )
+
+            if failed {
+                failedView
+            } else if let player, isPlaying {
+                VideoPlayerView(player: player)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            } else {
+                placeholderView
+            }
+        }
+        .frame(maxWidth: 360)
+        .aspectRatio(3.0 / 4.0, contentMode: .fit)
+        .onDisappear {
+            player?.pause()
+            player = nil
+            isPlaying = false
+        }
+    }
+
+    private var placeholderView: some View {
+        VStack(spacing: VSpacing.sm) {
+            Image(systemName: "play.circle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(VColor.textSecondary)
+
+            Text(attachment.filename)
+                .font(VFont.caption)
+                .foregroundStyle(VColor.textSecondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            prepareAndPlay()
+        }
+    }
+
+    private var failedView: some View {
+        VStack(spacing: VSpacing.xs) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 20))
+                .foregroundStyle(VColor.textSecondary)
+
+            Text("Could not play video")
+                .font(VFont.caption)
+                .foregroundStyle(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            openInExternalPlayer()
+        }
+    }
+
+    private func prepareAndPlay() {
+        guard let data = Data(base64Encoded: attachment.data) else {
+            failed = true
+            return
+        }
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent(attachment.filename)
+        do {
+            try data.write(to: fileURL)
+        } catch {
+            failed = true
+            return
+        }
+
+        let avPlayer = AVPlayer(url: fileURL)
+        self.player = avPlayer
+        self.isPlaying = true
+        avPlayer.play()
+    }
+
+    private func openInExternalPlayer() {
+        guard let data = Data(base64Encoded: attachment.data) else { return }
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent(attachment.filename)
+        try? data.write(to: fileURL)
+        NSWorkspace.shared.open(fileURL)
+    }
+}
+
+/// NSViewRepresentable wrapper for AVPlayerView.
+private struct VideoPlayerView: NSViewRepresentable {
+    let player: AVPlayer
+
+    func makeNSView(context: Context) -> AVPlayerView {
+        let view = AVPlayerView()
+        view.player = player
+        view.controlsStyle = .inline
+        view.showsFullScreenToggleButton = true
+        return view
+    }
+
+    func updateNSView(_ nsView: AVPlayerView, context: Context) {
+        nsView.player = player
+    }
+}


### PR DESCRIPTION
## Summary
- Videos sent by the assistant via `<vellum-attachment>` now play inline in chat bubbles using a native AVPlayer (click-to-play), instead of being shown as generic file chips
- Added `'video'` kind classification to both daemon and storage layers so video/* MIME types are properly categorized
- Added video file extensions (mp4, webm, mov, mpeg) to the MIME inference map

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
