### PR TITLE
fix(ios): revert style-changing color swaps from PR 5039

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -244,7 +244,7 @@ struct ChatContentView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .background(VColor.surfaceBorder)
+                        .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.error banner
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
             } else if viewModel.isRetryableError {
@@ -254,7 +254,7 @@ struct ChatContentView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .background(VColor.surfaceBorder)
+                        .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.error banner
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
             }

--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -68,7 +68,7 @@ struct InlineVideoEmbedView: View {
         } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(VColor.background.opacity(0.8))
+                    .fill(Color.black.opacity(0.8)) // Intentional: always-dark video placeholder
                     .frame(height: 200)
 
                 Image(systemName: "play.circle.fill")
@@ -105,7 +105,7 @@ struct InlineVideoEmbedView: View {
         }
         .frame(height: 200)
         .frame(maxWidth: .infinity)
-        .background(VColor.background.opacity(0.8))
+        .background(Color.black.opacity(0.8)) // Intentional: always-dark video error state
     }
 }
 

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -382,7 +382,7 @@ struct ThreadListView: View {
                     } label: {
                         Label("Rename", systemImage: "pencil")
                     }
-                    .tint(VColor.accent)
+                    .tint(.blue) // Intentional: system blue for non-destructive swipe actions
                 }
             }
 
@@ -408,7 +408,7 @@ struct ThreadListView: View {
                                 } label: {
                                     Label("Unarchive", systemImage: "tray.and.arrow.up")
                                 }
-                                .tint(VColor.accent)
+                                .tint(.blue) // Intentional: system blue for non-destructive swipe actions
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Revert 3 color substitutions from #5039 that changed visual appearance instead of being pure token swaps
- `VColor.surfaceBorder` → restore `Color.white.opacity(0.25)` on error banner buttons (translucent contrast on colored background)
- `VColor.background.opacity(0.8)` → restore `Color.black.opacity(0.8)` on video placeholders (always-dark context)
- `.tint(VColor.accent)` → restore `.tint(.blue)` on swipe actions (VColor.accent is near-black in light mode)
- Add `// Intentional:` comments explaining why these raw values don't use design tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
