### PR TITLE
fix: distinguish stop failure from not-running in stopDaemon return

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -185,11 +185,15 @@ export async function startDaemon(): Promise<{
   );
 }
 
-export async function stopDaemon(): Promise<{ stopped: boolean }> {
+export type StopResult =
+  | { stopped: true }
+  | { stopped: false; reason: 'not_running' | 'stop_failed' };
+
+export async function stopDaemon(): Promise<StopResult> {
   const pid = readPid();
   if (pid === null || !isProcessRunning(pid)) {
     cleanupPidFile();
-    return { stopped: false };
+    return { stopped: false, reason: 'not_running' };
   }
 
   process.kill(pid, 'SIGTERM');
@@ -235,7 +239,7 @@ export async function stopDaemon(): Promise<{ stopped: boolean }> {
   }
 
   log.warn({ pid }, 'Daemon process still running after SIGKILL + timeout, leaving socket and PID file intact');
-  return { stopped: false };
+  return { stopped: false, reason: 'stop_failed' };
 }
 
 export async function ensureDaemonRunning(): Promise<void> {

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -172,6 +172,9 @@ daemon
     const result = await stopDaemon();
     if (result.stopped) {
       log.info('Daemon stopped');
+    } else if (result.reason === 'stop_failed') {
+      log.error('Failed to stop daemon — process survived SIGKILL');
+      process.exit(1);
     } else {
       log.info('Daemon is not running');
     }
@@ -184,6 +187,9 @@ daemon
     const stopResult = await stopDaemon();
     if (stopResult.stopped) {
       log.info('Daemon stopped');
+    } else if (stopResult.reason === 'stop_failed') {
+      log.error('Failed to stop daemon — process survived SIGKILL, cannot restart');
+      process.exit(1);
     }
     const startResult = await startDaemon();
     log.info(`Daemon started (pid ${startResult.pid})`);
@@ -212,7 +218,11 @@ program
     const status = getDaemonStatus();
     if (status.running) {
       log.info('Stopping existing daemon...');
-      await stopDaemon();
+      const stopResult = await stopDaemon();
+      if (!stopResult.stopped && stopResult.reason === 'stop_failed') {
+        log.error('Failed to stop existing daemon — process survived SIGKILL');
+        process.exit(1);
+      }
     }
 
     const mainPath = `${import.meta.dirname}/daemon/main.ts`;


### PR DESCRIPTION
Addresses review feedback from PR #5049:
- stopDaemon now returns a discriminated union with reason field (not_running vs stop_failed)
- CLI callers updated to report stop failure and exit with error instead of misleading not-running message
- dev command also handles stop failure before attempting to start in watch mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
