### PR TITLE
fix: move Twilio webhooks before auth gate, capture CallSid early, and XML-escape TwiML URLs

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -34,7 +34,7 @@ function generateTwiML(callSessionId: string, wssBaseUrl: string, welcomeGreetin
 <Response>
   <Connect>
     <ConversationRelay
-      url="${wssBaseUrl}/v1/calls/relay?callSessionId=${callSessionId}"
+      url="${escapeXml(wssBaseUrl)}/v1/calls/relay?callSessionId=${escapeXml(callSessionId)}"
       welcomeGreeting="${escapeXml(welcomeGreeting)}"
       voice="Google.en-US-Journey-O"
       language="en-US"
@@ -88,6 +88,16 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   if (!session) {
     log.warn({ callSessionId }, 'Voice webhook: call session not found');
     return new Response('Call session not found', { status: 404 });
+  }
+
+  // Parse the Twilio POST body to capture CallSid immediately, so status
+  // callbacks (keyed by CallSid) can locate this session even if the
+  // WebSocket relay hasn't been set up yet.
+  const formBody = new URLSearchParams(await req.text());
+  const callSid = formBody.get('CallSid');
+  if (callSid && callSid !== session.providerCallSid) {
+    updateCallSession(callSessionId, { providerCallSid: callSid });
+    log.info({ callSessionId, callSid }, 'Stored CallSid from voice webhook');
   }
 
   const wssBaseUrl = process.env.WSS_BASE_URL ?? process.env.BASE_URL ?? 'wss://localhost:7821';

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -221,6 +221,18 @@ export class RuntimeHttpServer {
       return undefined as unknown as Response;
     }
 
+    // ── Twilio webhook endpoints — before auth check because Twilio
+    //    webhook POSTs don't include bearer tokens. ────────────────────
+    if (path === '/v1/calls/twilio/voice-webhook' && req.method === 'POST') {
+      return await handleVoiceWebhook(req);
+    }
+    if (path === '/v1/calls/twilio/status' && req.method === 'POST') {
+      return await handleStatusCallback(req);
+    }
+    if (path === '/v1/calls/twilio/connect-action' && req.method === 'POST') {
+      return await handleConnectAction(req);
+    }
+
     // Require bearer token when configured
     if ((process.env.DISABLE_HTTP_AUTH ?? "").toLowerCase() !== "true" && this.bearerToken) {
       const authHeader = req.headers.get('authorization');
@@ -411,20 +423,6 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'channels/replay' && req.method === 'POST') {
         return await handleReplayDeadLetters(req);
-      }
-
-      // ── Call/Twilio endpoints ─────────────────────────────────────────
-      const voiceWebhookMatch = endpoint.match(/^calls\/twilio\/voice-webhook$/);
-      if (voiceWebhookMatch && req.method === 'POST') {
-        return await handleVoiceWebhook(req);
-      }
-
-      if (endpoint === 'calls/twilio/status' && req.method === 'POST') {
-        return await handleStatusCallback(req);
-      }
-
-      if (endpoint === 'calls/twilio/connect-action' && req.method === 'POST') {
-        return await handleConnectAction(req);
       }
 
       return Response.json({ error: 'Not found', source: 'runtime' }, { status: 404 });


### PR DESCRIPTION
Addresses review feedback on PR #5214:

- Move Twilio HTTP webhook endpoints (voice-webhook, status, connect-action) before bearer token auth check so they're accessible to Twilio callbacks (Codex P1 + Devin)
- Capture CallSid from voice webhook immediately into session record so status callbacks work before WebSocket setup (Codex P1)
- XML-escape wssBaseUrl and callSessionId in TwiML template URL attribute (Devin)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
