### PR TITLE
fix: update Sparkle SUFeedURL to point to vellum-ai/velly releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ Run `/release [version]` in Claude Code. If no version is provided, the patch ve
 
 Creating the GitHub Release triggers three workflows in parallel:
 
-- **Build and Release macOS App** (`build-and-release-macos.yml`): Builds the macOS `.app` from source, compiles the Bun daemon binary, code-signs it with a Developer ID certificate, notarizes it with Apple, creates a DMG installer, and publishes both the DMG and a Sparkle-compatible ZIP + `appcast.xml` to the public updates repo ([alex-nork/vellum-assistant-macos-updates](https://github.com/alex-nork/vellum-assistant-macos-updates)). This takes ~15-20 minutes.
+- **Build and Release macOS App** (`build-and-release-macos.yml`): Builds the macOS `.app` from source, compiles the Bun daemon binary, code-signs it with a Developer ID certificate, notarizes it with Apple, creates a DMG installer, and publishes both the DMG and a Sparkle-compatible ZIP + `appcast.xml` to the public updates repo ([vellum-ai/velly](https://github.com/vellum-ai/velly)). This takes ~15-20 minutes.
 - **Publish velly to npm** (`publish-velly.yml`): Publishes the `velly` CLI package to npm with provenance.
 - **Slack Release Notification** (`slack-release-notification.yml`): Posts a summary message to the releases Slack channel with a threaded changelog.
 
@@ -520,7 +520,7 @@ The macOS app uses [Sparkle](https://sparkle-project.org/) for automatic updates
 
 ### First-time installation
 
-New users download the latest DMG from the [public updates repo releases page](https://github.com/alex-nork/vellum-assistant-macos-updates/releases/latest), open it, and drag the app to their Applications folder. All subsequent updates are handled automatically by Sparkle.
+New users download the latest DMG from the [public updates repo releases page](https://github.com/vellum-ai/velly/releases/latest), open it, and drag the app to their Applications folder. All subsequent updates are handled automatically by Sparkle.
 
 ## License
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -261,7 +261,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
     <key>SUFeedURL</key>
-    <string>https://github.com/alex-nork/vellum-assistant-macos-updates/releases/latest/download/appcast.xml</string>
+    <string>https://github.com/vellum-ai/velly/releases/latest/download/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>${SU_PUBLIC_ED_KEY:-}</string>
     <key>SUAutomaticallyUpdate</key>


### PR DESCRIPTION
## Summary
- Fix Sparkle auto-update feed URL mismatch: the app was checking `alex-nork/vellum-assistant-macos-updates` (stale, v0.1.5) instead of `vellum-ai/velly` (current, v0.1.28) where CI actually publishes releases
- Also updates README references to point to the correct repo
- This ensures locally-built and CI-built apps both check the correct update channel

Addresses feedback from #5029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
