### PR TITLE
refactor: normalize work item status to typed enum

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
@@ -1,6 +1,33 @@
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Work Item Status
+
+/// Normalized status enum that maps daemon status strings to typed cases.
+/// Case-insensitive matching protects against transport casing/serialization drift.
+enum WorkItemStatus: Equatable {
+    case queued
+    case running
+    case awaitingReview
+    case failed
+    case done
+    case archived
+    case unknown(String)
+
+    /// Case-insensitive mapping from the raw daemon status string.
+    init(rawStatus: String) {
+        switch rawStatus.lowercased() {
+        case "queued":          self = .queued
+        case "running":         self = .running
+        case "awaiting_review": self = .awaitingReview
+        case "failed":          self = .failed
+        case "done":            self = .done
+        case "archived":        self = .archived
+        default:                self = .unknown(rawStatus)
+        }
+    }
+}
+
 // MARK: - Table Column Definitions
 
 /// Single source of truth for the Tasks table layout, column sizing,
@@ -64,15 +91,15 @@ enum TasksTableContract {
         let color: Color
     }
 
-    static func statusStyle(for status: String) -> StatusStyle {
+    static func statusStyle(for status: WorkItemStatus) -> StatusStyle {
         switch status {
-        case "queued":          return StatusStyle(label: "Queued",    color: VColor.textSecondary)
-        case "running":         return StatusStyle(label: "Running",   color: VColor.warning)
-        case "awaiting_review": return StatusStyle(label: "Review",    color: VColor.accent)
-        case "failed":          return StatusStyle(label: "Failed",    color: VColor.error)
-        case "done":            return StatusStyle(label: "Done",      color: VColor.success)
-        case "archived":        return StatusStyle(label: "Archived",  color: VColor.textMuted)
-        default:                return StatusStyle(label: status,      color: VColor.textMuted)
+        case .queued:          return StatusStyle(label: "Queued",    color: VColor.textSecondary)
+        case .running:         return StatusStyle(label: "Running",   color: VColor.warning)
+        case .awaitingReview:  return StatusStyle(label: "Review",    color: VColor.accent)
+        case .failed:          return StatusStyle(label: "Failed",    color: VColor.error)
+        case .done:            return StatusStyle(label: "Done",      color: VColor.success)
+        case .archived:        return StatusStyle(label: "Archived",  color: VColor.textMuted)
+        case .unknown(let raw): return StatusStyle(label: raw,        color: VColor.textMuted)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -210,10 +210,10 @@ private struct TasksWindowRow: View {
     // MARK: - Status Column
 
     private var statusColumn: some View {
-        let style = TasksTableContract.statusStyle(for: item.status)
-        let showSpinner = item.status == "running"
+        let status = WorkItemStatus(rawStatus: item.status)
+        let style = TasksTableContract.statusStyle(for: status)
         return HStack(spacing: VSpacing.xs) {
-            if showSpinner {
+            if status == .running {
                 ProgressView()
                     .controlSize(.mini)
             }
@@ -231,8 +231,9 @@ private struct TasksWindowRow: View {
     // MARK: - Actions Column
 
     private var actionsColumn: some View {
-        HStack(spacing: VSpacing.xs) {
-            if item.status == "queued" {
+        let status = WorkItemStatus(rawStatus: item.status)
+        return HStack(spacing: VSpacing.xs) {
+            if status == .queued {
                 Button(action: onRun) {
                     HStack(spacing: VSpacing.xs) {
                         Image(systemName: "play.fill")
@@ -250,7 +251,7 @@ private struct TasksWindowRow: View {
                 .accessibilityLabel("Run task")
             }
 
-            if item.status == "awaiting_review" {
+            if status == .awaitingReview {
                 Button(action: onComplete) {
                     HStack(spacing: VSpacing.xs) {
                         Image(systemName: "checkmark")


### PR DESCRIPTION
## Summary
- Introduces a `WorkItemStatus` enum with case-insensitive mapping from raw daemon status strings, preventing silent UI breakage from transport casing/serialization drift
- Updates `TasksTableContract.statusStyle(for:)` to accept the enum instead of a raw string
- Replaces all raw string status comparisons in `TasksWindowView` row rendering with typed enum checks
- Includes an `unknown(String)` case for forward compatibility with new statuses

## Test plan
- [x] Build passes (`./build.sh`)
- [ ] Verify Tasks window renders correctly with queued, running, awaiting_review, done, archived items
- [ ] Verify Run button appears only for queued items
- [ ] Verify Reviewed button appears only for awaiting_review items
- [ ] Verify spinner appears only for running items
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
