### PR TITLE
fix: drain enrichment queue on shutdown instead of discarding pending jobs

### DIFF
--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -9,7 +9,7 @@
  * - Bounded queue with configurable max size (drops oldest on overflow)
  * - Bounded concurrency (default 1 worker)
  * - Per-job timeout with retry + exponential backoff
- * - Graceful shutdown: drains in-flight jobs, discards pending
+ * - Graceful shutdown: drains both in-flight and pending jobs
  * - Fire-and-forget: enqueue() never blocks or throws
  */
 
@@ -99,18 +99,24 @@ export class CommitEnrichmentService {
   }
 
   /**
-   * Graceful shutdown: wait for in-flight jobs to complete, discard pending.
+   * Graceful shutdown: drain pending queue and wait for all jobs to complete.
    */
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
-    const pendingCount = this.queue.length;
-    this.queue = [];
 
-    if (pendingCount > 0) {
-      log.info({ discarded: pendingCount }, 'Enrichment queue shutting down, discarding pending jobs');
+    // Process remaining queue items instead of discarding them
+    if (this.queue.length > 0) {
+      log.info({ pending: this.queue.length }, 'Enrichment queue shutting down, draining pending jobs');
+    }
+    while (this.queue.length > 0) {
+      const job = this.queue.shift()!;
+      const promise = this.executeJob(job).finally(() => {
+        this.inFlightPromises.delete(promise);
+      });
+      this.inFlightPromises.add(promise);
     }
 
-    // Wait for in-flight workers to finish
+    // Wait for all in-flight workers (including newly started ones) to finish
     if (this.inFlightPromises.size > 0) {
       log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
       await Promise.all(this.inFlightPromises);


### PR DESCRIPTION
Addresses Codex review feedback on PR #5215:

- Modified CommitEnrichmentService.shutdown() to process all pending queue items instead of discarding them
- With concurrency 1, the previous behavior would only finish the in-flight job and drop the rest during graceful shutdown
- Now all queued enrichment jobs are started and awaited before shutdown completes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
