### PR TITLE
feat: include original prompt/plan section in PR bodies

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -40,16 +40,20 @@ Review what changed, draft a commit message and PR title, then ship everything i
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree> && .claude/ship \
-  --commit-msg "<commit message>" \
-  --title "<PR title>" \
-  --body "## Summary
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
 <1-3 bullet points>
 
 ## Original task
-$ARGUMENTS
+<paste verbatim task text from $ARGUMENTS here>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+cd <worktree> && .claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<PR title>" \
+  --body "$PR_BODY" \
   --base main \
   --merge \
   --track-unreviewed \

--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -46,6 +46,9 @@ cd <worktree> && .claude/ship \
   --body "## Summary
 <1-3 bullet points>
 
+## Original task
+$ARGUMENTS
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
   --base main \
   --merge \

--- a/.claude/commands/execute-plan.md
+++ b/.claude/commands/execute-plan.md
@@ -46,6 +46,9 @@ Create a branch from the plan (or derive one from the PR title), then ship:
   --body "## Summary
 <1-3 bullet points>
 
+## Plan section
+<paste the full text of this PR's section from the plan file, verbatim>
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
   --base main \
   --merge \

--- a/.claude/commands/execute-plan.md
+++ b/.claude/commands/execute-plan.md
@@ -40,15 +40,17 @@ Read the PR section carefully. Implement all the changes described:
 Create a branch from the plan (or derive one from the PR title), then ship:
 
 ```bash
-PR_BODY=$(cat <<'BODY_EOF'
+PLAN_CONTENT=$(cat ".private/plans/<plan-filename>")
+PR_BODY=$(cat <<VELLUM_PR_BODY
 ## Summary
 <1-3 bullet points>
 
-## Plan section
-<paste the full text of this PR's section from the plan file, verbatim>
+## Plan
+
+$PLAN_CONTENT
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
-BODY_EOF
+VELLUM_PR_BODY
 )
 .claude/ship \
   --commit-msg "<commit message>" \

--- a/.claude/commands/execute-plan.md
+++ b/.claude/commands/execute-plan.md
@@ -40,16 +40,20 @@ Read the PR section carefully. Implement all the changes described:
 Create a branch from the plan (or derive one from the PR title), then ship:
 
 ```bash
-.claude/ship \
-  --commit-msg "<commit message>" \
-  --title "<title from plan>" \
-  --body "## Summary
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
 <1-3 bullet points>
 
 ## Plan section
 <paste the full text of this PR's section from the plan file, verbatim>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<title from plan>" \
+  --body "$PR_BODY" \
   --base main \
   --merge \
   --track-unreviewed \

--- a/.claude/commands/mainline.md
+++ b/.claude/commands/mainline.md
@@ -34,16 +34,20 @@ git stash pop
 Review the changes, draft a commit message and PR title (use `$ARGUMENTS` as the title if provided), then ship:
 
 ```bash
-.claude/ship \
-  --commit-msg "<commit message>" \
-  --title "<PR title>" \
-  --body "## Summary
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
 <1-3 bullet points>
 
 ## Context
-<if $ARGUMENTS was provided, include it here as the original prompt; otherwise describe what prompted these changes>
+<if $ARGUMENTS was provided, paste it here; otherwise briefly describe what prompted these changes>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+.claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<PR title>" \
+  --body "$PR_BODY" \
   --base main \
   --merge \
   --track-unreviewed \

--- a/.claude/commands/mainline.md
+++ b/.claude/commands/mainline.md
@@ -40,6 +40,9 @@ Review the changes, draft a commit message and PR title (use `$ARGUMENTS` as the
   --body "## Summary
 <1-3 bullet points>
 
+## Context
+<if $ARGUMENTS was provided, include it here as the original prompt; otherwise describe what prompted these changes>
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
   --base main \
   --merge \

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -97,6 +97,9 @@ cd <worktree> && .claude/ship \
   --body "## Summary
 <1-3 bullet points>
 
+## Plan section
+<paste the full text of this PR's section from the plan file, verbatim>
+
 Part of plan: <plan filename> (PR <X> of <total>)
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)" \

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -88,7 +88,7 @@ Read the next PR section from the plan. Implement all changes in the worktree.
 
 #### 8d. Ship (do NOT merge)
 
-**Run from the worktree root** (not `assistant/` or the main repo):
+**Run these commands from the main repo** (`.private/` only exists there, not in worktrees):
 
 ```bash
 PLAN_CONTENT=$(cat ".private/plans/<plan-filename>")
