### PR TITLE
fix: generate video thumbnails for lazy-loaded attachments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -143,7 +143,23 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func generateThumbnail() async {
-        guard !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) else { return }
+        let base64: String
+        if !attachment.data.isEmpty {
+            base64 = attachment.data
+        } else if attachment.isLazyLoad,
+                  let port = daemonHttpPort,
+                  let attachmentId = attachment.id.isEmpty ? nil : attachment.id {
+            do {
+                base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
+            } catch {
+                log.error("Failed to fetch attachment for thumbnail \(attachment.id): \(error.localizedDescription)")
+                return
+            }
+        } else {
+            return
+        }
+
+        guard let data = Data(base64Encoded: base64) else { return }
 
         let fileURL = safeTempURL()
         do {
@@ -160,7 +176,6 @@ struct InlineVideoAttachmentView: View {
         if let cgImage = try? generator.copyCGImage(at: .zero, actualTime: nil) {
             let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
 
-            // Also update aspect ratio from the thumbnail
             let w = CGFloat(cgImage.width)
             let h = CGFloat(cgImage.height)
             if w > 0, h > 0 {


### PR DESCRIPTION
## Summary
- `generateThumbnail()` now fetches video data via the daemon HTTP endpoint when the attachment is lazy-loaded (empty `data`, non-nil `sizeBytes`), instead of returning early
- Previously, large video attachments had their base64 data stripped for IPC efficiency, which caused thumbnail generation to silently skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
