### PR TITLE
feat: add disambiguation filters to task_list_update and task_list_remove

### DIFF
--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -1,7 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { resolveWorkItem, removeWorkItemFromQueue, identifyEntityById, buildTaskTemplateMismatchError } from '../../work-items/work-item-store.js';
+import { resolveWorkItem, removeWorkItemFromQueue, identifyEntityById, buildTaskTemplateMismatchError, type WorkItemStatus } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('task-list-remove');
@@ -65,7 +65,7 @@ class TaskListRemoveTool implements Tool {
         taskId: input.task_id as string | undefined,
         title: (input.task_name ?? input.title) as string | undefined,
         priorityTier: input.priority_tier as number | undefined,
-        status: input.status as import('../../work-items/work-item-store.js').WorkItemStatus | undefined,
+        status: input.status as WorkItemStatus | undefined,
         createdOrder: input.created_order as number | undefined,
       };
 

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -52,6 +52,22 @@ const definition: ToolDefinition = {
         type: 'number',
         description: 'Manual sort order within the same priority tier',
       },
+      filter_priority_tier: {
+        type: 'number',
+        description:
+          'Disambiguation filter: narrow by current priority tier (0=high, 1=medium, 2=low) when multiple items share the same title/task_id. This identifies WHICH item to update — it is NOT the new priority value.',
+      },
+      filter_status: {
+        type: 'string',
+        enum: ['queued', 'running', 'awaiting_review', 'failed', 'done', 'archived'],
+        description:
+          'Disambiguation filter: narrow by current status when multiple items share the same title/task_id.',
+      },
+      created_order: {
+        type: 'number',
+        description:
+          'Disambiguation filter: pick the Nth oldest match (1 = oldest, 2 = second oldest, etc.) when multiple items share the same title/task_id.',
+      },
     },
   },
 };
@@ -75,6 +91,9 @@ class TaskListUpdateTool implements Tool {
         workItemId: input.work_item_id as string | undefined,
         taskId: input.task_id as string | undefined,
         title: (input.task_name ?? input.title) as string | undefined,
+        priorityTier: input.filter_priority_tier as number | undefined,
+        status: input.filter_status as WorkItemStatus | undefined,
+        createdOrder: input.created_order as number | undefined,
       };
 
       // Resolve the target work item


### PR DESCRIPTION
## Summary

- Extends `WorkItemSelector` with three optional disambiguation fields: `filterPriorityTier`, `filterStatus`, and `createdOrder`
- Adds `applyDisambiguationFilters()` and `resolveFromCandidates()` helpers to `work-item-store.ts` so that `resolveWorkItem` automatically narrows ambiguous matches using these filters
- Adds `filter_priority_tier`, `filter_status`, and `created_order` parameters to both `task_list_update` and `task_list_remove` tool schemas, with clear descriptions distinguishing the disambiguation `filter_priority_tier` from the update value `priority_tier`
- Both tools now wire disambiguation fields through to `resolveWorkItem`, ensuring identical target-selection behavior
- Fixes a pre-existing duplicate `result` variable declaration in `work-item-remove.ts` that prevented TypeScript compilation

## Test plan

- [ ] Verify `bunx tsc --noEmit` passes (confirmed locally)
- [ ] Test that `task_list_update` with `filter_priority_tier` correctly narrows among same-titled items
- [ ] Test that `task_list_remove` with `created_order` picks the Nth oldest match
- [ ] Test that disambiguation filters returning zero matches produce a helpful error listing all candidates
- [ ] Test that single-match cases still work without any disambiguation fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
