### PR TITLE
fix: only auto-allow bash when sandbox is active

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -35,6 +35,7 @@ mock.module('../util/logger.js', () => ({
 const testConfig: Record<string, any> = {
   permissions: { mode: 'legacy' as 'legacy' | 'strict' },
   skills: { load: { extraDirs: [] as string[] } },
+  sandbox: { enabled: true },
 };
 
 mock.module('../config/loader.js', () => ({
@@ -363,6 +364,26 @@ describe('Permission Checker', () => {
       const low = await check('bash', { command: 'ls' }, '/tmp');
       expect(low.decision).toBe('allow');
       expect(low.matchedRule?.id).toBe('default:allow-bash-global');
+    });
+
+    test('bash prompts when sandbox is disabled (no global allow rule)', async () => {
+      testConfig.sandbox.enabled = false;
+      clearCache();
+      try {
+        const high = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
+        expect(high.decision).toBe('prompt');
+
+        const med = await check('bash', { command: 'rm file.txt' }, '/tmp');
+        expect(med.decision).toBe('prompt');
+
+        // Low risk still auto-allows via the normal risk-based fallback
+        const low = await check('bash', { command: 'ls' }, '/tmp');
+        expect(low.decision).toBe('allow');
+        expect(low.reason).toContain('Low risk');
+      } finally {
+        testConfig.sandbox.enabled = true;
+        clearCache();
+      }
     });
 
     test('host_bash high risk → always prompt', async () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -59,15 +59,20 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
 
   // Sandboxed bash commands run in an isolated container — auto-allow all of
   // them (including high-risk) so the user is never prompted for sandbox work.
-  const sandboxShellRule: DefaultRuleTemplate = {
-    id: 'default:allow-bash-global',
-    tool: 'bash',
-    pattern: '**',
-    scope: 'everywhere',
-    decision: 'allow',
-    priority: 50,
-    allowHighRisk: true,
-  };
+  // Only emit this rule when the sandbox is actually enabled; otherwise bash
+  // commands execute on the host and must go through normal permission checks.
+  const sandboxEnabled = getConfig().sandbox.enabled;
+  const sandboxShellRule: DefaultRuleTemplate | null = sandboxEnabled
+    ? {
+        id: 'default:allow-bash-global',
+        tool: 'bash',
+        pattern: '**',
+        scope: 'everywhere',
+        decision: 'allow',
+        priority: 50,
+        allowHighRisk: true,
+      }
+    : null;
 
   // Standalone "**" globstar — minimatch only treats ** as globstar when it is
   // its own path segment, so a "tool:**" prefix would collapse to single-star
@@ -223,7 +228,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   return [
     ...hostFileRules,
     hostShellRule,
-    sandboxShellRule,
+    ...(sandboxShellRule ? [sandboxShellRule] : []),
     ...computerUseRules,
     ...managedSkillRules,
     ...workspacePromptRules,


### PR DESCRIPTION
Addresses review feedback from PR #4956:\n- Check sandbox.enabled before emitting the default:allow-bash-global rule\n- When sandbox is disabled, bash commands go through normal permission checks (same as host_bash)\n- Stale default rules are automatically cleaned up by backfillDefaults\n- Added test for sandbox-disabled case
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
