### PR TITLE
fix: drain pending enrichment queue before awaiting in-flight on shutdown

### DIFF
--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -107,13 +107,10 @@ export class CommitEnrichmentService {
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
 
-    // Wait for any in-flight workers to finish first
-    if (this.inFlightPromises.size > 0) {
-      log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
-      await Promise.all(this.inFlightPromises);
-    }
-
-    // Now drain remaining queue items serially, respecting concurrency
+    // Drain pending queue items serially FIRST so they get a chance to run
+    // before the lifecycle force-exit timer fires. If we awaited in-flight
+    // jobs first, a slow/hung job could consume the entire grace period and
+    // pending jobs would never start.
     if (this.queue.length > 0) {
       log.info({ pending: this.queue.length }, 'Enrichment queue shutting down, draining pending jobs');
     }
@@ -125,6 +122,12 @@ export class CommitEnrichmentService {
       } finally {
         this.activeWorkers--;
       }
+    }
+
+    // Now wait for any in-flight workers that were already running
+    if (this.inFlightPromises.size > 0) {
+      log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
+      await Promise.all(this.inFlightPromises);
     }
 
     log.info(

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -383,12 +383,18 @@ export class WorkspaceGitService {
    *
    * @param decide - Called with the current status. Return an object with `message`
    *   (and optional `metadata`) to commit, or `null` to skip.
+   * @param options.bypassBreaker - Skip circuit breaker checks (used for shutdown commits).
+   * @param options.deadlineMs - Absolute timestamp (Date.now()) after which the commit
+   *   should be skipped. Checked before lock acquisition, after lock acquisition, and
+   *   before git add/commit to prevent stale queued attempts from doing expensive work.
    * @returns Whether a commit was created and the status at check time.
    */
   async commitIfDirty(
     decide: (status: GitStatus) => { message: string; metadata?: GitCommitMetadata } | null,
-    options?: { bypassBreaker?: boolean },
+    options?: { bypassBreaker?: boolean; deadlineMs?: number },
   ): Promise<{ committed: boolean; status: GitStatus }> {
+    const emptyStatus: GitStatus = { staged: [], modified: [], untracked: [], clean: false };
+
     // Circuit breaker: skip expensive git work if recent attempts have been failing.
     // Shutdown commits bypass the breaker because the process is about to exit and
     // this is the last chance to persist workspace state.
@@ -397,13 +403,43 @@ export class WorkspaceGitService {
         { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures },
         'Circuit breaker open, skipping commit attempt',
       );
-      return { committed: false, status: { staged: [], modified: [], untracked: [], clean: false } };
+      return { committed: false, status: emptyStatus };
+    }
+
+    // Deadline fast-path: bail before acquiring the lock if already past deadline.
+    if (isDeadlineExpired(options?.deadlineMs)) {
+      log.debug(
+        { workspaceDir: this.workspaceDir },
+        'Deadline expired before lock acquisition, skipping commit',
+      );
+      return { committed: false, status: emptyStatus };
     }
 
     await this.ensureInitialized();
 
     try {
       const result = await this.mutex.withLock(async () => {
+        // Re-check breaker under lock: a queued call that started before the
+        // breaker opened should not proceed with expensive git work now that
+        // the breaker is open.
+        if (!options?.bypassBreaker && this.isBreakerOpen()) {
+          log.debug(
+            { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures },
+            'Circuit breaker open after lock acquisition, skipping commit',
+          );
+          return { committed: false, status: emptyStatus };
+        }
+
+        // Re-check deadline after lock acquisition: the call may have waited
+        // in the mutex queue past its deadline.
+        if (isDeadlineExpired(options?.deadlineMs)) {
+          log.debug(
+            { workspaceDir: this.workspaceDir },
+            'Deadline expired after lock acquisition, skipping commit',
+          );
+          return { committed: false, status: emptyStatus };
+        }
+
         const status = await this.getStatusInternal();
         if (status.clean) {
           return { committed: false, status };
@@ -411,6 +447,15 @@ export class WorkspaceGitService {
 
         const decision = decide(status);
         if (!decision) {
+          return { committed: false, status };
+        }
+
+        // Check deadline before expensive git add/commit operations.
+        if (isDeadlineExpired(options?.deadlineMs)) {
+          log.debug(
+            { workspaceDir: this.workspaceDir },
+            'Deadline expired before git add/commit, skipping commit',
+          );
           return { committed: false, status };
         }
 
@@ -662,6 +707,14 @@ export class WorkspaceGitService {
   getWorkspaceDir(): string {
     return this.workspaceDir;
   }
+}
+
+/**
+ * Check whether a deadline has expired.
+ * Returns true when `deadlineMs` is provided and `Date.now()` has reached or passed it.
+ */
+export function isDeadlineExpired(deadlineMs?: number): boolean {
+  return deadlineMs !== undefined && Date.now() >= deadlineMs;
 }
 
 /**

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -44,12 +44,14 @@ export interface TurnCommitMetadata {
  * @param sessionId - Session/conversation identifier
  * @param turnNumber - 1-based turn number within the session
  * @param provider - Optional commit message provider (defaults to deterministic)
+ * @param deadlineMs - Optional absolute deadline (Date.now()) after which the commit should be skipped
  */
 export async function commitTurnChanges(
   workspaceDir: string,
   sessionId: string,
   turnNumber: number,
   provider?: CommitMessageProvider,
+  deadlineMs?: number,
 ): Promise<void> {
   const messageProvider = provider ?? new DefaultCommitMessageProvider();
   try {
@@ -71,7 +73,7 @@ export async function commitTurnChanges(
       };
 
       return messageProvider.buildImmediateMessage(ctx);
-    });
+    }, deadlineMs !== undefined ? { deadlineMs } : undefined);
 
     const commitDurationMs = Date.now() - commitStartMs;
 


### PR DESCRIPTION
Addresses Codex P1 feedback on #5231: reversed shutdown ordering so pending jobs are drained serially before awaiting in-flight promises, preventing job loss when lifecycle force-exits.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
