### PR TITLE
fix: resolve task output loading failure and add error handling

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -163,16 +163,23 @@ export function handleWorkItemOutput(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const workItem = getWorkItem(msg.id);
-  if (!workItem) {
-    ctx.send(socket, { type: 'work_item_output_response', id: msg.id, success: false, error: 'Work item not found' });
-    return;
-  }
+  try {
+    const workItem = getWorkItem(msg.id);
+    if (!workItem) {
+      ctx.send(socket, { type: 'work_item_output_response', id: msg.id, success: false, error: 'Work item not found' });
+      return;
+    }
 
-  let summary = '';
-  let highlights: string[] = [];
+    // If the work item has never been run, return an error so the client
+    // can show "No output yet" instead of an empty loaded state.
+    if (!workItem.lastRunConversationId) {
+      ctx.send(socket, { type: 'work_item_output_response', id: msg.id, success: false, error: 'This task has not been run yet. No output is available.' });
+      return;
+    }
 
-  if (workItem.lastRunConversationId) {
+    let summary = '';
+    let highlights: string[] = [];
+
     const msgs = getMessages(workItem.lastRunConversationId);
     // Find the last assistant message with text content (not tool calls)
     for (let i = msgs.length - 1; i >= 0; i--) {
@@ -208,28 +215,33 @@ export function handleWorkItemOutput(
       }
       break;
     }
-  }
 
-  let completedAt: number | null = null;
-  if (workItem.lastRunId) {
-    const run = getTaskRun(workItem.lastRunId);
-    completedAt = run?.finishedAt ?? null;
-  }
+    // Convert finishedAt from milliseconds (Date.now()) to seconds for the
+    // client, which uses Date(timeIntervalSince1970:) expecting seconds.
+    let completedAt: number | null = null;
+    if (workItem.lastRunId) {
+      const run = getTaskRun(workItem.lastRunId);
+      completedAt = run?.finishedAt != null ? Math.floor(run.finishedAt / 1000) : null;
+    }
 
-  ctx.send(socket, {
-    type: 'work_item_output_response',
-    id: msg.id,
-    success: true,
-    output: {
-      title: workItem.title,
-      status: workItem.lastRunStatus ?? workItem.status,
-      runId: workItem.lastRunId,
-      conversationId: workItem.lastRunConversationId,
-      completedAt,
-      summary,
-      highlights,
-    },
-  });
+    ctx.send(socket, {
+      type: 'work_item_output_response',
+      id: msg.id,
+      success: true,
+      output: {
+        title: workItem.title,
+        status: workItem.lastRunStatus ?? workItem.status,
+        runId: workItem.lastRunId,
+        conversationId: workItem.lastRunConversationId,
+        completedAt,
+        summary,
+        highlights,
+      },
+    });
+  } catch (err) {
+    log.error({ err, workItemId: msg.id }, 'handleWorkItemOutput failed');
+    ctx.send(socket, { type: 'work_item_output_response', id: msg.id, success: false, error: 'Failed to load task output' });
+  }
 }
 
 export async function handleWorkItemRunTask(


### PR DESCRIPTION
## Summary
- Wrapped handleWorkItemOutput in try-catch so unhandled exceptions send an error response instead of leaving the client in infinite loading
- Added early return with a descriptive error when a task has never been run (no lastRunConversationId), preventing an empty/blank loaded state
- Fixed completedAt timestamp unit mismatch: finishedAt is stored in milliseconds (Date.now()) but the Swift client expects seconds (Date(timeIntervalSince1970:)), so the handler now divides by 1000

## Test plan
- [ ] Click a completed task title and verify output loads with correct date
- [ ] Click a task that hasn't been run and verify 'This task has not been run yet' message
- [ ] Verify no infinite loading or blank toasts

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
