### PR TITLE
fix: slash command regex excludes hyphens and fast mode pricing unreachable

### DIFF
--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -86,7 +86,7 @@ function resolveProviderModelCommand(content: string): SlashResolution | null {
   if (!trimmed.startsWith('/')) return null;
 
   // Extract the command (e.g., "/gpt4" → "gpt4")
-  const match = trimmed.match(/^\/([a-z0-9]+)(\s|$)/i);
+  const match = trimmed.match(/^\/([a-z0-9-]+)(\s|$)/i);
   if (!match) return null;
 
   const command = match[1].toLowerCase();

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -594,7 +594,7 @@ export class AnthropicProvider implements Provider {
         content: response.content.map((block) =>
           this.fromAnthropicBlock(block),
         ),
-        model: response.model,
+        model: this.fastMode ? `${response.model}-fast` : response.model,
         usage: {
           inputTokens: response.usage.input_tokens
             + (response.usage.cache_creation_input_tokens ?? 0)


### PR DESCRIPTION
Addresses review feedback from PR #4923:
- Add hyphen to slash command regex character class so /opus-fast is reachable
- Fix fast mode pricing: provider now reports model with -fast suffix so the pricing entry is matched correctly (the API returns the base model name, which was being passed to pricing as-is)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
