### PR TITLE
fix: only hold TTS buffer for known control marker prefixes, not arbitrary brackets

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -185,13 +185,27 @@ export class CallOrchestrator {
           // No bracket at all — safe to flush everything
           this.relay.sendTextToken(ttsBuffer, false);
           ttsBuffer = '';
-        } else if (bracketIdx > 0) {
-          // Flush everything before the bracket; keep the bracket and after
-          this.relay.sendTextToken(ttsBuffer.slice(0, bracketIdx), false);
-          ttsBuffer = ttsBuffer.slice(bracketIdx);
+        } else {
+          // Flush everything before the bracket
+          if (bracketIdx > 0) {
+            this.relay.sendTextToken(ttsBuffer.slice(0, bracketIdx), false);
+            ttsBuffer = ttsBuffer.slice(bracketIdx);
+          }
+
+          // Only hold the buffer if the bracket text could be the start of a
+          // known control marker. Otherwise flush immediately so ordinary
+          // bracketed text (e.g. "[A]", "[note]") doesn't stall TTS.
+          const afterBracket = ttsBuffer;
+          const couldBeControl =
+            '[ASK_USER:'.startsWith(afterBracket) || '[END_CALL]'.startsWith(afterBracket);
+
+          if (!couldBeControl) {
+            // Not a control marker prefix — flush everything
+            this.relay.sendTextToken(ttsBuffer, false);
+            ttsBuffer = '';
+          }
+          // Otherwise hold it — might be a control marker still being streamed
         }
-        // If force is true, we still hold bracket-prefixed text — it will be
-        // evaluated after the stream completes.
       };
 
       stream.on('text', (text) => {


### PR DESCRIPTION
Addresses Codex review feedback on PR #5227:

- Only pause TTS streaming when bracket text could be a prefix of [ASK_USER: or [END_CALL] markers
- Flush ordinary bracketed text (like [A], [note]) immediately instead of buffering until stream end
- Prevents long silences during TTS when LLM uses non-control brackets
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