@@ -105,6 +105,11 @@ Part of plan: <plan filename> (PR <X> of <total>)
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 VELLUM_PR_BODY
 )
+```
+
+**Then ship from the worktree root** (`.claude/ship` must run from the worktree, not `assistant/`):
+
+```bash
 cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \
   --title "<title from plan>" \

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -91,17 +91,19 @@ Read the next PR section from the plan. Implement all changes in the worktree.
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-PR_BODY=$(cat <<'BODY_EOF'
+PLAN_CONTENT=$(cat ".private/plans/<plan-filename>")
+PR_BODY=$(cat <<VELLUM_PR_BODY
 ## Summary
 <1-3 bullet points>
 
-## Plan section
-<paste the full text of this PR's section from the plan file, verbatim>
+## Plan
+
+$PLAN_CONTENT
 
 Part of plan: <plan filename> (PR <X> of <total>)
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
-BODY_EOF
+VELLUM_PR_BODY
 )
 cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \

--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -91,10 +91,8 @@ Read the next PR section from the plan. Implement all changes in the worktree.
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree> && .claude/ship \
-  --commit-msg "<commit message>" \
-  --title "<title from plan>" \
-  --body "## Summary
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
 <1-3 bullet points>
 
 ## Plan section
@@ -102,7 +100,13 @@ cd <worktree> && .claude/ship \
 
 Part of plan: <plan filename> (PR <X> of <total>)
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+cd <worktree> && .claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<title from plan>" \
+  --body "$PR_BODY" \
   --base main \
   --track-unreviewed
 ```

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -201,7 +201,13 @@ ALL work happens here. Do NOT touch the main repo.
 1. Make the changes in your worktree.
 2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
 3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
-   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base <feature-branch-name> --merge --assignee @me
+   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "## Summary
+<1-3 bullet points>
+
+## Task
+<the exact TODO item text you were given>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" --base <feature-branch-name> --merge --assignee @me
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -200,14 +200,21 @@ ALL work happens here. Do NOT touch the main repo.
 ## Workflow
 1. Make the changes in your worktree.
 2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
-3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
-   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "## Summary
-<1-3 bullet points>
+3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/).
+   First build the PR body in a variable so task text with special characters doesn't break quoting:
+   ```bash
+   PR_BODY=$(cat <<'BODY_EOF'
+   ## Summary
+   <1-3 bullet points>
 
-## Task
-<the exact TODO item text you were given>
+   ## Task
+   <the exact TODO item text you were given>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" --base <feature-branch-name> --merge --assignee @me
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   BODY_EOF
+   )
+   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base <feature-branch-name> --merge --assignee @me
+   ```
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -279,9 +279,12 @@ This is the key difference from `/blitz`. Instead of closing the epic, we create
 2. Create the final PR from the feature branch into main. **Do NOT merge it.**
 
 ```bash
-gh pr create --base main --head <feature-branch-name> --title "<Feature Title>" --body "$(cat <<'EOF'
+gh pr create --base main --head <feature-branch-name> --title "<Feature Title>" --body "$(cat <<'PR_BODY_DELIM'
 ## Summary
 <1-3 sentence overview of the feature>
+
+## Original feature request
+<the verbatim feature description passed as $ARGUMENTS>
 
 ## Changes
 <bulleted list of all milestone changes>
@@ -298,7 +301,7 @@ Closes #<project-issue-number>
 - [ ] <verification steps>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
+PR_BODY_DELIM
 )" --assignee @me
 ```
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -201,20 +201,19 @@ ALL work happens here. Do NOT touch the main repo.
 1. Make the changes in your worktree.
 2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
 3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/).
-   First build the PR body in a variable so task text with special characters doesn't break quoting:
-   ```bash
-   PR_BODY=$(cat <<'BODY_EOF'
-   ## Summary
-   <1-3 bullet points>
+   Build the body in a variable using a heredoc (BODY_EOF delimiter MUST be at column 0), then pass via --body:
 
-   ## Task
-   <the exact TODO item text you were given>
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
+<1-3 bullet points>
 
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   BODY_EOF
-   )
-   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base <feature-branch-name> --merge --assignee @me
-   ```
+## Task
+<the exact TODO item text you were given>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base <feature-branch-name> --merge --assignee @me
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -46,6 +46,9 @@ cd <worktree> && .claude/ship \
   --body "## Summary
 <1-3 bullet points>
 
+## Original task
+$ARGUMENTS
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
   --base main \
   --track-unreviewed

--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -40,16 +40,20 @@ Review what changed, draft a commit message and PR title, then ship.
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree> && .claude/ship \
-  --commit-msg "<commit message>" \
-  --title "<PR title>" \
-  --body "## Summary
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
 <1-3 bullet points>
 
 ## Original task
-$ARGUMENTS
+<paste verbatim task text from $ARGUMENTS here>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+cd <worktree> && .claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<PR title>" \
+  --body "$PR_BODY" \
   --base main \
   --track-unreviewed
 ```

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -64,7 +64,7 @@ Read the PR section carefully. Implement all the changes described:
 
 #### 4d. Ship (do NOT merge)
 
