### PR TITLE
fix: clear stale pending IDs on QUEUE_FULL session errors

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1073,6 +1073,17 @@ extension ChatViewModel {
             } else {
                 // Always clear sending state so regenerate is unblocked.
                 isSending = false
+                // When QUEUE_FULL, the daemon rejected the message that
+                // triggered the error — no message_queued will arrive for it.
+                // Remove its stale pending ID (the last one appended) so
+                // subsequent message_queued/message_dequeued events don't
+                // mis-correlate to the wrong user message.
+                if msg.code == .queueFull, let rejectedId = pendingMessageIds.last {
+                    pendingMessageIds.removeLast()
+                    if let index = messages.firstIndex(where: { $0.id == rejectedId }) {
+                        messages[index].status = .sent
+                    }
+                }
                 if pendingQueuedCount == 0 {
                     // No queued work remains — safe to tear down everything.
                     pendingMessageIds = []


### PR DESCRIPTION
Addresses feedback from PR #5054. When the daemon rejects a message (QUEUE_FULL), the stale pending ID is now removed to prevent mis-correlation of subsequent message_queued/message_dequeued events.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
