### PR TITLE
feat: force refresh when re-showing existing Tasks window

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
@@ -17,6 +17,8 @@ final class TasksWindow {
         if let existing = window {
             existing.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
+            // Force a data refresh so the view doesn't show stale items
+            try? daemonClient.sendWorkItemsList()
             return
         }
 


### PR DESCRIPTION
## Summary
- When the Tasks window already exists and `showTasksWindow()` is called again, the window was only brought to front without refreshing data
- Now calls `daemonClient.sendWorkItemsList()` in the "window already exists" branch so the existing `onWorkItemsListResponse` callback receives fresh data
- No double-fetch on initial window creation — `onAppear` still handles that path

## Test plan
- [ ] Open the Tasks window, leave it in the background while tasks change, then re-open via menu — data should refresh immediately
- [ ] Open the Tasks window for the first time — verify it loads normally via `onAppear` (no double fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
