### PR TITLE
fix: include pre-anchor request logs in diagnostics export

### DIFF
--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -138,8 +138,11 @@ export async function handleDiagnosticsExport(
       .get();
 
     // Use the preceding user message timestamp as the range start,
-    // or fall back to the anchor message timestamp if none found
-    const rangeStart = precedingUserMessage?.createdAt ?? anchorMessage.createdAt;
+    // or fall back to the anchor message timestamp minus a small buffer.
+    // Request logs are recorded during the usage event before the assistant
+    // message is persisted, so same-turn logs can have timestamps slightly
+    // earlier than the anchor.
+    const rangeStart = precedingUserMessage?.createdAt ?? (anchorMessage.createdAt - 2000);
     const rangeEnd = anchorMessage.createdAt;
     // Usage events are recorded asynchronously after the assistant message
     // is persisted, so their createdAt can be slightly later. Use a separate


### PR DESCRIPTION
Addresses review feedback from PR #5000:
- Adds a 2-second timestamp buffer when rangeStart falls back to anchorMessage.createdAt
- Ensures request logs recorded slightly before the anchor message (same-turn logs from the usage event) are included in the export
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
