### PR TITLE
fix: preserve queue bookkeeping across session_error events

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1071,18 +1071,20 @@ extension ChatViewModel {
                     }
                 }
             } else {
-                // Always clear sending state on error — even with queued messages.
-                // Leaving isSending=true with a non-zero pendingQueuedCount creates
-                // a deadlock: regenerate guards on !isSending, so the user can never
-                // recover.
+                // Always clear sending state so regenerate is unblocked.
                 isSending = false
-                pendingQueuedCount = 0
-                pendingMessageIds = []
-                requestIdToMessageId = [:]
-                for i in messages.indices {
-                    if case .queued = messages[i].status, messages[i].role == .user {
-                        messages[i].status = .sent
-                    }
+                if pendingQueuedCount == 0 {
+                    // No queued work remains — safe to tear down everything.
+                    pendingMessageIds = []
+                    requestIdToMessageId = [:]
+                } else {
+                    // The daemon drains queued work after a session_error
+                    // (session.ts calls drainQueue in `finally`), so preserve
+                    // pendingQueuedCount, pendingMessageIds, requestIdToMessageId,
+                    // and queued message statuses. Incoming message_dequeued events
+                    // need requestIdToMessageId to correlate to user messages.
+                    // messageDequeued will re-set isSending=true when the next
+                    // queued message starts processing.
                 }
             }
 


### PR DESCRIPTION
Addresses review feedback from PR #5017:
- Stop unconditionally clearing pendingQueuedCount, pendingMessageIds, and requestIdToMessageId on session_error
- Preserve queue correlation state so dequeued events can still be tracked
- Prevents mis-tracked turns and premature regenerate during queue drain
- Still clears isSending to prevent the deadlock that PR #5017 originally fixed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
