### PR TITLE
fix: align Twilio webhook URL for registration and verification

### DIFF
--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -89,7 +89,7 @@ class CallStartTool implements Tool {
 
       log.info({ callSessionId: session.id, to: phoneNumber, task }, 'Initiating outbound call');
 
-      const baseUrl = process.env.BASE_URL ?? 'https://localhost:7821';
+      const baseUrl = config.webhookBaseUrl.replace(/\/$/, '');
       const { callSid } = await provider.initiateCall({
         from: config.phoneNumber,
         to: phoneNumber,


### PR DESCRIPTION
## Summary

Follow-up to #5235

Ensures Twilio webhook registration and signature verification use the same base URL to prevent 403 rejections when TWILIO_WEBHOOK_BASE_URL and BASE_URL differ.

The fix uses `config.webhookBaseUrl` (sourced from `TWILIO_WEBHOOK_BASE_URL`) in `call-start.ts` instead of `process.env.BASE_URL`, which is the same env var used by the signature verification in `http-server.ts`.

## Test plan
- Manual verification of URL consistency
- Type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
