### PR TITLE
docs: add download section to macOS README

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -54,6 +54,22 @@ Requires Apple Developer account + App Store Connect setup. Deferred to PR 12-13
 
 **Daemon Connection Note:** The iOS app connects to the daemon via TCP (default: localhost:8765). For Simulator testing, the daemon should run on your Mac. For device testing, configure the daemon hostname to your Mac's IP address in Settings.
 
+## Download
+
+To install the pre-built macOS app, download the signed and notarized DMG:
+
+**[Download Vellum.dmg](https://github.com/vellum-ai/velly/releases/latest/download/vellum-assistant.dmg)**
+
+1. Open the DMG and drag **Vellum.app** to your Applications folder
+2. Launch Vellum — macOS may prompt "are you sure?" on first launch (click Open)
+3. The app appears as a sparkles icon in your menu bar
+
+The app includes **Sparkle auto-update** — after the initial install, updates are downloaded and applied automatically in the background. You'll be prompted to relaunch when a new version is ready.
+
+> **Note:** You still need the daemon running for the app to function. See the [Daemon](#daemon) section below for setup.
+
+All releases are available at [github.com/vellum-ai/velly/releases](https://github.com/vellum-ai/velly/releases).
+
 ## Requirements
 
 - macOS 14.0 (Sonoma) or later


### PR DESCRIPTION
## Summary
- Add a "Download" section to the macOS README pointing to the pre-built DMG at `vellum-ai/velly` releases
- Document the Sparkle auto-update behavior (updates applied automatically after initial install)
- Link to the full releases page for browsing all versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
