### PR TITLE
ci: add macOS test execution to CI workflow

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -82,6 +82,10 @@ jobs:
           codesign --verify --deep --strict "dist/Vellum.app"
           echo "Code signature verified"
 
+      - name: Run tests
+        working-directory: clients/macos
+        run: ./build.sh test
+
       - name: Cleanup keychain
         if: always()
         run: |


### PR DESCRIPTION
Extend ci-macos.yml to run Xcode tests after building, not just build verification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
