### PR TITLE
fix: align credential injection with router apex wildcard matching

### DIFF
--- a/assistant/src/tools/credentials/resolve.ts
+++ b/assistant/src/tools/credentials/resolve.ts
@@ -13,7 +13,7 @@ import {
   type CredentialMetadata,
 } from './metadata-store.js';
 import type { CredentialInjectionTemplate } from './policy-types.js';
-import { minimatch } from 'minimatch';
+import { matchHostPattern } from './host-pattern-match.js';
 
 export interface ResolvedCredential {
   credentialId: string;
@@ -109,7 +109,7 @@ export function resolveForDomain(
   for (const meta of all) {
     const templates = meta.injectionTemplates ?? [];
     const matching = templates.filter((t) =>
-      minimatch(hostname, t.hostPattern, { nocase: true }),
+      matchHostPattern(hostname, t.hostPattern, { includeApexForWildcard: true }) !== 'none',
     );
     if (matching.length === 0) continue;
     results.push({


### PR DESCRIPTION
Addresses review feedback from PR #4896:
- Replace minimatch with matchHostPattern(includeApexForWildcard) in resolve.ts
- Ensures bare-domain MITM connections properly receive credential injection
- session-manager.ts and policy.ts already used matchHostPattern (fixed in earlier PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
