### PR TITLE
fix: strengthen abort signal linkage assertions in provider tests

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -480,7 +480,29 @@ describe('GeminiProvider', () => {
     // The provider wraps the signal via createStreamTimeout, so the API
     // receives a different AbortSignal linked to the external one.
     const config = lastStreamParams!.config as Record<string, unknown>;
-    expect(config.abortSignal).toBeInstanceOf(AbortSignal);
+    const apiSignal = config.abortSignal as AbortSignal;
+    expect(apiSignal).toBeInstanceOf(AbortSignal);
+    // When the caller hasn't aborted, the API signal should also be non-aborted.
+    expect(apiSignal.aborted).toBe(false);
+  });
+
+  test('propagates pre-aborted signal in config', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled'));
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { signal: controller.signal },
+    );
+
+    // When the caller's signal is already aborted, createStreamTimeout
+    // immediately aborts the internal signal — proving the linkage.
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    const apiSignal = config.abortSignal as AbortSignal;
+    expect(apiSignal.aborted).toBe(true);
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -587,7 +587,28 @@ describe('OpenAIProvider', () => {
 
     // The provider wraps the signal via createStreamTimeout, so the API
     // receives a different AbortSignal linked to the external one.
-    expect(lastCreateOptions!.signal).toBeInstanceOf(AbortSignal);
+    const apiSignal = lastCreateOptions!.signal as AbortSignal;
+    expect(apiSignal).toBeInstanceOf(AbortSignal);
+    // When the caller hasn't aborted, the API signal should also be non-aborted.
+    expect(apiSignal.aborted).toBe(false);
+  });
+
+  test('propagates pre-aborted signal to API call', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled'));
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { signal: controller.signal },
+    );
+
+    // When the caller's signal is already aborted, createStreamTimeout
+    // immediately aborts the internal signal — proving the linkage.
+    const apiSignal = lastCreateOptions!.signal as AbortSignal;
+    expect(apiSignal.aborted).toBe(true);
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Addresses review feedback from PR #5026:
- OpenAI provider test now verifies caller abort signal propagation, not just AbortSignal type
- Gemini provider test now verifies caller abort signal propagation, not just AbortSignal type

Adds pre-aborted signal tests to prove createStreamTimeout actually wires the external signal through.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
