### PR TITLE
fix: improve entity mismatch error messages in task tools

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -239,6 +239,20 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '- "Mark X as done" → task_list_update (NOT task_list_add)',
     '- "Remove X from my tasks" → task_list_remove (NOT task_list_update)',
     '- "Delete that task" / "clean up the duplicate" → task_list_remove',
+    '',
+    '### Entity type routing: work items vs task templates',
+    '',
+    'There are two entity types with separate ID spaces:',
+    '- **Work items** (the user\'s task queue) — managed by task_list_add, task_list_show, task_list_update, task_list_remove',
+    '- **Task templates** (reusable definitions) — managed by task_save, task_list, task_run, task_delete',
+    '',
+    'Do NOT pass a work item ID to a task template tool or vice versa:',
+    '- Deleting a work item from the queue → task_list_remove (NOT task_delete)',
+    '- Deleting a task template → task_delete (NOT task_list_remove)',
+    '- Running a task template → task_run with task_id (NOT a work item ID)',
+    '- Updating a work item → task_list_update with work_item_id (NOT a task template ID)',
+    '',
+    'If an error says "entity mismatch", read the corrective action and selector fields it provides to pick the right tool.',
   ].join('\n');
 }
 

--- a/assistant/src/tools/tasks/task-delete.ts
+++ b/assistant/src/tools/tasks/task-delete.ts
@@ -56,7 +56,7 @@ class TaskDeleteTool implements Tool {
             return { content: result.message, isError: false };
           }
           log.warn({ inputId: ids[0] }, 'no task or work item found for deletion');
-          return { content: `No task found with ID ${ids[0]}`, isError: true };
+          return { content: `No task template or work item found with ID "${ids[0]}". Use task_list to see task templates or task_list_show to see work items in the queue.`, isError: true };
         }
         log.info({ taskId: ids[0], title: task?.title, deletedCount: 1 }, 'task deleted');
         return { content: `Deleted task: ${task?.title ?? ids[0]}`, isError: false };

--- a/assistant/src/tools/tasks/task-run.ts
+++ b/assistant/src/tools/tasks/task-run.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getTask, listTasks } from '../../tasks/task-store.js';
 import { renderTemplate } from '../../tasks/task-runner.js';
