### PR TITLE
feat: add Remove button to Tasks window rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -99,6 +99,7 @@ struct TasksWindowView: View {
                                 item: item,
                                 onRun: { viewModel.runTask(id: item.id) },
                                 onComplete: { viewModel.completeTask(id: item.id) },
+                                onRemove: { viewModel.removeTask(id: item.id) },
                                 onPriorityChange: { newTier in
                                     viewModel.updatePriority(id: item.id, tier: newTier)
                                 }
@@ -122,6 +123,7 @@ private struct TasksWindowRow: View {
     let item: IPCWorkItemsListResponseItem
     let onRun: () -> Void
     let onComplete: () -> Void
+    let onRemove: () -> Void
     let onPriorityChange: (Double) -> Void
     @State private var isHovered = false
 
@@ -264,6 +266,19 @@ private struct TasksWindowRow: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Mark task as reviewed")
+            }
+
+            if isHovered {
+                Button(action: onRemove) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .frame(width: 20, height: 20)
+                        .background(VColor.surfaceBorder.opacity(0.5))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove task")
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -40,6 +40,13 @@ class TasksWindowViewModel: ObservableObject {
 
         daemonClient.onWorkItemStatusChanged = { _ in scheduleRefresh() }
         daemonClient.onTasksChanged = { _ in scheduleRefresh() }
+
+        daemonClient.onWorkItemDeleteResponse = { [weak self] response in
+            guard let self else { return }
+            if !response.success {
+                self.fetchItems()
+            }
+        }
     }
 
     func fetchItems() {
@@ -66,6 +73,23 @@ class TasksWindowViewModel: ObservableObject {
             try daemonClient.sendWorkItemComplete(id: id)
             items.removeAll { $0.id == id }
         } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func removeTask(id: String) {
+        let snapshot = items
+
+        withAnimation(.linear(duration: 0.15)) {
+            items.removeAll { $0.id == id }
+        }
+
+        do {
+            try daemonClient.sendWorkItemDelete(id: id)
+        } catch {
+            withAnimation(.linear(duration: 0.15)) {
+                items = snapshot
+            }
             errorMessage = error.localizedDescription
         }
     }


### PR DESCRIPTION
## Summary
- Adds a hover-visible "x" button in the Actions column of each task row in the Tasks window
- Wires the button to `viewModel.removeTask(id:)` which optimistically removes the item from the local list and sends a `work_item_delete` IPC request via `DaemonClient`
- Handles failure responses by re-fetching the full task list (rollback)
- Follows existing patterns: `.buttonStyle(.plain)`, design system tokens (VColor, VFont, VSpacing, VRadius), `.accessibilityLabel("Remove task")`

## Files changed
- `clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift` — added `onRemove` callback to `TasksWindowRow`, added hover-visible xmark button
- `clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift` — added `removeTask(id:)` method and `onWorkItemDeleteResponse` callback wiring

## Test plan
- [ ] Build succeeds (`./build.sh` passes)
- [ ] Hover over a task row — "x" button appears in the actions column
- [ ] Click "x" — item is immediately removed from the list
- [ ] If daemon reports failure, the list re-fetches to restore the item
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
