### PR TITLE
feat: emit tasks_changed broadcast from all work-item mutation handlers

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -57,6 +57,7 @@ export function handleWorkItemCreate(
 
   // Notify all connected clients so open Task Queue views refresh immediately
   broadcastWorkItemStatus(ctx, item.id);
+  ctx.broadcast({ type: 'tasks_changed' });
 }
 
 export function handleWorkItemUpdate(
@@ -78,6 +79,7 @@ export function handleWorkItemUpdate(
   // (e.g. priority/sort changes made by one client are reflected everywhere)
   if (item) {
     broadcastWorkItemStatus(ctx, item.id);
+    ctx.broadcast({ type: 'tasks_changed' });
   }
 }
 
@@ -102,6 +104,7 @@ export function handleWorkItemComplete(
         updatedAt: item.updatedAt,
       },
     });
+    ctx.broadcast({ type: 'tasks_changed' });
   }
 }
 
@@ -143,6 +146,7 @@ export async function handleWorkItemRunTask(
 
   // Broadcast the running state
   broadcastWorkItemStatus(ctx, msg.id);
+  ctx.broadcast({ type: 'tasks_changed' });
 
   // Execute task asynchronously — create a session and wire processMessage
   try {
@@ -165,6 +169,7 @@ export async function handleWorkItemRunTask(
     });
 
     broadcastWorkItemStatus(ctx, msg.id);
+    ctx.broadcast({ type: 'tasks_changed' });
   } catch (err) {
     log.error({ err, workItemId: msg.id }, 'work_item_run_task failed');
     updateWorkItem(msg.id, {
@@ -172,5 +177,6 @@ export async function handleWorkItemRunTask(
       lastRunStatus: 'failed',
     });
     broadcastWorkItemStatus(ctx, msg.id);
+    ctx.broadcast({ type: 'tasks_changed' });
   }
 }


### PR DESCRIPTION
## Summary

- Adds `ctx.broadcast({ type: 'tasks_changed' })` after every successful work-item mutation in the daemon IPC handlers
- Covers all four mutation handlers: `handleWorkItemCreate`, `handleWorkItemUpdate`, `handleWorkItemComplete`, and `handleWorkItemRunTask`
- For `handleWorkItemRunTask`, emits at all three mutation points: initial "running" status, completion (success), and error (failure)
- Complements existing per-item `work_item_status_changed` broadcasts with a simpler list-level invalidation signal that tells clients "refetch your task list"

## Test plan

- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Create a work item via IPC and verify `tasks_changed` is broadcast to connected clients
- [ ] Update a work item and verify `tasks_changed` is broadcast
- [ ] Complete a work item and verify `tasks_changed` is broadcast
- [ ] Run a task and verify `tasks_changed` is broadcast at each status transition (running, completed/failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
