### PR TITLE
Inline image and video embeds in iOS chat

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -80,6 +80,11 @@ struct ChatContentView: View {
                                 if message.role == .assistant && !message.isStreaming && !completedTools.isEmpty {
                                     UsedToolsListCompact(toolCalls: completedTools)
                                 }
+
+                                // Inline media embeds (images, videos)
+                                if !message.text.isEmpty && !message.isStreaming {
+                                    MessageMediaEmbedsView(message: message)
+                                }
                             }
 
                             // Subagent chips anchored to the message that spawned them

--- a/clients/ios/Views/InlineImageEmbedView.swift
+++ b/clients/ios/Views/InlineImageEmbedView.swift
@@ -1,0 +1,50 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// Renders a remote image inline within a chat bubble on iOS.
+///
+/// Uses `AsyncImage` with deferred loading (only fetches when the view
+/// appears on screen). Tapping the image opens it in Safari.
+struct InlineImageEmbedView: View {
+    let url: URL
+
+    @State private var isVisible = false
+
+    var body: some View {
+        Group {
+            if isVisible {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .empty:
+                        placeholderSkeleton
+                            .overlay(ProgressView())
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                    case .failure:
+                        EmptyView()
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+            } else {
+                placeholderSkeleton
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: 300)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .onAppear { isVisible = true }
+        .onTapGesture {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private var placeholderSkeleton: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.gray.opacity(0.15))
+            .frame(maxWidth: .infinity)
+            .frame(height: 120)
+    }
+}
+#endif

--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -1,0 +1,149 @@
+#if canImport(UIKit)
+import SwiftUI
+import WebKit
+import VellumAssistantShared
+
+/// Renders a video embed (YouTube, Vimeo, Loom) inline in an iOS chat message.
+///
+/// Shows a placeholder with a play button; tapping loads the embed URL
+/// in a WKWebView. Tapping the provider link opens in Safari.
+struct InlineVideoEmbedView: View {
+    let provider: String
+    let videoID: String
+    let embedURL: URL
+
+    @StateObject private var stateManager = InlineVideoEmbedStateManager()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            switch stateManager.state {
+            case .placeholder:
+                placeholderView
+            case .initializing:
+                ZStack {
+                    videoWebView
+                    ProgressView()
+                }
+            case .playing:
+                videoWebView
+            case .failed(let message):
+                failedView(message)
+            }
+
+            // Provider attribution bar
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "play.rectangle.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(VColor.textMuted)
+                Text(provider.capitalized)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+        }
+        .background(VColor.backgroundSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .frame(maxWidth: .infinity)
+    }
+
+    private var placeholderView: some View {
+        Button {
+            stateManager.requestPlay()
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(Color.black.opacity(0.8))
+                    .frame(height: 200)
+
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.white.opacity(0.9))
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var videoWebView: some View {
+        VideoEmbedWebView(
+            url: embedURL,
+            onLoaded: { stateManager.didStartPlaying() },
+            onFailed: { stateManager.didFail($0) }
+        )
+        .frame(height: 200)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    private func failedView(_ message: String) -> some View {
+        VStack(spacing: VSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 24))
+                .foregroundColor(VColor.textMuted)
+            Text("Failed to load video")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            Button("Open in Safari") {
+                UIApplication.shared.open(embedURL)
+            }
+            .font(VFont.caption)
+        }
+        .frame(height: 200)
+        .frame(maxWidth: .infinity)
+        .background(Color.black.opacity(0.8))
+    }
+}
+
+/// UIViewRepresentable wrapper for WKWebView to play video embeds.
+private struct VideoEmbedWebView: UIViewRepresentable {
+    let url: URL
+    let onLoaded: () -> Void
+    let onFailed: (String) -> Void
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+        config.mediaTypesRequiringUserActionForPlayback = []
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isOpaque = false
+        webView.backgroundColor = .black
+        webView.scrollView.isScrollEnabled = false
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onLoaded: onLoaded, onFailed: onFailed)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let onLoaded: () -> Void
+        let onFailed: (String) -> Void
+
+        init(onLoaded: @escaping () -> Void, onFailed: @escaping (String) -> Void) {
+            self.onLoaded = onLoaded
+            self.onFailed = onFailed
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            onLoaded()
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            onFailed(error.localizedDescription)
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            onFailed(error.localizedDescription)
+        }
+    }
+}
+#endif

