### PR TITLE
fix: use public webhook URL for Twilio signature validation instead of local req.url

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -145,8 +145,18 @@ async function validateTwilioWebhook(
     params[key] = value;
   }
 
+  // Reconstruct the public-facing URL that Twilio signed against.
+  // Behind proxies/gateways, req.url is the local server URL (e.g.
+  // http://127.0.0.1:7821/...) which differs from the public URL Twilio
+  // used to compute the HMAC-SHA1 signature.
+  const publicBaseUrl = process.env.TWILIO_WEBHOOK_BASE_URL;
+  const parsedUrl = new URL(req.url);
+  const publicUrl = publicBaseUrl
+    ? publicBaseUrl.replace(/\/$/, '') + parsedUrl.pathname + parsedUrl.search
+    : req.url;
+
   const isValid = TwilioConversationRelayProvider.verifyWebhookSignature(
-    req.url,
+    publicUrl,
     params,
     signature,
   );


### PR DESCRIPTION
Addresses review feedback on PR #5228 (Codex P1 + Devin):

- Reconstruct public-facing URL using TWILIO_WEBHOOK_BASE_URL for Twilio signature validation
- Local req.url (e.g., http://127.0.0.1:7821/...) differs from the public URL Twilio signed against behind proxies/gateways
- Falls back to req.url when TWILIO_WEBHOOK_BASE_URL is not configured
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
