### PR TITLE
Show skill invocation status in iOS chat messages

### DIFF
--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -53,6 +53,11 @@ public struct MessageBubbleView: View {
                 } else if message.role == .assistant && hasInterleavedContent {
                     interleavedContent
                 } else {
+                    // Skill invocation chip (shown above message text)
+                    if let skillInvocation = message.skillInvocation {
+                        SkillInvocationChip(data: skillInvocation)
+                    }
+
                     // Pre-text tool calls render above the bubble
                     let preTextCalls = message.toolCalls.filter { $0.arrivedBeforeText }
                     if !preTextCalls.isEmpty {

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -1,10 +1,13 @@
-import VellumAssistantShared
 import SwiftUI
 
-struct SkillInvocationChip: View {
+public struct SkillInvocationChip: View {
     let data: SkillInvocationData
 
-    var body: some View {
+    public init(data: SkillInvocationData) {
+        self.data = data
+    }
+
+    public var body: some View {
         HStack(spacing: VSpacing.md) {
             if let emoji = data.emoji {
                 Text(emoji)
@@ -35,24 +38,4 @@ struct SkillInvocationChip: View {
                 .stroke(Amber._600.opacity(0.6), lineWidth: 2)
         )
     }
-}
-
-#Preview("SkillInvocationChip") {
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VStack(spacing: VSpacing.lg) {
-            SkillInvocationChip(data: SkillInvocationData(
-                name: "Summarize Page",
-                emoji: "📝",
-                description: "Summarize the contents of the current page"
-            ))
-            SkillInvocationChip(data: SkillInvocationData(
-                name: "Start the Day",
-                emoji: nil,
-                description: "Morning routine skill"
-            ))
-        }
-        .padding()
-    }
-    .frame(width: 400, height: 200)
 }


### PR DESCRIPTION
## Summary
- Move SkillInvocationChip from macOS-only to shared library (no macOS-specific APIs)
- Render skill invocation chip in shared MessageBubbleView above message text
- Both iOS and macOS now display skill name, emoji, and description when a skill is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
