### PR TITLE
fix: use Preview for image open and balance NSCursor push/pop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -91,6 +91,7 @@ private struct UsedToolsRow: View {
 
     @State private var isExpanded = false
     @State private var isHovered = false
+    @State private var isImageHovered = false
     @Environment(\.displayScale) private var displayScale
 
     private var hasDetails: Bool {
@@ -190,7 +191,9 @@ private struct UsedToolsRow: View {
                             .onHover { hovering in
                                 if hovering { NSCursor.pointingHand.push() }
                                 else { NSCursor.pop() }
+                                isImageHovered = hovering
                             }
+                            .onDisappear { if isImageHovered { NSCursor.pop(); isImageHovered = false } }
                     } else if let img = toolCall.cachedImage {
                         Image(nsImage: img)
                             .resizable()
@@ -202,7 +205,9 @@ private struct UsedToolsRow: View {
                             .onHover { hovering in
                                 if hovering { NSCursor.pointingHand.push() }
                                 else { NSCursor.pop() }
+                                isImageHovered = hovering
                             }
+                            .onDisappear { if isImageHovered { NSCursor.pop(); isImageHovered = false } }
                     }
 
                     // Output
@@ -266,7 +271,7 @@ private struct UsedToolsRow: View {
         // Try opening the original file if inputFull points to a real file
         let path = toolCall.inputFull.components(separatedBy: "\n").first ?? ""
         if !path.isEmpty && FileManager.default.fileExists(atPath: path) {
-            NSWorkspace.shared.open(URL(fileURLWithPath: path))
+            openInPreview(URL(fileURLWithPath: path))
             return
         }
         // Fallback: write cached image to a temp file and open it
@@ -277,10 +282,19 @@ private struct UsedToolsRow: View {
             .appendingPathComponent("vellum-preview-\(UUID().uuidString).png")
         do {
             try png.write(to: tempURL)
-            NSWorkspace.shared.open(tempURL)
+            openInPreview(tempURL)
         } catch {
             // Not critical — silently fail
         }
+    }
+
+    private func openInPreview(_ url: URL) {
+        let previewURL = URL(fileURLWithPath: "/System/Applications/Preview.app")
+        NSWorkspace.shared.open(
+            [url],
+            withApplicationAt: previewURL,
+            configuration: NSWorkspace.OpenConfiguration()
+        )
     }
 
     private func diffLineColor(_ line: String, result: String, isError: Bool) -> Color {


### PR DESCRIPTION
Addresses review feedback from PR #4957:\n- Open images explicitly with Preview.app instead of default handler (NSWorkspace.open([url], withApplicationAt:))\n- Fix NSCursor stack imbalance when image view is removed while hovered by tracking hover state and popping on disappear
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
