### PR TITLE
M4: Observability + ARCHITECTURE.md update

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1029,8 +1029,9 @@ The workspace sandbox (`~/.vellum/workspace`) is automatically tracked by a per-
 graph TB
     subgraph "Turn-boundary commits (primary)"
         SESSION["Session.processMessage()"]
-        TURN_COMMIT["commitTurnChanges()<br/>awaited"]
-        GIT_SERVICE["WorkspaceGitService<br/>mutex-protected"]
+        TURN_COMMIT["commitTurnChanges()<br/>awaited, timeout-protected"]
+        MSG_PROVIDER["CommitMessageProvider<br/>buildImmediateMessage()"]
+        GIT_SERVICE["WorkspaceGitService<br/>mutex + circuit breaker"]
     end
 
     subgraph "Heartbeat safety net (secondary)"
@@ -1038,17 +1039,27 @@ graph TB
         CHECK["check(): age > 5 min<br/>OR files > 20"]
     end
 
+    subgraph "Post-commit enrichment (async)"
+        ENRICHMENT["CommitEnrichmentService<br/>bounded queue, fire-and-forget"]
+        GIT_NOTES["git notes --ref=vellum<br/>JSON metadata"]
+    end
+
     subgraph "Lifecycle"
         STARTUP["Daemon startup<br/>lifecycle.ts"]
         SHUTDOWN["Graceful shutdown<br/>commitAllPending()"]
     end
 
-    SESSION -->|"await"| TURN_COMMIT
-    TURN_COMMIT --> GIT_SERVICE
+    SESSION -->|"await + timeout"| TURN_COMMIT
+    TURN_COMMIT --> MSG_PROVIDER
+    MSG_PROVIDER --> GIT_SERVICE
+    TURN_COMMIT -->|"fire-and-forget"| ENRICHMENT
     HEARTBEAT --> CHECK
-    CHECK --> GIT_SERVICE
+    CHECK --> MSG_PROVIDER
+    CHECK -->|"fire-and-forget"| ENRICHMENT
+    ENRICHMENT --> GIT_NOTES
     STARTUP --> HEARTBEAT
     SHUTDOWN -->|"await"| HEARTBEAT
