### PR TITLE
fix: scope Siri deep-link to active thread with cold-launch buffering

### DIFF
--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -33,18 +33,14 @@ struct VellumAssistantApp: App {
         }
     }
 
-    /// Handle `vellum://send?message=...` deep links by posting a notification
-    /// that the active ChatViewModel observes to pre-fill the input field.
+    /// Handle `vellum://send?message=...` deep links by buffering the message
+    /// in `DeepLinkManager` for the active `ChatViewModel` to consume.
     private func handleDeepLink(_ url: URL) {
         guard url.scheme == "vellum", url.host == "send" else { return }
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let messageItem = components.queryItems?.first(where: { $0.name == "message" }),
               let message = messageItem.value, !message.isEmpty else { return }
-        NotificationCenter.default.post(
-            name: .vellumDeepLinkMessage,
-            object: nil,
-            userInfo: ["message": message]
-        )
+        DeepLinkManager.pendingMessage = message
     }
 }
 #else

--- a/clients/ios/App/VellumIntents.swift
+++ b/clients/ios/App/VellumIntents.swift
@@ -2,12 +2,16 @@
 import AppIntents
 import UIKit
 
-// MARK: - Notification for deep link messages
+// MARK: - Deep Link Manager
 
-extension Notification.Name {
-    /// Posted when a deep link or Siri Shortcut wants to pre-fill the chat input.
-    /// The notification's `userInfo` dictionary contains a "message" key with the text.
-    static let vellumDeepLinkMessage = Notification.Name("VellumDeepLinkMessage")
+/// Buffers a deep-link / Siri Shortcut message so it survives cold launch
+/// (where no `ChatViewModel` may exist yet) and is consumed only by the
+/// active thread's view model.
+enum DeepLinkManager {
+    /// The pending message text. Set by `SendMessageIntent` or the URL handler;
+    /// consumed (and cleared) by the active `ChatViewModel` via
+    /// `consumeDeepLinkIfNeeded()`.
+    @MainActor static var pendingMessage: String?
 }
 
 // MARK: - App Intent
@@ -27,11 +31,7 @@ struct SendMessageIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        NotificationCenter.default.post(
-            name: .vellumDeepLinkMessage,
-            object: nil,
-            userInfo: ["message": message]
-        )
+        DeepLinkManager.pendingMessage = message
         return .result()
     }
 }

--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -30,6 +30,9 @@ struct ChatTabView: View {
 
     var body: some View {
         ChatContentView(viewModel: viewModel)
+            .onAppear {
+                viewModel.consumeDeepLinkIfNeeded()
+            }
             .navigationTitle("Chat")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -184,6 +184,7 @@ struct ThreadListView: View {
             )
                 .onAppear {
                     store.loadHistoryIfNeeded(for: selectedId)
+                    store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
                 }
         } else {
             Text("Select a chat")

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -60,7 +60,6 @@ public final class ChatViewModel: ObservableObject {
     let daemonClient: any DaemonClientProtocol
     public var sessionId: String?
     private var reconnectObserver: NSObjectProtocol?
-    private var deepLinkObserver: NSObjectProtocol?
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
@@ -207,19 +206,20 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingLocalDeletions.removeAll()
             }
         }
-        #if os(iOS)
-        deepLinkObserver = NotificationCenter.default.addObserver(
-            forName: Notification.Name("VellumDeepLinkMessage"),
-            object: nil,
-            queue: nil
-        ) { [weak self] notification in
-            Task { @MainActor [weak self] in
-                guard let message = notification.userInfo?["message"] as? String else { return }
-                self?.inputText = message
-            }
-        }
-        #endif
     }
+
+    // MARK: - Deep Link
+
+    /// Check for a buffered deep-link message and apply it to `inputText`.
+    /// Called by the iOS view layer when this `ChatViewModel` becomes the
+    /// active/visible thread, ensuring only one VM ever consumes the message.
+    #if os(iOS)
+    public func consumeDeepLinkIfNeeded() {
+        guard let message = DeepLinkManager.pendingMessage else { return }
+        DeepLinkManager.pendingMessage = nil
+        inputText = message
+    }
+    #endif
 
     // MARK: - Sending
 
@@ -1244,9 +1244,6 @@ public final class ChatViewModel: ObservableObject {
     deinit {
         messageLoopTask?.cancel()
         if let observer = reconnectObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        if let observer = deepLinkObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }


### PR DESCRIPTION
## Summary
- Replaces broadcast NotificationCenter deep-link with targeted DeepLinkManager
- Stores pending message in static property so cold launch doesn't lose it
- Only the active/visible ChatViewModel consumes the message via consumeDeepLinkIfNeeded()
- Prevents cross-thread fan-out where all retained ChatViewModels got the message
- Fixes both P1 cross-thread leakage and cold-launch message loss

## Implementation
- `DeepLinkManager` enum with `@MainActor static var pendingMessage` buffers the deep-link text
- `SendMessageIntent.perform()` and `VellumAssistantApp.handleDeepLink` write to the buffer instead of posting a notification
- `ChatViewModel.consumeDeepLinkIfNeeded()` atomically reads and clears the buffer, setting `inputText`
- `ThreadChatView.onAppear` and `ChatTabView.onAppear` call the consume method, scoping delivery to the visible thread
- Removed the broadcast notification observer from `ChatViewModel.init` and its cleanup from `deinit`

## Key Technical Choices
- Used a static property on a case-less enum rather than UserDefaults because the message only needs to survive within a single app launch cycle (cold launch -> view creation), not across app terminations
- `@MainActor` isolation on the static property ensures thread safety without locks
- The consume-on-appear pattern is preferred over notification forwarding because it naturally handles both warm and cold launch without additional coordination logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
