### PR TITLE
fix: resolve TypeScript errors breaking CI

### DIFF
--- a/assistant/src/__tests__/call-store.test.ts
+++ b/assistant/src/__tests__/call-store.test.ts
@@ -414,8 +414,6 @@ describe('call-store', () => {
 
     // Verify the record was updated by querying directly
     const db = getDb();
-    const row = db.run('SELECT * FROM call_pending_questions WHERE id = ?', question.id);
-    // Check via a fresh query
     const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
     const updated = raw.query('SELECT * FROM call_pending_questions WHERE id = ?').get(question.id) as {
       status: string;

--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -119,7 +119,7 @@ describe('HTTP run → confirmation_request mirrors to assistant-events hub', ()
 
     const received: AssistantEvent[] = [];
     const sub = assistantEventHub.subscribe(
-      { assistantId: 'ast-http-1' },
+      { assistantId: 'self' },
       (e) => { received.push(e); },
     );
 
@@ -128,14 +128,14 @@ describe('HTTP run → confirmation_request mirrors to assistant-events hub', ()
       resolveAttachments: () => [],
     });
 
-    await orchestrator.startRun('ast-http-1', conversation.id, 'Do something');
+    await orchestrator.startRun(conversation.id, 'Do something');
     // Wait for the async hub chain to flush.
     await new Promise((r) => setTimeout(r, 20));
 
     sub.dispose();
 
     expect(received).toHaveLength(1);
-    expect(received[0].assistantId).toBe('ast-http-1');
+    expect(received[0].assistantId).toBe('self');
     expect(received[0].sessionId).toBe(conversation.id);
     expect(received[0].message.type).toBe('confirmation_request');
     expect(received[0].message).toBe(confirmationMsg);
@@ -165,7 +165,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
 
     const received: AssistantEvent[] = [];
     const sub = assistantEventHub.subscribe(
-      { assistantId: 'ast-http-2' },
+      { assistantId: 'self' },
       (e) => { received.push(e); },
     );
 
@@ -174,7 +174,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
       resolveAttachments: () => [],
     });
 
-    await orchestrator.startRun('ast-http-2', conversation.id, 'Hello');
+    await orchestrator.startRun(conversation.id, 'Hello');
     await new Promise((r) => setTimeout(r, 20));
 
     sub.dispose();
@@ -198,7 +198,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
 
     const received: AssistantEvent[] = [];
     const sub = assistantEventHub.subscribe(
-      { assistantId: 'ast-http-3' },
+      { assistantId: 'self' },
       (e) => { received.push(e); },
     );
 
@@ -207,7 +207,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
       resolveAttachments: () => [],
     });
 
-    await orchestrator.startRun('ast-http-3', conversation.id, 'ping');
+    await orchestrator.startRun(conversation.id, 'ping');
     await new Promise((r) => setTimeout(r, 20));
 
     sub.dispose();

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -194,7 +194,7 @@ export function getPendingQuestion(callSessionId: string): CallPendingQuestion |
 
 export function answerPendingQuestion(id: string, answerText: string): void {
   const db = getDb();
-  const result = db.update(callPendingQuestions)
+  db.update(callPendingQuestions)
     .set({
       status: 'answered',
       answerText,
@@ -207,7 +207,10 @@ export function answerPendingQuestion(id: string, answerText: string): void {
       ),
     )
     .run();
-  if (result.changes === 0) {
+  // Drizzle's .run() returns void for bun:sqlite, so verify via raw client.
+  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+  const check = raw.query('SELECT status FROM call_pending_questions WHERE id = ?').get(id) as { status: string } | null;
+  if (!check || check.status !== 'answered') {
     log.warn({ questionId: id }, 'answerPendingQuestion: no rows updated — question may have already been answered or expired');
   }
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -291,7 +291,7 @@ export class RuntimeHttpServer {
       if (!callSessionId) {
         return new Response('Missing callSessionId', { status: 400 });
       }
-      const upgraded = server.upgrade<RelayWebSocketData>(req, { data: { callSessionId } });
+      const upgraded = server.upgrade(req, { data: { callSessionId } });
       if (!upgraded) {
         return new Response('WebSocket upgrade failed', { status: 500 });
       }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -102,7 +102,7 @@ export class RunOrchestrator {
           ? (msgRecord.sessionId as string)
           : undefined;
       const resolvedSessionId = msgSessionId ?? conversationId;
-      const event = buildAssistantEvent(assistantId, msg, resolvedSessionId);
+      const event = buildAssistantEvent('self', msg, resolvedSessionId);
       hubChain = hubChain
         .then(() => assistantEventHub.publish(event))
         .catch((err: unknown) => {


### PR DESCRIPTION
## Summary
- Fixed `assistantId` reference error in `run-orchestrator.ts` (replaced with hardcoded `'self'`)
- Updated `run-orchestrator-assistant-events.test.ts` to match current `startRun(conversationId, content)` signature
- Fixed `call-store.ts` to use raw bun:sqlite client for verifying update success (Drizzle's `.run()` returns void)
- Removed dead `db.run()` call with unsupported extra argument in `call-store.test.ts`
- Removed unsupported type parameter from `server.upgrade()` in `http-server.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
