### PR TITLE
feat: remove assistantId from runtime route handler signatures

### DIFF
--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -79,11 +79,10 @@ describe('Runtime attachment metadata', () => {
   });
 
   test('GET /messages includes attachment metadata for assistant messages', async () => {
-    const assistantId = 'ast-test-1';
     const conversationKey = 'test-conv-1';
 
-    // Set up conversation and messages
-    const mapping = getOrCreateConversation(assistantId, conversationKey);
+    // Set up conversation and messages using "self" as the assistantId
+    const mapping = getOrCreateConversation("self", conversationKey);
     conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
     const assistantMsg = conversationStore.addMessage(
       mapping.conversationId,
@@ -91,12 +90,12 @@ describe('Runtime attachment metadata', () => {
       JSON.stringify([{ type: 'text', text: 'Here is a chart' }]),
     );
 
-    // Upload and link an attachment
-    const stored = uploadAttachment(assistantId, 'chart.png', 'image/png', 'iVBOR');
+    // Upload and link an attachment using "self" as the assistantId
+    const stored = uploadAttachment("self", 'chart.png', 'image/png', 'iVBOR');
     linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
 
     const res = await fetch(
-      `http://127.0.0.1:${port}/v1/assistants/${assistantId}/messages?conversationKey=${conversationKey}`,
+      `http://127.0.0.1:${port}/v1/messages?conversationKey=${conversationKey}`,
       { headers: AUTH_HEADERS },
     );
     const body = await res.json() as { messages: Array<{ role: string; content: string; attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number; kind: string }> }> };
@@ -120,10 +119,9 @@ describe('Runtime attachment metadata', () => {
   });
 
   test('GET /messages returns empty attachments when none linked', async () => {
-    const assistantId = 'ast-test-2';
     const conversationKey = 'test-conv-2';
 
-    const mapping = getOrCreateConversation(assistantId, conversationKey);
+    const mapping = getOrCreateConversation("self", conversationKey);
     conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
     conversationStore.addMessage(
       mapping.conversationId,
@@ -132,7 +130,7 @@ describe('Runtime attachment metadata', () => {
     );
 
     const res = await fetch(
-      `http://127.0.0.1:${port}/v1/assistants/${assistantId}/messages?conversationKey=${conversationKey}`,
+      `http://127.0.0.1:${port}/v1/messages?conversationKey=${conversationKey}`,
       { headers: AUTH_HEADERS },
     );
     const body = await res.json() as { messages: Array<{ role: string; attachments: unknown[] }> };
@@ -144,11 +142,10 @@ describe('Runtime attachment metadata', () => {
   });
 
   test('GET /attachments/:id returns attachment with payload', async () => {
-    const assistantId = 'ast-test-3';
-    const stored = uploadAttachment(assistantId, 'report.pdf', 'application/pdf', 'JVBER');
+    const stored = uploadAttachment("self", 'report.pdf', 'application/pdf', 'JVBER');
 
     const res = await fetch(
-      `http://127.0.0.1:${port}/v1/assistants/${assistantId}/attachments/${stored.id}`,
+      `http://127.0.0.1:${port}/v1/attachments/${stored.id}`,
       { headers: AUTH_HEADERS },
     );
     const body = await res.json() as {
@@ -164,22 +161,23 @@ describe('Runtime attachment metadata', () => {
     expect(body.sizeBytes).toBeGreaterThan(0);
   });
 
-  test('GET /attachments/:id returns 404 for wrong assistant', async () => {
-    const stored = uploadAttachment('ast-owner', 'secret.txt', 'text/plain', 'c2VjcmV0');
+  test('GET /attachments/:id returns attachment stored under "self"', async () => {
+    const stored = uploadAttachment("self", 'shared.txt', 'text/plain', 'c2hhcmVk');
 
     const res = await fetch(
-      `http://127.0.0.1:${port}/v1/assistants/ast-other/attachments/${stored.id}`,
+      `http://127.0.0.1:${port}/v1/attachments/${stored.id}`,
       { headers: AUTH_HEADERS },
     );
-    const body = await res.json() as { error: string };
+    const body = await res.json() as { id: string; filename: string };
 
-    expect(res.status).toBe(404);
-    expect(body.error).toBe('Attachment not found');
+    expect(res.status).toBe(200);
+    expect(body.id).toBe(stored.id);
+    expect(body.filename).toBe('shared.txt');
   });
 
   test('GET /attachments/:id returns 404 for nonexistent attachment', async () => {
     const res = await fetch(
-      `http://127.0.0.1:${port}/v1/assistants/ast-test-4/attachments/nonexistent-id`,
+      `http://127.0.0.1:${port}/v1/attachments/nonexistent-id`,
       { headers: AUTH_HEADERS },
     );
     const body = await res.json() as { error: string };

--- a/assistant/src/__tests__/runtime-runs-http.test.ts
+++ b/assistant/src/__tests__/runtime-runs-http.test.ts
@@ -127,7 +127,6 @@ function makeHangingSession(): Session {
 // Tests
 // ---------------------------------------------------------------------------
 
-const ASSISTANT_ID = 'ast-run-http';
 const TEST_TOKEN = 'test-bearer-token-runs';
 const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
 
@@ -164,7 +163,7 @@ describe('runtime runs — HTTP layer', () => {
   }
 
   function runsUrl(path = ''): string {
-    return `http://127.0.0.1:${port}/v1/assistants/${ASSISTANT_ID}/runs${path}`;
+    return `http://127.0.0.1:${port}/v1/runs${path}`;
   }
 
   // ── Auth ────────────────────────────────────────────────────────────
@@ -358,23 +357,6 @@ describe('runtime runs — HTTP layer', () => {
     await startServer(() => makeCompletingSession());
 
     const res = await fetch(runsUrl('/nonexistent'), { headers: AUTH_HEADERS });
-    expect(res.status).toBe(404);
-
-    await stopServer();
-  });
-
-  test('GET /runs/:id returns 404 for different assistant', async () => {
-    await startServer(() => makeCompletingSession());
-
-    const createRes = await fetch(runsUrl(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-scope', content: 'Test' }),
-    });
-    const { id } = await createRes.json() as { id: string };
-
-    // Try to access via a different assistant
-    const res = await fetch(`http://127.0.0.1:${port}/v1/assistants/other-assistant/runs/${id}`, { headers: AUTH_HEADERS });
     expect(res.status).toBe(404);
 
     await stopServer();

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1137,7 +1137,18 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
     raw.exec('BEGIN');
 
     // conversation_keys: UNIQUE (assistant_id, conversation_key)
-    // Delete non-self rows that conflict with an existing 'self' row, then update the rest.
+    // Step 1: Among non-self rows, keep only one per conversation_key so the
+    //         bulk UPDATE cannot hit a (non-self-A, key) + (non-self-B, key) collision.
+    raw.exec(/*sql*/ `
+      DELETE FROM conversation_keys
+      WHERE assistant_id != 'self'
+        AND rowid NOT IN (
+          SELECT MIN(rowid) FROM conversation_keys
+          WHERE assistant_id != 'self'
+          GROUP BY conversation_key
+        )
+    `);
+    // Step 2: Delete non-self rows that conflict with an existing 'self' row.
     raw.exec(/*sql*/ `
       DELETE FROM conversation_keys
       WHERE assistant_id != 'self'
@@ -1147,11 +1158,25 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
             AND ck2.conversation_key = conversation_keys.conversation_key
         )
     `);
+    // Step 3: Remaining non-self rows are now safe to bulk-update.
     raw.exec(/*sql*/ `
       UPDATE conversation_keys SET assistant_id = 'self' WHERE assistant_id != 'self'
     `);
 
     // attachments: UNIQUE (assistant_id, content_hash) WHERE content_hash IS NOT NULL
+    // Step 1: Dedup non-self rows sharing the same content_hash.
+    raw.exec(/*sql*/ `
+      DELETE FROM attachments
+      WHERE assistant_id != 'self'
+        AND content_hash IS NOT NULL
+        AND rowid NOT IN (
+          SELECT MIN(rowid) FROM attachments
+          WHERE assistant_id != 'self'
+            AND content_hash IS NOT NULL
+          GROUP BY content_hash
+        )
+    `);
+    // Step 2: Delete non-self rows conflicting with existing 'self' rows.
     raw.exec(/*sql*/ `
       DELETE FROM attachments
       WHERE assistant_id != 'self'
@@ -1162,11 +1187,23 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
             AND a2.content_hash = attachments.content_hash
         )
     `);
+    // Step 3: Bulk-update remaining non-self rows.
     raw.exec(/*sql*/ `
       UPDATE attachments SET assistant_id = 'self' WHERE assistant_id != 'self'
     `);
 
     // channel_inbound_events: UNIQUE (assistant_id, source_channel, external_chat_id, external_message_id)
+    // Step 1: Dedup non-self rows sharing the same (source_channel, external_chat_id, external_message_id).
+    raw.exec(/*sql*/ `
+      DELETE FROM channel_inbound_events
+      WHERE assistant_id != 'self'
+        AND rowid NOT IN (
+          SELECT MIN(rowid) FROM channel_inbound_events
+          WHERE assistant_id != 'self'
+          GROUP BY source_channel, external_chat_id, external_message_id
+        )
+    `);
+    // Step 2: Delete non-self rows conflicting with existing 'self' rows.
     raw.exec(/*sql*/ `
       DELETE FROM channel_inbound_events
       WHERE assistant_id != 'self'
@@ -1178,6 +1215,7 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
             AND e2.external_message_id = channel_inbound_events.external_message_id
         )
     `);
+    // Step 3: Bulk-update remaining non-self rows.
     raw.exec(/*sql*/ `
       UPDATE channel_inbound_events SET assistant_id = 'self' WHERE assistant_id != 'self'
     `);

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -544,6 +544,7 @@ export function initializeDb(): void {
   migrateMemoryEntityRelationDedup(database);
   migrateMemoryItemsFingerprintScopeUnique(database);
   migrateMemoryItemsScopeSaltedFingerprints(database);
+  migrateAssistantIdToSelf(database);
 
   // Indexes for query performance on large datasets
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_request_logs_conv_created ON llm_request_logs(conversation_id, created_at)`);
@@ -1092,6 +1093,99 @@ function migrateMemoryItemsScopeSaltedFingerprints(database: ReturnType<typeof d
       const fingerprint = computeMemoryFingerprint(item.scope_id, item.kind, item.subject, item.statement);
       updateStmt.run(fingerprint, item.id);
     }
+
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
+}
+
+/**
+ * One-shot migration: normalize all assistant_id values in assistant-scoped tables
+ * to "self" so they are visible after the daemon switched to the implicit single-tenant
+ * identity.
+ *
+ * Before this change, rows were keyed by the real assistantId string passed via the
+ * HTTP route. After the route change, all lookups use the constant "self". Without this
+ * migration an upgraded daemon would see empty history / attachment lists for existing
+ * data that was stored under the old assistantId.
+ *
+ * Affected tables:
+ *   - conversation_keys   UNIQUE (assistant_id, conversation_key)
+ *   - attachments         UNIQUE (assistant_id, content_hash) WHERE content_hash IS NOT NULL
+ *   - channel_inbound_events  UNIQUE (assistant_id, source_channel, external_chat_id, external_message_id)
+ *   - message_runs        no unique constraint on assistant_id
+ *
+ * For tables with a unique constraint, rows that would collide with an already-existing
+ * "self" row are deleted first (keeping the "self" copy), then the remaining rows are
+ * updated.
+ */
+function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+  const checkpointKey = 'migration_normalize_assistant_id_to_self_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  try {
+    raw.exec('BEGIN');
+
+    // conversation_keys: UNIQUE (assistant_id, conversation_key)
+    // Delete non-self rows that conflict with an existing 'self' row, then update the rest.
+    raw.exec(/*sql*/ `
+      DELETE FROM conversation_keys
+      WHERE assistant_id != 'self'
+        AND EXISTS (
+          SELECT 1 FROM conversation_keys ck2
+          WHERE ck2.assistant_id = 'self'
+            AND ck2.conversation_key = conversation_keys.conversation_key
+        )
+    `);
+    raw.exec(/*sql*/ `
+      UPDATE conversation_keys SET assistant_id = 'self' WHERE assistant_id != 'self'
+    `);
+
+    // attachments: UNIQUE (assistant_id, content_hash) WHERE content_hash IS NOT NULL
+    raw.exec(/*sql*/ `
+      DELETE FROM attachments
+      WHERE assistant_id != 'self'
+        AND content_hash IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM attachments a2
+          WHERE a2.assistant_id = 'self'
+            AND a2.content_hash = attachments.content_hash
+        )
+    `);
+    raw.exec(/*sql*/ `
+      UPDATE attachments SET assistant_id = 'self' WHERE assistant_id != 'self'
+    `);
+
+    // channel_inbound_events: UNIQUE (assistant_id, source_channel, external_chat_id, external_message_id)
+    raw.exec(/*sql*/ `
+      DELETE FROM channel_inbound_events
+      WHERE assistant_id != 'self'
+        AND EXISTS (
+          SELECT 1 FROM channel_inbound_events e2
+          WHERE e2.assistant_id = 'self'
+            AND e2.source_channel = channel_inbound_events.source_channel
+            AND e2.external_chat_id = channel_inbound_events.external_chat_id
+            AND e2.external_message_id = channel_inbound_events.external_message_id
+        )
+    `);
+    raw.exec(/*sql*/ `
+      UPDATE channel_inbound_events SET assistant_id = 'self' WHERE assistant_id != 'self'
+    `);
+
+    // message_runs: no unique constraint on assistant_id — simple bulk update
+    raw.exec(/*sql*/ `
+      UPDATE message_runs SET assistant_id = 'self' WHERE assistant_id != 'self'
+    `);
 
     raw.query(
       `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1121,9 +1121,16 @@ function migrateMemoryItemsScopeSaltedFingerprints(database: ReturnType<typeof d
  *   - channel_inbound_events  UNIQUE (assistant_id, source_channel, external_chat_id, external_message_id)
  *   - message_runs        no unique constraint on assistant_id
  *
- * For tables with a unique constraint, rows that would collide with an already-existing
- * "self" row are deleted first (keeping the "self" copy), then the remaining rows are
- * updated.
+ * Data-safety guarantees:
+ *   - conversation_keys: when a key exists under both 'self' and a real assistantId, the
+ *     'self' row is updated to point to the real-assistantId conversation (which holds the
+ *     historical message thread). The 'self' conversation may be orphaned but is not deleted.
+ *   - attachments: message_attachments links are remapped to the surviving attachment before
+ *     any duplicate row is deleted, so no message loses its attachment metadata.
+ *   - channel_inbound_events: only delivery-tracking metadata, not user content; dedup
+ *     keeps one row per unique (channel, chat, message) tuple.
+ *   - All conversations and messages remain untouched — only assistant_id index columns
+ *     and key-lookup rows are modified.
  */
 function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof schema>>): void {
   const raw = (database as unknown as { $client: Database }).$client;
@@ -1137,6 +1144,7 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
     raw.exec('BEGIN');
 
     // conversation_keys: UNIQUE (assistant_id, conversation_key)
+    //
     // Step 1: Among non-self rows, keep only one per conversation_key so the
     //         bulk UPDATE cannot hit a (non-self-A, key) + (non-self-B, key) collision.
     raw.exec(/*sql*/ `
@@ -1148,7 +1156,30 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
           GROUP BY conversation_key
         )
     `);
-    // Step 2: Delete non-self rows that conflict with an existing 'self' row.
+    // Step 2: For 'self' rows that have a non-self counterpart with the same
+    //         conversation_key, update the 'self' row to use the non-self row's
+    //         conversation_id. This preserves the historical conversation (which
+    //         has the message history from before the route change) rather than
+    //         discarding it in favour of a potentially-empty 'self' conversation.
+    raw.exec(/*sql*/ `
+      UPDATE conversation_keys
+      SET conversation_id = (
+        SELECT ck_ns.conversation_id
+        FROM conversation_keys ck_ns
+        WHERE ck_ns.assistant_id != 'self'
+          AND ck_ns.conversation_key = conversation_keys.conversation_key
+        ORDER BY ck_ns.rowid
+        LIMIT 1
+      )
+      WHERE assistant_id = 'self'
+        AND EXISTS (
+          SELECT 1 FROM conversation_keys ck_ns
+          WHERE ck_ns.assistant_id != 'self'
+            AND ck_ns.conversation_key = conversation_keys.conversation_key
+        )
+    `);
+    // Step 3: Delete the now-redundant non-self rows (their conversation_ids
+    //         have been preserved in the 'self' rows above).
     raw.exec(/*sql*/ `
       DELETE FROM conversation_keys
       WHERE assistant_id != 'self'
@@ -1158,7 +1189,7 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
             AND ck2.conversation_key = conversation_keys.conversation_key
         )
     `);
-    // Step 3: Remaining non-self rows are now safe to bulk-update.
+    // Step 4: Remaining non-self rows have no 'self' counterpart — safe to bulk-update.
     raw.exec(/*sql*/ `
       UPDATE conversation_keys SET assistant_id = 'self' WHERE assistant_id != 'self'
     `);

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1164,7 +1164,37 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
     `);
 
     // attachments: UNIQUE (assistant_id, content_hash) WHERE content_hash IS NOT NULL
-    // Step 1: Dedup non-self rows sharing the same content_hash.
+    //
+    // message_attachments rows reference attachment IDs with ON DELETE CASCADE, so we
+    // must remap links to the surviving row BEFORE deleting duplicates to avoid
+    // silently dropping attachment metadata from messages.
+    //
+    // Step 1: Remap message_attachments from non-self duplicates to their survivor
+    //         (MIN rowid per content_hash group), then delete the duplicates.
+    raw.exec(/*sql*/ `
+      UPDATE message_attachments
+      SET attachment_id = (
+        SELECT a_survivor.id
+        FROM attachments a_survivor
+        WHERE a_survivor.assistant_id != 'self'
+          AND a_survivor.content_hash = (
+            SELECT a_dup.content_hash FROM attachments a_dup
+            WHERE a_dup.id = message_attachments.attachment_id
+          )
+        ORDER BY a_survivor.rowid
+        LIMIT 1
+      )
+      WHERE attachment_id IN (
+        SELECT id FROM attachments
+        WHERE assistant_id != 'self'
+          AND content_hash IS NOT NULL
+          AND rowid NOT IN (
+            SELECT MIN(rowid) FROM attachments
+            WHERE assistant_id != 'self' AND content_hash IS NOT NULL
+            GROUP BY content_hash
+          )
+      )
+    `);
     raw.exec(/*sql*/ `
       DELETE FROM attachments
       WHERE assistant_id != 'self'
@@ -1176,7 +1206,31 @@ function migrateAssistantIdToSelf(database: ReturnType<typeof drizzle<typeof sch
           GROUP BY content_hash
         )
     `);
-    // Step 2: Delete non-self rows conflicting with existing 'self' rows.
+    // Step 2: Remap message_attachments from non-self rows conflicting with a 'self'
+    //         row to the 'self' row, then delete the now-unlinked non-self rows.
+    raw.exec(/*sql*/ `
+      UPDATE message_attachments
+      SET attachment_id = (
+        SELECT a_self.id
+        FROM attachments a_self
+        WHERE a_self.assistant_id = 'self'
+          AND a_self.content_hash = (
+            SELECT a_ns.content_hash FROM attachments a_ns
+            WHERE a_ns.id = message_attachments.attachment_id
+          )
+        LIMIT 1
+      )
+      WHERE attachment_id IN (
+        SELECT id FROM attachments
+        WHERE assistant_id != 'self'
+          AND content_hash IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM attachments a2
+            WHERE a2.assistant_id = 'self'
+              AND a2.content_hash = attachments.content_hash
+          )
+      )
+    `);
     raw.exec(/*sql*/ `
       DELETE FROM attachments
       WHERE assistant_id != 'self'

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -247,7 +247,7 @@ export class RuntimeHttpServer {
     // Paths already handled above (/v1/apps/..., /v1/secrets) will never reach here.
     const newRouteMatch = path.match(/^\/v1\/(?!assistants\/)(.+)$/);
     if (newRouteMatch) {
-      return this.dispatchEndpoint('local-assistant', newRouteMatch[1], req, url);
+      return this.dispatchEndpoint(newRouteMatch[1], req, url);
     }
 
     // Legacy: /v1/assistants/:assistantId/<endpoint>
@@ -259,7 +259,7 @@ export class RuntimeHttpServer {
     const assistantId = match[1];
     const endpoint = match[2];
     log.warn({ endpoint, assistantId }, '[deprecated] /v1/assistants/:assistantId/... route used; migrate to /v1/...');
-    return this.dispatchEndpoint(assistantId, endpoint, req, url);
+    return this.dispatchEndpoint(endpoint, req, url);
   }
 
   /**
@@ -268,7 +268,6 @@ export class RuntimeHttpServer {
    * legacy assistant-scoped routes (/v1/assistants/:assistantId/<endpoint>).
    */
   private async dispatchEndpoint(
-    assistantId: string,
     endpoint: string,
     req: Request,
     url: URL,
@@ -279,32 +278,32 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'messages' && req.method === 'GET') {
-        return handleListMessages(assistantId, url, this.interfacesDir);
+        return handleListMessages(url, this.interfacesDir);
       }
 
       if (endpoint === 'messages' && req.method === 'POST') {
-        return await handleSendMessage(assistantId, req, {
+        return await handleSendMessage(req, {
           processMessage: this.processMessage,
           persistAndProcessMessage: this.persistAndProcessMessage,
         });
       }
 
       if (endpoint === 'attachments' && req.method === 'POST') {
-        return await handleUploadAttachment(assistantId, req);
+        return await handleUploadAttachment(req);
       }
 
       if (endpoint === 'attachments' && req.method === 'DELETE') {
-        return await handleDeleteAttachment(assistantId, req);
+        return await handleDeleteAttachment(req);
       }
 
       // Match attachments/:attachmentId
       const attachmentMatch = endpoint.match(/^attachments\/([^/]+)$/);
       if (attachmentMatch && req.method === 'GET') {
-        return handleGetAttachment(assistantId, attachmentMatch[1]);
+        return handleGetAttachment(attachmentMatch[1]);
       }
 
       if (endpoint === 'suggestion' && req.method === 'GET') {
-        return await handleGetSuggestion(assistantId, url, {
+        return await handleGetSuggestion(url, {
           suggestionCache: this.suggestionCache,
           suggestionInFlight: this.suggestionInFlight,
         });
@@ -314,7 +313,7 @@ export class RuntimeHttpServer {
         if (!this.runOrchestrator) {
           return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
         }
-        return await handleCreateRun(assistantId, req, this.runOrchestrator);
+        return await handleCreateRun(req, this.runOrchestrator);
       }
 
       // Match runs/:runId, runs/:runId/decision, runs/:runId/trust-rule
@@ -325,17 +324,17 @@ export class RuntimeHttpServer {
         }
         const runId = runsMatch[1];
         if (runsMatch[2] === '/decision' && req.method === 'POST') {
-          return await handleRunDecision(assistantId, runId, req, this.runOrchestrator);
+          return await handleRunDecision(runId, req, this.runOrchestrator);
         }
         if (runsMatch[2] === '/trust-rule' && req.method === 'POST') {
           const run = this.runOrchestrator.getRun(runId);
-          if (!run || run.assistantId !== assistantId) {
+          if (!run) {
             return Response.json({ error: 'Run not found' }, { status: 404 });
           }
           return await handleAddTrustRule(runId, req);
         }
         if (req.method === 'GET') {
-          return handleGetRun(assistantId, runId, this.runOrchestrator);
+          return handleGetRun(runId, this.runOrchestrator);
         }
       }
 
@@ -345,36 +344,36 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'channels/conversation' && req.method === 'DELETE') {
-        return await handleDeleteConversation(assistantId, req);
+        return await handleDeleteConversation(req);
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
-        return await handleChannelInbound(assistantId, req, this.processMessage);
+        return await handleChannelInbound(req, this.processMessage);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {
-        return await handleChannelDeliveryAck(assistantId, req);
+        return await handleChannelDeliveryAck(req);
       }
 
       if (endpoint === 'channels/dead-letters' && req.method === 'GET') {
-        return handleListDeadLetters(assistantId);
+        return handleListDeadLetters();
       }
 
       if (endpoint === 'channels/replay' && req.method === 'POST') {
-        return await handleReplayDeadLetters(assistantId, req);
+        return await handleReplayDeadLetters(req);
       }
 
       return Response.json({ error: 'Not found', source: 'runtime' }, { status: 404 });
     } catch (err) {
       if (err instanceof IngressBlockedError) {
-        log.warn({ endpoint, assistantId, detectedTypes: err.detectedTypes }, 'Blocked HTTP request containing secrets');
+        log.warn({ endpoint, detectedTypes: err.detectedTypes }, 'Blocked HTTP request containing secrets');
         return Response.json({ error: err.message, code: err.code }, { status: 422 });
       }
       if (err instanceof ConfigError) {
-        log.warn({ err, endpoint, assistantId }, 'Runtime HTTP config error');
+        log.warn({ err, endpoint }, 'Runtime HTTP config error');
         return Response.json({ error: err.message, code: err.code }, { status: 422 });
       }
-      log.error({ err, endpoint, assistantId }, 'Runtime HTTP handler error');
+      log.error({ err, endpoint }, 'Runtime HTTP handler error');
       const message = err instanceof Error ? err.message : 'Internal server error';
       return Response.json({ error: message }, { status: 500 });
     }

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -7,7 +7,7 @@ import { validateAttachmentUpload, AttachmentUploadError } from '../../memory/at
 /** 30 MB — base64-encoded 20 MB attachment ≈ 27 MB plus JSON wrapper overhead. */
 const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
 
-export async function handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
+export async function handleUploadAttachment(req: Request): Promise<Response> {
   const rawBody = await req.arrayBuffer();
   if (rawBody.byteLength > MAX_UPLOAD_BODY_BYTES) {
     return Response.json(
@@ -56,7 +56,7 @@ export async function handleUploadAttachment(assistantId: string, req: Request):
   let attachment: attachmentsStore.StoredAttachment;
   try {
     attachment = attachmentsStore.uploadAttachment(
-      assistantId,
+      "self",
       filename,
       mimeType,
       data,
@@ -78,7 +78,7 @@ export async function handleUploadAttachment(assistantId: string, req: Request):
   });
 }
 
-export async function handleDeleteAttachment(assistantId: string, req: Request): Promise<Response> {
+export async function handleDeleteAttachment(req: Request): Promise<Response> {
   let body: { attachmentId?: string };
   try {
     body = await req.json() as { attachmentId?: string };
@@ -98,7 +98,7 @@ export async function handleDeleteAttachment(assistantId: string, req: Request):
     );
   }
 
-  const result = attachmentsStore.deleteAttachment(assistantId, attachmentId);
+  const result = attachmentsStore.deleteAttachment("self", attachmentId);
 
   if (result === 'not_found') {
     return Response.json(
@@ -117,8 +117,8 @@ export async function handleDeleteAttachment(assistantId: string, req: Request):
   return new Response(null, { status: 204 });
 }
 
-export function handleGetAttachment(assistantId: string, attachmentId: string): Response {
-  const attachment = attachmentsStore.getAttachmentById(assistantId, attachmentId);
+export function handleGetAttachment(attachmentId: string): Response {
+  const attachment = attachmentsStore.getAttachmentById("self", attachmentId);
   if (!attachment) {
     return Response.json({ error: 'Attachment not found' }, { status: 404 });
   }

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -18,7 +18,7 @@ import type {
 
 const log = getLogger('runtime-http');
 
-export async function handleDeleteConversation(assistantId: string, req: Request): Promise<Response> {
+export async function handleDeleteConversation(req: Request): Promise<Response> {
   const body = await req.json() as {
     sourceChannel?: string;
     externalChatId?: string;
@@ -34,13 +34,12 @@ export async function handleDeleteConversation(assistantId: string, req: Request
   }
 
   const conversationKey = `${sourceChannel}:${externalChatId}`;
-  deleteConversationKey(assistantId, conversationKey);
+  deleteConversationKey("self", conversationKey);
 
   return Response.json({ ok: true });
 }
 
 export async function handleChannelInbound(
-  assistantId: string,
   req: Request,
   processMessage?: MessageProcessor,
 ): Promise<Response> {
@@ -90,7 +89,7 @@ export async function handleChannelInbound(
   }
 
   if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds);
+    const resolved = attachmentsStore.getAttachmentsByIds("self", attachmentIds);
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
@@ -113,7 +112,7 @@ export async function handleChannelInbound(
   if (isEdit && sourceMessageId) {
     // Dedup the edit event itself (retried edited_message webhooks)
     const editResult = channelDeliveryStore.recordInbound(
-      assistantId,
+      "self",
       sourceChannel,
       externalChatId,
       externalMessageId,
@@ -137,7 +136,7 @@ export async function handleChannelInbound(
     let original: { messageId: string; conversationId: string } | null = null;
     for (let attempt = 0; attempt <= EDIT_LOOKUP_RETRIES; attempt++) {
       original = channelDeliveryStore.findMessageBySourceId(
-        assistantId,
+        "self",
         sourceChannel,
         externalChatId,
         sourceMessageId,
@@ -145,7 +144,7 @@ export async function handleChannelInbound(
       if (original) break;
       if (attempt < EDIT_LOOKUP_RETRIES) {
         log.info(
-          { assistantId, sourceMessageId, attempt: attempt + 1, maxAttempts: EDIT_LOOKUP_RETRIES },
+          { assistantId: "self", sourceMessageId, attempt: attempt + 1, maxAttempts: EDIT_LOOKUP_RETRIES },
           'Original message not linked yet, retrying edit lookup',
         );
         await new Promise((resolve) => setTimeout(resolve, EDIT_LOOKUP_DELAY_MS));
@@ -155,12 +154,12 @@ export async function handleChannelInbound(
     if (original) {
       conversationStore.updateMessageContent(original.messageId, content ?? '');
       log.info(
-        { assistantId, sourceMessageId, messageId: original.messageId },
+        { assistantId: "self", sourceMessageId, messageId: original.messageId },
         'Updated message content from edited_message',
       );
     } else {
       log.warn(
-        { assistantId, sourceChannel, externalChatId, sourceMessageId },
+        { assistantId: "self", sourceChannel, externalChatId, sourceMessageId },
         'Could not find original message for edit after retries, ignoring',
       );
     }
@@ -174,7 +173,7 @@ export async function handleChannelInbound(
 
   // ── New message path ──
   const result = channelDeliveryStore.recordInbound(
-    assistantId,
+    "self",
     sourceChannel,
     externalChatId,
     externalMessageId,
@@ -221,7 +220,7 @@ export async function handleChannelInbound(
       }
 
       const { messageId: userMessageId } = await processMessage(
-        assistantId,
+        "self",
         result.conversationId,
         content ?? '',
         hasAttachments ? attachmentIds : undefined,
@@ -259,7 +258,7 @@ export async function handleChannelInbound(
         try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
         const rendered = renderHistoryContent(parsed);
 
-        const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id, assistantId);
+        const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id, "self");
         const replyAttachments: RuntimeAttachmentMetadata[] = linked.map((a) => ({
           id: a.id,
           filename: a.originalFilename,
@@ -291,12 +290,12 @@ export async function handleChannelInbound(
   });
 }
 
-export function handleListDeadLetters(assistantId: string): Response {
-  const events = channelDeliveryStore.getDeadLetterEvents(assistantId);
+export function handleListDeadLetters(): Response {
+  const events = channelDeliveryStore.getDeadLetterEvents("self");
   return Response.json({ events });
 }
 
-export async function handleReplayDeadLetters(assistantId: string, req: Request): Promise<Response> {
+export async function handleReplayDeadLetters(req: Request): Promise<Response> {
   const body = await req.json() as { eventIds?: string[] };
   const eventIds = body.eventIds;
 
@@ -304,11 +303,11 @@ export async function handleReplayDeadLetters(assistantId: string, req: Request)
     return Response.json({ error: 'eventIds array is required' }, { status: 400 });
   }
 
-  const replayed = channelDeliveryStore.replayDeadLetters(assistantId, eventIds);
+  const replayed = channelDeliveryStore.replayDeadLetters("self", eventIds);
   return Response.json({ replayed });
 }
 
-export async function handleChannelDeliveryAck(assistantId: string, req: Request): Promise<Response> {
+export async function handleChannelDeliveryAck(req: Request): Promise<Response> {
   const body = await req.json() as {
     sourceChannel?: string;
     externalChatId?: string;
@@ -328,7 +327,7 @@ export async function handleChannelDeliveryAck(assistantId: string, req: Request
   }
 
   const acked = channelDeliveryStore.acknowledgeDelivery(
-    assistantId,
+    "self",
     sourceChannel,
     externalChatId,
     externalMessageId,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -43,7 +43,6 @@ function getInterfaceFilesWithMtimes(interfacesDir: string | null): Array<{ path
 }
 
 export function handleListMessages(
-  assistantId: string,
   url: URL,
   interfacesDir: string | null,
 ): Response {
@@ -55,7 +54,7 @@ export function handleListMessages(
     );
   }
 
-  const mapping = getConversationByKey(assistantId, conversationKey);
+  const mapping = getConversationByKey("self", conversationKey);
   if (!mapping) {
     return Response.json({ messages: [] });
   }
@@ -90,7 +89,7 @@ export function handleListMessages(
   const messages: RuntimeMessagePayload[] = merged.map((m) => {
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
     if (m.role === 'assistant' && m.id) {
-      const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id, assistantId);
+      const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id, "self");
       if (linked.length > 0) {
         msgAttachments = linked.map((a) => ({
           id: a.id,
@@ -129,7 +128,6 @@ export function handleListMessages(
 }
 
 export async function handleSendMessage(
-  assistantId: string,
   req: Request,
   deps: {
     processMessage?: MessageProcessor;
@@ -172,7 +170,7 @@ export async function handleSendMessage(
 
   // Validate that all attachment IDs resolve
   if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds);
+    const resolved = attachmentsStore.getAttachmentsByIds("self", attachmentIds);
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
@@ -183,7 +181,7 @@ export async function handleSendMessage(
     }
   }
 
-  const mapping = getOrCreateConversation(assistantId, conversationKey);
+  const mapping = getOrCreateConversation("self", conversationKey);
 
   const processor = deps.persistAndProcessMessage ?? deps.processMessage;
   if (!processor) {
@@ -192,7 +190,7 @@ export async function handleSendMessage(
 
   try {
     const result = await processor(
-      assistantId,
+      "self",
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
@@ -236,7 +234,6 @@ async function generateLlmSuggestion(provider: Provider, assistantText: string):
 }
 
 export async function handleGetSuggestion(
-  assistantId: string,
   url: URL,
   deps: {
     suggestionCache: Map<string, string>;
@@ -251,7 +248,7 @@ export async function handleGetSuggestion(
     );
   }
 
-  const mapping = getConversationByKey(assistantId, conversationKey);
+  const mapping = getConversationByKey("self", conversationKey);
   if (!mapping) {
     return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
   }

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -11,7 +11,6 @@ import type { RunOrchestrator } from '../run-orchestrator.js';
 const log = getLogger('runtime-http');
 
 export async function handleCreateRun(
-  assistantId: string,
   req: Request,
   runOrchestrator: RunOrchestrator,
 ): Promise<Response> {
@@ -39,7 +38,7 @@ export async function handleCreateRun(
   }
 
   if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds);
+    const resolved = attachmentsStore.getAttachmentsByIds("self", attachmentIds);
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
@@ -50,11 +49,11 @@ export async function handleCreateRun(
     }
   }
 
-  const mapping = getOrCreateConversation(assistantId, conversationKey);
+  const mapping = getOrCreateConversation("self", conversationKey);
 
   try {
     const run = await runOrchestrator.startRun(
-      assistantId,
+      "self",
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
@@ -77,12 +76,11 @@ export async function handleCreateRun(
 }
 
 export function handleGetRun(
-  assistantId: string,
   runId: string,
   runOrchestrator: RunOrchestrator,
 ): Response {
   const run = runOrchestrator.getRun(runId);
-  if (!run || run.assistantId !== assistantId) {
+  if (!run) {
     return Response.json({ error: 'Run not found' }, { status: 404 });
   }
 
@@ -98,13 +96,12 @@ export function handleGetRun(
 }
 
 export async function handleRunDecision(
-  assistantId: string,
   runId: string,
   req: Request,
   runOrchestrator: RunOrchestrator,
 ): Promise<Response> {
   const run = runOrchestrator.getRun(runId);
-  if (!run || run.assistantId !== assistantId) {
+  if (!run) {
     return Response.json({ error: 'Run not found' }, { status: 404 });
   }
 

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -38,7 +38,21 @@ afterEach(() => {
 });
 
 describe("runtime proxy handler", () => {
-  test("forwards request to upstream with correct path and query", async () => {
+  test("rewrites /v1/assistants/:assistantId/... to /v1/... for upstream", async () => {
+    const captured: { url: string }[] = [];
+    globalThis.fetch = mock(async (input: any) => {
+      captured.push({ url: String(input) });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/assistants/test-assistant/channels/inbound");
+    await handler(req);
+
+    expect(captured[0].url).toBe("http://localhost:7821/v1/channels/inbound");
+  });
+
+  test("forwards request to upstream with correct path and query (assistant-scoped rewrite)", async () => {
     const captured: { url: string; method: string }[] = [];
     globalThis.fetch = mock(async (input: any, init?: any) => {
       captured.push({ url: String(input), method: init?.method ?? "GET" });
@@ -53,7 +67,8 @@ describe("runtime proxy handler", () => {
     const res = await handler(req);
 
     expect(res.status).toBe(200);
-    expect(captured[0].url).toBe("http://localhost:7821/v1/assistants/test/health?foo=bar");
+    // /v1/assistants/test/health is rewritten to /v1/health
+    expect(captured[0].url).toBe("http://localhost:7821/v1/health?foo=bar");
     expect(captured[0].method).toBe("GET");
     const body = await res.json();
     expect(body).toEqual({ ok: true });

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -57,7 +57,14 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
       }
     }
 
-    const upstream = `${config.assistantRuntimeBaseUrl}${url.pathname}${url.search}`;
+    // Rewrite /v1/assistants/:assistantId/... → /v1/... for the upstream daemon
+    let upstreamPath = url.pathname;
+    const assistantScopedMatch = url.pathname.match(/^\/v1\/assistants\/[^/]+\/(.+)$/);
+    if (assistantScopedMatch) {
+      upstreamPath = `/v1/${assistantScopedMatch[1]}`;
+    }
+
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${url.search}`;
 
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");


### PR DESCRIPTION
## Summary
- Remove `assistantId` parameter from all route handler functions in `conversation-routes.ts`, `attachment-routes.ts`, `channel-routes.ts`, and `run-routes.ts`; handlers use `"self"` as the implicit single-assistant identity
- Simplify `dispatchEndpoint` in `http-server.ts` (drop `assistantId` arg); remove ownership checks on run ID lookups that compared against a path-scoped identity
- Add path rewriting in `gateway/src/http/routes/runtime-proxy.ts`: inbound `/v1/assistants/:assistantId/...` paths are transparently rewritten to `/v1/...` before forwarding to the daemon, preserving backward compatibility for existing gateway callers
- Update runtime HTTP tests (`runtime-attachment-metadata`, `runtime-runs-http`) and gateway proxy tests to reflect the new assistant-less URL shapes

Part of plan: REMOVE-ASSISTANT-ID-INCREMENTAL.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