+import { identifyEntityById, buildWorkItemMismatchError } from '../../work-items/work-item-store.js';
 
 const definition: ToolDefinition = {
   name: 'task_run',
@@ -57,7 +58,14 @@ class TaskRunTool implements Tool {
       if (taskId) {
         task = getTask(taskId);
         if (!task) {
-          return { content: `Error: No task found with ID "${taskId}"`, isError: true };
+          const entity = identifyEntityById(taskId);
+          if (entity.type === 'work_item') {
+            return {
+              content: `Error: ${buildWorkItemMismatchError(taskId, entity.title!, 'task_list_show to view work items, or task_list_update to modify them')}`,
+              isError: true,
+            };
+          }
+          return { content: `Error: No task template found with ID "${taskId}". Use task_list to see available templates.`, isError: true };
         }
       } else if (taskName) {
         const allTasks = listTasks();

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -2,7 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getTask, listTasks, createTask } from '../../tasks/task-store.js';
-import { createWorkItem, findActiveWorkItemsByTitle, updateWorkItem } from '../../work-items/work-item-store.js';
+import { createWorkItem, findActiveWorkItemsByTitle, updateWorkItem, identifyEntityById, buildWorkItemMismatchError } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('task-list-add');
@@ -179,7 +179,14 @@ class TaskListAddTool implements Tool {
       if (taskId) {
         resolvedTask = getTask(taskId);
         if (!resolvedTask) {
-          return { content: `Error: No task definition found with ID "${taskId}".`, isError: true };
+          const entity = identifyEntityById(taskId);
+          if (entity.type === 'work_item') {
+            return {
+              content: `Error: ${buildWorkItemMismatchError(taskId, entity.title!, 'task_list_update to modify the existing work item, or task_list_add with just a title for a new ad-hoc item')}`,
+              isError: true,
+            };
+          }
+          return { content: `Error: No task definition found with ID "${taskId}". Use task_list to see available task templates, or provide just a title to create an ad-hoc work item.`, isError: true };
         }
       } else {
         // Search by name (case-insensitive substring match)

--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -1,7 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { resolveWorkItem, removeWorkItemFromQueue } from '../../work-items/work-item-store.js';
+import { resolveWorkItem, removeWorkItemFromQueue, identifyEntityById, buildTaskTemplateMismatchError } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('task-list-remove');
@@ -53,27 +53,38 @@ class TaskListRemoveTool implements Tool {
         title: (input.task_name ?? input.title) as string | undefined,
       };
 
-      const result = resolveWorkItem(selector);
+      const resolveResult = resolveWorkItem(selector);
 
-      if (result.status === 'not_found') {
-        log.warn({ selectorType, error: result.message }, 'work item not found for removal');
-        return { content: `Error: ${result.message}`, isError: true };
+      if (resolveResult.status === 'not_found') {
+        // When the model passes an ID directly, check if it's a task template
+        if (selector.workItemId) {
+          const entity = identifyEntityById(selector.workItemId);
+          if (entity.type === 'task_template') {
+            log.warn({ selectorType, inputId: selector.workItemId }, 'task template ID passed as work_item_id');
+            return {
+              content: `Error: ${buildTaskTemplateMismatchError(selector.workItemId, entity.title!, 'task_delete to delete task templates')}`,
+              isError: true,
+            };
+          }
+        }
+        log.warn({ selectorType, error: resolveResult.message }, 'work item not found for removal');
+        return { content: `Error: ${resolveResult.message}`, isError: true };
       }
 
-      if (result.status === 'ambiguous') {
-        log.warn({ selectorType, matchCount: result.matches.length }, 'ambiguous selector for removal');
-        return { content: `Error: ${result.message}`, isError: true };
+      if (resolveResult.status === 'ambiguous') {
+        log.warn({ selectorType, matchCount: resolveResult.matches.length }, 'ambiguous selector for removal');
+        return { content: `Error: ${resolveResult.message}`, isError: true };
       }
 
-      const item = result.workItem;
+      const item = resolveResult.workItem;
 
       log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id, title: item.title }, 'resolved work item for removal');
 
-      const result = removeWorkItemFromQueue(item.id);
+      const removeResult = removeWorkItemFromQueue(item.id);
 
       log.info({ resolvedWorkItemId: item.id, deletedCount: 1 }, 'work item removed');
 
-      return { content: result.message, isError: false };
+      return { content: removeResult.message, isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ selectorType, error: msg }, 'remove failed');

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -1,7 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { resolveWorkItem, updateWorkItem, type WorkItemStatus } from '../../work-items/work-item-store.js';
+import { resolveWorkItem, updateWorkItem, identifyEntityById, buildTaskTemplateMismatchError, type WorkItemStatus } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('task-list-update');
@@ -81,6 +81,17 @@ class TaskListUpdateTool implements Tool {
       const result = resolveWorkItem(selector);
 
       if (result.status === 'not_found') {
+        // When the model passes an ID directly, check if it's a task template
+        if (selector.workItemId) {
+          const entity = identifyEntityById(selector.workItemId);
+          if (entity.type === 'task_template') {
+            log.warn({ selectorType, inputId: selector.workItemId }, 'task template ID passed as work_item_id');
+            return {
+              content: `Error: ${buildTaskTemplateMismatchError(selector.workItemId, entity.title!, 'task_delete to remove task templates, or task_list to view them')}`,
+              isError: true,
+            };
+          }
+        }
         log.warn({ selectorType, error: result.message }, 'work item not found for update');
         return { content: `Error: ${result.message}`, isError: true };
       }

--- a/assistant/src/work-items/work-item-store.ts
+++ b/assistant/src/work-items/work-item-store.ts
@@ -1,6 +1,7 @@
 import { eq, desc, asc } from 'drizzle-orm';
 import { getDb } from '../memory/db.js';
 import { workItems } from '../memory/schema.js';
+import { getTask } from '../tasks/task-store.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -186,4 +187,57 @@ export function resolveWorkItem(selector: WorkItemSelector): ResolveWorkItemResu
   }
 
   return { status: 'not_found', message: 'At least one selector field (workItemId, taskId, or title) must be provided' };
+}
+
+// ── Entity Identification ───────────────────────────────────────────
+
+export type EntityType = 'task_template' | 'work_item' | 'unknown';
+
+export interface EntityIdentification {
+  type: EntityType;
+  id: string;
+  title?: string;
+}
+
+/**
+ * Determine whether an ID refers to a task template (tasks table) or
+ * a work item (work_items table). Used by tool error messages to give
+ * the model corrective guidance when the wrong entity type is provided.
+ */
+export function identifyEntityById(id: string): EntityIdentification {
+  const workItem = getWorkItem(id);
+  if (workItem) {
+    return { type: 'work_item', id: workItem.id, title: workItem.title };
+  }
+
+  const task = getTask(id);
+  if (task) {
+    return { type: 'task_template', id: task.id, title: task.title };
+  }
+
+  return { type: 'unknown', id };
+}
+
+/**
+ * Build a corrective error message when a work item ID is passed where
+ * a task template ID is expected.
+ */
+export function buildWorkItemMismatchError(id: string, title: string, expectedTool: string): string {
+  return [
+    `Entity mismatch: The ID "${id}" refers to a work item ("${title}"), not a task template.`,
+    `Corrective action: Use ${expectedTool} to operate on work items in the task queue.`,
+    `Selector fields: work_item_id: "${id}" or title: "${title}"`,
+  ].join('\n');
+}
+
+/**
+ * Build a corrective error message when a task template ID is passed where
+ * a work item ID is expected.
+ */
+export function buildTaskTemplateMismatchError(id: string, title: string, expectedTool: string): string {
+  return [
+    `Entity mismatch: The ID "${id}" refers to a task template ("${title}"), not a work item.`,
+    `Corrective action: Use ${expectedTool} to operate on task templates.`,
+    `Selector fields: task_id: "${id}" or task_name: "${title}"`,
+  ].join('\n');
 }


### PR DESCRIPTION
## Summary

When the model incorrectly passes a work item ID to a task template tool (or vice versa), error messages were generic ("No task found with ID X") and gave no guidance on how to fix the routing. This PR improves those error messages across all task tools to include:

1. **What went wrong** — e.g., "The ID 'abc123' refers to a work item, not a task template"
2. **Corrective action** — e.g., "Use task_list_update to modify work items"
3. **Selector fields** — e.g., "work_item_id: 'abc123' or title: 'Buy groceries'"

Also adds an "Entity type routing" section to the system prompt to help prevent misrouting before it happens.

### Changes

- **`work-item-store.ts`**: Added `identifyEntityById()`, `buildWorkItemMismatchError()`, and `buildTaskTemplateMismatchError()` helpers
- **`task-delete.ts`**: Improved the "not found" error when neither task template nor work item exists
- **`task-run.ts`**: Detects when a work item ID is passed as `task_id` and provides corrective guidance
- **`work-item-enqueue.ts`**: Detects when a work item ID is passed as `task_id` to `task_list_add`
- **`work-item-update.ts`**: Detects when a task template ID is passed as `work_item_id`
- **`work-item-remove.ts`**: Detects when a task template ID is passed as `work_item_id`; also fixes a duplicate variable name bug (`const result` declared twice)
- **`system-prompt.ts`**: Added "Entity type routing" subsection to the task/schedule/reminder routing guidance

## Test plan

- [x] `bunx tsc --noEmit` passes
- [ ] Verify entity mismatch errors return structured corrective messages
- [ ] Verify system prompt includes new entity routing guidance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
