### PR TITLE
feat: structured error codes in work_item_run_task_response

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -151,7 +151,24 @@ export async function handleWorkItemRunTask(
 ): Promise<void> {
   const workItem = getWorkItem(msg.id);
   if (!workItem) {
-    ctx.send(socket, { type: 'work_item_run_task_response', id: msg.id, lastRunId: '', success: false, error: 'Work item not found' });
+    ctx.send(socket, { type: 'work_item_run_task_response', id: msg.id, lastRunId: '', success: false, error: 'Work item not found', errorCode: 'not_found' });
+    return;
+  }
+
+  if (workItem.status === 'running') {
+    ctx.send(socket, { type: 'work_item_run_task_response', id: msg.id, lastRunId: workItem.lastRunId ?? '', success: false, error: 'Work item is already running', errorCode: 'already_running' });
+    return;
+  }
+
+  const NON_RUNNABLE_STATUSES: readonly string[] = ['done', 'archived'];
+  if (NON_RUNNABLE_STATUSES.includes(workItem.status)) {
+    ctx.send(socket, { type: 'work_item_run_task_response', id: msg.id, lastRunId: workItem.lastRunId ?? '', success: false, error: `Work item has status '${workItem.status}' and cannot be run`, errorCode: 'invalid_status' });
+    return;
+  }
+
+  const task = getTask(workItem.taskId);
+  if (!task) {
+    ctx.send(socket, { type: 'work_item_run_task_response', id: msg.id, lastRunId: '', success: false, error: `Associated task not found: ${workItem.taskId}`, errorCode: 'no_task' });
     return;
   }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1932,12 +1932,16 @@ export interface WorkItemDeleteResponse {
   success: boolean;
 }
 
+export type WorkItemRunTaskErrorCode = 'not_found' | 'already_running' | 'invalid_status' | 'no_task';
+
 export interface WorkItemRunTaskResponse {
   type: 'work_item_run_task_response';
   id: string;
   lastRunId: string;
   success: boolean;
   error?: string;
+  /** Structured error code so the client can deterministically re-enable buttons or show contextual UI. */
+  errorCode?: WorkItemRunTaskErrorCode;
 }
 
 /** Server push — tells the client to open/focus the tasks window. */

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2004,6 +2004,8 @@ public struct IPCWorkItemRunTaskResponse: Codable, Sendable {
     public let lastRunId: String
     public let success: Bool
     public let error: String?
+    /// Structured error code so the client can deterministically re-enable buttons or show contextual UI.
+    public let errorCode: String?
 }
 
 public struct IPCWorkItemsListRequest: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Adds a typed `errorCode` field (`not_found` | `already_running` | `invalid_status` | `no_task`) to `WorkItemRunTaskResponse` so the macOS client can deterministically handle each failure case (e.g. re-enable run buttons, show specific error messages)
- Updates the daemon handler to validate work item state before execution: checks for missing items, already-running status, non-runnable statuses (done/archived), and missing associated tasks
- Updates the Swift IPC generated types to include the new optional `errorCode` field

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests pass (success case unchanged, new field is optional)
- [x] IPC contract inventory tests pass
- [ ] Verify macOS client gracefully handles the new `errorCode` field (Codable auto-decodes optional fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
