### PR TITLE
fix: call avPlayer.play() on MainActor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -165,8 +165,8 @@ struct InlineVideoAttachmentView: View {
         await MainActor.run {
             self.player = avPlayer
             self.isPlaying = true
+            avPlayer.play()
         }
-        avPlayer.play()
     }
 
     private func fetchAndPlay() {


### PR DESCRIPTION
Addresses review feedback from PR #5056:
- Moved avPlayer.play() inside MainActor.run block
- AVPlayer.play() must run on main thread per AVFoundation threading requirements
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
