### PR TITLE
fix: complete stream-end state cleanup to prevent UI stale state

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -472,6 +472,13 @@ public final class ChatViewModel: ObservableObject {
                 // never receives message_complete, leaving the UI stuck.
                 self?.isThinking = false
                 self?.isSending = false
+                self?.isCancelling = false
+                // Mark current assistant message as no longer streaming
+                if let existingId = self?.currentAssistantMessageId,
+                   let index = self?.messages.firstIndex(where: { $0.id == existingId }) {
+                    self?.messages[index].isStreaming = false
+                }
+                self?.currentAssistantMessageId = nil
             }
         }
     }


### PR DESCRIPTION
Addresses review feedback from PR #4949:
- Reset isCancelling on stream end so future deltas aren't suppressed
- Clear currentAssistantMessageId and isStreaming to remove permanent streaming indicator
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
