### PR TITLE
fix: activity tracking for reused VMs and throttled persistence

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -56,6 +56,8 @@ class IOSThreadStore: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     /// Maps daemon session IDs to thread IDs for history loading.
     private var pendingHistoryBySessionId: [String: UUID] = [:]
+    /// Tracks thread IDs that already have an activity-tracking observer to avoid duplicates.
+    private var observedActivityThreadIds: Set<UUID> = []
 
     init(daemonClient: any DaemonClientProtocol) {
         self.daemonClient = daemonClient
@@ -171,6 +173,7 @@ class IOSThreadStore: ObservableObject {
     /// Return the ChatViewModel for the given thread, creating it if necessary.
     func viewModel(for threadId: UUID) -> ChatViewModel {
         if let existing = viewModels[threadId] {
+            observeForActivityTracking(vm: existing, threadId: threadId)
             return existing
         }
         let vm = ChatViewModel(daemonClient: daemonClient)
@@ -214,10 +217,15 @@ class IOSThreadStore: ObservableObject {
             .store(in: &cancellables)
     }
 
-    /// Update lastActivityAt whenever the message list changes.
+    /// Update lastActivityAt whenever the message count changes (not on every streaming delta).
     private func observeForActivityTracking(vm: ChatViewModel, threadId: UUID) {
+        guard !observedActivityThreadIds.contains(threadId) else { return }
+        observedActivityThreadIds.insert(threadId)
+
         vm.$messages
             .dropFirst()
+            .map(\.count)
+            .removeDuplicates()
             .sink { [weak self] _ in
                 self?.touchLastActivity(for: threadId)
             }

--- a/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
@@ -45,6 +45,28 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
         daemonClient.disconnect()
     }
 
+    // MARK: - Callback Contract Tests
+
+    /// Verifies that IdentityPanel's init signature requires an onCustomizeAvatar callback.
+    /// Instantiates a real IdentityPanel so the test fails to compile if the parameter is removed.
+    func testIdentityPanelRequiresCustomizeAvatarCallback() {
+        var customizeCalled = false
+        var closeCalled = false
+
+        let panel = IdentityPanel(
+            onClose: { closeCalled = true },
+            onCustomizeAvatar: { customizeCalled = true },
+            daemonClient: DaemonClient()
+        )
+
+        // Verify callbacks are wired — invoke them directly to confirm the closures passed through
+        panel.onClose()
+        panel.onCustomizeAvatar()
+
+        XCTAssertTrue(closeCalled)
+        XCTAssertTrue(customizeCalled)
+    }
+
     // MARK: - State Transition Tests
 
     func testAvatarCustomizationIsDistinctFromIdentity() {


### PR DESCRIPTION
## Summary
- Attach activity tracking observer to existing/reused VMs, not just newly created ones
- Use .map(\.count).removeDuplicates() to only fire touchLastActivity on message count changes
- Prevents excessive UserDefaults writes during streaming (was firing on every text delta)

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/4988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
