### PR TITLE
fix: isolate video thumbnail temp files per attachment ID

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -134,10 +134,12 @@ struct InlineVideoAttachmentView: View {
 
     /// Builds a safe temp-file URL by stripping path components from the filename
     /// to prevent traversal attacks (e.g. "../../etc/passwd").
+    /// Includes attachment.id to avoid collisions between attachments with the same filename.
     private func safeTempURL() -> URL {
         let sanitized = (attachment.filename as NSString).lastPathComponent
         let safeName = sanitized.isEmpty ? "video" : sanitized
-        return FileManager.default.temporaryDirectory.appendingPathComponent(safeName)
+        let uniqueName = attachment.id.isEmpty ? safeName : "\(attachment.id)-\(safeName)"
+        return FileManager.default.temporaryDirectory.appendingPathComponent(uniqueName)
     }
 
     private func generateThumbnail() async {


### PR DESCRIPTION
Addresses feedback from PR #5253. Uses attachment.id in the temp file path for thumbnail generation instead of just the filename, preventing race conditions when two attachments share the same filename.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
