### PR TITLE
fix: preserve breaker state on under-lock skip and handle raceWithTimeout rejections

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1676,7 +1676,7 @@ async function raceWithTimeout<T>(
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
-      promise.then(() => 'completed' as const),
+      promise.then(() => 'completed' as const, () => 'completed' as const),
       new Promise<'timed_out'>((resolve) => {
         timer = setTimeout(() => resolve('timed_out'), timeoutMs);
       }),


### PR DESCRIPTION
Addresses feedback on #5250: (1) Under-lock breaker skip no longer falls through to recordSuccess(), preserving backoff state. (2) raceWithTimeout now handles promise rejections per its documented contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
