### PR TITLE
fix(ios): reset isConnected before foreground reconnect so onChange fires

### DIFF
--- a/clients/ios/App/SceneDelegate.swift
+++ b/clients/ios/App/SceneDelegate.swift
@@ -10,6 +10,7 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
         guard !provider.client.isConnected else { return }
         Task {
             do {
+                await MainActor.run { provider.isConnected = false }
                 try await provider.client.connect()
                 await MainActor.run { provider.isConnected = true }
             } catch {


### PR DESCRIPTION
## Summary
- Resets `clientProvider.isConnected = false` before calling `connect()` in SceneDelegate's foreground handler
- Without this, after a background disconnect `isConnected` stays `true`, so setting it to `true` again after reconnect doesn't trigger `.onChange` in Settings sections
- Addresses feedback from PR #5080

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
