### PR TITLE
refactor: remove assistantId from daemon runtime entrypoints + orchestrator

### DIFF
--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -92,7 +92,7 @@ describe('run failure detection', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Hello');
+    const run = await orchestrator.startRun(conversation.id, 'Hello');
 
     // The agent loop fires asynchronously; give it a tick to settle.
     await new Promise((r) => setTimeout(r, 50));
@@ -114,7 +114,7 @@ describe('run failure detection', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Hello');
+    const run = await orchestrator.startRun(conversation.id, 'Hello');
 
     await new Promise((r) => setTimeout(r, 50));
 
@@ -192,7 +192,7 @@ describe('run approval state executionTarget', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Run host command');
+    const run = await orchestrator.startRun(conversation.id, 'Run host command');
     const stored = orchestrator.getRun(run.id);
     expect(stored?.status).toBe('needs_confirmation');
     expect(stored?.pendingConfirmation?.executionTarget).toBe('host');

--- a/assistant/src/__tests__/runtime-runs.test.ts
+++ b/assistant/src/__tests__/runtime-runs.test.ts
@@ -145,7 +145,7 @@ describe('runtime runs — swarm lifecycle', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Build a feature');
+    const run = await orchestrator.startRun(conversation.id, 'Build a feature');
     expect(run.status).toBe('running');
 
     // Wait for agent loop to complete
@@ -162,7 +162,7 @@ describe('runtime runs — swarm lifecycle', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Run swarm');
+    const run = await orchestrator.startRun(conversation.id, 'Run swarm');
 
     await new Promise((r) => setTimeout(r, 50));
 
@@ -178,7 +178,7 @@ describe('runtime runs — swarm lifecycle', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Delegate a swarm task');
+    const run = await orchestrator.startRun(conversation.id, 'Delegate a swarm task');
 
     // Give agent loop time to emit confirmation_request
     await new Promise((r) => setTimeout(r, 50));
@@ -195,7 +195,7 @@ describe('runtime runs — swarm lifecycle', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Run with approval');
+    const run = await orchestrator.startRun(conversation.id, 'Run with approval');
     await new Promise((r) => setTimeout(r, 50));
 
     // Verify pending state
@@ -220,12 +220,12 @@ describe('runtime runs — swarm lifecycle', () => {
     });
 
     // First run starts and hangs
-    await orchestrator.startRun('assistant-1', conversation.id, 'First run');
+    await orchestrator.startRun(conversation.id, 'First run');
     await new Promise((r) => setTimeout(r, 20));
 
     // Second run on the same session should be rejected
     try {
-      await orchestrator.startRun('assistant-1', conversation.id, 'Second run');
+      await orchestrator.startRun(conversation.id, 'Second run');
       // Should not reach here
       expect(true).toBe(false);
     } catch (err) {
@@ -252,7 +252,7 @@ describe('runtime runs — swarm lifecycle', () => {
       resolveAttachments: () => [],
     });
 
-    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Run with principal');
+    const run = await orchestrator.startRun(conversation.id, 'Run with principal');
     await new Promise((r) => setTimeout(r, 50));
 
     const stored = orchestrator.getRun(run.id);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -328,7 +328,7 @@ export async function runDaemon(): Promise<void> {
 
   const scheduler = startScheduler(
     async (conversationId, message) => {
-      await server.processMessage('schedule', conversationId, message);
+      await server.processMessage(conversationId, message);
     },
     (reminder) => {
       server.broadcast({
@@ -382,10 +382,10 @@ export async function runDaemon(): Promise<void> {
         port,
         hostname,
         bearerToken,
-        processMessage: (assistantId, conversationId, content, attachmentIds, options, sourceChannel) =>
-          server.processMessage(assistantId, conversationId, content, attachmentIds, options, sourceChannel),
-        persistAndProcessMessage: (assistantId, conversationId, content, attachmentIds, options, sourceChannel) =>
-          server.persistAndProcessMessage(assistantId, conversationId, content, attachmentIds, options, sourceChannel),
+        processMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
+          server.processMessage(conversationId, content, attachmentIds, options, sourceChannel),
+        persistAndProcessMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
+          server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel),
         runOrchestrator: server.createRunOrchestrator(),
         interfacesDir: getInterfacesDir(),
       });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -967,7 +967,6 @@ export class DaemonServer {
    * is not blocked for the duration of the agent loop.
    */
   async persistAndProcessMessage(
-    assistantId: string,
     conversationId: string,
     content: string,
     attachmentIds?: string[],
@@ -988,14 +987,14 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
-    // Set assistantId AFTER the isProcessing check so a rejected request
-    // doesn't mutate the session state visible to an in-flight request.
-    session.setAssistantId(assistantId);
+    // Set the session identity AFTER the isProcessing check so a rejected
+    // request doesn't mutate the session state visible to an in-flight request.
+    session.setAssistantId('self');
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
-      ? attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds).map((a) => ({
+      ? attachmentsStore.getAttachmentsByIds('self', attachmentIds).map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,
@@ -1022,7 +1021,6 @@ export class DaemonServer {
    * Used by the channel inbound endpoint which needs the assistant reply.
    */
   async processMessage(
-    assistantId: string,
     conversationId: string,
     content: string,
     attachmentIds?: string[],
@@ -1041,14 +1039,14 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
-    // Set assistantId AFTER the isProcessing check so a rejected request
-    // doesn't mutate the session state visible to an in-flight request.
-    session.setAssistantId(assistantId);
+    // Set the session identity AFTER the isProcessing check so a rejected
+    // request doesn't mutate the session state visible to an in-flight request.
+    session.setAssistantId('self');
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
-      ? attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds).map((a) => ({
+      ? attachmentsStore.getAttachmentsByIds('self', attachmentIds).map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,
@@ -1072,8 +1070,8 @@ export class DaemonServer {
     return new RunOrchestrator({
       getOrCreateSession: (conversationId) =>
         this.getOrCreateSession(conversationId),
-      resolveAttachments: (assistantId, attachmentIds) =>
-        attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds).map((a) => ({
+      resolveAttachments: (attachmentIds) =>
+        attachmentsStore.getAttachmentsByIds('self', attachmentIds).map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -427,7 +427,6 @@ export class RuntimeHttpServer {
 
       try {
         const { messageId: userMessageId } = await this.processMessage(
-          event.assistantId,
           event.conversationId,
           content,
           attachmentIds,

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -12,7 +12,6 @@ export interface RuntimeMessageSessionOptions {
 }
 
 export type MessageProcessor = (
-  assistantId: string,
   conversationId: string,
   content: string,
   attachmentIds?: string[],
@@ -26,7 +25,6 @@ export type MessageProcessor = (
  * immediately.
  */
 export type NonBlockingMessageProcessor = (
-  assistantId: string,
   conversationId: string,
   content: string,
   attachmentIds?: string[],

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -220,7 +220,6 @@ export async function handleChannelInbound(
       }
 
       const { messageId: userMessageId } = await processMessage(
-        "self",
         result.conversationId,
         content ?? '',
         hasAttachments ? attachmentIds : undefined,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -190,7 +190,6 @@ export async function handleSendMessage(
 
   try {
     const result = await processor(
-      "self",
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -53,7 +53,6 @@ export async function handleCreateRun(
 
   try {
     const run = await runOrchestrator.startRun(
-      "self",
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -32,7 +32,7 @@ interface PendingRunState {
 
 export interface RunOrchestratorDeps {
   getOrCreateSession: (conversationId: string) => Promise<Session>;
-  resolveAttachments: (assistantId: string, attachmentIds: string[]) => Array<{
+  resolveAttachments: (attachmentIds: string[]) => Array<{
     id: string;
     filename: string;
     mimeType: string;
@@ -64,7 +64,6 @@ export class RunOrchestrator {
    * and fire the agent loop in the background.
    */
   async startRun(
-    assistantId: string,
     conversationId: string,
     content: string,
     attachmentIds?: string[],
@@ -82,15 +81,15 @@ export class RunOrchestrator {
     }
 
     const attachments = attachmentIds
-      ? this.deps.resolveAttachments(assistantId, attachmentIds)
+      ? this.deps.resolveAttachments(attachmentIds)
       : [];
 
     const requestId = crypto.randomUUID();
     const messageId = session.persistUserMessage(content, attachments, requestId);
-    const run = runsStore.createRun(assistantId, conversationId, messageId);
+    const run = runsStore.createRun('self', conversationId, messageId);
 
     // Set the assistant ID so attachments are scoped correctly.
-    session.setAssistantId(assistantId);
+    session.setAssistantId('self');
 
     // Hook into session to intercept confirmation_request events.
     // When the prompter sends a confirmation_request, we record it in the


### PR DESCRIPTION
## Summary
- Remove `assistantId` parameter from `DaemonServer.processMessage` and `persistAndProcessMessage`; hardcode `'self'` internally
- Remove `assistantId` from `RunOrchestrator.startRun` and `RunOrchestratorDeps.resolveAttachments`; use `'self'` throughout
- Update `MessageProcessor`/`NonBlockingMessageProcessor` types and all call sites in routes to drop the now-redundant `assistantId` argument
- Fix scheduler to pass only `conversationId` (not a synthetic `'schedule'` assistant ID) to `processMessage`

Part of plan: REMOVE-ASSISTANT-ID-INCREMENTAL.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
