### PR TITLE
fix: address PR #5194 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1192,6 +1192,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func createChromeDebugLaunchAgent() {
+        let chromeDataDir = NSHomeDirectory() + "/Library/Application Support/Google/Chrome-CDP"
+
+        guard let chromeURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") else {
+            return // Chrome not installed
+        }
+        let chromeBinary = chromeURL.appendingPathComponent("Contents/MacOS/Google Chrome").path
+
         let plistContent = """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1201,9 +1208,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             <string>com.vellum.chrome-debug</string>
             <key>ProgramArguments</key>
             <array>
-                <string>/Applications/Google Chrome.app/Contents/MacOS/Google Chrome</string>
+                <string>\(chromeBinary)</string>
                 <string>--remote-debugging-port=9222</string>
                 <string>--force-renderer-accessibility</string>
+                <string>--user-data-dir=\(chromeDataDir)</string>
             </array>
             <key>RunAtLoad</key>
             <true/>

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -111,7 +111,13 @@ final class ChromeAccessibilityHelper {
     static func launchChromeForCDP() async -> Bool {
         // Chrome 145+ requires a non-default --user-data-dir for CDP to bind the debugging port.
         let chromeDataDir = NSHomeDirectory() + "/Library/Application Support/Google/Chrome-CDP"
-        let chromeBinary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+        // Resolve Chrome binary dynamically via bundle ID to support non-standard install locations
+        guard let chromeURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") else {
+            log.error("Google Chrome not found via bundle ID")
+            return false
+        }
+        let chromeBinary = chromeURL.appendingPathComponent("Contents/MacOS/Google Chrome").path
 
         guard FileManager.default.fileExists(atPath: chromeBinary) else {
             log.error("Chrome binary not found at \(chromeBinary)")


### PR DESCRIPTION
## Summary
- Launch agent plist now includes `--user-data-dir=Chrome-CDP` so the "Always launch" checkbox doesn't hijack the user's normal Chrome at login
- Chrome binary path resolved dynamically via `NSWorkspace.urlForApplication(withBundleIdentifier:)` instead of hardcoding `/Applications/Google Chrome.app`

Addresses review feedback from Devin and Codex on #5194.

## Test plan
- [ ] Check "Always launch" checkbox, verify `~/Library/LaunchAgents/com.vellum.chrome-debug.plist` includes `--user-data-dir`
- [ ] Verify CDP launch works with Chrome installed in non-standard location

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
