### PR TITLE
docs: add task_progress template schema to ui_show tool description (#5127)

### DIFF
--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -35,6 +35,9 @@ export const uiShowTool: Tool = {
     'templateData shape: { location: string, currentTemp: number, feelsLike: number, unit: "F"|"C", condition: string, humidity: number, windSpeed: number, windDirection: string, ' +
     'hourly: Array<{ time: string, icon: string (SF Symbol name), temp: number }>, ' +
     'forecast: Array<{ day: string, icon: string (SF Symbol name), low: number, high: number, precip: number|null, condition: string }> }\n' +
+    '  Template "task_progress": renders a live-updating task progress widget showing structured step-by-step progress. ' +
+    'templateData shape: { title: string, status: "in_progress"|"completed"|"failed", ' +
+    'steps: Array<{ label: string, status: "pending"|"in_progress"|"completed"|"failed", detail?: string }> }\n' +
     '- table: Data table with columns, selectable rows, and action buttons. ' +
     'data shape: { columns: Array<{ id: string, label: string }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }\n' +
     '- form: Input form with typed fields. ' +


### PR DESCRIPTION
## Summary
- Add task_progress template documentation to uiShowTool.description
- Documents the templateData shape for task progress widgets (title, status, steps array)

Closes #5127
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
