### PR TITLE
fix: address PR 4972 review feedback

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -75,12 +75,6 @@ struct ChatContentView: View {
                                 )
                                 .id(message.id)
 
-                                // Compact used tools summary for completed assistant messages
-                                let completedTools = message.toolCalls.filter { $0.isComplete }
-                                if message.role == .assistant && !message.isStreaming && !completedTools.isEmpty {
-                                    UsedToolsListCompact(toolCalls: completedTools)
-                                }
-
                                 // Inline media embeds (images, videos)
                                 if !message.text.isEmpty && !message.isStreaming {
                                     MessageMediaEmbedsView(message: message)


### PR DESCRIPTION
## Summary
Addresses review feedback from https://github.com/vellum-ai/vellum-assistant/pull/4972

Removes the duplicate `UsedToolsListCompact` rendering from `ChatContentView`. The `MessageBubbleView` already renders `ToolCallProgressBar` for tool calls (both pre-text and post-text), so adding `UsedToolsListCompact` after the message bubble created a second tool execution UI for the same data. This fix removes the duplicate to show only one tool execution view per message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
