### PR TITLE
fix: keep sidebar open when navigating to panels

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -994,12 +994,21 @@ struct MainWindowView: View {
                         let newWidth = initialWidth + Double(deltaX)
                         let minDrawerWidth: CGFloat = 200
                         let minMainContent: CGFloat = 300
-                        let sidePanelVisible =
-                            (windowState.activePanel != nil &&
-                             !(windowState.isDynamicExpanded && windowState.activePanel == .generated) &&
-                             windowState.activePanel != .directory) ||
-                            (windowState.isDynamicExpanded && windowState.activePanel == .generated && windowState.isChatDockOpen)
-                        let activePanelWidth: CGFloat = sidePanelVisible ? sidePanelWidth : 0
+                        // Only subtract side panel width when a right-side split panel is
+                        // actually rendered. Full-window panels (identity, agent, settings,
+                        // debug, doctor, directory) don't have a right split.
+                        let hasRightSplitPanel: Bool = {
+                            guard let panel = windowState.activePanel else { return false }
+                            switch panel {
+                            case .documentEditor:
+                                return true
+                            case .generated:
+                                return windowState.isDynamicExpanded && windowState.isChatDockOpen
+                            default:
+                                return false
+                            }
+                        }()
+                        let activePanelWidth: CGFloat = hasRightSplitPanel ? sidePanelWidth : 0
                         let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.xs - (VSpacing.xs * 2) - activePanelWidth
 
                         // Update width without animation to prevent jitter

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -409,44 +409,35 @@ struct MainWindowView: View {
 
                     Divider().background(VColor.surfaceBorder)
 
-                    // Content area with sidebar
-                    // When a panel is selected, use HStack so sidebar pushes content.
-                    // Otherwise, use ZStack so sidebar overlays the chat.
-                    let sidebarVisible = sidebarOpen && windowState.layoutConfig.left.visible
-                    let sidebarPushesContent: Bool = {
-                        if case .panel = windowState.selection { return true }
-                        return false
-                    }()
+                    // Content area with sidebar drawer overlay.
+                    // On panel routes the sidebar pushes content via leading padding
+                    // so the panel view is never obscured. On chat routes the sidebar
+                    // floats as an overlay.
+                    ZStack(alignment: .leading) {
+                        let sidebarVisible = sidebarOpen && windowState.layoutConfig.left.visible
+                        let sidebarPushesContent: Bool = {
+                            if case .panel = windowState.selection { return true }
+                            return false
+                        }()
+                        let sidebarInset = sidebarVisible && sidebarPushesContent
+                            ? threadDrawerWidth + VSpacing.xs : 0
 
-                    if sidebarVisible && sidebarPushesContent {
-                        HStack(spacing: 0) {
+                        chatContentView(geometry: geometry)
+                            .padding(.leading, sidebarInset)
+
+                        // Sidebar drawer
+                        if sidebarVisible {
                             HStack(spacing: 0) {
                                 sidebarView
                                 drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
                             }
+                            .shadow(color: sidebarPushesContent ? .clear : .black.opacity(0.2),
+                                    radius: 8, x: 2, y: 0)
                             .transition(.move(edge: .leading))
                             .animation(nil, value: threadDrawerWidth)
-
-                            chatContentView(geometry: geometry)
                         }
-                        .coordinateSpace(name: drawerDragCoordinateSpaceName)
-                    } else {
-                        ZStack(alignment: .leading) {
-                            chatContentView(geometry: geometry)
-
-                            // Sidebar drawer overlay
-                            if sidebarVisible {
-                                HStack(spacing: 0) {
-                                    sidebarView
-                                    drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
-                                }
-                                .shadow(color: .black.opacity(0.2), radius: 8, x: 2, y: 0)
-                                .transition(.move(edge: .leading))
-                                .animation(nil, value: threadDrawerWidth)
-                            }
-                        }
-                        .coordinateSpace(name: drawerDragCoordinateSpaceName)
                     }
+                    .coordinateSpace(name: drawerDragCoordinateSpaceName)
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for control center drawer

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -313,11 +313,11 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = nil
                 }
 
-                // Close the left sidebar when any right-side content opens to avoid crowding
+                // Close the left sidebar when an app opens to avoid crowding
                 if sidebarOpen {
                     let shouldClose: Bool = {
                         switch newSelection {
-                        case .panel, .app, .appEditing: return true
+                        case .app, .appEditing: return true
                         default: return false
                         }
                     }()
@@ -409,23 +409,44 @@ struct MainWindowView: View {
 
                     Divider().background(VColor.surfaceBorder)
 
-                    // Content area with sidebar drawer overlay
-                    ZStack(alignment: .leading) {
-                        chatContentView(geometry: geometry)
+                    // Content area with sidebar
+                    // When a panel is selected, use HStack so sidebar pushes content.
+                    // Otherwise, use ZStack so sidebar overlays the chat.
+                    let sidebarVisible = sidebarOpen && windowState.layoutConfig.left.visible
+                    let sidebarPushesContent: Bool = {
+                        if case .panel = windowState.selection { return true }
+                        return false
+                    }()
 
-                        // Sidebar drawer overlay
-                        if sidebarOpen && windowState.layoutConfig.left.visible {
-                            // Sidebar panel + resize handle
+                    if sidebarVisible && sidebarPushesContent {
+                        HStack(spacing: 0) {
                             HStack(spacing: 0) {
                                 sidebarView
                                 drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
                             }
-                            .shadow(color: .black.opacity(0.2), radius: 8, x: 2, y: 0)
                             .transition(.move(edge: .leading))
                             .animation(nil, value: threadDrawerWidth)
+
+                            chatContentView(geometry: geometry)
                         }
+                        .coordinateSpace(name: drawerDragCoordinateSpaceName)
+                    } else {
+                        ZStack(alignment: .leading) {
+                            chatContentView(geometry: geometry)
+
+                            // Sidebar drawer overlay
+                            if sidebarVisible {
+                                HStack(spacing: 0) {
+                                    sidebarView
+                                    drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
+                                }
+                                .shadow(color: .black.opacity(0.2), radius: 8, x: 2, y: 0)
+                                .transition(.move(edge: .leading))
+                                .animation(nil, value: threadDrawerWidth)
+                            }
+                        }
+                        .coordinateSpace(name: drawerDragCoordinateSpaceName)
                     }
-                    .coordinateSpace(name: drawerDragCoordinateSpaceName)
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for control center drawer


### PR DESCRIPTION
## Summary
- Sidebar no longer auto-closes when navigating to panel pages (Skills, Identity, Home Base) from the sidebar
- When sidebar is open alongside a panel, content is pushed via HStack layout instead of being hidden behind the overlay
- Sidebar still overlays chat threads (ZStack) and auto-closes when opening app workspaces

## Test plan
- [ ] Open sidebar, click Skills/Identity/Home Base — sidebar should stay open
- [ ] Panel content should be pushed to the right, not hidden behind sidebar
- [ ] Open sidebar on a chat thread — sidebar should still overlay the chat
- [ ] Navigate to an app workspace — sidebar should auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
