### PR TITLE
feat: add disambiguation fields to task_list_remove schema

### DIFF
--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -9,7 +9,7 @@ const log = getLogger('task-list-remove');
 const definition: ToolDefinition = {
   name: 'task_list_remove',
   description:
-    'Remove a task from the Task Queue. Identifies the task by work item ID, task ID, task name, or title.',
+    'Remove a task from the Task Queue. Identifies the task by work item ID, task ID, task name, or title. When multiple items match, use the disambiguation fields (priority_tier, status, created_order) to narrow down.',
   input_schema: {
     type: 'object',
     properties: {
@@ -28,6 +28,19 @@ const definition: ToolDefinition = {
       title: {
         type: 'string',
         description: 'Work item title to search for (case-insensitive exact match)',
+      },
+      priority_tier: {
+        type: 'number',
+        description: 'Disambiguator: filter by priority tier (0 = high, 1 = medium, 2 = low)',
+      },
+      status: {
+        type: 'string',
+        enum: ['queued', 'running', 'awaiting_review', 'failed'],
+        description: 'Disambiguator: filter by work item status',
+      },
+      created_order: {
+        type: 'number',
+        description: 'Disambiguator: 1-indexed creation order among matches (1 = oldest, 2 = second oldest, etc.)',
       },
     },
   },
@@ -51,29 +64,32 @@ class TaskListRemoveTool implements Tool {
         workItemId: input.work_item_id as string | undefined,
         taskId: input.task_id as string | undefined,
         title: (input.task_name ?? input.title) as string | undefined,
+        priorityTier: input.priority_tier as number | undefined,
+        status: input.status as import('../../work-items/work-item-store.js').WorkItemStatus | undefined,
+        createdOrder: input.created_order as number | undefined,
       };
 
-      const result = resolveWorkItem(selector);
+      const resolveResult = resolveWorkItem(selector);
 
-      if (result.status === 'not_found') {
-        log.warn({ selectorType, error: result.message }, 'work item not found for removal');
-        return { content: `Error: ${result.message}`, isError: true };
+      if (resolveResult.status === 'not_found') {
+        log.warn({ selectorType, error: resolveResult.message }, 'work item not found for removal');
+        return { content: `Error: ${resolveResult.message}`, isError: true };
       }
 
-      if (result.status === 'ambiguous') {
-        log.warn({ selectorType, matchCount: result.matches.length }, 'ambiguous selector for removal');
-        return { content: `Error: ${result.message}`, isError: true };
+      if (resolveResult.status === 'ambiguous') {
+        log.warn({ selectorType, matchCount: resolveResult.matches.length }, 'ambiguous selector for removal');
+        return { content: `Error: ${resolveResult.message}`, isError: true };
       }
 
-      const item = result.workItem;
+      const item = resolveResult.workItem;
 
       log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id, title: item.title }, 'resolved work item for removal');
 
-      const result = removeWorkItemFromQueue(item.id);
+      const removeResult = removeWorkItemFromQueue(item.id);
 
       log.info({ resolvedWorkItemId: item.id, deletedCount: 1 }, 'work item removed');
 
-      return { content: result.message, isError: false };
+      return { content: removeResult.message, isError: false };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ selectorType, error: msg }, 'remove failed');

--- a/assistant/src/work-items/work-item-store.ts
+++ b/assistant/src/work-items/work-item-store.ts
@@ -118,6 +118,12 @@ export interface WorkItemSelector {
   workItemId?: string;
   taskId?: string;
   title?: string;
+  /** Disambiguator: filter by priority tier (0 = high, 1 = medium, 2 = low) */
+  priorityTier?: number;
+  /** Disambiguator: filter by status (queued, running, etc.) */
+  status?: WorkItemStatus;
+  /** Disambiguator: 1-indexed creation order (1 = oldest, 2 = second oldest, etc.) */
+  createdOrder?: number;
 }
 
 export type ResolveWorkItemResult =
