### PR TITLE
M2: Commit message provider abstraction

### DIFF
--- a/assistant/src/workspace/commit-message-provider.ts
+++ b/assistant/src/workspace/commit-message-provider.ts
@@ -1,0 +1,95 @@
+/**
+ * Abstraction for generating commit messages across different triggers.
+ *
+ * Provides a seam for future LLM-powered enrichment without changing
+ * the synchronous commit path.
+ */
+
+export interface CommitContext {
+  workspaceDir: string;
+  trigger: 'turn' | 'heartbeat' | 'shutdown';
+  sessionId?: string;
+  turnNumber?: number;
+  changedFiles: string[];
+  timestampMs: number;
+  /** Optional reason string (used by heartbeat to describe threshold exceeded). */
+  reason?: string;
+}
+
+export interface CommitMessageResult {
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CommitMessageProvider {
+  /** Build a commit message synchronously for immediate use. */
+  buildImmediateMessage(ctx: CommitContext): CommitMessageResult;
+  /** Optional: enqueue async enrichment after commit succeeds. */
+  enqueueEnrichment?(ctx: CommitContext & { commitHash: string }): Promise<void>;
+}
+
+/**
+ * Build a short summary of what changed from a list of file paths.
+ */
+export function buildChangeSummary(files: string[]): string {
+  if (files.length === 0) {
+    return 'workspace changes';
+  }
+  if (files.length === 1) {
+    return files[0];
+  }
+  if (files.length <= 3) {
+    return files.join(', ');
+  }
+  return `${files.slice(0, 2).join(', ')} and ${files.length - 2} more`;
+}
+
+/**
+ * Default deterministic commit message provider.
+ *
+ * Produces identical output to the pre-refactor inline logic in
+ * turn-commit.ts and heartbeat-service.ts.
+ */
+export class DefaultCommitMessageProvider implements CommitMessageProvider {
+  buildImmediateMessage(ctx: CommitContext): CommitMessageResult {
+    switch (ctx.trigger) {
+      case 'turn':
+        return this.buildTurnMessage(ctx);
+      case 'heartbeat':
+        return this.buildHeartbeatMessage(ctx);
+      case 'shutdown':
+        return this.buildShutdownMessage(ctx);
+    }
+  }
+
+  private buildTurnMessage(ctx: CommitContext): CommitMessageResult {
+    const summary = buildChangeSummary(ctx.changedFiles);
+    const timestamp = new Date(ctx.timestampMs).toISOString();
+    const message = [
+      `Turn: ${summary}`,
+      '',
+      `Session: ${ctx.sessionId}`,
+      `Turn: ${ctx.turnNumber}`,
+      `Timestamp: ${timestamp}`,
+      `Files: ${ctx.changedFiles.length} changed`,
+    ].join('\n');
+    return { message };
+  }
+
+  private buildHeartbeatMessage(ctx: CommitContext): CommitMessageResult {
+    const totalChanges = ctx.changedFiles.length;
+    const reason = ctx.reason ?? `${totalChanges} files`;
+    return {
+      message: `auto-commit: heartbeat safety net (${totalChanges} files, ${reason})`,
+      metadata: { trigger: 'heartbeat', timestamp: ctx.timestampMs },
+    };
+  }
+
+  private buildShutdownMessage(ctx: CommitContext): CommitMessageResult {
+    const totalChanges = ctx.changedFiles.length;
+    return {
+      message: `auto-commit: shutdown safety net (${totalChanges} files)`,
+      metadata: { trigger: 'shutdown', timestamp: ctx.timestampMs },
+    };
+  }
+}

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -1,5 +1,10 @@
 import { getLogger } from '../util/logger.js';
 import { getAllWorkspaceGitServices, type WorkspaceGitService } from './git-service.js';
+import {
+  DefaultCommitMessageProvider,
+  type CommitContext,
+  type CommitMessageProvider,
+} from './commit-message-provider.js';
 
 const log = getLogger('heartbeat');
 
@@ -23,6 +28,8 @@ export interface HeartbeatServiceOptions {
   getServices?: () => ReadonlyMap<string, WorkspaceGitService>;
   /** Override for getting the current timestamp (for testing). */
   now?: () => number;
+  /** Custom commit message provider. */
+  commitMessageProvider?: CommitMessageProvider;
 }
 
 /**
@@ -61,6 +68,7 @@ export class HeartbeatService {
   private readonly intervalMs: number;
   private readonly getServices: () => ReadonlyMap<string, WorkspaceGitService>;
   private readonly now: () => number;
+  private readonly commitMessageProvider: CommitMessageProvider;
   private timer: ReturnType<typeof setInterval> | null = null;
   /** Tracks the currently in-flight check to prevent overlapping runs and allow clean shutdown. */
   private activeCheck: Promise<HeartbeatCheckResult> | null = null;
@@ -71,6 +79,7 @@ export class HeartbeatService {
     this.intervalMs = options?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
     this.getServices = options?.getServices ?? getAllWorkspaceGitServices;
     this.now = options?.now ?? Date.now;
+    this.commitMessageProvider = options?.commitMessageProvider ?? new DefaultCommitMessageProvider();
   }
 
   /**
@@ -139,7 +148,7 @@ export class HeartbeatService {
         result.checked++;
 
         try {
-          const committed = await this.checkWorkspace(workspaceDir, service, 'heartbeat');
+          const committed = await this.checkWorkspace(workspaceDir, service);
           if (committed) {
             result.committed++;
           } else {
@@ -190,12 +199,17 @@ export class HeartbeatService {
       try {
         const now = this.now();
         const { committed } = await service.commitIfDirty((status) => {
-          const totalChanges = new Set([...status.staged, ...status.modified, ...status.untracked]).size;
-          log.info({ workspaceDir, totalChanges }, 'Committing pending changes on shutdown');
-          return {
-            message: `auto-commit: shutdown safety net (${totalChanges} files)`,
-            metadata: { trigger: 'shutdown', timestamp: now },
+          const uniqueFiles = [...new Set([...status.staged, ...status.modified, ...status.untracked])];
+          log.info({ workspaceDir, totalChanges: uniqueFiles.length }, 'Committing pending changes on shutdown');
+
+          const ctx: CommitContext = {
+            workspaceDir,
+            trigger: 'shutdown',
+            changedFiles: uniqueFiles,
+            timestampMs: now,
           };
+
+          return this.commitMessageProvider.buildImmediateMessage(ctx);
         });
 
         if (committed) {
@@ -225,13 +239,13 @@ export class HeartbeatService {
   private async checkWorkspace(
     workspaceDir: string,
     service: WorkspaceGitService,
-    trigger: string,
   ): Promise<boolean> {
     const now = this.now();
 
     // Atomic status check + conditional commit within a single mutex lock.
     const { committed, status } = await service.commitIfDirty((st) => {
-      const totalChanges = new Set([...st.staged, ...st.modified, ...st.untracked]).size;
+      const uniqueFiles = [...new Set([...st.staged, ...st.modified, ...st.untracked])];
+      const totalChanges = uniqueFiles.length;
 
       // Track when we first saw this workspace as dirty
       if (!firstSeenDirty.has(workspaceDir)) {
@@ -261,10 +275,15 @@ export class HeartbeatService {
         'Heartbeat auto-committing workspace changes',
       );
 
-      return {
-        message: `auto-commit: ${trigger} safety net (${totalChanges} files, ${reason})`,
-        metadata: { trigger, timestamp: now },
+      const ctx: CommitContext = {
+        workspaceDir,
+        trigger: 'heartbeat',
+        changedFiles: uniqueFiles,
+        timestampMs: now,
+        reason,
       };
+
+      return this.commitMessageProvider.buildImmediateMessage(ctx);
     });
 
     if (committed) {

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -11,6 +11,11 @@
 
 import { getWorkspaceGitService } from './git-service.js';
 import { getLogger } from '../util/logger.js';
+import {
+  DefaultCommitMessageProvider,
+  type CommitContext,
+  type CommitMessageProvider,
+} from './commit-message-provider.js';
 
 const log = getLogger('turn-commit');
 
@@ -26,46 +31,6 @@ export interface TurnCommitMetadata {
 }
 
 /**
- * Build a commit message with structured metadata for a turn boundary commit.
- *
- * Format:
- * ```
- * Turn: <summary>
- *
- * Session: sess_xyz
- * Turn: 5
- * Timestamp: 2026-02-18T15:30:00Z
- * Files: 3 changed
- * ```
- */
-function buildCommitMessage(summary: string, metadata: TurnCommitMetadata): string {
-  return [
-    `Turn: ${summary}`,
-    '',
-    `Session: ${metadata.sessionId}`,
-    `Turn: ${metadata.turnNumber}`,
-    `Timestamp: ${metadata.timestamp}`,
-    `Files: ${metadata.filesChanged} changed`,
-  ].join('\n');
-}
-
-/**
- * Build a short summary of what changed from a list of file paths.
- */
-function buildChangeSummary(files: string[]): string {
-  if (files.length === 0) {
-    return 'workspace changes';
-  }
-  if (files.length === 1) {
-    return files[0];
-  }
-  if (files.length <= 3) {
-    return files.join(', ');
-  }
-  return `${files.slice(0, 2).join(', ')} and ${files.length - 2} more`;
-}
-
-/**
  * Attempt a turn-boundary commit for the workspace.
  *
  * Checks the workspace for uncommitted changes. If any are found,
@@ -77,12 +42,15 @@ function buildChangeSummary(files: string[]): string {
  * @param workspaceDir - Absolute path to the workspace directory
  * @param sessionId - Session/conversation identifier
  * @param turnNumber - 1-based turn number within the session
+ * @param provider - Optional commit message provider (defaults to deterministic)
  */
 export async function commitTurnChanges(
   workspaceDir: string,
   sessionId: string,
   turnNumber: number,
+  provider?: CommitMessageProvider,
 ): Promise<void> {
+  const messageProvider = provider ?? new DefaultCommitMessageProvider();
   try {
     const gitService = getWorkspaceGitService(workspaceDir);
 
@@ -90,17 +58,17 @@ export async function commitTurnChanges(
     // TOCTOU races with heartbeat commits.
     const { committed, status } = await gitService.commitIfDirty((st) => {
       const uniqueFiles = [...new Set([...st.staged, ...st.modified, ...st.untracked])];
-      const timestamp = new Date().toISOString();
-      const summary = buildChangeSummary(uniqueFiles);
 
-      const metadata: TurnCommitMetadata = {
+      const ctx: CommitContext = {
+        workspaceDir,
+        trigger: 'turn',
         sessionId,
         turnNumber,
-        timestamp,
-        filesChanged: uniqueFiles.length,
+        changedFiles: uniqueFiles,
+        timestampMs: Date.now(),
       };
 
-      return { message: buildCommitMessage(summary, metadata) };
+      return messageProvider.buildImmediateMessage(ctx);
     });
 
     if (committed) {


### PR DESCRIPTION
## Summary
Extracts commit message construction into a pluggable `CommitMessageProvider` interface.

## Changes
- **New file `commit-message-provider.ts`**: Defines `CommitContext`, `CommitMessageResult`, `CommitMessageProvider` interface, `buildChangeSummary()` helper, and `DefaultCommitMessageProvider` class with `buildImmediateMessage()` dispatching to trigger-specific methods (turn, heartbeat, shutdown). Includes optional `enqueueEnrichment()` hook for future async enrichment.
- **`turn-commit.ts`**: Accepts optional `CommitMessageProvider` parameter, defaults to `DefaultCommitMessageProvider`. Builds `CommitContext` and delegates message construction.
- **`heartbeat-service.ts`**: Accepts optional `commitMessageProvider` in `HeartbeatServiceOptions`. Both `checkWorkspace()` and `commitAllPending()` build `CommitContext` and delegate to provider. Removed unused `trigger` parameter from `checkWorkspace()`.

## Test plan
- All 8 turn-commit tests pass
- All 14 heartbeat-service tests pass
- No functional change — identical commit message output

Closes #5154
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
