### PR TITLE
add work_item_update_response client callback

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -275,6 +275,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `work_item_run_task_response` message.
     public var onWorkItemRunTaskResponse: ((IPCWorkItemRunTaskResponse) -> Void)?
 
+    /// Called when the daemon sends a `work_item_update_response` message.
+    public var onWorkItemUpdateResponse: ((IPCWorkItemUpdateResponse) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -1415,6 +1418,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onWorkItemStatusChanged?(msg)
         case .workItemRunTaskResponse(let msg):
             onWorkItemRunTaskResponse?(msg)
+        case .workItemUpdateResponse(let msg):
+            onWorkItemUpdateResponse?(msg)
         case .openTasksWindow:
             onOpenTasksWindow?()
         case .subagentSpawned(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1803,6 +1803,7 @@ public enum ServerMessage: Decodable, Sendable {
     case workItemsListResponse(IPCWorkItemsListResponse)
     case workItemStatusChanged(IPCWorkItemStatusChanged)
     case workItemRunTaskResponse(IPCWorkItemRunTaskResponse)
+    case workItemUpdateResponse(IPCWorkItemUpdateResponse)
     case openTasksWindow(OpenTasksWindowMessage)
     case subagentSpawned(IPCSubagentSpawned)
     case subagentStatusChanged(IPCSubagentStatusChanged)
@@ -2077,6 +2078,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "work_item_run_task_response":
             let message = try IPCWorkItemRunTaskResponse(from: decoder)
             self = .workItemRunTaskResponse(message)
+        case "work_item_update_response":
+            let message = try IPCWorkItemUpdateResponse(from: decoder)
+            self = .workItemUpdateResponse(message)
         case "open_tasks_window":
             let message = try OpenTasksWindowMessage(from: decoder)
             self = .openTasksWindow(message)


### PR DESCRIPTION
## Summary
- Add `workItemUpdateResponse` case to the `ServerMessage` enum in `IPCMessages.swift`
- Add decoding logic for `work_item_update_response` wire type in the `ServerMessage.init(from:)` decoder
- Add `onWorkItemUpdateResponse` callback property to `DaemonClient` alongside the other work item callbacks
- Add dispatch case in `handleServerMessage` to invoke the callback when the message arrives

The daemon already sends `work_item_update_response` (via `work-items.ts` handler) and the Swift generated types (`IPCWorkItemUpdateResponse`, `IPCWorkItemUpdateResponseItem`) already exist in `IPCContractGenerated.swift`. This PR wires up the missing client-side plumbing so the tasks window can reconcile priority edits with server acknowledgments.

## Test plan
- [ ] Verify Swift build compiles successfully with the new enum case, decoding, and callback
- [ ] Confirm that sending a `work_item_update` request from the client results in the `onWorkItemUpdateResponse` callback being invoked with the server's response

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
