### PR TITLE
fix: attachment path traversal and video rendering in interleavedContent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1650,6 +1650,13 @@ private struct ChatBubble: View {
         if !partitioned.images.isEmpty {
             attachmentImageGrid(partitioned.images)
         }
+        if !partitioned.videos.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(partitioned.videos) { attachment in
+                    InlineVideoAttachmentView(attachment: attachment)
+                }
+            }
+        }
         if !partitioned.files.isEmpty {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 ForEach(partitioned.files) { attachment in
@@ -2080,7 +2087,8 @@ private struct ChatBubble: View {
     private func openImageInPreview(_ attachment: ChatAttachment) {
         guard let data = Data(base64Encoded: attachment.data) else { return }
         let tempDir = FileManager.default.temporaryDirectory
-        let fileURL = tempDir.appendingPathComponent(attachment.filename)
+        let sanitized = (attachment.filename as NSString).lastPathComponent
+        let fileURL = tempDir.appendingPathComponent(sanitized.isEmpty ? "image" : sanitized)
         do {
             try data.write(to: fileURL)
             NSWorkspace.shared.open(fileURL)

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -76,14 +76,21 @@ struct InlineVideoAttachmentView: View {
         }
     }
 
+    /// Builds a safe temp-file URL by stripping path components from the filename
+    /// to prevent traversal attacks (e.g. "../../etc/passwd").
+    private func safeTempURL() -> URL {
+        let sanitized = (attachment.filename as NSString).lastPathComponent
+        let safeName = sanitized.isEmpty ? "video" : sanitized
+        return FileManager.default.temporaryDirectory.appendingPathComponent(safeName)
+    }
+
     private func prepareAndPlay() {
         guard let data = Data(base64Encoded: attachment.data) else {
             failed = true
             return
         }
 
-        let tempDir = FileManager.default.temporaryDirectory
-        let fileURL = tempDir.appendingPathComponent(attachment.filename)
+        let fileURL = safeTempURL()
         do {
             try data.write(to: fileURL)
         } catch {
@@ -99,8 +106,7 @@ struct InlineVideoAttachmentView: View {
 
     private func openInExternalPlayer() {
         guard let data = Data(base64Encoded: attachment.data) else { return }
-        let tempDir = FileManager.default.temporaryDirectory
-        let fileURL = tempDir.appendingPathComponent(attachment.filename)
+        let fileURL = safeTempURL()
         try? data.write(to: fileURL)
         NSWorkspace.shared.open(fileURL)
     }


### PR DESCRIPTION
Addresses review feedback from PR #4966:
- Sanitize attachment filenames to prevent path traversal (strips directory components via lastPathComponent)
- Render video attachments in the interleavedContent path for assistant messages
- Also fixes path traversal in openImageInPreview
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
