### PR TITLE
fix: make task_progress title optional with card-level fallback

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
@@ -16,7 +16,7 @@ public struct InlineCardWidget: View {
             InlineWeatherWidget(data: weatherData)
         } else if data.template == "task_progress",
                   let templateData = data.templateData,
-                  let progressData = TaskProgressData.parse(from: templateData) {
+                  let progressData = TaskProgressData.parse(from: templateData, fallbackTitle: data.title) {
             InlineTaskProgressWidget(data: progressData)
         } else {
             standardCardLayout

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -27,11 +27,11 @@ public struct TaskProgressData {
         self.steps = steps
     }
 
-    public static func parse(from dict: [String: Any?]) -> TaskProgressData? {
-        guard let title = dict["title"] as? String,
-              let stepsArray = dict["steps"] as? [[String: Any?]] else {
+    public static func parse(from dict: [String: Any?], fallbackTitle: String? = nil) -> TaskProgressData? {
+        guard let stepsArray = dict["steps"] as? [[String: Any?]] else {
             return nil
         }
+        let title = dict["title"] as? String ?? fallbackTitle ?? "Task"
 
         let status = dict["status"] as? String ?? "in_progress"
 


### PR DESCRIPTION
## Summary
- Make `title` optional in `TaskProgressData.parse(from:)` — falls back to the card-level title from `CardSurfaceData`, then to `"Task"`
- Addresses Codex review feedback on #5132: senders no longer need to duplicate `title` in both `data` and `templateData`

## Test plan
- [x] `build.sh` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
