### PR TITLE
fix: recursive credential redaction for nested arrays and double-encoded JSON

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -150,10 +150,9 @@ extension ChatViewModel {
             if Self.isSensitiveKey(key) {
                 redacted[key] = "[redacted]"
             } else if let nested = val as? [String: Any] {
-                // Parse the redacted nested dict back as-is (store as string for encoding)
-                redacted[key] = redactDictionary(nested)
+                redacted[key] = redactDictionaryAsObject(nested)
             } else if let nested = val as? [Any] {
-                redacted[key] = redactArray(nested)
+                redacted[key] = redactArrayAsObject(nested)
             } else {
                 redacted[key] = val
             }
@@ -168,18 +167,24 @@ extension ChatViewModel {
 
     /// Recursively redact sensitive keys in array elements.
     private func redactArray(_ array: [Any]) -> String {
-        let redacted: [Any] = array.map { element in
-            if let dict = element as? [String: Any] {
-                // Return the redacted dict (not string) so JSONSerialization handles it
-                return redactDictionaryAsObject(dict)
-            }
-            return element
-        }
+        let redacted = redactArrayAsObject(array)
         if let data = try? JSONSerialization.data(withJSONObject: redacted, options: [.sortedKeys]),
            let json = String(data: data, encoding: .utf8) {
             return json
         }
         return String(describing: redacted)
+    }
+
+    /// Recursively redact sensitive keys in array elements, returning an array (not string) for nesting.
+    private func redactArrayAsObject(_ array: [Any]) -> [Any] {
+        return array.map { element -> Any in
+            if let dict = element as? [String: Any] {
+                return redactDictionaryAsObject(dict)
+            } else if let nested = element as? [Any] {
+                return redactArrayAsObject(nested)
+            }
+            return element
+        }
     }
 
     /// Recursively redact sensitive keys, returning a dictionary (not string) for nesting.
@@ -191,12 +196,7 @@ extension ChatViewModel {
             } else if let nested = val as? [String: Any] {
                 redacted[key] = redactDictionaryAsObject(nested)
             } else if let nested = val as? [Any] {
-                redacted[key] = nested.map { element -> Any in
-                    if let d = element as? [String: Any] {
-                        return redactDictionaryAsObject(d)
-                    }
-                    return element
-                }
+                redacted[key] = redactArrayAsObject(nested)
             } else {
                 redacted[key] = val
             }


### PR DESCRIPTION
Addresses review feedback from PR #4996:
- Fix redactDictionary to use redactDictionaryAsObject for nested dicts (prevents double-encoded JSON)
- Fix redactDictionary to use redactArrayAsObject for nested arrays (prevents double-encoded JSON)
- Add redactArrayAsObject helper for recursive array descent
- Fix redactDictionaryAsObject to use redactArrayAsObject for nested arrays (consistent recursive handling)
- Credentials in arrays-of-arrays (e.g. [[{"access_token":"..."}]]) are now properly redacted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
