### PR TITLE
fix: include VM-bound sessions in thread dedup

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -130,7 +130,13 @@ class IOSThreadStore: ObservableObject {
         } else {
             // Deduplicate: only prepend restored threads whose sessionId
             // doesn't already exist in the current thread list.
-            let existingSessionIds = Set(threads.compactMap { $0.sessionId })
+            let existingSessionIds: Set<String> = Set(
+                threads.compactMap { thread -> String? in
+                    // Check both the thread's own sessionId AND the VM's bound sessionId
+                    if let sid = thread.sessionId { return sid }
+                    return viewModels[thread.id]?.sessionId
+                }
+            )
             var newThreads: [IOSThread] = []
             for restored in restoredThreads {
                 if let sid = restored.sessionId, existingSessionIds.contains(sid) {


### PR DESCRIPTION
## Summary
- Include ChatViewModel.sessionId in deduplication check, not just IOSThread.sessionId
- Catches the common race where a locally-created thread has a VM-bound session but nil on the thread struct

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
