### PR TITLE
fix: refresh video embed coordinator provider on updates

### DIFF
--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -169,9 +169,10 @@ private struct VideoEmbedWebView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
-        // Keep coordinator callbacks in sync with the latest SwiftUI closures,
+        // Keep coordinator state in sync with the latest SwiftUI values,
         // since SwiftUI may recreate the struct (and its closures) without
         // recreating the coordinator.
+        context.coordinator.provider = provider
         context.coordinator.onLoaded = onLoaded
         context.coordinator.onFailed = onFailed
     }
@@ -199,7 +200,7 @@ private struct VideoEmbedWebView: UIViewRepresentable {
     }
 
     class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
-        let provider: String
+        var provider: String
         var onLoaded: () -> Void
         var onFailed: (String) -> Void
         /// The first programmatic navigation is the embed URL we control — always allow it.


### PR DESCRIPTION
## Summary
- Sync coordinator's provider property in updateUIView to keep navigation allowlist current
- Prevents stale provider allowlist when SwiftUI reuses VideoEmbedWebView for a different provider

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4984

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
