### PR TITLE
fix: respect BASE_DATA_DIR in readHttpToken path resolution

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -233,7 +233,16 @@ struct InlineVideoAttachmentView: View {
 
 /// Fetch attachment base64 data from the daemon HTTP endpoint.
 private func fetchAttachmentData(port: Int, attachmentId: String) async throws -> String {
-    let tokenPath = NSHomeDirectory() + "/.vellum/http-token"
+    let tokenBase: String
+    if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !baseDir.isEmpty {
+        tokenBase = baseDir.hasPrefix("~/")
+            ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2))
+            : (baseDir == "~" ? NSHomeDirectory() : baseDir)
+    } else {
+        tokenBase = NSHomeDirectory()
+    }
+    let tokenPath = tokenBase + "/.vellum/http-token"
     guard let tokenData = try? Data(contentsOf: URL(fileURLWithPath: tokenPath)),
           let token = String(data: tokenData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
           !token.isEmpty else {


### PR DESCRIPTION
Addresses review feedback from PR #5030:

- The inlined HTTP token path in `InlineVideoAttachmentView.swift` was hardcoded to `NSHomeDirectory()/.vellum/http-token`
- In environments that set `BASE_DATA_DIR`, the daemon writes the token under a different root, causing 401s on lazy-loaded video requests
- Now checks `BASE_DATA_DIR` with tilde expansion, consistent with `resolveSessionTokenPath` in `DaemonClient.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
