### PR TITLE
fix: correct contextTooLarge error icon and color on iOS

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -276,7 +276,7 @@ struct ChatContentView: View {
         case .queueFull: return "tray.full.fill"
         case .sessionAborted: return "stop.circle.fill"
         case .processingFailed, .regenerateFailed: return "arrow.triangle.2.circlepath"
-        case .contextTooLarge: return "doc.text.fill.viewfinder"
+        case .contextTooLarge: return "text.badge.xmark"
         case .unknown: return "exclamationmark.triangle.fill"
         }
     }
@@ -286,6 +286,7 @@ struct ChatContentView: View {
         case .rateLimit, .queueFull: return VColor.warning
         case .providerNetwork: return .orange
         case .sessionAborted: return VColor.textSecondary
+        case .contextTooLarge: return VColor.warning
         default: return VColor.error
         }
     }


### PR DESCRIPTION
## Summary
- Fix invalid SF Symbol name for contextTooLarge (use `text.badge.xmark` matching macOS)
- Add explicit `VColor.warning` for contextTooLarge error accent (matching macOS amber color)

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4631

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
