### PR TITLE
chore: remove debug print() noise from document editor/manager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -55,10 +55,8 @@ struct DocumentEditorView: NSViewRepresentable {
 
         // Register coordinator with DocumentManager (after loading so no double-load)
         documentManager.editorCoordinator = context.coordinator
-        print("\u{1F527} Coordinator registered with DocumentManager")
 
         log.info("DocumentEditorView created")
-        print("\u{1F4C4} DocumentEditorView created, loading HTML...")
         return webView
     }
 
@@ -121,11 +119,9 @@ struct DocumentEditorView: NSViewRepresentable {
 
         func sendContentUpdate(markdown: String, mode: String) {
             guard let webView = webView, isInitialized else {
-                log.warning("\u{26A0}\u{FE0F} Cannot send content update: editor not initialized (isInitialized=\(self.isInitialized))")
-                print("\u{26A0}\u{FE0F} Cannot send content update: editor not initialized (isInitialized=\(self.isInitialized))")
+                log.warning("Cannot send content update: editor not initialized (isInitialized=\(self.isInitialized))")
                 return
             }
-            print("\u{2705} Sending content update to WebView: mode=\(mode), length=\(markdown.count)")
 
             let escapedMarkdown = escapeForJS(markdown)
             let js: String
@@ -179,7 +175,6 @@ struct DocumentEditorView: NSViewRepresentable {
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             isInitialized = true
             log.info("Document editor loaded")
-            print("\u{2705} WebView finished loading - editor initialized!")
             // Apply any content that accumulated while the WebView was loading
             // (document_editor_update messages that arrived before isInitialized was set)
             if let tracked = documentManager.currentContent, !tracked.isEmpty {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -89,11 +89,9 @@ final class DocumentManager: ObservableObject {
         scheduleAutoSave()
         guard let coordinator = editorCoordinator else {
             log.warning("Cannot update document: editor coordinator not ready, content tracked for later")
-            print("Cannot update document: editor coordinator not ready, content tracked for later")
             return
         }
 
-        print("Sending update to coordinator: mode=\(mode), length=\(markdown.count)")
         coordinator.sendContentUpdate(markdown: markdown, mode: mode)
         log.info("Document updated: mode=\(mode), length=\(markdown.count)")
 
@@ -132,19 +130,15 @@ final class DocumentManager: ObservableObject {
     }
 
     func save() {
-        print("save() called - surfaceId: \(surfaceId ?? "nil"), sessionId: \(sessionId ?? "nil"), daemonClient: \(daemonClient != nil)")
-
         guard let surfaceId = surfaceId,
               let sessionId = sessionId,
               let daemonClient = daemonClient else {
             log.warning("Cannot save: missing surfaceId, sessionId, or daemonClient")
             lastSaveError = "Cannot save: missing document information"
-            print("Save failed: missing information")
             return
         }
 
         let contentToSave = currentContent ?? ""
-        print("Starting save: title=\(title), contentLength=\(contentToSave.count), wordCount=\(wordCount)")
         isSaving = true
         lastSaveError = nil
 
@@ -157,7 +151,6 @@ final class DocumentManager: ObservableObject {
                 wordCount: wordCount
             )
             log.info("Document save requested: \(surfaceId) - \(self.wordCount) words")
-            print("IPC message sent successfully")
         } catch {
             log.error("Failed to send document save: \(error.localizedDescription)")
             lastSaveError = error.localizedDescription


### PR DESCRIPTION
Remove 11 leftover emoji-decorated print() calls from DocumentEditorView.swift and DocumentManager.swift. All were duplicating adjacent os.Logger calls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
