### PR TITLE
Remove per-message copy button from chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -590,10 +590,7 @@ private struct ChatBubble: View {
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
     @State private var isRegenerateHovered = false
-    @State private var isCopyHovered = false
 
-    @State private var showCopyConfirmation = false
-    @State private var copyConfirmationTimer: DispatchWorkItem?
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
     @State private var stepsExpanded = false
 
@@ -712,10 +709,6 @@ private struct ChatBubble: View {
                 }
 
                 HStack(spacing: VSpacing.xs) {
-                    if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        copyButton
-                    }
-
                     if showRegenerate {
                         regenerateButton
                     }
@@ -780,59 +773,6 @@ private struct ChatBubble: View {
     /// Whether all tool calls are complete and the message is done streaming.
     private var allToolCallsComplete: Bool {
         !message.toolCalls.isEmpty && message.toolCalls.allSatisfy { $0.isComplete } && !message.isStreaming
-    }
-
-    private var copyButton: some View {
-        Button {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(message.text, forType: .string)
-            copyConfirmationTimer?.cancel()
-            showCopyConfirmation = true
-            let timer = DispatchWorkItem { showCopyConfirmation = false }
-            copyConfirmationTimer = timer
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
-        } label: {
-            Image(systemName: showCopyConfirmation ? "checkmark" : "doc.on.doc")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(showCopyConfirmation ? VColor.success : VColor.textMuted)
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Copy message")
-        .onHover { hovering in
-            isCopyHovered = hovering
-            if hovering {
-                NSCursor.pointingHand.set()
-            } else {
-                NSCursor.arrow.set()
-            }
-        }
-        .overlay(alignment: .bottom) {
-            if isCopyHovered && !showCopyConfirmation {
-                Text("Copy")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textPrimary)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(VColor.surface)
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-                    .vShadow(VShadow.sm)
-                    .fixedSize()
-                    .offset(y: 28)
-                    .transition(.opacity)
-                    .allowsHitTesting(false)
-            }
-        }
-        .opacity(isUser ? (isHovered ? 1 : 0) : 1)
-        .allowsHitTesting(isUser ? isHovered : true)
-        .animation(VAnimation.fast, value: isHovered)
     }
 
     private var regenerateButton: some View {


### PR DESCRIPTION
## Summary
- Removes the per-message copy button (clipboard icon) that appears below each message in the chat view
- Users can still copy message text via text selection or the "Copy thread" toolbar button

## Test plan
- [ ] Verify no copy icon appears below assistant or user messages
- [ ] Verify regenerate and report buttons still work
- [ ] Verify text selection still works for copying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
