### PR TITLE
fix: prevent duplicate Task Queue UI by consolidating presentation path

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -218,6 +218,8 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '',
     'You can create ad-hoc work items by providing just a `title` to `task_list_add` — no existing task template is needed. A lightweight template is auto-created behind the scenes. For reusable task definitions with templates and input schemas, use `task_save` first.',
     '',
+    '**IMPORTANT:** When you call `task_list_show`, the Tasks window opens automatically on the client. Do NOT also create a separate surface/UI (via `ui_show` or `app_create`) to display the task queue. Doing so causes duplicate Task Queue windows. Just call `task_list_show` and let the native window handle the presentation.',
+    '',
     '### Schedules (schedule_create / schedule_list / schedule_update / schedule_delete)',
     'For recurring automated jobs that run on a cron schedule. Use ONLY when the user explicitly wants:',
     '- Recurring automation: "every day at 9am", "weekly on Mondays", "every hour"',

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -535,6 +535,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupSurfaceManager() {
+        // Let SurfaceManager check whether the standalone Tasks window is already
+        // showing so it can suppress duplicate task queue surfaces from the LLM.
+        surfaceManager.isTasksWindowVisible = { [weak self] in
+            self?.tasksWindow?.isVisible ?? false
+        }
+
         // Wire daemon surface messages to SurfaceManager (or BrowserPiPManager for browser_view)
         daemonClient.onSurfaceShow = { [weak self] msg in
             guard let self else { return }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -92,13 +92,36 @@ final class SurfaceManager: ObservableObject {
     /// workspace instead of opening as floating NSPanels.
     var onDynamicPageShow: ((UiSurfaceShowMessage) -> Void)?
 
+    /// Returns true when the standalone Tasks window is already visible.
+    /// Set by AppDelegate so SurfaceManager can suppress duplicate task queue surfaces.
+    var isTasksWindowVisible: (() -> Bool)?
+
     /// Called when a dynamic page requests opening an external link.
     /// Parameters: url string, optional metadata dictionary.
     var onLinkOpen: ((String, [String: Any]?) -> Void)?
 
     // MARK: - Show
 
+    /// Checks whether a surface title looks like a task queue UI that would
+    /// duplicate the standalone TasksWindow.
+    private static let taskQueueTitlePatterns: [String] = [
+        "task queue", "task list", "tasks"
+    ]
+
+    private func isTaskQueueSurface(_ message: UiSurfaceShowMessage) -> Bool {
+        guard let title = message.title else { return false }
+        let lower = title.lowercased()
+        return Self.taskQueueTitlePatterns.contains { lower.contains($0) }
+    }
+
     func showSurface(_ message: UiSurfaceShowMessage) {
+        // Safety net: suppress surfaces that duplicate the standalone Tasks window.
+        // The LLM is prompted not to create these, but if it does anyway we skip them.
+        if isTaskQueueSurface(message), isTasksWindowVisible?() == true {
+            log.info("Suppressed duplicate task queue surface: id=\(message.surfaceId), title=\(message.title ?? "nil")")
+            return
+        }
+
         guard let surface = Surface.from(message) else {
             log.error("Failed to parse surface from message: surfaceId=\(message.surfaceId), type=\(message.surfaceType)")
             return

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
@@ -48,6 +48,10 @@ final class TasksWindow {
         self.window = window
     }
 
+    var isVisible: Bool {
+        window?.isVisible ?? false
+    }
+
     func close() {
         window?.close()
         window = nil


### PR DESCRIPTION
## Summary
- **System prompt**: Added guidance telling the model NOT to create a separate surface/UI when calling `task_list_show`, since the native Tasks window opens automatically via IPC
- **SurfaceManager**: Added a safety-net guard that suppresses surfaces with task-related titles ("Task Queue", "Task List", "Tasks") when the standalone TasksWindow is already visible
- **TasksWindow**: Exposed `isVisible` property so SurfaceManager can check visibility via a callback wired in AppDelegate

## Test plan
- [ ] Call `task_list_show` and verify only ONE Tasks window appears (no floating surface panel)
- [ ] Open Tasks window from Control Center drawer button, then trigger `task_list_show` — verify no duplicate
- [ ] Verify non-task surfaces still show normally (e.g. weather, flight results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
