### PR TITLE
debounce task list refreshes after priority edits

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -8,6 +8,7 @@ struct TasksWindowView: View {
     @State private var items: [IPCWorkItemsListResponseItem] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var refreshTask: Task<Void, Never>?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -139,10 +140,17 @@ struct TasksWindowView: View {
 
     private func listenForStatusChanges() {
         daemonClient.onWorkItemStatusChanged = { _ in
-            do {
-                try daemonClient.sendWorkItemsList()
-            } catch {
-                // Silently ignore; the list will refresh on next status change
+            // Debounce rapid broadcasts so multiple priority edits coalesce
+            // into a single re-fetch instead of N overlapping calls.
+            refreshTask?.cancel()
+            refreshTask = Task {
+                try? await Task.sleep(nanoseconds: 300_000_000) // 300ms
+                guard !Task.isCancelled else { return }
+                do {
+                    try daemonClient.sendWorkItemsList()
+                } catch {
+                    // Silently ignore; the list will refresh on next status change
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add 300ms debounce to the `onWorkItemStatusChanged` listener in `TasksWindowView` so rapid priority edits coalesce into a single `sendWorkItemsList` call instead of triggering N overlapping re-fetches
- The initial `.onAppear` fetch remains immediate and unaffected
- Uses `Task` cancellation to ensure only the last pending refresh executes

## Test plan
- [ ] Open the Tasks window with multiple queued items
- [ ] Rapidly change priorities on several items in quick succession
- [ ] Verify the list refreshes once after changes settle, not once per change
- [ ] Verify the list still loads immediately on window open

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
