### PR TITLE
fix: error bubble regenerate action and queued message deadlock

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1068,10 +1068,20 @@ extension ChatViewModel {
                         messages[i].status = .sent
                     }
                 }
-            } else if pendingQueuedCount == 0 {
+            } else {
+                // Always clear sending state on error — even with queued messages.
+                // Leaving isSending=true with a non-zero pendingQueuedCount creates
+                // a deadlock: regenerate guards on !isSending, so the user can never
+                // recover.
                 isSending = false
+                pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                for i in messages.indices {
+                    if case .queued = messages[i].status, messages[i].role == .user {
+                        messages[i].status = .sent
+                    }
+                }
             }
 
         case .watchStarted(let msg):

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -213,6 +213,15 @@ public struct MessageBubbleView: View {
                 RoundedRectangle(cornerRadius: VRadius.lg)
                     .strokeBorder(VColor.error.opacity(0.3), lineWidth: 1)
             )
+            .contextMenu {
+                if let onRegenerate {
+                    Button {
+                        onRegenerate()
+                    } label: {
+                        Label("Regenerate", systemImage: "arrow.trianglehead.counterclockwise")
+                    }
+                }
+            }
         } else {
             MarkdownRenderer(text: text)
                 .padding(VSpacing.md)


### PR DESCRIPTION
Addresses review feedback from PR #4965:\n- Restore regenerate context menu on error bubbles (iOS MessageBubbleView)\n- Handle session error with queued messages to prevent UI deadlock by always clearing isSending and pendingQueuedCount on error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
