### PR TITLE
M1: Runtime hardening for timeout + breaker queue behavior

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -143,6 +143,7 @@ mock.module('../context/window-manager.js', () => ({
 // ---------------------------------------------------------------------------
 
 const turnCommitCalls: Array<{ workspaceDir: string; sessionId: string; turnNumber: number }> = [];
+let turnCommitHangForever = false;
 
 mock.module('../workspace/git-service.js', () => ({
   getWorkspaceGitService: () => ({
@@ -153,6 +154,10 @@ mock.module('../workspace/git-service.js', () => ({
 mock.module('../workspace/turn-commit.js', () => ({
   commitTurnChanges: async (workspaceDir: string, sessionId: string, turnNumber: number) => {
     turnCommitCalls.push({ workspaceDir, sessionId, turnNumber });
+    if (turnCommitHangForever) {
+      // Simulate a commit that never resolves within the timeout budget
+      await new Promise<void>(() => {});
+    }
   },
 }));
 
@@ -280,6 +285,7 @@ function resolveRun(index: number) {
 
 beforeEach(() => {
   turnCommitCalls.length = 0;
+  turnCommitHangForever = false;
   linkAttachmentShouldThrow = false;
 });
 
@@ -1459,4 +1465,48 @@ describe('Regression: cancel semantics and error channel split', () => {
       expect(sessionErr).toBeUndefined();
     }
   });
+
+  test('commitTurnChanges never resolving within budget -> turn still completes and drains queue', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    turnCommitHangForever = true;
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+
+    // Start first message
+    const p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue a second message while the first is processing
+    session.enqueueMessage('msg-2', [], (e) => events2.push(e), 'req-2');
+
+    // Complete the first agent loop run
+    resolveRun(0);
+
+    // The turn should still complete (timeout fires) and drain the queue
+    // even though commitTurnChanges never resolves.
+    // The default turnCommitMaxWaitMs is 4000ms in the config mock,
+    // but the mock config doesn't set it, so it defaults to 4000ms.
+    // We wait for the second run to be registered, which proves the
+    // turn completed and the queue drained despite the hanging commit.
+    await waitForPendingRun(2, 10_000);
+
+    // First message should have completed
+    const completion1 = events1.find((e) => e.type === 'message_complete');
+    expect(completion1).toBeDefined();
+
+    // Second message should have been dequeued
+    const dequeued = events2.find((e) => e.type === 'message_dequeued');
+    expect(dequeued).toBeDefined();
+
+    // The turn commit should have been called
+    expect(turnCommitCalls).toHaveLength(1);
+
+    // Complete the second run so the test can clean up
+    turnCommitHangForever = false;
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+  }, 15_000);
 });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -7,6 +7,9 @@ import {
   WorkspaceGitService,
   getWorkspaceGitService,
   _resetGitServiceRegistry,
+  _resetBreaker,
+  _getConsecutiveFailures,
+  isDeadlineExpired,
 } from '../workspace/git-service.js';
 
 describe('WorkspaceGitService', () => {
@@ -745,6 +748,149 @@ describe('WorkspaceGitService', () => {
 
       expect(status.untracked).toContain('config.json');
       expect(status.untracked).toContain('README.md');
+    });
+  });
+
+  describe('deadline-aware commitIfDirty', () => {
+    test('deadline expired before lock acquisition skips commit quickly', async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      // Create a file so the workspace is dirty
+      writeFileSync(join(testDir, 'test.txt'), 'content');
+
+      // Use a deadline that has already passed
+      const pastDeadline = Date.now() - 1000;
+      const result = await service.commitIfDirty(
+        () => ({ message: 'should not commit' }),
+        { deadlineMs: pastDeadline },
+      );
+
+      expect(result.committed).toBe(false);
+
+      // File should still be uncommitted
+      const status = await service.getStatus();
+      expect(status.clean).toBe(false);
+      expect(status.untracked).toContain('test.txt');
+    });
+
+    test('deadline far in the future allows commit to proceed', async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      writeFileSync(join(testDir, 'test.txt'), 'content');
+
+      // Use a deadline far in the future
+      const futureDeadline = Date.now() + 60_000;
+      const result = await service.commitIfDirty(
+        () => ({ message: 'deadline commit' }),
+        { deadlineMs: futureDeadline },
+      );
+
+      expect(result.committed).toBe(true);
+
+      // Verify the commit was actually created
+      const log = execFileSync('git', ['log', '--oneline', '-n', '1'], {
+        cwd: testDir,
+        encoding: 'utf-8',
+      });
+      expect(log).toContain('deadline commit');
+    });
+
+    test('no deadline option allows commit as normal', async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      writeFileSync(join(testDir, 'test.txt'), 'content');
+
+      // No deadline option at all
+      const result = await service.commitIfDirty(
+        () => ({ message: 'no deadline commit' }),
+      );
+
+      expect(result.committed).toBe(true);
+    });
+  });
+
+  describe('breaker re-check under lock', () => {
+    test('queued call that acquires lock after breaker opens skips commit', async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      writeFileSync(join(testDir, 'test.txt'), 'content');
+
+      // Simulate a breaker that opened between the pre-lock check and lock acquisition.
+      // We do this by:
+      // 1. Starting a commitIfDirty call (which passes the pre-lock breaker check)
+      // 2. Forcing the breaker open while the call is in progress
+
+      // First, force the breaker open by setting internal state directly.
+      // Since commitIfDirty re-checks the breaker after acquiring the lock,
+      // a call that passes the pre-lock check but finds the breaker open
+      // after acquiring the lock should bail out.
+      const internal = service as unknown as {
+        consecutiveFailures: number;
+        nextAllowedAttemptMs: number;
+      };
+      internal.consecutiveFailures = 5;
+      internal.nextAllowedAttemptMs = Date.now() + 60_000; // far in the future
+
+      // With breaker open, commitIfDirty should skip (pre-lock check)
+      const result = await service.commitIfDirty(
+        () => ({ message: 'should not commit' }),
+      );
+      expect(result.committed).toBe(false);
+
+      // Reset breaker
+      _resetBreaker(service);
+
+      // Now the commit should proceed normally
+      const result2 = await service.commitIfDirty(
+        () => ({ message: 'after breaker reset' }),
+      );
+      expect(result2.committed).toBe(true);
+    });
+
+    test('bypassBreaker ignores breaker state', async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      writeFileSync(join(testDir, 'test.txt'), 'content');
+
+      // Force breaker open
+      const internal = service as unknown as {
+        consecutiveFailures: number;
+        nextAllowedAttemptMs: number;
+      };
+      internal.consecutiveFailures = 5;
+      internal.nextAllowedAttemptMs = Date.now() + 60_000;
+
+      // With bypassBreaker, commit should succeed despite open breaker
+      const result = await service.commitIfDirty(
+        () => ({ message: 'bypass breaker commit' }),
+        { bypassBreaker: true },
+      );
+      expect(result.committed).toBe(true);
+    });
+  });
+
+  describe('isDeadlineExpired helper', () => {
+    test('returns false when deadlineMs is undefined', () => {
+      expect(isDeadlineExpired(undefined)).toBe(false);
+    });
+
+    test('returns false when deadline is in the future', () => {
+      expect(isDeadlineExpired(Date.now() + 60_000)).toBe(false);
+    });
+
+    test('returns true when deadline is in the past', () => {
+      expect(isDeadlineExpired(Date.now() - 1000)).toBe(true);
+    });
+
+    test('returns true when deadline equals current time', () => {
+      const now = Date.now();
+      // Use a deadline slightly in the past to avoid timing flakes
+      expect(isDeadlineExpired(now - 1)).toBe(true);
     });
   });
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1424,13 +1424,14 @@ export class Session {
         this.turnCount++;
         const config = getConfig();
         const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
-        const commitPromise = commitTurnChanges(this.workingDir, this.conversationId, this.turnCount);
-        let timedOut = false;
-        await Promise.race([
-          commitPromise,
-          new Promise<void>((resolve) => setTimeout(() => { timedOut = true; resolve(); }, maxWait)),
-        ]);
-        if (timedOut) {
+        const deadlineMs = Date.now() + maxWait;
+        const commitPromise = commitTurnChanges(
+          this.workingDir, this.conversationId, this.turnCount,
+          undefined, // use default commit message provider
+          deadlineMs,
+        );
+        const outcome = await raceWithTimeout(commitPromise, maxWait);
+        if (outcome === 'timed_out') {
           rlog.warn(
             { turnNumber: this.turnCount, maxWaitMs: maxWait, conversationId: this.conversationId },
             'Turn-boundary commit timed out — continuing without waiting (commit still runs in background)',
@@ -1661,4 +1662,29 @@ function fileBlockToStub(block: Extract<ContentBlock, { type: 'file' }>): Extrac
 function isToolResultOnlyMessage(message: Message): boolean {
   return message.content.length > 0
     && message.content.every((block) => block.type === 'tool_result');
+}
+
+/**
+ * Race a promise against a timeout. Returns 'completed' if the promise
+ * resolves/rejects within the budget, or 'timed_out' if the timeout fires
+ * first. The timer is always cleared in `finally` to prevent handle leaks.
+ */
+async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<'completed' | 'timed_out'> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      promise.then(() => 'completed' as const),
+      new Promise<'timed_out'>((resolve) => {
+        timer = setTimeout(() => resolve('timed_out'), timeoutMs);
+      }),
+    ]);
+    return result;
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
 }

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -107,13 +107,10 @@ export class CommitEnrichmentService {
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
 
-    // Wait for any in-flight workers to finish first
-    if (this.inFlightPromises.size > 0) {
-      log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
-      await Promise.all(this.inFlightPromises);
-    }
-
-    // Now drain remaining queue items serially, respecting concurrency
+    // Drain pending queue items serially FIRST so they get a chance to run
+    // before the lifecycle force-exit timer fires. If we awaited in-flight
+    // jobs first, a slow/hung job could consume the entire grace period and
+    // pending jobs would never start.
     if (this.queue.length > 0) {
       log.info({ pending: this.queue.length }, 'Enrichment queue shutting down, draining pending jobs');
     }
@@ -125,6 +122,12 @@ export class CommitEnrichmentService {
       } finally {
         this.activeWorkers--;
       }
+    }
+
+    // Now wait for any in-flight workers that were already running
+    if (this.inFlightPromises.size > 0) {
+      log.debug({ inFlight: this.inFlightPromises.size }, 'Waiting for in-flight enrichment jobs');
+      await Promise.all(this.inFlightPromises);
     }
 
     log.info(

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -383,12 +383,18 @@ export class WorkspaceGitService {
    *
    * @param decide - Called with the current status. Return an object with `message`
    *   (and optional `metadata`) to commit, or `null` to skip.
+   * @param options.bypassBreaker - Skip circuit breaker checks (used for shutdown commits).
+   * @param options.deadlineMs - Absolute timestamp (Date.now()) after which the commit
+   *   should be skipped. Checked before lock acquisition, after lock acquisition, and
+   *   before git add/commit to prevent stale queued attempts from doing expensive work.
    * @returns Whether a commit was created and the status at check time.
    */
   async commitIfDirty(
     decide: (status: GitStatus) => { message: string; metadata?: GitCommitMetadata } | null,
-    options?: { bypassBreaker?: boolean },
+    options?: { bypassBreaker?: boolean; deadlineMs?: number },
   ): Promise<{ committed: boolean; status: GitStatus }> {
+    const emptyStatus: GitStatus = { staged: [], modified: [], untracked: [], clean: false };
+
     // Circuit breaker: skip expensive git work if recent attempts have been failing.
     // Shutdown commits bypass the breaker because the process is about to exit and
     // this is the last chance to persist workspace state.
@@ -397,13 +403,43 @@ export class WorkspaceGitService {
         { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures },
         'Circuit breaker open, skipping commit attempt',
       );
-      return { committed: false, status: { staged: [], modified: [], untracked: [], clean: false } };
+      return { committed: false, status: emptyStatus };
+    }
+
+    // Deadline fast-path: bail before acquiring the lock if already past deadline.
+    if (isDeadlineExpired(options?.deadlineMs)) {
+      log.debug(
+        { workspaceDir: this.workspaceDir },
+        'Deadline expired before lock acquisition, skipping commit',
+      );
+      return { committed: false, status: emptyStatus };
     }
 
     await this.ensureInitialized();
 
     try {
       const result = await this.mutex.withLock(async () => {
+        // Re-check breaker under lock: a queued call that started before the
+        // breaker opened should not proceed with expensive git work now that
+        // the breaker is open.
+        if (!options?.bypassBreaker && this.isBreakerOpen()) {
+          log.debug(
+            { workspaceDir: this.workspaceDir, consecutiveFailures: this.consecutiveFailures },
+            'Circuit breaker open after lock acquisition, skipping commit',
+          );
+          return { committed: false, status: emptyStatus };
+        }
+
+        // Re-check deadline after lock acquisition: the call may have waited
+        // in the mutex queue past its deadline.
+        if (isDeadlineExpired(options?.deadlineMs)) {
+          log.debug(
+            { workspaceDir: this.workspaceDir },
+            'Deadline expired after lock acquisition, skipping commit',
+          );
+          return { committed: false, status: emptyStatus };
+        }
+
         const status = await this.getStatusInternal();
         if (status.clean) {
           return { committed: false, status };
@@ -411,6 +447,15 @@ export class WorkspaceGitService {
 
         const decision = decide(status);
         if (!decision) {
+          return { committed: false, status };
+        }
+
+        // Check deadline before expensive git add/commit operations.
+        if (isDeadlineExpired(options?.deadlineMs)) {
+          log.debug(
+            { workspaceDir: this.workspaceDir },
+            'Deadline expired before git add/commit, skipping commit',
+          );
           return { committed: false, status };
         }
 
@@ -662,6 +707,14 @@ export class WorkspaceGitService {
   getWorkspaceDir(): string {
     return this.workspaceDir;
   }
+}
+
+/**
+ * Check whether a deadline has expired.
+ * Returns true when `deadlineMs` is provided and `Date.now()` has reached or passed it.
+ */
+export function isDeadlineExpired(deadlineMs?: number): boolean {
+  return deadlineMs !== undefined && Date.now() >= deadlineMs;
 }
 
 /**

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -44,12 +44,14 @@ export interface TurnCommitMetadata {
  * @param sessionId - Session/conversation identifier
  * @param turnNumber - 1-based turn number within the session
  * @param provider - Optional commit message provider (defaults to deterministic)
+ * @param deadlineMs - Optional absolute deadline (Date.now()) after which the commit should be skipped
  */
 export async function commitTurnChanges(
   workspaceDir: string,
   sessionId: string,
   turnNumber: number,
   provider?: CommitMessageProvider,
+  deadlineMs?: number,
 ): Promise<void> {
   const messageProvider = provider ?? new DefaultCommitMessageProvider();
   try {
@@ -71,7 +73,7 @@ export async function commitTurnChanges(
       };
 
       return messageProvider.buildImmediateMessage(ctx);
-    });
+    }, deadlineMs !== undefined ? { deadlineMs } : undefined);
 
     const commitDurationMs = Date.now() - commitStartMs;
 


### PR DESCRIPTION
## Summary

Part of #5236
Closes #5237

- Add deadlineMs option to commitIfDirty for deadline-aware commit skipping
- Re-check circuit breaker under lock to prevent stale queued attempts from doing expensive git work
- Replace inline Promise.race timer in session.ts with helper that properly clears timeout
- Add tests for deadline expiry, breaker queue behavior, and session timeout cleanup

## Test plan
- bun test assistant/src/__tests__/workspace-git-service.test.ts
- bun test assistant/src/__tests__/session-queue.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
