### PR TITLE
refactor(macos): replace raw colors with VColor design tokens

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineImageEmbedView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineImageEmbedView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import VellumAssistantShared
 
 /// Renders a remote image inline within a chat bubble.
 ///
@@ -54,7 +55,7 @@ struct InlineImageEmbedView: View {
     /// image is still downloading.
     private var placeholderSkeleton: some View {
         RoundedRectangle(cornerRadius: 8)
-            .fill(Color.gray.opacity(0.15))
+            .fill(VColor.backgroundSubtle)
             .frame(maxWidth: .infinity)
             .frame(height: 120)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -131,9 +131,9 @@ private struct TrustRuleRow: View {
 
     private func decisionColor(_ decision: String) -> Color {
         switch decision {
-        case "allow": return .green
-        case "ask": return .orange
-        default: return .red
+        case "allow": return VColor.success
+        case "ask": return VColor.warning
+        default: return VColor.error
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `Color.gray.opacity(0.15)` with `VColor.backgroundSubtle` in macOS InlineImageEmbedView (same change as iOS PR #5039)
- Replace `.green/.orange/.red` with `VColor.success/warning/error` in TrustRulesView status badges (aligns with iOS TrustRulesSection which already uses these tokens)

All other raw color usages in macOS files (`.foregroundColor(.white)` on colored backgrounds, custom shadow opacities) are intentional and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
