### PR TITLE
fix: avoid double /workspace/ prefix in path policy rewrites

### DIFF
--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -170,6 +170,16 @@ describe('sandboxPolicy', () => {
     }
   });
 
+  test('does not double-nest when boundaryDir is under /workspace', () => {
+    const boundary = '/workspace/project';
+
+    const result = sandboxPolicy('/workspace/project/file.ts', boundary, { mustExist: false });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe('/workspace/project/file.ts');
+    }
+  });
+
   test('remapped /workspace path still rejects traversal escapes', () => {
     const boundary = makeTempDir();
 

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -42,11 +42,19 @@ export function sandboxPolicy(
   const mustExist = options?.mustExist ?? true;
 
   // Remap container-scoped /workspace paths to the host boundary dir.
+  // Skip remapping if the path already starts with boundaryDir to avoid
+  // double-nesting (e.g. /workspace/project/file.ts → /workspace/project/project/file.ts
+  // when boundaryDir is /workspace/project).
   let effectivePath = rawPath;
-  if (rawPath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
-    effectivePath = rawPath.slice(CONTAINER_WORKSPACE_PREFIX.length);
-  } else if (rawPath === CONTAINER_WORKSPACE_EXACT) {
-    effectivePath = '.';
+  if (
+    !rawPath.startsWith(boundaryDir + '/') &&
+    rawPath !== boundaryDir
+  ) {
+    if (rawPath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
+      effectivePath = rawPath.slice(CONTAINER_WORKSPACE_PREFIX.length);
+    } else if (rawPath === CONTAINER_WORKSPACE_EXACT) {
+      effectivePath = '.';
+    }
   }
 
   const resolved = resolve(boundaryDir, effectivePath);


### PR DESCRIPTION
Addresses review feedback from PR #4958:
- Check if path already starts with boundaryDir before applying /workspace/ remapping
- Prevents double-nesting like /workspace/workspace/project/file.ts when boundaryDir is /workspace/project
- Adds test case covering the double-nesting scenario
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
