### PR TITLE
fix: remove model selection no-op guard to avoid race condition

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -40,7 +40,6 @@ struct ChatContentView: View {
                                     models: ModelListBubble.anthropicModels.map { (id: $0.model, name: $0.display) },
                                     selectedModelId: viewModel.selectedModel,
                                     onSelect: { modelId in
-                                        guard modelId != viewModel.selectedModel else { return }
                                         viewModel.setModel(modelId)
                                     }
                                 )


### PR DESCRIPTION
## Summary
- Remove the no-op guard in ChatContentView's model picker that could drop rapid model changes due to a race between the UI and daemon response timing
- The guard compared against selectedModel which updates async via model_info response, causing valid user selections to be silently dropped

Addresses feedback from #5025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
