### PR TITLE
fix: remove unused imports and isolate DoorDash session tests

### DIFF
--- a/assistant/src/__tests__/doordash-session.test.ts
+++ b/assistant/src/__tests__/doordash-session.test.ts
@@ -3,9 +3,6 @@ import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
-  loadSession,
-  saveSession,
-  clearSession,
   importFromRecording,
   getCookieHeader,
   getCsrfToken,
@@ -87,11 +84,19 @@ describe('DoorDash session persistence', () => {
   let originalDataDir: string | undefined;
 
   beforeEach(() => {
+    originalDataDir = process.env.BASE_DATA_DIR;
+    process.env.BASE_DATA_DIR = TEST_DIR;
     // Ensure test dir exists
     mkdirSync(TEST_DIR, { recursive: true });
   });
 
   afterEach(() => {
+    // Restore original BASE_DATA_DIR
+    if (originalDataDir === undefined) {
+      delete process.env.BASE_DATA_DIR;
+    } else {
+      process.env.BASE_DATA_DIR = originalDataDir;
+    }
     // Clean up test dir
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true, force: true });


### PR DESCRIPTION
Addresses feedback from PR #5067. Removes unused loadSession/saveSession/clearSession imports that would fail CI lint, and sets BASE_DATA_DIR to a temp directory to prevent tests from writing to the real ~/.vellum/ path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
