### PR TITLE
feat: add Siri Shortcuts and deep link support for iOS

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -94,7 +94,8 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedFramework("UIKit", .when(platforms: [.iOS])),
-                .linkedFramework("SwiftUI", .when(platforms: [.iOS]))
+                .linkedFramework("SwiftUI", .when(platforms: [.iOS])),
+                .linkedFramework("AppIntents", .when(platforms: [.iOS]))
             ]
         ),
         .testTarget(

--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -27,7 +27,24 @@ struct VellumAssistantApp: App {
                 }
             }
             .preferredColorScheme(preferredScheme)
+            .onOpenURL { url in
+                handleDeepLink(url)
+            }
         }
+    }
+
+    /// Handle `vellum://send?message=...` deep links by posting a notification
+    /// that the active ChatViewModel observes to pre-fill the input field.
+    private func handleDeepLink(_ url: URL) {
+        guard url.scheme == "vellum", url.host == "send" else { return }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let messageItem = components.queryItems?.first(where: { $0.name == "message" }),
+              let message = messageItem.value, !message.isEmpty else { return }
+        NotificationCenter.default.post(
+            name: .vellumDeepLinkMessage,
+            object: nil,
+            userInfo: ["message": message]
+        )
     }
 }
 #else

--- a/clients/ios/App/VellumIntents.swift
+++ b/clients/ios/App/VellumIntents.swift
@@ -1,0 +1,57 @@
+#if canImport(UIKit)
+import AppIntents
+import UIKit
+
+// MARK: - Notification for deep link messages
+
+extension Notification.Name {
+    /// Posted when a deep link or Siri Shortcut wants to pre-fill the chat input.
+    /// The notification's `userInfo` dictionary contains a "message" key with the text.
+    static let vellumDeepLinkMessage = Notification.Name("VellumDeepLinkMessage")
+}
+
+// MARK: - App Intent
+
+/// Siri Shortcut intent that opens the app and pre-fills the chat input
+/// with the user's message. The user confirms by tapping Send.
+@available(iOS 16.0, *)
+struct SendMessageIntent: AppIntent {
+    static var title: LocalizedStringResource = "Ask Vellum"
+    static var description = IntentDescription("Open Vellum Assistant with a pre-filled message")
+
+    /// Opens the app when the intent runs.
+    static var openAppWhenRun: Bool = true
+
+    @Parameter(title: "Message")
+    var message: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        NotificationCenter.default.post(
+            name: .vellumDeepLinkMessage,
+            object: nil,
+            userInfo: ["message": message]
+        )
+        return .result()
+    }
+}
+
+// MARK: - App Shortcuts Provider
+
+/// Makes the "Ask Vellum" shortcut discoverable in the Shortcuts app and via Siri.
+@available(iOS 16.0, *)
+struct VellumShortcutsProvider: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SendMessageIntent(),
+            phrases: [
+                "Ask \(.applicationName) \(\.$message)",
+                "Send \(.applicationName) \(\.$message)",
+                "Tell \(.applicationName) \(\.$message)"
+            ],
+            shortTitle: "Ask Vellum",
+            systemImageName: "message"
+        )
+    }
+}
+#endif

--- a/clients/ios/Resources/Info.plist
+++ b/clients/ios/Resources/Info.plist
@@ -26,5 +26,16 @@
     <string>Vellum Assistant needs access to speech recognition to transcribe your voice input.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Select photos to attach to your message</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.vellum.vellum-assistant-ios</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>vellum</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -60,6 +60,7 @@ public final class ChatViewModel: ObservableObject {
     let daemonClient: any DaemonClientProtocol
     public var sessionId: String?
     private var reconnectObserver: NSObjectProtocol?
+    private var deepLinkObserver: NSObjectProtocol?
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
@@ -206,6 +207,18 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingLocalDeletions.removeAll()
             }
         }
+        #if os(iOS)
+        deepLinkObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("VellumDeepLinkMessage"),
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            Task { @MainActor [weak self] in
+                guard let message = notification.userInfo?["message"] as? String else { return }
+                self?.inputText = message
+            }
+        }
+        #endif
     }
 
     // MARK: - Sending
@@ -1231,6 +1244,9 @@ public final class ChatViewModel: ObservableObject {
     deinit {
         messageLoopTask?.cancel()
         if let observer = reconnectObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = deepLinkObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }


### PR DESCRIPTION
## Summary
- Adds SendMessageIntent AppIntent for Siri Shortcuts ("Ask Vellum...")
- Registers vellum:// URL scheme for deep linking
- Adds .onOpenURL handler in VellumAssistantApp for vellum://send?message=...
- Intent opens app and pre-fills input text without auto-sending
- Uses NotificationCenter to pass deep link messages to active ChatViewModel

## Implementation
- **VellumIntents.swift**: New file with `SendMessageIntent` (AppIntent) and `VellumShortcutsProvider` (AppShortcutsProvider). The intent sets `openAppWhenRun = true` and posts a `VellumDeepLinkMessage` notification with the message text.
- **Info.plist**: Registers `vellum://` URL scheme via `CFBundleURLTypes`.
- **VellumAssistantApp.swift**: Adds `.onOpenURL` handler that parses `vellum://send?message=...` URLs and posts the same notification.
- **ChatViewModel.swift**: Subscribes to `VellumDeepLinkMessage` notifications (iOS only) to set `inputText`, pre-filling the composer without auto-sending.
- **Package.swift**: Links `AppIntents` framework for the iOS target.

## Key Technical Choices
- **NotificationCenter** bridges the gap between the App/Intent layer and the active ChatViewModel without tight coupling. Any active ChatViewModel will pick up the message.
- **Pre-fill only, no auto-send**: The user always confirms by tapping Send, which is safer and avoids accidental messages from Siri misinterpretation.
- **`@available(iOS 16.0, *)`** on intent types for clarity, though the project's minimum deployment target is iOS 17.

## Testing
1. Build and run the iOS app
2. Open Shortcuts app and verify "Ask Vellum" shortcut is discoverable
3. Say "Hey Siri, ask Vellum what's the weather" - app should open with "what's the weather" pre-filled
4. Open `vellum://send?message=hello` in Safari - app should open with "hello" pre-filled
5. Verify the message is NOT auto-sent (user must tap Send)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
