### PR TITLE
feat: mirror HTTP-triggered run/session flows into assistant-events hub

### DIFF
--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -2,12 +2,21 @@
  * Tests that HTTP-triggered run/session flows mirror messages into the
  * assistant-events hub with payload parity to IPC outbound messages.
  *
+ * The Session class has two distinct outbound paths:
+ *   1. updateClient handler — used by the prompter for confirmation_request,
+ *      trace emitter, secret prompter.
+ *   2. runAgentLoop onEvent callback — used for the primary streaming events:
+ *      assistant_text_delta, message_complete, tool_use_start, tool_result, etc.
+ *
+ * Both paths must publish to the hub.
+ *
  * Tests:
- *   - confirmation_request → hub emits one AssistantEvent
- *   - assistant_text_delta + message_complete → hub emits in order
+ *   - confirmation_request (updateClient path) → hub emits one AssistantEvent
+ *   - assistant_text_delta + message_complete (onEvent path) → hub emits in order
+ *   - sessionId falls back to conversationId when the message lacks it
  */
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
@@ -45,10 +54,10 @@ initializeDb();
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Build a session that calls the updateClient handler with all given messages,
- * then resolves (simulates a completed agent loop).
+ * Build a session that calls the updateClient handler with the given messages
+ * (simulates prompter / confirmation path).
  */
