### PR TITLE
fix: include filename in attachment dedup key to prevent false matches

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -385,7 +385,7 @@ describe('deduplicateDrafts', () => {
     expect(result[1].filename).toBe('other.txt');
   });
 
-  test('removes duplicates with different filenames but identical content', () => {
+  test('drops tool_block duplicate when directive has same content', () => {
     // Simulates directive tag ("chart.png") + auto-converted tool block
     // ("tool-output.png") for the same file data — the directive draft
     // should win because it appears first in the merged array.
@@ -396,6 +396,20 @@ describe('deduplicateDrafts', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].filename).toBe('chart.png');
+  });
+
+  test('keeps non-tool drafts with different filenames but identical content', () => {
+    // Two distinct files that happen to have the same bytes (e.g. empty
+    // files, or before.json / after.json with identical content) should
+    // both be kept.
+    const data = 'AAAA'.repeat(20);
+    const d1 = makeDraft({ sourceType: 'sandbox_file', filename: 'before.json', dataBase64: data });
+    const d2 = makeDraft({ sourceType: 'sandbox_file', filename: 'after.json', dataBase64: data });
+    const result = deduplicateDrafts([d1, d2]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].filename).toBe('before.json');
+    expect(result[1].filename).toBe('after.json');
   });
 
   test('keeps drafts with same filename but different content', () => {

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -640,21 +640,30 @@ export function cleanAssistantContent(
 // ---------------------------------------------------------------------------
 
 /**
- * De-duplicate drafts by content hash alone.
+ * De-duplicate drafts by filename + content hash.
  *
- * Uses a fast hash of the entire base64 payload so that identical file
- * content is only attached once — even when the same data appears under
- * different filenames (e.g. a directive tag with an explicit name vs. an
- * auto-converted tool block named "tool-output.png").  The first
- * occurrence wins, which is the directive draft when directives are
- * listed before tool blocks, preserving the user-chosen filename.
+ * Exact duplicates (same name, same bytes) are always collapsed.
+ * Additionally, tool_block drafts whose content already appeared from a
+ * non-tool source (directive) are dropped — this prevents the same file
+ * data from being attached twice when it appears as both a directive tag
+ * (user-chosen name) and an auto-converted tool block ("tool-output.png").
  */
 export function deduplicateDrafts(drafts: AssistantAttachmentDraft[]): AssistantAttachmentDraft[] {
-  const seen = new Set<string>();
+  const seenKeys = new Set<string>();
+  const seenDirectiveHashes = new Set<string>();
   return drafts.filter((d) => {
     const hash = Bun.hash(d.dataBase64).toString(36);
-    if (seen.has(hash)) return false;
-    seen.add(hash);
+    const key = `${d.filename}:${hash}`;
+
+    // Exact duplicate (same filename + same content): always skip.
+    if (seenKeys.has(key)) return false;
+
+    // Tool-block draft whose content was already attached via a directive:
+    // drop the tool-block copy so the directive's user-chosen name wins.
+    if (d.sourceType === 'tool_block' && seenDirectiveHashes.has(hash)) return false;
+
+    seenKeys.add(key);
+    if (d.sourceType !== 'tool_block') seenDirectiveHashes.add(hash);
     return true;
   });
 }


### PR DESCRIPTION
Addresses review feedback from PR #5018:

- Changed dedup key from content hash alone to filename+hash composite key
- tool_block drafts are still deduplicated against directive drafts by content hash alone (preserving the original PR's intent of dropping auto-converted tool blocks when a directive already attached the same data)
- Non-tool drafts with different filenames but identical content are now correctly preserved (e.g. before.json / after.json with same bytes)
- Added test for the non-tool same-content-different-name scenario
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
