### PR TITLE
feat: scale typography and spacing tokens for iPhone

### DIFF
--- a/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
@@ -9,8 +9,14 @@ public enum VSpacing {
     public static let md: CGFloat   = 12
     public static let lg: CGFloat   = 16
     public static let xl: CGFloat   = 24
+
+    #if os(iOS)
+    public static let xxl: CGFloat  = 24
+    public static let xxxl: CGFloat = 40
+    #else
     public static let xxl: CGFloat  = 32
     public static let xxxl: CGFloat = 48
+    #endif
 
     // MARK: - Semantic Aliases
 
@@ -19,7 +25,11 @@ public enum VSpacing {
     /// Standard content padding inside cards and panels
     public static let content: CGFloat = lg
     /// Standard section gap between major UI blocks
+    #if os(iOS)
+    public static let section: CGFloat = 20
+    #else
     public static let section: CGFloat = xl
+    #endif
     /// Standard window/page-level margin
     public static let page: CGFloat = xxl
     /// Compact vertical padding for buttons

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -12,6 +12,21 @@ import UIKit
 /// **Silkscreen** — pixelated bitmap font, used sparingly for buttons.
 public enum VFont {
 
+    // MARK: - Compact-width scaling (iPhone)
+
+    /// Scale factor applied to heading-sized fonts on iOS to avoid oversized text on iPhone.
+    private static let compactScale: CGFloat = 0.85
+
+    /// Returns a scaled size on iOS for fonts >= 18pt; smaller sizes pass through unchanged.
+    /// On macOS the base size is always returned unmodified.
+    private static func adaptiveSize(_ base: CGFloat) -> CGFloat {
+        #if os(iOS)
+        return base >= 18 ? round(base * compactScale) : base
+        #else
+        return base
+        #endif
+    }
+
     /// DM Mono's default "f" has an exaggerated italic-style hook.
     /// Stylistic Set 5 (ss05) provides a conventional "f" glyph.
     private static func dmMono(_ name: String, size: CGFloat) -> Font {
@@ -50,8 +65,8 @@ public enum VFont {
 
     // MARK: - Headings (Inter)
 
-    public static let largeTitle = Font.custom("Inter-SemiBold", size: 26)
-    public static let title      = Font.custom("Inter-SemiBold", size: 22)
+    public static let largeTitle = Font.custom("Inter-SemiBold", size: adaptiveSize(26))
+    public static let title      = Font.custom("Inter-SemiBold", size: adaptiveSize(22))
     public static let headline   = Font.custom("Inter-SemiBold", size: 13)
 
     // MARK: - Body / UI (Inter)
@@ -67,15 +82,15 @@ public enum VFont {
 
     public static let cardTitle  = Font.custom("Inter-Medium", size: 17)
     public static let cardEmoji  = Font.system(size: 32)
-    public static let onboardingEmoji = Font.system(size: 80)
+    public static let onboardingEmoji = Font.system(size: adaptiveSize(80))
     public static let mono       = dmMono("DMMono-Regular", size: 13)
     public static let monoSmall  = dmMono("DMMono-Regular", size: 11)
     public static let monoMedium = dmMono("DMMono-Medium", size: 16)
 
     /// Display font (used for panel headers like "AGENT", "GENERATED CONTENT")
-    public static let display    = Font.custom("Inter-SemiBold", size: 18)
-    public static let panelTitle   = Font.custom("Inter-Medium", size: 24)
-    public static let sectionTitle   = Font.custom("Inter-Medium", size: 18)
+    public static let display    = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
+    public static let panelTitle   = Font.custom("Inter-Medium", size: adaptiveSize(24))
+    public static let sectionTitle   = Font.custom("Inter-Medium", size: adaptiveSize(18))
 
     /// Small label (used for thread tab names)
     public static let tabLabel   = Font.custom("Inter", size: 11)


### PR DESCRIPTION
## Summary
- Scales heading font sizes down ~15% on iOS (largeTitle 26→22, title 22→19, panelTitle 24→20, sectionTitle 18→15, display 18→15)
- Scales large spacing values on iOS (page 32→24, section 24→20, xxxl 48→40)
- Only affects sizes >= 18pt — body text, captions, and small sizes unchanged
- Uses `#if os(iOS)` so macOS values are completely unaffected
- Font family (Inter) unchanged — only sizes are adjusted

## Implementation
- Added `compactScale` (0.85) and `adaptiveSize(_:)` helper to `VFont` — returns `round(base * 0.85)` for sizes >= 18pt on iOS, passes through unchanged on macOS
- Applied `adaptiveSize` to: `largeTitle`, `title`, `panelTitle`, `sectionTitle`, `display`, `onboardingEmoji`
- In `VSpacing`, used `#if os(iOS)` blocks to provide smaller values for `xxl` (32→24), `xxxl` (48→40), and `section` (24→20)

## Key Technical Choices
- Static compile-time `#if os(iOS)` rather than runtime environment/size-class checks — simpler, zero overhead, and sufficient since iPhone is the only iOS form factor where these tokens are oversized
- Single 0.85 scale factor with `round()` for clean point values rather than hand-tuned per-token sizes — easier to maintain and adjust globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
