### PR TITLE
fix: strip query params from logged request paths in policy decisions

### DIFF
--- a/assistant/src/tools/network/script-proxy/logging.ts
+++ b/assistant/src/tools/network/script-proxy/logging.ts
@@ -120,7 +120,7 @@ export interface ProxyDecisionTrace {
  * Strip the query string from a URL path so that secrets passed as
  * query parameters (API keys, tokens) are never recorded in traces.
  */
-function stripQueryString(p: string): string {
+export function stripQueryString(p: string): string {
   const idx = p.indexOf('?');
   return idx === -1 ? p : p.slice(0, idx);
 }

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -19,7 +19,7 @@ import { resolveById } from '../../credentials/resolve.js';
 import { listCredentialMetadata } from '../../credentials/metadata-store.js';
 import type { CredentialInjectionTemplate } from '../../credentials/policy-types.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
-import { buildDecisionTrace } from './logging.js';
+import { buildDecisionTrace, stripQueryString } from './logging.js';
 import { getLogger } from '../../../util/logger.js';
 
 const log = getLogger('proxy-session');
@@ -254,7 +254,7 @@ export async function startSession(sessionId: ProxySessionId, options?: { listen
       managed.session.credentialIds, templates, getAllKnown(), scheme,
     );
 
-    log.debug({ trace: buildDecisionTrace(hostname, port, reqPath, scheme, decision) }, 'Policy decision');
+    log.debug({ trace: buildDecisionTrace(hostname, port, stripQueryString(reqPath), scheme, decision) }, 'Policy decision');
 
     switch (decision.kind) {
       case 'matched': {


### PR DESCRIPTION
Addresses review feedback from PR #4915:\n- Redact query parameters from request paths before logging policy decisions\n- Prevents API keys/tokens from leaking into debug logs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
