### PR TITLE
feat: DoorDash item customization & fix broken payment queries

### DIFF
--- a/assistant/src/cli/doordash.ts
+++ b/assistant/src/cli/doordash.ts
@@ -326,7 +326,8 @@ export function registerDoordashCommand(program: Command): void {
     .description('Inspect GraphQL operations in a recording')
     .argument('<recordingId>', 'Recording ID or path to recording JSON file')
     .option('--op <operationName>', 'Filter to a specific operation name')
-    .action(async (recordingIdOrPath: string, opts: { op?: string }, cmd: Command) => {
+    .option('--extract-options', 'Extract item customization options from updateCartItem operations')
+    .action(async (recordingIdOrPath: string, opts: { op?: string; extractOptions?: boolean }, cmd: Command) => {
       const json = getJson(cmd);
 
       try {
@@ -351,6 +352,43 @@ export function registerDoordashCommand(program: Command): void {
         }
 
         const queries = extractQueries(recording);
+
+        if (opts.extractOptions) {
+          const cartOps = queries.filter(q => q.operationName === 'updateCartItem');
+          if (cartOps.length === 0) {
+            outputError('No updateCartItem operations found in this recording');
+            return;
+          }
+
+          const extracted = cartOps.map(q => {
+            const vars = (q.exampleVariables ?? {}) as Record<string, unknown>;
+            const params = (vars.updateCartItemApiParams ?? {}) as Record<string, unknown>;
+            return {
+              itemId: params.itemId as string | undefined,
+              itemName: params.itemName as string | undefined,
+              nestedOptions: params.nestedOptions as string | undefined,
+              specialInstructions: params.specialInstructions as string | undefined,
+              unitPrice: params.unitPrice as number | undefined,
+              menuId: params.menuId as string | undefined,
+              storeId: params.storeId as string | undefined,
+            };
+          });
+
+          if (json) {
+            output({ ok: true, items: extracted, count: extracted.length }, true);
+          } else {
+            for (const item of extracted) {
+              process.stderr.write(`\nItem: ${item.itemName ?? 'unknown'} (${item.itemId ?? '?'})\n`);
+              process.stderr.write(`  Store: ${item.storeId ?? '?'}, Menu: ${item.menuId ?? '?'}\n`);
+              process.stderr.write(`  Unit Price: ${item.unitPrice ?? '?'}\n`);
+              if (item.specialInstructions) {
+                process.stderr.write(`  Special Instructions: ${item.specialInstructions}\n`);
+              }
+              process.stderr.write(`  Options: ${item.nestedOptions ?? '[]'}\n`);
+            }
+          }
+          return;
+        }
 
         if (opts.op) {
           const match = queries.find(q => q.operationName === opts.op);
@@ -511,6 +549,7 @@ export function registerDoordashCommand(program: Command): void {
     .option('--quantity <n>', 'Quantity', '1')
     .option('--cart-id <cartId>', 'Existing cart ID (creates new if omitted)')
     .option('--special-instructions <text>', 'Special instructions')
+    .option('--options <json>', 'Item customization options as JSON array (from item details or recording)')
     .action(
       async (
         opts: {
@@ -522,6 +561,7 @@ export function registerDoordashCommand(program: Command): void {
           quantity: string;
           cartId?: string;
           specialInstructions?: string;
+          options?: string;
         },
         cmd: Command,
       ) => {
@@ -535,6 +575,7 @@ export function registerDoordashCommand(program: Command): void {
             quantity: parseInt(opts.quantity, 10),
             cartId: opts.cartId,
             specialInstructions: opts.specialInstructions,
+            nestedOptions: opts.options,
           });
           return { cart: result };
         });
@@ -578,6 +619,115 @@ export function registerDoordashCommand(program: Command): void {
         const carts = await listCarts(opts.storeId);
         return { carts, count: carts.length };
       });
+    });
+
+  // cart learn — capture customization options via CDP recording
+  cart
+    .command('learn')
+    .description(
+      'Learn item customization options by recording a browser interaction. ' +
+      'Opens Chrome and watches you customize an item — when you add it to cart, ' +
+      'the nestedOptions and specialInstructions are extracted and output.',
+    )
+    .option('--duration <seconds>', 'Max recording duration in seconds', '120')
+    .action(async (opts: { duration: string }, cmd: Command) => {
+      const json = getJson(cmd);
+      const duration = parseInt(opts.duration, 10);
+
+      try {
+        await ensureChromeWithCDP();
+
+        const startTime = Date.now() / 1000;
+        const recorder = new NetworkRecorder('doordash.com');
+        await recorder.startDirect('http://localhost:9222');
+
+        process.stderr.write('Recording... Navigate to an item, customize it, and add it to cart.\n');
+        process.stderr.write(`Will auto-stop when "updateCartItem" is detected. Timeout: ${duration}s.\n`);
+
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (poll) clearInterval(poll);
+            process.stderr.write(`\nTimeout reached (${duration}s).\n`);
+            resolve();
+          }, duration * 1000);
+
+          process.on('SIGINT', () => {
+            if (poll) clearInterval(poll);
+            clearTimeout(timer);
+            resolve();
+          });
+
+          const poll = setInterval(() => {
+            const entries = recorder.getEntries();
+            const found = entries.some(e => {
+              if (!e.request.postData) return false;
+              try {
+                const body = JSON.parse(e.request.postData) as { operationName?: string };
+                return body.operationName === 'updateCartItem';
+              } catch { return false; }
+            });
+            if (found) {
+              clearInterval(poll);
+              clearTimeout(timer);
+              process.stderr.write('\nDetected "updateCartItem" operation.\n');
+              setTimeout(() => resolve(), 3000);
+            }
+          }, 500);
+        });
+
+        process.stderr.write('Stopping recording...\n');
+        const cookies = await recorder.extractCookies('doordash.com');
+        const entries = await recorder.stop();
+
+        const recording: SessionRecording = {
+          id: crypto.randomUUID(),
+          startedAt: startTime,
+          endedAt: Date.now() / 1000,
+          targetDomain: 'doordash.com',
+          networkEntries: entries,
+          cookies,
+          observations: [],
+        };
+
+        // Extract updateCartItem operations
+        const queries = extractQueries(recording);
+        const cartOps = queries.filter(q => q.operationName === 'updateCartItem');
+
+        if (cartOps.length === 0) {
+          outputError('No updateCartItem operations captured. Did you add an item to cart?');
+          return;
+        }
+
+        const extracted = cartOps.map(q => {
+          const vars = (q.exampleVariables ?? {}) as Record<string, unknown>;
+          const params = (vars.updateCartItemApiParams ?? {}) as Record<string, unknown>;
+          return {
+            itemId: params.itemId as string | undefined,
+            itemName: params.itemName as string | undefined,
+            nestedOptions: params.nestedOptions as string | undefined,
+            specialInstructions: params.specialInstructions as string | undefined,
+            unitPrice: params.unitPrice as number | undefined,
+            menuId: params.menuId as string | undefined,
+            storeId: params.storeId as string | undefined,
+          };
+        });
+
+        // Also save the recording for future reference
+        const recordingPath = saveRecording(recording);
+
+        output(
+          {
+            ok: true,
+            items: extracted,
+            count: extracted.length,
+            recordingId: recording.id,
+            recordingPath,
+          },
+          json,
+        );
+      } catch (err) {
+        outputError(err instanceof Error ? err.message : String(err));
+      }
     });
 
   // =========================================================================

--- a/assistant/src/config/bundled-skills/doordash/SKILL.md
+++ b/assistant/src/config/bundled-skills/doordash/SKILL.md
@@ -41,9 +41,14 @@ When the user asks you to order food (e.g. "Order pizza from Andiamo's"):
 
 3b. **Search within a retail store** — for convenience/pharmacy stores, run `vellum doordash store-search <storeId> "<query>" --json` to find specific products. This returns items with IDs, prices, and menuIds that can be added to cart directly.
 
-4. **Get item details** (if needed) — run `vellum doordash item <storeId> <itemId> --json` to see options/customizations. If the item has required options (like size or toppings), ask the user or pick sensible defaults.
+4. **Get item details** (if needed) — run `vellum doordash item <storeId> <itemId> --json` to see options/customizations. The response includes:
+   - `options`: each option group has `minSelections`/`maxSelections` indicating how many choices are required
+   - Each choice has `unitAmount` (price impact in cents), `defaultQuantity`, and possibly `nestedOptions` (sub-choices like milk type within a size selection)
+   - `specialInstructionsConfig`: whether special instructions are accepted, max length, and placeholder text
 
-5. **Add to cart** — run `vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> --json`. For subsequent items at the same store, pass `--cart-id <id>` from the first add response.
+   If the item has required options (like size or toppings), construct the `nestedOptions` JSON from the option/choice IDs and pass it via `--options`. Ask the user for preferences or pick sensible defaults.
+
+5. **Add to cart** — run `vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> [--options '<json>'] [--special-instructions "<text>"] --json`. For subsequent items at the same store, pass `--cart-id <id>` from the first add response. Use `--special-instructions` for requests like "extra hot", "no ice", etc. Use `--options` to pass customization choices (see Customization Options below).
 
 6. **Review cart** — run `vellum doordash cart view <cartId> --json` and show the user what's in their cart with prices. Ask if they want to add anything else or proceed.
 
@@ -61,6 +66,65 @@ When the user asks you to order food (e.g. "Order pizza from Andiamo's"):
 - **Show prices.** Always show prices when presenting items or the cart summary.
 - **Use `--json` flag** on all commands for reliable parsing.
 - **Do NOT use the browser skill.** All DoorDash interaction goes through the CLI, not browser automation.
+- **Rate limiting.** DoorDash rate-limits rapid sequential requests. When adding multiple items (e.g. a team order), wait 8–10 seconds between `cart add` calls. If you get a 403 error, wait 15–20 seconds and retry. For large orders (5+ items), consider running `vellum doordash refresh --json` midway through if you hit repeated 403s.
+- **Special instructions are unreliable.** Some merchants disable special instructions entirely. Always prefer `--options` for customizations (size, milk type, etc.). Only use `--special-instructions` for free-text requests that aren't covered by the item's option groups. If the merchant rejects special instructions, drop them and proceed without.
+
+## Customization Options
+
+Many items (especially coffee, boba, sandwiches) have required customization options like size, milk type, or toppings. Here's how to handle them:
+
+### Constructing nestedOptions JSON
+
+1. Run `vellum doordash item <storeId> <itemId> --json` to get the item's option groups
+2. Each option group has `id`, `name`, `required`, `minSelections`, `maxSelections`, and `choices`
+3. Build a JSON array of selections matching the DoorDash format:
+
+```json
+[
+  {
+    "optionId": "<option-group-id>",
+    "optionChoiceId": "<choice-id>",
+    "quantity": 1,
+    "nestedOptions": []
+  }
+]
+```
+
+For choices with nested sub-options (e.g., selecting "Oat Milk" under the "Milk" option within a size), add them to the `nestedOptions` array of the parent choice.
+
+4. Pass the JSON string to `cart add --options '<json>'`
+
+### Special Instructions
+
+Use `--special-instructions` on `cart add` for free-text requests like "extra hot", "no ice", "light foam". The `item` command response includes `specialInstructionsConfig` with the max length and whether instructions are supported.
+
+**Warning:** Some merchants disable special instructions entirely. If `specialInstructionsConfig.isEnabled` is false, or if the add-to-cart call returns an error about special requests, drop the instructions and retry without them. Always prefer `--options` for customizations — special instructions are a last resort for requests not covered by the item's option groups.
+
+### Learning Customizations via Ride Shotgun
+
+For complex items where constructing the JSON manually is difficult, use `cart learn`:
+
+1. Run `vellum doordash cart learn --json`
+2. A Chrome window opens — navigate to the item, customize it visually, and click "Add to Cart"
+3. The command auto-detects the `updateCartItem` operation and extracts the exact `nestedOptions` and `specialInstructions`
+4. Use the extracted options directly with `cart add --options '<json>'`
+
+You can also extract options from an existing recording with `vellum doordash inspect <recordingId> --extract-options --json`.
+
+### Coffee Order Example
+
+**User**: "Order a large oat milk latte with an extra shot from Blue Bottle"
+
+1. `vellum doordash search "Blue Bottle" --json` -> finds store
+2. `vellum doordash menu <storeId> --json` -> finds "Latte" item
+3. `vellum doordash item <storeId> <latteItemId> --json` -> returns options:
+   - Size (required, min:1, max:1): Small (id:101), Medium (id:102), Large (id:103, +$1.00)
+   - Milk (required, min:1, max:1): Whole (id:201), Oat (id:202, +$0.70), Almond (id:203, +$0.70)
+   - Extras (optional, min:0, max:5): Extra Shot (id:301, +$0.90), Vanilla Syrup (id:302, +$0.60)
+4. Construct options JSON and add to cart:
+```
+vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "Latte" --unit-price 550 --options '[{"optionId":"size-group-id","optionChoiceId":"103","quantity":1,"nestedOptions":[]},{"optionId":"milk-group-id","optionChoiceId":"202","quantity":1,"nestedOptions":[]},{"optionId":"extras-group-id","optionChoiceId":"301","quantity":1,"nestedOptions":[]}]' --special-instructions "Extra hot" --json
+```
 
 ## Command Reference
 
@@ -73,10 +137,12 @@ vellum doordash search "<query>" --json    # Search restaurants
 vellum doordash menu <storeId> --json      # Get store menu (auto-detects retail stores)
 vellum doordash store-search <storeId> "<query>" --json  # Search items within a convenience/pharmacy store
 vellum doordash item <storeId> <itemId> --json  # Get item details + options
-vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> [--quantity <n>] [--cart-id <id>] --json
+vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> [--quantity <n>] [--cart-id <id>] [--options '<json>'] [--special-instructions "<text>"] --json
 vellum doordash cart remove --cart-id <id> --item-id <orderItemId> --json
 vellum doordash cart view <cartId> --json
 vellum doordash cart list [--store-id <id>] --json
+vellum doordash cart learn --json                 # Learn customization options by recording browser interaction
+vellum doordash inspect <recordingId> --extract-options --json  # Extract nestedOptions from a recording
 vellum doordash checkout <cartId> [--address-id <id>] --json
 vellum doordash payment-methods --json     # List saved payment methods
 vellum doordash order place --cart-id <id> --store-id <id> --total <cents> [--tip <cents>] [--delivery-option <type>] [--dropoff-option <id>] [--payment-uuid <uuid>] --json

--- a/assistant/src/doordash/client.ts
+++ b/assistant/src/doordash/client.ts
@@ -424,12 +424,31 @@ export interface ItemDetails {
     id: string;
     name: string;
     required: boolean;
+    minSelections?: number;
+    maxSelections?: number;
     choices: Array<{
       id: string;
       name: string;
       price?: string;
+      unitAmount?: number;
+      defaultQuantity?: number;
+      nestedOptions?: Array<{
+        id: string;
+        name: string;
+        required: boolean;
+        choices: Array<{
+          id: string;
+          name: string;
+          price?: string;
+        }>;
+      }>;
     }>;
   }>;
+  specialInstructionsConfig?: {
+    maxLength: number;
+    placeholderText?: string;
+    isEnabled: boolean;
+  };
 }
 
 export async function getItemDetails(
@@ -595,7 +614,6 @@ export interface PaymentMethod {
   id: string;
   type: string;
   last4: string;
-  cardBrand: string;
   isDefault: boolean;
   uuid: string;
 }
@@ -614,7 +632,6 @@ export async function getPaymentMethods(): Promise<PaymentMethod[]> {
     id: String(p.id ?? ''),
     type: String(p.type ?? ''),
     last4: String(p.last4 ?? ''),
-    cardBrand: String(p.cardBrand ?? ''),
     isDefault: Boolean(p.isDefault),
     uuid: String(p.paymentMethodUuid ?? p.uuid ?? ''),
   }));
