### PR TITLE
fix: use SessionTokenManager for video attachment auth

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -184,7 +184,7 @@ struct InlineVideoAttachmentView: View {
 
 /// Fetch attachment base64 data from the daemon HTTP endpoint.
 private func fetchAttachmentData(port: Int, attachmentId: String) async throws -> String {
-    guard let token = readSessionToken() else {
+    guard let token = await SessionTokenManager.getTokenAsync() else {
         throw URLError(.userAuthenticationRequired)
     }
     let url = URL(string: "http://localhost:\(port)/v1/attachments/\(attachmentId)")!


### PR DESCRIPTION
## Summary
- Replace nonexistent `readSessionToken()` call in `InlineVideoAttachmentView.swift` with `SessionTokenManager.getTokenAsync()`
- Fixes build error: "cannot find 'readSessionToken' in scope"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
