### PR TITLE
fix: generalize stream timeout wiring and fix cleanup on throw

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -8,6 +8,7 @@ import type {
   ContentBlock,
 } from "../types.js";
 import { ProviderError } from "../../util/errors.js";
+import { createStreamTimeout } from '../stream-timeout.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('anthropic-client');
@@ -499,95 +500,76 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      // Create a local AbortController that aborts after streamTimeoutMs.
-      // If the caller already provided a signal, link it so external
-      // cancellation also aborts the stream.
-      const timeoutController = new AbortController();
-      const timeoutHandle = setTimeout(() => {
-        timeoutController.abort(new Error(`Provider stream timed out after ${this.streamTimeoutMs / 1000}s`));
-      }, this.streamTimeoutMs);
-
-      const onExternalAbort = () => {
-        timeoutController.abort(signal!.reason);
-      };
-      if (signal) {
-        if (signal.aborted) {
-          clearTimeout(timeoutHandle);
-          timeoutController.abort(signal.reason);
-        } else {
-          signal.addEventListener('abort', onExternalAbort, { once: true });
-        }
-      }
-
-      const stream = this.fastMode
-        ? this.client.beta.messages.stream(
-            { ...params, betas: ['fast-mode-2026-02-01'], speed: 'fast' } as Parameters<typeof this.client.beta.messages.stream>[0],
-            { signal: timeoutController.signal },
-          )
-        : this.client.messages.stream(params, { signal: timeoutController.signal });
-
-      stream.on("text", (text) => {
-        onEvent?.({ type: "text_delta", text });
-      });
-
-      stream.on("thinking", (thinking) => {
-        onEvent?.({ type: "thinking_delta", thinking });
-      });
-
-      // Track which tool is currently streaming so we can attribute inputJson deltas.
-      let currentStreamingToolName: string | undefined;
-      let accumulatedInputJson = '';
-      let lastInputJsonEmitMs = 0;
-      let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
-
-      stream.on("streamEvent", (event) => {
-        if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
-          currentStreamingToolName = event.content_block.name;
-          accumulatedInputJson = '';
-          lastInputJsonEmitMs = 0;
-        }
-        if (event.type === 'content_block_stop') {
-          if (pendingInputJsonFlush) {
-            clearTimeout(pendingInputJsonFlush);
-            pendingInputJsonFlush = undefined;
-          }
-          if (currentStreamingToolName && accumulatedInputJson) {
-            onEvent?.({ type: "input_json_delta", toolName: currentStreamingToolName, accumulatedJson: accumulatedInputJson });
-          }
-          currentStreamingToolName = undefined;
-          accumulatedInputJson = '';
-        }
-      });
-
-      stream.on("inputJson", (partialJson) => {
-        if (!currentStreamingToolName) return;
-        accumulatedInputJson += partialJson;
-        const now = Date.now();
-        if (now - lastInputJsonEmitMs >= 150) {
-          lastInputJsonEmitMs = now;
-          if (pendingInputJsonFlush) {
-            clearTimeout(pendingInputJsonFlush);
-            pendingInputJsonFlush = undefined;
-          }
-          onEvent?.({ type: "input_json_delta", toolName: currentStreamingToolName, accumulatedJson: accumulatedInputJson });
-        } else if (!pendingInputJsonFlush) {
-          const toolName = currentStreamingToolName;
-          pendingInputJsonFlush = setTimeout(() => {
-            pendingInputJsonFlush = undefined;
-            lastInputJsonEmitMs = Date.now();
-            if (currentStreamingToolName === toolName) {
-              onEvent?.({ type: "input_json_delta", toolName, accumulatedJson: accumulatedInputJson });
-            }
-          }, 150);
-        }
-      });
+      const { signal: timeoutSignal, cleanup: cleanupTimeout } = createStreamTimeout(this.streamTimeoutMs, signal);
 
       let response: Anthropic.Message;
       try {
+        const stream = this.fastMode
+          ? this.client.beta.messages.stream(
+              { ...params, betas: ['fast-mode-2026-02-01'], speed: 'fast' } as Parameters<typeof this.client.beta.messages.stream>[0],
+              { signal: timeoutSignal },
+            )
+          : this.client.messages.stream(params, { signal: timeoutSignal });
+
+        stream.on("text", (text) => {
+          onEvent?.({ type: "text_delta", text });
+        });
+
+        stream.on("thinking", (thinking) => {
+          onEvent?.({ type: "thinking_delta", thinking });
+        });
+
+        // Track which tool is currently streaming so we can attribute inputJson deltas.
+        let currentStreamingToolName: string | undefined;
+        let accumulatedInputJson = '';
+        let lastInputJsonEmitMs = 0;
+        let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
+
+        stream.on("streamEvent", (event) => {
+          if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
+            currentStreamingToolName = event.content_block.name;
+            accumulatedInputJson = '';
+            lastInputJsonEmitMs = 0;
+          }
+          if (event.type === 'content_block_stop') {
+            if (pendingInputJsonFlush) {
+              clearTimeout(pendingInputJsonFlush);
+              pendingInputJsonFlush = undefined;
+            }
+            if (currentStreamingToolName && accumulatedInputJson) {
+              onEvent?.({ type: "input_json_delta", toolName: currentStreamingToolName, accumulatedJson: accumulatedInputJson });
+            }
+            currentStreamingToolName = undefined;
+            accumulatedInputJson = '';
+          }
+        });
+
+        stream.on("inputJson", (partialJson) => {
+          if (!currentStreamingToolName) return;
+          accumulatedInputJson += partialJson;
+          const now = Date.now();
+          if (now - lastInputJsonEmitMs >= 150) {
+            lastInputJsonEmitMs = now;
+            if (pendingInputJsonFlush) {
+              clearTimeout(pendingInputJsonFlush);
+              pendingInputJsonFlush = undefined;
+            }
+            onEvent?.({ type: "input_json_delta", toolName: currentStreamingToolName, accumulatedJson: accumulatedInputJson });
+          } else if (!pendingInputJsonFlush) {
+            const toolName = currentStreamingToolName;
+            pendingInputJsonFlush = setTimeout(() => {
+              pendingInputJsonFlush = undefined;
+              lastInputJsonEmitMs = Date.now();
+              if (currentStreamingToolName === toolName) {
+                onEvent?.({ type: "input_json_delta", toolName, accumulatedJson: accumulatedInputJson });
+              }
+            }, 150);
+          }
+        });
+
         response = await stream.finalMessage();
       } finally {
-        clearTimeout(timeoutHandle);
-        signal?.removeEventListener('abort', onExternalAbort);
+        cleanupTimeout();
       }
 
       return {

--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -3,6 +3,7 @@ import { OpenAIProvider } from '../openai/client.js';
 export interface FireworksProviderOptions {
   apiKey?: string;
   baseURL?: string;
+  streamTimeoutMs?: number;
 }
 
 const DEFAULT_FIREWORKS_BASE_URL = 'https://api.fireworks.ai/inference/v1';
@@ -13,6 +14,7 @@ export class FireworksProvider extends OpenAIProvider {
       baseURL: options.baseURL?.trim() || DEFAULT_FIREWORKS_BASE_URL,
       providerName: 'fireworks',
       providerLabel: 'Fireworks',
+      streamTimeoutMs: options.streamTimeoutMs,
     });
   }
 }

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -9,15 +9,18 @@ import type {
   ContentBlock,
 } from '../types.js';
 import { ProviderError } from '../../util/errors.js';
