### PR TITLE
feat: subscribe TasksWindowView to tasks_changed broadcasts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -115,7 +115,7 @@ struct TasksWindowView: View {
         .background(VColor.background)
         .onAppear {
             fetchWorkItems()
-            listenForStatusChanges()
+            listenForChanges()
         }
     }
 
@@ -138,10 +138,10 @@ struct TasksWindowView: View {
         }
     }
 
-    private func listenForStatusChanges() {
-        daemonClient.onWorkItemStatusChanged = { _ in
-            // Debounce rapid broadcasts so multiple priority edits coalesce
-            // into a single re-fetch instead of N overlapping calls.
+    private func listenForChanges() {
+        // Debounce rapid broadcasts so multiple mutations coalesce
+        // into a single re-fetch instead of N overlapping calls.
+        let scheduleRefresh = {
             refreshTask?.cancel()
             refreshTask = Task {
                 try? await Task.sleep(nanoseconds: 300_000_000) // 300ms
@@ -149,9 +149,17 @@ struct TasksWindowView: View {
                 do {
                     try daemonClient.sendWorkItemsList()
                 } catch {
-                    // Silently ignore; the list will refresh on next status change
+                    // Silently ignore; the list will refresh on next change
                 }
             }
+        }
+
+        daemonClient.onWorkItemStatusChanged = { _ in
+            scheduleRefresh()
+        }
+
+        daemonClient.onTasksChanged = { _ in
+            scheduleRefresh()
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `onTasksChanged` subscription to `TasksWindowView` so the task list refreshes when any queue mutation happens (not just individual item status changes)
- Refactors `listenForStatusChanges()` into `listenForChanges()` with a shared `scheduleRefresh` closure that both `onWorkItemStatusChanged` and `onTasksChanged` funnel into
- Both callbacks share the same 300ms debounce to coalesce rapid updates into a single re-fetch

## Test plan
- [ ] Verify Tasks window updates when a task is added/removed via daemon IPC (`tasks_changed` broadcast)
- [ ] Verify Tasks window still updates on individual work item status changes (`onWorkItemStatusChanged`)
- [ ] Verify rapid mutations are debounced (only one re-fetch fires after a burst)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
