### PR TITLE
fix: preserve PID file when daemon survives SIGKILL

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -224,16 +224,18 @@ export async function stopDaemon(): Promise<{ stopped: boolean }> {
     killWaited += 100;
   }
 
-  // Only remove the socket if the process has actually exited.
-  // If it's still alive after SIGKILL + timeout, leave the socket
-  // intact to avoid pulling the rug from under a still-running daemon.
+  // Only clean up if the process has actually exited.
+  // If it's still alive after SIGKILL + timeout, preserve both socket
+  // and PID file so isDaemonRunning() still reports true and prevents
+  // a duplicate daemon from being spawned.
   if (!isProcessRunning(pid)) {
     removeSocketFile(getSocketPath());
-  } else {
-    log.warn({ pid }, 'Daemon process still running after SIGKILL + timeout, leaving socket intact');
+    cleanupPidFile();
+    return { stopped: true };
   }
-  cleanupPidFile();
-  return { stopped: true };
+
+  log.warn({ pid }, 'Daemon process still running after SIGKILL + timeout, leaving socket and PID file intact');
+  return { stopped: false };
 }
 
 export async function ensureDaemonRunning(): Promise<void> {


### PR DESCRIPTION
Addresses review feedback from PR #5005:
- Move cleanupPidFile() inside the process-exited branch
- Return stopped: false when daemon is still alive after SIGKILL
- Prevents isDaemonRunning() from falsely reporting daemon is stopped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
