### PR TITLE
fix: apply 1100pt max content width to Identity panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -16,51 +16,54 @@ struct IdentityPanel: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header
-            HStack(alignment: .center) {
-                Text("Assistant ID")
-                    .font(VFont.panelTitle)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-            }
-            .padding(.top, VSpacing.xxl)
-            .padding(.bottom, VSpacing.xl)
-            .padding(.horizontal, VSpacing.xxl)
-
-            Divider().background(VColor.surfaceBorder)
-                .padding(.horizontal, VSpacing.xxl)
-
-            // Avatar + ID card + CTA
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
-                    .frame(width: 180, height: 200)
-
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    if let identity {
-                        idCardSection(identity: identity)
-                    }
-
-                    // Customize Avatar CTA
-                    Button(action: onCustomizeAvatar) {
-                        HStack(spacing: VSpacing.xs) {
-                            Image(systemName: "paintpalette")
-                                .font(.system(size: 12, weight: .medium))
-                            Text("Customize Avatar")
-                                .font(VFont.bodyMedium)
-                        }
-                        .foregroundColor(VColor.accent)
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.vertical, VSpacing.sm)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
-                        )
-                    }
-                    .buttonStyle(.plain)
+            // Header + ID card area (max width matches other panels)
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack(alignment: .center) {
+                    Text("Assistant ID")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
                 }
+                .padding(.top, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xl)
+
+                Divider().background(VColor.surfaceBorder)
+
+                // Avatar + ID card + CTA
+                HStack(alignment: .center, spacing: VSpacing.lg) {
+                    DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                        .frame(width: 180, height: 200)
+
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        if let identity {
+                            idCardSection(identity: identity)
+                        }
+
+                        // Customize Avatar CTA
+                        Button(action: onCustomizeAvatar) {
+                            HStack(spacing: VSpacing.xs) {
+                                Image(systemName: "paintpalette")
+                                    .font(.system(size: 12, weight: .medium))
+                                Text("Customize Avatar")
+                                    .font(VFont.bodyMedium)
+                            }
+                            .foregroundColor(VColor.accent)
+                            .padding(.horizontal, VSpacing.lg)
+                            .padding(.vertical, VSpacing.sm)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.vertical, VSpacing.xl)
             }
-            .padding(.vertical, VSpacing.xl)
+            .frame(maxWidth: maxContentWidth)
             .padding(.horizontal, VSpacing.xxl)
+            .frame(maxWidth: .infinity)
 
             // Constellation fills remaining space (pan + zoom to navigate)
             ConstellationView(


### PR DESCRIPTION
## Summary
- Wrap Identity panel header and ID card section in a container with 1100pt max width, centered — matching Directory and Skills panels
- Constellation canvas stays full-width below since it's an interactive canvas

## Test plan
- [ ] Compare Identity panel header/divider width with Skills and Directory — should match
- [ ] Constellation still fills remaining space below the header area

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