-**Run from the worktree root** (not `assistant/` or the main repo):
+**Run these commands from the main repo** (`.private/` only exists there, not in worktrees):
 
 ```bash
 PLAN_CONTENT=$(cat ".private/plans/<plan-filename>")
@@ -81,6 +81,11 @@ Part of plan: <plan filename> (PR <X> of <total>)
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 VELLUM_PR_BODY
 )
+```
+
+**Then ship from the worktree root** (`.claude/ship` must run from the worktree, not `assistant/`):
+
+```bash
 cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \
   --title "<title from plan>" \

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -73,6 +73,9 @@ cd <worktree> && .claude/ship \
   --body "## Summary
 <1-3 bullet points>
 
+## Plan section
+<paste the full text of this PR's section from the plan file, verbatim>
+
 Part of plan: <plan filename> (PR <X> of <total>)
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)" \

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -67,17 +67,19 @@ Read the PR section carefully. Implement all the changes described:
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-PR_BODY=$(cat <<'BODY_EOF'
+PLAN_CONTENT=$(cat ".private/plans/<plan-filename>")
+PR_BODY=$(cat <<VELLUM_PR_BODY
 ## Summary
 <1-3 bullet points>
 
-## Plan section
-<paste the full text of this PR's section from the plan file, verbatim>
+## Plan
+
+$PLAN_CONTENT
 
 Part of plan: <plan filename> (PR <X> of <total>)
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
-BODY_EOF
+VELLUM_PR_BODY
 )
 cd <worktree> && .claude/ship \
   --commit-msg "<commit message>" \

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -67,10 +67,8 @@ Read the PR section carefully. Implement all the changes described:
 **Run from the worktree root** (not `assistant/` or the main repo):
 
 ```bash
-cd <worktree> && .claude/ship \
-  --commit-msg "<commit message>" \
-  --title "<title from plan>" \
-  --body "## Summary
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
 <1-3 bullet points>
 
 ## Plan section
@@ -78,7 +76,13 @@ cd <worktree> && .claude/ship \
 
 Part of plan: <plan filename> (PR <X> of <total>)
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+cd <worktree> && .claude/ship \
+  --commit-msg "<commit message>" \
+  --title "<title from plan>" \
+  --body "$PR_BODY" \
   --base main \
   --track-unreviewed
 ```

--- a/.claude/commands/ship-and-merge.md
+++ b/.claude/commands/ship-and-merge.md
@@ -41,7 +41,7 @@ git commit -m "<commit message>
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
 git push -u origin HEAD
-gh pr create --base main --title "<PR title>" --body "$(cat <<'EOF'
+gh pr create --base main --title "<PR title>" --body "$(cat <<'PR_BODY_DELIM'
 ## Summary
 <1-3 bullet points>
 
@@ -49,7 +49,7 @@ gh pr create --base main --title "<PR title>" --body "$(cat <<'EOF'
 <$ARGUMENTS if provided, otherwise a brief description of what changes are being shipped>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
+PR_BODY_DELIM
 )" --assignee @me
 ```
 

--- a/.claude/commands/ship-and-merge.md
+++ b/.claude/commands/ship-and-merge.md
@@ -45,6 +45,9 @@ gh pr create --base main --title "<PR title>" --body "$(cat <<'EOF'
 ## Summary
 <1-3 bullet points>
 
