### PR TITLE
M7: Tests + architecture documentation (#5211)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3167,6 +3167,126 @@ The avatar evolves during onboarding based on conversation and identity choices.
 
 **Persistence:** Evolution state in UserDefaults, resolved appearance in LOOKS.md
 
+## Outgoing AI Phone Calls — Twilio ConversationRelay
+
+The Calls subsystem enables the assistant to place outgoing phone calls on behalf of the user via Twilio's ConversationRelay protocol. The assistant uses an LLM-driven conversation loop to speak with the callee in real time, and can pause to consult the user (in the chat UI) when it encounters questions it cannot answer on its own.
+
+### Call Flow
+
+```mermaid
+sequenceDiagram
+    participant User as User (Chat UI)
+    participant Session as Session / Tool Executor
+    participant CallStore as CallStore (SQLite)
+    participant TwilioProvider as TwilioProvider
+    participant TwilioAPI as Twilio REST API
+    participant TwilioWH as Twilio Webhooks
+    participant Routes as twilio-routes.ts
+    participant WS as RelayConnection (WebSocket)
+    participant Orch as CallOrchestrator
+    participant LLM as Anthropic Claude
+    participant State as CallState (Notifiers)
+
+    User->>Session: call_start tool
+    Session->>CallStore: createCallSession()
+    Session->>TwilioProvider: initiateCall()
+    TwilioProvider->>TwilioAPI: POST /Calls.json
+    TwilioAPI-->>TwilioProvider: { callSid }
+    Session->>CallStore: updateCallSession(providerCallSid)
+
+    TwilioAPI->>Routes: POST /v1/calls/voice-webhook
+    Routes->>CallStore: getCallSession()
+    Routes-->>TwilioAPI: TwiML (ConversationRelay connect)
+
+    TwilioAPI->>WS: WebSocket /v1/calls/relay
+    WS->>WS: setup message (callSid)
+    WS->>Orch: new CallOrchestrator()
+    Orch->>State: registerCallOrchestrator()
+
+    loop Conversation turns
+        TwilioAPI->>WS: prompt (caller utterance)
+        WS->>Orch: handleCallerUtterance()
+        Orch->>LLM: messages.stream()
+        LLM-->>Orch: text tokens (streaming)
+        Orch->>WS: sendTextToken() (for TTS)
+        Orch->>CallStore: recordCallEvent()
+    end
+
+    alt ASK_USER pattern detected
+        Orch->>CallStore: createPendingQuestion()
+        Orch->>State: fireCallQuestionNotifier()
+        State->>Session: question callback
+        Session->>User: display question in chat
+        User->>Routes: POST /v1/calls/:id/answer
+        Routes->>CallStore: answerPendingQuestion()
+        Routes->>Orch: handleUserAnswer()
+        Orch->>LLM: continue with [USER_ANSWERED: ...]
+    end
+
+    alt END_CALL pattern detected
+        Orch->>WS: endSession()
+        Orch->>CallStore: updateCallSession(completed)
+        Orch->>State: fireCallCompletionNotifier()
+    end
+
+    TwilioAPI->>Routes: POST /v1/calls/status-callback
+    Routes->>CallStore: updateCallSession(status)
+```
+
+### Key Components
+
+| File | Role |
+|------|------|
+| `assistant/src/calls/call-store.ts` | CRUD operations for call sessions, call events, and pending questions in SQLite via Drizzle ORM |
+| `assistant/src/calls/twilio-provider.ts` | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency |
+| `assistant/src/calls/twilio-routes.ts` | HTTP webhook handlers: voice webhook (returns TwiML), status callback, connect action, and user answer endpoint |
+| `assistant/src/calls/relay-server.ts` | WebSocket handler for the Twilio ConversationRelay protocol; manages RelayConnection instances per call |
+| `assistant/src/calls/call-orchestrator.ts` | LLM-driven conversation manager: receives caller utterances, streams responses via Anthropic Claude, detects ASK_USER and END_CALL control markers |
+| `assistant/src/calls/call-state.ts` | Notifier pattern (Maps with register/unregister/fire helpers) for cross-component communication: question notifiers, completion notifiers, and orchestrator registry |
+| `assistant/src/calls/call-constants.ts` | Configuration constants: MAX_CALL_DURATION_MS (12 min), USER_CONSULTATION_TIMEOUT_MS (90 s), SILENCE_TIMEOUT_MS (30 s), denied emergency numbers |
+| `assistant/src/calls/voice-provider.ts` | Abstract VoiceProvider interface for provider-agnostic call initiation |
+| `assistant/src/calls/twilio-config.ts` | Twilio credential and configuration resolution from secure key store and environment |
+| `assistant/src/calls/types.ts` | TypeScript type definitions: CallSession, CallEvent, CallPendingQuestion, CallStatus, CallEventType |
+
+### New SQLite Tables
+
+All three tables live in `~/.vellum/workspace/data/db/assistant.db` alongside existing tables:
+
+- **`call_sessions`** — One row per outgoing call. Tracks conversation association, provider info (Twilio CallSid), phone numbers, task description, status lifecycle (`initiated` -> `ringing` -> `in_progress` -> `waiting_on_user` -> `completed`/`failed`), and timestamps. Foreign key to `conversations(id)` with cascade delete.
+
+- **`call_events`** — Append-only event log for each call session. Event types include `call_started`, `call_connected`, `caller_spoke`, `assistant_spoke`, `user_question_asked`, `user_answered`, `call_ended`, `call_failed`. Each event carries a JSON payload. Foreign key to `call_sessions(id)` with cascade delete.
+
+- **`call_pending_questions`** — Tracks questions the AI asks the user during a call (via the `[ASK_USER: ...]` pattern). Status lifecycle: `pending` -> `answered`/`expired`/`cancelled`. Foreign key to `call_sessions(id)` with cascade delete.
+
+### New HTTP Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/calls/voice-webhook` | Twilio voice webhook; returns TwiML with ConversationRelay connect |
+| POST | `/v1/calls/status-callback` | Twilio status callback (ringing, in-progress, completed, failed) |
+| POST | `/v1/calls/connect-action` | TwiML connect action callback when ConversationRelay ends |
+| POST | `/v1/calls/:callSessionId/answer` | User answers a pending question from the chat UI |
+| WS | `/v1/calls/relay` | ConversationRelay WebSocket (bidirectional: prompt/interrupt/dtmf from Twilio, text tokens/end to Twilio) |
+
+### New Tools
+
+| Tool | Description |
+|------|-------------|
+| `call_start` | Initiates an outgoing phone call to a specified number with an optional task description |
+| `call_status` | Retrieves the current status of a call session |
+| `call_end` | Terminates an active call |
+
+### Control Markers
+
+The CallOrchestrator detects two special markers in the LLM's response text:
+
+- **`[ASK_USER: question]`** — The AI needs to consult the user. The orchestrator creates a pending question, notifies the session via `fireCallQuestionNotifier`, puts the caller on hold, and waits up to 90 seconds for a user answer.
+- **`[END_CALL]`** — The AI has determined the call's purpose is fulfilled. The orchestrator sends a goodbye, closes the ConversationRelay session, and marks the call as completed.
+
+Both markers are stripped from the TTS output so the callee never hears the raw control text.
+
+---
+
 ## Storage Summary
 
 | What | Where | Format | ORM/Driver | Retention |
@@ -3198,4 +3318,6 @@ The avatar evolves during onboarding based on conversation and identity choices.
 | Proxy CA cert + key | `{dataDir}/proxy-ca/` | PEM files (ca.pem, ca-key.pem) | openssl CLI | Permanent (10-year validity) |
 | Proxy leaf certs | `{dataDir}/proxy-ca/issued/` | PEM files per hostname | openssl CLI, cached | 1-year validity, re-issued on CA change |
 | Proxy sessions | In-memory (SessionManager) | Map<ProxySessionId, ManagedSession> | Manual lifecycle | Ephemeral; 5min idle timeout, cleared on shutdown |
+| Call sessions, events, pending questions | `~/.vellum/workspace/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent, cascade on session delete |
+| Active call orchestrators | In-memory (CallState) | Map<callSessionId, CallOrchestrator> | Manual lifecycle | Ephemeral; cleared on call end or destroy |
 | IPC transport | `~/.vellum/vellum.sock` | Unix domain socket | NWConnection (Swift) / Bun net | Ephemeral |

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -1,0 +1,333 @@
+import { describe, test, expect, beforeEach, afterAll, mock, type Mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EventEmitter } from 'node:events';
+
+const testDir = mkdtempSync(join(tmpdir(), 'call-orchestrator-test-'));
+
+// ── Platform + logger mocks (must come before any source imports) ────
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Config mock ─────────────────────────────────────────────────────
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({ apiKeys: { anthropic: 'test-key' } }),
+}));
+
+// ── Helpers for building mock streaming responses ───────────────────
+
+/**
+ * Creates a mock Anthropic stream object that emits 'text' events
+ * for each token and resolves `finalMessage()` with the full response.
+ */
+function createMockStream(tokens: string[]) {
+  const emitter = new EventEmitter();
+  const fullText = tokens.join('');
+
+  const stream = {
+    on: (event: string, handler: (...args: unknown[]) => void) => {
+      emitter.on(event, handler);
+      return stream;
+    },
+    finalMessage: () => {
+      // Emit tokens synchronously so the on('text') handler has fired
+      // before finalMessage resolves.
+      for (const token of tokens) {
+        emitter.emit('text', token);
+      }
+      return Promise.resolve({
+        content: [{ type: 'text', text: fullText }],
+      });
+    },
+  };
+
+  return stream;
+}
+
+// ── Anthropic SDK mock ──────────────────────────────────────────────
+
+let mockStreamFn: Mock<(...args: unknown[]) => unknown>;
+
+mock.module('@anthropic-ai/sdk', () => {
+  mockStreamFn = mock((..._args: unknown[]) => createMockStream(['Hello', ' there']));
+  return {
+    default: class MockAnthropic {
+      messages = {
+        stream: (...args: unknown[]) => mockStreamFn(...args),
+      };
+    },
+  };
+});
+
+// ── Import source modules after all mocks are registered ────────────
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import {
+  createCallSession,
+  getCallSession,
+  updateCallSession,
+  recordCallEvent,
+  createPendingQuestion,
+  getPendingQuestion,
+} from '../calls/call-store.js';
+import {
+  registerCallOrchestrator,
+  unregisterCallOrchestrator,
+  getCallOrchestrator,
+} from '../calls/call-state.js';
+import { CallOrchestrator } from '../calls/call-orchestrator.js';
+import type { RelayConnection } from '../calls/relay-server.js';
+
+initializeDb();
+
+afterAll(() => {
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ── RelayConnection mock factory ────────────────────────────────────
+
+interface MockRelay extends RelayConnection {
+  sentTokens: Array<{ token: string; last: boolean }>;
+  endCalled: boolean;
+  endReason: string | undefined;
+}
+
+function createMockRelay(): MockRelay {
+  const state = {
+    sentTokens: [] as Array<{ token: string; last: boolean }>,
+    _endCalled: false,
+    _endReason: undefined as string | undefined,
+  };
+
+  return {
+    get sentTokens() { return state.sentTokens; },
+    get endCalled() { return state._endCalled; },
+    get endReason() { return state._endReason; },
+    sendTextToken(token: string, last: boolean) {
+      state.sentTokens.push({ token, last });
+    },
+    endSession(reason?: string) {
+      state._endCalled = true;
+      state._endReason = reason;
+    },
+  } as unknown as MockRelay;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+let ensuredConvIds = new Set<string>();
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+/**
+ * Create a call session and an orchestrator wired to a mock relay.
+ */
+function setupOrchestrator(task?: string) {
+  ensureConversation('conv-orch-test');
+  const session = createCallSession({
+    conversationId: 'conv-orch-test',
+    provider: 'twilio',
+    fromNumber: '+15551111111',
+    toNumber: '+15552222222',
+    task,
+  });
+  const relay = createMockRelay();
+  const orchestrator = new CallOrchestrator(session.id, relay as unknown as RelayConnection, task ?? null);
+  return { session, relay, orchestrator };
+}
+
+describe('call-orchestrator', () => {
+  beforeEach(() => {
+    resetTables();
+    // Reset the stream mock to default behaviour
+    mockStreamFn.mockImplementation(() => createMockStream(['Hello', ' there']));
+  });
+
+  // ── handleCallerUtterance ─────────────────────────────────────────
+
+  test('handleCallerUtterance: streams tokens via sendTextToken', async () => {
+    mockStreamFn.mockImplementation(() => createMockStream(['Hi', ', how', ' are you?']));
+    const { relay, orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleCallerUtterance('Hello');
+
+    // Verify tokens were sent to the relay
+    const nonEmptyTokens = relay.sentTokens.filter((t) => t.token.length > 0);
+    expect(nonEmptyTokens.length).toBeGreaterThan(0);
+    // The last token should have last=true (empty string token signaling end)
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken.last).toBe(true);
+
+    orchestrator.destroy();
+  });
+
+  test('handleCallerUtterance: sends last=true at end of turn', async () => {
+    mockStreamFn.mockImplementation(() => createMockStream(['Simple response.']));
+    const { relay, orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleCallerUtterance('Test');
+
+    // Find the final empty-string token that marks end of turn
+    const endMarkers = relay.sentTokens.filter((t) => t.last === true);
+    expect(endMarkers.length).toBeGreaterThanOrEqual(1);
+
+    orchestrator.destroy();
+  });
+
+  // ── ASK_USER pattern ──────────────────────────────────────────────
+
+  test('ASK_USER pattern: detects pattern, creates pending question, enters waiting_on_user', async () => {
+    mockStreamFn.mockImplementation(() =>
+      createMockStream(['Let me check on that. ', '[ASK_USER: What date works best?]']),
+    );
+    const { session, relay, orchestrator } = setupOrchestrator('Book appointment');
+
+    await orchestrator.handleCallerUtterance('I need to schedule something');
+
+    // Verify a pending question was created
+    const question = getPendingQuestion(session.id);
+    expect(question).not.toBeNull();
+    expect(question!.questionText).toBe('What date works best?');
+    expect(question!.status).toBe('pending');
+
+    // Verify session status was updated to waiting_on_user
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe('waiting_on_user');
+
+    // The ASK_USER marker text should NOT appear in the relay tokens
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).not.toContain('[ASK_USER:');
+
+    orchestrator.destroy();
+  });
+
+  // ── END_CALL pattern ──────────────────────────────────────────────
+
+  test('END_CALL pattern: detects marker, calls endSession, updates status to completed', async () => {
+    mockStreamFn.mockImplementation(() =>
+      createMockStream(['Thank you for calling, goodbye! ', '[END_CALL]']),
+    );
+    const { session, relay, orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleCallerUtterance('That is all, thanks');
+
+    // endSession should have been called
+    expect(relay.endCalled).toBe(true);
+
+    // Session status should be completed
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe('completed');
+    expect(updatedSession!.endedAt).not.toBeNull();
+
+    // The END_CALL marker text should NOT appear in the relay tokens
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).not.toContain('[END_CALL]');
+
+    orchestrator.destroy();
+  });
+
+  // ── handleUserAnswer ──────────────────────────────────────────────
+
+  test('handleUserAnswer: appends USER_ANSWERED to history and runs LLM', async () => {
+    // First utterance triggers ASK_USER
+    mockStreamFn.mockImplementation(() =>
+      createMockStream(['Hold on. [ASK_USER: Preferred time?]']),
+    );
+    const { session, relay, orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleCallerUtterance('I need an appointment');
+
+    // Now provide the answer — reset mock for second LLM call
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      // Verify the messages include the USER_ANSWERED marker
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      const lastUserMsg = firstArg.messages.filter((m: { role: string }) => m.role === 'user').pop();
+      expect(lastUserMsg?.content).toContain('[USER_ANSWERED: 3pm tomorrow]');
+      return createMockStream(['Great, I have scheduled for 3pm tomorrow.']);
+    });
+
+    await orchestrator.handleUserAnswer('3pm tomorrow');
+
+    // Should have streamed a response for the answer
+    const tokensAfterAnswer = relay.sentTokens.filter((t) => t.token.includes('3pm'));
+    expect(tokensAfterAnswer.length).toBeGreaterThan(0);
+
+    orchestrator.destroy();
+  });
+
+  // ── handleInterrupt ───────────────────────────────────────────────
+
+  test('handleInterrupt: resets state to idle', () => {
+    const { orchestrator } = setupOrchestrator();
+
+    // Calling handleInterrupt should not throw
+    orchestrator.handleInterrupt();
+
+    orchestrator.destroy();
+  });
+
+  // ── destroy ───────────────────────────────────────────────────────
+
+  test('destroy: unregisters orchestrator', () => {
+    const { session, orchestrator } = setupOrchestrator();
+
+    // Orchestrator should be registered
+    expect(getCallOrchestrator(session.id)).toBeDefined();
+
+    orchestrator.destroy();
+
+    // After destroy, orchestrator should be unregistered
+    expect(getCallOrchestrator(session.id)).toBeUndefined();
+  });
+
+  test('destroy: can be called multiple times without error', () => {
+    const { orchestrator } = setupOrchestrator();
+
+    orchestrator.destroy();
+    // Second destroy should not throw
+    expect(() => orchestrator.destroy()).not.toThrow();
+  });
+});

--- a/assistant/src/__tests__/call-state.test.ts
+++ b/assistant/src/__tests__/call-state.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  registerCallQuestionNotifier,
+  unregisterCallQuestionNotifier,
+  fireCallQuestionNotifier,
+  registerCallCompletionNotifier,
+  unregisterCallCompletionNotifier,
+  fireCallCompletionNotifier,
+  registerCallOrchestrator,
+  unregisterCallOrchestrator,
+  getCallOrchestrator,
+} from '../calls/call-state.js';
+import type { CallOrchestrator } from '../calls/call-orchestrator.js';
+
+describe('call-state', () => {
+  // Clean up notifiers between tests
+  beforeEach(() => {
+    unregisterCallQuestionNotifier('test-conv');
+    unregisterCallCompletionNotifier('test-conv');
+    unregisterCallOrchestrator('test-session');
+  });
+
+  // ── Question notifiers ────────────────────────────────────────────
+
+  test('registerCallQuestionNotifier + fireCallQuestionNotifier: callback receives args', () => {
+    let receivedSessionId = '';
+    let receivedQuestion = '';
+
+    registerCallQuestionNotifier('test-conv', (callSessionId, question) => {
+      receivedSessionId = callSessionId;
+      receivedQuestion = question;
+    });
+
+    fireCallQuestionNotifier('test-conv', 'session-123', 'What is the date?');
+
+    expect(receivedSessionId).toBe('session-123');
+    expect(receivedQuestion).toBe('What is the date?');
+  });
+
+  test('unregisterCallQuestionNotifier: fire after unregister does nothing', () => {
+    let called = false;
+
+    registerCallQuestionNotifier('test-conv', () => {
+      called = true;
+    });
+
+    unregisterCallQuestionNotifier('test-conv');
+    fireCallQuestionNotifier('test-conv', 'session-123', 'Some question');
+
+    expect(called).toBe(false);
+  });
+
+  test('fireCallQuestionNotifier does nothing when no notifier is registered', () => {
+    // Should not throw
+    fireCallQuestionNotifier('unregistered-conv', 'session-1', 'question');
+  });
+
+  // ── Completion notifiers ──────────────────────────────────────────
+
+  test('registerCallCompletionNotifier + fireCallCompletionNotifier: callback receives callSessionId', () => {
+    let receivedSessionId = '';
+
+    registerCallCompletionNotifier('test-conv', (callSessionId) => {
+      receivedSessionId = callSessionId;
+    });
+
+    fireCallCompletionNotifier('test-conv', 'session-456');
+
+    expect(receivedSessionId).toBe('session-456');
+  });
+
+  test('unregisterCallCompletionNotifier: fire after unregister does nothing', () => {
+    let called = false;
+
+    registerCallCompletionNotifier('test-conv', () => {
+      called = true;
+    });
+
+    unregisterCallCompletionNotifier('test-conv');
+    fireCallCompletionNotifier('test-conv', 'session-456');
+
+    expect(called).toBe(false);
+  });
+
+  test('fireCallCompletionNotifier does nothing when no notifier is registered', () => {
+    // Should not throw
+    fireCallCompletionNotifier('unregistered-conv', 'session-1');
+  });
+
+  // ── Orchestrator registry ─────────────────────────────────────────
+
+  test('registerCallOrchestrator + getCallOrchestrator: retrieves orchestrator', () => {
+    const fakeOrchestrator = { id: 'fake-orch' } as unknown as CallOrchestrator;
+
+    registerCallOrchestrator('test-session', fakeOrchestrator);
+
+    const retrieved = getCallOrchestrator('test-session');
+    expect(retrieved).toBe(fakeOrchestrator);
+  });
+
+  test('unregisterCallOrchestrator: getCallOrchestrator returns undefined after unregister', () => {
+    const fakeOrchestrator = { id: 'fake-orch-2' } as unknown as CallOrchestrator;
+
+    registerCallOrchestrator('test-session', fakeOrchestrator);
+    unregisterCallOrchestrator('test-session');
+
+    const retrieved = getCallOrchestrator('test-session');
+    expect(retrieved).toBeUndefined();
+  });
+
+  test('getCallOrchestrator returns undefined for unregistered session', () => {
+    const retrieved = getCallOrchestrator('nonexistent-session');
+    expect(retrieved).toBeUndefined();
+  });
+
+  test('registering a new orchestrator for same session overwrites the previous one', () => {
+    const first = { id: 'first' } as unknown as CallOrchestrator;
+    const second = { id: 'second' } as unknown as CallOrchestrator;
+
+    registerCallOrchestrator('test-session', first);
+    registerCallOrchestrator('test-session', second);
+
+    const retrieved = getCallOrchestrator('test-session');
+    expect(retrieved).toBe(second);
+  });
+});

--- a/assistant/src/__tests__/call-store.test.ts
+++ b/assistant/src/__tests__/call-store.test.ts
@@ -1,0 +1,478 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'call-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import {
+  createCallSession,
+  getCallSession,
+  getCallSessionByCallSid,
+  getActiveCallSessionForConversation,
+  updateCallSession,
+  recordCallEvent,
+  getCallEvents,
+  createPendingQuestion,
+  getPendingQuestion,
+  answerPendingQuestion,
+  expirePendingQuestions,
+} from '../calls/call-store.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+/** Ensure a conversation row exists for the given ID so FK constraints pass. */
+let ensuredConvIds = new Set<string>();
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+/** Wrapper that ensures the FK conversation row exists before creating a session. */
+function createTestCallSession(opts: Parameters<typeof createCallSession>[0]) {
+  ensureConversation(opts.conversationId);
+  return createCallSession(opts);
+}
+
+describe('call-store', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  // ── Call Sessions ─────────────────────────────────────────────────
+
+  test('createCallSession creates a session with correct defaults', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-1',
+      provider: 'twilio',
+      fromNumber: '+15551234567',
+      toNumber: '+15559876543',
+      task: 'Book appointment',
+    });
+
+    expect(session.id).toBeDefined();
+    expect(session.conversationId).toBe('conv-1');
+    expect(session.provider).toBe('twilio');
+    expect(session.fromNumber).toBe('+15551234567');
+    expect(session.toNumber).toBe('+15559876543');
+    expect(session.task).toBe('Book appointment');
+    expect(session.status).toBe('initiated');
+    expect(session.providerCallSid).toBeNull();
+    expect(session.startedAt).toBeNull();
+    expect(session.endedAt).toBeNull();
+    expect(session.lastError).toBeNull();
+    expect(typeof session.createdAt).toBe('number');
+    expect(typeof session.updatedAt).toBe('number');
+  });
+
+  test('createCallSession defaults task to null when not provided', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-2',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    expect(session.task).toBeNull();
+  });
+
+  test('getCallSession retrieves by ID', () => {
+    const created = createTestCallSession({
+      conversationId: 'conv-3',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const retrieved = getCallSession(created.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.id).toBe(created.id);
+    expect(retrieved!.conversationId).toBe('conv-3');
+  });
+
+  test('getCallSession returns null for missing ID', () => {
+    const result = getCallSession('nonexistent-id');
+    expect(result).toBeNull();
+  });
+
+  test('getCallSessionByCallSid looks up by provider call SID', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-4',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    updateCallSession(session.id, { providerCallSid: 'CA_test_sid_123' });
+
+    const found = getCallSessionByCallSid('CA_test_sid_123');
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(session.id);
+    expect(found!.providerCallSid).toBe('CA_test_sid_123');
+  });
+
+  test('getCallSessionByCallSid returns null for unknown SID', () => {
+    const result = getCallSessionByCallSid('CA_unknown');
+    expect(result).toBeNull();
+  });
+
+  test('getActiveCallSessionForConversation finds non-terminal sessions', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-5',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const active = getActiveCallSessionForConversation('conv-5');
+    expect(active).not.toBeNull();
+    expect(active!.id).toBe(session.id);
+  });
+
+  test('getActiveCallSessionForConversation returns null when all sessions are completed', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-6',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    updateCallSession(session.id, { status: 'completed' });
+
+    const active = getActiveCallSessionForConversation('conv-6');
+    expect(active).toBeNull();
+  });
+
+  test('getActiveCallSessionForConversation returns null when all sessions are failed', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-7',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    updateCallSession(session.id, { status: 'failed' });
+
+    const active = getActiveCallSessionForConversation('conv-7');
+    expect(active).toBeNull();
+  });
+
+  test('getActiveCallSessionForConversation returns most recent active session', () => {
+    // Create two sessions for the same conversation
+    const older = createTestCallSession({
+      conversationId: 'conv-8',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    // Mark older as completed
+    updateCallSession(older.id, { status: 'completed' });
+
+    const newer = createTestCallSession({
+      conversationId: 'conv-8',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15553333333',
+    });
+
+    const active = getActiveCallSessionForConversation('conv-8');
+    expect(active).not.toBeNull();
+    expect(active!.id).toBe(newer.id);
+  });
+
+  test('updateCallSession updates status, providerCallSid, and timestamps', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-9',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const now = Date.now();
+    updateCallSession(session.id, {
+      status: 'in_progress',
+      providerCallSid: 'CA_updated_sid',
+      startedAt: now,
+    });
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('in_progress');
+    expect(updated!.providerCallSid).toBe('CA_updated_sid');
+    expect(updated!.startedAt).toBe(now);
+    // updatedAt should be updated
+    expect(updated!.updatedAt).toBeGreaterThanOrEqual(session.updatedAt);
+  });
+
+  test('updateCallSession sets endedAt and lastError', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-10',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const endTime = Date.now();
+    updateCallSession(session.id, {
+      status: 'failed',
+      endedAt: endTime,
+      lastError: 'Network timeout',
+    });
+
+    const updated = getCallSession(session.id);
+    expect(updated!.status).toBe('failed');
+    expect(updated!.endedAt).toBe(endTime);
+    expect(updated!.lastError).toBe('Network timeout');
+  });
+
+  // ── Call Events ───────────────────────────────────────────────────
+
+  test('recordCallEvent creates events with correct fields', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-11',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const event = recordCallEvent(session.id, 'call_started', { twilioStatus: 'initiated' });
+
+    expect(event.id).toBeDefined();
+    expect(event.callSessionId).toBe(session.id);
+    expect(event.eventType).toBe('call_started');
+    expect(typeof event.createdAt).toBe('number');
+  });
+
+  test('recordCallEvent stores JSON payload', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-12',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const payload = { text: 'Hello, how are you?', lang: 'en-US' };
+    const event = recordCallEvent(session.id, 'caller_spoke', payload);
+
+    const parsed = JSON.parse(event.payloadJson);
+    expect(parsed.text).toBe('Hello, how are you?');
+    expect(parsed.lang).toBe('en-US');
+  });
+
+  test('recordCallEvent defaults payload to empty JSON object', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-13',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const event = recordCallEvent(session.id, 'call_connected');
+
+    expect(event.payloadJson).toBe('{}');
+  });
+
+  test('getCallEvents retrieves events in creation order', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-14',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    recordCallEvent(session.id, 'call_started');
+    recordCallEvent(session.id, 'call_connected');
+    recordCallEvent(session.id, 'caller_spoke', { transcript: 'Hi' });
+
+    const events = getCallEvents(session.id);
+    expect(events).toHaveLength(3);
+    expect(events[0].eventType).toBe('call_started');
+    expect(events[1].eventType).toBe('call_connected');
+    expect(events[2].eventType).toBe('caller_spoke');
+    // Should be in ascending creation order
+    expect(events[0].createdAt).toBeLessThanOrEqual(events[1].createdAt);
+    expect(events[1].createdAt).toBeLessThanOrEqual(events[2].createdAt);
+  });
+
+  test('getCallEvents returns empty array for session with no events', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-15',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const events = getCallEvents(session.id);
+    expect(events).toHaveLength(0);
+  });
+
+  // ── Pending Questions ─────────────────────────────────────────────
+
+  test('createPendingQuestion creates with status pending', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-16',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const question = createPendingQuestion(session.id, 'What is your preferred date?');
+
+    expect(question.id).toBeDefined();
+    expect(question.callSessionId).toBe(session.id);
+    expect(question.questionText).toBe('What is your preferred date?');
+    expect(question.status).toBe('pending');
+    expect(typeof question.askedAt).toBe('number');
+    expect(question.answeredAt).toBeNull();
+    expect(question.answerText).toBeNull();
+  });
+
+  test('getPendingQuestion finds pending question for session', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-17',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const created = createPendingQuestion(session.id, 'What is your name?');
+
+    const found = getPendingQuestion(session.id);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(created.id);
+    expect(found!.questionText).toBe('What is your name?');
+    expect(found!.status).toBe('pending');
+  });
+
+  test('getPendingQuestion returns null when no pending questions', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-18',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const found = getPendingQuestion(session.id);
+    expect(found).toBeNull();
+  });
+
+  test('answerPendingQuestion updates status to answered', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-19',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const question = createPendingQuestion(session.id, 'What color?');
+    answerPendingQuestion(question.id, 'Blue');
+
+    // Should no longer appear as pending
+    const pending = getPendingQuestion(session.id);
+    expect(pending).toBeNull();
+
+    // Verify the record was updated by querying directly
+    const db = getDb();
+    const row = db.run('SELECT * FROM call_pending_questions WHERE id = ?', question.id);
+    // Check via a fresh query
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const updated = raw.query('SELECT * FROM call_pending_questions WHERE id = ?').get(question.id) as {
+      status: string;
+      answer_text: string;
+      answered_at: number;
+    };
+    expect(updated.status).toBe('answered');
+    expect(updated.answer_text).toBe('Blue');
+    expect(typeof updated.answered_at).toBe('number');
+  });
+
+  test('expirePendingQuestions marks all pending questions as expired', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-20',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    createPendingQuestion(session.id, 'Question 1');
+    createPendingQuestion(session.id, 'Question 2');
+
+    expirePendingQuestions(session.id);
+
+    // No more pending questions
+    const pending = getPendingQuestion(session.id);
+    expect(pending).toBeNull();
+
+    // Verify both were expired
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const rows = raw.query('SELECT status FROM call_pending_questions WHERE call_session_id = ?').all(session.id) as Array<{ status: string }>;
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.status).toBe('expired');
+    }
+  });
+
+  test('expirePendingQuestions does not affect already-answered questions', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-21',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const q1 = createPendingQuestion(session.id, 'Question 1');
+    createPendingQuestion(session.id, 'Question 2');
+
+    // Answer q1 first
+    answerPendingQuestion(q1.id, 'Answer 1');
+
+    // Then expire all pending
+    expirePendingQuestions(session.id);
+
+    // q1 should still be answered, not expired
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const q1Row = raw.query('SELECT status FROM call_pending_questions WHERE id = ?').get(q1.id) as { status: string };
+    expect(q1Row.status).toBe('answered');
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for the Calls subsystem: call-store (23 tests), call-state (10 tests), call-orchestrator (8 tests)
- Add architecture documentation section for the Outgoing AI Phone Calls feature (Twilio ConversationRelay)
- Tests cover CRUD operations, notifier pattern, LLM-driven orchestration with ASK_USER/END_CALL control markers
- Architecture section includes mermaid sequence diagram, component table, SQLite tables, HTTP endpoints, tools, and control markers

## Test plan
- [x] call-store.test.ts: 23 tests pass (session CRUD, event recording, pending question lifecycle)
- [x] call-state.test.ts: 10 tests pass (question/completion notifiers, orchestrator registry)
- [x] call-orchestrator.test.ts: 8 tests pass (utterance handling, ASK_USER, END_CALL, interrupt, destroy)
- [x] ARCHITECTURE.md updated with Calls subsystem section and storage summary entries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
