### PR TITLE
fix: deduplicate restored sessions before prepending threads

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -128,7 +128,19 @@ class IOSThreadStore: ObservableObject {
             viewModels.removeValue(forKey: defaultThread.id)
             threads = restoredThreads
         } else {
-            threads = restoredThreads + threads
+            // Deduplicate: only prepend restored threads whose sessionId
+            // doesn't already exist in the current thread list.
+            let existingSessionIds = Set(threads.compactMap { $0.sessionId })
+            var newThreads: [IOSThread] = []
+            for restored in restoredThreads {
+                if let sid = restored.sessionId, existingSessionIds.contains(sid) {
+                    // Already have a thread for this session — discard the duplicate VM.
+                    viewModels.removeValue(forKey: restored.id)
+                } else {
+                    newThreads.append(restored)
+                }
+            }
+            threads = newThreads + threads
         }
     }
 


### PR DESCRIPTION
## Summary
- Deduplicate restored daemon sessions by sessionId before prepending to local threads
- Prevents duplicate sidebar entries when a thread already has a VM-bound daemon sessionId
- Cleans up orphaned viewModels for filtered-out duplicate threads

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
