### PR TITLE
fix: add missing originalDataDir declaration in doordash session test

### DIFF
--- a/assistant/src/__tests__/doordash-session.test.ts
+++ b/assistant/src/__tests__/doordash-session.test.ts
@@ -11,6 +11,7 @@ import {
 
 // Override getDataDir to use a temp directory during tests
 const TEST_DIR = join(tmpdir(), `vellum-dd-test-${process.pid}`);
+let originalDataDir: string | undefined;
 
 // We mock getDataDir by patching the module at the fs level:
 // session.ts calls getSessionDir() -> join(getDataDir(), 'doordash')


### PR DESCRIPTION
## Summary
- Added missing `let originalDataDir` declaration in `doordash-session.test.ts` that was causing TS2304 errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
