### PR TITLE
fix: use correct bearer token for lazy-load video fetch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -184,7 +184,7 @@ struct InlineVideoAttachmentView: View {
 
 /// Fetch attachment base64 data from the daemon HTTP endpoint.
 private func fetchAttachmentData(port: Int, attachmentId: String) async throws -> String {
-    guard let token = await SessionTokenManager.getTokenAsync() else {
+    guard let token = readHttpToken() else {
         throw URLError(.userAuthenticationRequired)
     }
     let url = URL(string: "http://localhost:\(port)/v1/attachments/\(attachmentId)")!

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -51,6 +51,18 @@ func readSessionToken(environment: [String: String]? = nil) -> String? {
     }
     return token
 }
+
+/// Read the daemon HTTP bearer token from disk (~/.vellum/http-token).
+func readHttpToken() -> String? {
+    let tokenPath = NSHomeDirectory() + "/.vellum/http-token"
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: tokenPath)),
+          let token = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+          !token.isEmpty else {
+        return nil
+    }
+    return token
+}
 #endif
 
 /// Protocol for daemon client communication, enabling dependency injection and testing.


### PR DESCRIPTION
## Summary
- Video lazy-load was using the Keychain auth token (SessionTokenManager) instead of the daemon HTTP bearer token (~/.vellum/http-token), causing 401 errors when fetching attachment data
- Added readHttpToken() helper to read the correct bearer token from disk
- Updated InlineVideoAttachmentView to use readHttpToken() for HTTP API auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
