### PR TITLE
fix: persist dismissed widget IDs in ChatViewModel instead of @State

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -48,6 +48,8 @@ struct ChatView: View {
     var isTemporaryChat: Bool = false
     var activeSubagents: [SubagentInfo] = []
     var daemonHttpPort: Int?
+    var dismissedDocumentSurfaceIds: Set<String> = []
+    var onDismissDocumentWidget: ((String) -> Void)?
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     /// Sums utf8.count over each segment (O(1) per contiguous segment) instead of joining first,
@@ -68,7 +70,6 @@ struct ChatView: View {
     @State private var isQueueExpanded = true
     @State private var identity: IdentityInfo? = IdentityInfo.load()
     @State private var appearance = AvatarAppearanceManager.shared
-    @State private var dismissedDocumentSurfaceIds: Set<String> = []
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
     private var isEmptyState: Bool {
@@ -452,7 +453,7 @@ struct ChatView: View {
                                 onRegenerate: onRegenerate,
                                 onSurfaceAction: onSurfaceAction,
                                 onDismissDocumentWidget: { surfaceId in
-                                    dismissedDocumentSurfaceIds.insert(surfaceId)
+                                    onDismissDocumentWidget?(surfaceId)
                                 },
                                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                                 onReportMessage: onReportMessage,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1668,7 +1668,9 @@ private struct ActiveChatViewWrapper: View {
             ),
             isTemporaryChat: isTemporaryChat,
             activeSubagents: viewModel.activeSubagents,
-            daemonHttpPort: daemonClient.httpPort
+            daemonHttpPort: daemonClient.httpPort,
+            dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
+            onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) }
         )
     }
 }

--- a/clients/macos/vellum-assistantTests/DocumentReopenDismissTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentReopenDismissTests.swift
@@ -190,9 +190,9 @@ final class DocumentReopenDismissTests: XCTestCase {
         XCTAssertEqual(receivedSurfaceId, "doc-notify-test")
     }
 
-    // MARK: - Dismiss state via ChatView's dismissedDocumentSurfaceIds
+    // MARK: - Dismiss state via ChatViewModel's dismissedDocumentSurfaceIds
 
-    /// Simulates the dismiss flow: ChatView tracks dismissed surface IDs in a Set.
+    /// Simulates the dismiss flow: ChatViewModel tracks dismissed surface IDs in a Set.
     /// After inserting a surface ID, the widget should not render (the guard in
     /// `documentWidget` checks `!dismissedDocumentSurfaceIds.contains(surfaceId)`).
     func testDismissedSetBlocksRendering() {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -43,6 +43,8 @@ public final class ChatViewModel: ObservableObject {
     @Published public var pendingSkillInvocation: SkillInvocationData?
     @Published public var isWatchSessionActive: Bool = false
     @Published public var activeSubagents: [SubagentInfo] = []
+    /// Widget IDs dismissed by the user, persisted across view recreation.
+    @Published public var dismissedDocumentSurfaceIds: Set<String> = []
 
     /// The currently active model ID, updated via `model_info` IPC messages.
     @Published public var selectedModel: String = "claude-opus-4-6"
@@ -805,6 +807,10 @@ public final class ChatViewModel: ObservableObject {
         guard isWatchSessionActive else { return }
         isWatchSessionActive = false
         onStopWatch?()
+    }
+
+    public func dismissDocumentSurface(id: String) {
+        dismissedDocumentSurfaceIds.insert(id)
     }
 
     public func dismissError() {


### PR DESCRIPTION
Addresses feedback from PR #5072. Moves dismissedDocumentSurfaceIds from @State on ChatView to ChatViewModel so dismissed document widgets stay hidden when the view is recreated (e.g., when switching away from chat and back).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
