### PR TITLE
feat: add compact latest-output IPC for work items

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -449,6 +449,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'work_item_run_task',
     id: 'wi-001',
   },
+  work_item_output: {
+    type: 'work_item_output',
+    id: 'wi-001',
+  },
   document_save: {
     type: 'document_save',
     surfaceId: 'doc-001',
@@ -1327,6 +1331,20 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     id: 'wi-001',
     lastRunId: 'run-001',
     success: true,
+  },
+  work_item_output_response: {
+    type: 'work_item_output_response',
+    id: 'wi-001',
+    success: true,
+    output: {
+      title: 'Process report',
+      status: 'completed',
+      runId: 'run-001',
+      conversationId: 'conv-001',
+      completedAt: 1700002000,
+      summary: 'Report processed successfully.',
+      highlights: ['- Key finding 1', '- Key finding 2'],
+    },
   },
   work_item_status_changed: {
     type: 'work_item_status_changed',

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -106,6 +106,7 @@ import {
   handleWorkItemComplete,
   handleWorkItemDelete,
   handleWorkItemRunTask,
+  handleWorkItemOutput,
 } from './work-items.js';
 
 import {
@@ -334,6 +335,7 @@ const handlers: DispatchMap = {
   work_item_complete: handleWorkItemComplete,
   work_item_delete: handleWorkItemDelete,
   work_item_run_task: handleWorkItemRunTask,
+  work_item_output: handleWorkItemOutput,
 
   subagent_abort: handleSubagentAbort,
   subagent_status: handleSubagentStatus,

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -7,6 +7,7 @@ import type {
   WorkItemCompleteRequest,
   WorkItemDeleteRequest,
   WorkItemRunTaskRequest,
+  WorkItemOutputRequest,
 } from '../ipc-protocol.js';
 import { log, type HandlerContext } from './shared.js';
 import {
@@ -17,8 +18,9 @@ import {
   updateWorkItem,
   type WorkItemStatus,
 } from '../../work-items/work-item-store.js';
-import { getTask } from '../../tasks/task-store.js';
+import { getTask, getTaskRun } from '../../tasks/task-store.js';
 import { runTask } from '../../tasks/task-runner.js';
+import { getMessages } from '../../memory/conversation-store.js';
 
 export function handleWorkItemsList(
   msg: WorkItemsListRequest,
@@ -142,6 +144,80 @@ function broadcastWorkItemStatus(ctx: HandlerContext, id: string): void {
       },
     });
   }
+}
+
+export function handleWorkItemOutput(
+  msg: WorkItemOutputRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const workItem = getWorkItem(msg.id);
+  if (!workItem) {
+    ctx.send(socket, { type: 'work_item_output_response', id: msg.id, success: false, error: 'Work item not found' });
+    return;
+  }
+
+  let summary = '';
+  let highlights: string[] = [];
+
+  if (workItem.lastRunConversationId) {
+    const msgs = getMessages(workItem.lastRunConversationId);
+    // Find the last assistant message with text content (not tool calls)
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i];
+      if (m.role !== 'assistant') continue;
+
+      let text = m.content;
+      // Content may be JSON array of content blocks — extract text blocks only
+      try {
+        const parsed = JSON.parse(text);
+        if (Array.isArray(parsed)) {
+          text = parsed
+            .filter((b: { type: string }) => b.type === 'text')
+            .map((b: { text: string }) => b.text)
+            .join('\n');
+        }
+      } catch {
+        // Plain text content — use as-is
+      }
+
+      if (!text.trim()) continue;
+
+      summary = text.length > 2000 ? text.slice(0, 2000) : text;
+
+      // Extract up to 5 notable lines (bullet points or key findings)
+      const lines = text.split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if ((trimmed.startsWith('-') || trimmed.startsWith('*')) && trimmed.length > 2) {
+          highlights.push(trimmed);
+          if (highlights.length >= 5) break;
+        }
+      }
+      break;
+    }
+  }
+
+  let completedAt: number | null = null;
+  if (workItem.lastRunId) {
+    const run = getTaskRun(workItem.lastRunId);
+    completedAt = run?.finishedAt ?? null;
+  }
+
+  ctx.send(socket, {
+    type: 'work_item_output_response',
+    id: msg.id,
+    success: true,
+    output: {
+      title: workItem.title,
+      status: workItem.lastRunStatus ?? workItem.status,
+      runId: workItem.lastRunId,
+      conversationId: workItem.lastRunConversationId,
+      completedAt,
+      summary,
+      highlights,
+    },
+  });
 }
 
 export async function handleWorkItemRunTask(

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -93,6 +93,7 @@
     "WorkItemCreateRequest",
     "WorkItemDeleteRequest",
     "WorkItemGetRequest",
+    "WorkItemOutputRequest",
     "WorkItemRunTaskRequest",
     "WorkItemUpdateRequest",
     "WorkItemsListRequest"
@@ -201,6 +202,7 @@
     "WorkItemCreateResponse",
     "WorkItemDeleteResponse",
     "WorkItemGetResponse",
+    "WorkItemOutputResponse",
     "WorkItemRunTaskResponse",
     "WorkItemStatusChanged",
     "WorkItemUpdateResponse",
@@ -300,6 +302,7 @@
     "work_item_create",
     "work_item_delete",
     "work_item_get",
+    "work_item_output",
     "work_item_run_task",
     "work_item_update",
     "work_items_list"
@@ -407,6 +410,7 @@
     "work_item_create_response",
     "work_item_delete_response",
     "work_item_get_response",
+    "work_item_output_response",
     "work_item_run_task_response",
     "work_item_status_changed",
     "work_item_update_response",

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -808,6 +808,11 @@ export interface WorkItemRunTaskRequest {
   id: string;
 }
 
+export interface WorkItemOutputRequest {
+  type: 'work_item_output';
+  id: string;
+}
+
 export type ClientMessage =
   | AuthMessage
   | UserMessage
@@ -902,6 +907,7 @@ export type ClientMessage =
   | WorkItemCompleteRequest
   | WorkItemDeleteRequest
   | WorkItemRunTaskRequest
+  | WorkItemOutputRequest
   | SubagentAbortRequest
   | SubagentStatusRequest
   | SubagentMessageRequest;
@@ -1944,6 +1950,22 @@ export interface WorkItemRunTaskResponse {
   errorCode?: WorkItemRunTaskErrorCode;
 }
 
+export interface WorkItemOutputResponse {
+  type: 'work_item_output_response';
+  id: string;
+  success: boolean;
+  error?: string;
+  output?: {
+    title: string;
+    status: string;
+    runId: string | null;
+    conversationId: string | null;
+    completedAt: number | null;
+    summary: string;
+    highlights: string[];
+  };
+}
+
 /** Server push — tells the client to open/focus the tasks window. */
 export interface OpenTasksWindow {
   type: 'open_tasks_window';
@@ -2071,6 +2093,7 @@ export type ServerMessage =
   | WorkItemUpdateResponse
   | WorkItemDeleteResponse
   | WorkItemRunTaskResponse
+  | WorkItemOutputResponse
   | WorkItemStatusChanged
   | TasksChanged
   | OpenTasksWindow

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -281,6 +281,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `work_item_run_task_response` message.
     public var onWorkItemRunTaskResponse: ((IPCWorkItemRunTaskResponse) -> Void)?
 
+    /// Called when the daemon sends a `work_item_output_response` message.
+    public var onWorkItemOutputResponse: ((IPCWorkItemOutputResponse) -> Void)?
+
     /// Called when the daemon sends a `work_item_update_response` message.
     public var onWorkItemUpdateResponse: ((IPCWorkItemUpdateResponse) -> Void)?
 
@@ -882,6 +885,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(IPCWorkItemRunTaskRequest(type: "work_item_run_task", id: id))
     }
 
+    /// Request the latest output for a work item.
+    public func sendWorkItemOutput(id: String) throws {
+        try send(IPCWorkItemOutputRequest(type: "work_item_output", id: id))
+    }
+
     /// Update fields on an existing work item.
     public func sendWorkItemUpdate(id: String, title: String? = nil, notes: String? = nil, status: String? = nil, priorityTier: Double? = nil, sortIndex: Int? = nil) throws {
         try send(IPCWorkItemUpdateRequest(type: "work_item_update", id: id, title: title, notes: notes, status: status, priorityTier: priorityTier, sortIndex: sortIndex))
@@ -1438,6 +1446,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onWorkItemDeleteResponse?(msg)
         case .workItemRunTaskResponse(let msg):
             onWorkItemRunTaskResponse?(msg)
+        case .workItemOutputResponse(let msg):
+            onWorkItemOutputResponse?(msg)
         case .workItemUpdateResponse(let msg):
             onWorkItemUpdateResponse?(msg)
         case .openTasksWindow:

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1924,17 +1924,6 @@ public struct IPCWorkItemCompleteRequest: Codable, Sendable {
     public let id: String
 }
 
-public struct IPCWorkItemDeleteRequest: Codable, Sendable {
-    public let type: String
-    public let id: String
-}
-
-public struct IPCWorkItemDeleteResponse: Codable, Sendable {
-    public let type: String
-    public let id: String
-    public let success: Bool
-}
-
 public struct IPCWorkItemCreateRequest: Codable, Sendable {
     public let type: String
     public let taskId: String
@@ -1966,6 +1955,17 @@ public struct IPCWorkItemCreateResponseItem: Codable, Sendable {
     public let updatedAt: Int
 }
 
+public struct IPCWorkItemDeleteRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
+public struct IPCWorkItemDeleteResponse: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let success: Bool
+}
+
 public struct IPCWorkItemGetRequest: Codable, Sendable {
     public let type: String
     public let id: String
@@ -1991,6 +1991,29 @@ public struct IPCWorkItemGetResponseItem: Codable, Sendable {
     public let sourceId: String?
     public let createdAt: Int
     public let updatedAt: Int
+}
+
+public struct IPCWorkItemOutputRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
+public struct IPCWorkItemOutputResponse: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let success: Bool
+    public let error: String?
+    public let output: IPCWorkItemOutputResponseOutput?
+}
+
+public struct IPCWorkItemOutputResponseOutput: Codable, Sendable {
+    public let title: String
+    public let status: String
+    public let runId: String?
+    public let conversationId: String?
+    public let completedAt: Int?
+    public let summary: String
+    public let highlights: [String]
 }
 
 public struct IPCWorkItemRunTaskRequest: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1815,6 +1815,7 @@ public enum ServerMessage: Decodable, Sendable {
     case tasksChanged(IPCTasksChanged)
     case workItemDeleteResponse(IPCWorkItemDeleteResponse)
     case workItemRunTaskResponse(IPCWorkItemRunTaskResponse)
+    case workItemOutputResponse(IPCWorkItemOutputResponse)
     case workItemUpdateResponse(IPCWorkItemUpdateResponse)
     case openTasksWindow(OpenTasksWindowMessage)
     case subagentSpawned(IPCSubagentSpawned)
@@ -2096,6 +2097,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "work_item_run_task_response":
             let message = try IPCWorkItemRunTaskResponse(from: decoder)
             self = .workItemRunTaskResponse(message)
+        case "work_item_output_response":
+            let message = try IPCWorkItemOutputResponse(from: decoder)
+            self = .workItemOutputResponse(message)
         case "work_item_update_response":
             let message = try IPCWorkItemUpdateResponse(from: decoder)
             self = .workItemUpdateResponse(message)


### PR DESCRIPTION
## Summary
- Add `work_item_output` request and `work_item_output_response` response IPC message types to let the macOS client fetch a work item's latest run output
- Handler extracts a compact summary (last assistant message text, truncated to 2000 chars), up to 5 bullet-point highlights, and completion timestamp from the task run
- Wire up Swift client support: `ServerMessage.workItemOutputResponse` case, `sendWorkItemOutput(id:)` method, and `onWorkItemOutputResponse` callback

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (only pre-existing errors remain)
- [ ] Verify IPC inventory is in sync via `bun run ipc:inventory`
- [ ] Verify generated `IPCContractGenerated.swift` compiles with the macOS app
- [ ] Manual test: trigger a work item run, then call `sendWorkItemOutput(id:)` and verify the response contains summary/highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
