### PR TITLE
fix: add client-side fallback timeout for stale in-flight run state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -98,6 +98,7 @@ struct TasksWindowView: View {
                             TasksWindowRow(
                                 item: item,
                                 runningIds: viewModel.runInFlightIds,
+                                timeoutIds: viewModel.runTimeoutIds,
                                 onRun: { viewModel.runTask(id: item.id) },
                                 onComplete: { viewModel.completeTask(id: item.id) },
                                 onRemove: { viewModel.removeTask(id: item.id) },
@@ -123,6 +124,7 @@ struct TasksWindowView: View {
 private struct TasksWindowRow: View {
     let item: IPCWorkItemsListResponseItem
     let runningIds: Set<String>
+    let timeoutIds: Set<String>
     let onRun: () -> Void
     let onComplete: () -> Void
     let onRemove: () -> Void
@@ -239,32 +241,46 @@ private struct TasksWindowRow: View {
     private var actionsColumn: some View {
         let status = WorkItemStatus(rawStatus: item.status)
         let isRunning = runningIds.contains(item.id)
+        let isTimedOut = timeoutIds.contains(item.id)
         let isFailed = status == .failed
         let runEnabled = !isRunning
-        let showRun = status == .queued || isFailed
-        let buttonColor = isFailed ? VColor.warning : VColor.accent
-        let buttonLabel = isRunning ? "Starting..." : (isFailed ? "Retry" : "Run")
+        let showRun = status == .queued || isFailed || isTimedOut
+        let buttonColor = (isFailed || isTimedOut) ? VColor.warning : VColor.accent
+        let buttonLabel: String = {
+            if isRunning { return "Starting..." }
+            if isTimedOut || isFailed { return "Retry" }
+            return "Run"
+        }()
+        let buttonIcon = (isFailed || isTimedOut) ? "arrow.clockwise" : "play.fill"
         return HStack(spacing: VSpacing.xs) {
             if showRun {
-                Button(action: onRun) {
-                    HStack(spacing: VSpacing.xs) {
-                        Image(systemName: isFailed ? "arrow.clockwise" : "play.fill")
-                            .font(.system(size: 10))
-                        Text(buttonLabel)
-                            .font(VFont.caption)
+                VStack(alignment: .center, spacing: 2) {
+                    Button(action: onRun) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: buttonIcon)
+                                .font(.system(size: 10))
+                            Text(buttonLabel)
+                                .font(VFont.caption)
+                        }
+                        .foregroundColor(buttonColor)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(buttonColor.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .contentShape(Rectangle())
                     }
-                    .foregroundColor(buttonColor)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(buttonColor.opacity(0.12))
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                    .contentShape(Rectangle())
+                    .buttonStyle(.plain)
+                    .disabled(!runEnabled)
+                    .opacity(runEnabled ? 1.0 : 0.4)
+                    .accessibilityLabel(isRunning ? "Task is starting" : ((isFailed || isTimedOut) ? "Retry task" : "Run task"))
+                    .accessibilityHint(isRunning ? "Task is already starting" : (isTimedOut ? "No response received, tap to retry" : (isFailed ? "Retry running this failed task" : "")))
+
+                    if isTimedOut {
+                        Text("No response")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.warning)
+                    }
                 }
-                .buttonStyle(.plain)
-                .disabled(!runEnabled)
-                .opacity(runEnabled ? 1.0 : 0.4)
-                .accessibilityLabel(isRunning ? "Task is starting" : (isFailed ? "Retry task" : "Run task"))
-                .accessibilityHint(isRunning ? "Task is already starting" : (isFailed ? "Retry running this failed task" : ""))
             }
 
             if status == .awaitingReview {

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -16,6 +16,18 @@ class TasksWindowViewModel: ObservableObject {
     /// Tracks work item IDs with an in-flight run request so we can
     /// detect duplicate taps and disable the Run button in the view.
     @Published var runInFlightIds: Set<String> = []
+    /// Tracks IDs where the run request timed out without a daemon response,
+    /// so the view can show a recoverable "no response" warning.
+    @Published var runTimeoutIds: Set<String> = []
+
+    /// Handles for pending timeout tasks keyed by work item ID, so we can
+    /// cancel the timer when the daemon responds before the deadline.
+    private var runTimeoutTasks: [String: Task<Void, Never>] = [:]
+
+    /// How long to wait for a daemon run-task response before treating
+    /// the request as timed out. 10 seconds is generous enough to cover
+    /// normal latency while still recovering from connection drops quickly.
+    private static let runTimeoutSeconds: UInt64 = 10
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -30,6 +42,9 @@ class TasksWindowViewModel: ObservableObject {
         daemonClient.onWorkItemsListResponse = { [weak self] response in
             self?.items = response.items
             self?.isLoading = false
+            // A fresh list response means the daemon is alive — clear any
+            // stale timeout warnings since the user can now retry.
+            self?.runTimeoutIds.removeAll()
         }
 
         // Debounce rapid broadcasts so multiple mutations coalesce
@@ -46,7 +61,9 @@ class TasksWindowViewModel: ObservableObject {
         daemonClient.onWorkItemStatusChanged = { [weak self] notification in
             // The daemon confirmed a status transition — clear in-flight tracking
             // so subsequent run requests for this item are allowed.
-            self?.runInFlightIds.remove(notification.item.id)
+            let id = notification.item.id
+            self?.runInFlightIds.remove(id)
+            self?.cancelRunTimeout(id: id)
             scheduleRefresh()
         }
         daemonClient.onTasksChanged = { _ in scheduleRefresh() }
@@ -54,6 +71,7 @@ class TasksWindowViewModel: ObservableObject {
         daemonClient.onWorkItemRunTaskResponse = { [weak self] response in
             guard let self else { return }
             self.runInFlightIds.remove(response.id)
+            self.cancelRunTimeout(id: response.id)
             if !response.success {
                 self.logger.error("onWorkItemRunTaskResponse: run failed for id=\(response.id, privacy: .public) errorCode=\(response.errorCode ?? "none", privacy: .public) error=\(response.error ?? "none", privacy: .public)")
                 self.fetchItems()
@@ -93,14 +111,45 @@ class TasksWindowViewModel: ObservableObject {
             return
         }
 
+        // Clear any previous timeout warning for this item before retrying.
+        runTimeoutIds.remove(id)
+
         runInFlightIds.insert(id)
+        startRunTimeout(id: id)
         do {
             try daemonClient.sendWorkItemRunTask(id: id)
         } catch {
             logger.error("runTask: transport error for id=\(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             runInFlightIds.remove(id)
+            cancelRunTimeout(id: id)
             errorMessage = error.localizedDescription
         }
+    }
+
+    // MARK: - Run Timeout
+
+    /// Starts a delayed task that fires after `runTimeoutSeconds`. If the ID
+    /// is still in `runInFlightIds` when the timer expires, we treat it as a
+    /// dropped response: remove the in-flight state and mark it as timed out
+    /// so the view can show a recoverable warning.
+    private func startRunTimeout(id: String) {
+        cancelRunTimeout(id: id)
+        runTimeoutTasks[id] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.runTimeoutSeconds * 1_000_000_000)
+            guard !Task.isCancelled, let self else { return }
+            guard self.runInFlightIds.contains(id) else { return }
+            self.logger.warning("runTask timeout: no response after \(Self.runTimeoutSeconds)s for id=\(id, privacy: .public)")
+            self.runInFlightIds.remove(id)
+            self.runTimeoutIds.insert(id)
+            self.runTimeoutTasks.removeValue(forKey: id)
+        }
+    }
+
+    /// Cancels a pending timeout task and clears its tracking state.
+    private func cancelRunTimeout(id: String) {
+        runTimeoutTasks[id]?.cancel()
+        runTimeoutTasks.removeValue(forKey: id)
+        runTimeoutIds.remove(id)
     }
 
     func completeTask(id: String) {


### PR DESCRIPTION
## Summary
- Adds a 10-second client-side fallback timeout to `TasksWindowViewModel` that fires when the daemon never responds to a `run-task` IPC message (e.g. connection drop, daemon restart/crash)
- When the timeout fires, removes the item from `runInFlightIds` (re-enables the button) and adds it to a new `runTimeoutIds` set
- The view shows an inline amber "No response" warning below the Retry button for timed-out items
- Timeout state is cleared when the user retaps Run, when a daemon response arrives, or when a fresh list response comes in

## Test plan
- [ ] Verify normal run flow still works (daemon responds within 10s, no timeout warning shown)
- [ ] Simulate daemon disconnect: tap Run, kill daemon before response — after 10s the button should change to "Retry" with amber "No response" text
- [ ] Verify tapping Retry clears the warning and re-sends the request
- [ ] Verify a fresh list response (daemon reconnect) clears stale timeout warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
