### PR TITLE
fix: subscribe before model_set and skip no-op model changes

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -40,6 +40,7 @@ struct ChatContentView: View {
                                     models: ModelListBubble.anthropicModels.map { (id: $0.model, name: $0.display) },
                                     selectedModelId: viewModel.selectedModel,
                                     onSelect: { modelId in
+                                        guard modelId != viewModel.selectedModel else { return }
                                         viewModel.setModel(modelId)
                                     }
                                 )

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -511,6 +511,11 @@ public final class ChatViewModel: ObservableObject {
 
     /// Switch the active model via the daemon's `model_set` IPC command.
     public func setModel(_ modelId: String) {
+        // Ensure the message loop is running so we receive the model_info response.
+        // VMs restored with an existing sessionId may not have started it yet.
+        if messageLoopTask == nil {
+            startMessageLoop()
+        }
         try? daemonClient.send(ModelSetRequestMessage(model: modelId))
     }
 


### PR DESCRIPTION
## Summary
- Ensure message loop is running before sending model_set IPC command
- Skip no-op model changes when user taps the already-selected model
- Prevents dropped model_info responses and unnecessary provider reinitialization

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/5003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
