### PR TITLE
feat: add task_list_remove tool

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -200,7 +200,7 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '',
     'These three systems serve different purposes. Choose the right one based on user intent:',
     '',
-    '### Task Queue (task_list_add / task_list_show / task_list_update)',
+    '### Task Queue (task_list_add / task_list_show / task_list_update / task_list_remove)',
     'For tracking things the user wants to do or remember. Use when the user says:',
     '- "Add to my tasks", "add to my queue", "put this on my task list"',
     '- "Track this", "I need to do X", "queue this up"',
@@ -211,6 +211,10 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '- "Change the status of X", "mark X as done"',
     '- "Update the notes on X"',
     'Do NOT use `task_list_add` for updates — it will detect duplicates and suggest using `task_list_update` instead.',
+    '',
+    'To remove a task from the queue, use `task_list_remove`:',
+    '- "Remove X from my tasks", "delete that task", "clean up the duplicate"',
+    '- "Take this off the list", "drop this task"',
     '',
     'You can create ad-hoc work items by providing just a `title` to `task_list_add` — no existing task template is needed. A lightweight template is auto-created behind the scenes. For reusable task definitions with templates and input schemas, use `task_save` first.',
     '',
@@ -233,6 +237,8 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '- "Bump priority on X" → task_list_update (NOT task_list_add)',
     '- "Move this up" / "change this task priority" → task_list_update (NOT task_list_add)',
     '- "Mark X as done" → task_list_update (NOT task_list_add)',
+    '- "Remove X from my tasks" → task_list_remove (NOT task_list_update)',
+    '- "Delete that task" / "clean up the duplicate" → task_list_remove',
   ].join('\n');
 }
 

--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -24,3 +24,4 @@ export { taskDeleteTool } from './task-delete.js';
 export { taskListShowTool } from './work-item-list.js';
 export { taskListAddTool } from './work-item-enqueue.js';
 export { taskListUpdateTool } from './work-item-update.js';
+export { taskListRemoveTool } from './work-item-remove.js';

--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -1,0 +1,64 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { resolveWorkItem, deleteWorkItem } from '../../work-items/work-item-store.js';
+
+const definition: ToolDefinition = {
+  name: 'task_list_remove',
+  description:
+    'Remove a task from the Task Queue. Identifies the task by work item ID, task ID, task name, or title.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      work_item_id: {
+        type: 'string',
+        description: 'Direct work item ID (most precise selector)',
+      },
+      task_id: {
+        type: 'string',
+        description: 'Task definition ID to find the work item for',
+      },
+      task_name: {
+        type: 'string',
+        description: 'Task name/title to search for (case-insensitive exact match)',
+      },
+      title: {
+        type: 'string',
+        description: 'Work item title to search for (case-insensitive exact match)',
+      },
+    },
+  },
+};
+
+class TaskListRemoveTool implements Tool {
+  name = 'task_list_remove';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    try {
+      const selector = {
+        workItemId: input.work_item_id as string | undefined,
+        taskId: input.task_id as string | undefined,
+        title: (input.task_name ?? input.title) as string | undefined,
+      };
+
+      const item = resolveWorkItem(selector);
+      const title = item.title;
+
+      deleteWorkItem(item.id);
+
+      return { content: `Removed "${title}" from the task queue.`, isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const taskListRemoveTool = new TaskListRemoveTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -18,7 +18,7 @@ import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
 import { followupCreateTool, followupListTool, followupResolveTool } from './followups/index.js';
-import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, taskListShowTool, taskListAddTool, taskListUpdateTool } from './tasks/index.js';
+import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, taskListShowTool, taskListAddTool, taskListUpdateTool, taskListRemoveTool } from './tasks/index.js';
 import {
   subagentSpawnTool,
   subagentStatusTool,
@@ -122,6 +122,7 @@ export const explicitTools: Tool[] = [
   taskListShowTool,
   taskListAddTool,
   taskListUpdateTool,
+  taskListRemoveTool,
   subagentSpawnTool,
   subagentStatusTool,
   subagentAbortTool,


### PR DESCRIPTION
## Summary
- Add `task_list_remove` tool for removing work items from the task queue
- Uses `resolveWorkItem` selector (by ID, task ID, or title) to find the target
- Update system prompt routing to guide "remove/delete task" requests to the new tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
