### PR TITLE
fix: circuit breaker synthetic status should not claim clean

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -394,7 +394,7 @@ export class WorkspaceGitService {
         { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures },
         'Circuit breaker open, skipping commit attempt',
       );
-      return { committed: false, status: { staged: [], modified: [], untracked: [], clean: true } };
+      return { committed: false, status: { staged: [], modified: [], untracked: [], clean: false } };
     }
 
     await this.ensureInitialized();


### PR DESCRIPTION
## Summary
Fixes a bug where the circuit breaker's early return from commitIfDirty() returned a synthetic status with clean:true, causing the heartbeat service to incorrectly clear its firstSeenDirty tracking entry. This reset the dirty-age clock, delaying safety-net commits after breaker recovery.

## Changes
- Changed clean:true to clean:false in the circuit breaker early return in git-service.ts

## Test plan
- All workspace-git-service tests pass
- All workspace-heartbeat-service tests pass

Addresses feedback from #5196
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
