### PR TITLE
fix: add daemon-side no-op guard for model_set to avoid expensive reinit

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -41,6 +41,23 @@ export function handleModelSet(
   ctx: HandlerContext,
 ): void {
   try {
+    // If the requested model is already the current model, skip expensive
+    // reinitialization but still send model_info so the client confirms.
+    {
+      const current = getConfig();
+      if (msg.model === current.model) {
+        const configured = Object.keys(current.apiKeys).filter((k) => !!current.apiKeys[k]);
+        if (!configured.includes('ollama')) configured.push('ollama');
+        ctx.send(socket, {
+          type: 'model_info',
+          model: current.model,
+          provider: current.provider,
+          configuredProviders: configured,
+        });
+        return;
+      }
+    }
+
     // Validate API key before switching
     const provider = MODEL_TO_PROVIDER[msg.model];
     if (provider && provider !== 'ollama') {


### PR DESCRIPTION
## Summary
- Add no-op guard in the daemon's model_set handler that skips provider reinitialization when the requested model matches the current model
- Still sends model_info response so the client gets confirmation
- Complements client-side removal of the race-prone guard (PR #5031)

Addresses feedback from #5031.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
