### PR TITLE
fix: preserve attachment links during message consolidation

### DIFF
--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -203,6 +203,20 @@ export function consolidateAssistantMessages(conversationId: string, userMessage
   const firstAssistantMsg = messagesToConsolidate[0];
   conversationStore.updateMessageContent(firstAssistantMsg.id, JSON.stringify(consolidatedContent));
 
+  // Re-link attachments from messages about to be deleted to the consolidated
+  // message. Without this, ON DELETE CASCADE on message_attachments destroys
+  // the attachment links, and deleteOrphanAttachments removes the data.
+  const messageIdsToDelete = [
+    ...messagesToConsolidate.slice(1).map((m) => m.id),
+    ...messagesToDelete,
+  ];
+  if (messageIdsToDelete.length > 0) {
+    const relinked = conversationStore.relinkAttachments(messageIdsToDelete, firstAssistantMsg.id);
+    if (relinked > 0) {
+      log.info({ relinked, targetMessageId: firstAssistantMsg.id }, 'Re-linked attachments to consolidated message');
+    }
+  }
+
   // Delete the other assistant messages and internal tool_result messages,
   // and collect IDs for vector cleanup
   const allSegmentIds: string[] = [];

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -333,6 +333,32 @@ export function updateMessageContent(messageId: string, newContent: string): voi
 }
 
 /**
+ * Re-link all attachments from a set of source messages to a target message.
+ * Used during message consolidation so that attachments linked to deleted
+ * messages survive the ON DELETE CASCADE on message_attachments.
+ */
+export function relinkAttachments(fromMessageIds: string[], toMessageId: string): number {
+  if (fromMessageIds.length === 0) return 0;
+  const db = getDb();
+
+  // Count how many links will be moved before updating.
+  const [{ total }] = db
+    .select({ total: count() })
+    .from(messageAttachments)
+    .where(inArray(messageAttachments.messageId, fromMessageIds))
+    .all();
+
+  if (total === 0) return 0;
+
+  db.update(messageAttachments)
+    .set({ messageId: toMessageId })
+    .where(inArray(messageAttachments.messageId, fromMessageIds))
+    .run();
+
+  return total;
+}
+
+/**
  * Delete a single message by ID without cascading to message_runs or
  * channel_inbound_events. Nullable FK columns in those tables are set to
  * NULL before the message row is removed, so associated run and event


### PR DESCRIPTION
## Summary
- **Root cause**: `resolveAssistantAttachments` links attachments to `lastAssistantMessageId` (the final assistant message). `consolidateAssistantMessages` then merges everything into the first message and deletes the rest — `ON DELETE CASCADE` on `message_attachments` destroys the link, and `deleteOrphanAttachments` removes the data.
- Adds `relinkAttachments()` to conversation-store to move attachment links from soon-to-be-deleted messages to the consolidated message
- Calls it in `consolidateAssistantMessages` before the deletion loop

## Test plan
- [ ] Generate a video (or any file attachment) in a multi-turn agent loop
- [ ] Verify the attachment appears in the chat after the turn completes
- [ ] Verify the attachment persists after app restart (history reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
