### PR TITLE
fix: fire-and-forget runLlm in handleUserAnswer to unblock HTTP and persist answer immediately

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -271,7 +271,7 @@ describe('call-orchestrator', () => {
 
   // ── handleUserAnswer ──────────────────────────────────────────────
 
-  test('handleUserAnswer: appends USER_ANSWERED to history and runs LLM', async () => {
+  test('handleUserAnswer: returns true immediately and fires LLM asynchronously', async () => {
     // First utterance triggers ASK_USER
     mockStreamFn.mockImplementation(() =>
       createMockStream(['Hold on. [ASK_USER: Preferred time?]']),
@@ -289,7 +289,12 @@ describe('call-orchestrator', () => {
       return createMockStream(['Great, I have scheduled for 3pm tomorrow.']);
     });
 
-    await orchestrator.handleUserAnswer('3pm tomorrow');
+    const accepted = await orchestrator.handleUserAnswer('3pm tomorrow');
+    expect(accepted).toBe(true);
+
+    // handleUserAnswer fires runLlm without awaiting, so give the
+    // microtask queue a tick to let the async LLM work complete.
+    await new Promise((r) => setTimeout(r, 50));
 
     // Should have streamed a response for the answer
     const tokensAfterAnswer = relay.sentTokens.filter((t) => t.token.includes('3pm'));

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -101,7 +101,11 @@ export class CallOrchestrator {
     // Append the user's answer as a special message the model recognizes
     this.conversationHistory.push({ role: 'user', content: `[USER_ANSWERED: ${answerText}]` });
 
-    await this.runLlm();
+    // Fire-and-forget: unblock the caller so the HTTP response and answer
+    // persistence happen immediately, before LLM streaming begins.
+    this.runLlm().catch((err) =>
+      log.error({ err, callSessionId: this.callSessionId }, 'runLlm failed after user answer'),
+    );
     return true;
   }
 


### PR DESCRIPTION
Addresses feedback on #5259: (1) handleUserAnswer no longer awaits runLlm(), returning immediately after state transition so HTTP response is not blocked. (2) Answer persistence happens before LLM work starts, preventing race with terminal status.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
