### PR TITLE
fix: auto-scroll to subagent chips on iOS

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -114,6 +114,10 @@ struct ChatContentView: View {
                             .padding(.horizontal, VSpacing.lg)
                             .id("step-indicator")
                         }
+
+                        // Invisible anchor at the very bottom of all content
+                        Color.clear.frame(height: 1)
+                            .id("scroll-bottom-anchor")
                     }
                     .padding(VSpacing.lg)
                 }
@@ -132,9 +136,12 @@ struct ChatContentView: View {
                 .onChange(of: viewModel.isSending) { _, isSending in
                     if isSending {
                         withAnimation(.easeOut(duration: 0.3)) {
-                            proxy.scrollTo("step-indicator", anchor: .bottom)
+                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                         }
                     }
+                }
+                .onChange(of: viewModel.activeSubagents.count) { _, _ in
+                    scrollToBottom(proxy: proxy, animated: true)
                 }
             }
             } // end else (messages non-empty)
@@ -350,13 +357,12 @@ struct ChatContentView: View {
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy, animated: Bool) {
-        guard let lastMessage = viewModel.messages.last else { return }
         if animated {
             withAnimation(.easeOut(duration: 0.3)) {
-                proxy.scrollTo(lastMessage.id, anchor: .bottom)
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
         } else {
-            proxy.scrollTo(lastMessage.id, anchor: .bottom)
+            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add invisible scroll-bottom-anchor below all chat content (matching macOS pattern)
- Update scrollToBottom to target the anchor instead of lastMessage.id
- Add onChange handler for activeSubagents.count to trigger scroll when new subagents appear
- Update isSending onChange handler to also use scroll-bottom-anchor
- Ensures subagent status chips are visible without manual scrolling

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4970

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
