### PR TITLE
fix: defer onOpenURL deep-link consumption to next run loop

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -34,7 +34,9 @@ struct ChatTabView: View {
                 viewModel.consumeDeepLinkIfNeeded()
             }
             .onOpenURL { _ in
-                viewModel.consumeDeepLinkIfNeeded()
+                DispatchQueue.main.async {
+                    viewModel.consumeDeepLinkIfNeeded()
+                }
             }
             .navigationTitle("Chat")
             .navigationBarTitleDisplayMode(.inline)

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -187,7 +187,9 @@ struct ThreadListView: View {
                     store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
                 }
                 .onOpenURL { _ in
-                    store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
+                    DispatchQueue.main.async {
+                        store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
+                    }
                 }
         } else {
             Text("Select a chat")


### PR DESCRIPTION
## Summary

- Wrap consumeDeepLinkIfNeeded() in DispatchQueue.main.async inside onOpenURL handlers
- SwiftUI dispatches onOpenURL from child to parent (inner-to-outer), so the child handler was firing before the parent set DeepLinkManager.pendingMessage
- Deferring by one run-loop tick ensures the parent handler has set the message before consumption

Addresses review feedback from PR #5091.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
