### PR TITLE
Add mutation audit logging for queue operation tools

### DIFF
--- a/assistant/src/tools/tasks/task-delete.ts
+++ b/assistant/src/tools/tasks/task-delete.ts
@@ -3,6 +3,9 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { deleteTask, deleteTasks, getTask } from '../../tasks/task-store.js';
 import { getWorkItem, deleteWorkItem } from '../../work-items/work-item-store.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('task-delete');
 
 const definition: ToolDefinition = {
   name: 'task_delete',
@@ -50,10 +53,13 @@ class TaskDeleteTool implements Tool {
           const workItem = getWorkItem(ids[0]);
           if (workItem) {
             deleteWorkItem(workItem.id);
+            log.info({ inputId: ids[0], resolvedWorkItemId: workItem.id, fallback: true, deletedCount: 1 }, 'deleted via work item fallback');
             return { content: `Removed "${workItem.title}" from the task queue.`, isError: false };
           }
+          log.warn({ inputId: ids[0] }, 'no task or work item found for deletion');
           return { content: `No task found with ID ${ids[0]}`, isError: true };
         }
+        log.info({ taskId: ids[0], title: task?.title, deletedCount: 1 }, 'task deleted');
         return { content: `Deleted task: ${task?.title ?? ids[0]}`, isError: false };
       }
 
@@ -70,7 +76,10 @@ class TaskDeleteTool implements Tool {
           const workItem = getWorkItem(id);
           if (workItem) {
             deleteWorkItem(workItem.id);
+            log.info({ inputId: id, resolvedWorkItemId: workItem.id, fallback: true }, 'deleted work item in batch (fallback)');
             workItemTitles.push(workItem.title);
+          } else {
+            log.warn({ inputId: id }, 'batch delete: no task or work item found');
           }
         }
       }
