### PR TITLE
fix: display daemon error message when Run action fails

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -80,6 +80,7 @@ class TasksWindowViewModel: ObservableObject {
             self.cancelRunTimeout(id: response.id)
             if !response.success {
                 self.logger.error("onWorkItemRunTaskResponse: run failed for id=\(response.id, privacy: .public) errorCode=\(response.errorCode ?? "none", privacy: .public) error=\(response.error ?? "none", privacy: .public)")
+                self.errorMessage = response.error ?? "Failed to run task"
                 self.fetchItems()
             }
         }


### PR DESCRIPTION
## Summary
- Set errorMessage from daemon response when work_item_run_task fails
- Previously the error was logged but never displayed to the user
- Now shows the actual daemon error (e.g. 'Work item not found', 'Already running')

## Test plan
- [ ] Click Run on a task and verify errors display in the UI instead of blank toast

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