--- a/clients/ios/Views/MessageMediaEmbedsView.swift
+++ b/clients/ios/Views/MessageMediaEmbedsView.swift
@@ -1,0 +1,56 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Resolves and renders media embeds (images, videos) for a chat message on iOS.
+///
+/// Runs the async MediaEmbedResolver when the message text changes
+/// (but not during streaming to avoid per-token re-resolution).
+struct MessageMediaEmbedsView: View {
+    let message: ChatMessage
+
+    @State private var intents: [MediaEmbedIntent] = []
+
+    /// Default settings: embeds always enabled, all major video domains allowed.
+    private static let defaultSettings = MediaEmbedResolverSettings(
+        enabled: true,
+        enabledSince: nil,
+        allowedDomains: [
+            "youtube.com", "youtu.be",
+            "vimeo.com",
+            "loom.com",
+        ]
+    )
+
+    private var taskID: String {
+        if message.isStreaming { return "streaming-\(message.id)" }
+        return "\(message.text.hashValue)"
+    }
+
+    var body: some View {
+        if !intents.isEmpty {
+            VStack(spacing: VSpacing.sm) {
+                ForEach(intents.indices, id: \.self) { idx in
+                    switch intents[idx] {
+                    case .image(let url):
+                        InlineImageEmbedView(url: url)
+                    case .video(let provider, let videoID, let embedURL):
+                        InlineVideoEmbedView(provider: provider, videoID: videoID, embedURL: embedURL)
+                    }
+                }
+            }
+        }
+
+        EmptyView()
+            .task(id: taskID) {
+                guard !message.isStreaming else { return }
+                let resolved = await MediaEmbedResolver.resolve(
+                    message: message,
+                    settings: Self.defaultSettings
+                )
+                guard !Task.isCancelled else { return }
+                intents = resolved
+            }
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/MediaEmbeds/DomainAllowlistMatcher.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/DomainAllowlistMatcher.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-enum DomainAllowlistMatcher {
+public enum DomainAllowlistMatcher {
     /// Returns true if the URL's host matches any domain in the allowlist.
     /// Supports exact and subdomain matching (e.g., "youtube.com" matches "www.youtube.com").
-    static func isAllowed(_ url: URL, allowedDomains: [String]) -> Bool {
+    public static func isAllowed(_ url: URL, allowedDomains: [String]) -> Bool {
         guard url.scheme?.lowercased() == "https",
               let host = url.host?.lowercased() else { return false }
 

--- a/clients/shared/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
@@ -5,8 +5,8 @@ import Foundation
 /// This is the second stage of image detection, used for extensionless URLs
 /// that `ImageURLClassifier` returns `.unknown` for. Results are cached
 /// in-memory to avoid redundant network requests.
-final class ImageMIMEProbe {
-    static let shared = ImageMIMEProbe()
+public final class ImageMIMEProbe {
+    public static let shared = ImageMIMEProbe()
 
     private let cache = NSCache<NSString, CacheEntry>()
     private let session: URLSession
@@ -29,7 +29,7 @@ final class ImageMIMEProbe {
     /// Returns `.image` when the Content-Type starts with `image/`,
     /// `.notImage` for any other content type, and `.unknown` on
     /// network errors or timeouts. Never throws.
-    func probe(_ url: URL) async -> ImageURLClassification {
+    public func probe(_ url: URL) async -> ImageURLClassification {
         guard url.scheme?.lowercased() == "https" else {
             return .notImage
         }
@@ -63,7 +63,7 @@ final class ImageMIMEProbe {
         return result
     }
 
-    func clearCache() {
+    public func clearCache() {
         cache.removeAllObjects()
     }
 }

--- a/clients/shared/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ImageURLClassification {
+public enum ImageURLClassification {
     case image
     case notImage
     case unknown
@@ -11,14 +11,14 @@ enum ImageURLClassification {
 /// This is the first stage of image detection in the media-embed pipeline.
 /// Only truly extensionless URLs return `.unknown` (triggering the MIME-probe
 /// fallback); URLs with a non-image extension return `.notImage`.
-enum ImageURLClassifier {
+public enum ImageURLClassifier {
 
     private static let imageExtensions: Set<String> = [
         "png", "jpg", "jpeg", "gif", "webp", "svg",
         "bmp", "ico", "tiff", "tif", "avif", "heic"
     ]
 
-    static func classify(_ url: URL) -> ImageURLClassification {
+    public static func classify(_ url: URL) -> ImageURLClassification {
         // Only allow https for security.
         guard url.scheme?.lowercased() == "https" else {
             return .notImage

--- a/clients/shared/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// Transitions: placeholder → initializing → playing (or failed).
 /// A reset from any state returns to placeholder.
-enum InlineVideoEmbedState: Equatable {
+public enum InlineVideoEmbedState: Equatable {
     case placeholder
     case initializing
     case playing
@@ -16,14 +16,14 @@ enum InlineVideoEmbedState: Equatable {
 /// All mutations are main-actor–isolated because the state
 /// feeds directly into SwiftUI views.
 @MainActor
-final class InlineVideoEmbedStateManager: ObservableObject {
+public final class InlineVideoEmbedStateManager: ObservableObject {
     @Published private(set) var state: InlineVideoEmbedState = .placeholder
 
     /// Request the transition from placeholder (or failed) to initializing.
     ///
     /// Ignored when already initializing or playing — tapping play
     /// on an active player is a no-op.
-    func requestPlay() {
+    public func requestPlay() {
         switch state {
         case .placeholder, .failed:
             state = .initializing
@@ -32,15 +32,15 @@ final class InlineVideoEmbedStateManager: ObservableObject {
         }
     }
 
-    func didStartPlaying() {
+    public func didStartPlaying() {
         state = .playing
     }
 
-    func didFail(_ message: String) {
+    public func didFail(_ message: String) {
         state = .failed(message)
     }
 
-    func reset() {
+    public func reset() {
         state = .placeholder
     }
 }

--- a/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -1,17 +1,22 @@
 import Foundation
-import VellumAssistantShared
 
 /// The type of media embed that should be rendered for a URL.
-enum MediaEmbedIntent: Equatable {
+public enum MediaEmbedIntent: Equatable {
     case image(url: URL)
     case video(provider: String, videoID: String, embedURL: URL)
 }
 
 /// Snapshot of user-facing settings that gate media embed resolution.
-struct MediaEmbedResolverSettings {
-    let enabled: Bool
-    let enabledSince: Date?
-    let allowedDomains: [String]
+public struct MediaEmbedResolverSettings {
+    public let enabled: Bool
+    public let enabledSince: Date?
+    public let allowedDomains: [String]
+
+    public init(enabled: Bool, enabledSince: Date?, allowedDomains: [String]) {
+        self.enabled = enabled
+        self.enabledSince = enabledSince
+        self.allowedDomains = allowedDomains
+    }
 }
 
 /// Assembles URL extraction, video parsing, image classification, and
@@ -20,7 +25,7 @@ struct MediaEmbedResolverSettings {
 /// The resolver is role-agnostic (works for both user and assistant
 /// messages), deduplicates by canonical URL, and respects the feature
 /// gate (`enabled` / `enabledSince`).
-enum MediaEmbedResolver {
+public enum MediaEmbedResolver {
 
     /// Video parsers tried in order for each extracted URL.
     private static let videoParsers: [(URL) -> VideoParseResult?] = [
@@ -38,7 +43,7 @@ enum MediaEmbedResolver {
     /// Uses a two-stage image detection approach: first tries extension-based
     /// classification via `ImageURLClassifier`, then falls back to an async
     /// HTTP HEAD probe via `ImageMIMEProbe` for extensionless URLs.
-    static func resolve(
+    public static func resolve(
         message: ChatMessage,
         settings: MediaEmbedResolverSettings
     ) async -> [MediaEmbedIntent] {

--- a/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -5,7 +5,7 @@ import Foundation
 /// This is the first stage of the media-embed pipeline: deterministic,
 /// regex-based URL discovery with no markdown awareness (markdown link
 /// syntax handling is layered on top in a later stage).
-enum MessageURLExtractor {
+public enum MessageURLExtractor {
 
     // Characters that commonly trail a URL in natural prose but aren't
     // part of the URL itself.
@@ -13,7 +13,7 @@ enum MessageURLExtractor {
 
     /// Extracts all distinct `http(s)://` URLs from `text`, returned in
     /// first-occurrence order. Duplicates are suppressed (first wins).
-    static func extractPlainURLs(from text: String) -> [URL] {
+    public static func extractPlainURLs(from text: String) -> [URL] {
         extractPlainURLsWithPositions(from: text).map(\.url)
     }
 
@@ -65,7 +65,7 @@ enum MessageURLExtractor {
 
     /// Extracts `http(s)://` URLs that appear as markdown link targets
     /// (`[text](url)`) in `text`, returned in first-occurrence order.
-    static func extractMarkdownLinkURLs(from text: String) -> [URL] {
+    public static func extractMarkdownLinkURLs(from text: String) -> [URL] {
         extractMarkdownLinkURLsWithPositions(from: text).map(\.url)
     }
 
@@ -124,7 +124,7 @@ enum MessageURLExtractor {
     /// Matches are replaced with a single space (not an empty string)
     /// to preserve token boundaries — otherwise surrounding text could
     /// concatenate into a spurious URL.
-    static func stripCodeRegions(from text: String) -> String {
+    public static func stripCodeRegions(from text: String) -> String {
         let mutable = NSMutableString(string: text)
         let fullRange = NSRange(location: 0, length: mutable.length)
 
@@ -141,7 +141,7 @@ enum MessageURLExtractor {
     /// Combines plain-text and markdown-link URL extraction, returning a
     /// deduplicated list in first-occurrence order across both sources.
     /// URLs inside inline code spans and fenced code blocks are excluded.
-    static func extractAllURLs(from text: String) -> [URL] {
+    public static func extractAllURLs(from text: String) -> [URL] {
         let stripped = stripCodeRegions(from: text)
 
         let plain = extractPlainURLsWithPositions(from: stripped)

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoEmbedURLBuilder.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoEmbedURLBuilder.swift
@@ -5,9 +5,9 @@ import Foundation
 /// The parsers (`YouTubeParser`, `VimeoParser`, `LoomParser`) extract video IDs
 /// and produce bare embed URLs. This builder adds player query parameters
 /// (autoplay, rel suppression, etc.) that are provider-specific.
-enum VideoEmbedURLBuilder {
+public enum VideoEmbedURLBuilder {
 
-    static func buildEmbedURL(provider: String, videoID: String) -> URL? {
+    public static func buildEmbedURL(provider: String, videoID: String) -> URL? {
         switch provider.lowercased() {
         case "youtube":
             return URL(string: "https://www.youtube.com/embed/\(videoID)?autoplay=1&rel=0")

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/LoomParser.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/LoomParser.swift
@@ -7,14 +7,14 @@ import Foundation
 /// - `loom.com/embed/VIDEO_ID`  (with optional www subdomain)
 ///
 /// Only `https` URLs are accepted.
-enum LoomParser {
+public enum LoomParser {
 
     private static let loomHosts: Set<String> = [
         "loom.com",
         "www.loom.com"
     ]
 
-    static func parse(_ url: URL) -> VideoParseResult? {
+    public static func parse(_ url: URL) -> VideoParseResult? {
         guard url.scheme?.lowercased() == "https" else { return nil }
 
         guard let host = url.host?.lowercased() else { return nil }

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/VimeoParser.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/VimeoParser.swift
@@ -10,7 +10,7 @@ import Foundation
 /// - `vimeo.com/groups/GROUP/videos/VIDEO_ID`    (group)
 ///
 /// Only `https` URLs are accepted. Video IDs must be numeric.
-enum VimeoParser {
+public enum VimeoParser {
 
     private static let vimeoHosts: Set<String> = [
         "vimeo.com",
@@ -18,7 +18,7 @@ enum VimeoParser {
         "player.vimeo.com"
     ]
 
-    static func parse(_ url: URL) -> VideoParseResult? {
+    public static func parse(_ url: URL) -> VideoParseResult? {
         guard url.scheme?.lowercased() == "https" else { return nil }
 
         guard let host = url.host?.lowercased() else { return nil }

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
@@ -1,9 +1,15 @@
 import Foundation
 
-struct VideoParseResult {
-    let videoID: String
-    let provider: String
-    let embedURL: URL
+public struct VideoParseResult {
+    public let videoID: String
+    public let provider: String
+    public let embedURL: URL
+
+    public init(videoID: String, provider: String, embedURL: URL) {
+        self.videoID = videoID
+        self.provider = provider
+        self.embedURL = embedURL
+    }
 }
 
 /// Parses YouTube URLs in various formats and produces a canonical embed URL.
@@ -15,7 +21,7 @@ struct VideoParseResult {
 /// - `youtube.com/embed/ID`
 ///
 /// Only `https` URLs are accepted.
-enum YouTubeParser {
+public enum YouTubeParser {
 
     private static let youtubeHosts: Set<String> = [
         "youtube.com",
@@ -23,7 +29,7 @@ enum YouTubeParser {
         "m.youtube.com"
     ]
 
-    static func parse(_ url: URL) -> VideoParseResult? {
+    public static func parse(_ url: URL) -> VideoParseResult? {
         guard url.scheme?.lowercased() == "https" else { return nil }
 
         guard let host = url.host?.lowercased() else { return nil }


### PR DESCRIPTION
## Summary
- Move platform-agnostic media embed logic to shared library (URL extraction, video provider parsing, image classification, domain allowlisting)
- Create iOS-specific InlineImageEmbedView (AsyncImage) and InlineVideoEmbedView (WKWebView via UIViewRepresentable)
- Add MessageMediaEmbedsView wrapper that resolves embeds asynchronously per message
- macOS rendering files (InlineImageEmbedView, InlineVideoEmbedCard, InlineVideoWebView) stay in macOS target

## Files moved to shared
- MediaEmbedResolver, MessageURLExtractor, ImageURLClassifier, ImageMIMEProbe
- DomainAllowlistMatcher, VideoEmbedURLBuilder, InlineVideoEmbedState
- VideoProviders/ (YouTube, Vimeo, Loom parsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