@@ -151,11 +157,70 @@ export function findActiveWorkItemsByTitle(title: string): WorkItem[] {
 }
 
 /**
+ * Apply disambiguator fields to narrow down a set of candidate matches.
+ * Filters by priorityTier, then status, then picks by createdOrder if provided.
+ * Returns the filtered list (may still contain multiple items if disambiguation
+ * fields are insufficient).
+ */
+function applyDisambiguators(items: WorkItem[], selector: WorkItemSelector): WorkItem[] {
+  let filtered = items;
+
+  if (selector.priorityTier !== undefined) {
+    filtered = filtered.filter(i => i.priorityTier === selector.priorityTier);
+  }
+
+  if (selector.status !== undefined) {
+    filtered = filtered.filter(i => i.status === selector.status);
+  }
+
+  if (selector.createdOrder !== undefined && filtered.length > 0) {
+    const sorted = [...filtered].sort((a, b) => a.createdAt - b.createdAt);
+    const idx = selector.createdOrder - 1; // convert 1-indexed to 0-indexed
+    if (idx >= 0 && idx < sorted.length) {
+      filtered = [sorted[idx]];
+    }
+    // If createdOrder is out of range, return the full filtered list so the
+    // caller can report ambiguity with the remaining candidates.
+  }
+
+  return filtered;
+}
+
+/**
+ * Given a list of candidate matches, apply disambiguators and return a resolution result.
+ * Centralises the disambiguate-or-return-ambiguous logic shared across selector branches.
+ */
+function resolveFromCandidates(items: WorkItem[], selectorLabel: string, selector: WorkItemSelector): ResolveWorkItemResult {
+  if (items.length === 0) {
+    return { status: 'not_found', message: `No active work item found for "${selectorLabel}"` };
+  }
+  if (items.length === 1) {
+    return { status: 'found', workItem: items[0] };
+  }
+
+  // Multiple matches — try to narrow down with disambiguator fields
+  const narrowed = applyDisambiguators(items, selector);
+
+  if (narrowed.length === 1) {
+    return { status: 'found', workItem: narrowed[0] };
+  }
+  if (narrowed.length === 0) {
+    // Disambiguators filtered out everything — report the original set so the
+    // caller sees what was available
+    return { status: 'ambiguous', matches: items, message: formatAmbiguityMessage(selectorLabel, items) };
+  }
+  return { status: 'ambiguous', matches: narrowed, message: formatAmbiguityMessage(selectorLabel, narrowed) };
+}
+
+/**
  * Resolve a single active work item from a selector.
  * Tries fields in priority order: workItemId > taskId > title.
  * Only considers active items (status not 'done' or 'archived').
  * Returns a discriminated union so callers can handle ambiguity explicitly
  * instead of silently picking one match when multiple exist.
+ *
+ * When multiple items match, the optional disambiguator fields (priorityTier,
+ * status, createdOrder) are applied to narrow down the set.
  */
 export function resolveWorkItem(selector: WorkItemSelector): ResolveWorkItemResult {
   if (selector.workItemId) {
@@ -169,20 +234,12 @@ export function resolveWorkItem(selector: WorkItemSelector): ResolveWorkItemResu
 
   if (selector.taskId) {
     const items = findActiveWorkItemsByTaskId(selector.taskId);
-    if (items.length === 0) return { status: 'not_found', message: `No active work item found for task "${selector.taskId}"` };
-    if (items.length > 1) {
-      return { status: 'ambiguous', matches: items, message: formatAmbiguityMessage(selector.taskId, items) };
-    }
-    return { status: 'found', workItem: items[0] };
+    return resolveFromCandidates(items, selector.taskId, selector);
   }
 
   if (selector.title) {
     const items = findActiveWorkItemsByTitle(selector.title);
-    if (items.length === 0) return { status: 'not_found', message: `No active work item found with title "${selector.title}"` };
-    if (items.length > 1) {
-      return { status: 'ambiguous', matches: items, message: formatAmbiguityMessage(selector.title, items) };
-    }
-    return { status: 'found', workItem: items[0] };
+    return resolveFromCandidates(items, selector.title, selector);
   }
 
   return { status: 'not_found', message: 'At least one selector field (workItemId, taskId, or title) must be provided' };


### PR DESCRIPTION
## Summary

Extends `task_list_remove` with explicit disambiguator fields (`priority_tier`, `status`, `created_order`) so the model can resolve ambiguous matches deterministically when multiple work items share the same title or task ID.

- **`WorkItemSelector`** now includes optional `priorityTier`, `status`, and `createdOrder` fields
- **`applyDisambiguators()`** filters candidates by priority tier, then status, then picks by 1-indexed creation order
- **`resolveFromCandidates()`** centralises the disambiguate-or-return-ambiguous logic across selector branches
- **`task_list_remove` schema** gains `priority_tier`, `status`, and `created_order` parameters, passed through to `resolveWorkItem`
- Fixes a pre-existing duplicate `const result` declaration bug in `work-item-remove.ts`

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] Existing tests pass (4 pre-existing failures in `task_list_show` unrelated to this change)
- [ ] Verify disambiguation resolves "remove the low-priority duplicate" correctly
- [ ] Verify created_order=1 picks the oldest matching item

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
