### PR TITLE
fix: preserve active thread during daemon session sync

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -101,6 +101,7 @@ class IOSThreadStore: ObservableObject {
         guard !response.sessions.isEmpty else { return }
 
         let recentSessions = Array(response.sessions.filter { $0.threadType != "private" }.prefix(10))
+        guard !recentSessions.isEmpty else { return }
 
         var restoredThreads: [IOSThread] = []
         for session in recentSessions {
@@ -121,8 +122,10 @@ class IOSThreadStore: ObservableObject {
             && viewModels[threads[0].id]?.sessionId == nil
         if defaultIsEmpty, let defaultThread = threads.first {
             viewModels.removeValue(forKey: defaultThread.id)
+            threads = restoredThreads
+        } else {
+            threads = restoredThreads + threads
         }
-        threads = restoredThreads
     }
 
     private func handleHistoryResponse(_ response: HistoryResponseMessage) {


### PR DESCRIPTION
## Summary
- Preserve user's in-progress thread when daemon session list arrives (append instead of replace)
- Guard against empty thread list when all daemon sessions are private

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4974

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
