### PR TITLE
refactor(ios): add VFont.onboardingEmoji token for 80pt emoji sizing

### DIFF
--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -51,7 +51,7 @@ struct WelcomeStep: View {
             Spacer()
 
             Text("✨")
-                .font(.system(size: 80))
+                .font(VFont.onboardingEmoji)
 
             Text("Welcome to Vellum Assistant")
                 .font(VFont.title)
@@ -84,7 +84,7 @@ struct ConnectionModeStep: View {
             Spacer()
 
             Text("🔗")
-                .font(.system(size: 80))
+                .font(VFont.onboardingEmoji)
 
             Text("How do you want to connect?")
                 .font(VFont.title)
@@ -183,7 +183,7 @@ struct APIKeyStep: View {
             Spacer()
 
             Text("🔑")
-                .font(.system(size: 80))
+                .font(VFont.onboardingEmoji)
 
             Text("Anthropic API Key")
                 .font(VFont.title)
@@ -244,7 +244,7 @@ struct DaemonSetupStep: View {
             Spacer()
 
             Text("🔌")
-                .font(.system(size: 80))
+                .font(VFont.onboardingEmoji)
 
             Text("Connect to Mac")
                 .font(VFont.title)
@@ -330,7 +330,7 @@ struct PermissionsStep: View {
             Spacer()
 
             Text("🎤")
-                .font(.system(size: 80))
+                .font(VFont.onboardingEmoji)
 
             Text("Permissions")
                 .font(VFont.title)
@@ -369,7 +369,7 @@ struct ReadyStep: View {
             Spacer()
 
             Text("🎉")
-                .font(.system(size: 80))
+                .font(VFont.onboardingEmoji)
 
             Text("You're All Set!")
                 .font(VFont.title)

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -67,6 +67,7 @@ public enum VFont {
 
     public static let cardTitle  = Font.custom("Inter-Medium", size: 17)
     public static let cardEmoji  = Font.system(size: 32)
+    public static let onboardingEmoji = Font.system(size: 80)
     public static let mono       = dmMono("DMMono-Regular", size: 13)
     public static let monoSmall  = dmMono("DMMono-Regular", size: 11)
     public static let monoMedium = dmMono("DMMono-Medium", size: 16)


### PR DESCRIPTION
## Summary
- Add `VFont.onboardingEmoji` constant (`Font.system(size: 80)`) to shared TypographyTokens
- Replace 6 identical `.font(.system(size: 80))` calls in iOS OnboardingView with the new token

## What was NOT changed (and why)
- SF Symbol icon fonts (`.system(size: N)` on Image views) — SF Symbols require system font for optical sizing
- Text views with specific weight/family combos that don't match any VFont token — changing would alter visual appearance

## Testing
- macOS build: `./build.sh` passes
- iOS build: `xcodebuild build -scheme vellum-assistant-ios` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
