### PR TITLE
fix: correct stale 'collapsed by default' comment

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -155,7 +155,7 @@ public struct ToolConfirmationBubble: View {
 
             Divider()
 
-            // More Details accordion (collapsed by default)
+            // More Details accordion (expanded by default)
             VStack(alignment: .leading, spacing: 0) {
                 Button {
                     withAnimation(VAnimation.fast) {


### PR DESCRIPTION
Addresses review feedback from PR #4953:
- Update comment to say 'expanded by default' matching actual behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
