### PR TITLE
test: add regression tests for document reopen/dismiss behavior

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1600,7 +1600,7 @@ private struct ChatBubble: View {
 
     @ViewBuilder
     private func documentWidget(for toolCall: ToolCallData) -> some View {
-        let parsed = parseDocumentResult(from: toolCall)
+        let parsed = DocumentResultParser.parse(from: toolCall)
 
         if let surfaceId = parsed.surfaceId, !dismissedDocumentSurfaceIds.contains(surfaceId) {
             DocumentReopenWidget(
@@ -1618,29 +1618,6 @@ private struct ChatBubble: View {
             )
             .padding(.top, VSpacing.sm)
         }
-    }
-
-    /// Parse the document_create tool call result JSON for surface_id and title.
-    private func parseDocumentResult(from toolCall: ToolCallData) -> (surfaceId: String?, title: String) {
-        // The result is JSON: {"surface_id": "doc-...", "title": "...", ...}
-        if let result = toolCall.result,
-           let data = result.data(using: .utf8),
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            let surfaceId = json["surface_id"] as? String
-            let title = json["title"] as? String ?? parseDocumentTitleFromSummary(toolCall.inputSummary)
-            return (surfaceId, title)
-        }
-        return (nil, parseDocumentTitleFromSummary(toolCall.inputSummary))
-    }
-
-    private func parseDocumentTitleFromSummary(_ summary: String) -> String {
-        if let colonIndex = summary.firstIndex(of: ":") {
-            let afterColon = summary[summary.index(after: colonIndex)...].trimmingCharacters(in: .whitespaces)
-            if !afterColon.isEmpty {
-                return String(afterColon)
-            }
-        }
-        return "Untitled Document"
     }
 
     private func attachmentImageGrid(_ images: [(ChatAttachment, NSImage)]) -> some View {

--- a/clients/macos/vellum-assistant/Features/Chat/DocumentResultParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DocumentResultParser.swift
@@ -1,0 +1,33 @@
+import Foundation
+import VellumAssistantShared
+
+/// Extracts surface_id and title from a document_create tool call result.
+/// Pulled out of ChatBubble so the logic is testable.
+enum DocumentResultParser {
+
+    struct Result {
+        let surfaceId: String?
+        let title: String
+    }
+
+    static func parse(from toolCall: ToolCallData) -> Result {
+        if let result = toolCall.result,
+           let data = result.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let surfaceId = json["surface_id"] as? String
+            let title = json["title"] as? String ?? titleFromSummary(toolCall.inputSummary)
+            return Result(surfaceId: surfaceId, title: title)
+        }
+        return Result(surfaceId: nil, title: titleFromSummary(toolCall.inputSummary))
+    }
+
+    static func titleFromSummary(_ summary: String) -> String {
+        if let colonIndex = summary.firstIndex(of: ":") {
+            let afterColon = summary[summary.index(after: colonIndex)...].trimmingCharacters(in: .whitespaces)
+            if !afterColon.isEmpty {
+                return String(afterColon)
+            }
+        }
+        return "Untitled Document"
+    }
+}

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1530,7 +1530,7 @@ final class ChatViewModelTests: XCTestCase {
         // Complete with attachments
         let attachment = IPCUserMessageAttachment(
             id: "att-1", filename: "photo.png", mimeType: "image/png",
-            data: "iVBORw0KGgo=", extractedText: nil
+            data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil
         )
         viewModel.handleServerMessage(.messageComplete(
             MessageCompleteMessage(sessionId: nil, attachments: [attachment])
@@ -1550,7 +1550,7 @@ final class ChatViewModelTests: XCTestCase {
         // Complete with attachments but no prior text deltas (attachment-only turn)
         let attachment = IPCUserMessageAttachment(
             id: "att-1", filename: "report.pdf", mimeType: "application/pdf",
-            data: "JVBER", extractedText: nil
+            data: "JVBER", extractedText: nil, sizeBytes: nil
         )
         viewModel.handleServerMessage(.messageComplete(
             MessageCompleteMessage(sessionId: nil, attachments: [attachment])
@@ -1573,7 +1573,7 @@ final class ChatViewModelTests: XCTestCase {
         // Handoff with attachments
         let attachment = IPCUserMessageAttachment(
             id: "att-2", filename: "output.csv", mimeType: "text/csv",
-            data: "Y29sQQ==", extractedText: nil
+            data: "Y29sQQ==", extractedText: nil, sizeBytes: nil
         )
         viewModel.handleServerMessage(.generationHandoff(
             GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1, attachments: [attachment])
@@ -1613,7 +1613,7 @@ final class ChatViewModelTests: XCTestCase {
     func testPopulateFromHistoryHydratesAssistantAttachments() {
         let attachment = IPCUserMessageAttachment(
             id: "hist-att-1", filename: "chart.png", mimeType: "image/png",
-            data: "iVBORw0KGgo=", extractedText: nil
+            data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil
         )
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
             IPCHistoryResponseMessage(id: nil, role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil),
@@ -1632,7 +1632,7 @@ final class ChatViewModelTests: XCTestCase {
     func testPopulateFromHistoryIncludesAttachmentOnlyMessages() {
         let attachment = IPCUserMessageAttachment(
             id: "hist-att-2", filename: "report.pdf", mimeType: "application/pdf",
-            data: "JVBER", extractedText: nil
+            data: "JVBER", extractedText: nil, sizeBytes: nil
         )
         let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
             IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil),

--- a/clients/macos/vellum-assistantTests/DocumentReopenDismissTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentReopenDismissTests.swift
@@ -1,0 +1,285 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Regression tests for document reopen and dismiss behavior (PRs #5069 / #5072).
+///
+/// Covers:
+/// - `DocumentResultParser.parse` extracting surface_id and title from JSON
+/// - `DocumentResultParser.titleFromSummary` colon-based fallback extraction
+/// - `openDocumentEditor` notification posting with correct userInfo
+/// - Dismiss state: dismissed surface IDs prevent widget rendering
+@MainActor
+final class DocumentReopenDismissTests: XCTestCase {
+
+    // MARK: - parseDocumentResult: valid JSON
+
+    func testParseValidJsonExtractsSurfaceIdAndTitle() {
+        let json = #"{"surface_id": "doc-abc", "title": "My Essay"}"#
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: fallback",
+            result: json,
+            isComplete: true
+        )
+
+        let result = DocumentResultParser.parse(from: toolCall)
+
+        XCTAssertEqual(result.surfaceId, "doc-abc")
+        XCTAssertEqual(result.title, "My Essay")
+    }
+
+    func testParseValidJsonWithExtraFieldsStillWorks() {
+        let json = #"{"surface_id": "doc-xyz", "title": "Report", "extra": 42}"#
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: ignored",
+            result: json,
+            isComplete: true
+        )
+
+        let result = DocumentResultParser.parse(from: toolCall)
+
+        XCTAssertEqual(result.surfaceId, "doc-xyz")
+        XCTAssertEqual(result.title, "Report")
+    }
+
+    // MARK: - parseDocumentResult: missing surface_id
+
+    func testParseMissingSurfaceIdReturnsNilSurfaceId() {
+        let json = #"{"title": "Orphan Doc"}"#
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: fallback title",
+            result: json,
+            isComplete: true
+        )
+
+        let result = DocumentResultParser.parse(from: toolCall)
+
+        XCTAssertNil(result.surfaceId)
+        XCTAssertEqual(result.title, "Orphan Doc")
+    }
+
+    // MARK: - parseDocumentResult: missing title falls back to summary
+
+    func testParseMissingTitleFallsBackToSummary() {
+        let json = #"{"surface_id": "doc-123"}"#
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: Pizza Recipe",
+            result: json,
+            isComplete: true
+        )
+
+        let result = DocumentResultParser.parse(from: toolCall)
+
+        XCTAssertEqual(result.surfaceId, "doc-123")
+        XCTAssertEqual(result.title, "Pizza Recipe")
+    }
+
+    // MARK: - parseDocumentResult: invalid / nil result
+
+    func testParseNilResultReturnsNilSurfaceId() {
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: My Doc",
+            result: nil,
+            isComplete: true
+        )
+
+        let result = DocumentResultParser.parse(from: toolCall)
+
+        XCTAssertNil(result.surfaceId)
+        XCTAssertEqual(result.title, "My Doc")
+    }
+
+    func testParseInvalidJsonReturnsNilSurfaceId() {
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: Fallback",
+            result: "not valid json {{{",
+            isComplete: true
+        )
+
+        let result = DocumentResultParser.parse(from: toolCall)
+
+        XCTAssertNil(result.surfaceId)
+        XCTAssertEqual(result.title, "Fallback")
+    }
+
+    func testParseEmptyStringResultReturnsNilSurfaceId() {
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: Empty",
+            result: "",
+            isComplete: true
+        )
+
+        let result = DocumentResultParser.parse(from: toolCall)
+
+        XCTAssertNil(result.surfaceId)
+        XCTAssertEqual(result.title, "Empty")
+    }
+
+    // MARK: - titleFromSummary
+
+    func testTitleFromSummaryExtractsAfterColon() {
+        XCTAssertEqual(
+            DocumentResultParser.titleFromSummary("document_create: A Great Title"),
+            "A Great Title"
+        )
+    }
+
+    func testTitleFromSummaryTrimsWhitespace() {
+        XCTAssertEqual(
+            DocumentResultParser.titleFromSummary("document_create:   Spaced Out  "),
+            "Spaced Out"
+        )
+    }
+
+    func testTitleFromSummaryWithNoColonReturnsUntitled() {
+        XCTAssertEqual(
+            DocumentResultParser.titleFromSummary("no colon here"),
+            "Untitled Document"
+        )
+    }
+
+    func testTitleFromSummaryWithEmptyAfterColonReturnsUntitled() {
+        XCTAssertEqual(
+            DocumentResultParser.titleFromSummary("prefix:   "),
+            "Untitled Document"
+        )
+    }
+
+    func testTitleFromSummaryEmptyStringReturnsUntitled() {
+        XCTAssertEqual(
+            DocumentResultParser.titleFromSummary(""),
+            "Untitled Document"
+        )
+    }
+
+    // MARK: - openDocumentEditor notification
+
+    func testOpenDocumentEditorNotificationNameIsDefined() {
+        let name = Notification.Name.openDocumentEditor
+        XCTAssertEqual(name.rawValue, "MainWindow.openDocumentEditor")
+    }
+
+    func testOpenDocumentEditorNotificationCarriesSurfaceId() {
+        let expectation = expectation(description: "openDocumentEditor received")
+        var receivedSurfaceId: String?
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: .openDocumentEditor,
+            object: nil,
+            queue: .main
+        ) { notification in
+            receivedSurfaceId = notification.userInfo?["documentSurfaceId"] as? String
+            expectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        NotificationCenter.default.post(
+            name: .openDocumentEditor,
+            object: nil,
+            userInfo: ["documentSurfaceId": "doc-notify-test"]
+        )
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedSurfaceId, "doc-notify-test")
+    }
+
+    // MARK: - Dismiss state via ChatView's dismissedDocumentSurfaceIds
+
+    /// Simulates the dismiss flow: ChatView tracks dismissed surface IDs in a Set.
+    /// After inserting a surface ID, the widget should not render (the guard in
+    /// `documentWidget` checks `!dismissedDocumentSurfaceIds.contains(surfaceId)`).
+    func testDismissedSetBlocksRendering() {
+        var dismissedIds: Set<String> = []
+
+        // Initially the surface is not dismissed
+        XCTAssertFalse(dismissedIds.contains("doc-dismiss-1"))
+
+        // Simulate the onDismiss closure
+        dismissedIds.insert("doc-dismiss-1")
+
+        XCTAssertTrue(dismissedIds.contains("doc-dismiss-1"),
+                      "After dismiss, surface ID should be in the set")
+    }
+
+    func testDismissedSetPersistsAcrossMultipleInsertions() {
+        var dismissedIds: Set<String> = []
+
+        dismissedIds.insert("doc-a")
+        dismissedIds.insert("doc-b")
+        dismissedIds.insert("doc-c")
+
+        XCTAssertEqual(dismissedIds.count, 3)
+        XCTAssertTrue(dismissedIds.contains("doc-a"))
+        XCTAssertTrue(dismissedIds.contains("doc-b"))
+        XCTAssertTrue(dismissedIds.contains("doc-c"))
+    }
+
+    func testDismissedSetDoesNotAffectOtherSurfaces() {
+        var dismissedIds: Set<String> = []
+
+        dismissedIds.insert("doc-dismissed")
+
+        XCTAssertTrue(dismissedIds.contains("doc-dismissed"))
+        XCTAssertFalse(dismissedIds.contains("doc-other"),
+                       "Non-dismissed surface should not be blocked")
+    }
+
+    func testDuplicateDismissIsIdempotent() {
+        var dismissedIds: Set<String> = []
+
+        dismissedIds.insert("doc-dup")
+        dismissedIds.insert("doc-dup")
+
+        XCTAssertEqual(dismissedIds.count, 1,
+                       "Inserting the same ID twice should not create duplicates")
+    }
+
+    // MARK: - Integration: parse + dismiss guard logic
+
+    func testDocumentWidgetGuardLogic() {
+        let json = #"{"surface_id": "doc-guard", "title": "Guarded"}"#
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: Guarded",
+            result: json,
+            isComplete: true
+        )
+
+        let parsed = DocumentResultParser.parse(from: toolCall)
+        var dismissedIds: Set<String> = []
+
+        // Widget should render when not dismissed
+        let shouldRender = parsed.surfaceId != nil && !dismissedIds.contains(parsed.surfaceId!)
+        XCTAssertTrue(shouldRender, "Widget should render for non-dismissed surface")
+
+        // Dismiss the surface
+        dismissedIds.insert(parsed.surfaceId!)
+
+        // Widget should not render after dismiss
+        let shouldRenderAfterDismiss = parsed.surfaceId != nil && !dismissedIds.contains(parsed.surfaceId!)
+        XCTAssertFalse(shouldRenderAfterDismiss, "Widget should not render after dismiss")
+    }
+
+    func testDocumentWidgetGuardWithNilSurfaceId() {
+        let toolCall = ToolCallData(
+            toolName: "document_create",
+            inputSummary: "document_create: No ID",
+            result: #"{"title": "No Surface"}"#,
+            isComplete: true
+        )
+
+        let parsed = DocumentResultParser.parse(from: toolCall)
+        let dismissedIds: Set<String> = []
+
+        // nil surfaceId means the widget should not render regardless
+        let shouldRender = parsed.surfaceId != nil && !dismissedIds.contains(parsed.surfaceId ?? "")
+        XCTAssertFalse(shouldRender, "Widget should not render without a surface ID")
+    }
+}

--- a/clients/macos/vellum-assistantTests/DomainAllowlistMatcherTests.swift
+++ b/clients/macos/vellum-assistantTests/DomainAllowlistMatcherTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class DomainAllowlistMatcherTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/ImageMIMEProbeTests.swift
+++ b/clients/macos/vellum-assistantTests/ImageMIMEProbeTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 // MARK: - Mock URLProtocol
 

--- a/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
+++ b/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class ImageURLClassifierExtensionTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/InlineVideoEmbedStateTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoEmbedStateTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class InlineVideoEmbedStateTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/InlineVideoOffscreenTeardownTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoOffscreenTeardownTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class InlineVideoOffscreenTeardownTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/InlineVideoPlayerIntegrationTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoPlayerIntegrationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class InlineVideoPlayerIntegrationTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewFailureTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import WebKit
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class InlineVideoWebViewFailureTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/LoomParserTests.swift
+++ b/clients/macos/vellum-assistantTests/LoomParserTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class LoomParserTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class MainWindowAvatarRoutingTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorCodeExclusionTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorCodeExclusionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class MessageURLExtractorCodeExclusionTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorMarkdownTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorMarkdownTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class MessageURLExtractorMarkdownTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/MessageURLExtractorPlainTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageURLExtractorPlainTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class MessageURLExtractorPlainTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/VideoEmbedURLBuilderTests.swift
+++ b/clients/macos/vellum-assistantTests/VideoEmbedURLBuilderTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class VideoEmbedURLBuilderTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/VimeoParserTests.swift
+++ b/clients/macos/vellum-assistantTests/VimeoParserTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class VimeoParserTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/YouTubeParserTests.swift
+++ b/clients/macos/vellum-assistantTests/YouTubeParserTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class YouTubeParserTests: XCTestCase {


### PR DESCRIPTION
Add Swift tests covering document widget reopen (parseDocumentResult, notification posting) and dismiss (stateful hiding by surface ID) behavior. Extract DocumentResultParser from private ChatBubble scope for testability. Also fix pre-existing broken test imports across 14 test files (missing VellumAssistantShared import after types moved to shared module).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
