### PR TITLE
fix: validate orchestrator state before persisting call answer

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -80,13 +80,13 @@ export class CallOrchestrator {
   /**
    * Called when the user (in the chat UI) answers a pending question.
    */
-  async handleUserAnswer(answerText: string): Promise<void> {
+  async handleUserAnswer(answerText: string): Promise<boolean> {
     if (this.state !== 'waiting_on_user') {
       log.warn(
         { callSessionId: this.callSessionId, state: this.state },
         'handleUserAnswer called but orchestrator is not in waiting_on_user state',
       );
-      return;
+      return false;
     }
 
     // Clear the consultation timeout
@@ -102,6 +102,7 @@ export class CallOrchestrator {
     this.conversationHistory.push({ role: 'user', content: `[USER_ANSWERED: ${answerText}]` });
 
     await this.runLlm();
+    return true;
   }
 
   /**

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -209,28 +209,28 @@ export async function handleCallAnswer(req: Request, callSessionId: string): Pro
     return Response.json({ error: 'No pending question found' }, { status: 404 });
   }
 
-  // Verify the orchestrator exists and is waiting for input before persisting the answer.
-  // If the orchestrator is missing (e.g. after a reconnect/restart) or is no longer in the
-  // waiting_on_user state, reject the answer so the question stays open for retry.
+  // Verify the orchestrator exists before attempting to route the answer.
   const orchestrator = getCallOrchestrator(callSessionId);
   if (!orchestrator) {
     log.warn({ callSessionId }, 'handleCallAnswer: no active orchestrator for call session');
     return Response.json({ error: 'No active orchestrator for this call' }, { status: 409 });
   }
 
-  if (orchestrator.getState() !== 'waiting_on_user') {
+  // Route answer to the orchestrator FIRST — it atomically checks whether it is
+  // in the `waiting_on_user` state and transitions to `processing`. Only persist
+  // the answer to the DB if the orchestrator actually accepted it, preventing a
+  // race where the consultation timer expires between our check and the persist.
+  const accepted = await orchestrator.handleUserAnswer(body.answer);
+  if (!accepted) {
     log.warn(
-      { callSessionId, state: orchestrator.getState() },
-      'handleCallAnswer: orchestrator is not in waiting_on_user state',
+      { callSessionId },
+      'handleCallAnswer: orchestrator rejected the answer (not in waiting_on_user state)',
     );
     return Response.json({ error: 'Orchestrator is not waiting for an answer' }, { status: 409 });
   }
 
-  // Mark question as answered — only after confirming the orchestrator is ready
+  // Mark question as answered — only after the orchestrator has accepted
   answerPendingQuestion(question.id, body.answer);
-
-  // Route answer to the orchestrator
-  await orchestrator.handleUserAnswer(body.answer);
 
   return Response.json({ ok: true, questionId: question.id });
 }


### PR DESCRIPTION
## Summary

Follow-up to #5233

Fixes race condition where answer was persisted to DB before orchestrator state validation. Now handleUserAnswer returns a boolean, and answerPendingQuestion is only called on success. Returns 409 if orchestrator is not in waiting_on_user state.

## Test plan
- Manual verification of answer handling flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
