### PR TITLE
fix: verify daemon process exited before removing socket file

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -224,9 +224,14 @@ export async function stopDaemon(): Promise<{ stopped: boolean }> {
     killWaited += 100;
   }
 
-  // Clean up socket file — the old daemon's shutdown handler may have
-  // already removed it, or it may still point to the old process.
-  removeSocketFile(getSocketPath());
+  // Only remove the socket if the process has actually exited.
+  // If it's still alive after SIGKILL + timeout, leave the socket
+  // intact to avoid pulling the rug from under a still-running daemon.
+  if (!isProcessRunning(pid)) {
+    removeSocketFile(getSocketPath());
+  } else {
+    log.warn({ pid }, 'Daemon process still running after SIGKILL + timeout, leaving socket intact');
+  }
   cleanupPidFile();
   return { stopped: true };
 }


### PR DESCRIPTION
Addresses review feedback from PR #4943:\n- Check if the daemon process has actually exited before deleting the socket\n- Prevents deleting the socket of a still-running daemon
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
