### PR TITLE
fix: build universal binary (arm64 + x86_64) for release builds

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -103,7 +103,7 @@ CONFIG="debug"
 SWIFT_FLAGS=""
 if [ "$CMD" = "release" ]; then
     CONFIG="release"
-    SWIFT_FLAGS="-c release"
+    SWIFT_FLAGS="-c release --arch arm64 --arch x86_64"
     # Force clean for release builds to prevent stale artifacts in production
     echo "Release build: forcing clean to ensure no stale artifacts..."
     rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"


### PR DESCRIPTION
## Summary
- Add `--arch arm64 --arch x86_64` to release builds in `build.sh`
- Debug builds remain single-arch for fast iteration
- Ensures the DMG works on both Apple Silicon and Intel Macs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
