### PR TITLE
fix: use local-assistant ID for /v1/ HTTP routes

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -247,7 +247,7 @@ export class RuntimeHttpServer {
     // Paths already handled above (/v1/apps/..., /v1/secrets) will never reach here.
     const newRouteMatch = path.match(/^\/v1\/(?!assistants\/)(.+)$/);
     if (newRouteMatch) {
-      return this.dispatchEndpoint('self', newRouteMatch[1], req, url);
+      return this.dispatchEndpoint('local-assistant', newRouteMatch[1], req, url);
     }
 
     // Legacy: /v1/assistants/:assistantId/<endpoint>


### PR DESCRIPTION
## Summary
- The `/v1/<endpoint>` HTTP routes passed `'self'` as the assistantId, but all IPC-created data (attachments, conversations) is stored with `assistant_id = 'local-assistant'`
- This caused attachment lookups via `/v1/attachments/:id` to return 404, breaking lazy-load video playback
- Changed the route to pass `'local-assistant'` directly, matching the canonical ID used by the daemon session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
