### PR TITLE
M3: Enrichment shutdown policy + missing behavior tests + docs alignment

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -85,44 +85,29 @@ describe('CommitEnrichmentService', () => {
   test('queue overflow drops oldest job', async () => {
     const service = new CommitEnrichmentService({
       maxQueueSize: 2,
-      maxConcurrency: 0, // 0 concurrency means nothing processes, for testing queue behavior
-      jobTimeoutMs: 5000,
-      maxRetries: 0,
-    });
-
-    // Override concurrency so nothing actually runs
-    // We want to test queue overflow behavior only
-    const hash1 = await createCommit();
-    const hash2 = await createCommit();
-    const hash3 = await createCommit();
-
-    // With maxConcurrency 0, nothing will process; but let's use 1 and block processing
-    // Instead, use a service with concurrency 1 but fill the queue faster than it drains
-    const service2 = new CommitEnrichmentService({
-      maxQueueSize: 2,
       maxConcurrency: 1,
       jobTimeoutMs: 30000,
       maxRetries: 0,
     });
 
-    // Enqueue 3 jobs — the first starts immediately (active worker),
-    // second goes to queue, third overflows and drops the second
-    service2.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
-    service2.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
-    service2.enqueue({ workspaceDir: testDir, commitHash: hash3, context: makeContext(), gitService });
+    const hash1 = await createCommit();
+    const hash2 = await createCommit();
+    const hash3 = await createCommit();
 
-    // The queue should have 2 items (hash2 and hash3 or hash3 depending on timing)
-    // But hash1 is being processed. Let's check dropped count.
-    // With maxQueueSize=2, after hash1 starts processing (active worker=1),
-    // hash2 goes to queue (size=1), hash3 goes to queue (size=2), no drop yet.
-    // Actually the first job is picked up immediately, so queue has 2 items max.
-    // Let's check dropped count after shutdown.
-    await service2.shutdown();
+    // Enqueue 3 jobs — hash1 starts immediately (active worker),
+    // hash2 goes to queue (size=1), hash3 goes to queue (size=2), no overflow drop.
+    service.enqueue({ workspaceDir: testDir, commitHash: hash1, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash2, context: makeContext(), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hash3, context: makeContext(), gitService });
 
-    // No drops expected since queue size 2 can hold 2 pending while 1 is active
-    expect(service2._getDroppedCount()).toBe(0);
+    // No overflow drops — queue size 2 can hold 2 pending while 1 is active
+    expect(service._getDroppedCount()).toBe(0);
+    expect(service._getQueueSize()).toBe(2);
 
+    // Shutdown discards the 2 pending jobs
     await service.shutdown();
+    expect(service._getDroppedCount()).toBe(2);
+    expect(service._getSucceededCount()).toBe(1);
   });
 
   test('queue overflow actually drops when truly full', async () => {
@@ -191,8 +176,60 @@ describe('CommitEnrichmentService', () => {
     // Shutdown should complete without hanging
     await service.shutdown();
 
-    // At least the first job should have completed (it was in-flight)
-    expect(service._getSucceededCount()).toBeGreaterThanOrEqual(1);
+    // The first job was in-flight and should complete. The second was pending
+    // and should be discarded, counted as dropped.
+    expect(service._getSucceededCount()).toBe(1);
+    expect(service._getDroppedCount()).toBe(1);
+    expect(service._getQueueSize()).toBe(0);
+  });
+
+  test('shutdown discards all pending jobs and counts them as dropped', async () => {
+    // Use maxConcurrency 1 so only one job starts processing; the rest stay pending.
+    const hashes: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      hashes.push(await createCommit());
+    }
+
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    for (const hash of hashes) {
+      service.enqueue({ workspaceDir: testDir, commitHash: hash, context: makeContext(), gitService });
+    }
+
+    // First job is in-flight, remaining 4 are pending
+    await service.shutdown();
+
+    // In-flight job completes, pending jobs are discarded
+    expect(service._getSucceededCount()).toBe(1);
+    expect(service._getDroppedCount()).toBe(4);
+  });
+
+  test('shutdown does not cause concurrency spike', async () => {
+    const hashes: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      hashes.push(await createCommit());
+    }
+
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    for (const hash of hashes) {
+      service.enqueue({ workspaceDir: testDir, commitHash: hash, context: makeContext(), gitService });
+    }
+
+    await service.shutdown();
+
+    // Active workers should be 0 after shutdown
+    expect(service._getActiveWorkers()).toBe(0);
   });
 
   test('discards jobs enqueued after shutdown', async () => {
@@ -259,5 +296,114 @@ describe('CommitEnrichmentService', () => {
     expect(note1.turnNumber).toBe(1);
     expect(note2.turnNumber).toBe(2);
     expect(service._getSucceededCount()).toBe(2);
+  });
+
+  test('job timeout triggers retry with backoff then fails after max retries', async () => {
+    // Use a very short timeout so the real git notes write times out
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 10,
+      maxConcurrency: 1,
+      jobTimeoutMs: 1, // 1ms timeout — will always time out
+      maxRetries: 2,
+    });
+
+    const commitHash = await createCommit();
+    service.enqueue({
+      workspaceDir: testDir,
+      commitHash,
+      context: makeContext(),
+      gitService,
+    });
+
+    // Wait for all retries to complete (initial + 2 retries, with backoff)
+    // Backoff: 1s after attempt 1, 2s after attempt 2 = ~3s total
+    // But since the job itself is very fast to time out, total time is dominated by backoff
+    while (service._getActiveWorkers() > 0 || service._getQueueSize() > 0) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    await service.shutdown();
+
+    // After 1 initial attempt + 2 retries (3 total), the job should be counted as failed
+    expect(service._getFailedCount()).toBe(1);
+    expect(service._getSucceededCount()).toBe(0);
+  }, 15000); // Allow up to 15s for backoff delays
+
+  test('queue overflow drop behavior is deterministic', async () => {
+    // With maxQueueSize=2 and maxConcurrency=1:
+    // - Job A starts processing immediately (in-flight)
+    // - Job B enters queue (size=1)
+    // - Job C enters queue (size=2)
+    // - Job D overflows: drops oldest (B), adds D → queue has [C, D]
+    // - Job E overflows: drops oldest (C), adds E → queue has [D, E]
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 2,
+      maxConcurrency: 1,
+      jobTimeoutMs: 30000,
+      maxRetries: 0,
+    });
+
+    const hashA = await createCommit();
+    const hashB = await createCommit();
+    const hashC = await createCommit();
+    const hashD = await createCommit();
+    const hashE = await createCommit();
+
+    service.enqueue({ workspaceDir: testDir, commitHash: hashA, context: makeContext({ turnNumber: 1 }), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hashB, context: makeContext({ turnNumber: 2 }), gitService });
+    service.enqueue({ workspaceDir: testDir, commitHash: hashC, context: makeContext({ turnNumber: 3 }), gitService });
+    // No drops yet: A is in-flight, B and C in queue (size=2)
+    expect(service._getDroppedCount()).toBe(0);
+
+    service.enqueue({ workspaceDir: testDir, commitHash: hashD, context: makeContext({ turnNumber: 4 }), gitService });
+    // Queue was full (2), so oldest (B) was dropped
+    expect(service._getDroppedCount()).toBe(1);
+
+    service.enqueue({ workspaceDir: testDir, commitHash: hashE, context: makeContext({ turnNumber: 5 }), gitService });
+    // Queue was full again (2), so oldest (C) was dropped
+    expect(service._getDroppedCount()).toBe(2);
+
+    // Queue should have exactly 2 items: D and E
+    expect(service._getQueueSize()).toBe(2);
+
+    await service.shutdown();
+
+    // A was in-flight and completed; D and E were pending and discarded at shutdown
+    expect(service._getSucceededCount()).toBe(1);
+    // 2 overflow drops + 2 shutdown discards = 4 total
+    expect(service._getDroppedCount()).toBe(4);
+  });
+
+  test('enqueue is fire-and-forget and never throws even when called rapidly', async () => {
+    const service = new CommitEnrichmentService({
+      maxQueueSize: 3,
+      maxConcurrency: 1,
+      jobTimeoutMs: 5000,
+      maxRetries: 0,
+    });
+
+    const hashes: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      hashes.push(await createCommit());
+    }
+
+    // Rapidly enqueue more jobs than the queue can hold — must never throw
+    const fn = () => {
+      for (const hash of hashes) {
+        service.enqueue({
+          workspaceDir: testDir,
+          commitHash: hash,
+          context: makeContext(),
+          gitService,
+        });
+      }
+    };
+
+    expect(fn).not.toThrow();
+
+    // Some jobs should have been dropped due to overflow (queue size 3, 1 in-flight)
+    // 5 jobs: 1 in-flight + 3 queue + 1 overflow = at least 1 drop
+    expect(service._getDroppedCount()).toBeGreaterThanOrEqual(1);
+
+    await service.shutdown();
   });
 });

