### PR TITLE
fix: clarify review action button to distinguish from status label

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -320,15 +320,15 @@ private struct TasksWindowRow: View {
             if status == .awaitingReview {
                 Button(action: onComplete) {
                     HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "checkmark")
+                        Image(systemName: "checkmark.circle")
                             .font(.system(size: 10))
-                        Text("Reviewed")
+                        Text("Mark Reviewed")
                             .font(VFont.caption)
                     }
-                    .foregroundColor(VColor.success)
+                    .foregroundColor(.white)
                     .padding(.horizontal, VSpacing.sm)
                     .padding(.vertical, VSpacing.xs)
-                    .background(VColor.success.opacity(0.12))
+                    .background(VColor.success)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                     .contentShape(Rectangle())
                 }


### PR DESCRIPTION
## Summary
- Change 'Reviewed' button text to 'Mark Reviewed' to distinguish action from status
- Switch to solid green background with white text (matching Run button pattern)
- Change icon from checkmark to checkmark.circle for button appearance

## Test plan
- [ ] Tasks in awaiting_review show 'Awaiting Review' purple status AND 'Mark Reviewed' green action button
- [ ] The two elements are visually distinct — status label vs action button

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
