### PR TITLE
fix: close sidebar on New Chat and add Cmd+N shortcut

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -18,6 +18,21 @@ extension AppDelegate {
         }
     }
 
+    func setupFileMenu() {
+        guard let mainMenu = NSApp.mainMenu else { return }
+
+        let fileMenu = NSMenu(title: "File")
+
+        let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "n")
+        newChatItem.keyEquivalentModifierMask = .command
+        newChatItem.target = self
+        fileMenu.addItem(newChatItem)
+
+        let fileMenuItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
+        fileMenuItem.submenu = fileMenu
+        mainMenu.insertItem(fileMenuItem, at: 1)
+    }
+
     func setupViewMenu() {
         guard let mainMenu = NSApp.mainMenu else { return }
 
@@ -258,6 +273,7 @@ extension AppDelegate {
     @objc func openNewChat() {
         showMainWindow()
         mainWindow?.threadManager.createThread()
+        UserDefaults.standard.set(false, forKey: "sidebarOpen")
     }
 
     @objc func openAppCollection() {

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -21,6 +21,9 @@ extension AppDelegate {
     func setupFileMenu() {
         guard let mainMenu = NSApp.mainMenu else { return }
 
+        // Avoid duplicate File menus on logout/re-login cycles
+        if mainMenu.indexOfItem(withTitle: "File") >= 0 { return }
+
         let fileMenu = NSMenu(title: "File")
 
         let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "n")

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -182,6 +182,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         setupDaemonClient()
         setupMenuBar()
+        setupFileMenu()
         setupViewMenu()
         setupHotKey()
         setupEscapeMonitor()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -284,9 +284,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             if let mainMenu = NSApp.mainMenu {
-                if let viewIndex = mainMenu.indexOfItem(withTitle: "View") as Int?,
-                   viewIndex >= 0 {
-                    mainMenu.removeItem(at: viewIndex)
+                for title in ["File", "View"] {
+                    let idx = mainMenu.indexOfItem(withTitle: title)
+                    if idx >= 0 { mainMenu.removeItem(at: idx) }
                 }
             }
 
@@ -349,9 +349,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             if let mainMenu = NSApp.mainMenu {
-                if let viewIndex = mainMenu.indexOfItem(withTitle: "View") as Int?,
-                   viewIndex >= 0 {
-                    mainMenu.removeItem(at: viewIndex)
+                for title in ["File", "View"] {
+                    let idx = mainMenu.indexOfItem(withTitle: title)
+                    if idx >= 0 { mainMenu.removeItem(at: idx) }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -772,6 +772,9 @@ struct MainWindowView: View {
                     SidebarNavRow(icon: "plus.circle", label: "New chat") {
                         windowState.selection = nil
                         threadManager.createThread()
+                        withAnimation(.easeInOut(duration: 0.35)) {
+                            sidebarOpen = false
+                        }
                     }
 
                     Spacer().frame(height: VSpacing.lg)


### PR DESCRIPTION
## Summary
- Sidebar automatically closes when "New chat" is clicked from the sidebar
- Added Cmd+N keyboard shortcut to create a new chat (via File menu)
- Cmd+N also closes the sidebar if it's open

## Test plan
- [ ] Open sidebar, click "New chat" — verify sidebar closes and new chat is created
- [ ] Press Cmd+N with sidebar open — verify new chat is created and sidebar closes
- [ ] Press Cmd+N with sidebar closed — verify new chat is created normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
