### PR TITLE
fix: exclude history loads from activity tracking and add disconnect to test

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -218,6 +218,8 @@ class IOSThreadStore: ObservableObject {
     }
 
     /// Update lastActivityAt whenever the message count changes (not on every streaming delta).
+    /// Skips updates while the VM is loading history so that hydrating old messages
+    /// doesn't stamp the thread as recently active.
     private func observeForActivityTracking(vm: ChatViewModel, threadId: UUID) {
         guard !observedActivityThreadIds.contains(threadId) else { return }
         observedActivityThreadIds.insert(threadId)
@@ -226,7 +228,8 @@ class IOSThreadStore: ObservableObject {
             .dropFirst()
             .map(\.count)
             .removeDuplicates()
-            .sink { [weak self] _ in
+            .sink { [weak self, weak vm] _ in
+                guard let vm, !vm.isLoadingHistory else { return }
                 self?.touchLastActivity(for: threadId)
             }
             .store(in: &cancellables)

--- a/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
@@ -52,11 +52,12 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
     func testIdentityPanelRequiresCustomizeAvatarCallback() {
         var customizeCalled = false
         var closeCalled = false
+        let daemonClient = DaemonClient()
 
         let panel = IdentityPanel(
             onClose: { closeCalled = true },
             onCustomizeAvatar: { customizeCalled = true },
-            daemonClient: DaemonClient()
+            daemonClient: daemonClient
         )
 
         // Verify callbacks are wired — invoke them directly to confirm the closures passed through
@@ -65,6 +66,7 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
         XCTAssertTrue(closeCalled)
         XCTAssertTrue(customizeCalled)
+        daemonClient.disconnect()
     }
 
     // MARK: - State Transition Tests

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -167,6 +167,10 @@ public final class ChatViewModel: ObservableObject {
     /// Whether this view model has had its history loaded from the daemon.
     public var isHistoryLoaded: Bool = false
 
+    /// True while `populateFromHistory` is actively inserting messages.
+    /// Observers can check this to avoid treating the history hydration as new activity.
+    public private(set) var isLoadingHistory: Bool = false
+
     /// Surface the user is currently viewing in workspace mode.
     /// Set by MainWindowView when the dynamic workspace is expanded.
     public var activeSurfaceId: String? {
@@ -1199,6 +1203,7 @@ public final class ChatViewModel: ObservableObject {
             try? daemonClient.send(ModelGetRequestMessage())
         }
 
+        self.isLoadingHistory = true
         let hasUserSentMessages = messages.contains { $0.role == .user }
         if hasUserSentMessages {
             // History arrived after the user already sent messages.
@@ -1218,6 +1223,7 @@ public final class ChatViewModel: ObservableObject {
         } else {
             self.messages = chatMessages
         }
+        self.isLoadingHistory = false
         self.isHistoryLoaded = true
         // Surfaces are now included directly in the history response and populated above
     }


### PR DESCRIPTION
## Summary
- Skip activity tracking updates during history population to avoid stamping old threads as recently active
- Add missing DaemonClient.disconnect() call in MainWindowAvatarRoutingTests

Addresses feedback from #5024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
