### PR TITLE
fix: preserve paragraph indentation in MarkdownParser

### DIFF
--- a/clients/shared/Features/Chat/MarkdownRenderer.swift
+++ b/clients/shared/Features/Chat/MarkdownRenderer.swift
@@ -210,7 +210,7 @@ private enum MarkdownParser {
             }
             if !paraLines.isEmpty {
                 let text = paraLines.joined(separator: "\n")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: .newlines)
                 if !text.isEmpty {
                     blocks.append(.paragraph(text: text))
                 }


### PR DESCRIPTION
## Summary
- Replaces .trimmingCharacters(in: .whitespacesAndNewlines) with .trimmingCharacters(in: .newlines) in paragraph accumulation
- Preserves leading indentation and trailing spaces in user-authored text
- Still strips stray newlines at paragraph boundaries from the accumulation logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
