### PR TITLE
Workspace Git Hardening + Commit Message Enrichment Scaffold

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1029,8 +1029,9 @@ The workspace sandbox (`~/.vellum/workspace`) is automatically tracked by a per-
 graph TB
     subgraph "Turn-boundary commits (primary)"
         SESSION["Session.processMessage()"]
-        TURN_COMMIT["commitTurnChanges()<br/>awaited"]
-        GIT_SERVICE["WorkspaceGitService<br/>mutex-protected"]
+        TURN_COMMIT["commitTurnChanges()<br/>awaited, timeout-protected"]
+        MSG_PROVIDER["CommitMessageProvider<br/>buildImmediateMessage()"]
+        GIT_SERVICE["WorkspaceGitService<br/>mutex + circuit breaker"]
     end
 
     subgraph "Heartbeat safety net (secondary)"
@@ -1038,17 +1039,27 @@ graph TB
         CHECK["check(): age > 5 min<br/>OR files > 20"]
     end
 
+    subgraph "Post-commit enrichment (async)"
+        ENRICHMENT["CommitEnrichmentService<br/>bounded queue, fire-and-forget"]
+        GIT_NOTES["git notes --ref=vellum<br/>JSON metadata"]
+    end
+
     subgraph "Lifecycle"
         STARTUP["Daemon startup<br/>lifecycle.ts"]
         SHUTDOWN["Graceful shutdown<br/>commitAllPending()"]
     end
 
-    SESSION -->|"await"| TURN_COMMIT
-    TURN_COMMIT --> GIT_SERVICE
+    SESSION -->|"await + timeout"| TURN_COMMIT
+    TURN_COMMIT --> MSG_PROVIDER
+    MSG_PROVIDER --> GIT_SERVICE
+    TURN_COMMIT -->|"fire-and-forget"| ENRICHMENT
     HEARTBEAT --> CHECK
-    CHECK --> GIT_SERVICE
+    CHECK --> MSG_PROVIDER
+    CHECK -->|"fire-and-forget"| ENRICHMENT
+    ENRICHMENT --> GIT_NOTES
     STARTUP --> HEARTBEAT
     SHUTDOWN -->|"await"| HEARTBEAT
