### PR TITLE
feat: wire tasks_changed callback in DaemonClient

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -272,6 +272,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `work_item_status_changed` broadcast.
     public var onWorkItemStatusChanged: ((IPCWorkItemStatusChanged) -> Void)?
 
+    /// Called when the daemon sends a `tasks_changed` broadcast.
+    public var onTasksChanged: ((IPCTasksChanged) -> Void)?
+
     /// Called when the daemon sends a `work_item_run_task_response` message.
     public var onWorkItemRunTaskResponse: ((IPCWorkItemRunTaskResponse) -> Void)?
 
@@ -1416,6 +1419,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onWorkItemsListResponse?(msg)
         case .workItemStatusChanged(let msg):
             onWorkItemStatusChanged?(msg)
+        case .tasksChanged(let msg):
+            onTasksChanged?(msg)
         case .workItemRunTaskResponse(let msg):
             onWorkItemRunTaskResponse?(msg)
         case .workItemUpdateResponse(let msg):


### PR DESCRIPTION
## Summary
- Add `onTasksChanged` callback property to `DaemonClient` for receiving `tasks_changed` broadcasts from the daemon
- Add dispatch case in `handleServerMessage` to invoke the callback when a `.tasksChanged` message arrives
- Follows the exact same pattern as `onWorkItemStatusChanged`

## Context
PR08 added the `tasks_changed` IPC message type (`IPCTasksChanged` struct in generated code, `.tasksChanged` case in `ServerMessage`). This PR wires the callback so downstream consumers (PR12) can subscribe to task change notifications.

## Test plan
- [x] Swift build succeeds with no errors
- [ ] Callback is invoked when daemon sends `tasks_changed` (verified in PR12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
