### PR TITLE
M3: Non-blocking enrichment queue scaffold

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -1,0 +1,263 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import {
+  CommitEnrichmentService,
+  _resetEnrichmentService,
+} from '../workspace/commit-message-enrichment-service.js';
+import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
+import type { CommitContext } from '../workspace/commit-message-provider.js';
+
+describe('CommitEnrichmentService', () => {
+  let testDir: string;
+  let gitService: WorkspaceGitService;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `vellum-enrichment-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    _resetGitServiceRegistry();
+    _resetEnrichmentService();
+
+    gitService = new WorkspaceGitService(testDir);
+    await gitService.ensureInitialized();
+  });
+
+  afterEach(async () => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeContext(overrides?: Partial<CommitContext>): CommitContext {
+    return {
+      workspaceDir: testDir,
+      trigger: 'turn',
+      sessionId: 'sess_test',
+      turnNumber: 1,
+      changedFiles: ['file.txt'],
+      timestampMs: Date.now(),
+      ...overrides,
+    };
+  }
+
+  async function createCommit(): Promise<string> {
+    writeFileSync(join(testDir, `file-${Date.now()}.txt`), 'content');
+    await gitService.commitChanges('test commit');
+    return await gitService.getHeadHash();
+  }
+
+  test('enqueue and execute writes git note on success', async () => {
+    const commitHash = await createCommit();
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash,
+      context: makeContext(),
+      gitService,
+    });
+
+    // Wait for async processing
+    await service.shutdown();
+
+    // Verify git note was written
+    const noteContent = execFileSync('git', ['notes', '--ref=vellum', 'show', commitHash], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    const note = JSON.parse(noteContent);
+    expect(note.enriched).toBe(true);
+    expect(note.trigger).toBe('turn');
+    expect(note.sessionId).toBe('sess_test');
+    expect(note.turnNumber).toBe(1);
+    expect(note.filesChanged).toBe(1);
+    expect(service._getSucceededCount()).toBe(1);
+  });
+
+  test('queue overflow drops oldest job', async () => {
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 2,
+      maxConcurrency: 0, // 0 concurrency means nothing processes, for testing queue behavior
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    // Override concurrency so nothing actually runs
+    // We want to test queue overflow behavior only
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+    const hash3 = await createCommit();
+
+    // With maxConcurrency 0, nothing will process; but let's use 1 and block processing
+    // Instead, use a service with concurrency 1 but fill the queue faster than it drains
+    const service2 = new CommitEnrichmentService({
+      maxQueueSize: 2,
+      maxConcurrency: 1,
+      jobTimeoutMs: 30000,
+      maxRetries: 0,
+    });
+
+    // Enqueue 3 jobs — the first starts immediately (active worker),
+    // second goes to queue, third overflows and drops the second
+    service2.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
+    service2.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
+    service2.enqueue({ workspaceDir: testDir, commitHash: hash3, context: makeContext(), gitService });
+
+    // The queue should have 2 items (hash2 and hash3 or hash3 depending on timing)
+    // But hash1 is being processed. Let's check dropped count.
+    // With maxQueueSize=2, after hash1 starts processing (active worker=1),
+    // hash2 goes to queue (size=1), hash3 goes to queue (size=2), no drop yet.
+    // Actually the first job is picked up immediately, so queue has 2 items max.
+    // Let's check dropped count after shutdown.
+    await service2.shutdown();
+
+    // No drops expected since queue size 2 can hold 2 pending while 1 is active
+    expect(service2._getDroppedCount()).toBe(0);
+
+    await service.shutdown();
+  });
+
+  test('queue overflow actually drops when truly full', async () => {
+    // Create a service where the worker is slow
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 1,
+      maxConcurrency: 1,
+      jobTimeoutMs: 30000,
+      maxRetries: 0,
+    });
+
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+    const hash3 = await createCommit();
+
+    // hash1 starts processing immediately (active worker = 1, queue empty)
+    // hash2 goes to queue (queue size = 1)
+    // hash3 tries to go to queue but it's full → drops hash2, adds hash3
+    service.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash3, context: makeContext(), gitService });
+
+    expect(service._getDroppedCount()).toBe(1);
+
+    await service.shutdown();
+  });
+
+  test('fire-and-forget enqueue does not block caller', async () => {
+    const commitHash = await createCommit();
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    const start = Date.now();
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash,
+      context: makeContext(),
+      gitService,
+    });
+    const elapsed = Date.now() - start;
+
+    // enqueue should return immediately (< 50ms)
+    expect(elapsed).toBeLessThan(50);
+
+    await service.shutdown();
+  });
+
+  test('graceful shutdown drains in-flight and discards pending', async () => {
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    service.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
+
+    // Shutdown should complete without hanging
+    await service.shutdown();
+
+    // At least the first job should have completed (it was in-flight)
+    expect(service._getSucceededCount()).toBeGreaterThanOrEqual(1);
+  });
+
+  test('discards jobs enqueued after shutdown', async () => {
+    const commitHash = await createCommit();
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    await service.shutdown();
+
+    // Enqueue after shutdown should be silently discarded
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash,
+      context: makeContext(),
+      gitService,
+    });
+
+    expect(service._getQueueSize()).toBe(0);
+    expect(service._getSucceededCount()).toBe(0);
+  });
+
+  test('multiple successful enrichments write separate git notes', async () => {
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash: hash1,
+      context: makeContext({ turnNumber: 1 }),
+      gitService,
+    });
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash: hash2,
+      context: makeContext({ turnNumber: 2 }),
+      gitService,
+    });
+
+    // Wait for queue to drain before shutdown (avoids discarding pending jobs)
+    while (service._getQueueSize() > 0 || service._getActiveWorkers() > 0) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    await service.shutdown();
+
+    // Both notes should exist
+    const note1 = JSON.parse(execFileSync('git', ['notes', '--ref=vellum', 'show', hash1], {
+      cwd: testDir, encoding: 'utf-8',
+    }));
+    const note2 = JSON.parse(execFileSync('git', ['notes', '--ref=vellum', 'show', hash2], {
+      cwd: testDir, encoding: 'utf-8',
+    }));
+
+    expect(note1.turnNumber).toBe(1);
+    expect(note2.turnNumber).toBe(2);
+    expect(service._getSucceededCount()).toBe(2);
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -719,6 +719,26 @@ export const WorkspaceGitConfigSchema = z.object({
     .int('workspaceGit.failureBackoffMaxMs must be an integer')
     .positive('workspaceGit.failureBackoffMaxMs must be a positive integer')
     .default(60000),
+  enrichmentQueueSize: z
+    .number({ error: 'workspaceGit.enrichmentQueueSize must be a number' })
+    .int('workspaceGit.enrichmentQueueSize must be an integer')
+    .positive('workspaceGit.enrichmentQueueSize must be a positive integer')
+    .default(50),
+  enrichmentConcurrency: z
+    .number({ error: 'workspaceGit.enrichmentConcurrency must be a number' })
+    .int('workspaceGit.enrichmentConcurrency must be an integer')
+    .positive('workspaceGit.enrichmentConcurrency must be a positive integer')
+    .default(1),
+  enrichmentJobTimeoutMs: z
+    .number({ error: 'workspaceGit.enrichmentJobTimeoutMs must be a number' })
+    .int('workspaceGit.enrichmentJobTimeoutMs must be an integer')
+    .positive('workspaceGit.enrichmentJobTimeoutMs must be a positive integer')
+    .default(30000),
+  enrichmentMaxRetries: z
+    .number({ error: 'workspaceGit.enrichmentMaxRetries must be a number' })
+    .int('workspaceGit.enrichmentMaxRetries must be an integer')
+    .nonnegative('workspaceGit.enrichmentMaxRetries must be non-negative')
+    .default(2),
 });
 
 export const SwarmConfigSchema = z.object({
@@ -972,6 +992,10 @@ export const AssistantConfigSchema = z.object({
     turnCommitMaxWaitMs: 4000,
     failureBackoffBaseMs: 2000,
     failureBackoffMaxMs: 60000,
+    enrichmentQueueSize: 50,
+    enrichmentConcurrency: 1,
+    enrichmentJobTimeoutMs: 30000,
+    enrichmentMaxRetries: 2,
   }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -1,0 +1,250 @@
+/**
+ * Non-blocking enrichment queue for post-commit message enhancement.
+ *
+ * After a synchronous commit succeeds, callers can enqueue enrichment jobs
+ * that run asynchronously without blocking the commit path. This is the
+ * scaffold for future LLM-powered commit message enrichment.
+ *
+ * Key properties:
+ * - Bounded queue with configurable max size (drops oldest on overflow)
+ * - Bounded concurrency (default 1 worker)
+ * - Per-job timeout with retry + exponential backoff
+ * - Graceful shutdown: drains in-flight jobs, discards pending
+ * - Fire-and-forget: enqueue() never blocks or throws
+ */
+
+import { getLogger } from '../util/logger.js';
+import { getConfig } from '../config/loader.js';
+import type { WorkspaceGitService } from './git-service.js';
+import type { CommitContext } from './commit-message-provider.js';
+
+const log = getLogger('enrichment-queue');
+
+export interface EnrichmentJob {
+  workspaceDir: string;
+  commitHash: string;
+  context: CommitContext;
+  gitService: WorkspaceGitService;
+}
+
+interface InternalJob extends EnrichmentJob {
+  attempts: number;
+}
+
+export interface EnrichmentServiceOptions {
+  maxQueueSize?: number;
+  maxConcurrency?: number;
+  jobTimeoutMs?: number;
+  maxRetries?: number;
+}
+
+/**
+ * Non-blocking enrichment queue service.
+ *
+ * Enqueue jobs after successful commits. Each job runs the enrichment
+ * worker (currently a no-op placeholder) and writes the result as a
+ * git note on the commit.
+ */
+export class CommitEnrichmentService {
+  private readonly maxQueueSize: number;
+  private readonly maxConcurrency: number;
+  private readonly jobTimeoutMs: number;
+  private readonly maxRetries: number;
+
+  private queue: InternalJob[] = [];
+  private activeWorkers = 0;
+  private droppedCount = 0;
+  private succeededCount = 0;
+  private failedCount = 0;
+  private shuttingDown = false;
+  private inFlightPromises: Set<Promise<void>> = new Set();
+
+  constructor(options?: EnrichmentServiceOptions) {
+    const config = getConfig();
+    const gitConfig = config.workspaceGit;
+    this.maxQueueSize = options?.maxQueueSize ?? gitConfig?.enrichmentQueueSize ?? 50;
+    this.maxConcurrency = options?.maxConcurrency ?? gitConfig?.enrichmentConcurrency ?? 1;
+    this.jobTimeoutMs = options?.jobTimeoutMs ?? gitConfig?.enrichmentJobTimeoutMs ?? 30000;
+    this.maxRetries = options?.maxRetries ?? gitConfig?.enrichmentMaxRetries ?? 2;
+  }
+
+  /**
+   * Enqueue an enrichment job. Fire-and-forget — never blocks or throws.
+   */
+  enqueue(job: EnrichmentJob): void {
+    if (this.shuttingDown) {
+      log.debug({ commitHash: job.commitHash }, 'Enrichment queue shutting down, discarding job');
+      return;
+    }
+
+    const internalJob: InternalJob = { ...job, attempts: 0 };
+
+    // Drop oldest if queue is full
+    if (this.queue.length >= this.maxQueueSize) {
+      const dropped = this.queue.shift()!;
+      this.droppedCount++;
+      log.warn(
+        { droppedHash: dropped.commitHash, queueSize: this.queue.length, droppedCount: this.droppedCount },
+        'Enrichment queue full, dropping oldest job',
+      );
+    }
+
+    this.queue.push(internalJob);
+    log.debug(
+      { commitHash: job.commitHash, queueSize: this.queue.length },
+      'Enrichment job enqueued',
+    );
+
+    this.processNext();
+  }
+
+  /**
+   * Graceful shutdown: wait for in-flight jobs to complete, discard pending.
+   */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    const pendingCount = this.queue.length;
+    this.queue = [];
+
+    if (pendingCount > 0) {
+      log.info({ discarded: pendingCount }, 'Enrichment queue shutting down, discarding pending jobs');
+    }
+
+    // Wait for in-flight workers to finish
+    if (this.inFlightPromises.size > 0) {
+      log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
+      await Promise.all(this.inFlightPromises);
+    }
+
+    log.info(
+      { succeeded: this.succeededCount, failed: this.failedCount, dropped: this.droppedCount },
+      'Enrichment queue shut down',
+    );
+  }
+
+  /** @internal Test-only: get queue size */
+  _getQueueSize(): number {
+    return this.queue.length;
+  }
+
+  /** @internal Test-only: get dropped count */
+  _getDroppedCount(): number {
+    return this.droppedCount;
+  }
+
+  /** @internal Test-only: get succeeded count */
+  _getSucceededCount(): number {
+    return this.succeededCount;
+  }
+
+  /** @internal Test-only: get failed count */
+  _getFailedCount(): number {
+    return this.failedCount;
+  }
+
+  /** @internal Test-only: get active workers */
+  _getActiveWorkers(): number {
+    return this.activeWorkers;
+  }
+
+  private processNext(): void {
+    if (this.shuttingDown) return;
+    if (this.activeWorkers >= this.maxConcurrency) return;
+    if (this.queue.length === 0) return;
+
+    const job = this.queue.shift()!;
+    this.activeWorkers++;
+
+    const promise = this.executeJob(job).finally(() => {
+      this.activeWorkers--;
+      this.inFlightPromises.delete(promise);
+      // Try to process next job after this one completes
+      this.processNext();
+    });
+
+    this.inFlightPromises.add(promise);
+  }
+
+  private async executeJob(job: InternalJob): Promise<void> {
+    job.attempts++;
+
+    try {
+      // Race the enrichment work against a timeout
+      await Promise.race([
+        this.doEnrichment(job),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Enrichment job timed out')), this.jobTimeoutMs),
+        ),
+      ]);
+      this.succeededCount++;
+      log.debug(
+        { commitHash: job.commitHash, attempts: job.attempts },
+        'Enrichment job completed',
+      );
+    } catch (err) {
+      if (job.attempts <= this.maxRetries) {
+        // Exponential backoff: 1s, 2s, 4s, ...
+        const backoffMs = 1000 * Math.pow(2, job.attempts - 1);
+        log.debug(
+          { commitHash: job.commitHash, attempts: job.attempts, backoffMs, err },
+          'Enrichment job failed, scheduling retry',
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, backoffMs));
+
+        if (!this.shuttingDown) {
+          // Re-enqueue at front for retry (don't count against queue limit)
+          this.queue.unshift(job);
+          this.processNext();
+        }
+        return;
+      }
+
+      this.failedCount++;
+      log.warn(
+        { commitHash: job.commitHash, attempts: job.attempts, err },
+        'Enrichment job failed after max retries',
+      );
+    }
+  }
+
+  /**
+   * Perform the actual enrichment work.
+   *
+   * Currently a no-op placeholder that writes a scaffold JSON note
+   * to prove the plumbing works. Future: call LLM to generate a
+   * rich commit description and write it as a git note.
+   */
+  private async doEnrichment(job: InternalJob): Promise<void> {
+    const note = JSON.stringify({
+      enriched: true,
+      trigger: job.context.trigger,
+      filesChanged: job.context.changedFiles.length,
+      timestamp: job.context.timestampMs,
+      sessionId: job.context.sessionId,
+      turnNumber: job.context.turnNumber,
+    });
+
+    await job.gitService.writeNote(job.commitHash, note);
+  }
+}
+
+/** Singleton enrichment service instance. */
+let enrichmentService: CommitEnrichmentService | null = null;
+
+/**
+ * Get the global enrichment service singleton.
+ * Created lazily on first access.
+ */
+export function getEnrichmentService(): CommitEnrichmentService {
+  if (!enrichmentService) {
+    enrichmentService = new CommitEnrichmentService();
+  }
+  return enrichmentService;
+}
+
+/**
+ * @internal Test-only: reset the singleton
+ */
+export function _resetEnrichmentService(): void {
+  enrichmentService = null;
+}

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -619,6 +619,23 @@ export class WorkspaceGitService {
   }
 
   /**
+   * Get the commit hash of the current HEAD.
+   * This is a lightweight read-only operation that does not require the mutex.
+   */
+  async getHeadHash(): Promise<string> {
+    const { stdout } = await this.execGit(['rev-parse', 'HEAD']);
+    return stdout.trim();
+  }
+
+  /**
+   * Write a git note to a specific commit.
+   * Uses the 'vellum' notes ref to avoid conflicts with default notes.
+   */
+  async writeNote(commitHash: string, noteContent: string): Promise<void> {
+    await this.execGit(['notes', '--ref=vellum', 'add', '-f', '-m', noteContent, commitHash]);
+  }
+
+  /**
    * Check if the workspace has a git repository initialized.
    * This is a non-blocking check that doesn't trigger initialization.
    */

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -5,6 +5,7 @@ import {
   type CommitContext,
   type CommitMessageProvider,
 } from './commit-message-provider.js';
+import { getEnrichmentService } from './commit-message-enrichment-service.js';
 
 const log = getLogger('heartbeat');
 
@@ -198,8 +199,10 @@ export class HeartbeatService {
 
       try {
         const now = this.now();
-        const { committed } = await service.commitIfDirty((status) => {
-          const uniqueFiles = [...new Set([...status.staged, ...status.modified, ...status.untracked])];
+        let shutdownFiles: string[] = [];
+        const { committed } = await service.commitIfDirty((st) => {
+          const uniqueFiles = [...new Set([...st.staged, ...st.modified, ...st.untracked])];
+          shutdownFiles = uniqueFiles;
           log.info({ workspaceDir, totalChanges: uniqueFiles.length }, 'Committing pending changes on shutdown');
 
           const ctx: CommitContext = {
@@ -215,6 +218,20 @@ export class HeartbeatService {
         if (committed) {
           firstSeenDirty.delete(workspaceDir);
           result.committed++;
+
+          // Fire-and-forget enrichment
+          try {
+            const commitHash = await service.getHeadHash();
+            const shutdownCtx: CommitContext = {
+              workspaceDir,
+              trigger: 'shutdown',
+              changedFiles: shutdownFiles,
+              timestampMs: this.now(),
+            };
+            getEnrichmentService().enqueue({ workspaceDir, commitHash, context: shutdownCtx, gitService: service });
+          } catch (enrichErr) {
+            log.debug({ enrichErr }, 'Failed to enqueue shutdown enrichment (non-fatal)');
+          }
         } else {
           result.skipped++;
         }
@@ -241,6 +258,8 @@ export class HeartbeatService {
     service: WorkspaceGitService,
   ): Promise<boolean> {
     const now = this.now();
+    let heartbeatFiles: string[] = [];
+    let heartbeatReason: string | undefined;
 
     // Atomic status check + conditional commit within a single mutex lock.
     const { committed, status } = await service.commitIfDirty((st) => {
@@ -270,6 +289,9 @@ export class HeartbeatService {
         ? `changes older than ${Math.round(dirtyAge / 1000)}s`
         : `${totalChanges} files changed (threshold: ${this.fileThreshold})`;
 
+      heartbeatFiles = uniqueFiles;
+      heartbeatReason = reason;
+
       log.info(
         { workspaceDir, totalChanges, dirtyAgeMs: dirtyAge, reason },
         'Heartbeat auto-committing workspace changes',
@@ -288,6 +310,22 @@ export class HeartbeatService {
 
     if (committed) {
       firstSeenDirty.delete(workspaceDir);
+
+      // Fire-and-forget enrichment
+      try {
+        const commitHash = await service.getHeadHash();
+        const hbCtx: CommitContext = {
+          workspaceDir,
+          trigger: 'heartbeat',
+          changedFiles: heartbeatFiles,
+          timestampMs: now,
+          reason: heartbeatReason,
+        };
+        getEnrichmentService().enqueue({ workspaceDir, commitHash, context: hbCtx, gitService: service });
+      } catch (enrichErr) {
+        log.debug({ enrichErr }, 'Failed to enqueue heartbeat enrichment (non-fatal)');
+      }
+
       return true;
     }
 

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -16,6 +16,7 @@ import {
   type CommitContext,
   type CommitMessageProvider,
 } from './commit-message-provider.js';
+import { getEnrichmentService } from './commit-message-enrichment-service.js';
 
 const log = getLogger('turn-commit');
 
@@ -77,6 +78,22 @@ export async function commitTurnChanges(
         { sessionId, turnNumber, filesChanged: uniqueFiles.length },
         'Turn-boundary commit created',
       );
+
+      // Fire-and-forget enrichment — never blocks turn completion
+      try {
+        const commitHash = await gitService.getHeadHash();
+        const ctx: CommitContext = {
+          workspaceDir,
+          trigger: 'turn',
+          sessionId,
+          turnNumber,
+          changedFiles: uniqueFiles,
+          timestampMs: Date.now(),
+        };
+        getEnrichmentService().enqueue({ workspaceDir, commitHash, context: ctx, gitService });
+      } catch (enrichErr) {
+        log.debug({ enrichErr }, 'Failed to enqueue enrichment (non-fatal)');
+      }
     } else {
       log.debug({ sessionId, turnNumber }, 'No workspace changes to commit for turn');
     }


### PR DESCRIPTION
## Summary
Adds a non-blocking enrichment queue that runs asynchronously after successful workspace commits.

## Changes
- **New `commit-message-enrichment-service.ts`**: `CommitEnrichmentService` class with bounded queue (configurable max size, default 50), bounded concurrency (default 1), per-job timeout (default 30s), retry with exponential backoff (max 2 retries), drop-oldest overflow policy, and graceful shutdown (drains in-flight, discards pending). No-op worker writes placeholder JSON to git notes (`refs/notes/vellum`).
- **`config/schema.ts`**: Added `enrichmentQueueSize`, `enrichmentConcurrency`, `enrichmentJobTimeoutMs`, `enrichmentMaxRetries` to `WorkspaceGitConfigSchema`.
- **`git-service.ts`**: Added `getHeadHash()` and `writeNote()` public methods.
- **`turn-commit.ts`**: After successful commit, fire-and-forget enqueue enrichment with commit hash and context.
- **`heartbeat-service.ts`**: Same fire-and-forget enrichment hook in both `checkWorkspace()` and `commitAllPending()`.
- **New test file**: 7 tests covering enqueue+execute, queue overflow/drop, fire-and-forget non-blocking, graceful shutdown, discard-after-shutdown, and multi-note writes.

## Test plan
- 7 new enrichment service tests pass
- 34 existing git-service tests pass
- 14 existing heartbeat-service tests pass
- 8 existing turn-commit tests pass

Closes #5155
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
