### PR TITLE
fix: prevent duplicate attachments from auto-converted tool content blocks

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -376,13 +376,26 @@ describe('contentBlocksToDrafts', () => {
 // ---------------------------------------------------------------------------
 
 describe('deduplicateDrafts', () => {
-  test('removes duplicates by filename + content hash', () => {
+  test('removes exact duplicates with same filename and content', () => {
     const d = makeDraft({ filename: 'same.txt', dataBase64: 'AAAA'.repeat(20) });
     const result = deduplicateDrafts([d, { ...d }, makeDraft({ filename: 'other.txt' })]);
 
     expect(result).toHaveLength(2);
     expect(result[0].filename).toBe('same.txt');
     expect(result[1].filename).toBe('other.txt');
+  });
+
+  test('removes duplicates with different filenames but identical content', () => {
+    // Simulates directive tag ("chart.png") + auto-converted tool block
+    // ("tool-output.png") for the same file data — the directive draft
+    // should win because it appears first in the merged array.
+    const data = 'AAAA'.repeat(20);
+    const directive = makeDraft({ sourceType: 'sandbox_file', filename: 'chart.png', dataBase64: data });
+    const toolBlock = makeDraft({ sourceType: 'tool_block', filename: 'tool-output.png', dataBase64: data });
+    const result = deduplicateDrafts([directive, toolBlock]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].filename).toBe('chart.png');
   });
 
   test('keeps drafts with same filename but different content', () => {

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -640,19 +640,21 @@ export function cleanAssistantContent(
 // ---------------------------------------------------------------------------
 
 /**
- * De-duplicate drafts by filename + full content hash.
+ * De-duplicate drafts by content hash alone.
  *
- * Uses a fast hash of the entire base64 payload so that files with shared
- * prefixes (common for image formats, tool screenshots named identically)
- * are not incorrectly treated as duplicates.
+ * Uses a fast hash of the entire base64 payload so that identical file
+ * content is only attached once — even when the same data appears under
+ * different filenames (e.g. a directive tag with an explicit name vs. an
+ * auto-converted tool block named "tool-output.png").  The first
+ * occurrence wins, which is the directive draft when directives are
+ * listed before tool blocks, preserving the user-chosen filename.
  */
 export function deduplicateDrafts(drafts: AssistantAttachmentDraft[]): AssistantAttachmentDraft[] {
   const seen = new Set<string>();
   return drafts.filter((d) => {
     const hash = Bun.hash(d.dataBase64).toString(36);
-    const key = `${d.filename}:${hash}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
+    if (seen.has(hash)) return false;
+    seen.add(hash);
     return true;
   });
 }


### PR DESCRIPTION
Addresses review feedback from PR #4968:\n- Changed deduplicateDrafts to key on content hash alone instead of filename+hash\n- Prevents auto-converted tool content blocks (named 'tool-output.png') from duplicating directive tags (named 'chart.png') that reference the same file data\n- Directive draft wins (appears first in merged array), preserving user-chosen filenames\n- Added test case for the cross-name duplicate scenario
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
