### PR TITLE
broadcast work item updates for cross-client sync

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -73,6 +73,12 @@ export function handleWorkItemUpdate(
 
   const item = updateWorkItem(msg.id, updates as Parameters<typeof updateWorkItem>[1]) ?? null;
   ctx.send(socket, { type: 'work_item_update_response', item });
+
+  // Broadcast to all clients so other open task views stay in sync
+  // (e.g. priority/sort changes made by one client are reflected everywhere)
+  if (item) {
+    broadcastWorkItemStatus(ctx, item.id);
+  }
 }
 
 export function handleWorkItemComplete(


### PR DESCRIPTION
## Summary

- `handleWorkItemUpdate` previously only sent the response to the requesting socket, so priority tier, sort index, and status mutations made by one client were invisible to other connected task views.
- Added a `broadcastWorkItemStatus` call after a successful update, reusing the existing `work_item_status_changed` message type that clients already listen for to trigger list refreshes.
- No new IPC message types or client-side changes needed — piggybacks on the existing broadcast infrastructure.

## Files changed

- `assistant/src/daemon/handlers/work-items.ts` — added broadcast after `handleWorkItemUpdate` sends its response

## Test plan

- [ ] Open two macOS app windows connected to the same daemon
- [ ] In one window, change a work item's priority or sort order
- [ ] Verify the other window's task list updates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
