### PR TITLE
add priority labels and edit dropdown to Tasks window

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
@@ -42,6 +42,13 @@ enum TasksTableContract {
         let color: Color
     }
 
+    /// All priority tiers in display order, used to populate the priority edit menu.
+    static let allPriorityTiers: [(tier: Double, label: String, color: Color)] = [
+        (0, "High",   VColor.error),
+        (1, "Medium", VColor.accent),
+        (2, "Low",    VColor.textMuted),
+    ]
+
     static func priorityStyle(for tier: Double) -> PriorityStyle {
         switch tier {
         case 0:  return PriorityStyle(label: "High",   color: VColor.error)

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -98,7 +98,10 @@ struct TasksWindowView: View {
                             TasksWindowRow(
                                 item: item,
                                 onRun: { runTask(id: item.id) },
-                                onComplete: { completeTask(id: item.id) }
+                                onComplete: { completeTask(id: item.id) },
+                                onPriorityChange: { newTier in
+                                    updatePriority(id: item.id, tier: newTier)
+                                }
                             )
                         }
                     }
@@ -162,6 +165,14 @@ struct TasksWindowView: View {
             errorMessage = error.localizedDescription
         }
     }
+
+    private func updatePriority(id: String, tier: Double) {
+        do {
+            try daemonClient.sendWorkItemUpdate(id: id, priorityTier: tier)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }
 
 // MARK: - Row View
@@ -171,6 +182,7 @@ private struct TasksWindowRow: View {
     let item: IPCWorkItemsListResponseItem
     let onRun: () -> Void
     let onComplete: () -> Void
+    let onPriorityChange: (Double) -> Void
     @State private var isHovered = false
 
     var body: some View {
@@ -218,10 +230,31 @@ private struct TasksWindowRow: View {
 
     private var priorityColumn: some View {
         let style = TasksTableContract.priorityStyle(for: item.priorityTier)
-        return Circle()
-            .fill(style.color)
-            .frame(width: 8, height: 8)
-            .accessibilityLabel("Priority \(style.label)")
+        return Menu {
+            ForEach(TasksTableContract.allPriorityTiers, id: \.tier) { option in
+                Button {
+                    onPriorityChange(option.tier)
+                } label: {
+                    Label {
+                        Text(option.label)
+                    } icon: {
+                        Image(systemName: option.tier == item.priorityTier ? "checkmark.circle.fill" : "circle.fill")
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Circle()
+                    .fill(style.color)
+                    .frame(width: 8, height: 8)
+                Text(style.label)
+                    .font(VFont.caption)
+                    .foregroundColor(style.color)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .accessibilityLabel("Priority \(style.label)")
     }
 
     // MARK: - Status Column


### PR DESCRIPTION
## Summary
- Display textual priority labels (High/Medium/Low) next to the colored circle in the priority column
- Add a clickable dropdown menu on the priority indicator to change priority tier via `sendWorkItemUpdate`
- Add `allPriorityTiers` to `TasksTableContract` as the single source of truth for menu options

## Test plan
- [ ] Open the Tasks window with items at different priority tiers — verify colored circle and text label appear
- [ ] Click a priority indicator — verify the dropdown menu appears with all three options
- [ ] Select a different priority — verify the update is sent to the daemon and the UI refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
