### PR TITLE
optimistic priority updates with rollback and smooth reorder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -167,9 +167,35 @@ struct TasksWindowView: View {
     }
 
     private func updatePriority(id: String, tier: Double) {
+        // Snapshot for rollback on failure
+        let snapshot = items
+
+        // Optimistic local update: replace the item's priority and re-sort
+        if let index = items.firstIndex(where: { $0.id == id }) {
+            var updated = items
+            updated[index] = updated[index].withPriorityTier(tier)
+            updated.sort {
+                if $0.priorityTier != $1.priorityTier {
+                    return $0.priorityTier < $1.priorityTier
+                }
+                if let s0 = $0.sortIndex, let s1 = $1.sortIndex, s0 != s1 {
+                    return s0 < s1
+                }
+                return $0.updatedAt > $1.updatedAt
+            }
+            // Fast linear transition to avoid jittery spring animations on reorder
+            withAnimation(.linear(duration: 0.15)) {
+                items = updated
+            }
+        }
+
         do {
             try daemonClient.sendWorkItemUpdate(id: id, priorityTier: tier)
         } catch {
+            // Rollback to pre-update state
+            withAnimation(.linear(duration: 0.15)) {
+                items = snapshot
+            }
             errorMessage = error.localizedDescription
         }
     }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2173,3 +2173,12 @@ public struct SlotContentWire: Decodable, Sendable {
     public let panel: String?
     public let surfaceId: String?
 }
+
+// MARK: - Work Item Helpers
+
+extension IPCWorkItemsListResponseItem {
+    /// Returns a copy with a different `priorityTier`, preserving all other fields.
+    public func withPriorityTier(_ newTier: Double) -> Self {
+        Self(id: id, taskId: taskId, title: title, notes: notes, status: status, priorityTier: newTier, sortIndex: sortIndex, lastRunId: lastRunId, lastRunConversationId: lastRunConversationId, lastRunStatus: lastRunStatus, sourceType: sourceType, sourceId: sourceId, createdAt: createdAt, updatedAt: updatedAt)
+    }
+}


### PR DESCRIPTION
## Summary
- Optimistically updates the local task list when priority changes, so the UI responds instantly without waiting for the daemon round-trip
- Saves a snapshot before the optimistic update and rolls back if the IPC request fails, surfacing the error via the existing `errorMessage` display
- Wraps reorder mutations in `withAnimation(.linear(duration: 0.15))` to avoid SwiftUI's default springy list animations causing jank
- Adds `withPriorityTier(_:)` helper on `IPCWorkItemsListResponseItem` following the existing `withState` pattern for immutable struct copies

## Test plan
- [ ] Change a task's priority and verify the row reorders immediately without waiting for a daemon response
- [ ] Verify the reorder animation is smooth (fast linear, no bouncing)
- [ ] Simulate a daemon IPC failure and confirm the list rolls back to its previous state
- [ ] Confirm that eventual daemon broadcast reconciliation still works correctly after optimistic updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
