### PR TITLE
feat: add task output detail view with generic renderer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TaskOutputDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TaskOutputDetailView.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// The loading/loaded/error state for fetching task output.
+enum TaskOutputState {
+    case loading
+    case loaded(IPCWorkItemOutputResponseOutput)
+    case error(String)
+}
+
+/// A sheet that displays the output details of a completed task.
+/// Renders a generic layout: title, status badge, completion time,
+/// summary text, and highlights as a bullet list. Works for all task
+/// types with no special-case logic.
+struct TaskOutputDetailView: View {
+    let itemTitle: String
+    let state: TaskOutputState
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().background(VColor.surfaceBorder)
+            content
+        }
+        .frame(width: 460)
+        .frame(minHeight: 320)
+        .background(VColor.background)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text(itemTitle)
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+                .lineLimit(2)
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 24, height: 24)
+                    .background(VColor.surfaceBorder.opacity(0.5))
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            VStack {
+                Spacer()
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading output…")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.top, VSpacing.sm)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .error(let message):
+            VStack(spacing: VSpacing.md) {
+                Spacer()
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 24))
+                    .foregroundColor(VColor.warning)
+                Text(message)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .padding(VSpacing.lg)
+
+        case .loaded(let output):
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    outputMetadata(output)
+                    outputSummary(output)
+                    if !output.highlights.isEmpty {
+                        outputHighlights(output.highlights)
+                    }
+                }
+                .padding(VSpacing.lg)
+            }
+        }
+    }
+
+    // MARK: - Output Sections
+
+    private func outputMetadata(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+        HStack(spacing: VSpacing.md) {
+            // Status badge
+            HStack(spacing: VSpacing.xs) {
+                Circle()
+                    .fill(TaskOutputRenderer.statusColor(for: output.status))
+                    .frame(width: 8, height: 8)
+                Text(TaskOutputRenderer.statusLabel(for: output.status))
+                    .font(VFont.caption)
+                    .foregroundColor(TaskOutputRenderer.statusColor(for: output.status))
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(TaskOutputRenderer.statusColor(for: output.status).opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+
+            // Completion time
+            if let completedAt = output.completedAt {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "clock")
+                        .font(.system(size: 10))
+                    Text(TaskOutputRenderer.formattedDate(from: completedAt))
+                        .font(VFont.caption)
+                }
+                .foregroundColor(VColor.textMuted)
+            }
+
+            Spacer()
+        }
+    }
+
+    private func outputSummary(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Summary")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+            Text(output.summary)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func outputHighlights(_ highlights: [String]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Highlights")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(Array(highlights.enumerated()), id: \.offset) { _, highlight in
+                    HStack(alignment: .top, spacing: VSpacing.sm) {
+                        Text("\u{2022}")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                        Text(highlight)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct TaskOutputDetailViewPreview: PreviewProvider {
+    /// Helper to create preview output data via JSON decoding, since
+    /// the generated struct's memberwise init is module-internal.
+    private static func makeOutput(
+        title: String, status: String, summary: String, highlights: [String],
+        completedAt: Int? = nil
+    ) -> IPCWorkItemOutputResponseOutput {
+        var dict: [String: Any] = [
+            "title": title,
+            "status": status,
+            "summary": summary,
+            "highlights": highlights,
+        ]
+        if let ts = completedAt { dict["completedAt"] = ts }
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        return try! JSONDecoder().decode(IPCWorkItemOutputResponseOutput.self, from: data)
+    }
+
+    static var previews: some View {
+        Group {
+            ZStack {
+                VColor.background.ignoresSafeArea()
+                TaskOutputDetailView(
+                    itemTitle: "Review inbox emails",
+                    state: .loaded(makeOutput(
+                        title: "Review inbox emails",
+                        status: "done",
+                        summary: "Processed 12 emails. Drafted 3 replies, archived 7 newsletters, and flagged 2 items requiring follow-up.",
+                        highlights: [
+                            "Replied to meeting request from Sarah \u{2014} confirmed Thursday 2pm",
+                            "Flagged contract renewal from Legal \u{2014} needs review by Friday",
+                            "Archived 7 promotional newsletters",
+                        ],
+                        completedAt: Int(Date().timeIntervalSince1970)
+                    )),
+                    onDismiss: {}
+                )
+            }
+            .previewDisplayName("Loaded")
+
+            ZStack {
+                VColor.background.ignoresSafeArea()
+                TaskOutputDetailView(
+                    itemTitle: "Process support tickets",
+                    state: .loading,
+                    onDismiss: {}
+                )
+            }
+            .previewDisplayName("Loading")
+
+            ZStack {
+                VColor.background.ignoresSafeArea()
+                TaskOutputDetailView(
+                    itemTitle: "Failed task",
+                    state: .error("Output not available for this task."),
+                    onDismiss: {}
+                )
+            }
+            .previewDisplayName("Error")
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Tasks/TaskOutputRenderer.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TaskOutputRenderer.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Renders work item output in a generic layout suitable for any task type.
+/// Displays title, status badge, completion time, summary, and highlights.
+enum TaskOutputRenderer {
+
+    /// Formats a unix timestamp (seconds) into a human-readable date string.
+    static func formattedDate(from timestamp: Int) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    /// Returns a color for the given status string, falling back to textMuted
+    /// for unrecognized values.
+    static func statusColor(for status: String) -> Color {
+        let normalized = WorkItemStatus(rawStatus: status)
+        return TasksTableContract.statusStyle(for: normalized).color
+    }
+
+    /// Returns a display label for the given status string.
+    static func statusLabel(for status: String) -> String {
+        let normalized = WorkItemStatus(rawStatus: status)
+        return TasksTableContract.statusStyle(for: normalized).label
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -97,8 +97,10 @@ struct TasksWindowView: View {
                         ForEach(viewModel.items, id: \.id) { item in
                             TasksWindowRow(
                                 item: item,
+                                hasOutput: viewModel.taskHasOutput(item),
                                 runningIds: viewModel.runInFlightIds,
                                 timeoutIds: viewModel.runTimeoutIds,
+                                onTap: { viewModel.fetchOutput(for: item) },
                                 onRun: { viewModel.runTask(id: item.id) },
                                 onComplete: { viewModel.completeTask(id: item.id) },
                                 onRemove: { viewModel.removeTask(id: item.id) },
@@ -115,6 +117,18 @@ struct TasksWindowView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(VColor.background)
+        .sheet(isPresented: Binding(
+            get: { viewModel.selectedOutputItem != nil },
+            set: { if !$0 { viewModel.dismissOutput() } }
+        )) {
+            if let item = viewModel.selectedOutputItem {
+                TaskOutputDetailView(
+                    itemTitle: item.title,
+                    state: viewModel.outputState,
+                    onDismiss: { viewModel.dismissOutput() }
+                )
+            }
+        }
     }
 }
 
@@ -123,13 +137,16 @@ struct TasksWindowView: View {
 /// Row view using explicit columns aligned to `TasksTableContract`.
 private struct TasksWindowRow: View {
     let item: IPCWorkItemsListResponseItem
+    let hasOutput: Bool
     let runningIds: Set<String>
     let timeoutIds: Set<String>
+    let onTap: () -> Void
     let onRun: () -> Void
     let onComplete: () -> Void
     let onRemove: () -> Void
     let onPriorityChange: (Double) -> Void
     @State private var isHovered = false
+    @State private var isTitleHovered = false
 
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
@@ -169,12 +186,29 @@ private struct TasksWindowRow: View {
     // MARK: - Task Column
 
     private var taskColumn: some View {
-        Text(item.title)
-            .font(VFont.body)
-            .foregroundColor(VColor.textPrimary)
-            .lineLimit(TasksTableContract.titleLineLimit)
-            .truncationMode(.tail)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        Group {
+            if hasOutput {
+                Text(item.title)
+                    .font(VFont.body)
+                    .foregroundColor(isTitleHovered ? VColor.accent : VColor.textPrimary)
+                    .underline(isTitleHovered, color: VColor.accent)
+                    .lineLimit(TasksTableContract.titleLineLimit)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onHover { hovering in isTitleHovered = hovering }
+                    .onTapGesture(perform: onTap)
+                    .accessibilityLabel("View output for \(item.title)")
+                    .accessibilityAddTraits(.isButton)
+            } else {
+                Text(item.title)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(TasksTableContract.titleLineLimit)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
     }
 
     // MARK: - Priority Column

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -20,6 +20,12 @@ class TasksWindowViewModel: ObservableObject {
     /// so the view can show a recoverable "no response" warning.
     @Published var runTimeoutIds: Set<String> = []
 
+    /// The currently selected item for output detail viewing, or nil when
+    /// the detail sheet is dismissed.
+    @Published var selectedOutputItem: IPCWorkItemsListResponseItem?
+    /// Loading/loaded/error state for the output detail sheet.
+    @Published var outputState: TaskOutputState = .loading
+
     /// Handles for pending timeout tasks keyed by work item ID, so we can
     /// cancel the timer when the daemon responds before the deadline.
     private var runTimeoutTasks: [String: Task<Void, Never>] = [:]
@@ -83,6 +89,17 @@ class TasksWindowViewModel: ObservableObject {
             if !response.success {
                 self.logger.warning("onWorkItemDeleteResponse: server rejected delete for id=\(response.id, privacy: .public)")
                 self.fetchItems()
+            }
+        }
+
+        daemonClient.onWorkItemOutputResponse = { [weak self] response in
+            guard let self else { return }
+            // Only update if the response matches the currently selected item
+            guard self.selectedOutputItem?.id == response.id else { return }
+            if response.success, let output = response.output {
+                self.outputState = .loaded(output)
+            } else {
+                self.outputState = .error(response.error ?? "Output not available for this task.")
             }
         }
     }
@@ -180,6 +197,34 @@ class TasksWindowViewModel: ObservableObject {
             }
             errorMessage = error.localizedDescription
         }
+    }
+
+    /// Whether a task's status indicates it may have output to display.
+    func taskHasOutput(_ item: IPCWorkItemsListResponseItem) -> Bool {
+        let status = WorkItemStatus(rawStatus: item.status)
+        switch status {
+        case .awaitingReview, .done, .failed: return true
+        default: return false
+        }
+    }
+
+    /// Opens the output detail sheet for the given item and fetches its
+    /// output from the daemon.
+    func fetchOutput(for item: IPCWorkItemsListResponseItem) {
+        logger.info("fetchOutput: id=\(item.id, privacy: .public)")
+        selectedOutputItem = item
+        outputState = .loading
+        do {
+            try daemonClient.sendWorkItemOutput(id: item.id)
+        } catch {
+            logger.error("fetchOutput: transport error for id=\(item.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            outputState = .error(error.localizedDescription)
+        }
+    }
+
+    /// Dismisses the output detail sheet.
+    func dismissOutput() {
+        selectedOutputItem = nil
     }
 
     func updatePriority(id: String, tier: Double) {


### PR DESCRIPTION
## Summary
- Make task row titles clickable to open output details for tasks with output (awaiting_review, done, or failed status)
- Add generic TaskOutputDetailView that renders title, status badge, completion time, summary, and highlights as a bullet list
- Add TaskOutputRenderer utility for status color/label mapping and date formatting
- Works for all task types — no special-case logic for any specific workflow
- Uses the work_item_output IPC (from #5226) to fetch compact output on demand
- Shows loading spinner while fetching, handles error state gracefully
- Title text turns accent-colored with underline on hover to signal clickability

## Test plan
- [ ] Verify that task rows with `awaiting_review`, `done`, or `failed` status show underline on title hover
- [ ] Verify that clicking a title opens the detail sheet with a loading spinner
- [ ] Verify that the detail sheet shows status badge, completion time, summary, and highlights once loaded
- [ ] Verify that tasks with `queued` or `running` status do NOT show clickable title styling
- [ ] Verify that action buttons (Run, Reviewed, Remove) still receive clicks without interference
- [ ] Verify that the sheet dismisses correctly via the X button or sheet gesture

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
