### PR TITLE
fix: enforce work item status rules and recover stuck running items

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -90,6 +90,18 @@ export function handleWorkItemComplete(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
+  // Only allow completion from the 'awaiting_review' state — this ensures
+  // items go through the full run lifecycle before being marked done.
+  const existing = getWorkItem(msg.id);
+  if (!existing) {
+    ctx.send(socket, { type: 'error', message: `Work item not found: ${msg.id}` });
+    return;
+  }
+  if (existing.status !== 'awaiting_review') {
+    ctx.send(socket, { type: 'error', message: `Cannot complete work item: status is '${existing.status}', expected 'awaiting_review'` });
+    return;
+  }
+
   const item = updateWorkItem(msg.id, { status: 'done' }) ?? null;
   ctx.send(socket, { type: 'work_item_update_response', item });
   if (item) {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -22,6 +22,7 @@ import { initializeTools } from '../tools/registry.js';
 import { loadConfig } from '../config/loader.js';
 import { ensurePromptFiles } from '../config/system-prompt.js';
 import { DaemonServer } from './server.js';
+import { listWorkItems, updateWorkItem } from '../work-items/work-item-store.js';
 import { getLogger, initLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
 import { initSentry } from '../instrument.js';
@@ -279,6 +280,17 @@ export async function runDaemon(): Promise<void> {
   ensurePromptFiles();
   initializeDb();
   log.info('Daemon startup: DB initialized');
+
+  // Recover orphaned work items that were left in 'running' state when the
+  // daemon previously crashed or was killed mid-task.
+  const orphanedRunning = listWorkItems({ status: 'running' });
+  if (orphanedRunning.length > 0) {
+    for (const item of orphanedRunning) {
+      updateWorkItem(item.id, { status: 'failed', lastRunStatus: 'interrupted' });
+      log.info({ workItemId: item.id, title: item.title }, 'Recovered orphaned running work item → failed (interrupted)');
+    }
+    log.info({ count: orphanedRunning.length }, 'Recovered orphaned running work items');
+  }
 
   log.info('Daemon startup: loading config');
   const config = loadConfig();

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -45,7 +45,7 @@ const definition: ToolDefinition = {
       },
       status: {
         type: 'string',
-        enum: ['queued', 'running', 'awaiting_review', 'failed', 'done', 'archived'],
+        enum: ['queued', 'running', 'awaiting_review', 'failed', 'archived'],
         description: 'New status for the work item',
       },
       sort_index: {
@@ -121,6 +121,16 @@ class TaskListUpdateTool implements Tool {
       }
 
       const item = result.workItem;
+
+      // Block direct transitions to 'done' — the only path to done is
+      // through the Review action (handleWorkItemComplete in the daemon).
+      if (input.status === 'done') {
+        log.warn({ selectorType, resolvedWorkItemId: item.id }, 'rejected attempt to set status to done directly');
+        return {
+          content: 'Error: Cannot set status to \'done\' directly. Use the Review action in the Tasks window.',
+          isError: true,
+        };
+      }
 
       log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id }, 'resolved work item for update');
 


### PR DESCRIPTION
## Summary
- Removed `done` from the `task_list_update` tool's status enum so the model cannot bypass the review workflow, with a runtime guard as defense-in-depth
- Guarded `handleWorkItemComplete` to only allow completion from the `awaiting_review` state, rejecting transitions from other states with a descriptive error
- Added daemon startup recovery for orphaned `running` work items (from daemon crashes) by marking them as `failed` with `lastRunStatus: 'interrupted'`

## Test plan
- [x] Type-check passes (no new errors introduced)
- [x] Existing task-tools tests pass (6 pre-existing failures unrelated to this change)
- [ ] Manual: verify that setting status to `done` via `task_list_update` returns an error
- [ ] Manual: verify that clicking Review on a non-`awaiting_review` item returns an error
- [ ] Manual: kill daemon while a task is running, restart, verify the work item is marked `failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
