### PR TITLE
fix: don't expand tildes in BASE_DATA_DIR for HTTP token path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -267,9 +267,7 @@ private func fetchAttachmentData(port: Int, attachmentId: String) async throws -
     let tokenBase: String
     if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
        !baseDir.isEmpty {
-        tokenBase = baseDir.hasPrefix("~/")
-            ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2))
-            : (baseDir == "~" ? NSHomeDirectory() : baseDir)
+        tokenBase = baseDir
     } else {
         tokenBase = NSHomeDirectory()
     }


### PR DESCRIPTION
Addresses review feedback from PR #5055:
- Removed tilde expansion from BASE_DATA_DIR token path resolution
- Matches daemon's path.join() behavior which treats ~ as literal
- Consistent with existing resolveBlobDir pattern in IpcBlobStore.swift
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
