### PR TITLE
Render model picker, model list, and command list on iOS

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -35,28 +35,46 @@ struct ChatContentView: View {
                     LazyVStack(spacing: VSpacing.md) {
                         let messages = viewModel.messages
                         ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
-                            let isLastAssistant = message.role == .assistant
-                                && !message.isStreaming
-                                && (index == messages.count - 1
-                                    || (index == messages.count - 2
-                                        && messages[messages.count - 1].confirmation != nil
-                                        && messages[messages.count - 1].confirmation?.state != .pending))
-                                && !viewModel.isSending
-                                && !viewModel.isThinking
-                            MessageBubbleView(
-                                message: message,
-                                onConfirmationResponse: { requestId, decision in
-                                    viewModel.respondToConfirmation(requestId: requestId, decision: decision)
-                                },
-                                onSurfaceAction: { surfaceId, actionId, data in
-                                    viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
-                                },
-                                onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
-                                onAddTrustRule: { toolName, pattern, scope, decision in
-                                    viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision)
-                                }
-                            )
-                            .id(message.id)
+                            if message.modelPicker != nil {
+                                ModelPickerBubble(
+                                    models: ModelListBubble.anthropicModels.map { (id: $0.cmd, name: $0.display) },
+                                    selectedModelId: "claude-opus-4-6",
+                                    onSelect: { modelId in
+                                        viewModel.inputText = "/\(modelId)"
+                                        viewModel.sendMessage()
+                                    }
+                                )
+                                .id(message.id)
+                            } else if message.modelList != nil {
+                                ModelListBubble(currentModel: "claude-opus-4-6", configuredProviders: ["anthropic"])
+                                    .id(message.id)
+                            } else if message.commandList != nil {
+                                CommandListBubble()
+                                    .id(message.id)
+                            } else {
+                                let isLastAssistant = message.role == .assistant
+                                    && !message.isStreaming
+                                    && (index == messages.count - 1
+                                        || (index == messages.count - 2
+                                            && messages[messages.count - 1].confirmation != nil
+                                            && messages[messages.count - 1].confirmation?.state != .pending))
+                                    && !viewModel.isSending
+                                    && !viewModel.isThinking
+                                MessageBubbleView(
+                                    message: message,
+                                    onConfirmationResponse: { requestId, decision in
+                                        viewModel.respondToConfirmation(requestId: requestId, decision: decision)
+                                    },
+                                    onSurfaceAction: { surfaceId, actionId, data in
+                                        viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
+                                    },
+                                    onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
+                                    onAddTrustRule: { toolName, pattern, scope, decision in
+                                        viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision)
+                                    }
+                                )
+                                .id(message.id)
+                            }
                         }
 
                         // Current step indicator shown while generating

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -17,13 +17,16 @@ public struct ModelListBubble: View {
     let currentModel: String
     let configuredProviders: Set<String>
 
+    /// Anthropic model shortcuts, exposed for use by ModelPickerBubble on iOS.
+    public static let anthropicModels: [(cmd: String, model: String, display: String)] = [
+        ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
+        ("opus-fast", "claude-opus-4-6-fast", "Claude Opus 4.6 Fast"),
+        ("sonnet", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
+        ("haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
+    ]
+
     private static let providerGroups: [(key: String, name: String, models: [(cmd: String, model: String, display: String)])] = [
-        ("anthropic", "Anthropic", [
-            ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
-            ("opus-fast", "claude-opus-4-6-fast", "Claude Opus 4.6 Fast"),
-            ("sonnet", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
-            ("haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
-        ]),
+        ("anthropic", "Anthropic", anthropicModels),
         ("openai", "OpenAI", [
             ("gpt4", "gpt-4", "GPT-4"),
             ("gpt4o", "gpt-4o", "GPT-4o"),


### PR DESCRIPTION
## Summary
- Wire existing shared ModelPickerBubble, ModelListBubble, and CommandListBubble components into iOS ChatContentView
- Add conditional rendering in the message loop for modelPicker, modelList, and commandList message types
- Expose Anthropic model list from ModelListBubble as a public static for reuse by ModelPickerBubble on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
