### PR TITLE
refactor(ios): deduplicate date formatting and greeting arrays

### DIFF
--- a/clients/ios/App/DateFormatting.swift
+++ b/clients/ios/App/DateFormatting.swift
@@ -1,0 +1,19 @@
+#if canImport(UIKit)
+import Foundation
+
+enum DateFormatting {
+    /// Returns a relative timestamp string (e.g. "2 min. ago", "3 hr. ago").
+    static func relativeTimestamp(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    /// Returns a relative timestamp from a millisecond Unix epoch, or nil if <= 0.
+    static func relativeTimestamp(fromMilliseconds ms: Int) -> String? {
+        guard ms > 0 else { return nil }
+        let date = Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0)
+        return relativeTimestamp(date)
+    }
+}
+#endif

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -8,21 +8,20 @@ let chatBackgroundImage: UIImage? = {
     return UIImage(contentsOfFile: url.path)
 }()
 
+private let greetingChoices = [
+    "What are we working on?",
+    "I'm here whenever you need me.",
+    "What's on your mind?",
+    "Let's make something happen.",
+    "Ready when you are.",
+]
+
 struct ChatContentView: View {
     @ObservedObject var viewModel: ChatViewModel
     @FocusState private var isInputFocused: Bool
     @Environment(\.colorScheme) private var colorScheme
     @State private var emptyStateVisible = false
-    @State private var greeting: String = {
-        let choices = [
-            "What are we working on?",
-            "I'm here whenever you need me.",
-            "What's on your mind?",
-            "Let's make something happen.",
-            "Ready when you are.",
-        ]
-        return choices.randomElement()!
-    }()
+    @State private var greeting: String = greetingChoices.randomElement()!
 
     var body: some View {
         VStack(spacing: 0) {
@@ -167,9 +166,7 @@ struct ChatContentView: View {
         .animation(.easeInOut(duration: 0.2), value: viewModel.errorText)
         .onChange(of: viewModel.messages.isEmpty) { _, isEmpty in
             if isEmpty {
-                greeting = ["What are we working on?", "I'm here whenever you need me.",
-                            "What's on your mind?", "Let's make something happen.",
-                            "Ready when you are."].randomElement()!
+                greeting = greetingChoices.randomElement()!
             }
         }
     }

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -100,10 +100,7 @@ struct RemindersSection: View {
     }
 
     private func formatTimestamp(_ ms: Int) -> String? {
-        let date = Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0)
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        DateFormatting.relativeTimestamp(fromMilliseconds: ms)
     }
 }
 #endif

--- a/clients/ios/Views/Settings/SchedulesSection.swift
+++ b/clients/ios/Views/Settings/SchedulesSection.swift
@@ -98,10 +98,7 @@ struct SchedulesSection: View {
     }
 
     private func formatTimestamp(_ ms: Int) -> String? {
-        let date = Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0)
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        DateFormatting.relativeTimestamp(fromMilliseconds: ms)
     }
 }
 #endif

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -168,9 +168,7 @@ struct ThreadListView: View {
     }
 
     private func relativeDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        DateFormatting.relativeTimestamp(date)
     }
 
     // MARK: - Detail


### PR DESCRIPTION
## Summary
- Add `DateFormatting` utility with shared `relativeTimestamp` methods
- Replace 3 identical `RelativeDateTimeFormatter` instances (ThreadListView, SchedulesSection, RemindersSection)
- Extract greeting choices to a module-level constant in ChatContentView, eliminating the duplicate array

## Testing
- macOS build: `./build.sh` passes
- iOS build: `xcodebuild build -scheme vellum-assistant-ios` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
