### PR TITLE
fix: FIFO mapping corruption and stale pendingLocalDeletions on cancel

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -471,6 +471,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                pendingLocalDeletions.removeAll()
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
                         messages[i].status = .sent

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -762,7 +762,9 @@ public final class ChatViewModel: ObservableObject {
     /// Remove a queued message from local state without a daemon round-trip.
     /// Used when the message hasn't been acknowledged by the daemon yet.
     private func removeQueuedMessageLocally(messageId: UUID) {
-        pendingMessageIds.removeAll { $0 == messageId }
+        // Do NOT remove from pendingMessageIds — the FIFO queue must stay
+        // intact so incoming message_queued acks map to the correct messages.
+        // The deferred deletion is tracked via pendingLocalDeletions instead.
         messages.removeAll { $0.id == messageId }
         pendingQueuedCount = max(0, pendingQueuedCount - 1)
         if pendingQueuedCount == 0 && !isThinking {


### PR DESCRIPTION
Addresses review feedback from PR #4916:\n- Fix removeQueuedMessageLocally to not corrupt pendingMessageIds FIFO mapping\n- Clear pendingLocalDeletions in generationCancelled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/4997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
