### PR TITLE
fix: build universal daemon and CLI binaries for Intel Mac support

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -83,20 +83,38 @@ jobs:
           bun build --compile --target=bun-darwin-arm64 src/daemon/main.ts \
             --external electron --external "chromium-bidi/*" \
             --define "process.env.APP_VERSION='$DISPLAY_VERSION'" \
-            --outfile ../clients/macos/daemon-bin/vellum-daemon
+            --outfile ../clients/macos/daemon-bin/vellum-daemon-arm64
+          bun build --compile --target=bun-darwin-x64 src/daemon/main.ts \
+            --external electron --external "chromium-bidi/*" \
+            --define "process.env.APP_VERSION='$DISPLAY_VERSION'" \
+            --outfile ../clients/macos/daemon-bin/vellum-daemon-x64
+          lipo -create \
+            ../clients/macos/daemon-bin/vellum-daemon-arm64 \
+            ../clients/macos/daemon-bin/vellum-daemon-x64 \
+            -output ../clients/macos/daemon-bin/vellum-daemon
+          rm ../clients/macos/daemon-bin/vellum-daemon-arm64 ../clients/macos/daemon-bin/vellum-daemon-x64
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
-          echo "Daemon binary built:"
+          echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
+          file ../clients/macos/daemon-bin/vellum-daemon
 
       - name: Build CLI binary
         working-directory: cli
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/index.ts \
-            --outfile ../clients/macos/cli-bin/vellum-cli
+            --outfile ../clients/macos/cli-bin/vellum-cli-arm64
+          bun build --compile --target=bun-darwin-x64 src/index.ts \
+            --outfile ../clients/macos/cli-bin/vellum-cli-x64
+          lipo -create \
+            ../clients/macos/cli-bin/vellum-cli-arm64 \
+            ../clients/macos/cli-bin/vellum-cli-x64 \
+            -output ../clients/macos/cli-bin/vellum-cli
+          rm ../clients/macos/cli-bin/vellum-cli-arm64 ../clients/macos/cli-bin/vellum-cli-x64
           chmod +x ../clients/macos/cli-bin/vellum-cli
-          echo "CLI binary built:"
+          echo "CLI universal binary built:"
           ls -lh ../clients/macos/cli-bin/vellum-cli
+          file ../clients/macos/cli-bin/vellum-cli
 
       - name: Build release .app
         run: |

--- a/.github/workflows/ci-macos-dmg.yml
+++ b/.github/workflows/ci-macos-dmg.yml
@@ -62,20 +62,37 @@ jobs:
           bun install
           bun build --compile --target=bun-darwin-arm64 src/daemon/main.ts \
             --external electron --external "chromium-bidi/*" \
-            --outfile ../clients/macos/daemon-bin/vellum-daemon
+            --outfile ../clients/macos/daemon-bin/vellum-daemon-arm64
+          bun build --compile --target=bun-darwin-x64 src/daemon/main.ts \
+            --external electron --external "chromium-bidi/*" \
+            --outfile ../clients/macos/daemon-bin/vellum-daemon-x64
+          lipo -create \
+            ../clients/macos/daemon-bin/vellum-daemon-arm64 \
+            ../clients/macos/daemon-bin/vellum-daemon-x64 \
+            -output ../clients/macos/daemon-bin/vellum-daemon
+          rm ../clients/macos/daemon-bin/vellum-daemon-arm64 ../clients/macos/daemon-bin/vellum-daemon-x64
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
-          echo "Daemon binary built:"
+          echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
+          file ../clients/macos/daemon-bin/vellum-daemon
 
       - name: Build CLI binary
         working-directory: cli
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/index.ts \
-            --outfile ../clients/macos/cli-bin/vellum-cli
+            --outfile ../clients/macos/cli-bin/vellum-cli-arm64
+          bun build --compile --target=bun-darwin-x64 src/index.ts \
+            --outfile ../clients/macos/cli-bin/vellum-cli-x64
+          lipo -create \
+            ../clients/macos/cli-bin/vellum-cli-arm64 \
+            ../clients/macos/cli-bin/vellum-cli-x64 \
+            -output ../clients/macos/cli-bin/vellum-cli
+          rm ../clients/macos/cli-bin/vellum-cli-arm64 ../clients/macos/cli-bin/vellum-cli-x64
           chmod +x ../clients/macos/cli-bin/vellum-cli
-          echo "CLI binary built:"
+          echo "CLI universal binary built:"
           ls -lh ../clients/macos/cli-bin/vellum-cli
+          file ../clients/macos/cli-bin/vellum-cli
 
       - name: Build release .app
         working-directory: clients/macos

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -57,20 +57,37 @@ jobs:
           bun install
           bun build --compile --target=bun-darwin-arm64 src/daemon/main.ts \
             --external electron --external "chromium-bidi/*" \
-            --outfile ../clients/macos/daemon-bin/vellum-daemon
+            --outfile ../clients/macos/daemon-bin/vellum-daemon-arm64
+          bun build --compile --target=bun-darwin-x64 src/daemon/main.ts \
+            --external electron --external "chromium-bidi/*" \
+            --outfile ../clients/macos/daemon-bin/vellum-daemon-x64
+          lipo -create \
+            ../clients/macos/daemon-bin/vellum-daemon-arm64 \
+            ../clients/macos/daemon-bin/vellum-daemon-x64 \
+            -output ../clients/macos/daemon-bin/vellum-daemon
+          rm ../clients/macos/daemon-bin/vellum-daemon-arm64 ../clients/macos/daemon-bin/vellum-daemon-x64
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
-          echo "Daemon binary built:"
+          echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
+          file ../clients/macos/daemon-bin/vellum-daemon
 
       - name: Build CLI binary
         working-directory: cli
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/index.ts \
-            --outfile ../clients/macos/cli-bin/vellum-cli
+            --outfile ../clients/macos/cli-bin/vellum-cli-arm64
+          bun build --compile --target=bun-darwin-x64 src/index.ts \
+            --outfile ../clients/macos/cli-bin/vellum-cli-x64
+          lipo -create \
+            ../clients/macos/cli-bin/vellum-cli-arm64 \
+            ../clients/macos/cli-bin/vellum-cli-x64 \
+            -output ../clients/macos/cli-bin/vellum-cli
+          rm ../clients/macos/cli-bin/vellum-cli-arm64 ../clients/macos/cli-bin/vellum-cli-x64
           chmod +x ../clients/macos/cli-bin/vellum-cli
-          echo "CLI binary built:"
+          echo "CLI universal binary built:"
           ls -lh ../clients/macos/cli-bin/vellum-cli
+          file ../clients/macos/cli-bin/vellum-cli
 
       - name: Build release .app
         working-directory: clients/macos


### PR DESCRIPTION
## Summary
- Updates CI workflows to build daemon and CLI binaries for both arm64 and x86_64
- Uses lipo to merge into universal binaries that work on both Apple Silicon and Intel Macs
- Completes the universal binary support started in PR #5063
- Addresses feedback from PR #5063

## Files Changed
- `.github/workflows/build-and-release-macos.yml` — universal daemon + CLI builds
- `.github/workflows/ci-macos.yml` — universal daemon + CLI builds
- `.github/workflows/ci-macos-dmg.yml` — universal daemon + CLI builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
