### PR TITLE
fix: separate config errors from git errors in execGit

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -647,9 +647,9 @@ export class WorkspaceGitService {
    * enrichment jobs use their own dedicated timeout.
    */
   private async execGit(args: string[]): Promise<{ stdout: string; stderr: string }> {
+    const config = getConfig();
+    const timeoutMs = config.workspaceGit?.interactiveGitTimeoutMs ?? 10_000;
     try {
-      const config = getConfig();
-      const timeoutMs = config.workspaceGit?.interactiveGitTimeoutMs ?? 10_000;
       const { stdout, stderr } = await execFileAsync('git', args, {
         cwd: this.workspaceDir,
         encoding: 'utf-8',


### PR DESCRIPTION
## Summary

Follow-up to #5242

Moves getConfig() call outside the try/catch in execGit() so config loading errors don't get caught as git command failures, which could incorrectly trigger the .git deletion corruption recovery path.

## Test plan
- bun test assistant/src/__tests__/workspace-git-service.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