@@ -800,11 +817,25 @@ function extractStoreInfo(feed: Record<string, unknown>): StoreInfo {
   };
 }
 
+function extractNestedOptions(extrasList: Array<Record<string, unknown>>): ItemDetails['options'][number]['choices'][number]['nestedOptions'] {
+  return extrasList.map(nested => ({
+    id: String(nested.id),
+    name: String(nested.name ?? ''),
+    required: !nested.isOptional,
+    choices: ((nested.options ?? []) as Array<Record<string, unknown>>).map(o => ({
+      id: String(o.id),
+      name: String(o.name ?? ''),
+      price: o.displayString as string | undefined,
+    })),
+  }));
+}
+
 function extractItemDetails(page: Record<string, unknown>): ItemDetails {
   const header = (page.itemHeader ?? {}) as Record<string, unknown>;
   const optionLists = (page.optionLists ?? []) as Array<Record<string, unknown>>;
+  const itemPreferences = page.itemPreferences as Record<string, unknown> | undefined;
 
-  return {
+  const result: ItemDetails = {
     id: String(header.id ?? ''),
     name: String(header.name ?? ''),
     description: header.description as string | undefined,
@@ -813,17 +844,42 @@ function extractItemDetails(page: Record<string, unknown>): ItemDetails {
     currency: header.currency as string | undefined,
     imageUrl: header.imgUrl as string | undefined,
     menuId: header.menuId as string | undefined,
-    options: optionLists.map(ol => ({
-      id: String(ol.id),
-      name: String(ol.name ?? ''),
-      required: !ol.isOptional,
-      choices: ((ol.options ?? []) as Array<Record<string, unknown>>).map(o => ({
-        id: String(o.id),
-        name: String(o.name ?? ''),
-        price: o.displayString as string | undefined,
-      })),
-    })),
+    options: optionLists.map(ol => {
+      const choices = ((ol.options ?? []) as Array<Record<string, unknown>>).map(o => {
+        const choice: ItemDetails['options'][number]['choices'][number] = {
+          id: String(o.id),
+          name: String(o.name ?? ''),
+          price: o.displayString as string | undefined,
+          unitAmount: o.unitAmount as number | undefined,
+          defaultQuantity: o.defaultQuantity as number | undefined,
+        };
+        const nestedExtrasList = (o.nestedExtrasList ?? []) as Array<Record<string, unknown>>;
+        if (nestedExtrasList.length > 0) {
+          choice.nestedOptions = extractNestedOptions(nestedExtrasList);
+        }
+        return choice;
+      });
+
+      return {
+        id: String(ol.id),
+        name: String(ol.name ?? ''),
+        required: !ol.isOptional,
+        minSelections: ol.minNumOptions as number | undefined,
+        maxSelections: ol.maxNumOptions as number | undefined,
+        choices,
+      };
+    }),
   };
+
+  if (itemPreferences) {
+    result.specialInstructionsConfig = {
+      maxLength: Number(itemPreferences.maxLength ?? 500),
+      placeholderText: itemPreferences.placeholderText as string | undefined,
+      isEnabled: itemPreferences.isEnabled !== false,
+    };
+  }
+
+  return result;
 }
 
 function extractRetailStoreInfo(feed: Record<string, unknown>): StoreInfo {

--- a/assistant/src/doordash/client.ts
+++ b/assistant/src/doordash/client.ts
@@ -872,10 +872,11 @@ function extractItemDetails(page: Record<string, unknown>): ItemDetails {
   };
 
   if (itemPreferences) {
+    const specialInstructions = (itemPreferences.specialInstructions ?? {}) as Record<string, unknown>;
     result.specialInstructionsConfig = {
-      maxLength: Number(itemPreferences.maxLength ?? 500),
-      placeholderText: itemPreferences.placeholderText as string | undefined,
-      isEnabled: itemPreferences.isEnabled !== false,
+      maxLength: Number(specialInstructions.characterMaxLength ?? 500),
+      placeholderText: specialInstructions.placeholderText as string | undefined,
+      isEnabled: specialInstructions.isEnabled !== false,
     };
   }
 

--- a/assistant/src/doordash/queries.ts
+++ b/assistant/src/doordash/queries.ts
@@ -1304,9 +1304,8 @@ query paymentMethodQuery {
     id
     type
     last4
-    cardBrand
     isDefault
-    uuid
+    paymentMethodUuid
     __typename
   }
 }`;


### PR DESCRIPTION
## Summary
- Add `--options` flag to `cart add` for passing item customization options (size, milk type, etc.) as nestedOptions JSON
- Add `cart learn` command that records a browser interaction via CDP and extracts the exact nestedOptions format
- Add `--extract-options` flag to `inspect` for pulling nestedOptions from existing recordings
- Enhance `ItemDetails` with selection constraints (`minSelections`/`maxSelections`), `unitAmount`, `defaultQuantity`, nested sub-options, and `specialInstructionsConfig`
- Fix broken `payment-methods` query: remove stale `cardBrand` field, rename `uuid` → `paymentMethodUuid` to match current DoorDash schema
- Update SKILL.md with customization guidance, coffee order example, rate limiting advice, and special instructions warnings

## Test plan
- [x] All 29 existing doordash tests pass
- [x] No new TypeScript errors introduced
- [ ] Smoke test: `vellum doordash item <storeId> <itemId> --json` returns richer option data
- [ ] Smoke test: `vellum doordash payment-methods --json` no longer errors on schema mismatch
- [ ] Smoke test: `vellum doordash cart add --options '<json>' ...` passes customizations through

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
