### PR TITLE
fix: use SELECT changes() for answerPendingQuestion update verification

### DIFF
--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -207,10 +207,10 @@ export function answerPendingQuestion(id: string, answerText: string): void {
       ),
     )
     .run();
-  // Drizzle's .run() returns void for bun:sqlite, so verify via raw client.
+  // Drizzle's .run() returns void for bun:sqlite, so check affected rows via raw client.
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  const check = raw.query('SELECT status FROM call_pending_questions WHERE id = ?').get(id) as { status: string } | null;
-  if (!check || check.status !== 'answered') {
+  const changes = raw.query('SELECT changes() as c').get() as { c: number };
+  if (changes.c === 0) {
     log.warn({ questionId: id }, 'answerPendingQuestion: no rows updated — question may have already been answered or expired');
   }
 }


### PR DESCRIPTION
Addresses feedback from PR #5251. Replaces the SELECT-based post-update check with SELECT changes() to correctly distinguish between 'this call updated the row' and 'already answered by a prior call'. The previous approach conflated both cases since it only checked the current status value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
