### PR TITLE
fix: skip settings reload on failed daemon connect

### DIFF
--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -311,13 +311,18 @@ struct SettingsView: View {
         }
         clientProvider.client = newClient
         Task {
-            try? await clientProvider.client.connect()
-            // Reload Connected-mode data after establishing connection
-            if mode == ConnectionMode.connected.rawValue {
-                loadIntegrations()
-                loadTrustRules()
-                loadSchedules()
-                loadReminders()
+            do {
+                try await clientProvider.client.connect()
+                // Reload Connected-mode data after establishing connection
+                if mode == ConnectionMode.connected.rawValue {
+                    loadIntegrations()
+                    loadTrustRules()
+                    loadSchedules()
+                    loadReminders()
+                }
+            } catch {
+                // Connection failed — skip reloading connected-mode data
+                // to avoid setting loading flags that never get cleared.
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wrap daemon connect in do/catch instead of try?
- Only reload integrations/trust rules/schedules/reminders after successful connect
- Prevents perpetual loading spinners when daemon is unreachable

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