+    SHUTDOWN -->|"drain in-flight"| ENRICHMENT
 ```
 
 ### How it works
@@ -1063,6 +1074,14 @@ graph TB
 
 5. **Corrupted repo recovery**: If a `.git` directory exists but is corrupted (e.g. missing HEAD), the service detects this via `git rev-parse --git-dir`, removes the corrupted directory, and reinitializes cleanly.
 
+6. **Commit message provider abstraction**: All commit message construction is handled by a `CommitMessageProvider` interface (`commit-message-provider.ts`). The `DefaultCommitMessageProvider` produces deterministic messages based on trigger type (turn, heartbeat, shutdown). Both `turn-commit.ts` and `heartbeat-service.ts` accept an optional custom provider, creating a seam for future LLM-powered enrichment without changing the synchronous commit path.
+
+7. **Circuit breaker with exponential backoff**: `WorkspaceGitService` tracks consecutive commit failures and backs off exponentially (2s, 4s, 8s... up to 60s configurable max). When the breaker is open, `commitIfDirty()` short-circuits without attempting git operations. On success, the breaker resets. State transitions are logged at info/warn level with structured fields (`consecutiveFailures`, `backoffMs`).
+
+8. **Turn-commit timeout protection**: The turn-boundary commit in `session.ts` uses `Promise.race` with a configurable timeout (`workspaceGit.turnCommitMaxWaitMs`, default 4s). If the commit exceeds the timeout, the turn proceeds immediately (the commit continues in the background). This prevents slow git operations from blocking the conversation loop.
+
+9. **Non-blocking enrichment queue**: After each successful commit, a `CommitEnrichmentService` runs async enrichment fire-and-forget. The queue has configurable max size (default 50), concurrency (default 1), per-job timeout (default 30s), and retry count (default 2 with exponential backoff). On queue overflow, the oldest job is dropped with a warning log. On graceful shutdown, in-flight jobs drain while pending jobs are discarded. Currently writes placeholder JSON metadata to git notes (`refs/notes/vellum`) as a scaffold for future LLM enrichment.
+
 ### Design decisions
 
 - **Commit at turn boundaries, not per-tool-call**: A single commit per turn captures all file mutations from that turn atomically. This avoids noisy per-file commits and keeps the history meaningful.
@@ -1076,11 +1095,14 @@ graph TB
 
 | File | Role |
 |------|------|
-| `assistant/src/workspace/git-service.ts` | `WorkspaceGitService`: lazy init, mutex, `commitChanges()`, `getStatus()`, singleton registry |
-| `assistant/src/workspace/turn-commit.ts` | `commitTurnChanges()`: turn-boundary commit with structured metadata |
-| `assistant/src/workspace/heartbeat-service.ts` | `HeartbeatService`: periodic safety-net auto-commits and shutdown commits |
-| `assistant/src/daemon/session.ts` | Integration: `await commitTurnChanges(...)` at turn boundary |
+| `assistant/src/workspace/git-service.ts` | `WorkspaceGitService`: lazy init, mutex, circuit breaker, `commitIfDirty()`, `getHeadHash()`, `writeNote()`, singleton registry |
+| `assistant/src/workspace/commit-message-provider.ts` | `CommitMessageProvider` interface, `DefaultCommitMessageProvider`, `CommitContext`/`CommitMessageResult` types |
+| `assistant/src/workspace/commit-message-enrichment-service.ts` | `CommitEnrichmentService`: bounded async queue, fire-and-forget enrichment, git notes output |
+| `assistant/src/workspace/turn-commit.ts` | `commitTurnChanges()`: turn-boundary commit with structured metadata + enrichment enqueue |
+| `assistant/src/workspace/heartbeat-service.ts` | `HeartbeatService`: periodic safety-net auto-commits, shutdown commits, enrichment enqueue |
+| `assistant/src/daemon/session.ts` | Integration: `await commitTurnChanges(...)` at turn boundary with timeout protection |
 | `assistant/src/daemon/lifecycle.ts` | Integration: `HeartbeatService` start/stop and shutdown commit |
+| `assistant/src/config/schema.ts` | `WorkspaceGitConfigSchema`: timeout, backoff, and enrichment queue configuration |
 
 ---
 

--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -1,0 +1,263 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import {
+  CommitEnrichmentService,
+  _resetEnrichmentService,
+} from '../workspace/commit-message-enrichment-service.js';
+import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
+import type { CommitContext } from '../workspace/commit-message-provider.js';
+
+describe('CommitEnrichmentService', () => {
+  let testDir: string;
+  let gitService: WorkspaceGitService;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `vellum-enrichment-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    _resetGitServiceRegistry();
+    _resetEnrichmentService();
+
+    gitService = new WorkspaceGitService(testDir);
+    await gitService.ensureInitialized();
+  });
+
+  afterEach(async () => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeContext(overrides?: Partial<CommitContext>): CommitContext {
+    return {
+      workspaceDir: testDir,
+      trigger: 'turn',
+      sessionId: 'sess_test',
+      turnNumber: 1,
+      changedFiles: ['file.txt'],
+      timestampMs: Date.now(),
+      ...overrides,
+    };
+  }
+
+  async function createCommit(): Promise<string> {
+    writeFileSync(join(testDir, `file-${Date.now()}.txt`), 'content');
+    await gitService.commitChanges('test commit');
+    return await gitService.getHeadHash();
+  }
+
+  test('enqueue and execute writes git note on success', async () => {
+    const commitHash = await createCommit();
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash,
+      context: makeContext(),
+      gitService,
+    });
+
+    // Wait for async processing
+    await service.shutdown();
+
+    // Verify git note was written
+    const noteContent = execFileSync('git', ['notes', '--ref=vellum', 'show', commitHash], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    const note = JSON.parse(noteContent);
+    expect(note.enriched).toBe(true);
+    expect(note.trigger).toBe('turn');
+    expect(note.sessionId).toBe('sess_test');
+    expect(note.turnNumber).toBe(1);
+    expect(note.filesChanged).toBe(1);
+    expect(service._getSucceededCount()).toBe(1);
+  });
+
+  test('queue overflow drops oldest job', async () => {
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 2,
+      maxConcurrency: 0, // 0 concurrency means nothing processes, for testing queue behavior
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    // Override concurrency so nothing actually runs
+    // We want to test queue overflow behavior only
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+    const hash3 = await createCommit();
+
+    // With maxConcurrency 0, nothing will process; but let's use 1 and block processing
+    // Instead, use a service with concurrency 1 but fill the queue faster than it drains
+    const service2 = new CommitEnrichmentService({
+      maxQueueSize: 2,
+      maxConcurrency: 1,
+      jobTimeoutMs: 30000,
+      maxRetries: 0,
+    });
+
+    // Enqueue 3 jobs — the first starts immediately (active worker),
+    // second goes to queue, third overflows and drops the second
+    service2.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
+    service2.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
+    service2.enqueue({ workspaceDir: testDir, commitHash: hash3, context: makeContext(), gitService });
+
+    // The queue should have 2 items (hash2 and hash3 or hash3 depending on timing)
+    // But hash1 is being processed. Let's check dropped count.
+    // With maxQueueSize=2, after hash1 starts processing (active worker=1),
+    // hash2 goes to queue (size=1), hash3 goes to queue (size=2), no drop yet.
+    // Actually the first job is picked up immediately, so queue has 2 items max.
+    // Let's check dropped count after shutdown.
+    await service2.shutdown();
+
+    // No drops expected since queue size 2 can hold 2 pending while 1 is active
+    expect(service2._getDroppedCount()).toBe(0);
+
+    await service.shutdown();
+  });
+
+  test('queue overflow actually drops when truly full', async () => {
+    // Create a service where the worker is slow
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 1,
+      maxConcurrency: 1,
+      jobTimeoutMs: 30000,
+      maxRetries: 0,
+    });
+
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+    const hash3 = await createCommit();
+
+    // hash1 starts processing immediately (active worker = 1, queue empty)
+    // hash2 goes to queue (queue size = 1)
+    // hash3 tries to go to queue but it's full → drops hash2, adds hash3
+    service.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash3, context: makeContext(), gitService });
+
+    expect(service._getDroppedCount()).toBe(1);
+
+    await service.shutdown();
+  });
+
+  test('fire-and-forget enqueue does not block caller', async () => {
+    const commitHash = await createCommit();
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    const start = Date.now();
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash,
+      context: makeContext(),
+      gitService,
+    });
+    const elapsed = Date.now() - start;
+
+    // enqueue should return immediately (< 50ms)
+    expect(elapsed).toBeLessThan(50);
+
+    await service.shutdown();
+  });
+
+  test('graceful shutdown drains in-flight and discards pending', async () => {
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    service.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
+
+    // Shutdown should complete without hanging
+    await service.shutdown();
+
+    // At least the first job should have completed (it was in-flight)
+    expect(service._getSucceededCount()).toBeGreaterThanOrEqual(1);
+  });
+
+  test('discards jobs enqueued after shutdown', async () => {
+    const commitHash = await createCommit();
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    await service.shutdown();
+
+    // Enqueue after shutdown should be silently discarded
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash,
+      context: makeContext(),
+      gitService,
+    });
+
+    expect(service._getQueueSize()).toBe(0);
+    expect(service._getSucceededCount()).toBe(0);
+  });
+
+  test('multiple successful enrichments write separate git notes', async () => {
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash: hash1,
+      context: makeContext({ turnNumber: 1 }),
+      gitService,
+    });
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash: hash2,
+      context: makeContext({ turnNumber: 2 }),
+      gitService,
+    });
+
+    // Wait for queue to drain before shutdown (avoids discarding pending jobs)
+    while (service._getQueueSize() > 0 || service._getActiveWorkers() > 0) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    await service.shutdown();
+
+    // Both notes should exist
+    const note1 = JSON.parse(execFileSync('git', ['notes', '--ref=vellum', 'show', hash1], {
+      cwd: testDir, encoding: 'utf-8',
+    }));
+    const note2 = JSON.parse(execFileSync('git', ['notes', '--ref=vellum', 'show', hash2], {
+      cwd: testDir, encoding: 'utf-8',
+    }));
+
+    expect(note1.turnNumber).toBe(1);
+    expect(note2.turnNumber).toBe(2);
+    expect(service._getSucceededCount()).toBe(2);
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -703,6 +703,24 @@ export const SkillsInstallConfigSchema = z.object({
   }).default('npm'),
 });
 