+    SHUTDOWN -->|"drain in-flight"| ENRICHMENT
 ```
 
 ### How it works
@@ -1063,6 +1074,14 @@ graph TB
 
 5. **Corrupted repo recovery**: If a `.git` directory exists but is corrupted (e.g. missing HEAD), the service detects this via `git rev-parse --git-dir`, removes the corrupted directory, and reinitializes cleanly.
 
+6. **Commit message provider abstraction**: All commit message construction is handled by a `CommitMessageProvider` interface (`commit-message-provider.ts`). The `DefaultCommitMessageProvider` produces deterministic messages based on trigger type (turn, heartbeat, shutdown). Both `turn-commit.ts` and `heartbeat-service.ts` accept an optional custom provider, creating a seam for future LLM-powered enrichment without changing the synchronous commit path.
+
+7. **Circuit breaker with exponential backoff**: `WorkspaceGitService` tracks consecutive commit failures and backs off exponentially (2s, 4s, 8s... up to 60s configurable max). When the breaker is open, `commitIfDirty()` short-circuits without attempting git operations. On success, the breaker resets. State transitions are logged at info/warn level with structured fields (`consecutiveFailures`, `backoffMs`).
+
+8. **Turn-commit timeout protection**: The turn-boundary commit in `session.ts` uses `Promise.race` with a configurable timeout (`workspaceGit.turnCommitMaxWaitMs`, default 4s). If the commit exceeds the timeout, the turn proceeds immediately (the commit continues in the background). This prevents slow git operations from blocking the conversation loop.
+
+9. **Non-blocking enrichment queue**: After each successful commit, a `CommitEnrichmentService` runs async enrichment fire-and-forget. The queue has configurable max size (default 50), concurrency (default 1), per-job timeout (default 30s), and retry count (default 2 with exponential backoff). On queue overflow, the oldest job is dropped with a warning log. On graceful shutdown, in-flight jobs drain while pending jobs are discarded. Currently writes placeholder JSON metadata to git notes (`refs/notes/vellum`) as a scaffold for future LLM enrichment.
+
 ### Design decisions
 
 - **Commit at turn boundaries, not per-tool-call**: A single commit per turn captures all file mutations from that turn atomically. This avoids noisy per-file commits and keeps the history meaningful.
@@ -1076,11 +1095,14 @@ graph TB
 
 | File | Role |
 |------|------|
-| `assistant/src/workspace/git-service.ts` | `WorkspaceGitService`: lazy init, mutex, `commitChanges()`, `getStatus()`, singleton registry |
-| `assistant/src/workspace/turn-commit.ts` | `commitTurnChanges()`: turn-boundary commit with structured metadata |
-| `assistant/src/workspace/heartbeat-service.ts` | `HeartbeatService`: periodic safety-net auto-commits and shutdown commits |
-| `assistant/src/daemon/session.ts` | Integration: `await commitTurnChanges(...)` at turn boundary |
+| `assistant/src/workspace/git-service.ts` | `WorkspaceGitService`: lazy init, mutex, circuit breaker, `commitIfDirty()`, `getHeadHash()`, `writeNote()`, singleton registry |
+| `assistant/src/workspace/commit-message-provider.ts` | `CommitMessageProvider` interface, `DefaultCommitMessageProvider`, `CommitContext`/`CommitMessageResult` types |
+| `assistant/src/workspace/commit-message-enrichment-service.ts` | `CommitEnrichmentService`: bounded async queue, fire-and-forget enrichment, git notes output |
+| `assistant/src/workspace/turn-commit.ts` | `commitTurnChanges()`: turn-boundary commit with structured metadata + enrichment enqueue |
+| `assistant/src/workspace/heartbeat-service.ts` | `HeartbeatService`: periodic safety-net auto-commits, shutdown commits, enrichment enqueue |
+| `assistant/src/daemon/session.ts` | Integration: `await commitTurnChanges(...)` at turn boundary with timeout protection |
 | `assistant/src/daemon/lifecycle.ts` | Integration: `HeartbeatService` start/stop and shutdown commit |
+| `assistant/src/config/schema.ts` | `WorkspaceGitConfigSchema`: timeout, backoff, and enrichment queue configuration |
 
 ---
 

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -182,12 +182,13 @@ export class CommitEnrichmentService {
         'Enrichment job completed',
       );
     } catch (err) {
+      const isTimeout = err instanceof Error && err.message === 'Enrichment job timed out';
       if (job.attempts <= this.maxRetries) {
         // Exponential backoff: 1s, 2s, 4s, ...
         const backoffMs = 1000 * Math.pow(2, job.attempts - 1);
         log.debug(
-          { commitHash: job.commitHash, attempts: job.attempts, backoffMs, err },
-          'Enrichment job failed, scheduling retry',
+          { commitHash: job.commitHash, attempts: job.attempts, backoffMs, timedOut: isTimeout, err },
+          isTimeout ? 'Enrichment job timed out, scheduling retry' : 'Enrichment job failed, scheduling retry',
         );
         await new Promise<void>((resolve) => setTimeout(resolve, backoffMs));
 
@@ -201,8 +202,8 @@ export class CommitEnrichmentService {
 
       this.failedCount++;
       log.warn(
-        { commitHash: job.commitHash, attempts: job.attempts, err },
-        'Enrichment job failed after max retries',
+        { commitHash: job.commitHash, attempts: job.attempts, timedOut: isTimeout, err },
+        isTimeout ? 'Enrichment job timed out after max retries' : 'Enrichment job failed after max retries',
       );
     }
   }

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -161,6 +161,12 @@ export class WorkspaceGitService {
   }
 
   private recordSuccess(): void {
+    if (this.consecutiveFailures > 0) {
+      log.info(
+        { workspaceDir: this.workspaceDir, previousFailures: this.consecutiveFailures },
+        'Circuit breaker closed: commit succeeded after failures',
+      );
+    }
     this.consecutiveFailures = 0;
     this.nextAllowedAttemptMs = 0;
   }
@@ -175,6 +181,10 @@ export class WorkspaceGitService {
       failureBackoffMaxMs,
     );
     this.nextAllowedAttemptMs = Date.now() + delay;
+    log.warn(
+      { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures, backoffMs: delay },
+      'Circuit breaker opened: commit failed, backing off',
+    );
   }
 
   /**

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -54,6 +54,7 @@ export async function commitTurnChanges(
   const messageProvider = provider ?? new DefaultCommitMessageProvider();
   try {
     const gitService = getWorkspaceGitService(workspaceDir);
+    const commitStartMs = Date.now();
 
     // Atomic status check + commit within a single mutex lock to prevent
     // TOCTOU races with heartbeat commits.
@@ -72,10 +73,12 @@ export async function commitTurnChanges(
       return messageProvider.buildImmediateMessage(ctx);
     });
 
+    const commitDurationMs = Date.now() - commitStartMs;
+
     if (committed) {
       const uniqueFiles = [...new Set([...status.staged, ...status.modified, ...status.untracked])];
       log.info(
-        { sessionId, turnNumber, filesChanged: uniqueFiles.length },
+        { sessionId, turnNumber, filesChanged: uniqueFiles.length, durationMs: commitDurationMs },
         'Turn-boundary commit created',
       );
 
@@ -95,7 +98,7 @@ export async function commitTurnChanges(
         log.debug({ enrichErr }, 'Failed to enqueue enrichment (non-fatal)');
       }
     } else {
-      log.debug({ sessionId, turnNumber }, 'No workspace changes to commit for turn');
+      log.debug({ sessionId, turnNumber, durationMs: commitDurationMs }, 'No workspace changes to commit for turn');
     }
   } catch (err) {
     // Never let commit failures propagate — they must not affect the turn


### PR DESCRIPTION
## Summary
Adds structured observability logging and updates architecture documentation for the workspace git hardening feature.

## Changes
- **`git-service.ts`**: Added circuit breaker state transition logs — `recordSuccess()` logs when breaker closes after failures (info), `recordFailure()` logs on each failure with backoff duration (warn).
- **`turn-commit.ts`**: Added `durationMs` to turn-boundary commit log entries for both committed and skipped cases.
- **`commit-message-enrichment-service.ts`**: Added `timedOut` boolean field to retry/failure logs, with timeout-specific message variants.
- **`ARCHITECTURE.md`**: Updated mermaid diagram with commit message provider, enrichment queue, and circuit breaker. Added sections 6-9 documenting provider abstraction, circuit breaker, timeout protection, and enrichment queue. Updated key files table with all new files and roles.

## Test plan
- 34 git-service tests pass
- 14 heartbeat-service tests pass
- 8 turn-commit tests pass
- 7 enrichment service tests pass
- Verified new structured log fields appear in test output (durationMs, timedOut, consecutiveFailures, backoffMs)

Closes #5156
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
