### PR TITLE
fix: prevent customParams from overwriting critical Twilio API fields

### DIFF
--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -48,8 +48,13 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
       StatusCallbackEvent: 'initiated ringing answered completed',
     });
 
+    const reservedKeys = new Set(['From', 'To', 'Url', 'StatusCallback', 'StatusCallbackEvent']);
     if (opts.customParams) {
       for (const [key, value] of Object.entries(opts.customParams)) {
+        if (reservedKeys.has(key)) {
+          log.warn({ key }, 'Ignoring reserved Twilio parameter in customParams');
+          continue;
+        }
         body.set(key, value);
       }
     }


### PR DESCRIPTION
Addresses Devin security review feedback on PR #5213:

- Add reserved key set (From, To, Url, StatusCallback, StatusCallbackEvent) to prevent customParams from overwriting critical Twilio API parameters
- Log warning when reserved keys are encountered in customParams
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
