### PR TITLE
fix: show Retry button with warning styling for failed tasks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -232,28 +232,28 @@ private struct TasksWindowRow: View {
 
     private var actionsColumn: some View {
         let status = WorkItemStatus(rawStatus: item.status)
-        let runEnabled = status == .queued
-        let showRun = status == .queued || status == .failed
+        let isFailed = status == .failed
+        let showRun = status == .queued || isFailed
+        let buttonColor = isFailed ? VColor.warning : VColor.accent
+        let buttonLabel = isFailed ? "Retry" : "Run"
         return HStack(spacing: VSpacing.xs) {
             if showRun {
                 Button(action: onRun) {
                     HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "play.fill")
+                        Image(systemName: isFailed ? "arrow.clockwise" : "play.fill")
                             .font(.system(size: 10))
-                        Text("Run")
+                        Text(buttonLabel)
                             .font(VFont.caption)
                     }
-                    .foregroundColor(VColor.accent)
+                    .foregroundColor(buttonColor)
                     .padding(.horizontal, VSpacing.sm)
                     .padding(.vertical, VSpacing.xs)
-                    .background(VColor.accent.opacity(0.12))
+                    .background(buttonColor.opacity(0.12))
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
                 .buttonStyle(.plain)
-                .disabled(!runEnabled)
-                .opacity(runEnabled ? 1.0 : 0.4)
-                .accessibilityLabel("Run task")
-                .accessibilityHint(runEnabled ? "" : "Task cannot be run because it has failed")
+                .accessibilityLabel(isFailed ? "Retry task" : "Run task")
+                .accessibilityHint(isFailed ? "Retry running this failed task" : "")
             }
 
             if status == .awaitingReview {


### PR DESCRIPTION
## Summary
- Failed tasks in the actions column now show a **Retry** button (with `arrow.clockwise` icon) instead of a disabled **Run** button at 0.4 opacity.
- Button uses `VColor.warning` styling to distinguish retry from a normal run, making the failed state feel actionable rather than broken.
- Adds `.accessibilityHint("Retry running this failed task")` for the failed state.
- Removes `.disabled()` and `.opacity()` modifiers — the button is always clickable for both `.queued` and `.failed` states.

## Test plan
- [ ] Build succeeds (`./build.sh`)
- [ ] Queued task shows "Run" with purple/accent play icon
- [ ] Failed task shows "Retry" with amber/warning clockwise arrow icon
- [ ] Both buttons are clickable and trigger `runTask`
- [ ] VoiceOver reads "Retry task — Retry running this failed task" for failed items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
