### PR TITLE
feat: add task_list_update tool for in-place work item mutations

### DIFF
--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -23,3 +23,4 @@ export { taskListTool } from './task-list.js';
 export { taskDeleteTool } from './task-delete.js';
 export { taskListShowTool } from './work-item-list.js';
 export { taskListAddTool } from './work-item-enqueue.js';
+export { taskListUpdateTool } from './work-item-update.js';

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -1,0 +1,122 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { resolveWorkItem, updateWorkItem, type WorkItemStatus } from '../../work-items/work-item-store.js';
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'high',
+  1: 'medium',
+  2: 'low',
+};
+
+const definition: ToolDefinition = {
+  name: 'task_list_update',
+  description:
+    'Update an existing task in the Task Queue. Can change priority, notes, status, or sort order. Identifies the task by work item ID, task ID, task name, or title.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      work_item_id: {
+        type: 'string',
+        description: 'Direct work item ID (most precise selector)',
+      },
+      task_id: {
+        type: 'string',
+        description: 'Task definition ID to find the work item for',
+      },
+      task_name: {
+        type: 'string',
+        description: 'Task name/title to search for (case-insensitive exact match)',
+      },
+      title: {
+        type: 'string',
+        description: 'Work item title to search for (case-insensitive exact match)',
+      },
+      priority_tier: {
+        type: 'number',
+        description: '0 = high, 1 = medium, 2 = low',
+      },
+      notes: {
+        type: 'string',
+        description: 'Updated notes for the work item',
+      },
+      status: {
+        type: 'string',
+        enum: ['queued', 'running', 'awaiting_review', 'failed', 'done', 'archived'],
+        description: 'New status for the work item',
+      },
+      sort_index: {
+        type: 'number',
+        description: 'Manual sort order within the same priority tier',
+      },
+    },
+  },
+};
+
+class TaskListUpdateTool implements Tool {
+  name = 'task_list_update';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    try {
+      // Build selector from whichever identifier was provided
+      const selector = {
+        workItemId: input.work_item_id as string | undefined,
+        taskId: input.task_id as string | undefined,
+        title: (input.task_name ?? input.title) as string | undefined,
+      };
+
+      // Resolve the target work item
+      const item = resolveWorkItem(selector);
+
+      // Build updates from provided fields
+      const updates: Partial<{
+        priorityTier: number;
+        notes: string;
+        status: WorkItemStatus;
+        sortIndex: number;
+      }> = {};
+      if (input.priority_tier !== undefined) updates.priorityTier = input.priority_tier as number;
+      if (input.notes !== undefined) updates.notes = input.notes as string;
+      if (input.status !== undefined) updates.status = input.status as WorkItemStatus;
+      if (input.sort_index !== undefined) updates.sortIndex = input.sort_index as number;
+
+      if (Object.keys(updates).length === 0) {
+        return {
+          content: 'No updates specified. Provide at least one field to update (priority_tier, notes, status, sort_index).',
+          isError: true,
+        };
+      }
+
+      const updated = updateWorkItem(item.id, updates);
+      if (!updated) {
+        return {
+          content: `Error: Failed to update work item "${item.title}".`,
+          isError: true,
+        };
+      }
+
+      // Build confirmation message
+      const parts: string[] = [`Updated "${updated.title}"`];
+      if (input.priority_tier !== undefined) {
+        parts.push(`priority → ${PRIORITY_LABELS[updated.priorityTier] ?? updated.priorityTier}`);
+      }
+      if (input.notes !== undefined) parts.push('notes updated');
+      if (input.status !== undefined) parts.push(`status → ${updated.status}`);
+      if (input.sort_index !== undefined) parts.push(`sort index → ${updated.sortIndex}`);
+
+      return { content: parts.join(', ') + '.', isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const taskListUpdateTool = new TaskListUpdateTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,7 +18,7 @@ import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 import { followupCreateTool, followupListTool, followupResolveTool } from './followups/index.js';
-import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, taskListShowTool, taskListAddTool } from './tasks/index.js';
+import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, taskListShowTool, taskListAddTool, taskListUpdateTool } from './tasks/index.js';
 import {
   subagentSpawnTool,
   subagentStatusTool,
@@ -121,6 +121,7 @@ export const explicitTools: Tool[] = [
   taskDeleteTool,
   taskListShowTool,
   taskListAddTool,
+  taskListUpdateTool,
   subagentSpawnTool,
   subagentStatusTool,
   subagentAbortTool,


### PR DESCRIPTION
## Summary
- Adds a new `task_list_update` tool that enables in-place mutation of existing work items in the Task Queue
- Supports updating `priority_tier`, `notes`, `status`, and `sort_index` fields
- Identifies target work items via flexible selectors: `work_item_id`, `task_id`, `task_name`, or `title` (uses `resolveWorkItem` helper for deterministic resolution)
- Follows the same class-based `Tool` pattern as `task_list_add`, with proper error handling and confirmation messages

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed locally)
- [ ] Create a work item via `task_list_add`, then update it via `task_list_update` using each selector type
- [ ] Confirm error handling for missing selectors, no matching items, and empty updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
