### PR TITLE
fix: guard ChatViewModel error handler against unrelated daemon errors

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -678,6 +678,12 @@ extension ChatViewModel {
 
         case .error(let err):
             log.error("Server error: \(err.message)")
+            // Only process errors relevant to this chat session. Generic daemon
+            // errors (e.g., IPC validation failures from unrelated message types
+            // like work_item_delete) should not pollute the chat UI.
+            guard isSending || isThinking || isCancelling || currentAssistantMessageId != nil || isWorkspaceRefinementInFlight else {
+                return
+            }
             isWorkspaceRefinementInFlight = false
             refinementMessagePreview = nil
             refinementStreamingText = nil


### PR DESCRIPTION
## Summary
- Generic daemon errors (e.g., IPC validation failures) were broadcast to all ChatViewModel subscribers, showing error toasts in chat even for unrelated operations like task deletion
- Added a guard to the `.error` handler in `ChatViewModel+MessageHandling.swift` so it only processes errors when the ChatViewModel is actively sending, thinking, cancelling, streaming, or refining
- This prevents unrelated daemon errors from polluting the chat UI and interfering with operations like work item deletion

## Test plan
- [ ] Delete a task from the task queue window — should not show "Invalid message type" toast in chat
- [ ] Send a chat message that triggers a daemon error — should still show the error toast correctly
- [ ] Cancel a pending message — error during cancellation should still be handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
