### PR TITLE
fix: add missing sizeBytes param to IPCUserMessageAttachment convenience init

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -139,7 +139,7 @@ public typealias IPCAttachment = IPCUserMessageAttachment
 
 extension IPCUserMessageAttachment {
     public init(filename: String, mimeType: String, data: String, extractedText: String?) {
-        self.init(id: nil, filename: filename, mimeType: mimeType, data: data, extractedText: extractedText)
+        self.init(id: nil, filename: filename, mimeType: mimeType, data: data, extractedText: extractedText, sizeBytes: nil)
     }
 }
 


### PR DESCRIPTION
## Summary
- The generated `IPCUserMessageAttachment` struct gained a `sizeBytes` field, but the convenience initializer in `IPCMessages.swift` wasn't updated to pass it
- Added `sizeBytes: nil` to the delegating `self.init` call to fix the build error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
