### PR TITLE
fix: tighten row hit-test areas so action buttons always receive clicks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -140,13 +140,17 @@ private struct TasksWindowRow: View {
             statusColumn
                 .frame(width: TasksTableContract.statusWidth)
 
-            // Actions column — fixed width
+            // Actions column — fixed width; sits above the row background
+            // in the hit-test stack so button clicks are never intercepted.
             actionsColumn
                 .frame(width: TasksTableContract.actionsWidth)
+                .contentShape(Rectangle())
+                .allowsHitTesting(true)
         }
         .frame(minHeight: 36)
         .padding(.vertical, VSpacing.sm)
         .padding(.horizontal, VSpacing.md)
+        .contentShape(Rectangle())
         .background(isHovered ? VColor.surface.opacity(0.8) : VColor.surface.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
@@ -248,6 +252,7 @@ private struct TasksWindowRow: View {
                     .padding(.vertical, VSpacing.xs)
                     .background(VColor.accent.opacity(0.12))
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .disabled(!runEnabled)
@@ -269,6 +274,7 @@ private struct TasksWindowRow: View {
                     .padding(.vertical, VSpacing.xs)
                     .background(VColor.success.opacity(0.12))
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Mark task as reviewed")
@@ -282,6 +288,7 @@ private struct TasksWindowRow: View {
                         .frame(width: 20, height: 20)
                         .background(VColor.surfaceBorder.opacity(0.5))
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Remove task")


### PR DESCRIPTION
## Summary
- Added `.contentShape(Rectangle())` to the row's main `HStack` (before the `.background`) to explicitly define the hit-test region, preventing the background fill and hover layers from intercepting clicks meant for child controls.
- Added `.contentShape(Rectangle())` and `.allowsHitTesting(true)` to the actions column container so it takes priority in the hit-test stack.
- Added `.contentShape(Rectangle())` to each action button label (Run, Reviewed, Remove) so their tappable areas are clearly defined and not obscured by the row's background layers.
- Verified `.buttonStyle(.plain)` is already correctly applied to all action buttons.

## Test plan
- [ ] Open the Tasks window with queued tasks visible
- [ ] Hover over a task row and confirm the Run button is clickable on the first attempt
- [ ] Confirm the Remove (x) button appears on hover and responds to clicks
- [ ] Confirm the Reviewed button (for awaiting-review tasks) responds to clicks
- [ ] Verify hover background still applies correctly across the entire row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
