### PR TITLE
fix(ios): restore post-connect data reload in decomposed SettingsView

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -9,6 +9,9 @@ import VellumAssistantShared
 @MainActor
 final class ClientProvider: ObservableObject {
     @Published var client: any DaemonClientProtocol
+    /// Flipped to `true` after a successful `connect()` call; sections observe
+    /// this to trigger data reloads once the daemon is reachable.
+    @Published var isConnected: Bool = false
 
     init(client: any DaemonClientProtocol) {
         self.client = client

--- a/clients/ios/App/SceneDelegate.swift
+++ b/clients/ios/App/SceneDelegate.swift
@@ -6,9 +6,16 @@ import UIKit
 class SceneDelegate: NSObject, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        let client = appDelegate.clientProvider.client
-        guard !client.isConnected else { return }
-        Task { try? await client.connect() }
+        let provider = appDelegate.clientProvider
+        guard !provider.client.isConnected else { return }
+        Task {
+            do {
+                try await provider.client.connect()
+                await MainActor.run { provider.isConnected = true }
+            } catch {
+                // Connection failed — will retry on next foreground transition
+            }
+        }
     }
 }
 #endif

--- a/clients/ios/Views/Settings/IntegrationsSection.swift
+++ b/clients/ios/Views/Settings/IntegrationsSection.swift
@@ -49,6 +49,9 @@ struct IntegrationsSection: View {
             }
         }
         .onAppear { loadIntegrations() }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected { loadIntegrations() }
+        }
         .onDisappear {
             if let daemon = clientProvider.client as? DaemonClient {
                 daemon.onIntegrationListResponse = nil

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -32,6 +32,9 @@ struct RemindersSection: View {
             }
         }
         .onAppear { loadReminders() }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected { loadReminders() }
+        }
         .onDisappear {
             if let daemon = clientProvider.client as? DaemonClient {
                 daemon.onRemindersListResponse = nil

--- a/clients/ios/Views/Settings/SchedulesSection.swift
+++ b/clients/ios/Views/Settings/SchedulesSection.swift
@@ -32,6 +32,9 @@ struct SchedulesSection: View {
             }
         }
         .onAppear { loadSchedules() }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected { loadSchedules() }
+        }
         .onDisappear {
             if let daemon = clientProvider.client as? DaemonClient {
                 daemon.onSchedulesListResponse = nil

--- a/clients/ios/Views/Settings/TrustRulesSection.swift
+++ b/clients/ios/Views/Settings/TrustRulesSection.swift
@@ -43,6 +43,9 @@ struct TrustRulesSection: View {
             }
         }
         .onAppear { loadTrustRules() }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected { loadTrustRules() }
+        }
         .onDisappear {
             if let daemon = clientProvider.client as? DaemonClient {
                 daemon.onTrustRulesListResponse = nil

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -61,6 +61,7 @@ struct SettingsView: View {
 
     private func switchClient(to mode: String) {
         clientProvider.client.disconnect()
+        clientProvider.isConnected = false
         let newClient: any DaemonClientProtocol
         if mode == ConnectionMode.connected.rawValue {
             newClient = DaemonClient(config: .fromUserDefaults())
@@ -71,6 +72,7 @@ struct SettingsView: View {
         Task {
             do {
                 try await clientProvider.client.connect()
+                clientProvider.isConnected = true
             } catch {
                 // Connection failed — sections will handle their own loading
             }


### PR DESCRIPTION
## Summary
Restores the post-connection data reload that was lost during the SettingsView decomposition in PR #5044.

## Problem
When switching from Standalone to Connected mode, the decomposed sections (Integrations, TrustRules, Schedules, Reminders) rely on `onAppear` to load their data. However, `onAppear` fires before `connect()` completes, so the daemon sends fail silently (they use `try?`), and no reload happens after the connection is actually established. This leaves sections permanently showing empty states.

## Implementation
Added a `@Published var isConnected: Bool` property to `ClientProvider` that acts as a reactive signal for connection readiness:

- **ClientProvider** (`AppDelegate.swift`): New `@Published var isConnected` property
- **SettingsView.swift**: `switchClient(to:)` resets `isConnected = false` on disconnect, sets `isConnected = true` after `connect()` succeeds
- **SceneDelegate.swift**: Sets `isConnected = true` after foreground reconnect succeeds
- **All four connected-mode sections**: Added `.onChange(of: clientProvider.isConnected)` modifier that triggers their respective load methods when the connection becomes ready

## Key Technical Choice
Used a `@Published` property on `ClientProvider` rather than `NotificationCenter` or direct method calls because:
- It integrates naturally with SwiftUI's reactive data flow via `.onChange(of:)`
- Each section independently observes and reacts, preserving the decomposed architecture
- No coupling between SettingsView and the section implementations
- The same mechanism works for both mode-switch connections and foreground reconnections

## Files Changed
- `clients/ios/App/AppDelegate.swift` — Added `isConnected` published property to `ClientProvider`
- `clients/ios/App/SceneDelegate.swift` — Set `isConnected = true` after foreground reconnect
- `clients/ios/Views/SettingsView.swift` — Toggle `isConnected` in `switchClient(to:)`
- `clients/ios/Views/Settings/IntegrationsSection.swift` — Observe `isConnected` to reload
- `clients/ios/Views/Settings/TrustRulesSection.swift` — Observe `isConnected` to reload
- `clients/ios/Views/Settings/SchedulesSection.swift` — Observe `isConnected` to reload
- `clients/ios/Views/Settings/RemindersSection.swift` — Observe `isConnected` to reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
