### PR TITLE
M5: User consultation bridge + call session notifiers

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -18,6 +18,7 @@ import {
 } from './call-store.js';
 import { MAX_CALL_DURATION_MS, USER_CONSULTATION_TIMEOUT_MS, SILENCE_TIMEOUT_MS } from './call-constants.js';
 import type { RelayConnection } from './relay-server.js';
+import { registerCallOrchestrator, unregisterCallOrchestrator, fireCallQuestionNotifier, fireCallCompletionNotifier } from './call-state.js';
 
 const log = getLogger('call-orchestrator');
 
@@ -45,6 +46,7 @@ export class CallOrchestrator {
     this.task = task;
     this.startDurationTimer();
     this.resetSilenceTimer();
+    registerCallOrchestrator(callSessionId, this);
   }
 
   /**
@@ -110,6 +112,7 @@ export class CallOrchestrator {
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
     if (this.consultationTimer) clearTimeout(this.consultationTimer);
     this.abortController.abort();
+    unregisterCallOrchestrator(this.callSessionId);
     log.info({ callSessionId: this.callSessionId }, 'CallOrchestrator destroyed');
   }
 
@@ -195,6 +198,12 @@ export class CallOrchestrator {
         updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
         recordCallEvent(this.callSessionId, 'user_question_asked', { question: questionText });
 
+        // Notify the conversation that a question was asked
+        const session = getCallSession(this.callSessionId);
+        if (session) {
+          fireCallQuestionNotifier(session.conversationId, this.callSessionId, questionText);
+        }
+
         // Set a consultation timeout
         this.consultationTimer = setTimeout(() => {
           if (this.state === 'waiting_on_user') {
@@ -215,6 +224,12 @@ export class CallOrchestrator {
         this.relay.endSession('Call completed');
         updateCallSession(this.callSessionId, { status: 'completed', endedAt: Date.now() });
         recordCallEvent(this.callSessionId, 'call_ended', { reason: 'completed' });
+
+        // Notify the conversation that the call completed
+        const endSession = getCallSession(this.callSessionId);
+        if (endSession) {
+          fireCallCompletionNotifier(endSession.conversationId, this.callSessionId);
+        }
         this.state = 'idle';
         return;
       }

--- a/assistant/src/calls/call-state.ts
+++ b/assistant/src/calls/call-state.ts
@@ -1,0 +1,64 @@
+/**
+ * Call session notifiers and orchestrator registry.
+ *
+ * Follows the same notifier pattern as watch-state.ts: module-level Maps
+ * with register/unregister/fire helpers keyed by conversationId.
+ */
+
+import { getLogger } from '../util/logger.js';
+import type { CallOrchestrator } from './call-orchestrator.js';
+
+const log = getLogger('call-state');
+
+// ── Question notifiers ──────────────────────────────────────────────
+const questionNotifiers = new Map<string, (callSessionId: string, question: string) => void>();
+
+export function registerCallQuestionNotifier(
+  conversationId: string,
+  callback: (callSessionId: string, question: string) => void,
+): void {
+  questionNotifiers.set(conversationId, callback);
+}
+
+export function unregisterCallQuestionNotifier(conversationId: string): void {
+  questionNotifiers.delete(conversationId);
+}
+
+export function fireCallQuestionNotifier(conversationId: string, callSessionId: string, question: string): void {
+  questionNotifiers.get(conversationId)?.(callSessionId, question);
+}
+
+// ── Completion notifiers ────────────────────────────────────────────
+const completionNotifiers = new Map<string, (callSessionId: string) => void>();
+
+export function registerCallCompletionNotifier(
+  conversationId: string,
+  callback: (callSessionId: string) => void,
+): void {
+  completionNotifiers.set(conversationId, callback);
+}
+
+export function unregisterCallCompletionNotifier(conversationId: string): void {
+  completionNotifiers.delete(conversationId);
+}
+
+export function fireCallCompletionNotifier(conversationId: string, callSessionId: string): void {
+  completionNotifiers.get(conversationId)?.(callSessionId);
+}
+
+// ── Active orchestrator registry ────────────────────────────────────
+const activeCallOrchestrators = new Map<string, CallOrchestrator>();
+
+export function registerCallOrchestrator(callSessionId: string, orchestrator: CallOrchestrator): void {
+  activeCallOrchestrators.set(callSessionId, orchestrator);
+  log.info({ callSessionId }, 'Call orchestrator registered');
+}
+
+export function unregisterCallOrchestrator(callSessionId: string): void {
+  activeCallOrchestrators.delete(callSessionId);
+  log.info({ callSessionId }, 'Call orchestrator unregistered');
+}
+
+export function getCallOrchestrator(callSessionId: string): CallOrchestrator | undefined {
+  return activeCallOrchestrators.get(callSessionId);
+}

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -13,8 +13,11 @@ import {
   updateCallSession,
   recordCallEvent,
   expirePendingQuestions,
+  getPendingQuestion,
+  answerPendingQuestion,
 } from './call-store.js';
 import type { CallStatus } from './types.js';
+import { getCallOrchestrator } from './call-state.js';
 
 const log = getLogger('twilio-routes');
 
@@ -188,4 +191,32 @@ export async function handleConnectAction(_req: Request): Promise<Response> {
       headers: { 'Content-Type': 'text/xml' },
     },
   );
+}
+
+/**
+ * Answer a pending question for an active call.
+ * POST /v1/calls/:callSessionId/answer
+ * Body: { answer: string }
+ */
+export async function handleCallAnswer(req: Request, callSessionId: string): Promise<Response> {
+  const body = await req.json() as { answer?: string };
+  if (!body.answer) {
+    return Response.json({ error: 'Missing answer' }, { status: 400 });
+  }
+
+  const question = getPendingQuestion(callSessionId);
+  if (!question) {
+    return Response.json({ error: 'No pending question found' }, { status: 404 });
+  }
+
+  // Mark question as answered
+  answerPendingQuestion(question.id, body.answer);
+
+  // Route answer to the orchestrator
+  const orchestrator = getCallOrchestrator(callSessionId);
+  if (orchestrator) {
+    await orchestrator.handleUserAnswer(body.answer);
+  }
+
+  return Response.json({ ok: true, questionId: question.id });
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -49,6 +49,7 @@ import {
   handleVoiceWebhook,
   handleStatusCallback,
   handleConnectAction,
+  handleCallAnswer,
 } from '../calls/twilio-routes.js';
 import { RelayConnection, activeRelayConnections } from '../calls/relay-server.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';
@@ -240,6 +241,12 @@ export class RuntimeHttpServer {
       if (!token || !this.verifyToken(token)) {
         return Response.json({ error: 'Unauthorized' }, { status: 401 });
       }
+    }
+
+    // ── Call answer endpoint — behind auth gate ──────────────────────
+    const callAnswerMatch = path.match(/^\/v1\/calls\/([^/]+)\/answer$/);
+    if (callAnswerMatch && req.method === 'POST') {
+      return await handleCallAnswer(req, callAnswerMatch[1]);
     }
 
     // Serve shareable app pages


### PR DESCRIPTION
## Summary
- Create call-state.ts with notifier pattern (question + completion events)
- Wire orchestrator to fire notifiers on ASK_USER and END_CALL
- Add POST /v1/calls/:callSessionId/answer endpoint for user consultation
- Register/unregister orchestrator instances for endpoint routing

Part of #5204
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
