### PR TITLE
fix: add missing IPC snapshot entries for preflight/approve_permissions messages

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -716,6 +716,24 @@ exports[`IPC message snapshots ClientMessage types work_item_output serializes t
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types work_item_preflight serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "type": "work_item_preflight",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_item_approve_permissions serializes to expected JSON 1`] = `
+{
+  "approvedTools": [
+    "bash",
+    "file_write",
+  ],
+  "id": "wi-001",
+  "type": "work_item_approve_permissions",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types document_save serializes to expected JSON 1`] = `
 {
   "content": "# Hello",
@@ -2072,6 +2090,30 @@ exports[`IPC message snapshots ServerMessage types work_item_output_response ser
   },
   "success": true,
   "type": "work_item_output_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_preflight_response serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "permissions": [
+    {
+      "currentDecision": "prompt",
+      "description": "Run shell commands",
+      "riskLevel": "medium",
+      "tool": "bash",
+    },
+  ],
+  "success": true,
+  "type": "work_item_preflight_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_approve_permissions_response serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "success": true,
+  "type": "work_item_approve_permissions_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -453,6 +453,15 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'work_item_output',
     id: 'wi-001',
   },
+  work_item_preflight: {
+    type: 'work_item_preflight',
+    id: 'wi-001',
+  },
+  work_item_approve_permissions: {
+    type: 'work_item_approve_permissions',
+    id: 'wi-001',
+    approvedTools: ['bash', 'file_write'],
+  },
   document_save: {
     type: 'document_save',
     surfaceId: 'doc-001',
@@ -1345,6 +1354,19 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       summary: 'Report processed successfully.',
       highlights: ['- Key finding 1', '- Key finding 2'],
     },
+  },
+  work_item_preflight_response: {
+    type: 'work_item_preflight_response',
+    id: 'wi-001',
+    success: true,
+    permissions: [
+      { tool: 'bash', description: 'Run shell commands', riskLevel: 'medium', currentDecision: 'prompt' },
+    ],
+  },
+  work_item_approve_permissions_response: {
+    type: 'work_item_approve_permissions_response',
+    id: 'wi-001',
+    success: true,
   },
   work_item_status_changed: {
     type: 'work_item_status_changed',


### PR DESCRIPTION
## Summary
- Added `work_item_preflight` and `work_item_approve_permissions` to client message test entries
- Added `work_item_preflight_response` and `work_item_approve_permissions_response` to server message test entries
- Regenerated IPC snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
