### PR TITLE
M2: Config completeness + git timeout wiring

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -496,6 +496,55 @@ describe('AssistantConfigSchema', () => {
       expect(msgs.some(m => m.includes('permissions.mode'))).toBe(true);
     }
   });
+
+  test('applies workspaceGit defaults including interactiveGitTimeoutMs', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.workspaceGit).toEqual({
+      turnCommitMaxWaitMs: 4000,
+      failureBackoffBaseMs: 2000,
+      failureBackoffMaxMs: 60000,
+      interactiveGitTimeoutMs: 10000,
+      enrichmentQueueSize: 50,
+      enrichmentConcurrency: 1,
+      enrichmentJobTimeoutMs: 30000,
+      enrichmentMaxRetries: 2,
+    });
+  });
+
+  test('accepts custom workspaceGit.interactiveGitTimeoutMs', () => {
+    const result = AssistantConfigSchema.parse({
+      workspaceGit: { interactiveGitTimeoutMs: 5000 },
+    });
+    expect(result.workspaceGit.interactiveGitTimeoutMs).toBe(5000);
+    // Other fields should still get defaults
+    expect(result.workspaceGit.turnCommitMaxWaitMs).toBe(4000);
+  });
+
+  test('rejects non-positive workspaceGit.interactiveGitTimeoutMs', () => {
+    const zeroResult = AssistantConfigSchema.safeParse({
+      workspaceGit: { interactiveGitTimeoutMs: 0 },
+    });
+    expect(zeroResult.success).toBe(false);
+
+    const negativeResult = AssistantConfigSchema.safeParse({
+      workspaceGit: { interactiveGitTimeoutMs: -1 },
+    });
+    expect(negativeResult.success).toBe(false);
+  });
+
+  test('rejects non-integer workspaceGit.interactiveGitTimeoutMs', () => {
+    const result = AssistantConfigSchema.safeParse({
+      workspaceGit: { interactiveGitTimeoutMs: 3.5 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects non-number workspaceGit.interactiveGitTimeoutMs', () => {
+    const result = AssistantConfigSchema.safeParse({
+      workspaceGit: { interactiveGitTimeoutMs: 'fast' },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -184,4 +184,14 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     install: { nodeManager: 'npm' },
     allowBundled: null,
   },
+  workspaceGit: {
+    turnCommitMaxWaitMs: 4000,
+    failureBackoffBaseMs: 2000,
+    failureBackoffMaxMs: 60000,
+    interactiveGitTimeoutMs: 10000,
+    enrichmentQueueSize: 50,
+    enrichmentConcurrency: 1,
+    enrichmentJobTimeoutMs: 30000,
+    enrichmentMaxRetries: 2,
+  },
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -719,6 +719,11 @@ export const WorkspaceGitConfigSchema = z.object({
     .int('workspaceGit.failureBackoffMaxMs must be an integer')
     .positive('workspaceGit.failureBackoffMaxMs must be a positive integer')
     .default(60000),
+  interactiveGitTimeoutMs: z
+    .number({ error: 'workspaceGit.interactiveGitTimeoutMs must be a number' })
+    .int('workspaceGit.interactiveGitTimeoutMs must be an integer')
+    .positive('workspaceGit.interactiveGitTimeoutMs must be a positive integer')
+    .default(10000),
   enrichmentQueueSize: z
     .number({ error: 'workspaceGit.enrichmentQueueSize must be a number' })
     .int('workspaceGit.enrichmentQueueSize must be an integer')
@@ -992,6 +997,7 @@ export const AssistantConfigSchema = z.object({
     turnCommitMaxWaitMs: 4000,
     failureBackoffBaseMs: 2000,
     failureBackoffMaxMs: 60000,
+    interactiveGitTimeoutMs: 10000,
     enrichmentQueueSize: 50,
     enrichmentConcurrency: 1,
     enrichmentJobTimeoutMs: 30000,

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -29,4 +29,5 @@ export type {
   SkillsInstallConfig,
   SwarmConfig,
   SkillsConfig,
+  WorkspaceGitConfig,
 } from './schema.js';

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -596,15 +596,19 @@ export class WorkspaceGitService {
 
   /**
    * Execute a git command in the workspace directory.
-   * Includes a 30-second timeout to prevent hung operations
-   * (e.g. stale git lock files).
+   * Uses the configurable interactiveGitTimeoutMs (default 10 000 ms) to
+   * prevent hung operations (e.g. stale git lock files). The timeout is
+   * intentionally short for interactive workspace operations — background
+   * enrichment jobs use their own dedicated timeout.
    */
   private async execGit(args: string[]): Promise<{ stdout: string; stderr: string }> {
     try {
+      const config = getConfig();
+      const timeoutMs = config.workspaceGit?.interactiveGitTimeoutMs ?? 10_000;
       const { stdout, stderr } = await execFileAsync('git', args, {
         cwd: this.workspaceDir,
         encoding: 'utf-8',
-        timeout: 30_000,
+        timeout: timeoutMs,
         env: cleanGitEnv(this.workspaceDir),
       });
       return { stdout, stderr };


### PR DESCRIPTION
## Summary

Part of #5236
Closes #5238

- Add workspaceGit.interactiveGitTimeoutMs config key (default 10000ms)
- Wire config to execGit replacing hardcoded timeout
- Ensure WorkspaceGitConfig types are exported consistently
- Add config schema tests for valid/invalid values and defaults

## Test plan
- bun test assistant/src/__tests__/config-schema.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
