### PR TITLE
refactor(ios): replace raw colors with VColor design tokens

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -244,7 +244,7 @@ struct ChatContentView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .background(Color.white.opacity(0.25))
+                        .background(VColor.surfaceBorder)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
             } else if viewModel.isRetryableError {
@@ -254,7 +254,7 @@ struct ChatContentView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .background(Color.white.opacity(0.25))
+                        .background(VColor.surfaceBorder)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
             }

--- a/clients/ios/Views/InlineImageEmbedView.swift
+++ b/clients/ios/Views/InlineImageEmbedView.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import SwiftUI
+import VellumAssistantShared
 
 /// Renders a remote image inline within a chat bubble on iOS.
 ///
@@ -42,7 +43,7 @@ struct InlineImageEmbedView: View {
 
     private var placeholderSkeleton: some View {
         RoundedRectangle(cornerRadius: 8)
-            .fill(Color.gray.opacity(0.15))
+            .fill(VColor.backgroundSubtle)
             .frame(maxWidth: .infinity)
             .frame(height: 120)
     }

--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -68,7 +68,7 @@ struct InlineVideoEmbedView: View {
         } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(Color.black.opacity(0.8))
+                    .fill(VColor.background.opacity(0.8))
                     .frame(height: 200)
 
                 Image(systemName: "play.circle.fill")
@@ -105,7 +105,7 @@ struct InlineVideoEmbedView: View {
         }
         .frame(height: 200)
         .frame(maxWidth: .infinity)
-        .background(Color.black.opacity(0.8))
+        .background(VColor.background.opacity(0.8))
     }
 }
 

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -373,7 +373,7 @@ struct ThreadListView: View {
                     } label: {
                         Label("Archive", systemImage: "archivebox")
                     }
-                    .tint(.orange)
+                    .tint(VColor.warning)
                 }
                 .swipeActions(edge: .leading) {
                     Button {
@@ -382,7 +382,7 @@ struct ThreadListView: View {
                     } label: {
                         Label("Rename", systemImage: "pencil")
                     }
-                    .tint(.blue)
+                    .tint(VColor.accent)
                 }
             }
 
@@ -408,7 +408,7 @@ struct ThreadListView: View {
                                 } label: {
                                     Label("Unarchive", systemImage: "tray.and.arrow.up")
                                 }
-                                .tint(.blue)
+                                .tint(VColor.accent)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
Replace hardcoded color values with semantic VColor design tokens across 4 iOS view files, improving dark/light mode consistency and enabling global palette updates.

## Changes
- **ChatContentView** — `Color.white.opacity(0.25)` → `VColor.surfaceBorder` in error banner button backgrounds
- **InlineImageEmbedView** — `Color.gray.opacity(0.15)` → `VColor.backgroundSubtle` in image placeholder skeleton
- **InlineVideoEmbedView** — `Color.black.opacity(0.8)` → `VColor.background.opacity(0.8)` in video placeholder and failed-state backgrounds
- **ThreadListView** — `.tint(.orange)` → `.tint(VColor.warning)` for archive swipe action; `.tint(.blue)` → `.tint(VColor.accent)` for rename/unarchive swipe actions

## Testing
- macOS build: `./build.sh` passes
- iOS build: `xcodebuild build -scheme vellum-assistant-ios` passes
- Visual inspection: verify error banners, image placeholders, video embeds, and swipe actions render correctly in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
