### PR TITLE
feat: add export conversation to iOS

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -1,9 +1,28 @@
 #if canImport(UIKit)
 import SwiftUI
+import UIKit
 import VellumAssistantShared
+
+// MARK: - ActivityViewController
+
+/// Lightweight SwiftUI wrapper around UIActivityViewController for sharing content.
+struct ActivityViewController: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+// MARK: - ChatTabView
 
 struct ChatTabView: View {
     @StateObject private var viewModel: ChatViewModel
+    @State private var showCopiedConfirmation = false
+    @State private var showShareSheet = false
+    @State private var shareMarkdown: String = ""
 
     init(daemonClient: any DaemonClientProtocol) {
         _viewModel = StateObject(wrappedValue: ChatViewModel(daemonClient: daemonClient))
@@ -13,6 +32,63 @@ struct ChatTabView: View {
         ChatContentView(viewModel: viewModel)
             .navigationTitle("Chat")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    exportMenu(messages: viewModel.messages, threadTitle: nil)
+                }
+            }
+            .sheet(isPresented: $showShareSheet) {
+                ActivityViewController(activityItems: [shareMarkdown])
+            }
+    }
+
+    @ViewBuilder
+    private func exportMenu(messages: [ChatMessage], threadTitle: String?) -> some View {
+        let hasTextMessages = messages.contains {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        Menu {
+            Button {
+                let markdown = buildMarkdown(messages: messages, threadTitle: threadTitle)
+                guard !markdown.isEmpty else { return }
+                UIPasteboard.general.string = markdown
+                showCopiedConfirmation = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    showCopiedConfirmation = false
+                }
+            } label: {
+                Label(
+                    showCopiedConfirmation ? "Copied!" : "Copy as Markdown",
+                    systemImage: showCopiedConfirmation ? "checkmark" : "doc.on.doc"
+                )
+            }
+
+            Button {
+                let markdown = buildMarkdown(messages: messages, threadTitle: threadTitle)
+                guard !markdown.isEmpty else { return }
+                shareMarkdown = markdown
+                showShareSheet = true
+            } label: {
+                Label("Share\u{2026}", systemImage: "square.and.arrow.up")
+            }
+        } label: {
+            Image(systemName: showCopiedConfirmation ? "checkmark" : "square.and.arrow.up")
+                .foregroundColor(showCopiedConfirmation ? VColor.success : VColor.textMuted)
+        }
+        .disabled(!hasTextMessages)
+    }
+
+    private func buildMarkdown(messages: [ChatMessage], threadTitle: String?) -> String {
+        let names = ChatTranscriptFormatter.ParticipantNames(
+            assistantName: "Assistant",
+            userName: "You"
+        )
+        return ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: threadTitle,
+            participantNames: names
+        )
     }
 }
 

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import SwiftUI
+import UIKit
 import VellumAssistantShared
 
 // MARK: - ThreadListView
@@ -176,8 +177,11 @@ struct ThreadListView: View {
     @ViewBuilder
     private var detailView: some View {
         if let selectedId = selectedThreadId,
-           store.threads.contains(where: { $0.id == selectedId }) {
-            ThreadChatView(viewModel: store.viewModel(for: selectedId))
+           let thread = store.threads.first(where: { $0.id == selectedId }) {
+            ThreadChatView(
+                viewModel: store.viewModel(for: selectedId),
+                threadTitle: thread.title
+            )
                 .onAppear {
                     store.loadHistoryIfNeeded(for: selectedId)
                 }
@@ -193,11 +197,73 @@ struct ThreadListView: View {
 /// Thin wrapper around ChatContentView for a thread-owned ChatViewModel.
 struct ThreadChatView: View {
     @ObservedObject var viewModel: ChatViewModel
+    var threadTitle: String?
+
+    @State private var showCopiedConfirmation = false
+    @State private var showShareSheet = false
+    @State private var shareMarkdown: String = ""
 
     var body: some View {
         ChatContentView(viewModel: viewModel)
             .navigationTitle("Chat")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    exportMenu
+                }
+            }
+            .sheet(isPresented: $showShareSheet) {
+                ActivityViewController(activityItems: [shareMarkdown])
+            }
+    }
+
+    @ViewBuilder
+    private var exportMenu: some View {
+        let hasTextMessages = viewModel.messages.contains {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        Menu {
+            Button {
+                let markdown = buildMarkdown()
+                guard !markdown.isEmpty else { return }
+                UIPasteboard.general.string = markdown
+                showCopiedConfirmation = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    showCopiedConfirmation = false
+                }
+            } label: {
+                Label(
+                    showCopiedConfirmation ? "Copied!" : "Copy as Markdown",
+                    systemImage: showCopiedConfirmation ? "checkmark" : "doc.on.doc"
+                )
+            }
+
+            Button {
+                let markdown = buildMarkdown()
+                guard !markdown.isEmpty else { return }
+                shareMarkdown = markdown
+                showShareSheet = true
+            } label: {
+                Label("Share\u{2026}", systemImage: "square.and.arrow.up")
+            }
+        } label: {
+            Image(systemName: showCopiedConfirmation ? "checkmark" : "square.and.arrow.up")
+                .foregroundColor(showCopiedConfirmation ? VColor.success : VColor.textMuted)
+        }
+        .disabled(!hasTextMessages)
+    }
+
+    private func buildMarkdown() -> String {
+        let names = ChatTranscriptFormatter.ParticipantNames(
+            assistantName: "Assistant",
+            userName: "You"
+        )
+        return ChatTranscriptFormatter.threadMarkdown(
+            messages: viewModel.messages,
+            threadTitle: threadTitle,
+            participantNames: names
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds toolbar button to iOS chat view for exporting conversations
- Copy as Markdown copies the full thread transcript to clipboard using ChatTranscriptFormatter
- Share option presents UIActivityViewController with the markdown content
- Uses existing ChatTranscriptFormatter.threadMarkdown() for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
