### PR TITLE
fix: use appcast.xml filename in CI workflow for Sparkle auto-update

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -286,7 +286,7 @@ jobs:
           SIZE=$(stat -f%z dist/vellum-assistant.zip)
 
           REPO="vellum-ai/velly"
-          FILENAME="appcast-${REPO//\//-}.xml"
+          FILENAME="appcast.xml"
           cat > "dist/$FILENAME" << EOF
           <?xml version="1.0" encoding="utf-8"?>
           <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
@@ -315,7 +315,7 @@ jobs:
           path: |
             clients/macos/build/vellum-assistant.dmg
             clients/macos/dist/vellum-assistant.zip
-            clients/macos/dist/appcast-*.xml
+            clients/macos/dist/appcast.xml
           if-no-files-found: error
           retention-days: 1
 
@@ -438,7 +438,7 @@ jobs:
           if [ -d "macos-artifacts" ]; then
             DMG=$(find macos-artifacts -name "vellum-assistant.dmg" -type f | head -1)
             ZIP=$(find macos-artifacts -name "vellum-assistant.zip" -type f | head -1)
-            APPCAST=$(find macos-artifacts -name "appcast-*.xml" -type f | head -1)
+            APPCAST=$(find macos-artifacts -name "appcast.xml" -type f | head -1)
             [ -n "$DMG" ] && ASSETS+=("$DMG#vellum-assistant.dmg")
             [ -n "$ZIP" ] && ASSETS+=("$ZIP#vellum-assistant.zip")
             [ -n "$APPCAST" ] && ASSETS+=("$APPCAST#appcast.xml")


### PR DESCRIPTION
## Summary
- Change CI appcast filename from `appcast-${REPO//\//-}.xml` (→ `appcast-vellum-ai-velly.xml`) to plain `appcast.xml`
- Update artifact glob and find pattern to match the new filename
- This aligns with the `SUFeedURL` in `build.sh` which expects `appcast.xml` at the `vellum-ai/velly` releases download URL
- Also manually uploaded `appcast.xml` to the current v0.1.28 release so existing installs can auto-update immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
