### PR TITLE
fix: make Run button visually prominent and update status to Awaiting Review

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
@@ -53,7 +53,7 @@ enum TasksTableContract {
     /// Fixed-width columns. The `task` column is flexible and fills remaining space.
     static let taskMinWidth: CGFloat = 200
     static let priorityWidth: CGFloat = 80
-    static let statusWidth: CGFloat = 100
+    static let statusWidth: CGFloat = 120
     static let actionsWidth: CGFloat = 90
 
     // MARK: Truncation
@@ -95,7 +95,7 @@ enum TasksTableContract {
         switch status {
         case .queued:          return StatusStyle(label: "Queued",    color: VColor.textSecondary)
         case .running:         return StatusStyle(label: "Running",   color: VColor.warning)
-        case .awaitingReview:  return StatusStyle(label: "Review",    color: VColor.accent)
+        case .awaitingReview:  return StatusStyle(label: "Awaiting Review", color: VColor.accent)
         case .failed:          return StatusStyle(label: "Failed",    color: VColor.error)
         case .done:            return StatusStyle(label: "Done",      color: VColor.success)
         case .archived:        return StatusStyle(label: "Archived",  color: VColor.textMuted)

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -262,10 +262,10 @@ private struct TasksWindowRow: View {
                             Text(buttonLabel)
                                 .font(VFont.caption)
                         }
-                        .foregroundColor(buttonColor)
+                        .foregroundColor(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .background(buttonColor.opacity(0.12))
+                        .background(buttonColor)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .contentShape(Rectangle())
                     }


### PR DESCRIPTION
## Summary
- **Run/Retry button now uses solid filled background** (accent/warning color with white text) instead of the subtle 12% opacity tint, making it clearly clickable at a glance.
- **Status label renamed** from "Review" to "Awaiting Review" for clarity.
- **Status column widened** from 100pt to 120pt to accommodate the longer label.

## Files changed
- `clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift`
- `clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift`

## Test plan
- [ ] Build succeeds (`./build.sh` passes)
- [ ] Run button appears with solid accent background and white text for queued tasks
- [ ] Retry button appears with solid warning background and white text for failed/timed-out tasks
- [ ] "Starting..." state remains dimmed (0.4 opacity)
- [ ] Status badge shows "Awaiting Review" instead of "Review"
- [ ] Status column is wide enough to fit "Awaiting Review" without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
