### PR TITLE
fix: apply preferredTransform for video aspect ratio and ensure MainActor state updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -128,7 +128,7 @@ struct InlineVideoAttachmentView: View {
 
     private func playFromBase64(_ base64: String) async {
         guard let data = Data(base64Encoded: base64) else {
-            failed = true
+            await MainActor.run { failed = true }
             return
         }
 
@@ -136,7 +136,7 @@ struct InlineVideoAttachmentView: View {
         do {
             try data.write(to: fileURL)
         } catch {
-            failed = true
+            await MainActor.run { failed = true }
             return
         }
 
@@ -144,13 +144,21 @@ struct InlineVideoAttachmentView: View {
         if let tracks = try? await asset.load(.tracks),
            let videoTrack = tracks.first(where: { $0.mediaType == .video }),
            let size = try? await videoTrack.load(.naturalSize),
+           let transform = try? await videoTrack.load(.preferredTransform),
            size.width > 0, size.height > 0 {
-            videoAspectRatio = size.width / size.height
+            let transformed = CGRect(origin: .zero, size: size).applying(transform).size
+            let w = abs(transformed.width)
+            let h = abs(transformed.height)
+            if w > 0, h > 0 {
+                await MainActor.run { videoAspectRatio = w / h }
+            }
         }
 
         let avPlayer = AVPlayer(url: fileURL)
-        self.player = avPlayer
-        self.isPlaying = true
+        await MainActor.run {
+            self.player = avPlayer
+            self.isPlaying = true
+        }
         avPlayer.play()
     }
 


### PR DESCRIPTION
Addresses review feedback from PR #5038:
- Apply preferredTransform to naturalSize for correct aspect ratio on rotated/portrait videos
- Ensure playFromBase64 state mutations happen on MainActor to prevent background thread publishing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
