### PR TITLE
fix: index-safe onDelete for schedules and reminders

### DIFF
--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -232,8 +232,9 @@ struct SettingsView: View {
                                 scheduleRow(schedule)
                             }
                             .onDelete { indexSet in
-                                for index in indexSet {
-                                    deleteSchedule(schedules[index].id)
+                                let schedulesToDelete = indexSet.map { schedules[$0] }
+                                for schedule in schedulesToDelete {
+                                    deleteSchedule(schedule.id)
                                 }
                             }
                         }
@@ -256,8 +257,9 @@ struct SettingsView: View {
                                 reminderRow(reminder)
                             }
                             .onDelete { indexSet in
-                                for index in indexSet {
-                                    cancelReminder(reminders[index].id)
+                                let remindersToCancel = indexSet.map { reminders[$0] }
+                                for reminder in remindersToCancel {
+                                    cancelReminder(reminder.id)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Apply the same index-safe onDelete pattern (capture items before mutation) to schedules and reminders
- Matches the fix already applied to trust rules in PR #4985
- Prevents potential crashes when multiple items are deleted at once

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
