### PR TITLE
fix: use visible placeholder color for InlineImageEmbedView skeleton

### DIFF
--- a/clients/shared/Features/Chat/MediaEmbeds/InlineImageEmbedView.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/InlineImageEmbedView.swift
@@ -64,7 +64,7 @@ public struct InlineImageEmbedView: View {
     /// image is still downloading.
     private var placeholderSkeleton: some View {
         RoundedRectangle(cornerRadius: 8)
-            .fill(VColor.backgroundSubtle)
+            .fill(VColor.surface)
             .frame(maxWidth: .infinity)
             .frame(height: 120)
     }


### PR DESCRIPTION
## Summary
- Fixes invisible placeholder skeleton in dark mode where VColor.backgroundSubtle matched VColor.background
- Addresses feedback from PR #5057

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
