### PR TITLE
fix: clean up titledThreads on empty title response

### DIFF
--- a/clients/ios/App/TitleGenerator.swift
+++ b/clients/ios/App/TitleGenerator.swift
@@ -52,7 +52,11 @@ actor TitleGenerator {
                 return nil
             }
             let title = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            return title.isEmpty ? nil : title
+            if title.isEmpty {
+                titledThreads.remove(threadId)
+                return nil
+            }
+            return title
         } catch {
             titledThreads.remove(threadId)
             return nil


### PR DESCRIPTION
## Summary
- Fixes edge case where empty API title response permanently locks thread out of title generation
- Adds titledThreads.remove(threadId) before returning nil on empty title

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4632

🤖 Generated with [Claude Code](https://claude.com/claude-code)