### PR TITLE
feat: expose runInFlightIds and wire onWorkItemRunTaskResponse

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -97,6 +97,7 @@ struct TasksWindowView: View {
                         ForEach(viewModel.items, id: \.id) { item in
                             TasksWindowRow(
                                 item: item,
+                                runningIds: viewModel.runInFlightIds,
                                 onRun: { viewModel.runTask(id: item.id) },
                                 onComplete: { viewModel.completeTask(id: item.id) },
                                 onRemove: { viewModel.removeTask(id: item.id) },
@@ -121,6 +122,7 @@ struct TasksWindowView: View {
 /// Row view using explicit columns aligned to `TasksTableContract`.
 private struct TasksWindowRow: View {
     let item: IPCWorkItemsListResponseItem
+    let runningIds: Set<String>
     let onRun: () -> Void
     let onComplete: () -> Void
     let onRemove: () -> Void
@@ -232,7 +234,8 @@ private struct TasksWindowRow: View {
 
     private var actionsColumn: some View {
         let status = WorkItemStatus(rawStatus: item.status)
-        let runEnabled = status == .queued
+        let isRunning = runningIds.contains(item.id)
+        let runEnabled = status == .queued && !isRunning
         let showRun = status == .queued || status == .failed
         return HStack(spacing: VSpacing.xs) {
             if showRun {
@@ -240,7 +243,7 @@ private struct TasksWindowRow: View {
                     HStack(spacing: VSpacing.xs) {
                         Image(systemName: "play.fill")
                             .font(.system(size: 10))
-                        Text("Run")
+                        Text(isRunning ? "Starting..." : "Run")
                             .font(VFont.caption)
                     }
                     .foregroundColor(VColor.accent)
@@ -252,8 +255,8 @@ private struct TasksWindowRow: View {
                 .buttonStyle(.plain)
                 .disabled(!runEnabled)
                 .opacity(runEnabled ? 1.0 : 0.4)
-                .accessibilityLabel("Run task")
-                .accessibilityHint(runEnabled ? "" : "Task cannot be run because it has failed")
+                .accessibilityLabel(isRunning ? "Task is starting" : "Run task")
+                .accessibilityHint(runEnabled ? "" : isRunning ? "Task is already starting" : "Task cannot be run because it has failed")
             }
 
             if status == .awaitingReview {

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -14,8 +14,8 @@ class TasksWindowViewModel: ObservableObject {
     private let daemonClient: DaemonClient
     private var refreshTask: Task<Void, Never>?
     /// Tracks work item IDs with an in-flight run request so we can
-    /// detect duplicate taps and log them as a precondition failure.
-    private var runInFlightIds: Set<String> = []
+    /// detect duplicate taps and disable the Run button in the view.
+    @Published var runInFlightIds: Set<String> = []
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -50,6 +50,15 @@ class TasksWindowViewModel: ObservableObject {
             scheduleRefresh()
         }
         daemonClient.onTasksChanged = { _ in scheduleRefresh() }
+
+        daemonClient.onWorkItemRunTaskResponse = { [weak self] response in
+            guard let self else { return }
+            self.runInFlightIds.remove(response.id)
+            if !response.success {
+                self.logger.error("onWorkItemRunTaskResponse: run failed for id=\(response.id, privacy: .public) errorCode=\(response.errorCode ?? "none", privacy: .public) error=\(response.error ?? "none", privacy: .public)")
+                self.fetchItems()
+            }
+        }
 
         daemonClient.onWorkItemDeleteResponse = { [weak self] response in
             guard let self else { return }


### PR DESCRIPTION
## Summary
- Make `runInFlightIds` a `@Published` property on `TasksWindowViewModel` so the view layer can react to in-flight run request state changes
- Wire `onWorkItemRunTaskResponse` callback in `setupCallbacks()` — clears the in-flight ID on any response, logs errors and triggers `fetchItems()` on failure to reconcile state
- Pass `runningIds` to `TasksWindowRow` and disable the Run button + show "Starting..." text while a run request is in flight
- Update accessibility labels/hints to reflect the running state

## Test plan
- [ ] Tap Run on a queued task — button should show "Starting..." and become disabled
- [ ] When the daemon responds with success, the button state should clear (item transitions to running status via `onWorkItemStatusChanged`)
- [ ] When the daemon responds with failure, the button re-enables and the list refreshes to reconcile server state
- [ ] Verify no duplicate run requests can be sent while one is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