+export const WorkspaceGitConfigSchema = z.object({
+  turnCommitMaxWaitMs: z
+    .number({ error: 'workspaceGit.turnCommitMaxWaitMs must be a number' })
+    .int('workspaceGit.turnCommitMaxWaitMs must be an integer')
+    .positive('workspaceGit.turnCommitMaxWaitMs must be a positive integer')
+    .default(4000),
+  failureBackoffBaseMs: z
+    .number({ error: 'workspaceGit.failureBackoffBaseMs must be a number' })
+    .int('workspaceGit.failureBackoffBaseMs must be an integer')
+    .positive('workspaceGit.failureBackoffBaseMs must be a positive integer')
+    .default(2000),
+  failureBackoffMaxMs: z
+    .number({ error: 'workspaceGit.failureBackoffMaxMs must be a number' })
+    .int('workspaceGit.failureBackoffMaxMs must be an integer')
+    .positive('workspaceGit.failureBackoffMaxMs must be a positive integer')
+    .default(60000),
+});
+
 export const SwarmConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'swarm.enabled must be a boolean' })
@@ -950,6 +968,11 @@ export const AssistantConfigSchema = z.object({
     install: { nodeManager: 'npm' },
     allowBundled: null,
   }),
+  workspaceGit: WorkspaceGitConfigSchema.default({
+    turnCommitMaxWaitMs: 4000,
+    failureBackoffBaseMs: 2000,
+    failureBackoffMaxMs: 60000,
+  }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -1005,3 +1028,4 @@ export type SkillsLoadConfig = z.infer<typeof SkillsLoadConfigSchema>;
 export type SkillsInstallConfig = z.infer<typeof SkillsInstallConfigSchema>;
 export type SwarmConfig = z.infer<typeof SwarmConfigSchema>;
 export type SkillsConfig = z.infer<typeof SkillsConfigSchema>;
+export type WorkspaceGitConfig = z.infer<typeof WorkspaceGitConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -719,6 +719,26 @@ export const WorkspaceGitConfigSchema = z.object({
     .int('workspaceGit.failureBackoffMaxMs must be an integer')
     .positive('workspaceGit.failureBackoffMaxMs must be a positive integer')
     .default(60000),
+  enrichmentQueueSize: z
+    .number({ error: 'workspaceGit.enrichmentQueueSize must be a number' })
+    .int('workspaceGit.enrichmentQueueSize must be an integer')
+    .positive('workspaceGit.enrichmentQueueSize must be a positive integer')
+    .default(50),
+  enrichmentConcurrency: z
+    .number({ error: 'workspaceGit.enrichmentConcurrency must be a number' })
+    .int('workspaceGit.enrichmentConcurrency must be an integer')
+    .positive('workspaceGit.enrichmentConcurrency must be a positive integer')
+    .default(1),
+  enrichmentJobTimeoutMs: z
+    .number({ error: 'workspaceGit.enrichmentJobTimeoutMs must be a number' })
+    .int('workspaceGit.enrichmentJobTimeoutMs must be an integer')
+    .positive('workspaceGit.enrichmentJobTimeoutMs must be a positive integer')
+    .default(30000),
+  enrichmentMaxRetries: z
+    .number({ error: 'workspaceGit.enrichmentMaxRetries must be a number' })
+    .int('workspaceGit.enrichmentMaxRetries must be an integer')
+    .nonnegative('workspaceGit.enrichmentMaxRetries must be non-negative')
+    .default(2),
 });
 
 export const SwarmConfigSchema = z.object({
@@ -972,6 +992,10 @@ export const AssistantConfigSchema = z.object({
     turnCommitMaxWaitMs: 4000,
     failureBackoffBaseMs: 2000,
     failureBackoffMaxMs: 60000,
+    enrichmentQueueSize: 50,
+    enrichmentConcurrency: 1,
+    enrichmentJobTimeoutMs: 30000,
+    enrichmentMaxRetries: 2,
   }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1422,7 +1422,20 @@ export class Session {
       // the agent loop started, even if post-processing threw.
       if (turnStarted) {
         this.turnCount++;
-        await commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
+        const config = getConfig();
+        const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
+        const commitPromise = commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
+        let timedOut = false;
+        await Promise.race([
+          commitPromise,
+          new Promise<void>((resolve) => setTimeout(() => { timedOut = true; resolve(); }, maxWait)),
+        ]);
+        if (timedOut) {
+          rlog.warn(
+            { turnNumber: this.turnCount, maxWaitMs: maxWait, conversationId: this.conversationId },
+            'Turn-boundary commit timed out — continuing without waiting (commit still runs in background)',
+          );
+        }
       }
 
       this.profiler.emitSummary(this.traceEmitter, reqId);

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -1,0 +1,250 @@
+/**
+ * Non-blocking enrichment queue for post-commit message enhancement.
+ *
+ * After a synchronous commit succeeds, callers can enqueue enrichment jobs
+ * that run asynchronously without blocking the commit path. This is the
+ * scaffold for future LLM-powered commit message enrichment.
+ *
+ * Key properties:
+ * - Bounded queue with configurable max size (drops oldest on overflow)
+ * - Bounded concurrency (default 1 worker)
+ * - Per-job timeout with retry + exponential backoff
+ * - Graceful shutdown: drains in-flight jobs, discards pending
+ * - Fire-and-forget: enqueue() never blocks or throws
+ */
+
+import { getLogger } from '../util/logger.js';
+import { getConfig } from '../config/loader.js';
+import type { WorkspaceGitService } from './git-service.js';
+import type { CommitContext } from './commit-message-provider.js';
+
+const log = getLogger('enrichment-queue');
+
+export interface EnrichmentJob {
+  workspaceDir: string;
+  commitHash: string;
+  context: CommitContext;
+  gitService: WorkspaceGitService;
+}
+
+interface InternalJob extends EnrichmentJob {
+  attempts: number;
+}
+
+export interface EnrichmentServiceOptions {
+  maxQueueSize?: number;
+  maxConcurrency?: number;
+  jobTimeoutMs?: number;
+  maxRetries?: number;
+}
+
+/**
+ * Non-blocking enrichment queue service.
+ *
+ * Enqueue jobs after successful commits. Each job runs the enrichment
+ * worker (currently a no-op placeholder) and writes the result as a
+ * git note on the commit.
+ */
+export class CommitEnrichmentService {
+  private readonly maxQueueSize: number;
+  private readonly maxConcurrency: number;
+  private readonly jobTimeoutMs: number;
+  private readonly maxRetries: number;
+
+  private queue: InternalJob[] = [];
+  private activeWorkers = 0;
+  private droppedCount = 0;
+  private succeededCount = 0;
+  private failedCount = 0;
+  private shuttingDown = false;
+  private inFlightPromises: Set<Promise<void>> = new Set();
+
+  constructor(options?: EnrichmentServiceOptions) {
+    const config = getConfig();
+    const gitConfig = config.workspaceGit;
+    this.maxQueueSize = options?.maxQueueSize ?? gitConfig?.enrichmentQueueSize ?? 50;
+    this.maxConcurrency = options?.maxConcurrency ?? gitConfig?.enrichmentConcurrency ?? 1;
+    this.jobTimeoutMs = options?.jobTimeoutMs ?? gitConfig?.enrichmentJobTimeoutMs ?? 30000;
+    this.maxRetries = options?.maxRetries ?? gitConfig?.enrichmentMaxRetries ?? 2;
+  }
+
+  /**
+   * Enqueue an enrichment job. Fire-and-forget — never blocks or throws.
+   */
+  enqueue(job: EnrichmentJob): void {
+    if (this.shuttingDown) {
+      log.debug({ commitHash: job.commitHash }, 'Enrichment queue shutting down, discarding job');
+      return;
+    }
+
+    const internalJob: InternalJob = { ...job, attempts: 0 };
+
+    // Drop oldest if queue is full
+    if (this.queue.length >= this.maxQueueSize) {
+      const dropped = this.queue.shift()!;
+      this.droppedCount++;
+      log.warn(
+        { droppedHash: dropped.commitHash, queueSize: this.queue.length, droppedCount: this.droppedCount },
+        'Enrichment queue full, dropping oldest job',
+      );
+    }
+
+    this.queue.push(internalJob);
+    log.debug(
+      { commitHash: job.commitHash, queueSize: this.queue.length },
+      'Enrichment job enqueued',
+    );
+
+    this.processNext();
+  }
+
+  /**
+   * Graceful shutdown: wait for in-flight jobs to complete, discard pending.
+   */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    const pendingCount = this.queue.length;
+    this.queue = [];
+
+    if (pendingCount > 0) {
+      log.info({ discarded: pendingCount }, 'Enrichment queue shutting down, discarding pending jobs');
+    }
+
+    // Wait for in-flight workers to finish
+    if (this.inFlightPromises.size > 0) {
+      log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
+      await Promise.all(this.inFlightPromises);
+    }
+
+    log.info(
+      { succeeded: this.succeededCount, failed: this.failedCount, dropped: this.droppedCount },
+      'Enrichment queue shut down',
+    );
+  }
+
+  /** @internal Test-only: get queue size */
+  _getQueueSize(): number {
+    return this.queue.length;
+  }
+
+  /** @internal Test-only: get dropped count */
+  _getDroppedCount(): number {
+    return this.droppedCount;
+  }
+
+  /** @internal Test-only: get succeeded count */
+  _getSucceededCount(): number {
+    return this.succeededCount;
+  }
+
+  /** @internal Test-only: get failed count */
+  _getFailedCount(): number {
+    return this.failedCount;
+  }
+
+  /** @internal Test-only: get active workers */
+  _getActiveWorkers(): number {
+    return this.activeWorkers;
+  }
+
+  private processNext(): void {
+    if (this.shuttingDown) return;
+    if (this.activeWorkers >= this.maxConcurrency) return;
+    if (this.queue.length === 0) return;
+
+    const job = this.queue.shift()!;
+    this.activeWorkers++;
+
+    const promise = this.executeJob(job).finally(() => {
+      this.activeWorkers--;
+      this.inFlightPromises.delete(promise);
+      // Try to process next job after this one completes
+      this.processNext();
+    });
+
+    this.inFlightPromises.add(promise);
+  }
+
+  private async executeJob(job: InternalJob): Promise<void> {
+    job.attempts++;
+
+    try {
+      // Race the enrichment work against a timeout
+      await Promise.race([
+        this.doEnrichment(job),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Enrichment job timed out')), this.jobTimeoutMs),
+        ),
+      ]);
+      this.succeededCount++;
+      log.debug(
+        { commitHash: job.commitHash, attempts: job.attempts },
+        'Enrichment job completed',
+      );
+    } catch (err) {
+      if (job.attempts <= this.maxRetries) {
+        // Exponential backoff: 1s, 2s, 4s, ...
+        const backoffMs = 1000 * Math.pow(2, job.attempts - 1);
+        log.debug(
+          { commitHash: job.commitHash, attempts: job.attempts, backoffMs, err },
+          'Enrichment job failed, scheduling retry',
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, backoffMs));
+
+        if (!this.shuttingDown) {
+          // Re-enqueue at front for retry (don't count against queue limit)
+          this.queue.unshift(job);
+          this.processNext();
+        }
+        return;
+      }
+
+      this.failedCount++;
+      log.warn(
+        { commitHash: job.commitHash, attempts: job.attempts, err },
+        'Enrichment job failed after max retries',
+      );
+    }
+  }
+
+  /**
+   * Perform the actual enrichment work.
+   *
+   * Currently a no-op placeholder that writes a scaffold JSON note
+   * to prove the plumbing works. Future: call LLM to generate a
+   * rich commit description and write it as a git note.
+   */
+  private async doEnrichment(job: InternalJob): Promise<void> {
+    const note = JSON.stringify({
+      enriched: true,
+      trigger: job.context.trigger,
+      filesChanged: job.context.changedFiles.length,
+      timestamp: job.context.timestampMs,
+      sessionId: job.context.sessionId,
+      turnNumber: job.context.turnNumber,
+    });
+
+    await job.gitService.writeNote(job.commitHash, note);
+  }
+}
+
+/** Singleton enrichment service instance. */
+let enrichmentService: CommitEnrichmentService | null = null;
+
+/**
+ * Get the global enrichment service singleton.
+ * Created lazily on first access.
+ */
+export function getEnrichmentService(): CommitEnrichmentService {
+  if (!enrichmentService) {
+    enrichmentService = new CommitEnrichmentService();
+  }
+  return enrichmentService;
+}
+
+/**
+ * @internal Test-only: reset the singleton
+ */
+export function _resetEnrichmentService(): void {
+  enrichmentService = null;
+}

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -182,12 +182,13 @@ export class CommitEnrichmentService {
         'Enrichment job completed',
       );
     } catch (err) {
+      const isTimeout = err instanceof Error && err.message === 'Enrichment job timed out';
       if (job.attempts <= this.maxRetries) {
         // Exponential backoff: 1s, 2s, 4s, ...
         const backoffMs = 1000 * Math.pow(2, job.attempts - 1);
         log.debug(
-          { commitHash: job.commitHash, attempts: job.attempts, backoffMs, err },
-          'Enrichment job failed, scheduling retry',
+          { commitHash: job.commitHash, attempts: job.attempts, backoffMs, timedOut: isTimeout, err },
+          isTimeout ? 'Enrichment job timed out, scheduling retry' : 'Enrichment job failed, scheduling retry',
         );
         await new Promise<void>((resolve) => setTimeout(resolve, backoffMs));
 
@@ -201,8 +202,8 @@ export class CommitEnrichmentService {
 
       this.failedCount++;
       log.warn(
-        { commitHash: job.commitHash, attempts: job.attempts, err },
-        'Enrichment job failed after max retries',
+        { commitHash: job.commitHash, attempts: job.attempts, timedOut: isTimeout, err },
+        isTimeout ? 'Enrichment job timed out after max retries' : 'Enrichment job failed after max retries',
       );
     }
   }

--- a/assistant/src/workspace/commit-message-provider.ts
+++ b/assistant/src/workspace/commit-message-provider.ts
@@ -1,0 +1,95 @@
+/**
+ * Abstraction for generating commit messages across different triggers.
+ *
+ * Provides a seam for future LLM-powered enrichment without changing
+ * the synchronous commit path.
+ */
+
+export interface CommitContext {
+  workspaceDir: string;
+  trigger: 'turn' | 'heartbeat' | 'shutdown';
+  sessionId?: string;
+  turnNumber?: number;
+  changedFiles: string[];
+  timestampMs: number;
+  /** Optional reason string (used by heartbeat to describe threshold exceeded). */
+  reason?: string;
+}
+
+export interface CommitMessageResult {
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CommitMessageProvider {
+  /** Build a commit message synchronously for immediate use. */
+  buildImmediateMessage(ctx: CommitContext): CommitMessageResult;
+  /** Optional: enqueue async enrichment after commit succeeds. */
+  enqueueEnrichment?(ctx: CommitContext & { commitHash: string }): Promise<void>;
+}
+
+/**
+ * Build a short summary of what changed from a list of file paths.
+ */
+export function buildChangeSummary(files: string[]): string {
+  if (files.length === 0) {
+    return 'workspace changes';
+  }
+  if (files.length === 1) {
+    return files[0];
+  }
+  if (files.length <= 3) {
+    return files.join(', ');
+  }
+  return `${files.slice(0, 2).join(', ')} and ${files.length - 2} more`;
+}
+
+/**
+ * Default deterministic commit message provider.
+ *
+ * Produces identical output to the pre-refactor inline logic in
+ * turn-commit.ts and heartbeat-service.ts.
+ */
+export class DefaultCommitMessageProvider implements CommitMessageProvider {
+  buildImmediateMessage(ctx: CommitContext): CommitMessageResult {
+    switch (ctx.trigger) {
+      case 'turn':
+        return this.buildTurnMessage(ctx);
+      case 'heartbeat':
+        return this.buildHeartbeatMessage(ctx);
+      case 'shutdown':
+        return this.buildShutdownMessage(ctx);
+    }
+  }
+
+  private buildTurnMessage(ctx: CommitContext): CommitMessageResult {
+    const summary = buildChangeSummary(ctx.changedFiles);
+    const timestamp = new Date(ctx.timestampMs).toISOString();
+    const message = [
+      `Turn: ${summary}`,
+      '',
+      `Session: ${ctx.sessionId}`,
+      `Turn: ${ctx.turnNumber}`,
+      `Timestamp: ${timestamp}`,
+      `Files: ${ctx.changedFiles.length} changed`,
+    ].join('\n');
+    return { message };
+  }
+
+  private buildHeartbeatMessage(ctx: CommitContext): CommitMessageResult {
+    const totalChanges = ctx.changedFiles.length;
+    const reason = ctx.reason ?? `${totalChanges} files`;
+    return {
+      message: `auto-commit: heartbeat safety net (${totalChanges} files, ${reason})`,
+      metadata: { trigger: 'heartbeat', timestamp: ctx.timestampMs },
+    };
+  }
+
+  private buildShutdownMessage(ctx: CommitContext): CommitMessageResult {
+    const totalChanges = ctx.changedFiles.length;
+    return {
+      message: `auto-commit: shutdown safety net (${totalChanges} files)`,
+      metadata: { trigger: 'shutdown', timestamp: ctx.timestampMs },
+    };
+  }
+}

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -619,6 +619,23 @@ export class WorkspaceGitService {
   }
 
   /**
+   * Get the commit hash of the current HEAD.
+   * This is a lightweight read-only operation that does not require the mutex.
+   */
+  async getHeadHash(): Promise<string> {
+    const { stdout } = await this.execGit(['rev-parse', 'HEAD']);
+    return stdout.trim();
+  }
+
+  /**
+   * Write a git note to a specific commit.
+   * Uses the 'vellum' notes ref to avoid conflicts with default notes.
+   */
+  async writeNote(commitHash: string, noteContent: string): Promise<void> {
+    await this.execGit(['notes', '--ref=vellum', 'add', '-f', '-m', noteContent, commitHash]);
+  }
+
+  /**
    * Check if the workspace has a git repository initialized.
    * This is a non-blocking check that doesn't trigger initialization.
    */

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -161,6 +161,12 @@ export class WorkspaceGitService {
   }
 
   private recordSuccess(): void {
+    if (this.consecutiveFailures > 0) {
+      log.info(
+        { workspaceDir: this.workspaceDir, previousFailures: this.consecutiveFailures },
+        'Circuit breaker closed: commit succeeded after failures',
+      );
+    }
     this.consecutiveFailures = 0;
     this.nextAllowedAttemptMs = 0;
   }
@@ -175,6 +181,10 @@ export class WorkspaceGitService {
       failureBackoffMaxMs,
     );
     this.nextAllowedAttemptMs = Date.now() + delay;
+    log.warn(
+      { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures, backoffMs: delay },
+      'Circuit breaker opened: commit failed, backing off',
+    );
   }
 
   /**

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { getLogger } from '../util/logger.js';
+import { getConfig } from '../config/loader.js';
 
 const execFileAsync = promisify(execFile);
 const log = getLogger('workspace-git');
@@ -142,10 +143,38 @@ export class WorkspaceGitService {
   private readonly mutex: Mutex;
   private initialized = false;
   private initPromise: Promise<void> | null = null;
+  private consecutiveFailures = 0;
+  private nextAllowedAttemptMs = 0;
 
   constructor(workspaceDir: string) {
     this.workspaceDir = workspaceDir;
     this.mutex = new Mutex();
+  }
+
+  /**
+   * Check if the circuit breaker is open (too many recent failures).
+   * When open, commit attempts are skipped until the backoff window expires.
+   */
+  private isBreakerOpen(): boolean {
+    if (this.consecutiveFailures === 0) return false;
+    return Date.now() < this.nextAllowedAttemptMs;
+  }
+
+  private recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.nextAllowedAttemptMs = 0;
+  }
+
+  private recordFailure(): void {
+    const config = getConfig();
+    const failureBackoffBaseMs = config.workspaceGit?.failureBackoffBaseMs ?? 2000;
+    const failureBackoffMaxMs = config.workspaceGit?.failureBackoffMaxMs ?? 60000;
+    this.consecutiveFailures++;
+    const delay = Math.min(
+      failureBackoffBaseMs * Math.pow(2, this.consecutiveFailures - 1),
+      failureBackoffMaxMs,
+    );
+    this.nextAllowedAttemptMs = Date.now() + delay;
   }
 
   /**
@@ -349,42 +378,64 @@ export class WorkspaceGitService {
   async commitIfDirty(
     decide: (status: GitStatus) => { message: string; metadata?: GitCommitMetadata } | null,
   ): Promise<{ committed: boolean; status: GitStatus }> {
+    // Circuit breaker: skip expensive git work if recent attempts have been failing
+    if (this.isBreakerOpen()) {
+      log.debug(
+        { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures },
+        'Circuit breaker open, skipping commit attempt',
+      );
+      return { committed: false, status: { staged: [], modified: [], untracked: [], clean: true } };
+    }
+
     await this.ensureInitialized();
 
-    return this.mutex.withLock(async () => {
-      const status = await this.getStatusInternal();
-      if (status.clean) {
-        return { committed: false, status };
-      }
+    try {
+      const result = await this.mutex.withLock(async () => {
+        const status = await this.getStatusInternal();
+        if (status.clean) {
+          return { committed: false, status };
+        }
 
-      const decision = decide(status);
-      if (!decision) {
-        return { committed: false, status };
-      }
+        const decision = decide(status);
+        if (!decision) {
+          return { committed: false, status };
+        }
 
-      await this.execGit(['add', '-A']);
+        await this.execGit(['add', '-A']);
 
-      // Verify something was actually staged. Another service instance
-      // (or external process) could have committed between our status
-      // check and the add, leaving the index clean.
-      try {
-        await this.execGit(['diff', '--cached', '--quiet']);
-        // Exit code 0 means nothing staged — nothing to commit
-        return { committed: false, status };
-      } catch {
-        // Exit code 1 means there ARE staged changes — proceed
-      }
+        // Verify something was actually staged. Another service instance
+        // (or external process) could have committed between our status
+        // check and the add, leaving the index clean.
+        try {
+          await this.execGit(['diff', '--cached', '--quiet']);
+          // Exit code 0 means nothing staged — nothing to commit
+          return { committed: false, status };
+        } catch (err) {
+          // git diff --cached --quiet exits with code 1 when there are staged changes.
+          // Any other error (timeout, permission, etc.) should be treated as a failure.
+          const execErr = err as ExecError;
+          if (execErr.code !== 1) {
+            throw err;
+          }
+          // Exit code 1 = staged changes exist — proceed with commit
+        }
 
-      let fullMessage = decision.message;
-      if (decision.metadata && Object.keys(decision.metadata).length > 0) {
-        fullMessage += '\n\n' + Object.entries(decision.metadata)
-          .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
-          .join('\n');
-      }
+        let fullMessage = decision.message;
+        if (decision.metadata && Object.keys(decision.metadata).length > 0) {
+          fullMessage += '\n\n' + Object.entries(decision.metadata)
+            .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+            .join('\n');
+        }
 
-      await this.execGit(['commit', '-m', fullMessage]);
-      return { committed: true, status };
-    });
+        await this.execGit(['commit', '-m', fullMessage]);
+        return { committed: true, status };
+      });
+      this.recordSuccess();
+      return result;
+    } catch (err) {
+      this.recordFailure();
+      throw err;
+    }
   }
 
   /**
@@ -617,4 +668,19 @@ export function getAllWorkspaceGitServices(): ReadonlyMap<string, WorkspaceGitSe
  */
 export function _resetGitServiceRegistry(): void {
   serviceRegistry.clear();
+}
+
+/**
+ * @internal Test-only: reset circuit breaker state for a service instance
+ */
+export function _resetBreaker(service: WorkspaceGitService): void {
+  (service as unknown as { consecutiveFailures: number }).consecutiveFailures = 0;
+  (service as unknown as { nextAllowedAttemptMs: number }).nextAllowedAttemptMs = 0;
+}
+
+/**
+ * @internal Test-only: get consecutive failure count
+ */
+export function _getConsecutiveFailures(service: WorkspaceGitService): number {
+  return (service as unknown as { consecutiveFailures: number }).consecutiveFailures;
 }

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -1,5 +1,10 @@
 import { getLogger } from '../util/logger.js';
 import { getAllWorkspaceGitServices, type WorkspaceGitService } from './git-service.js';
+import {
+  DefaultCommitMessageProvider,
+  type CommitContext,
+  type CommitMessageProvider,
+} from './commit-message-provider.js';
 
 const log = getLogger('heartbeat');
 
@@ -23,6 +28,8 @@ export interface HeartbeatServiceOptions {
   getServices?: () => ReadonlyMap<string, WorkspaceGitService>;
   /** Override for getting the current timestamp (for testing). */
   now?: () => number;
+  /** Custom commit message provider. */
+  commitMessageProvider?: CommitMessageProvider;
 }
 
 /**
@@ -61,6 +68,7 @@ export class HeartbeatService {
   private readonly intervalMs: number;
   private readonly getServices: () => ReadonlyMap<string, WorkspaceGitService>;
   private readonly now: () => number;
+  private readonly commitMessageProvider: CommitMessageProvider;
   private timer: ReturnType<typeof setInterval> | null = null;
   /** Tracks the currently in-flight check to prevent overlapping runs and allow clean shutdown. */
   private activeCheck: Promise<HeartbeatCheckResult> | null = null;
@@ -71,6 +79,7 @@ export class HeartbeatService {
     this.intervalMs = options?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
     this.getServices = options?.getServices ?? getAllWorkspaceGitServices;
     this.now = options?.now ?? Date.now;
+    this.commitMessageProvider = options?.commitMessageProvider ?? new DefaultCommitMessageProvider();
   }
 
   /**
@@ -139,7 +148,7 @@ export class HeartbeatService {
         result.checked++;
 
         try {
-          const committed = await this.checkWorkspace(workspaceDir, service, 'heartbeat');
+          const committed = await this.checkWorkspace(workspaceDir, service);
           if (committed) {
             result.committed++;
           } else {
@@ -190,12 +199,17 @@ export class HeartbeatService {
       try {
         const now = this.now();
         const { committed } = await service.commitIfDirty((status) => {
-          const totalChanges = new Set([...status.staged, ...status.modified, ...status.untracked]).size;
-          log.info({ workspaceDir, totalChanges }, 'Committing pending changes on shutdown');
-          return {
-            message: `auto-commit: shutdown safety net (${totalChanges} files)`,
-            metadata: { trigger: 'shutdown', timestamp: now },
+          const uniqueFiles = [...new Set([...status.staged, ...status.modified, ...status.untracked])];
+          log.info({ workspaceDir, totalChanges: uniqueFiles.length }, 'Committing pending changes on shutdown');
+
+          const ctx: CommitContext = {
+            workspaceDir,
+            trigger: 'shutdown',
+            changedFiles: uniqueFiles,
+            timestampMs: now,
           };
+
+          return this.commitMessageProvider.buildImmediateMessage(ctx);
         });
 
         if (committed) {
@@ -225,13 +239,13 @@ export class HeartbeatService {
   private async checkWorkspace(
     workspaceDir: string,
     service: WorkspaceGitService,
-    trigger: string,
   ): Promise<boolean> {
     const now = this.now();
 
     // Atomic status check + conditional commit within a single mutex lock.
     const { committed, status } = await service.commitIfDirty((st) => {
-      const totalChanges = new Set([...st.staged, ...st.modified, ...st.untracked]).size;
+      const uniqueFiles = [...new Set([...st.staged, ...st.modified, ...st.untracked])];
+      const totalChanges = uniqueFiles.length;
 
       // Track when we first saw this workspace as dirty
       if (!firstSeenDirty.has(workspaceDir)) {
@@ -261,10 +275,15 @@ export class HeartbeatService {
         'Heartbeat auto-committing workspace changes',
       );
 
-      return {
-        message: `auto-commit: ${trigger} safety net (${totalChanges} files, ${reason})`,
-        metadata: { trigger, timestamp: now },
+      const ctx: CommitContext = {
+        workspaceDir,
+        trigger: 'heartbeat',
+        changedFiles: uniqueFiles,
+        timestampMs: now,
+        reason,
       };
+
+      return this.commitMessageProvider.buildImmediateMessage(ctx);
     });
 
     if (committed) {

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -5,6 +5,7 @@ import {
   type CommitContext,
   type CommitMessageProvider,
 } from './commit-message-provider.js';
+import { getEnrichmentService } from './commit-message-enrichment-service.js';
 
 const log = getLogger('heartbeat');
 
@@ -198,8 +199,10 @@ export class HeartbeatService {
 
       try {
         const now = this.now();
-        const { committed } = await service.commitIfDirty((status) => {
-          const uniqueFiles = [...new Set([...status.staged, ...status.modified, ...status.untracked])];
+        let shutdownFiles: string[] = [];
+        const { committed } = await service.commitIfDirty((st) => {
+          const uniqueFiles = [...new Set([...st.staged, ...st.modified, ...st.untracked])];
+          shutdownFiles = uniqueFiles;
           log.info({ workspaceDir, totalChanges: uniqueFiles.length }, 'Committing pending changes on shutdown');
 
           const ctx: CommitContext = {
@@ -215,6 +218,20 @@ export class HeartbeatService {
         if (committed) {
           firstSeenDirty.delete(workspaceDir);
           result.committed++;
+
+          // Fire-and-forget enrichment
+          try {
+            const commitHash = await service.getHeadHash();
+            const shutdownCtx: CommitContext = {
+              workspaceDir,
+              trigger: 'shutdown',
+              changedFiles: shutdownFiles,
+              timestampMs: this.now(),
+            };
+            getEnrichmentService().enqueue({ workspaceDir, commitHash, context: shutdownCtx, gitService: service });
+          } catch (enrichErr) {
+            log.debug({ enrichErr }, 'Failed to enqueue shutdown enrichment (non-fatal)');
+          }
         } else {
           result.skipped++;
         }
@@ -241,6 +258,8 @@ export class HeartbeatService {
     service: WorkspaceGitService,
   ): Promise<boolean> {
     const now = this.now();
+    let heartbeatFiles: string[] = [];
+    let heartbeatReason: string | undefined;
 
     // Atomic status check + conditional commit within a single mutex lock.
     const { committed, status } = await service.commitIfDirty((st) => {
@@ -270,6 +289,9 @@ export class HeartbeatService {
         ? `changes older than ${Math.round(dirtyAge / 1000)}s`
         : `${totalChanges} files changed (threshold: ${this.fileThreshold})`;
 
+      heartbeatFiles = uniqueFiles;
+      heartbeatReason = reason;
+
       log.info(
         { workspaceDir, totalChanges, dirtyAgeMs: dirtyAge, reason },
         'Heartbeat auto-committing workspace changes',
@@ -288,6 +310,22 @@ export class HeartbeatService {
 
     if (committed) {
       firstSeenDirty.delete(workspaceDir);
+
+      // Fire-and-forget enrichment
+      try {
+        const commitHash = await service.getHeadHash();
+        const hbCtx: CommitContext = {
+          workspaceDir,
+          trigger: 'heartbeat',
+          changedFiles: heartbeatFiles,
+          timestampMs: now,
+          reason: heartbeatReason,
+        };
+        getEnrichmentService().enqueue({ workspaceDir, commitHash, context: hbCtx, gitService: service });
+      } catch (enrichErr) {
+        log.debug({ enrichErr }, 'Failed to enqueue heartbeat enrichment (non-fatal)');
+      }
+
       return true;
     }
 

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -16,6 +16,7 @@ import {
   type CommitContext,
   type CommitMessageProvider,
 } from './commit-message-provider.js';
+import { getEnrichmentService } from './commit-message-enrichment-service.js';
 
 const log = getLogger('turn-commit');
 
@@ -77,6 +78,22 @@ export async function commitTurnChanges(
         { sessionId, turnNumber, filesChanged: uniqueFiles.length },
         'Turn-boundary commit created',
       );
+
+      // Fire-and-forget enrichment — never blocks turn completion
+      try {
+        const commitHash = await gitService.getHeadHash();
+        const ctx: CommitContext = {
+          workspaceDir,
+          trigger: 'turn',
+          sessionId,
+          turnNumber,
+          changedFiles: uniqueFiles,
+          timestampMs: Date.now(),
+        };
+        getEnrichmentService().enqueue({ workspaceDir, commitHash, context: ctx, gitService });
+      } catch (enrichErr) {
+        log.debug({ enrichErr }, 'Failed to enqueue enrichment (non-fatal)');
+      }
     } else {
       log.debug({ sessionId, turnNumber }, 'No workspace changes to commit for turn');
     }

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -54,6 +54,7 @@ export async function commitTurnChanges(
   const messageProvider = provider ?? new DefaultCommitMessageProvider();
   try {
     const gitService = getWorkspaceGitService(workspaceDir);
+    const commitStartMs = Date.now();
 
     // Atomic status check + commit within a single mutex lock to prevent
     // TOCTOU races with heartbeat commits.
@@ -72,10 +73,12 @@ export async function commitTurnChanges(
       return messageProvider.buildImmediateMessage(ctx);
     });
 
+    const commitDurationMs = Date.now() - commitStartMs;
+
     if (committed) {
       const uniqueFiles = [...new Set([...status.staged, ...status.modified, ...status.untracked])];
       log.info(
-        { sessionId, turnNumber, filesChanged: uniqueFiles.length },
+        { sessionId, turnNumber, filesChanged: uniqueFiles.length, durationMs: commitDurationMs },
         'Turn-boundary commit created',
       );
 
@@ -95,7 +98,7 @@ export async function commitTurnChanges(
         log.debug({ enrichErr }, 'Failed to enqueue enrichment (non-fatal)');
       }
     } else {
-      log.debug({ sessionId, turnNumber }, 'No workspace changes to commit for turn');
+      log.debug({ sessionId, turnNumber, durationMs: commitDurationMs }, 'No workspace changes to commit for turn');
     }
   } catch (err) {
     // Never let commit failures propagate — they must not affect the turn

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -11,6 +11,11 @@
 
 import { getWorkspaceGitService } from './git-service.js';
 import { getLogger } from '../util/logger.js';
+import {
+  DefaultCommitMessageProvider,
+  type CommitContext,
+  type CommitMessageProvider,
+} from './commit-message-provider.js';
 
 const log = getLogger('turn-commit');
 
@@ -26,46 +31,6 @@ export interface TurnCommitMetadata {
 }
 
 /**
- * Build a commit message with structured metadata for a turn boundary commit.
- *
- * Format:
- * ```
- * Turn: <summary>
- *
- * Session: sess_xyz
- * Turn: 5
- * Timestamp: 2026-02-18T15:30:00Z
- * Files: 3 changed
- * ```
- */
-function buildCommitMessage(summary: string, metadata: TurnCommitMetadata): string {
-  return [
-    `Turn: ${summary}`,
-    '',
-    `Session: ${metadata.sessionId}`,
-    `Turn: ${metadata.turnNumber}`,
-    `Timestamp: ${metadata.timestamp}`,
-    `Files: ${metadata.filesChanged} changed`,
-  ].join('\n');
-}
-
-/**
- * Build a short summary of what changed from a list of file paths.
- */
-function buildChangeSummary(files: string[]): string {
-  if (files.length === 0) {
-    return 'workspace changes';
-  }
-  if (files.length === 1) {
-    return files[0];
-  }
-  if (files.length <= 3) {
-    return files.join(', ');
-  }
-  return `${files.slice(0, 2).join(', ')} and ${files.length - 2} more`;
-}
-
-/**
  * Attempt a turn-boundary commit for the workspace.
  *
  * Checks the workspace for uncommitted changes. If any are found,
@@ -77,12 +42,15 @@ function buildChangeSummary(files: string[]): string {
  * @param workspaceDir - Absolute path to the workspace directory
  * @param sessionId - Session/conversation identifier
  * @param turnNumber - 1-based turn number within the session
+ * @param provider - Optional commit message provider (defaults to deterministic)
  */
 export async function commitTurnChanges(
   workspaceDir: string,
   sessionId: string,
   turnNumber: number,
+  provider?: CommitMessageProvider,
 ): Promise<void> {
+  const messageProvider = provider ?? new DefaultCommitMessageProvider();
   try {
     const gitService = getWorkspaceGitService(workspaceDir);
 
@@ -90,17 +58,17 @@ export async function commitTurnChanges(
     // TOCTOU races with heartbeat commits.
     const { committed, status } = await gitService.commitIfDirty((st) => {
       const uniqueFiles = [...new Set([...st.staged, ...st.modified, ...st.untracked])];
-      const timestamp = new Date().toISOString();
-      const summary = buildChangeSummary(uniqueFiles);
 
-      const metadata: TurnCommitMetadata = {
+      const ctx: CommitContext = {
+        workspaceDir,
+        trigger: 'turn',
         sessionId,
         turnNumber,
-        timestamp,
-        filesChanged: uniqueFiles.length,
+        changedFiles: uniqueFiles,
+        timestampMs: Date.now(),
       };
 
-      return { message: buildCommitMessage(summary, metadata) };
+      return messageProvider.buildImmediateMessage(ctx);
     });
 
     if (committed) {


### PR DESCRIPTION
## Summary
Complete workspace git hardening feature: runtime hardening, commit message provider abstraction, non-blocking enrichment queue scaffold, and observability improvements.

## Milestone PRs (all merged into this feature branch)
- **M1** (#5190): Runtime hardening — configurable turn-commit timeout via `Promise.race`, fixed `diff --cached --quiet` error semantics (exit code 1 = staged changes, not an error), circuit breaker with exponential backoff for repeated failures
- **M2** (#5191): Commit message provider abstraction — `CommitMessageProvider` interface + `DefaultCommitMessageProvider`, plugged into `turn-commit.ts` and `heartbeat-service.ts`
- **M3** (#5193): Non-blocking enrichment queue scaffold — `CommitEnrichmentService` with bounded queue, concurrency, timeout, retry, fire-and-forget from commit path, writes placeholder JSON to git notes (`refs/notes/vellum`)
- **M4** (#5195): Observability + docs — structured logs for circuit breaker state transitions, commit duration tracking, timeout differentiation in enrichment; ARCHITECTURE.md updated with flow diagram and documentation

## Key changes
- 2 new files: `commit-message-provider.ts`, `commit-message-enrichment-service.ts`
- 1 new test file: `commit-message-enrichment-service.test.ts` (7 tests)
- Config: `WorkspaceGitConfigSchema` extended with timeout, backoff, and enrichment queue settings
- Total: +929 / -99 lines across 9 files

## Test plan
- [x] 34 git-service tests pass
- [x] 14 heartbeat-service tests pass
- [x] 8 turn-commit tests pass
- [x] 7 enrichment service tests pass

## Related issues
Closes #5152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
