### PR TITLE
fix: broadcast tasks_changed after LLM tool queue mutations

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -181,6 +181,12 @@ export function createToolExecutor(
       ctx.sendToClient({ type: 'open_tasks_window' });
     }
 
+    // Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
+    // auto-refresh when the LLM mutates the task queue via tools
+    if ((name === 'task_list_add' || name === 'task_list_update' || name === 'task_list_remove') && !result.isError) {
+      broadcastToAllClients?.({ type: 'tasks_changed' });
+    }
+
     // Auto-refresh workspace surfaces when app files are edited
     if ((name === 'app_file_edit' || name === 'app_file_write') && !result.isError) {
       const appId = input.app_id as string | undefined;


### PR DESCRIPTION
## Summary
- The IPC handlers in `work-items.ts` already broadcast `tasks_changed` after queue mutations, but the LLM tools (`task_list_add`, `task_list_update`, `task_list_remove`) did not emit this notification
- Added a post-execution hook in `session-tool-setup.ts` that broadcasts `{ type: 'tasks_changed' }` to all connected clients after these tools succeed
- Follows the existing pattern already used for `app_update` → `app_files_changed` and `task_list_show` → `open_tasks_window`

## Why
When the LLM added/updated/removed items from the task queue via tools, the macOS client's Tasks window did not auto-refresh because no `tasks_changed` signal was emitted. This made the tool-based mutation path inconsistent with the IPC handler mutation path.

## Test plan
- [ ] Start the daemon and macOS app with Tasks window open
- [ ] Ask the LLM to "add X to my tasks" — verify the Tasks window refreshes automatically
- [ ] Ask the LLM to "update task X priority" — verify the Tasks window refreshes
- [ ] Ask the LLM to "remove task X" — verify the Tasks window refreshes
- [ ] Verify type-check passes: `bunx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
