### PR TITLE
fix: resolve ESLint errors breaking CI

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -85,14 +85,9 @@ import { conversations } from '../memory/schema.js';
 import {
   createCallSession,
   getCallSession,
-  updateCallSession,
-  recordCallEvent,
-  createPendingQuestion,
   getPendingQuestion,
 } from '../calls/call-store.js';
 import {
-  registerCallOrchestrator,
-  unregisterCallOrchestrator,
   getCallOrchestrator,
 } from '../calls/call-state.js';
 import { CallOrchestrator } from '../calls/call-orchestrator.js';
@@ -276,7 +271,7 @@ describe('call-orchestrator', () => {
     mockStreamFn.mockImplementation(() =>
       createMockStream(['Hold on. [ASK_USER: Preferred time?]']),
     );
-    const { session, relay, orchestrator } = setupOrchestrator();
+    const { relay, orchestrator } = setupOrchestrator();
 
     await orchestrator.handleCallerUtterance('I need an appointment');
 

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1475,8 +1475,8 @@ describe('Regression: cancel semantics and error channel split', () => {
     const events1: ServerMessage[] = [];
     const events2: ServerMessage[] = [];
 
-    // Start first message
-    const p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
+    // Start first message (promise intentionally not awaited — we test queue drain behavior)
+    const _p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
     await waitForPendingRun(1);
 
     // Enqueue a second message while the first is processing

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -14,7 +14,6 @@ import {
   updateCallSession,
   recordCallEvent,
   createPendingQuestion,
-  getPendingQuestion,
   expirePendingQuestions,
 } from './call-store.js';
 import { MAX_CALL_DURATION_MS, USER_CONSULTATION_TIMEOUT_MS, SILENCE_TIMEOUT_MS } from './call-constants.js';
@@ -187,7 +186,7 @@ export class CallOrchestrator {
       // could be the start of a control marker.
       let ttsBuffer = '';
 
-      const flushSafeText = (force: boolean): void => {
+      const flushSafeText = (_force: boolean): void => {
         if (ttsBuffer.length === 0) return;
         const bracketIdx = ttsBuffer.indexOf('[');
         if (bracketIdx === -1) {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -128,7 +128,7 @@ export class RelayConnection {
         this.handleError(parsed);
         break;
       default:
-        log.warn({ callSessionId: this.callSessionId, type: (parsed as any).type }, 'Unknown relay message type');
+        log.warn({ callSessionId: this.callSessionId, type: (parsed as Record<string, unknown>).type }, 'Unknown relay message type');
     }
   }
 

--- a/assistant/src/cli/doordash.ts
+++ b/assistant/src/cli/doordash.ts
@@ -664,7 +664,7 @@ export function registerDoordashCommand(program: Command): void {
 // Chrome CDP restart helper
 // ---------------------------------------------------------------------------
 
-import { execSync, spawn as spawnChild } from 'node:child_process';
+import { spawn as spawnChild } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join as pathJoin } from 'node:path';
 

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -170,7 +170,7 @@ export function handleWorkItemOutput(
   }
 
   let summary = '';
-  let highlights: string[] = [];
+  const highlights: string[] = [];
 
   if (workItem.lastRunConversationId) {
     const msgs = getMessages(workItem.lastRunConversationId);


### PR DESCRIPTION
## Summary
- Fixed 12 ESLint errors across 6 files: unused imports/variables, `any` type, and `let` vs `const`
- Covers `call-orchestrator.test.ts`, `session-queue.test.ts`, `call-orchestrator.ts`, `relay-server.ts`, `doordash.ts`, `work-items.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
