### PR TITLE
feat: implement document widget dismiss behavior

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -68,6 +68,7 @@ struct ChatView: View {
     @State private var isQueueExpanded = true
     @State private var identity: IdentityInfo? = IdentityInfo.load()
     @State private var appearance = AvatarAppearanceManager.shared
+    @State private var dismissedDocumentSurfaceIds: Set<String> = []
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
     private var isEmptyState: Bool {
@@ -450,6 +451,10 @@ struct ChatView: View {
                                 showRegenerate: isLastAssistant,
                                 onRegenerate: onRegenerate,
                                 onSurfaceAction: onSurfaceAction,
+                                onDismissDocumentWidget: { surfaceId in
+                                    dismissedDocumentSurfaceIds.insert(surfaceId)
+                                },
+                                dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                                 onReportMessage: onReportMessage,
                                 mediaEmbedSettings: mediaEmbedSettings,
                                 daemonHttpPort: daemonHttpPort
@@ -576,6 +581,8 @@ private struct ChatBubble: View {
     let showRegenerate: Bool
     let onRegenerate: () -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
+    let onDismissDocumentWidget: (String) -> Void
+    let dismissedDocumentSurfaceIds: Set<String>
     var onReportMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     var daemonHttpPort: Int?
@@ -1595,7 +1602,7 @@ private struct ChatBubble: View {
     private func documentWidget(for toolCall: ToolCallData) -> some View {
         let parsed = parseDocumentResult(from: toolCall)
 
-        if let surfaceId = parsed.surfaceId {
+        if let surfaceId = parsed.surfaceId, !dismissedDocumentSurfaceIds.contains(surfaceId) {
             DocumentReopenWidget(
                 documentTitle: parsed.title,
                 onReopen: {
@@ -1606,7 +1613,7 @@ private struct ChatBubble: View {
                     )
                 },
                 onDismiss: {
-                    // TODO: Hide this widget (would need state management)
+                    onDismissDocumentWidget(surfaceId)
                 }
             )
             .padding(.top, VSpacing.sm)


### PR DESCRIPTION
Add stateful dismiss for document widgets in chat — dismissed surface IDs are tracked in the view model so widgets stay hidden after dismissal.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
