### PR TITLE
docs: document optional dependencies for full type-checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ bun install
 bun run src/index.ts daemon start
 ```
 
+> **Note:** Some dependencies (`agentmail`, `@pydantic/logfire-node`) are optional at runtime but required for full `tsc --noEmit` type-checking to pass. They are installed automatically by `bun install`.
+
 ## Sandbox and Host Access Model
 
 - Default tool workspace: `~/.vellum/workspace` (persistent global sandbox filesystem).


### PR DESCRIPTION
Add a note to README about agentmail and @pydantic/logfire-node optional deps that are needed for clean tsc output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
