### PR TITLE
fix: sanitize URL query params in decision traces

### DIFF
--- a/assistant/src/__tests__/script-proxy-decision-trace.test.ts
+++ b/assistant/src/__tests__/script-proxy-decision-trace.test.ts
@@ -83,6 +83,29 @@ describe('buildDecisionTrace', () => {
     expect(trace.candidateCount).toBe(0);
   });
 
+  test('strips query parameters from path to prevent secret leakage', () => {
+    const decision: PolicyDecision = {
+      kind: 'matched',
+      credentialId: 'cred-fal',
+      template: {
+        hostPattern: '*.fal.ai',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Key ',
+      },
+    };
+    const trace = buildDecisionTrace('api.fal.ai', 443, '/v1/run?api_key=sk-secret-123&token=abc', 'https', decision);
+    expect(trace.path).toBe('/v1/run');
+    expect(JSON.stringify(trace)).not.toContain('sk-secret-123');
+    expect(JSON.stringify(trace)).not.toContain('abc');
+  });
+
+  test('path without query string is unchanged', () => {
+    const decision: PolicyDecision = { kind: 'missing' };
+    const trace = buildDecisionTrace('example.com', 443, '/v1/models', 'https', decision);
+    expect(trace.path).toBe('/v1/models');
+  });
+
   test('trace never contains secret values', () => {
     const decision: PolicyDecision = {
       kind: 'matched',

--- a/assistant/src/tools/network/script-proxy/logging.ts
+++ b/assistant/src/tools/network/script-proxy/logging.ts
@@ -117,11 +117,21 @@ export interface ProxyDecisionTrace {
 }
 
 /**
+ * Strip the query string from a URL path so that secrets passed as
+ * query parameters (API keys, tokens) are never recorded in traces.
+ */
+function stripQueryString(p: string): string {
+  const idx = p.indexOf('?');
+  return idx === -1 ? p : p.slice(0, idx);
+}
+
+/**
  * Build a structured trace record from a policy decision.
  *
  * Intentionally excludes all secret-bearing fields (header values,
  * storage keys, injected tokens) — only patterns, counts, and
- * decision metadata are included.
+ * decision metadata are included. Query parameters are stripped from
+ * the path to prevent leaking secrets (API keys, tokens) into logs.
  */
 export function buildDecisionTrace(
   host: string,
@@ -152,7 +162,7 @@ export function buildDecisionTrace(
   return {
     host,
     port,
-    path,
+    path: stripQueryString(path),
     scheme,
     decisionKind: decision.kind,
     candidateCount,


### PR DESCRIPTION
Addresses review feedback from PR #4910:\n- Strip query parameters from URL paths before recording in decision traces\n- Prevents API keys and tokens from leaking into debug logs\n- Adds tests verifying query-string stripping behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
