### PR TITLE
refactor: shared removeWorkItemFromQueue helper for queue deletions

### DIFF
--- a/assistant/src/tools/tasks/task-delete.ts
+++ b/assistant/src/tools/tasks/task-delete.ts
@@ -2,7 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { deleteTask, deleteTasks, getTask } from '../../tasks/task-store.js';
-import { getWorkItem, deleteWorkItem } from '../../work-items/work-item-store.js';
+import { removeWorkItemFromQueue } from '../../work-items/work-item-store.js';
 
 const definition: ToolDefinition = {
   name: 'task_delete',
@@ -47,10 +47,9 @@ class TaskDeleteTool implements Tool {
         if (!deleted) {
           // The LLM may pass a work item ID instead of a task template ID.
           // Fall back to removing from the task queue so the user's intent succeeds.
-          const workItem = getWorkItem(ids[0]);
-          if (workItem) {
-            deleteWorkItem(workItem.id);
-            return { content: `Removed "${workItem.title}" from the task queue.`, isError: false };
+          const result = removeWorkItemFromQueue(ids[0]);
+          if (result.success) {
+            return { content: result.message, isError: false };
           }
           return { content: `No task found with ID ${ids[0]}`, isError: true };
         }
@@ -67,10 +66,9 @@ class TaskDeleteTool implements Tool {
           taskIds.push(id);
           taskTitles.push(task.title);
         } else {
-          const workItem = getWorkItem(id);
-          if (workItem) {
-            deleteWorkItem(workItem.id);
-            workItemTitles.push(workItem.title);
+          const result = removeWorkItemFromQueue(id);
+          if (result.success) {
+            workItemTitles.push(result.title);
           }
         }
       }

--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -1,7 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { resolveWorkItem, deleteWorkItem } from '../../work-items/work-item-store.js';
+import { resolveWorkItem, removeWorkItemFromQueue } from '../../work-items/work-item-store.js';
 
 const definition: ToolDefinition = {
   name: 'task_list_remove',
@@ -49,11 +49,9 @@ class TaskListRemoveTool implements Tool {
       };
 
       const item = resolveWorkItem(selector);
-      const title = item.title;
+      const result = removeWorkItemFromQueue(item.id);
 
-      deleteWorkItem(item.id);
-
-      return { content: `Removed "${title}" from the task queue.`, isError: false };
+      return { content: result.message, isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { content: `Error: ${msg}`, isError: true };

--- a/assistant/src/work-items/work-item-store.ts
+++ b/assistant/src/work-items/work-item-store.ts
@@ -90,6 +90,28 @@ export function deleteWorkItem(id: string): void {
   db.delete(workItems).where(eq(workItems.id, id)).run();
 }
 
+// ── Queue Removal ───────────────────────────────────────────────────
+
+export interface RemoveWorkItemResult {
+  success: boolean;
+  title: string;
+  message: string;
+}
+
+/**
+ * Shared helper for removing a single work item from the queue by ID.
+ * Used by both task_delete (compat path) and task_list_remove so all
+ * single-item deletions follow one codepath.
+ */
+export function removeWorkItemFromQueue(id: string): RemoveWorkItemResult {
+  const item = getWorkItem(id);
+  if (!item) {
+    return { success: false, title: '', message: `No work item found with ID "${id}"` };
+  }
+  deleteWorkItem(item.id);
+  return { success: true, title: item.title, message: `Removed "${item.title}" from the task queue.` };
+}
+
 // ── Selectors / Helpers ─────────────────────────────────────────────
 
 export interface WorkItemSelector {


### PR DESCRIPTION
## Summary
- Introduced a `removeWorkItemFromQueue(id)` helper in `work-item-store.ts` that looks up a work item by ID, deletes it, and returns a structured `{ success, title, message }` result.
- Updated `task_delete` (compat path for work item IDs) and `task_list_remove` to both use this shared helper instead of their own inline lookup-and-delete logic.
- All single-item queue deletions now follow one codepath, reducing duplication and ensuring consistent response messages.

## Test plan
- [ ] Verify `task_delete` with a task template ID still works (not affected by this change)
- [ ] Verify `task_delete` with a work item ID falls back to `removeWorkItemFromQueue` and returns the correct message
- [ ] Verify `task_list_remove` resolves the selector, then delegates to `removeWorkItemFromQueue` and returns the correct message
- [ ] Verify `task_delete` with multiple IDs (mix of task and work item IDs) works correctly
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
