### PR TITLE
fix: lazy-load large video attachments in message_complete

### DIFF
--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -313,6 +313,12 @@ export function drainDirectiveDisplayBuffer(buffer: string): DirectiveDisplayDra
 
     if (!isValidDirective) {
       emitText += tag;
+    } else {
+      // Trim the trailing newline before a stripped directive so consecutive
+      // tags don't leave a stack of blank lines in the streamed text.
+      if (emitText.endsWith('\n')) {
+        emitText = emitText.slice(0, -1);
+      }
     }
 
     cursor = end + 2;

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -131,7 +131,11 @@ export async function resolveAssistantAttachments(
     log.info('No directives or tool content blocks to resolve');
   }
 
-  // Persist resolved attachments and link to the last assistant message
+  // Persist resolved attachments and link to the last assistant message.
+  // Large video attachments are omitted from the IPC payload and lazy-loaded
+  // by the client via the HTTP endpoint (same pattern as history_response).
+  const MAX_INLINE_B64_SIZE = 512 * 1024;
+
   if (assistantAttachments.length > 0 && lastAssistantMessageId) {
     for (let i = 0; i < assistantAttachments.length; i++) {
       const draft = assistantAttachments[i];
@@ -152,11 +156,13 @@ export async function resolveAssistantAttachments(
         throw err;
       }
       linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
+      const omitData = draft.mimeType.startsWith('video/') && draft.dataBase64.length > MAX_INLINE_B64_SIZE;
       emittedAttachments.push({
         id: stored.id,
         filename: draft.filename,
         mimeType: draft.mimeType,
-        data: draft.dataBase64,
+        data: omitData ? '' : draft.dataBase64,
+        ...(omitData ? { sizeBytes: draft.sizeBytes } : {}),
       });
     }
   } else if (assistantAttachments.length > 0) {


### PR DESCRIPTION
## Summary
- Strip large video attachment data (>512KB base64) from the `message_complete` IPC event, matching the existing `history_response` pattern — the client already supports lazy-loading video data via the HTTP endpoint
- This prevents ~20MB+ IPC payloads when the assistant emits multiple video attachments, which could cause JSON decode failures on the Swift client
- Also trim trailing newlines when stripping directive tags during streaming to reduce the blank space left where `<vellum-attachment>` tags were

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
