### PR TITLE
fix: resolve readHttpToken scope error in lazy-load video fetch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -184,7 +184,10 @@ struct InlineVideoAttachmentView: View {
 
 /// Fetch attachment base64 data from the daemon HTTP endpoint.
 private func fetchAttachmentData(port: Int, attachmentId: String) async throws -> String {
-    guard let token = readHttpToken() else {
+    let tokenPath = NSHomeDirectory() + "/.vellum/http-token"
+    guard let tokenData = try? Data(contentsOf: URL(fileURLWithPath: tokenPath)),
+          let token = String(data: tokenData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !token.isEmpty else {
         throw URLError(.userAuthenticationRequired)
     }
     let url = URL(string: "http://localhost:\(port)/v1/attachments/\(attachmentId)")!

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -52,17 +52,6 @@ func readSessionToken(environment: [String: String]? = nil) -> String? {
     return token
 }
 
-/// Read the daemon HTTP bearer token from disk (~/.vellum/http-token).
-func readHttpToken() -> String? {
-    let tokenPath = NSHomeDirectory() + "/.vellum/http-token"
-    guard let data = try? Data(contentsOf: URL(fileURLWithPath: tokenPath)),
-          let token = String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-          !token.isEmpty else {
-        return nil
-    }
-    return token
-}
 #endif
 
 /// Protocol for daemon client communication, enabling dependency injection and testing.


### PR DESCRIPTION
## Summary
- `readHttpToken()` was internal to VellumAssistantShared but called from VellumAssistantLib, causing "cannot find in scope" build error
- Inlined the http-token file read directly in `fetchAttachmentData` and removed the unused shared function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
