### PR TITLE
Add expandable tool execution summary to iOS chat

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -74,6 +74,12 @@ struct ChatContentView: View {
                                     }
                                 )
                                 .id(message.id)
+
+                                // Compact used tools summary for completed assistant messages
+                                let completedTools = message.toolCalls.filter { $0.isComplete }
+                                if message.role == .assistant && !message.isStreaming && !completedTools.isEmpty {
+                                    UsedToolsListCompact(toolCalls: completedTools)
+                                }
                             }
 
                             // Subagent chips anchored to the message that spawned them

--- a/clients/shared/Features/Chat/UsedToolsListCompact.swift
+++ b/clients/shared/Features/Chat/UsedToolsListCompact.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// Mobile-friendly compact tool execution summary. Shows a collapsible pill
+/// ("Completed N steps") that expands to list tool names, status icons, and durations.
+public struct UsedToolsListCompact: View {
+    let toolCalls: [ToolCallData]
+    @State private var isExpanded = false
+
+    private var hasErrors: Bool { toolCalls.contains { $0.isError } }
+
+    private var pillLabel: String {
+        let count = toolCalls.count
+        if count == 1 { return toolCalls[0].actionDescription }
+        if hasErrors {
+            let errCount = toolCalls.filter { $0.isError }.count
+            return errCount == count ? "All \(count) steps failed" : "\(errCount) of \(count) steps failed"
+        }
+        return "Completed \(count) steps"
+    }
+
+    private var pillIcon: String {
+        hasErrors ? "xmark.circle.fill" : "checkmark.circle.fill"
+    }
+
+    private var pillIconColor: Color {
+        hasErrors ? VColor.error : VColor.success
+    }
+
+    public init(toolCalls: [ToolCallData]) {
+        self.toolCalls = toolCalls
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Summary pill
+            Button {
+                withAnimation(VAnimation.fast) { isExpanded.toggle() }
+            } label: {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: pillIcon)
+                        .font(.system(size: 10))
+                        .foregroundColor(pillIconColor)
+
+                    Text(pillLabel)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(VAnimation.fast, value: isExpanded)
+                }
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .fill(VColor.backgroundSubtle.opacity(0.3))
+                )
+                .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            }
+            .buttonStyle(.plain)
+
+            // Expanded steps list
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
+                        CompactToolRow(toolCall: toolCall)
+
+                        if index < toolCalls.count - 1 {
+                            Divider()
+                                .padding(.leading, 34)
+                        }
+                    }
+                }
+                .padding(.top, VSpacing.xs)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .animation(VAnimation.fast, value: isExpanded)
+    }
+}
+
+private struct CompactToolRow: View {
+    let toolCall: ToolCallData
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            // Status icon
+            ZStack {
+                RoundedRectangle(cornerRadius: VRadius.xs)
+                    .fill(toolCall.isError ? VColor.error : VColor.success)
+                    .frame(width: 20, height: 20)
+
+                Image(systemName: toolCall.isError ? "xmark" : "checkmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(.white)
+            }
+
+            // Tool description + duration
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(toolCall.actionDescription)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(toolCall.isError ? VColor.error : VColor.textPrimary)
+                    .lineLimit(1)
+
+                if let started = toolCall.startedAt, let completed = toolCall.completedAt {
+                    Text(formatDuration(completed.timeIntervalSince(started)))
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+    }
+
+    private func formatDuration(_ s: TimeInterval) -> String {
+        s < 60
+            ? String(format: "%.1fs", s)
+            : "\(Int(s) / 60)m \(Int(s) % 60)s"
+    }
+}


### PR DESCRIPTION
## Summary
- Create UsedToolsListCompact in shared library — mobile-friendly collapsible pill showing "Completed N steps"
- Tapping expands to show individual tool names, status icons, and durations
- Render after assistant messages with completed tool calls in iOS ChatContentView
- Skip screenshot rendering and diff highlighting (deferred to later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
