### PR TITLE
chore: bump version to 0.1.29

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vellum-assistant",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "bin": {
     "vellum": "./src/index.ts"


### PR DESCRIPTION
Triggers a new release with universal binary (arm64 + x86_64) DMG.

Fixes install issue for Intel Mac users — see #5063 for the build fix.

Context: Rok reported the DMG not working on both Ventura and Sequoia. Ventura is expected (min macOS 14.0), but Sequoia failure was likely due to the DMG being single-arch (ARM only).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
