### PR TITLE
fix: gate font/spacing scaling to iPhone via device idiom check

### DIFF
--- a/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
@@ -1,8 +1,20 @@
 import Foundation
+#if os(iOS)
+import UIKit
+#endif
 
 /// Spacing scale based on 4pt grid.
 /// Usage: `.padding(VSpacing.lg)` or `.padding(.horizontal, VSpacing.xl)`
 public enum VSpacing {
+
+    private static var isPhone: Bool {
+        #if os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .phone
+        #else
+        return false
+        #endif
+    }
+
     public static let xxs: CGFloat  = 2
     public static let xs: CGFloat   = 4
     public static let sm: CGFloat   = 8
@@ -10,13 +22,8 @@ public enum VSpacing {
     public static let lg: CGFloat   = 16
     public static let xl: CGFloat   = 24
 
-    #if os(iOS)
-    public static let xxl: CGFloat  = 24
-    public static let xxxl: CGFloat = 40
-    #else
-    public static let xxl: CGFloat  = 32
-    public static let xxxl: CGFloat = 48
-    #endif
+    public static var xxl: CGFloat  { isPhone ? 24 : 32 }
+    public static var xxxl: CGFloat { isPhone ? 40 : 48 }
 
     // MARK: - Semantic Aliases
 
@@ -25,13 +32,9 @@ public enum VSpacing {
     /// Standard content padding inside cards and panels
     public static let content: CGFloat = lg
     /// Standard section gap between major UI blocks
-    #if os(iOS)
-    public static let section: CGFloat = 20
-    #else
-    public static let section: CGFloat = xl
-    #endif
+    public static var section: CGFloat { isPhone ? 20 : xl }
     /// Standard window/page-level margin
-    public static let page: CGFloat = xxl
+    public static var page: CGFloat { xxl }
     /// Compact vertical padding for buttons
     public static let buttonV: CGFloat = 5.5
 }

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -21,6 +21,7 @@ public enum VFont {
     /// On macOS the base size is always returned unmodified.
     private static func adaptiveSize(_ base: CGFloat) -> CGFloat {
         #if os(iOS)
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return base }
         return base >= 18 ? round(base * compactScale) : base
         #else
         return base


### PR DESCRIPTION
## Summary
- Changes `#if os(iOS)` compile-time scaling to runtime `UIDevice.current.userInterfaceIdiom == .phone` check
- iPad now retains the original macOS-sized font and spacing values
- iPhone still gets the compact scaling (largeTitle 26→22, etc.)
- Fixes review feedback that iPad shouldn't get reduced sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
