### PR TITLE
fix: use underscores in swift test filter for iOS tests

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -190,7 +190,7 @@ cd clients/macos
 
 ```bash
 cd clients
-swift test --filter vellum-assistant-iosTests    # 70 iOS-specific tests
+swift test --filter vellum_assistant_iosTests    # 70 iOS-specific tests
 ```
 
 Test files in `clients/ios/Tests/`:

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -132,7 +132,7 @@ The `vellum-assistant-iosTests` target contains 70 iOS-specific integration test
 
 ```bash
 cd clients
-swift test --filter vellum-assistant-iosTests
+swift test --filter vellum_assistant_iosTests
 ```
 
 Test files in `clients/ios/Tests/`:


### PR DESCRIPTION
## Summary

- Replace vellum-assistant-iosTests with vellum_assistant_iosTests in swift test --filter commands
- SPM normalizes hyphens to underscores in test specifiers, so the old filter matched 0 tests

Addresses review feedback from PR #5090.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
