### PR TITLE
fix: request log privacy, export redaction, and JSON.parse safety

### DIFF
--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -45,6 +45,36 @@ function truncateAndRedact(text: string): string {
   return redact(truncated);
 }
 
+/** Keys whose values should always be fully redacted in LLM request/response payloads. */
+const SENSITIVE_KEYS = new Set([
+  'api_key', 'apikey', 'api-key',
+  'authorization', 'x-api-key',
+  'secret', 'password', 'token',
+  'credential', 'credentials',
+]);
+
+/**
+ * Recursively walk a parsed JSON value and apply redaction to all string
+ * leaves. Object keys matching known sensitive field names have their
+ * entire value replaced with '[REDACTED]'.
+ */
+function redactDeep(value: unknown): unknown {
+  if (typeof value === 'string') return redact(value);
+  if (Array.isArray(value)) return value.map(redactDeep);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.has(k.toLowerCase())) {
+        out[k] = '[REDACTED]';
+      } else {
+        out[k] = redactDeep(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
 export async function handleDiagnosticsExport(
   msg: DiagnosticsExportRequest,
   socket: net.Socket,
@@ -159,12 +189,17 @@ export async function handleDiagnosticsExport(
       .orderBy(llmUsageEvents.createdAt)
       .all();
 
-    // 5b. Query ALL raw LLM request/response logs for the conversation
-    // (not time-scoped — we want the full request history for debugging)
+    // 5b. Query raw LLM request/response logs in the range
     const rangeRequestLogs = db
       .select()
       .from(llmRequestLogs)
-      .where(eq(llmRequestLogs.conversationId, conversationId))
+      .where(
+        and(
+          eq(llmRequestLogs.conversationId, conversationId),
+          gte(llmRequestLogs.createdAt, rangeStart),
+          lte(llmRequestLogs.createdAt, usageRangeEnd),
+        ),
+      )
       .orderBy(llmRequestLogs.createdAt)
       .all();
 
@@ -231,15 +266,19 @@ export async function handleDiagnosticsExport(
       writeFileSync(join(tempDir, 'usage.jsonl'), usageLines.join('\n') + (usageLines.length > 0 ? '\n' : ''));
 
       // llm_requests.jsonl — raw request/response payloads sent to the LLM provider
-      const requestLogLines = rangeRequestLogs.map((r) =>
-        JSON.stringify({
+      const requestLogLines = rangeRequestLogs.map((r) => {
+        let request: unknown;
+        let response: unknown;
+        try { request = JSON.parse(r.requestPayload); } catch { request = r.requestPayload; }
+        try { response = JSON.parse(r.responsePayload); } catch { response = r.responsePayload; }
+        return JSON.stringify({
           id: r.id,
           conversationId: r.conversationId,
-          request: JSON.parse(r.requestPayload),
-          response: JSON.parse(r.responsePayload),
+          request: redactDeep(request),
+          response: redactDeep(response),
           createdAt: r.createdAt,
-        }),
-      );
+        });
+      });
       writeFileSync(join(tempDir, 'llm_requests.jsonl'), requestLogLines.join('\n') + (requestLogLines.length > 0 ? '\n' : ''));
 
       // 7. Zip the temp directory

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,7 +1,7 @@
 import { eq, desc, asc, and, count, sql, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { conversations, messages, toolInvocations, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments } from './schema.js';
+import { conversations, messages, toolInvocations, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments, llmRequestLogs } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { getLogger } from '../util/logger.js';
@@ -77,6 +77,7 @@ export function getConversationMemoryScopeId(conversationId: string): string {
 export function deleteConversation(id: string): void {
   const db = getDb();
   db.transaction((tx) => {
+    tx.delete(llmRequestLogs).where(eq(llmRequestLogs.conversationId, id)).run();
     tx.delete(toolInvocations).where(eq(toolInvocations.conversationId, id)).run();
     tx.delete(messages).where(eq(messages.conversationId, id)).run();
     tx.delete(conversations).where(eq(conversations.id, id)).run();
@@ -221,6 +222,7 @@ export function clearAll(): { conversations: number; messages: number } {
   raw.exec('DELETE FROM memory_embeddings');
   raw.exec('DELETE FROM memory_jobs');
   raw.exec('DELETE FROM memory_checkpoints');
+  raw.exec('DELETE FROM llm_request_logs');
   raw.exec('DELETE FROM llm_usage_events');
   raw.exec('DELETE FROM message_attachments');
   raw.exec('DELETE FROM attachments');


### PR DESCRIPTION
Addresses review feedback from PR #4936:\n- Clear request logs when conversation is wiped (clearAll + deleteConversation)\n- Narrow timestamp window for request log queries to match usage event range\n- Redact sensitive fields in exported LLM payloads via recursive redactDeep\n- Guard JSON.parse with try-catch for corrupted records
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
