### PR TITLE
fix: address PR 4969 review feedback

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -37,16 +37,15 @@ struct ChatContentView: View {
                         ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
                             if message.modelPicker != nil {
                                 ModelPickerBubble(
-                                    models: ModelListBubble.anthropicModels.map { (id: $0.cmd, name: $0.display) },
-                                    selectedModelId: "claude-opus-4-6",
+                                    models: ModelListBubble.anthropicModels.map { (id: $0.model, name: $0.display) },
+                                    selectedModelId: viewModel.selectedModel,
                                     onSelect: { modelId in
-                                        viewModel.inputText = "/\(modelId)"
-                                        viewModel.sendMessage()
+                                        viewModel.setModel(modelId)
                                     }
                                 )
                                 .id(message.id)
                             } else if message.modelList != nil {
-                                ModelListBubble(currentModel: "claude-opus-4-6", configuredProviders: ["anthropic"])
+                                ModelListBubble(currentModel: viewModel.selectedModel, configuredProviders: viewModel.configuredProviders)
                                     .id(message.id)
                             } else if message.commandList != nil {
                                 CommandListBubble()

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1011,6 +1011,12 @@ extension ChatViewModel {
             // the dedicated subagents panel once it's built.
             break
 
+        case .modelInfo(let msg):
+            selectedModel = msg.model
+            if let providers = msg.configuredProviders {
+                configuredProviders = Set(providers)
+            }
+
         default:
             break
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -44,6 +44,11 @@ public final class ChatViewModel: ObservableObject {
     @Published public var isWatchSessionActive: Bool = false
     @Published public var activeSubagents: [SubagentInfo] = []
 
+    /// The currently active model ID, updated via `model_info` IPC messages.
+    @Published public var selectedModel: String = "claude-opus-4-6"
+    /// Set of provider keys with configured API keys, updated via `model_info` IPC messages.
+    @Published public var configuredProviders: Set<String> = ["anthropic"]
+
     /// Maximum file size per attachment (20 MB).
     static let maxFileSize = 20 * 1024 * 1024
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
@@ -500,6 +505,13 @@ public final class ChatViewModel: ObservableObject {
             self.threadType = threadType
         }
         bootstrapSession(userMessage: nil, attachments: nil)
+    }
+
+    // MARK: - Model
+
+    /// Switch the active model via the daemon's `model_set` IPC command.
+    public func setModel(_ modelId: String) {
+        try? daemonClient.send(ModelSetRequestMessage(model: modelId))
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
Addresses review feedback from https://github.com/vellum-ai/vellum-assistant/pull/4969

## Changes

**Fix model picker selection highlight never matching (Devin review)**
- Changed model ID mapping from `$0.cmd` (short names like "opus") to `$0.model` (full IDs like "claude-opus-4-6") so that `ModelPickerBubble`'s selection check matches `selectedModelId`
- Model selection now uses IPC `model_set` command (matching macOS behavior) instead of sending a slash command

**Replace hardcoded model/provider state with live data (Codex review)**
- Added `selectedModel` and `configuredProviders` as `@Published` properties on `ChatViewModel`
- Added `model_info` IPC message handling in `ChatViewModel+MessageHandling` to keep these properties in sync with the daemon
- Added `setModel()` public method on `ChatViewModel` for switching models via IPC
- iOS `ChatContentView` now uses `viewModel.selectedModel` and `viewModel.configuredProviders` instead of hardcoded values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
