### PR TITLE
Remove assistant-scoped session/usage identity plumbing

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -43,7 +43,6 @@ function makeInput(overrides?: Partial<UsageEventInput>): UsageEventInput {
     cacheCreationInputTokens: null,
     cacheReadInputTokens: null,
     actor: 'main_agent',
-    assistantId: null,
     conversationId: null,
     runId: null,
     requestId: null,
@@ -86,7 +85,7 @@ describe('recordUsageEvent', () => {
   });
 
   test('persists a priced event that can be retrieved', () => {
-    const input = makeInput({ assistantId: 'a1', conversationId: 'c1' });
+    const input = makeInput({ conversationId: 'c1' });
     const event = recordUsageEvent(input, pricedResult);
 
     const events = listUsageEvents();
@@ -94,7 +93,6 @@ describe('recordUsageEvent', () => {
     expect(events[0].id).toBe(event.id);
     expect(events[0].estimatedCostUsd).toBe(0.0045);
     expect(events[0].pricingStatus).toBe('priced');
-    expect(events[0].assistantId).toBe('a1');
     expect(events[0].conversationId).toBe('c1');
   });
 
@@ -113,7 +111,6 @@ describe('recordUsageEvent', () => {
 
   test('handles null optional fields', () => {
     const input = makeInput({
-      assistantId: null,
       conversationId: null,
       runId: null,
       requestId: null,
@@ -124,7 +121,6 @@ describe('recordUsageEvent', () => {
 
     const events = listUsageEvents();
     expect(events).toHaveLength(1);
-    expect(events[0].assistantId).toBeNull();
     expect(events[0].conversationId).toBeNull();
     expect(events[0].runId).toBeNull();
     expect(events[0].requestId).toBeNull();
@@ -134,7 +130,6 @@ describe('recordUsageEvent', () => {
 
   test('handles populated optional fields', () => {
     const input = makeInput({
-      assistantId: 'assistant-1',
       conversationId: 'conv-1',
       runId: 'run-1',
       requestId: 'req-1',
@@ -145,7 +140,6 @@ describe('recordUsageEvent', () => {
 
     const events = listUsageEvents();
     expect(events).toHaveLength(1);
-    expect(events[0].assistantId).toBe('assistant-1');
     expect(events[0].conversationId).toBe('conv-1');
     expect(events[0].runId).toBe('run-1');
     expect(events[0].requestId).toBe('req-1');

--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -62,7 +62,7 @@ function makeSessionEmittingViaClient(...messages: ServerMessage[]): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
+    setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -83,7 +83,7 @@ function makeSessionEmittingViaAgentLoop(...messages: ServerMessage[]): Session 
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       for (const msg of messages) {

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -60,6 +60,7 @@ function makeSessionWithEvent(message: ServerMessage): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent(message);

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -40,6 +40,7 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     // Return undefined so createRun stores messageId as null and avoids
     // a foreign-key dependency on the conversation-store message table.
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -40,7 +40,6 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     // Return undefined so createRun stores messageId as null and avoids
     // a foreign-key dependency on the conversation-store message table.
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -60,7 +59,6 @@ function makeSessionWithEvent(message: ServerMessage): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent(message);

--- a/assistant/src/__tests__/runtime-runs-http.test.ts
+++ b/assistant/src/__tests__/runtime-runs-http.test.ts
@@ -58,6 +58,7 @@ function makeCompletingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -72,6 +73,7 @@ function makeFailingSession(errorMsg: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'error', message: errorMsg });
@@ -85,6 +87,7 @@ function makeConfirmationSession(toolName: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -110,6 +113,7 @@ function makeHangingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;

--- a/assistant/src/__tests__/runtime-runs-http.test.ts
+++ b/assistant/src/__tests__/runtime-runs-http.test.ts
@@ -58,7 +58,6 @@ function makeCompletingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -73,7 +72,6 @@ function makeFailingSession(errorMsg: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'error', message: errorMsg });
@@ -87,7 +85,6 @@ function makeConfirmationSession(toolName: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -113,7 +110,6 @@ function makeHangingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;

--- a/assistant/src/__tests__/runtime-runs.test.ts
+++ b/assistant/src/__tests__/runtime-runs.test.ts
@@ -48,7 +48,6 @@ function makeCompletingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -66,7 +65,6 @@ function makeHangingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -82,7 +80,6 @@ function makeFailingSession(errorMsg: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'error', message: errorMsg });
@@ -97,7 +94,6 @@ function makeConfirmationSession(toolName: string, principal?: { kind?: string; 
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
-    setAssistantId: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },

--- a/assistant/src/__tests__/runtime-runs.test.ts
+++ b/assistant/src/__tests__/runtime-runs.test.ts
@@ -48,6 +48,7 @@ function makeCompletingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -65,6 +66,7 @@ function makeHangingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -80,6 +82,7 @@ function makeFailingSession(errorMsg: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'error', message: errorMsg });
@@ -94,6 +97,7 @@ function makeConfirmationSession(toolName: string, principal?: { kind?: string; 
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -24,7 +24,6 @@ import { getTask, getTaskRun } from '../../tasks/task-store.js';
 import { runTask } from '../../tasks/task-runner.js';
 import { getMessages } from '../../memory/conversation-store.js';
 import { classifyRisk, check } from '../../permissions/checker.js';
-import { RiskLevel } from '../../permissions/types.js';
 
 export function handleWorkItemsList(
   msg: WorkItemsListRequest,

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -987,9 +987,6 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
-    // Set the session identity AFTER the isProcessing check so a rejected
-    // request doesn't mutate the session state visible to an in-flight request.
-    session.setAssistantId('self');
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session
@@ -1039,9 +1036,6 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
-    // Set the session identity AFTER the isProcessing check so a rejected
-    // request doesn't mutate the session state visible to an in-flight request.
-    session.setAssistantId('self');
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     // Resolve attachment IDs to full attachment data for the session

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -744,10 +744,7 @@ export class DaemonServer {
       ('sessionId' in msg && typeof msgRecord.sessionId === 'string'
         ? msgRecord.sessionId as string
         : undefined) ?? this.socketToSession.get(socket);
-    // Resolve assistantId from the session if available; fall back to daemon default.
-    const socketSession = sessionId ? this.sessions.get(sessionId) : undefined;
-    const assistantId = socketSession?.assistantId ?? this.assistantId;
-    this.publishAssistantEvent(msg, sessionId, assistantId);
+    this.publishAssistantEvent(msg, sessionId, this.assistantId);
   }
 
   broadcast(msg: ServerMessage, excludeSocket?: net.Socket): void {
@@ -763,10 +760,7 @@ export class DaemonServer {
       ('sessionId' in msg && typeof msgRecord.sessionId === 'string'
         ? msgRecord.sessionId as string
         : undefined) ?? (excludeSocket ? this.socketToSession.get(excludeSocket) : undefined);
-    // Resolve assistantId from the origin session if available; fall back to daemon default.
-    const originSession = sessionId ? this.sessions.get(sessionId) : undefined;
-    const assistantId = originSession?.assistantId ?? this.assistantId;
-    this.publishAssistantEvent(msg, sessionId, assistantId);
+    this.publishAssistantEvent(msg, sessionId, this.assistantId);
   }
 
   /**

--- a/assistant/src/daemon/session-usage.ts
+++ b/assistant/src/daemon/session-usage.ts
@@ -11,7 +11,6 @@ const log = getLogger('session-usage');
 export interface UsageContext {
   conversationId: string;
   providerName: string;
-  assistantId: string | null;
   usageStats: UsageStats;
 }
 
@@ -60,7 +59,6 @@ export function recordUsage(
         outputTokens,
         cacheCreationInputTokens: null,
         cacheReadInputTokens: null,
-        assistantId: ctx.assistantId,
         conversationId: ctx.conversationId,
         runId: null,
         requestId,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -159,8 +159,6 @@ export class Session {
   private contextCompactedAt: number | null = null;
   /** @internal — exposed for session-history.ts module functions. */
   currentRequestId?: string;
-  /** @internal — exposed for session-usage.ts module functions. */
-  assistantId: string | null = null;
   private conflictGate = new ConflictGate();
   /** @internal — exposed for session-tool-setup.ts to propagate into ToolContext. */
   hasNoClient = false;
@@ -567,14 +565,6 @@ export class Session {
 
   handleSecretResponse(requestId: string, value?: string, delivery?: 'store' | 'transient_send'): void {
     this.secretPrompter.resolveSecret(requestId, value, delivery);
-  }
-
-  /**
-   * Bind a runtime assistant ID to this session.
-   * IPC-only desktop sessions can leave this unset and use a local scope.
-   */
-  setAssistantId(assistantId: string): void {
-    this.assistantId = assistantId;
   }
 
   setChannelCapabilities(caps: ChannelCapabilities): void {
@@ -1334,7 +1324,7 @@ export class Session {
         this.workingDir,
         async (filePath) => this.approveHostAttachmentReadImpl(filePath),
         lastAssistantMessageId,
-        this.assistantId ?? 'local-assistant',
+        'self',
       );
       const { assistantAttachments, emittedAttachments } = attachmentResult;
 
@@ -1528,7 +1518,7 @@ export class Session {
     requestId: string | null = null,
   ): void {
     recordUsage(
-      { conversationId: this.conversationId, providerName: this.provider.name, assistantId: this.assistantId, usageStats: this.usageStats },
+      { conversationId: this.conversationId, providerName: this.provider.name, usageStats: this.usageStats },
       inputTokens, outputTokens, model, onEvent, actor, requestId,
     );
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1324,7 +1324,10 @@ export class Session {
         this.workingDir,
         async (filePath) => this.approveHostAttachmentReadImpl(filePath),
         lastAssistantMessageId,
-        'self',
+        // HTTP sessions (which call setChannelCapabilities) use 'self'; IPC/desktop
+        // sessions preserve 'local-assistant' to keep attachment namespaces isolated.
+        // PR 6 will remove assistantId from the attachment store APIs entirely.
+        this.channelCapabilities != null ? 'self' : 'local-assistant',
       );
       const { assistantAttachments, emittedAttachments } = attachmentResult;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -567,8 +567,8 @@ export class Session {
     this.secretPrompter.resolveSecret(requestId, value, delivery);
   }
 
-  setChannelCapabilities(caps: ChannelCapabilities): void {
-    this.channelCapabilities = caps;
+  setChannelCapabilities(caps: ChannelCapabilities | null): void {
+    this.channelCapabilities = caps ?? undefined;
   }
 
   private async approveHostAttachmentReadImpl(filePath: string): Promise<boolean> {

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -16,7 +16,7 @@ export function recordUsageEvent(input: UsageEventInput, pricing: PricingResult)
   db.insert(llmUsageEvents).values({
     id: event.id,
     createdAt: event.createdAt,
-    assistantId: event.assistantId,
+    assistantId: 'self',
     conversationId: event.conversationId,
     runId: event.runId,
     requestId: event.requestId,
@@ -45,7 +45,6 @@ export function listUsageEvents(options?: { limit?: number }): UsageEvent[] {
   return rows.map(row => ({
     id: row.id,
     createdAt: row.createdAt,
-    assistantId: row.assistantId,
     conversationId: row.conversationId,
     runId: row.runId,
     requestId: row.requestId,

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -147,6 +147,9 @@ export class RunOrchestrator {
     // Fire-and-forget the agent loop
     const cleanup = () => {
       this.pending.delete(run.id);
+      // Reset channel capabilities so a subsequent IPC/desktop session on the
+      // same conversation is not incorrectly treated as an HTTP-API client.
+      session.setChannelCapabilities(null);
       // Reset the session's client callback to a no-op so the stale
       // closure doesn't intercept events from future runs on the same session.
       // Set hasNoClient=true here since the run is done and no HTTP caller

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -14,6 +14,7 @@ import * as runsStore from '../memory/runs-store.js';
 import type { Run } from '../memory/runs-store.js';
 import type { Session } from '../daemon/session.js';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import { resolveChannelCapabilities } from '../daemon/session-runtime-assembly.js';
 import type { UserDecision } from '../permissions/types.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { IngressBlockedError } from '../util/errors.js';

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -90,8 +90,9 @@ export class RunOrchestrator {
     const messageId = session.persistUserMessage(content, attachments, requestId);
     const run = runsStore.createRun('self', conversationId, messageId);
 
-    // Set the assistant ID so attachments are scoped correctly.
-    session.setAssistantId('self');
+    // Runs are always HTTP-originated; set channel capabilities so the attachment
+    // scope heuristic resolves to 'self' rather than 'local-assistant'.
+    session.setChannelCapabilities(resolveChannelCapabilities('http-api'));
 
     // Serialized publish chain so hub subscribers observe events in order.
     let hubChain: Promise<void> = Promise.resolve();
@@ -109,6 +110,7 @@ export class RunOrchestrator {
           log.warn({ err }, 'assistant-events hub subscriber threw during HTTP run');
         });
     };
+
 
     // Hook into session to intercept confirmation_request events.
     // When the prompter sends a confirmation_request, we record it in the

--- a/assistant/src/usage/types.ts
+++ b/assistant/src/usage/types.ts
@@ -12,7 +12,6 @@ export interface UsageEventInput {
   cacheCreationInputTokens: number | null;
   cacheReadInputTokens: number | null;
   actor: UsageActor;
-  assistantId: string | null;
   conversationId: string | null;
   runId: string | null;
   requestId: string | null;


### PR DESCRIPTION
## Summary
- Remove `assistantId` field and `setAssistantId()` method from `Session`; replace `this.assistantId` with hardcoded `'self'`
- Remove `assistantId` from `UsageContext`, `UsageEventInput`/`UsageEvent` types, and `recordUsageEvent` call chain
- Hardcode `assistantId: 'self'` in the DB insert in `llm-usage-store` (keeps legacy column for schema continuity; writes canonical value)

Part of plan: REMOVE-ASSISTANT-ID-INCREMENTAL.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
