### PR TITLE
fix: schedule display and loading state recovery in iOS settings

### DIFF
--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -444,7 +444,7 @@ struct SettingsView: View {
                     Text(schedule.cronExpression)
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
-                    if let nextRun = formatTimestamp(schedule.nextRunAt) {
+                    if schedule.enabled, schedule.nextRunAt > 0, let nextRun = formatTimestamp(schedule.nextRunAt) {
                         Text("Next: \(nextRun)")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
@@ -467,7 +467,11 @@ struct SettingsView: View {
             schedules = items
             schedulesLoading = false
         }
-        try? daemon.sendListSchedules()
+        do {
+            try daemon.sendListSchedules()
+        } catch {
+            schedulesLoading = false
+        }
     }
 
     private func toggleSchedule(_ id: String, enabled: Bool) {
@@ -535,7 +539,11 @@ struct SettingsView: View {
             reminders = items
             remindersLoading = false
         }
-        try? daemon.sendListReminders()
+        do {
+            try daemon.sendListReminders()
+        } catch {
+            remindersLoading = false
+        }
     }
 
     private func cancelReminder(_ id: String) {


### PR DESCRIPTION
## Summary
- Only show next-run timestamp for enabled schedules with valid nextRunAt
- Clear schedulesLoading and remindersLoading flags when IPC send fails (matching macOS error handling)

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4977

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
