### PR TITLE
fix: InlineVideoEmbedStateManager access level for cross-module use

### DIFF
--- a/clients/shared/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
@@ -17,7 +17,9 @@ public enum InlineVideoEmbedState: Equatable {
 /// feeds directly into SwiftUI views.
 @MainActor
 public final class InlineVideoEmbedStateManager: ObservableObject {
-    @Published private(set) var state: InlineVideoEmbedState = .placeholder
+    @Published public private(set) var state: InlineVideoEmbedState = .placeholder
+
+    public init() {}
 
     /// Request the transition from placeholder (or failed) to initializing.
     ///


### PR DESCRIPTION
## Summary
- Added explicit `public init()` to `InlineVideoEmbedStateManager` (Swift synthesizes `internal` by default)
- Changed `state` property to `public private(set)` so it can be read from `VellumAssistantLib`
- These were causing build failures when running `./build.sh` for the desktop app in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
