### PR TITLE
fix: bypass circuit breaker for shutdown commits and flush enrichment on exit

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -43,6 +43,7 @@ import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { getHookManager } from '../hooks/manager.js';
 import { installTemplates } from '../hooks/templates.js';
 import { HeartbeatService } from '../workspace/heartbeat-service.js';
+import { getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
 
 const log = getLogger('lifecycle');
 
@@ -477,6 +478,15 @@ export async function runDaemon(): Promise<void> {
     } catch (err) {
       log.warn({ err, phase: 'post_stop' }, 'Post-stop workspace commit failed');
     }
+
+    // Flush in-flight enrichment jobs so shutdown commit notes are not dropped.
+    // The enrichment service's shutdown() drains active jobs and discards pending ones.
+    try {
+      await getEnrichmentService().shutdown();
+    } catch (err) {
+      log.warn({ err }, 'Enrichment service shutdown failed (non-fatal)');
+    }
+
     if (runtimeHttp) await runtimeHttp.stop();
     await browserManager.closeAllPages();
     scheduler.stop();

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -387,9 +387,12 @@ export class WorkspaceGitService {
    */
   async commitIfDirty(
     decide: (status: GitStatus) => { message: string; metadata?: GitCommitMetadata } | null,
+    options?: { bypassBreaker?: boolean },
   ): Promise<{ committed: boolean; status: GitStatus }> {
-    // Circuit breaker: skip expensive git work if recent attempts have been failing
-    if (this.isBreakerOpen()) {
+    // Circuit breaker: skip expensive git work if recent attempts have been failing.
+    // Shutdown commits bypass the breaker because the process is about to exit and
+    // this is the last chance to persist workspace state.
+    if (!options?.bypassBreaker && this.isBreakerOpen()) {
       log.debug(
         { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures },
         'Circuit breaker open, skipping commit attempt',

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -213,7 +213,7 @@ export class HeartbeatService {
           };
 
           return this.commitMessageProvider.buildImmediateMessage(ctx);
-        });
+        }, { bypassBreaker: true });
 
         if (committed) {
           firstSeenDirty.delete(workspaceDir);


### PR DESCRIPTION
Addresses Codex review feedback on PR #5196:

- P1: Add bypassBreaker option to commitIfDirty() so shutdown commits always attempt git operations even when the circuit breaker is open
- P2: Call enrichment service shutdown() in daemon lifecycle to flush in-flight enrichment jobs before process exit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
