### PR TITLE
fix: also check provider alignment in model_set no-op guard

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -41,11 +41,16 @@ export function handleModelSet(
   ctx: HandlerContext,
 ): void {
   try {
-    // If the requested model is already the current model, skip expensive
+    // If the requested model is already the current model AND the provider
+    // is already aligned with what MODEL_TO_PROVIDER expects, skip expensive
     // reinitialization but still send model_info so the client confirms.
+    // If the provider has drifted (e.g. manual config edit), fall through
+    // so the full reinit path can repair it.
     {
       const current = getConfig();
-      if (msg.model === current.model) {
+      const expectedProvider = MODEL_TO_PROVIDER[msg.model];
+      const providerAligned = !expectedProvider || current.provider === expectedProvider;
+      if (msg.model === current.model && providerAligned) {
         const configured = Object.keys(current.apiKeys).filter((k) => !!current.apiKeys[k]);
         if (!configured.includes('ollama')) configured.push('ollama');
         ctx.send(socket, {


### PR DESCRIPTION
## Summary
- Extends the model_set no-op guard to also verify provider alignment before early-returning
- Without this, a same-model call with drifted provider config wouldn't trigger reinitialization
- Addresses feedback from PR #5036

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