--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { commitTurnChanges } from '../workspace/turn-commit.js';
 import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
+import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
 
 describe('commitTurnChanges', () => {
   let testDir: string;
@@ -215,5 +216,60 @@ describe('commitTurnChanges', () => {
       encoding: 'utf-8',
     });
     expect(turn1Msg).toContain('Turn: 1');
+  });
+
+  test('custom commit message provider output is used in commit', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    const customProvider: CommitMessageProvider = {
+      buildImmediateMessage(ctx: CommitContext): CommitMessageResult {
+        return {
+          message: `CUSTOM-TURN: session=${ctx.sessionId} turn=${ctx.turnNumber} files=${ctx.changedFiles.length}`,
+          metadata: { custom: true, provider: 'test-provider' },
+        };
+      },
+    };
+
+    writeFileSync(join(testDir, 'provider-test.txt'), 'provider test content');
+
+    await commitTurnChanges(testDir, 'sess_provider', 42, customProvider);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    // Verify the custom provider's message was used, not the default
+    expect(fullMessage).toContain('CUSTOM-TURN: session=sess_provider turn=42 files=1');
+    expect(fullMessage).toContain('custom: true');
+    expect(fullMessage).toContain('provider: "test-provider"');
+  });
+
+  test('custom provider metadata is included in commit message', async () => {
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    const customProvider: CommitMessageProvider = {
+      buildImmediateMessage(_ctx: CommitContext): CommitMessageResult {
+        return {
+          message: 'Minimal custom message',
+          metadata: { enriched: false, source: 'unit-test' },
+        };
+      },
+    };
+
+    writeFileSync(join(testDir, 'meta-test.txt'), 'metadata test');
+
+    await commitTurnChanges(testDir, 'sess_meta', 1, customProvider);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(fullMessage).toContain('Minimal custom message');
+    expect(fullMessage).toContain('enriched: false');
+    expect(fullMessage).toContain('source: "unit-test"');
   });
 });

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -11,6 +11,7 @@ import {
   HeartbeatService,
   _resetHeartbeatState,
 } from '../workspace/heartbeat-service.js';
