### PR TITLE
fix: consume deep links on warm launch via onOpenURL

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -33,6 +33,9 @@ struct ChatTabView: View {
             .onAppear {
                 viewModel.consumeDeepLinkIfNeeded()
             }
+            .onOpenURL { _ in
+                viewModel.consumeDeepLinkIfNeeded()
+            }
             .navigationTitle("Chat")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -186,6 +186,9 @@ struct ThreadListView: View {
                     store.loadHistoryIfNeeded(for: selectedId)
                     store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
                 }
+                .onOpenURL { _ in
+                    store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
+                }
         } else {
             Text("Select a chat")
                 .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary

- Add .onOpenURL modifiers alongside existing .onAppear blocks in ThreadListView and ChatTabView
- Ensures deep links and Siri intents are consumed even when the chat view is already visible (warm launch)
- Without this fix, warm-launch deep links sit in DeepLinkManager.pendingMessage unconsumed until the user navigates away and back

Addresses review feedback from PR #5089.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
