### PR TITLE
add sticky header row to Tasks window

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -32,6 +32,32 @@ struct TasksWindowView: View {
             Divider()
                 .background(VColor.surfaceBorder)
 
+            // Column headers — fixed above the scrollable list
+            HStack(alignment: .center, spacing: 0) {
+                Text("Task")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text("Priority")
+                    .frame(width: TasksTableContract.priorityWidth)
+
+                Text("Status")
+                    .frame(width: TasksTableContract.statusWidth)
+
+                Text("Actions")
+                    .frame(width: TasksTableContract.actionsWidth)
+            }
+            .font(VFont.captionMedium)
+            .foregroundColor(VColor.textMuted)
+            .padding(.vertical, VSpacing.sm)
+            .padding(.horizontal, VSpacing.lg)
+            // Inner horizontal padding matches row padding so labels sit
+            // directly above their respective columns.
+            .padding(.horizontal, VSpacing.md)
+
+            Rectangle()
+                .fill(VColor.surfaceBorder)
+                .frame(height: 1)
+
             // Content
             if isLoading {
                 VStack {


### PR DESCRIPTION
## Summary
- Adds a fixed column header row (Task, Priority, Status, Actions) above the scrollable task list in `TasksWindowView`
- Header labels use `VFont.captionMedium` + `VColor.textMuted` per the design system
- Column widths reference `TasksTableContract` constants so headers stay aligned with the data rows below
- A 1pt `VColor.surfaceBorder` divider separates the header from the scrollable content
- Header stays fixed (outside the ScrollView) so column labels remain visible while scrolling

## Test plan
- [ ] Open the Tasks window and verify column labels appear above the list
- [ ] Scroll the task list and confirm the header stays pinned at the top
- [ ] Resize the window and verify the Task column stretches while fixed-width columns stay aligned
- [ ] Verify empty/loading/error states still display correctly below the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
