### PR TITLE
fix: align avatar customization panel with shared layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -25,31 +25,24 @@ struct AvatarCustomizationPanel: View {
     private let accessoryOptions = ["none", "sunglasses", "monocle", "bowtie", "necklace", "scarf", "cape"]
     private let heldItemOptions = ["none", "sword", "staff", "shield", "balloon"]
 
+    private let maxContentWidth: CGFloat = 1100
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header
-            HStack {
-                Text("Customize Avatar")
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-                Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 32, height: 32)
-                        .contentShape(Rectangle())
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack(alignment: .center) {
+                    Text("Customize Avatar")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close Customize Avatar")
-            }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.lg)
+                .padding(.top, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xl)
 
-            Divider()
-                .background(VColor.surfaceBorder)
+                Divider().background(VColor.surfaceBorder)
+                    .padding(.bottom, VSpacing.xl)
 
-            ScrollView {
                 VStack(alignment: .leading, spacing: VSpacing.xl) {
                     // Live avatar preview
                     avatarPreview
@@ -77,15 +70,14 @@ struct AvatarCustomizationPanel: View {
                     // Reset button
                     resetButton
                 }
-                .padding(VSpacing.lg)
+
+                Spacer(minLength: VSpacing.xxl)
             }
+            .frame(maxWidth: maxContentWidth)
+            .padding(.horizontal, VSpacing.xxl)
+            .frame(maxWidth: .infinity)
         }
-        .background(Meadow.panelBackground)
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(Meadow.panelBorder, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .background(VColor.backgroundSubtle)
         .onAppear {
             evolutionState.load()
             identity = IdentityInfo.load()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1094,7 +1094,7 @@ struct MainWindowView: View {
         case .identity:
             IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
         case .avatarCustomization:
-            AvatarCustomizationPanel(onClose: { windowState.selection = nil })
+            AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
         }
     }
 
@@ -1319,7 +1319,7 @@ struct MainWindowView: View {
             IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .avatarCustomization:
-            AvatarCustomizationPanel(onClose: { windowState.dismissOverlay() })
+            AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;
@@ -1337,8 +1337,17 @@ struct MainWindowView: View {
     }
 
     /// Consistent X close button for panel overlays.
+    private func panelDismissAction() {
+        // Avatar customization → back to Identity; everything else → dismiss overlay
+        if case .panel(.avatarCustomization) = windowState.selection {
+            windowState.selection = .panel(.identity)
+        } else {
+            windowState.dismissOverlay()
+        }
+    }
+
     private var panelDismissButton: some View {
-        Button(action: { windowState.dismissOverlay() }) {
+        Button(action: panelDismissAction) {
             Image(systemName: "xmark")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(VColor.textSecondary)


### PR DESCRIPTION
## Summary
- Replace custom Meadow theme (panelBackground, border overlay, clipShape) with `VColor.backgroundSubtle`
- Use `VFont.panelTitle` instead of custom `.system(size: 18)` font
- Match shared panel padding (32pt sides/top, 24pt post-divider) and 1100pt max content width
- Remove redundant internal close button (parent already provides `panelDismissButton`)

## Test plan
- [ ] Open Customize Avatar panel — verify header matches Skills/Directory/Identity styling
- [ ] Background should be consistent dark theme, not the old Meadow green-tinted background
- [ ] Close button (parent overlay) still works
- [ ] All customization controls (colors, outfits, reset) still functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