+import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
 
 describe('HeartbeatService', () => {
   let testDir: string;
@@ -342,6 +343,134 @@ describe('HeartbeatService', () => {
       heartbeat.start(); // Idempotent
       await heartbeat.stop();
       await heartbeat.stop(); // Idempotent
+    });
+  });
+
+  describe('custom commit message provider', () => {
+    test('heartbeat commit uses custom provider message', async () => {
+      writeFileSync(join(testDir, 'file.txt'), 'content');
+
+      const customProvider: CommitMessageProvider = {
+        buildImmediateMessage(ctx: CommitContext): CommitMessageResult {
+          return {
+            message: `CUSTOM-HEARTBEAT: ${ctx.changedFiles.length} files via ${ctx.trigger}`,
+            metadata: { customProvider: true, trigger: ctx.trigger },
+          };
+        },
+      };
+
+      let currentTime = 1000000;
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 5 * 60 * 1000,
+        fileThreshold: 100,
+        getServices: () => services,
+        now: () => currentTime,
+        commitMessageProvider: customProvider,
+      });
+
+      // First check registers dirty state
+      await heartbeat.check();
+      // Advance time past threshold
+      currentTime += 6 * 60 * 1000;
+      // Second check commits
+      const result = await heartbeat.check();
+      expect(result.committed).toBe(1);
+
+      const commitMsg = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+      expect(commitMsg).toContain('CUSTOM-HEARTBEAT:');
+      expect(commitMsg).toContain('via heartbeat');
+      expect(commitMsg).toContain('customProvider: true');
+    });
+
+    test('shutdown commit uses custom provider message', async () => {
+      writeFileSync(join(testDir, 'unsaved.txt'), 'uncommitted content');
+
+      const customProvider: CommitMessageProvider = {
+        buildImmediateMessage(ctx: CommitContext): CommitMessageResult {
+          return {
+            message: `CUSTOM-SHUTDOWN: saving ${ctx.changedFiles.length} files`,
+            metadata: { shutdownProvider: true },
+          };
+        },
+      };
+
+      const heartbeat = new HeartbeatService({
+        getServices: () => services,
+        commitMessageProvider: customProvider,
+      });
+
+      const result = await heartbeat.commitAllPending();
+      expect(result.committed).toBe(1);
+
+      const commitMsg = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+      expect(commitMsg).toContain('CUSTOM-SHUTDOWN: saving');
+      expect(commitMsg).toContain('shutdownProvider: true');
+    });
+
+    test('custom provider receives correct context fields for heartbeat trigger', async () => {
+      writeFileSync(join(testDir, 'a.txt'), 'a');
+      writeFileSync(join(testDir, 'b.txt'), 'b');
+
+      let capturedCtx: CommitContext | null = null;
+      const customProvider: CommitMessageProvider = {
+        buildImmediateMessage(ctx: CommitContext): CommitMessageResult {
+          capturedCtx = ctx;
+          return { message: 'capture-context' };
+        },
+      };
+
+      let currentTime = 1000000;
+      const heartbeat = new HeartbeatService({
+        ageThresholdMs: 5 * 60 * 1000,
+        fileThreshold: 100,
+        getServices: () => services,
+        now: () => currentTime,
+        commitMessageProvider: customProvider,
+      });
+
+      // Register dirty state
+      await heartbeat.check();
+      // Advance past threshold
+      currentTime += 6 * 60 * 1000;
+      await heartbeat.check();
+
+      expect(capturedCtx).not.toBeNull();
+      expect(capturedCtx!.trigger).toBe('heartbeat');
+      expect(capturedCtx!.workspaceDir).toBe(testDir);
+      expect(capturedCtx!.changedFiles).toContain('a.txt');
+      expect(capturedCtx!.changedFiles).toContain('b.txt');
+      expect(capturedCtx!.timestampMs).toBe(currentTime);
+      expect(capturedCtx!.reason).toBeDefined();
+    });
+
+    test('custom provider receives correct context fields for shutdown trigger', async () => {
+      writeFileSync(join(testDir, 'shutdown-file.txt'), 'data');
+
+      let capturedCtx: CommitContext | null = null;
+      const customProvider: CommitMessageProvider = {
+        buildImmediateMessage(ctx: CommitContext): CommitMessageResult {
+          capturedCtx = ctx;
+          return { message: 'capture-shutdown-context' };
+        },
+      };
+
+      const heartbeat = new HeartbeatService({
+        getServices: () => services,
+        commitMessageProvider: customProvider,
+      });
+
+      await heartbeat.commitAllPending();
+
+      expect(capturedCtx).not.toBeNull();
+      expect(capturedCtx!.trigger).toBe('shutdown');
+      expect(capturedCtx!.workspaceDir).toBe(testDir);
+      expect(capturedCtx!.changedFiles).toContain('shutdown-file.txt');
     });
   });
 });

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -9,7 +9,7 @@
  * - Bounded queue with configurable max size (drops oldest on overflow)
  * - Bounded concurrency (default 1 worker)
  * - Per-job timeout with retry + exponential backoff