+import { createStreamTimeout } from '../stream-timeout.js';
 
 export class GeminiProvider implements Provider {
   public readonly name = 'gemini';
   private client: GoogleGenAI;
   private model: string;
+  private streamTimeoutMs: number;
 
-  constructor(apiKey: string, model: string) {
+  constructor(apiKey: string, model: string, options: { streamTimeoutMs?: number } = {}) {
     this.client = new GoogleGenAI({ apiKey });
     this.model = model;
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
   }
 
   async sendMessage(
@@ -42,10 +45,6 @@ export class GeminiProvider implements Provider {
       if (maxTokens) {
         geminiConfig.maxOutputTokens = maxTokens;
       }
-      if (signal) {
-        geminiConfig.abortSignal = signal;
-      }
-
       if (tools && tools.length > 0) {
         geminiConfig.tools = [{
           functionDeclarations: tools.map((t) => ({
@@ -56,11 +55,8 @@ export class GeminiProvider implements Provider {
         }];
       }
 
-      const stream = await this.client.models.generateContentStream({
-        model: modelOverride ?? this.model,
-        contents: geminiContents,
-        config: geminiConfig,
-      });
+      const { signal: timeoutSignal, cleanup: cleanupTimeout } = createStreamTimeout(this.streamTimeoutMs, signal);
+      geminiConfig.abortSignal = timeoutSignal;
 
       // Accumulate from streaming chunks
       let fullText = '';
@@ -70,40 +66,50 @@ export class GeminiProvider implements Provider {
       let outputTokens = 0;
       let responseModel = modelOverride ?? this.model;
 
-      for await (const chunk of stream) {
-        // Extract text delta
-        const chunkText = chunk.text;
-        if (chunkText) {
-          fullText += chunkText;
-          onEvent?.({ type: 'text_delta', text: chunkText });
-        }
+      try {
+        const stream = await this.client.models.generateContentStream({
+          model: modelOverride ?? this.model,
+          contents: geminiContents,
+          config: geminiConfig,
+        });
 
-        // Extract function calls
-        const calls = chunk.functionCalls;
-        if (calls) {
-          for (const fc of calls) {
-            functionCalls.push({
-              id: fc.id ?? `call_${crypto.randomUUID()}`,
-              name: fc.name ?? '',
-              args: fc.args ?? {},
-            });
+        for await (const chunk of stream) {
+          // Extract text delta
+          const chunkText = chunk.text;
+          if (chunkText) {
+            fullText += chunkText;
+            onEvent?.({ type: 'text_delta', text: chunkText });
+          }
+
+          // Extract function calls
+          const calls = chunk.functionCalls;
+          if (calls) {
+            for (const fc of calls) {
+              functionCalls.push({
+                id: fc.id ?? `call_${crypto.randomUUID()}`,
+                name: fc.name ?? '',
+                args: fc.args ?? {},
+              });
+            }
+          }
+
+          // Extract metadata from chunks
+          const candidate = chunk.candidates?.[0];
+          if (candidate?.finishReason) {
+            finishReason = candidate.finishReason;
+          }
+
+          if (chunk.usageMetadata) {
+            promptTokens = chunk.usageMetadata.promptTokenCount ?? 0;
+            outputTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
+          }
+
+          if (chunk.modelVersion) {
+            responseModel = chunk.modelVersion;
           }
         }
-
-        // Extract metadata from chunks
-        const candidate = chunk.candidates?.[0];
-        if (candidate?.finishReason) {
-          finishReason = candidate.finishReason;
-        }
-
-        if (chunk.usageMetadata) {
-          promptTokens = chunk.usageMetadata.promptTokenCount ?? 0;
-          outputTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
-        }
-
-        if (chunk.modelVersion) {
-          responseModel = chunk.modelVersion;
-        }
+      } finally {
+        cleanupTimeout();
       }
 
       // Build content blocks

--- a/assistant/src/providers/ollama/client.ts
+++ b/assistant/src/providers/ollama/client.ts
@@ -3,6 +3,7 @@ import { OpenAIProvider } from '../openai/client.js';
 export interface OllamaProviderOptions {
   apiKey?: string;
   baseURL?: string;
+  streamTimeoutMs?: number;
 }
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434/v1';
@@ -13,6 +14,7 @@ export class OllamaProvider extends OpenAIProvider {
       baseURL: resolveBaseUrl(options.baseURL),
       providerName: 'ollama',
       providerLabel: 'Ollama',
+      streamTimeoutMs: options.streamTimeoutMs,
     });
   }
 }

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -8,12 +8,14 @@ import type {
   ContentBlock,
 } from '../types.js';
 import { ProviderError } from '../../util/errors.js';
+import { createStreamTimeout } from '../stream-timeout.js';
 import { escapeXmlAttr } from '../../util/xml.js';
 
 export interface OpenAICompatibleProviderOptions {
   baseURL?: string;
   providerName?: string;
   providerLabel?: string;
+  streamTimeoutMs?: number;
 }
 
 const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
@@ -25,6 +27,7 @@ export class OpenAIProvider implements Provider {
   private readonly providerLabel: string;
   private client: OpenAI;
   private model: string;
+  private streamTimeoutMs: number;
 
   constructor(apiKey: string, model: string, options: OpenAICompatibleProviderOptions = {}) {
     this.name = options.providerName ?? 'openai';
@@ -34,6 +37,7 @@ export class OpenAIProvider implements Provider {
       baseURL: options.baseURL,
     });
     this.model = model;
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
   }
 
   async sendMessage(
@@ -72,7 +76,7 @@ export class OpenAIProvider implements Provider {
         }));
       }
 
-      const stream = await this.client.chat.completions.create(params, { signal });
+      const { signal: timeoutSignal, cleanup: cleanupTimeout } = createStreamTimeout(this.streamTimeoutMs, signal);
 
       // Accumulate the response from chunks
       let contentText = '';
@@ -82,37 +86,43 @@ export class OpenAIProvider implements Provider {
       let promptTokens = 0;
       let completionTokens = 0;
 
-      for await (const chunk of stream) {
-        const choice = chunk.choices[0];
-        if (choice) {
-          if (choice.delta.content) {
-            contentText += choice.delta.content;
-            onEvent?.({ type: 'text_delta', text: choice.delta.content });
-          }
+      try {
+        const stream = await this.client.chat.completions.create(params, { signal: timeoutSignal });
 
-          if (choice.delta.tool_calls) {
-            for (const tc of choice.delta.tool_calls) {
-              if (!toolCallMap.has(tc.index)) {
-                toolCallMap.set(tc.index, { id: '', name: '', args: '' });
+        for await (const chunk of stream) {
+          const choice = chunk.choices[0];
+          if (choice) {
+            if (choice.delta.content) {
+              contentText += choice.delta.content;
+              onEvent?.({ type: 'text_delta', text: choice.delta.content });
+            }
+
+            if (choice.delta.tool_calls) {
+              for (const tc of choice.delta.tool_calls) {
+                if (!toolCallMap.has(tc.index)) {
+                  toolCallMap.set(tc.index, { id: '', name: '', args: '' });
+                }
+                const entry = toolCallMap.get(tc.index)!;
+                if (tc.id) entry.id = tc.id;
+                if (tc.function?.name) entry.name += tc.function.name;
+                if (tc.function?.arguments) entry.args += tc.function.arguments;
               }
-              const entry = toolCallMap.get(tc.index)!;
-              if (tc.id) entry.id = tc.id;
-              if (tc.function?.name) entry.name += tc.function.name;
-              if (tc.function?.arguments) entry.args += tc.function.arguments;
+            }
+
+            if (choice.finish_reason) {
+              finishReason = choice.finish_reason;
             }
           }
 
-          if (choice.finish_reason) {
-            finishReason = choice.finish_reason;
+          if (chunk.usage) {
+            promptTokens = chunk.usage.prompt_tokens;
+            completionTokens = chunk.usage.completion_tokens;
           }
-        }
 
-        if (chunk.usage) {
-          promptTokens = chunk.usage.prompt_tokens;
-          completionTokens = chunk.usage.completion_tokens;
+          responseModel = chunk.model;
         }
-
-        responseModel = chunk.model;
+      } finally {
+        cleanupTimeout();
       }
 
       // Build content blocks

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -100,37 +100,39 @@ export function initializeProviders(config: ProvidersConfig): void {
   cachedFailoverProvider = null;
   cachedFailoverKey = null;
 
+  const streamTimeoutMs = (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000;
+
   if (config.apiKeys.anthropic) {
     const model = resolveModel(config, 'anthropic');
     registerProvider('anthropic', new RetryProvider(
       wrapWithLogfire(new AnthropicProvider(config.apiKeys.anthropic, model, {
         useNativeWebSearch: config.webSearchProvider === 'anthropic-native',
-        streamTimeoutMs: (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000,
+        streamTimeoutMs,
       })),
     ));
   }
   if (config.apiKeys.openai) {
     const model = resolveModel(config, 'openai');
     registerProvider('openai', new RetryProvider(
-      wrapWithLogfire(new OpenAIProvider(config.apiKeys.openai, model)),
+      wrapWithLogfire(new OpenAIProvider(config.apiKeys.openai, model, { streamTimeoutMs })),
     ));
   }
   if (config.apiKeys.gemini) {
     const model = resolveModel(config, 'gemini');
     registerProvider('gemini', new RetryProvider(
-      wrapWithLogfire(new GeminiProvider(config.apiKeys.gemini, model)),
+      wrapWithLogfire(new GeminiProvider(config.apiKeys.gemini, model, { streamTimeoutMs })),
     ));
   }
   if (config.provider === 'ollama' || config.apiKeys.ollama) {
     const model = resolveModel(config, 'ollama');
     registerProvider('ollama', new RetryProvider(
-      wrapWithLogfire(new OllamaProvider(model, { apiKey: config.apiKeys.ollama })),
+      wrapWithLogfire(new OllamaProvider(model, { apiKey: config.apiKeys.ollama, streamTimeoutMs })),
     ));
   }
   if (config.apiKeys.fireworks) {
     const model = resolveModel(config, 'fireworks');
     registerProvider('fireworks', new RetryProvider(
-      wrapWithLogfire(new FireworksProvider(config.apiKeys.fireworks, model)),
+      wrapWithLogfire(new FireworksProvider(config.apiKeys.fireworks, model, { streamTimeoutMs })),
     ));
   }
 }

--- a/assistant/src/providers/stream-timeout.ts
+++ b/assistant/src/providers/stream-timeout.ts
@@ -1,0 +1,38 @@
+/**
+ * Creates an AbortController that auto-aborts after `timeoutMs`, optionally
+ * linked to an external AbortSignal so cancellation propagates both ways.
+ *
+ * Returns a `signal` to pass to the provider SDK and a `cleanup` function
+ * that MUST be called in a finally block to clear the timer and detach
+ * the external signal listener.
+ */
+export function createStreamTimeout(
+  timeoutMs: number,
+  externalSignal?: AbortSignal,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+
+  const handle = setTimeout(() => {
+    controller.abort(new Error(`Provider stream timed out after ${timeoutMs / 1000}s`));
+  }, timeoutMs);
+
+  const onExternalAbort = () => {
+    controller.abort(externalSignal!.reason);
+  };
+
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      clearTimeout(handle);
+      controller.abort(externalSignal.reason);
+    } else {
+      externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+    }
+  }
+
+  const cleanup = () => {
+    clearTimeout(handle);
+    externalSignal?.removeEventListener('abort', onExternalAbort);
+  };
+
+  return { signal: controller.signal, cleanup };
+}


### PR DESCRIPTION
Addresses review feedback from PR #4890:\n\n- **P1 — Generalize provider stream-timeout wiring**: Extracted the timeout+abort logic into a shared `createStreamTimeout` utility (`stream-timeout.ts`) and wired `providerStreamTimeoutSec` through to all providers (Anthropic, OpenAI, Gemini, Ollama, Fireworks) instead of only Anthropic.\n- **P2 — Ensure timeout cleanup when stream creation throws**: Moved the `try/finally` block to wrap stream creation (not just `stream.finalMessage()`) in Anthropic, and added equivalent cleanup patterns to OpenAI and Gemini, so timers and abort listeners are always cleaned up even if the SDK call throws synchronously.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
