### PR TITLE
fix: task_delete falls back to work item removal for misrouted IDs

### DIFF
--- a/assistant/src/tools/tasks/task-delete.ts
+++ b/assistant/src/tools/tasks/task-delete.ts
@@ -2,6 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { deleteTask, deleteTasks, getTask } from '../../tasks/task-store.js';
+import { getWorkItem, deleteWorkItem } from '../../work-items/work-item-store.js';
 
 const definition: ToolDefinition = {
   name: 'task_delete',
@@ -44,20 +45,49 @@ class TaskDeleteTool implements Tool {
         const task = getTask(ids[0]);
         const deleted = deleteTask(ids[0]);
         if (!deleted) {
+          // The LLM may pass a work item ID instead of a task template ID.
+          // Fall back to removing from the task queue so the user's intent succeeds.
+          const workItem = getWorkItem(ids[0]);
+          if (workItem) {
+            deleteWorkItem(workItem.id);
+            return { content: `Removed "${workItem.title}" from the task queue.`, isError: false };
+          }
           return { content: `No task found with ID ${ids[0]}`, isError: true };
         }
         return { content: `Deleted task: ${task?.title ?? ids[0]}`, isError: false };
       }
 
-      const titles = ids.map((id) => {
-        const t = getTask(id);
-        return t ? t.title : id;
-      });
-      const count = deleteTasks(ids);
-      if (count === 0) {
+      const taskIds: string[] = [];
+      const taskTitles: string[] = [];
+      const workItemTitles: string[] = [];
+
+      for (const id of ids) {
+        const task = getTask(id);
+        if (task) {
+          taskIds.push(id);
+          taskTitles.push(task.title);
+        } else {
+          const workItem = getWorkItem(id);
+          if (workItem) {
+            deleteWorkItem(workItem.id);
+            workItemTitles.push(workItem.title);
+          }
+        }
+      }
+
+      const taskCount = taskIds.length > 0 ? deleteTasks(taskIds) : 0;
+
+      if (taskCount === 0 && workItemTitles.length === 0) {
         return { content: 'No matching tasks found to delete.', isError: true };
       }
-      const lines = [`Deleted ${count} task(s):`, ...titles.map((t) => `- ${t}`)];
+
+      const lines: string[] = [];
+      if (taskCount > 0) {
+        lines.push(`Deleted ${taskCount} task(s):`, ...taskTitles.map((t) => `- ${t}`));
+      }
+      if (workItemTitles.length > 0) {
+        lines.push(`Removed ${workItemTitles.length} item(s) from the task queue:`, ...workItemTitles.map((t) => `- ${t}`));
+      }
       return { content: lines.join('\n'), isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

When the LLM calls `task_delete` with a work item ID (instead of the correct `task_list_remove`), the tool now gracefully handles it by checking the `work_items` table before returning "not found":

- **Single ID**: If `deleteTask` fails, checks `getWorkItem` and calls `deleteWorkItem` if found, returning a success message matching `task_list_remove`'s format
- **Multi ID**: Partitions IDs into task templates and work items, deletes each appropriately, and reports both in the response

This prevents the common failure mode where a user says "remove that task" and the LLM picks `task_delete` instead of `task_list_remove`.

## Files changed

- `assistant/src/tools/tasks/task-delete.ts` — added work item fallback logic

## Test plan

- [ ] Call `task_delete` with a valid task template ID — should delete as before
- [ ] Call `task_delete` with a work item ID — should remove from queue with success message
- [ ] Call `task_delete` with a mix of task template IDs and work item IDs — should handle both
- [ ] Call `task_delete` with an ID that matches neither — should return "not found" error
- [ ] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
