### PR TITLE
fix: remove legacy avatar file on clear to prevent migration re-copy

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -114,6 +114,7 @@ final class AvatarAppearanceManager {
 
     func clearCustomAvatar() {
         try? FileManager.default.removeItem(at: customAvatarURL)
+        try? FileManager.default.removeItem(at: Self.legacyAppSupportCustomAvatarURL())
         customAvatarImage = nil
     }
 


### PR DESCRIPTION
Addresses review feedback from PR #4933:
- Delete the legacy avatar file when clearing custom avatar
- Prevents migration code from re-copying the old avatar on next launch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