- * - Graceful shutdown: drains both in-flight and pending jobs
+ * - Graceful shutdown: drains in-flight jobs, discards pending jobs
  * - Fire-and-forget: enqueue() never blocks or throws
  */
 
@@ -99,32 +99,27 @@ export class CommitEnrichmentService {
   }
 
   /**
-   * Graceful shutdown: drain pending queue and wait for all jobs to complete.
+   * Graceful shutdown: discard pending queue and wait for in-flight jobs only.
    *
-   * Jobs are processed serially to respect maxConcurrency (default 1),
-   * preventing concurrent git notes writes that can race.
+   * Bounded shutdown time is more important than processing all pending
+   * enrichments. Enrichment is best-effort metadata and must never delay
+   * daemon shutdown materially. Pending jobs are counted as dropped.
    */
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
 
-    // Wait for any in-flight workers to finish first
+    // Discard pending jobs — enrichment is best-effort and must not delay shutdown
+    if (this.queue.length > 0) {
+      const pendingCount = this.queue.length;
+      this.droppedCount += pendingCount;
+      this.queue = [];
+      log.info({ discarded: pendingCount, droppedCount: this.droppedCount }, 'Enrichment queue shutting down, discarded pending jobs');
+    }
+
+    // Wait for any in-flight workers to finish
     if (this.inFlightPromises.size > 0) {
       log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
       await Promise.all(this.inFlightPromises);
-    }
-
-    // Now drain remaining queue items serially, respecting concurrency
-    if (this.queue.length > 0) {
-      log.info({ pending: this.queue.length }, 'Enrichment queue shutting down, draining pending jobs');
-    }
-    while (this.queue.length > 0) {
-      const job = this.queue.shift()!;
-      this.activeWorkers++;
-      try {
-        await this.executeJob(job);
-      } finally {
-        this.activeWorkers--;
-      }
     }
 
     log.info(


### PR DESCRIPTION
## Summary

Part of #5236
Closes #5239

- Enforce drain-in-flight/discard-pending shutdown policy in enrichment service
- Add provider injection tests for turn-commit and heartbeat service
- Add enrichment retry/timeout/queue-overflow test coverage
- Align ARCHITECTURE.md and inline comments with actual shutdown behavior

## Test plan
- bun test assistant/src/__tests__/commit-message-enrichment-service.test.ts
- bun test assistant/src/__tests__/turn-commit.test.ts
- bun test assistant/src/__tests__/workspace-heartbeat-service.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
