### PR TITLE
feat: add Image Generation settings with Gemini API key

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -20,6 +20,7 @@ struct SettingsPanel: View {
     @State private var apiKeyText: String = ""
     @State private var braveKeyText: String = ""
     @State private var perplexityKeyText: String = ""
+    @State private var imageGenKeyText: String = ""
     @State private var showingTrustRules = false
     @State private var showingScheduledTasks = false
     @State private var showingReminders = false
@@ -413,6 +414,79 @@ struct SettingsPanel: View {
                     VButton(label: "Save", style: .primary) {
                         store.saveBraveKey(braveKeyText)
                         braveKeyText = ""
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            // IMAGE GENERATION section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Image Generation")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                if store.hasImageGenKey {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 14))
+                        Text(store.maskedImageGenKey)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        VButton(label: "Clear", style: .danger) {
+                            store.clearImageGenKey()
+                            imageGenKeyText = ""
+                        }
+                    }
+
+                    HStack {
+                        Text("Model")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        Picker("", selection: Binding(
+                            get: { store.selectedImageGenModel },
+                            set: { store.setImageGenModel($0) }
+                        )) {
+                            ForEach(SettingsStore.availableImageGenModels, id: \.self) { model in
+                                Text(SettingsStore.imageGenModelDisplayNames[model] ?? model)
+                                    .tag(model)
+                            }
+                        }
+                        .labelsHidden()
+                        .fixedSize()
+                    }
+                } else {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Enter Gemini API Key")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.textMuted)
+                    }
+
+                    SecureField("Your Gemini API key", text: $imageGenKeyText)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(VSpacing.md)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                        )
+
+                    Text("Get your API key at aistudio.google.com/apikey")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    VButton(label: "Save", style: .primary) {
+                        store.saveImageGenKey(imageGenKeyText)
+                        imageGenKeyText = ""
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -11,15 +11,18 @@ public final class SettingsStore: ObservableObject {
     @Published var hasKey: Bool
     @Published var hasBraveKey: Bool
     @Published var hasPerplexityKey: Bool
+    @Published var hasImageGenKey: Bool
     @Published var hasVercelKey: Bool = false
     @Published var maskedKey: String = ""
     @Published var maskedBraveKey: String = ""
     @Published var maskedPerplexityKey: String = ""
+    @Published var maskedImageGenKey: String = ""
 
     // MARK: - Model Selection
 
     @Published var selectedModel: String = "claude-opus-4-6"
     @Published var configuredProviders: Set<String> = ["ollama"]
+    @Published var selectedImageGenModel: String = "gemini-2.5-flash-image"
 
     static let availableModels: [String] = [
         "claude-opus-4-6",
@@ -33,6 +36,16 @@ public final class SettingsStore: ObservableObject {
         "claude-opus-4-6-fast": "Claude Opus 4.6 Fast",
         "claude-sonnet-4-6": "Claude Sonnet 4.6",
         "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+    ]
+
+    static let availableImageGenModels: [String] = [
+        "gemini-2.5-flash-image",
+        "gemini-3-pro-image-preview",
+    ]
+
+    static let imageGenModelDisplayNames: [String: String] = [
+        "gemini-2.5-flash-image": "Gemini 2.5 Flash Image",
+        "gemini-3-pro-image-preview": "Gemini 3 Pro Image (Preview)",
     ]
 
     // MARK: - Settings Values
@@ -83,6 +96,14 @@ public final class SettingsStore: ObservableObject {
         let perplexityKey = APIKeyManager.getKey(for: "perplexity")
         self.hasPerplexityKey = perplexityKey != nil
         self.maskedPerplexityKey = Self.maskKey(perplexityKey)
+        let imageGenKey = APIKeyManager.getKey(for: "gemini")
+        self.hasImageGenKey = imageGenKey != nil
+        self.maskedImageGenKey = Self.maskKey(imageGenKey)
+
+        let storedImageGenModel = UserDefaults.standard.string(forKey: "selectedImageGenModel")
+        if let storedImageGenModel, Self.availableImageGenModels.contains(storedImageGenModel) {
+            self.selectedImageGenModel = storedImageGenModel
+        }
 
         let storedMaxSteps = UserDefaults.standard.double(forKey: "maxStepsPerSession")
         self.maxSteps = storedMaxSteps == 0 ? 50 : storedMaxSteps
@@ -183,6 +204,25 @@ public final class SettingsStore: ObservableObject {
         maskedPerplexityKey = ""
     }
 
+    func saveImageGenKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setKey(trimmed, for: "gemini")
+        hasImageGenKey = true
+        maskedImageGenKey = Self.maskKey(trimmed)
+    }
+
+    func clearImageGenKey() {
+        APIKeyManager.deleteKey(for: "gemini")
+        hasImageGenKey = false
+        maskedImageGenKey = ""
+    }
+
+    func setImageGenModel(_ model: String) {
+        selectedImageGenModel = model
+        UserDefaults.standard.set(model, forKey: "selectedImageGenModel")
+    }
+
     func refreshAPIKeyState() {
         let anthropicKey = APIKeyManager.getKey()
         hasKey = anthropicKey != nil
@@ -195,6 +235,10 @@ public final class SettingsStore: ObservableObject {
         let perplexityKey = APIKeyManager.getKey(for: "perplexity")
         hasPerplexityKey = perplexityKey != nil
         maskedPerplexityKey = Self.maskKey(perplexityKey)
+
+        let imageGenKey = APIKeyManager.getKey(for: "gemini")
+        hasImageGenKey = imageGenKey != nil
+        maskedImageGenKey = Self.maskKey(imageGenKey)
     }
 
     /// Shows the first 10 and last 4 characters of a key, e.g. "sk-ant-api...Ab1x".

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ public struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var braveKeyText = ""
     @State private var perplexityKeyText = ""
+    @State private var imageGenKeyText = ""
     @State private var vercelKeyText = ""
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
@@ -142,6 +143,48 @@ public struct SettingsView: View {
                             braveKeyText = ""
                         }
                         .disabled(braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+
+            Section("Image Generation") {
+                if store.hasImageGenKey {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.system(size: 14))
+                        Text(store.maskedImageGenKey)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Clear") {
+                            store.clearImageGenKey()
+                            imageGenKeyText = ""
+                        }
+                        .tint(.red)
+                    }
+
+                    Picker("Model", selection: $store.selectedImageGenModel) {
+                        ForEach(SettingsStore.availableImageGenModels, id: \.self) { model in
+                            Text(SettingsStore.imageGenModelDisplayNames[model] ?? model)
+                                .tag(model)
+                        }
+                    }
+                    .onChange(of: store.selectedImageGenModel) { _, newValue in
+                        store.setImageGenModel(newValue)
+                    }
+                } else {
+                    SecureField("Enter Gemini API key", text: $imageGenKeyText)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Text("Get your API key at aistudio.google.com/apikey")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Save") {
+                            store.saveImageGenKey(imageGenKeyText)
+                            imageGenKeyText = ""
+                        }
+                        .disabled(imageGenKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds a new "Image Generation" section to both the standalone Settings window and the Settings side panel
- Users can enter their Gemini API key (stored in macOS Keychain under the `gemini` provider) and select between Gemini 2.5 Flash Image and Gemini 3 Pro Image (Preview) models
- Model selection persisted via UserDefaults; key managed through existing `APIKeyManager` keychain infrastructure

## Test plan
- [ ] Open Settings window → verify "Image Generation" section appears between Brave Search and Vercel
- [ ] Enter a Gemini API key → verify it saves and shows masked key with green checkmark
- [ ] Verify model picker appears after key is saved with both Gemini models
- [ ] Switch models → relaunch app → verify selection persists
- [ ] Clear the key → verify section reverts to key entry state
- [ ] Open Settings side panel (Integrations tab) → verify matching Image Generation card appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
