### PR TITLE
refactor: separate visible vs enabled logic for Run button in tasks actions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -232,8 +232,10 @@ private struct TasksWindowRow: View {
 
     private var actionsColumn: some View {
         let status = WorkItemStatus(rawStatus: item.status)
+        let runEnabled = status == .queued
+        let showRun = status == .queued || status == .failed
         return HStack(spacing: VSpacing.xs) {
-            if status == .queued {
+            if showRun {
                 Button(action: onRun) {
                     HStack(spacing: VSpacing.xs) {
                         Image(systemName: "play.fill")
@@ -248,7 +250,10 @@ private struct TasksWindowRow: View {
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
                 .buttonStyle(.plain)
+                .disabled(!runEnabled)
+                .opacity(runEnabled ? 1.0 : 0.4)
                 .accessibilityLabel("Run task")
+                .accessibilityHint(runEnabled ? "" : "Task cannot be run because it has failed")
             }
 
             if status == .awaitingReview {


### PR DESCRIPTION
## Summary
- The Run button in the tasks actions column is now shown for both `.queued` and `.failed` statuses, instead of only `.queued`.
- When the status is `.failed`, the Run button is disabled (`.disabled(true)`) with reduced opacity (0.4) to visually indicate it's not actionable.
- An `.accessibilityHint()` is added to the disabled Run button explaining why it cannot be used ("Task cannot be run because it has failed").
- The "Reviewed" button remains unchanged (only visible for `.awaitingReview`).

## Test plan
- [ ] Build passes (`./build.sh`)
- [ ] Verify queued tasks show an enabled Run button at full opacity
- [ ] Verify failed tasks show a disabled Run button at reduced opacity
- [ ] Verify VoiceOver reads the accessibility hint on the disabled Run button
- [ ] Verify other statuses (running, done, archived) do not show a Run button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
