### PR TITLE
Show subagent execution status in iOS chat

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -75,6 +75,20 @@ struct ChatContentView: View {
                                 )
                                 .id(message.id)
                             }
+
+                            // Subagent chips anchored to the message that spawned them
+                            ForEach(viewModel.activeSubagents.filter { $0.parentMessageId == message.id }) { subagent in
+                                SubagentStatusChip(subagent: subagent)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .id("subagent-\(subagent.id)")
+                            }
+                        }
+
+                        // Subagents with no parent message (e.g. from history load)
+                        ForEach(viewModel.activeSubagents.filter { $0.parentMessageId == nil }) { subagent in
+                            SubagentStatusChip(subagent: subagent)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .id("subagent-\(subagent.id)")
                         }
 
                         // Current step indicator shown while generating

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -1,7 +1,6 @@
-import VellumAssistantShared
 import SwiftUI
 
-struct SubagentStatusChip: View {
+public struct SubagentStatusChip: View {
     let subagent: SubagentInfo
 
     @State private var phase: Int = 0
@@ -24,7 +23,11 @@ struct SubagentStatusChip: View {
         }
     }
 
-    var body: some View {
+    public init(subagent: SubagentInfo) {
+        self.subagent = subagent
+    }
+
+    public var body: some View {
         HStack(spacing: VSpacing.sm) {
             Image(systemName: statusIcon)
                 .font(.system(size: 11))
@@ -88,24 +91,4 @@ struct SubagentStatusChip: View {
             }
         }
     }
-}
-
-#Preview("SubagentStatusChip") {
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VStack(spacing: VSpacing.md) {
-            SubagentStatusChip(subagent: SubagentInfo(
-                id: "1", label: "Researching API docs", status: .running
-            ))
-            SubagentStatusChip(subagent: SubagentInfo(
-                id: "2", label: "Writing tests", status: .completed
-            ))
-            SubagentStatusChip(subagent: SubagentInfo(
-                id: "3", label: "Deploying service", status: .failed
-            ))
-        }
-        .padding()
-        .frame(maxWidth: 520)
-    }
-    .frame(width: 600, height: 200)
 }


### PR DESCRIPTION
## Summary
- Move SubagentStatusChip from macOS-only to shared library (no macOS-specific APIs)
- Render subagent chips in iOS ChatContentView, anchored to spawning messages
- Orphaned subagents (from history load) render at the end of the message list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