+## Original prompt
+<$ARGUMENTS if provided, otherwise a brief description of what changes are being shipped>
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )" --assignee @me

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -69,7 +69,13 @@ ALL work happens here. Do NOT touch the main repo.
 1. Make the changes in your worktree.
 2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
 3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
-   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base main --merge --assignee @me
+   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "## Summary
+<1-3 bullet points>
+
+## Task
+<the exact TODO item text you were given>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" --base main --merge --assignee @me
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -69,20 +69,19 @@ ALL work happens here. Do NOT touch the main repo.
 1. Make the changes in your worktree.
 2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
 3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/).
-   First build the PR body in a variable so task text with special characters doesn't break quoting:
-   ```bash
-   PR_BODY=$(cat <<'BODY_EOF'
-   ## Summary
-   <1-3 bullet points>
+   Build the body in a variable using a heredoc (BODY_EOF delimiter MUST be at column 0), then pass via --body:
 
-   ## Task
-   <the exact TODO item text you were given>
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
+<1-3 bullet points>
 
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   BODY_EOF
-   )
-   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base main --merge --assignee @me
-   ```
+## Task
+<the exact TODO item text you were given>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base main --merge --assignee @me
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -68,14 +68,21 @@ ALL work happens here. Do NOT touch the main repo.
 ## Workflow
 1. Make the changes in your worktree.
 2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
-3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
-   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "## Summary
-<1-3 bullet points>
+3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/).
+   First build the PR body in a variable so task text with special characters doesn't break quoting:
+   ```bash
+   PR_BODY=$(cat <<'BODY_EOF'
+   ## Summary
+   <1-3 bullet points>
 
-## Task
-<the exact TODO item text you were given>
+   ## Task
+   <the exact TODO item text you were given>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" --base main --merge --assignee @me
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   BODY_EOF
+   )
+   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base main --merge --assignee @me
+   ```
 4. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
    - A summary of what you changed and why

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -28,7 +28,7 @@ If you need to break it down into multiple PRs:
 
 If you can implement it in a single PR:
 
-- Create a PR for it (output a link to the PR)
+- Create a PR for it (output a link to the PR). Include the original task description in the PR body under a `## Task` section so reviewers have context for why the changes were made.
 - Append the link to only this new PR to .private/UNREVIEWED_PRS.md
 - CRITICAL: Merge it immediately with `gh pr merge <N> --squash` and switch back to the main branch
 - If this task was addressing feedback on a previous PR (either "Address the feedback on <PR URL>" or a sub-task with "(feedback from <PR URL>)"), leave a paper trail on the original PR:

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -28,21 +28,19 @@ If you need to break it down into multiple PRs:
 
 If you can implement it in a single PR:
 
-- Create a PR for it using `.claude/ship`. Build the body with a heredoc so task text with special characters doesn't break quoting:
+- Create a PR for it using `.claude/ship`. Build the body in a variable first (BODY_EOF delimiter MUST be at column 0), then ship:
 
-  ```bash
-  PR_BODY=$(cat <<'BODY_EOF'
-  ## Summary
-  <1-3 bullet points>
+PR_BODY=$(cat <<'BODY_EOF'
+## Summary
+<1-3 bullet points>
 
-  ## Task
-  <the verbatim task — from $ARGUMENTS if provided, or the exact TODO item text>
+## Task
+<the verbatim task — from $ARGUMENTS if provided, or the exact TODO item text>
 
-  🤖 Generated with [Claude Code](https://claude.com/claude-code)
-  BODY_EOF
-  )
-  .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base main --merge --track-unreviewed --pull-base
-  ```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY_EOF
+)
+.claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base main --merge --track-unreviewed --pull-base
 
   Output the PR link.
 - Append the link to only this new PR to .private/UNREVIEWED_PRS.md

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -28,7 +28,23 @@ If you need to break it down into multiple PRs:
 
 If you can implement it in a single PR:
 