@@ -78,8 +87,11 @@ class TaskDeleteTool implements Tool {
       const taskCount = taskIds.length > 0 ? deleteTasks(taskIds) : 0;
 
       if (taskCount === 0 && workItemTitles.length === 0) {
+        log.warn({ inputIds: ids }, 'no matching tasks found to delete');
         return { content: 'No matching tasks found to delete.', isError: true };
       }
+
+      log.info({ deletedTasks: taskCount, deletedWorkItems: workItemTitles.length, totalInput: ids.length }, 'batch delete completed');
 
       const lines: string[] = [];
       if (taskCount > 0) {
@@ -91,6 +103,7 @@ class TaskDeleteTool implements Tool {
       return { content: lines.join('\n'), isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      log.error({ inputIds: ids, error: msg }, 'delete failed');
       return { content: `Error: ${msg}`, isError: true };
     }
   }

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -154,6 +154,8 @@ class TaskListAddTool implements Tool {
           sortIndex,
         });
 
+        log.info({ selectorType: 'title', workItemId: workItem.id, title: workItem.title }, 'ad-hoc work item created');
+
         const priority = PRIORITY_LABELS[workItem.priorityTier] ?? `tier ${workItem.priorityTier}`;
         const lines = [
           `Enqueued work item:`,
@@ -218,6 +220,7 @@ class TaskListAddTool implements Tool {
 
       log.debug({ title: finalTitle }, 'task_list_add: creating new item');
 
+      const selectorType = taskId ? 'task_id' : 'task_name';
       const workItem = createWorkItem({
         taskId: resolvedTask.id,
         title: finalTitle,
@@ -225,6 +228,8 @@ class TaskListAddTool implements Tool {
         priorityTier: priorityTier ?? 1,
         sortIndex,
       });
+
+      log.info({ selectorType, taskId: resolvedTask.id, workItemId: workItem.id, title: workItem.title }, 'work item created from task definition');
 
       const priority = PRIORITY_LABELS[workItem.priorityTier] ?? `tier ${workItem.priorityTier}`;
       const lines = [
@@ -245,6 +250,7 @@ class TaskListAddTool implements Tool {
       return { content: lines.join('\n'), isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      log.error({ error: msg }, 'enqueue failed');
       return { content: `Error: ${msg}`, isError: true };
     }
   }

--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -2,6 +2,9 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { resolveWorkItem, deleteWorkItem } from '../../work-items/work-item-store.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('task-list-remove');
 
 const definition: ToolDefinition = {
   name: 'task_list_remove',
@@ -41,6 +44,8 @@ class TaskListRemoveTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const selectorType = input.work_item_id ? 'work_item_id' : input.task_id ? 'task_id' : input.task_name ? 'task_name' : input.title ? 'title' : 'none';
+
     try {
       const selector = {
         workItemId: input.work_item_id as string | undefined,
@@ -49,13 +54,17 @@ class TaskListRemoveTool implements Tool {
       };
 
       const item = resolveWorkItem(selector);
-      const title = item.title;
+
+      log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id, title: item.title }, 'resolved work item for removal');
 
       deleteWorkItem(item.id);
 
-      return { content: `Removed "${title}" from the task queue.`, isError: false };
+      log.info({ resolvedWorkItemId: item.id, deletedCount: 1 }, 'work item removed');
+
+      return { content: `Removed "${item.title}" from the task queue.`, isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      log.error({ selectorType, error: msg }, 'remove failed');
       return { content: `Error: ${msg}`, isError: true };
     }
   }

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -2,6 +2,9 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { resolveWorkItem, updateWorkItem, type WorkItemStatus } from '../../work-items/work-item-store.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('task-list-update');
 
 const PRIORITY_LABELS: Record<number, string> = {
   0: 'high',
@@ -64,6 +67,8 @@ class TaskListUpdateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const selectorType = input.work_item_id ? 'work_item_id' : input.task_id ? 'task_id' : input.task_name ? 'task_name' : input.title ? 'title' : 'none';
+
     try {
       // Build selector from whichever identifier was provided
       const selector = {
@@ -74,6 +79,8 @@ class TaskListUpdateTool implements Tool {
 
       // Resolve the target work item
       const item = resolveWorkItem(selector);
+
+      log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id }, 'resolved work item for update');
 
       // Build updates from provided fields
       const updates: Partial<{
@@ -88,6 +95,7 @@ class TaskListUpdateTool implements Tool {
       if (input.sort_index !== undefined) updates.sortIndex = input.sort_index as number;
 
       if (Object.keys(updates).length === 0) {
+        log.warn({ selectorType, resolvedWorkItemId: item.id }, 'update called with no fields to update');
         return {
           content: 'No updates specified. Provide at least one field to update (priority_tier, notes, status, sort_index).',
           isError: true,
@@ -96,11 +104,14 @@ class TaskListUpdateTool implements Tool {
 
       const updated = updateWorkItem(item.id, updates);
       if (!updated) {
+        log.error({ selectorType, resolvedWorkItemId: item.id, updates }, 'updateWorkItem returned null');
         return {
           content: `Error: Failed to update work item "${item.title}".`,
           isError: true,
         };
       }
+
+      log.info({ resolvedWorkItemId: item.id, updatedFields: Object.keys(updates) }, 'work item updated');
 
       // Build confirmation message
       const parts: string[] = [`Updated "${updated.title}"`];
@@ -114,6 +125,7 @@ class TaskListUpdateTool implements Tool {
       return { content: parts.join(', ') + '.', isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      log.error({ selectorType, error: msg }, 'update failed');
       return { content: `Error: ${msg}`, isError: true };
     }
   }


### PR DESCRIPTION
## Summary

Add structured pino audit logging to all four queue operation tools so that delete/update regressions are diagnosable from logs alone:

- **task_list_update** (`work-item-update.ts`): Logs selector type, resolved work item ID, updated fields on success; warns on no-op updates; errors with context on failure
- **task_list_remove** (`work-item-remove.ts`): Logs selector resolution and deletion with affected count; errors with selector context on failure
- **task_delete** (`task-delete.ts`): Logs single/batch delete outcomes, work item fallback path usage, and warns when IDs don't resolve to any entity
- **task_list_add** (`work-item-enqueue.ts`): Adds success outcome logs for both ad-hoc and task-definition-based creation paths; adds error logging in the catch block

Each log entry includes the selector type used (work_item_id, task_id, title, etc.), the resolved work_item_id, the operation performed, success/failure outcome, and failure reason when applicable.

## Test plan

- [x] `bunx tsc --noEmit` passes with no errors
- [ ] Verify log output appears in `~/.vellum/logs/` when exercising queue operations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
