### PR TITLE
fix: return structured ambiguity error from resolveWorkItem

### DIFF
--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -53,7 +53,19 @@ class TaskListRemoveTool implements Tool {
         title: (input.task_name ?? input.title) as string | undefined,
       };
 
-      const item = resolveWorkItem(selector);
+      const result = resolveWorkItem(selector);
+
+      if (result.status === 'not_found') {
+        log.warn({ selectorType, error: result.message }, 'work item not found for removal');
+        return { content: `Error: ${result.message}`, isError: true };
+      }
+
+      if (result.status === 'ambiguous') {
+        log.warn({ selectorType, matchCount: result.matches.length }, 'ambiguous selector for removal');
+        return { content: `Error: ${result.message}`, isError: true };
+      }
+
+      const item = result.workItem;
 
       log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id, title: item.title }, 'resolved work item for removal');
 

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -78,7 +78,19 @@ class TaskListUpdateTool implements Tool {
       };
 
       // Resolve the target work item
-      const item = resolveWorkItem(selector);
+      const result = resolveWorkItem(selector);
+
+      if (result.status === 'not_found') {
+        log.warn({ selectorType, error: result.message }, 'work item not found for update');
+        return { content: `Error: ${result.message}`, isError: true };
+      }
+
+      if (result.status === 'ambiguous') {
+        log.warn({ selectorType, matchCount: result.matches.length }, 'ambiguous selector for update');
+        return { content: `Error: ${result.message}`, isError: true };
+      }
+
+      const item = result.workItem;
 
       log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id }, 'resolved work item for update');
 

--- a/assistant/src/work-items/work-item-store.ts
+++ b/assistant/src/work-items/work-item-store.ts
@@ -98,6 +98,21 @@ export interface WorkItemSelector {
   title?: string;
 }
 
+export type ResolveWorkItemResult =
+  | { status: 'found'; workItem: WorkItem }
+  | { status: 'not_found'; message: string }
+  | { status: 'ambiguous'; matches: WorkItem[]; message: string };
+
+const PRIORITY_TIER_LABELS: Record<number, string> = { 0: 'high', 1: 'medium', 2: 'low' };
+
+function formatAmbiguityMessage(selectorLabel: string, matches: WorkItem[]): string {
+  const lines = matches.map(
+    m =>
+      `  - ID: ${m.id} | title: "${m.title}" | priority: ${PRIORITY_TIER_LABELS[m.priorityTier] ?? m.priorityTier} | status: ${m.status}`,
+  );
+  return `Multiple items match '${selectorLabel}'. Please specify which one:\n${lines.join('\n')}`;
+}
+
 /** Find all active work items for a given task ID */
 export function findActiveWorkItemsByTaskId(taskId: string): WorkItem[] {
   return listWorkItems().filter(
@@ -117,37 +132,36 @@ export function findActiveWorkItemsByTitle(title: string): WorkItem[] {
  * Resolve a single active work item from a selector.
  * Tries fields in priority order: workItemId > taskId > title.
  * Only considers active items (status not 'done' or 'archived').
- * Throws if no match or ambiguous match.
+ * Returns a discriminated union so callers can handle ambiguity explicitly
+ * instead of silently picking one match when multiple exist.
  */
-export function resolveWorkItem(selector: WorkItemSelector): WorkItem {
+export function resolveWorkItem(selector: WorkItemSelector): ResolveWorkItemResult {
   if (selector.workItemId) {
     const item = getWorkItem(selector.workItemId);
-    if (!item) throw new Error(`No work item found with ID "${selector.workItemId}"`);
+    if (!item) return { status: 'not_found', message: `No work item found with ID "${selector.workItemId}"` };
     if (item.status === 'done' || item.status === 'archived') {
-      throw new Error(`Work item "${selector.workItemId}" is ${item.status}`);
+      return { status: 'not_found', message: `Work item "${selector.workItemId}" is ${item.status}` };
     }
-    return item;
+    return { status: 'found', workItem: item };
   }
 
   if (selector.taskId) {
     const items = findActiveWorkItemsByTaskId(selector.taskId);
-    if (items.length === 0) throw new Error(`No active work item found for task "${selector.taskId}"`);
+    if (items.length === 0) return { status: 'not_found', message: `No active work item found for task "${selector.taskId}"` };
     if (items.length > 1) {
-      // Deterministic tie-break: lowest priorityTier, then earliest createdAt
-      items.sort((a, b) => a.priorityTier - b.priorityTier || a.createdAt - b.createdAt);
+      return { status: 'ambiguous', matches: items, message: formatAmbiguityMessage(selector.taskId, items) };
     }
-    return items[0];
+    return { status: 'found', workItem: items[0] };
   }
 
   if (selector.title) {
     const items = findActiveWorkItemsByTitle(selector.title);
-    if (items.length === 0) throw new Error(`No active work item found with title "${selector.title}"`);
+    if (items.length === 0) return { status: 'not_found', message: `No active work item found with title "${selector.title}"` };
     if (items.length > 1) {
-      // Deterministic tie-break: lowest priorityTier, then earliest createdAt
-      items.sort((a, b) => a.priorityTier - b.priorityTier || a.createdAt - b.createdAt);
+      return { status: 'ambiguous', matches: items, message: formatAmbiguityMessage(selector.title, items) };
     }
-    return items[0];
+    return { status: 'found', workItem: items[0] };
   }
 
-  throw new Error('At least one selector field (workItemId, taskId, or title) must be provided');
+  return { status: 'not_found', message: 'At least one selector field (workItemId, taskId, or title) must be provided' };
 }


### PR DESCRIPTION
## Summary
- Changed `resolveWorkItem` return type from `WorkItem` (with throws) to a discriminated union `ResolveWorkItemResult` with three variants: `found`, `not_found`, and `ambiguous`.
- When a selector (taskId or title) matches multiple active work items, returns `{ status: 'ambiguous', matches, message }` instead of silently picking the first by sort order. The message lists each match with ID, title, priority, and status so the model can disambiguate.
- Updated `task_list_update` and `task_list_remove` tools to handle `not_found` and `ambiguous` results explicitly, surfacing informative error messages instead of relying on try/catch around thrown errors.

## Files changed
- `assistant/src/work-items/work-item-store.ts` — new `ResolveWorkItemResult` type, `formatAmbiguityMessage` helper, refactored `resolveWorkItem` to return result union
- `assistant/src/tools/tasks/work-item-update.ts` — handle `not_found` and `ambiguous` statuses before proceeding
- `assistant/src/tools/tasks/work-item-remove.ts` — handle `not_found` and `ambiguous` statuses before proceeding

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors
- [ ] Verify that selecting by `workItemId` still returns `found` for valid active items
- [ ] Verify that selecting by `taskId` or `title` with a single match returns `found`
- [ ] Verify that selecting by `taskId` or `title` with multiple matches returns `ambiguous` with a descriptive message
- [ ] Verify that tools return the ambiguity message as an error to the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