-- Create a PR for it (output a link to the PR). Include the original task description in the PR body under a `## Task` section so reviewers have context for why the changes were made.
+- Create a PR for it using `.claude/ship`. Build the body with a heredoc so task text with special characters doesn't break quoting:
+
+  ```bash
+  PR_BODY=$(cat <<'BODY_EOF'
+  ## Summary
+  <1-3 bullet points>
+
+  ## Task
+  <the verbatim task — from $ARGUMENTS if provided, or the exact TODO item text>
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  BODY_EOF
+  )
+  .claude/ship --commit-msg "<message>" --title "<title>" --body "$PR_BODY" --base main --merge --track-unreviewed --pull-base
+  ```
+
+  Output the PR link.
 - Append the link to only this new PR to .private/UNREVIEWED_PRS.md
 - CRITICAL: Merge it immediately with `gh pr merge <N> --squash` and switch back to the main branch
 - If this task was addressing feedback on a previous PR (either "Address the feedback on <PR URL>" or a sub-task with "(feedback from <PR URL>)"), leave a paper trail on the original PR:

--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ All workflows use squash-merge (no merge commits), worktree isolation for parall
 
 **Validation**: Slash commands do **not** run tests, type-checking (`tsc`), or linting by default. These steps are only performed when the task specifically requires it (e.g., "fix the type errors", "make the tests pass"). This keeps agent-driven workflows fast for well-scoped changes.
 
-**PR body context**: Every PR created by a slash command includes the original prompt or plan section that triggered the work. Task-based commands (`/do`, `/safe-do`, `/work`, `/swarm`, `/blitz`, `/safe-blitz`) include the original task description under `## Original task` or `## Task`. Plan-based commands (`/execute-plan`, `/safe-execute-plan`, `/resume-plan`) include the verbatim plan section under `## Plan section`. This keeps reviewers oriented without needing to trace back through chat history.
+**PR body context**: Every PR created by a slash command includes the original prompt or plan that triggered the work. Task-based commands (`/do`, `/safe-do`, `/work`, `/swarm`, `/blitz`, `/safe-blitz`) include the original task description under `## Original task` or `## Task`. Plan-based commands (`/execute-plan`, `/safe-execute-plan`, `/resume-plan`) embed the full plan file content under `## Plan`. This keeps reviewers oriented without needing to trace back through chat history.
 
 ## Release Management
 

--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ All workflows use squash-merge (no merge commits), worktree isolation for parall
 
 **Validation**: Slash commands do **not** run tests, type-checking (`tsc`), or linting by default. These steps are only performed when the task specifically requires it (e.g., "fix the type errors", "make the tests pass"). This keeps agent-driven workflows fast for well-scoped changes.
 
+**PR body context**: Every PR created by a slash command includes the original prompt or plan section that triggered the work. Task-based commands (`/do`, `/safe-do`, `/work`, `/swarm`, `/blitz`, `/safe-blitz`) include the original task description under `## Original task` or `## Task`. Plan-based commands (`/execute-plan`, `/safe-execute-plan`, `/resume-plan`) include the verbatim plan section under `## Plan section`. This keeps reviewers oriented without needing to trace back through chat history.
+
 ## Release Management
 
 Releases are cut using the `/release` Claude Code command and follow a fully automated pipeline from tag to client update.


### PR DESCRIPTION
## Summary

- Adds a `## Original task` section (with the verbatim `$ARGUMENTS`) to PR bodies in `/do`, `/safe-do`
- Adds a `## Context` section to `/mainline` PR bodies so the reason for changes is captured
- Adds a `## Original prompt` section to `/ship-and-merge` PR bodies
- Adds a `## Plan section` block (verbatim plan file section) to `/execute-plan`, `/safe-execute-plan`, and `/resume-plan` PR bodies
- Updates the swarm-agent prompt in `swarm.md` and `safe-blitz.md` to include a `## Task` section with the exact TODO item text in every milestone PR
- Adds an instruction to `/work` to include the task description in the PR body

## Original task

Make a PR that modifies the claude commands in this repo's `.claude` and agents.md to include the original prompt or the body of the plan MD file that it is working off of in the body of the pull request so that there is context.

## Files changed

- `.claude/commands/do.md`
- `.claude/commands/safe-do.md`
- `.claude/commands/mainline.md`
- `.claude/commands/execute-plan.md`
- `.claude/commands/safe-execute-plan.md`
- `.claude/commands/resume-plan.md`
- `.claude/commands/swarm.md`
- `.claude/commands/safe-blitz.md`
- `.claude/commands/work.md`
- `.claude/commands/ship-and-merge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
