### PR TITLE
fix: restrict END_CALL prefix matching to exact marker candidates

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -216,7 +216,8 @@ export class CallOrchestrator {
             '[ASK_USER:'.startsWith(afterBracket) ||
             '[END_CALL]'.startsWith(afterBracket) ||
             afterBracket.startsWith('[ASK_USER:') ||
-            afterBracket.startsWith('[END_CALL');
+            afterBracket === '[END_CALL' ||
+            afterBracket.startsWith('[END_CALL]');
 
           if (!couldBeControl) {
             // Not a control marker prefix — flush up to the next '[' (if any)


### PR DESCRIPTION
Addresses Codex P2 on #5257: tightened END_CALL prefix check so only the exact partial marker or full marker is matched, preventing false buffering of text like [END_CALLER].
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
