### PR TITLE
feat: restore per-message copy button in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -590,7 +590,10 @@ private struct ChatBubble: View {
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
     @State private var isRegenerateHovered = false
+    @State private var isCopyHovered = false
 
+    @State private var showCopyConfirmation = false
+    @State private var copyConfirmationTimer: DispatchWorkItem?
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
     @State private var stepsExpanded = false
 
@@ -709,6 +712,10 @@ private struct ChatBubble: View {
                 }
 
                 HStack(spacing: VSpacing.xs) {
+                    if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        copyButton
+                    }
+
                     if showRegenerate {
                         regenerateButton
                     }
@@ -773,6 +780,59 @@ private struct ChatBubble: View {
     /// Whether all tool calls are complete and the message is done streaming.
     private var allToolCallsComplete: Bool {
         !message.toolCalls.isEmpty && message.toolCalls.allSatisfy { $0.isComplete } && !message.isStreaming
+    }
+
+    private var copyButton: some View {
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(message.text, forType: .string)
+            copyConfirmationTimer?.cancel()
+            showCopyConfirmation = true
+            let timer = DispatchWorkItem { showCopyConfirmation = false }
+            copyConfirmationTimer = timer
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+        } label: {
+            Image(systemName: showCopyConfirmation ? "checkmark" : "doc.on.doc")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(showCopyConfirmation ? VColor.success : VColor.textMuted)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Copy message")
+        .onHover { hovering in
+            isCopyHovered = hovering
+            if hovering {
+                NSCursor.pointingHand.set()
+            } else {
+                NSCursor.arrow.set()
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if isCopyHovered && !showCopyConfirmation {
+                Text("Copy")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill(VColor.surface)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                    .vShadow(VShadow.sm)
+                    .fixedSize()
+                    .offset(y: 28)
+                    .transition(.opacity)
+                    .allowsHitTesting(false)
+            }
+        }
+        .opacity(isUser ? (isHovered ? 1 : 0) : 1)
+        .allowsHitTesting(isUser ? isHovered : true)
+        .animation(VAnimation.fast, value: isHovered)
     }
 
     private var regenerateButton: some View {


### PR DESCRIPTION
## Summary
- Re-add the per-message copy button that was removed in #5123
- Shows on hover for user messages, always visible for assistant messages
- Copies message text to clipboard with checkmark confirmation (1.5s)
- Includes hover tooltip ("Copy") with proper styling

## Test plan
- [ ] Hover over a user message — copy button appears
- [ ] Hover over an assistant message — copy button is always visible
- [ ] Click copy — text copied to clipboard, icon changes to checkmark for 1.5s
- [ ] Messages with no text content don't show the copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
