### PR TITLE
fix: gate subagent auto-scroll to additions only

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -133,8 +133,10 @@ struct ChatContentView: View {
                         }
                     }
                 }
-                .onChange(of: viewModel.activeSubagents.count) { _, _ in
-                    scrollToBottom(proxy: proxy, animated: true)
+                .onChange(of: viewModel.activeSubagents.count) { oldCount, newCount in
+                    if newCount > oldCount {
+                        scrollToBottom(proxy: proxy, animated: true)
+                    }
                 }
             }
             } // end else (messages non-empty)


### PR DESCRIPTION
## Summary
- Only scroll to bottom when activeSubagents count increases (new chip added)
- Don't scroll when subagents finish (count decreases), preserving scroll position for users reading history

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4986

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