-function makeSessionEmitting(...messages: ServerMessage[]): Session {
+function makeSessionEmittingViaClient(...messages: ServerMessage[]): Session {
   let clientHandler: (msg: ServerMessage) => void = () => {};
   return {
     isProcessing: () => false,
@@ -66,6 +75,25 @@ function makeSessionEmitting(...messages: ServerMessage[]): Session {
   } as unknown as Session;
 }
 
+/**
+ * Build a session that calls the onEvent callback with the given messages
+ * (simulates the primary agent-loop streaming path).
+ */
+function makeSessionEmittingViaAgentLoop(...messages: ServerMessage[]): Session {
+  return {
+    isProcessing: () => false,
+    persistUserMessage: () => undefined as unknown as string,
+    setAssistantId: () => {},
+    updateClient: () => {},
+    runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
+      for (const msg of messages) {
+        onEvent(msg);
+      }
+    },
+    handleConfirmationResponse: () => {},
+  } as unknown as Session;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('HTTP run → confirmation_request mirrors to assistant-events hub', () => {
@@ -76,7 +104,7 @@ describe('HTTP run → confirmation_request mirrors to assistant-events hub', ()
     db.run('DELETE FROM conversations');
   });
 
-  test('confirmation_request emits one AssistantEvent with correct shape', async () => {
+  test('confirmation_request (updateClient path) emits one AssistantEvent', async () => {
     const conversation = createConversation('http-confirmation-test');
     const confirmationMsg: ServerMessage = {
       type: 'confirmation_request',
@@ -87,7 +115,7 @@ describe('HTTP run → confirmation_request mirrors to assistant-events hub', ()
       allowlistOptions: [{ label: 'ls', description: 'List files', pattern: 'ls' }],
       scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
     };
-    const session = makeSessionEmitting(confirmationMsg);
+    const session = makeSessionEmittingViaClient(confirmationMsg);
 
     const received: AssistantEvent[] = [];
     const sub = assistantEventHub.subscribe(
@@ -122,7 +150,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
     db.run('DELETE FROM conversations');
   });
 
-  test('assistant_text_delta and message_complete emit in order', async () => {
+  test('assistant_text_delta and message_complete (onEvent path) emit in order', async () => {
     const conversation = createConversation('http-message-flow-test');
     const deltaMsg: ServerMessage = {
       type: 'assistant_text_delta',
@@ -133,7 +161,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
       type: 'message_complete',
       sessionId: conversation.id,
     };
-    const session = makeSessionEmitting(deltaMsg, completeMsg);
+    const session = makeSessionEmittingViaAgentLoop(deltaMsg, completeMsg);
 
     const received: AssistantEvent[] = [];
     const sub = assistantEventHub.subscribe(
@@ -162,11 +190,11 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
     expect(received[1].message).toBe(completeMsg);
   });
 
-  test('sessionId falls back to conversationId when message lacks it', async () => {
+  test('sessionId falls back to conversationId when message lacks it (onEvent path)', async () => {
     const conversation = createConversation('http-session-fallback-test');
     // pong has no sessionId field
     const msg: ServerMessage = { type: 'pong' };
-    const session = makeSessionEmitting(msg);
+    const session = makeSessionEmittingViaAgentLoop(msg);
 
     const received: AssistantEvent[] = [];
     const sub = assistantEventHub.subscribe(

--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests that HTTP-triggered run/session flows mirror messages into the
+ * assistant-events hub with payload parity to IPC outbound messages.
+ *
+ * Tests:
+ *   - confirmation_request → hub emits one AssistantEvent
+ *   - assistant_text_delta + message_complete → hub emits in order
+ */
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import type { Session } from '../daemon/session.js';
+import type { AssistantEvent } from '../runtime/assistant-event.js';
+
+const testDir = mkdtempSync(join(tmpdir(), 'run-orch-hub-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { createConversation } from '../memory/conversation-store.js';
+import { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import { assistantEventHub } from '../runtime/assistant-event-hub.js';
+
+initializeDb();
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a session that calls the updateClient handler with all given messages,
+ * then resolves (simulates a completed agent loop).
+ */
+function makeSessionEmitting(...messages: ServerMessage[]): Session {
+  let clientHandler: (msg: ServerMessage) => void = () => {};
+  return {
+    isProcessing: () => false,
+    persistUserMessage: () => undefined as unknown as string,
+    setAssistantId: () => {},
+    updateClient: (handler: (msg: ServerMessage) => void) => {
+      clientHandler = handler;
+    },
+    runAgentLoop: async () => {
+      for (const msg of messages) {
+        clientHandler(msg);
+      }
+    },
+    handleConfirmationResponse: () => {},
+  } as unknown as Session;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('HTTP run → confirmation_request mirrors to assistant-events hub', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_runs');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('confirmation_request emits one AssistantEvent with correct shape', async () => {
+    const conversation = createConversation('http-confirmation-test');
+    const confirmationMsg: ServerMessage = {
+      type: 'confirmation_request',
+      requestId: 'req-http-1',
+      toolName: 'bash',
+      input: { command: 'ls' },
+      riskLevel: 'medium',
+      allowlistOptions: [{ label: 'ls', description: 'List files', pattern: 'ls' }],
+      scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
+    };
+    const session = makeSessionEmitting(confirmationMsg);
+
+    const received: AssistantEvent[] = [];
+    const sub = assistantEventHub.subscribe(
+      { assistantId: 'ast-http-1' },
+      (e) => { received.push(e); },
+    );
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    await orchestrator.startRun('ast-http-1', conversation.id, 'Do something');
+    // Wait for the async hub chain to flush.
+    await new Promise((r) => setTimeout(r, 20));
+
+    sub.dispose();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].assistantId).toBe('ast-http-1');
+    expect(received[0].sessionId).toBe(conversation.id);
+    expect(received[0].message.type).toBe('confirmation_request');
+    expect(received[0].message).toBe(confirmationMsg);
+  });
+});
+
+describe('HTTP run → message flow mirrors to assistant-events hub', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_runs');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('assistant_text_delta and message_complete emit in order', async () => {
+    const conversation = createConversation('http-message-flow-test');
+    const deltaMsg: ServerMessage = {
+      type: 'assistant_text_delta',
+      sessionId: conversation.id,
+      text: 'Working on it...',
+    };
+    const completeMsg: ServerMessage = {
+      type: 'message_complete',
+      sessionId: conversation.id,
+    };
+    const session = makeSessionEmitting(deltaMsg, completeMsg);
+
+    const received: AssistantEvent[] = [];
+    const sub = assistantEventHub.subscribe(
+      { assistantId: 'ast-http-2' },
+      (e) => { received.push(e); },
+    );
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    await orchestrator.startRun('ast-http-2', conversation.id, 'Hello');
+    await new Promise((r) => setTimeout(r, 20));
+
+    sub.dispose();
+
+    expect(received).toHaveLength(2);
+    expect(received[0].message.type).toBe('assistant_text_delta');
+    expect(received[1].message.type).toBe('message_complete');
+    // Both should carry the session id
+    expect(received[0].sessionId).toBe(conversation.id);
+    expect(received[1].sessionId).toBe(conversation.id);
+    // Messages are the unmodified originals
+    expect(received[0].message).toBe(deltaMsg);
+    expect(received[1].message).toBe(completeMsg);
+  });
+
+  test('sessionId falls back to conversationId when message lacks it', async () => {
+    const conversation = createConversation('http-session-fallback-test');
+    // pong has no sessionId field
+    const msg: ServerMessage = { type: 'pong' };
+    const session = makeSessionEmitting(msg);
+
+    const received: AssistantEvent[] = [];
+    const sub = assistantEventHub.subscribe(
+      { assistantId: 'ast-http-3' },
+      (e) => { received.push(e); },
+    );
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    await orchestrator.startRun('ast-http-3', conversation.id, 'ping');
+    await new Promise((r) => setTimeout(r, 20));
+
+    sub.dispose();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].sessionId).toBe(conversation.id);
+  });
+});

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -18,6 +18,8 @@ import type { UserDecision } from '../permissions/types.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
+import { assistantEventHub } from './assistant-event-hub.js';
+import { buildAssistantEvent } from './assistant-event.js';
 
 const log = getLogger('run-orchestrator');
 
@@ -92,6 +94,23 @@ export class RunOrchestrator {
     // Set the assistant ID so attachments are scoped correctly.
     session.setAssistantId(assistantId);
 
+    // Serialized publish chain so hub subscribers observe events in order.
+    let hubChain: Promise<void> = Promise.resolve();
+    const publishToHub = (msg: ServerMessage): void => {
+      const msgRecord = msg as unknown as Record<string, unknown>;
+      const msgSessionId =
+        'sessionId' in msg && typeof msgRecord.sessionId === 'string'
+          ? (msgRecord.sessionId as string)
+          : undefined;
+      const resolvedSessionId = msgSessionId ?? conversationId;
+      const event = buildAssistantEvent(assistantId, msg, resolvedSessionId);
+      hubChain = hubChain
+        .then(() => assistantEventHub.publish(event))
+        .catch((err: unknown) => {
+          log.warn({ err }, 'assistant-events hub subscriber threw during HTTP run');
+        });
+    };
+
     // Hook into session to intercept confirmation_request events.
     // When the prompter sends a confirmation_request, we record it in the
     // run store so the web UI can poll and submit a decision.
@@ -118,6 +137,9 @@ export class RunOrchestrator {
           session,
         });
       }
+      // Mirror every outbound message to the assistant-events hub so SSE
+      // subscribers receive the same payload parity as IPC clients.
+      publishToHub(msg);
     });
 
     // Fire-and-forget the agent loop

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -158,6 +158,12 @@ export class RunOrchestrator {
       } else if (msg.type === 'session_error') {
         lastError = msg.userMessage;
       }
+      // Mirror agent-loop events (assistant_text_delta, message_complete,
+      // tool_use_start, tool_result, etc.) to the hub. These travel through
+      // the onEvent path, distinct from the updateClient path used by the
+      // prompter (confirmation_request). Both paths must publish so SSE
+      // consumers receive the full response stream.
+      publishToHub(msg);
     }).then(() => {
       if (lastError) {
         log.error({ runId: run.id, error: lastError }, 'Run failed (error event from agent loop)');


### PR DESCRIPTION
## Summary
- Add hub publishing to `RunOrchestrator.startRun` via the `updateClient` callback, mirroring all outbound messages (`confirmation_request`, `assistant_text_delta`, `message_complete`, etc.) to the `assistantEventHub`
- Use message-level `sessionId` when present, falling back to `conversationId` (parity with IPC daemon fallback to socket binding)
- Serialize hub publishes through a per-run promise chain so subscribers observe events in emission order

Part of plan: ASSISTANT-EVENTS-SSE-INCREMENTAL.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
