### PR TITLE
fix: correct riskLevel and always_deny decision in secret prompt denial events

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -512,8 +512,8 @@ export class ToolExecutor {
                 sessionId: context.sessionId,
                 conversationId: context.conversationId,
                 requestId: context.requestId,
-                riskLevel,
-                decision: 'deny',
+                riskLevel: RiskLevel.High,
+                decision: response.decision === 'always_deny' ? 'always_deny' : 'deny',
                 reason: `User denied output containing secrets: ${types}`,
                 durationMs,
               });


### PR DESCRIPTION
Addresses review feedback from PR #4905:
- Use RiskLevel.High in denied secret prompt events instead of tool's original riskLevel
- Preserve always_deny vs deny distinction in decision field
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
