### PR TITLE
chore: add diagnostic logging to attachment resolution

### DIFF
--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -97,11 +97,24 @@ export async function resolveAssistantAttachments(
   let assistantAttachments: AssistantAttachmentDraft[] = [];
   const emittedAttachments: UserMessageAttachment[] = [];
 
+  log.info(
+    { directiveCount: accumulatedDirectives.length, toolBlockCount: accumulatedToolContentBlocks.length, workingDir },
+    'Resolving assistant attachments',
+  );
+
   if (accumulatedDirectives.length > 0 || accumulatedToolContentBlocks.length > 0) {
     const directiveDrafts = accumulatedDirectives.length > 0
       ? await resolveDirectives(accumulatedDirectives, workingDir, approveHostRead)
       : { drafts: [], warnings: [] };
     directiveWarnings.push(...directiveDrafts.warnings);
+
+    if (directiveDrafts.warnings.length > 0) {
+      log.warn({ warnings: directiveDrafts.warnings }, 'Directive resolution warnings');
+    }
+    log.info(
+      { resolvedDrafts: directiveDrafts.drafts.length, directives: accumulatedDirectives.map(d => ({ source: d.source, path: d.path, filename: d.filename, mimeType: d.mimeType })) },
+      'Directive resolution complete',
+    );
 
     const toolDrafts = contentBlocksToDrafts(accumulatedToolContentBlocks);
 
@@ -109,6 +122,13 @@ export async function resolveAssistantAttachments(
     const validated = validateDrafts(merged);
     directiveWarnings.push(...validated.warnings);
     assistantAttachments = validated.accepted;
+
+    log.info(
+      { merged: merged.length, accepted: validated.accepted.length, validationWarnings: validated.warnings },
+      'Attachment validation complete',
+    );
+  } else {
+    log.info('No directives or tool content blocks to resolve');
   }
 
   // Persist resolved attachments and link to the last assistant message

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -983,6 +983,12 @@ export class Session {
               cleanAssistantContent(event.message.content);
             accumulatedDirectives.push(...msgDirectives);
             directiveWarnings.push(...msgWarnings);
+            if (msgDirectives.length > 0) {
+              rlog.info(
+                { parsedDirectives: msgDirectives.map(d => ({ source: d.source, path: d.path, mimeType: d.mimeType })), totalAccumulated: accumulatedDirectives.length },
+                'Parsed attachment directives from assistant message',
+              );
+            }
 
             // Add surface blocks to content for persistence
             const contentWithSurfaces: ContentBlock[] = [...cleanedContent as ContentBlock[]];


### PR DESCRIPTION
## Summary
- Log when directives are parsed from assistant messages (source, path, mimeType)
- Log directive resolution results including warnings (file not found, too large, etc.)
- Log attachment validation outcomes (merged count, accepted count)
- Helps debug cases where video/file attachments don't appear in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
