### PR TITLE
fix: address review feedback for calls feature

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -52,6 +52,13 @@ export class CallOrchestrator {
   }
 
   /**
+   * Returns the current orchestrator state.
+   */
+  getState(): OrchestratorState {
+    return this.state;
+  }
+
+  /**
    * Handle a final caller utterance from the ConversationRelay.
    */
   async handleCallerUtterance(transcript: string): Promise<void> {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -218,7 +218,15 @@ export async function handleCallAnswer(req: Request, callSessionId: string): Pro
     return Response.json({ error: 'No active orchestrator for this call' }, { status: 409 });
   }
 
-  // Mark question as answered
+  if (orchestrator.getState() !== 'waiting_on_user') {
+    log.warn(
+      { callSessionId, state: orchestrator.getState() },
+      'handleCallAnswer: orchestrator is not in waiting_on_user state',
+    );
+    return Response.json({ error: 'Orchestrator is not waiting for an answer' }, { status: 409 });
+  }
+
+  // Mark question as answered — only after confirming the orchestrator is ready
   answerPendingQuestion(question.id, body.answer);
 
   // Route answer to the orchestrator

--- a/assistant/src/tools/calls/call-end.ts
+++ b/assistant/src/tools/calls/call-end.ts
@@ -5,6 +5,7 @@ import { registerTool } from '../registry.js';
 import { getCallSession, updateCallSession } from '../../calls/call-store.js';
 import { getCallOrchestrator, unregisterCallOrchestrator } from '../../calls/call-state.js';
 import { activeRelayConnections } from '../../calls/relay-server.js';
+import { TwilioConversationRelayProvider } from '../../calls/twilio-provider.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('call-end');
@@ -60,6 +61,17 @@ class CallEndTool implements Tool {
       }
 
       log.info({ callSessionId, reason }, 'Ending call');
+
+      // Terminate the call via the provider API so Twilio hangs up,
+      // even if the relay WebSocket is not connected.
+      if (session.providerCallSid) {
+        try {
+          const provider = new TwilioConversationRelayProvider();
+          await provider.endCall(session.providerCallSid);
+        } catch (endErr) {
+          log.warn({ err: endErr, callSessionId, callSid: session.providerCallSid }, 'Failed to terminate call via provider API — proceeding with cleanup');
+        }
+      }
 
       // End the relay connection if active
       const relayConnection = activeRelayConnections.get(callSessionId);

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -70,6 +70,10 @@ class CallStartTool implements Tool {
 
     const callContext = input.context as string | undefined;
 
+    // Create session outside the try block so it's available in the catch block
+    // for marking as failed if the provider call fails.
+    let sessionId: string | null = null;
+
     try {
       const config = getTwilioConfig();
       const provider = new TwilioConversationRelayProvider();
@@ -81,6 +85,7 @@ class CallStartTool implements Tool {
         toNumber: phoneNumber,
         task: callContext ? `${task}\n\nContext: ${callContext}` : task,
       });
+      sessionId = session.id;
 
       log.info({ callSessionId: session.id, to: phoneNumber, task }, 'Initiating outbound call');
 
@@ -111,6 +116,16 @@ class CallStartTool implements Tool {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ err, phoneNumber }, 'Failed to initiate call');
+
+      // Mark the session as failed so it doesn't stay in 'initiated' state
+      if (sessionId) {
+        updateCallSession(sessionId, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: msg,
+        });
+      }
+
       return { content: `Error initiating call: ${msg}`, isError: true };
     }
   }


### PR DESCRIPTION
## Summary
- Gate answer persistence on orchestrator waiting_on_user state before marking question as answered (#4)
- Terminate Twilio call via provider API before marking session completed in call_end tool (#5)
- Mark call session as failed with error details when call initiation throws (#9)

## Verified
- Issues #1 (control tag filtering), #2 (Twilio auth bypass), #3 (CallSid capture), #6 (deterministic ordering), #7 (pending status enforcement), #8 (status reset on user answer) were already fixed in prior PRs

## Test plan
- [x] call-orchestrator tests pass (8/8)
- [x] call-state tests pass (10/10)
- [x] call-store tests pass (23/23)
- [x] No new TypeScript errors introduced
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
