### PR TITLE
fix: make Identity panel scrollable with fixed-height constellation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -285,7 +285,7 @@ struct ConstellationView: View {
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .clipped()
                 .contentShape(Rectangle())
-                .highPriorityGesture(
+                .gesture(
                     DragGesture()
                         .onChanged { value in
                             dragOffset = value.translation

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -285,7 +285,7 @@ struct ConstellationView: View {
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .clipped()
                 .contentShape(Rectangle())
-                .gesture(
+                .highPriorityGesture(
                     DragGesture()
                         .onChanged { value in
                             dragOffset = value.translation
@@ -327,7 +327,8 @@ struct ConstellationView: View {
 
     @ViewBuilder
     private func canvas(size: CGSize) -> some View {
-        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        // Shift center down so upper nodes aren't clipped by the panel header
+        let center = CGPoint(x: size.width / 2, y: size.height * 0.55)
         let hubRadius: CGFloat = 160
         let leafRadius: CGFloat = 110
         let layoutGroups = groups

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -15,68 +15,61 @@ struct IdentityPanel: View {
     private let maxContentWidth: CGFloat = 1100
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                // Header
-                HStack(alignment: .center) {
-                    Text("Assistant ID")
-                        .font(VFont.panelTitle)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                }
-                .padding(.top, VSpacing.xxl)
-                .padding(.bottom, VSpacing.xl)
-
-                Divider().background(VColor.surfaceBorder)
-                    .padding(.bottom, VSpacing.xl)
-
-                // Avatar + ID card + CTA
-                HStack(alignment: .center, spacing: VSpacing.lg) {
-                    DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
-                        .frame(width: 180, height: 200)
-
-                    VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        if let identity {
-                            idCardSection(identity: identity)
-                        }
-
-                        // Customize Avatar CTA
-                        Button(action: onCustomizeAvatar) {
-                            HStack(spacing: VSpacing.xs) {
-                                Image(systemName: "paintpalette")
-                                    .font(.system(size: 12, weight: .medium))
-                                Text("Customize Avatar")
-                                    .font(VFont.bodyMedium)
-                            }
-                            .foregroundColor(VColor.accent)
-                            .padding(.horizontal, VSpacing.lg)
-                            .padding(.vertical, VSpacing.sm)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
-                            )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.bottom, VSpacing.xl)
-
-                // Constellation with fixed height so it's scrollable
-                ConstellationView(
-                    identity: identity,
-                    skills: skills,
-                    workspaceFiles: workspaceFiles
-                )
-                .frame(maxWidth: .infinity)
-                .frame(height: 700)
-                .background(VColor.background)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-
-                Spacer(minLength: VSpacing.xxl)
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack(alignment: .center) {
+                Text("Assistant ID")
+                    .font(VFont.panelTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
             }
-            .frame(maxWidth: maxContentWidth)
+            .padding(.top, VSpacing.xxl)
+            .padding(.bottom, VSpacing.xl)
             .padding(.horizontal, VSpacing.xxl)
-            .frame(maxWidth: .infinity)
+
+            Divider().background(VColor.surfaceBorder)
+                .padding(.horizontal, VSpacing.xxl)
+
+            // Avatar + ID card + CTA
+            HStack(alignment: .center, spacing: VSpacing.lg) {
+                DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                    .frame(width: 180, height: 200)
+
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    if let identity {
+                        idCardSection(identity: identity)
+                    }
+
+                    // Customize Avatar CTA
+                    Button(action: onCustomizeAvatar) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "paintpalette")
+                                .font(.system(size: 12, weight: .medium))
+                            Text("Customize Avatar")
+                                .font(VFont.bodyMedium)
+                        }
+                        .foregroundColor(VColor.accent)
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, VSpacing.xl)
+            .padding(.horizontal, VSpacing.xxl)
+
+            // Constellation fills remaining space (pan + zoom to navigate)
+            ConstellationView(
+                identity: identity,
+                skills: skills,
+                workspaceFiles: workspaceFiles
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(VColor.background)
         }
         .background(VColor.backgroundSubtle)
         .onAppear {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -15,61 +15,68 @@ struct IdentityPanel: View {
     private let maxContentWidth: CGFloat = 1100
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header
-            HStack(alignment: .center) {
-                Text("Assistant ID")
-                    .font(VFont.panelTitle)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-            }
-            .padding(.top, VSpacing.xxl)
-            .padding(.bottom, VSpacing.xl)
-            .padding(.horizontal, VSpacing.xxl)
-
-            Divider().background(VColor.surfaceBorder)
-                .padding(.horizontal, VSpacing.xxl)
-
-            // Avatar + ID card + CTA
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
-                    .frame(width: 180, height: 200)
-
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    if let identity {
-                        idCardSection(identity: identity)
-                    }
-
-                    // Customize Avatar CTA
-                    Button(action: onCustomizeAvatar) {
-                        HStack(spacing: VSpacing.xs) {
-                            Image(systemName: "paintpalette")
-                                .font(.system(size: 12, weight: .medium))
-                            Text("Customize Avatar")
-                                .font(VFont.bodyMedium)
-                        }
-                        .foregroundColor(VColor.accent)
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.vertical, VSpacing.sm)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
-                        )
-                    }
-                    .buttonStyle(.plain)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack(alignment: .center) {
+                    Text("Assistant ID")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
                 }
-            }
-            .padding(.vertical, VSpacing.xl)
-            .padding(.horizontal, VSpacing.xxl)
+                .padding(.top, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xl)
 
-            // Constellation fills remaining space
-            ConstellationView(
-                identity: identity,
-                skills: skills,
-                workspaceFiles: workspaceFiles
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.background)
+                Divider().background(VColor.surfaceBorder)
+                    .padding(.bottom, VSpacing.xl)
+
+                // Avatar + ID card + CTA
+                HStack(alignment: .center, spacing: VSpacing.lg) {
+                    DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                        .frame(width: 180, height: 200)
+
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        if let identity {
+                            idCardSection(identity: identity)
+                        }
+
+                        // Customize Avatar CTA
+                        Button(action: onCustomizeAvatar) {
+                            HStack(spacing: VSpacing.xs) {
+                                Image(systemName: "paintpalette")
+                                    .font(.system(size: 12, weight: .medium))
+                                Text("Customize Avatar")
+                                    .font(VFont.bodyMedium)
+                            }
+                            .foregroundColor(VColor.accent)
+                            .padding(.horizontal, VSpacing.lg)
+                            .padding(.vertical, VSpacing.sm)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.bottom, VSpacing.xl)
+
+                // Constellation with fixed height so it's scrollable
+                ConstellationView(
+                    identity: identity,
+                    skills: skills,
+                    workspaceFiles: workspaceFiles
+                )
+                .frame(maxWidth: .infinity)
+                .frame(height: 700)
+                .background(VColor.background)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+
+                Spacer(minLength: VSpacing.xxl)
+            }
+            .frame(maxWidth: maxContentWidth)
+            .padding(.horizontal, VSpacing.xxl)
+            .frame(maxWidth: .infinity)
         }
         .background(VColor.backgroundSubtle)
         .onAppear {


### PR DESCRIPTION
## Summary
- Wrap IdentityPanel in ScrollView so users can scroll down to see the full constellation canvas
- Give constellation a fixed 700pt height instead of `.infinity` so ScrollView has content to scroll
- Shift constellation center to 55% vertical so upper nodes aren't clipped
- Change canvas drag from `.gesture()` to `.highPriorityGesture()` so panning wins over scroll within the canvas

## Test plan
- [ ] Open Identity panel — scroll down on the header area to reveal more constellation
- [ ] Drag on the constellation canvas — should pan the constellation, not scroll the page
- [ ] All constellation nodes should be visible without being clipped at the top
- [ ] Pinch to zoom still works on the constellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
