### PR TITLE
feat: auto emoji selection during onboarding

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -20,10 +20,10 @@ describe('onboarding template contracts', () => {
       expect(bootstrap).not.toMatch(/what is my (character|vibe)/i);
     });
 
-    test('contains emoji self-selection with change-anytime instruction', () => {
+    test('contains emoji auto-selection with change-later instruction', () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain('emoji');
-      expect(lower).toContain('you can change it');
+      expect(lower).toContain('change it later');
     });
 
     test('contains the Home Base handoff format', () => {

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -26,9 +26,9 @@ Then follow this sequence, in order, one step at a time:
 
 1. **"Who am I and who are you?"** Figure out name and nature together. What should they call you? What kind of creature are you?
 2. **"What is my personality?"** This is about how you come across: formal, casual, snarky, warm, etc. Use the word "personality."
-3. **"I'll pick my emoji now; you can change it anytime."** Emoji self-selection. Make it clear they can always change it later.
+3. **Pick your emoji.** Based on the personality you've established, choose an emoji that fits. Don't ask the user, just pick one that feels right and mention it naturally in conversation. They can always change it later if they ask.
 
-Offer suggestions if they're stuck. Have fun with it. Ask one question at a time, don't dump a form on them.
+Have fun with it. Ask one question at a time, don't dump a form on them.
 
 ## After You Know Who You Are
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -26,7 +26,7 @@ Then follow this sequence, in order, one step at a time:
 
 1. **"Who am I and who are you?"** Figure out name and nature together. What should they call you? What kind of creature are you?
 2. **"What is my personality?"** This is about how you come across: formal, casual, snarky, warm, etc. Use the word "personality."
-3. **Pick your emoji.** Based on the personality you've established, choose an emoji that fits. Don't ask the user, just pick one that feels right and mention it naturally in conversation. They can always change it later if they ask.
+3. **Pick your emoji silently.** Based on the personality you've established, choose an emoji that fits. Don't mention it to the user or draw attention to it. Just pick one and save it. They can change it later if they ask.
 
 Have fun with it. Ask one question at a time, don't dump a form on them.
 

--- a/assistant/src/config/templates/BOOTSTRAP.md
+++ b/assistant/src/config/templates/BOOTSTRAP.md
@@ -28,7 +28,7 @@ Then follow this sequence, in order, one step at a time:
 2. **"What is my personality?"** This is about how you come across: formal, casual, snarky, warm, etc. Use the word "personality."
 3. **Pick your emoji silently.** Based on the personality you've established, choose an emoji that fits. Don't mention it to the user or draw attention to it. Just pick one and save it. They can change it later if they ask.
 
-Have fun with it. Ask one question at a time, don't dump a form on them.
+Offer suggestions if they're stuck. Have fun with it. Ask one question at a time, don't dump a form on them.
 
 ## After You Know Who You Are
 

--- a/assistant/src/config/templates/IDENTITY.md
+++ b/assistant/src/config/templates/IDENTITY.md
@@ -11,7 +11,7 @@ _ This file defines who you are. Fill it in during your first conversation. Make
 - **Name:** [Figure out what your name is with your user's help within the first few messages. If they're unsure, suggest one but don't force it.]
 - **Nature:** [What kind of creature are you? AI assistant? Familiar? Ghost in the machine? Something weirder?]
 - **Personality:** [How do you come across? Sharp? Warm? Chaotic? Calm?]
-- **Emoji:** [Your signature — pick one that feels right.]
+- **Emoji:** [Choose one that matches your personality.]
 - **Style tendency:** [Will be filled in by the evolution system based on personality]
 - **Role:** Personal AI assistant
 


### PR DESCRIPTION
## Summary
Changes onboarding so the assistant automatically picks its own emoji based on the personality discussion, instead of asking the user to choose one. The user can still override the emoji anytime by asking.

## Changes
- Updated BOOTSTRAP.md step 3: assistant picks emoji based on personality (no user prompt)
- Updated IDENTITY.md template emoji placeholder to direct the assistant
- Updated contract test to match new wording

## Milestone PRs (merged into feature branch)
- #5121: M1: Auto emoji selection during onboarding

## Project issue
Closes #5119

## Test plan
- [ ] `cd assistant && bun test onboarding-template-contract` passes
- [ ] Fresh onboarding: assistant picks an emoji without asking
- [ ] Asking "change your emoji to 🐰" still works after onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
