### PR TITLE
fix: prevent control marker leak in TTS buffer

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -203,14 +203,31 @@ export class CallOrchestrator {
           // Only hold the buffer if the bracket text could be the start of a
           // known control marker. Otherwise flush immediately so ordinary
           // bracketed text (e.g. "[A]", "[note]") doesn't stall TTS.
+          //
+          // The check must be bidirectional:
+          //  - When the buffer is shorter than the prefix (e.g. "[ASK"), the
+          //    buffer is a prefix of the control tag → hold it.
+          //  - When the buffer is longer than the prefix (e.g. "[ASK_USER: what"),
+          //    the buffer starts with the control tag prefix → hold it (the
+          //    variable-length payload hasn't been closed yet).
           const afterBracket = ttsBuffer;
           const couldBeControl =
-            '[ASK_USER:'.startsWith(afterBracket) || '[END_CALL]'.startsWith(afterBracket);
+            '[ASK_USER:'.startsWith(afterBracket) ||
+            '[END_CALL]'.startsWith(afterBracket) ||
+            afterBracket.startsWith('[ASK_USER:') ||
+            afterBracket.startsWith('[END_CALL');
 
           if (!couldBeControl) {
-            // Not a control marker prefix — flush everything
-            this.relay.sendTextToken(ttsBuffer, false);
-            ttsBuffer = '';
+            // Not a control marker prefix — flush up to the next '[' (if any)
+            // so we don't accidentally flush a later partial control marker.
+            const nextBracket = ttsBuffer.indexOf('[', 1);
+            if (nextBracket === -1) {
+              this.relay.sendTextToken(ttsBuffer, false);
+              ttsBuffer = '';
+            } else {
+              this.relay.sendTextToken(ttsBuffer.slice(0, nextBracket), false);
+              ttsBuffer = ttsBuffer.slice(nextBracket);
+            }
           }
           // Otherwise hold it — might be a control marker still being streamed
         }


### PR DESCRIPTION
## Summary

Follow-up to #5232

Fixes TTS buffer flushing that could leak control markers ([ASK_USER:...], [END_CALL]) to callers. The couldBeControl check now works bidirectionally: holds the buffer both when it's a prefix of a control tag AND when it starts with a known control tag prefix.

Also fixes a secondary issue where flushing non-control brackets (e.g. "[note]") would flush the entire remaining buffer, potentially including a later partial control marker. Now only flushes up to the next "[" to preserve any subsequent partial markers.

## Test plan
- Manual verification of control marker handling logic
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
