### PR TITLE
fix: lazy-load attachment safety (MIME filter, isLoading reset)

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -348,17 +348,20 @@ export function handleHistoryRequest(
     if (m.role === 'assistant' && m.id) {
       const linked = getAttachmentsForMessageUnscoped(m.id);
       if (linked.length > 0) {
-        // Skip embedding base64 data for attachments larger than 512KB to keep
-        // the history_response payload small enough for the client to decode
-        // reliably. The client fetches large attachment data lazily via HTTP.
+        // Skip embedding base64 data for large video attachments to keep the
+        // history_response payload small. Only videos have a lazy-fetch path on
+        // the client, so non-video attachments always keep their inline data.
         const MAX_INLINE_B64_SIZE = 512 * 1024;
-        attachments = linked.map((a) => ({
-          id: a.id,
-          filename: a.originalFilename,
-          mimeType: a.mimeType,
-          data: a.dataBase64.length > MAX_INLINE_B64_SIZE ? '' : a.dataBase64,
-          ...(a.dataBase64.length > MAX_INLINE_B64_SIZE ? { sizeBytes: a.sizeBytes } : {}),
-        }));
+        attachments = linked.map((a) => {
+          const omit = a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE;
+          return {
+            id: a.id,
+            filename: a.originalFilename,
+            mimeType: a.mimeType,
+            data: omit ? '' : a.dataBase64,
+            ...(omit ? { sizeBytes: a.sizeBytes } : {}),
+          };
+        });
       }
     }
     return {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -189,13 +189,19 @@ struct InlineVideoAttachmentView: View {
                 do {
                     let base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
                     guard let data = Data(base64Encoded: base64) else {
-                        await MainActor.run { isLoading = false }
+                        await MainActor.run {
+                            isLoading = false
+                            failed = true
+                        }
                         return
                     }
                     try data.write(to: destURL)
                     await MainActor.run { isLoading = false }
                 } catch {
-                    await MainActor.run { isLoading = false }
+                    await MainActor.run {
+                        isLoading = false
+                        failed = true
+                    }
                 }
             }
         } else {
@@ -211,7 +217,13 @@ struct InlineVideoAttachmentView: View {
             Task {
                 do {
                     let base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
-                    guard let data = Data(base64Encoded: base64) else { return }
+                    guard let data = Data(base64Encoded: base64) else {
+                        await MainActor.run {
+                            isLoading = false
+                            failed = true
+                        }
+                        return
+                    }
                     let fileURL = safeTempURL()
                     try data.write(to: fileURL)
                     await MainActor.run {


### PR DESCRIPTION
Addresses review feedback from PR #5019:
- Limit attachment data omission to video MIME types only (non-video attachments keep inline data)
- Reset isLoading and set failed on base64 decode failure in openInExternalPlayer and saveVideo
- Auth token (#1) and assistant ID routing (#2) were already fixed by PRs #5030 and #5037
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
