### PR TITLE
feat: add logging for task_list_add duplicate-prevention decisions

### DIFF
--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -3,6 +3,9 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getTask, listTasks, createTask } from '../../tasks/task-store.js';
 import { createWorkItem, findActiveWorkItemsByTitle, updateWorkItem } from '../../work-items/work-item-store.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('task-list-add');
 
 const PRIORITY_LABELS: Record<number, string> = {
   0: 'high',
@@ -77,8 +80,10 @@ class TaskListAddTool implements Tool {
     if (existing.length === 0) return null;
 
     const match = existing[0];
+    log.info({ title, existingId: match.id, ifExists }, 'task_list_add: duplicate detected');
 
     if (ifExists === 'reuse_existing') {
+      log.info({ title, existingId: match.id }, 'task_list_add: reused existing item');
       return {
         content: `Task "${match.title}" already exists in the queue (ID: ${match.id}, status: ${match.status}). Use task_list_update to modify it.`,
         isError: false,
@@ -93,6 +98,7 @@ class TaskListAddTool implements Tool {
       if (Object.keys(updates).length > 0) {
         updateWorkItem(match.id, updates);
       }
+      log.info({ title, existingId: match.id, updates }, 'task_list_add: updated existing item');
       return {
         content: `Reused existing task "${match.title}" (ID: ${match.id}) instead of creating a duplicate.${
           Object.keys(updates).length > 0 ? ` Updated: ${Object.keys(updates).join(', ')}.` : ''
@@ -128,7 +134,11 @@ class TaskListAddTool implements Tool {
         if (ifExists !== 'create_duplicate') {
           const duplicateResult = this.handleDuplicate(titleOverride, ifExists, input);
           if (duplicateResult) return duplicateResult;
+        } else {
+          log.info({ title: titleOverride }, 'task_list_add: creating duplicate (if_exists=create_duplicate)');
         }
+
+        log.debug({ title: titleOverride }, 'task_list_add: creating new item');
 
         // Auto-create a lightweight task template for the ad-hoc item
         const adHocTask = createTask({
@@ -202,7 +212,11 @@ class TaskListAddTool implements Tool {
       if (ifExists !== 'create_duplicate') {
         const duplicateResult = this.handleDuplicate(finalTitle, ifExists, input);
         if (duplicateResult) return duplicateResult;
+      } else {
+        log.info({ title: finalTitle }, 'task_list_add: creating duplicate (if_exists=create_duplicate)');
       }
+
+      log.debug({ title: finalTitle }, 'task_list_add: creating new item');
 
       const workItem = createWorkItem({
         taskId: resolvedTask.id,


### PR DESCRIPTION
## Summary
- Adds pino logging at each duplicate-prevention decision point in `task_list_add` so regressions are diagnosable from daemon traces
- Logs at `info` level when duplicates are detected, reused, updated, or explicitly bypassed via `create_duplicate`
- Logs at `debug` level for normal item creation (no duplicate found)

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify log output by triggering each code path: add item, add duplicate (default reuse), add duplicate with `update_existing`, add duplicate with `create_duplicate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
