### PR TITLE
fix: exclude base and area tags from href asset extraction

### DIFF
--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -50,12 +50,12 @@ export function extractRemoteUrls(html: string): string[] {
     }
   }
 
-  // Match href="..." on any element except <a> tags (which are navigation links, not assets).
-  // Captures the tag name and href value so we can skip anchors.
+  // Match href="..." on any element except navigation/resolution tags (not assets).
+  // Captures the tag name and href value so we can skip them.
   const hrefRe = /<(\w+)\b[^>]*?\bhref\s*=\s*(?:"([^"]*?)"|'([^']*?)'|([^\s>]+))[^>]*?\/?>/gi;
   while ((m = hrefRe.exec(html)) !== null) {
     const tagName = m[1];
-    if (tagName.toLowerCase() === 'a') continue;
+    if (['a', 'base', 'area'].includes(tagName.toLowerCase())) continue;
     const url = m[2] ?? m[3] ?? m[4];
     if (url && /^https?:\/\//i.test(url)) {
       urls.add(url);


### PR DESCRIPTION
Addresses feedback from PR #5267. Adds base and area to the tag exclusion list alongside a, preventing navigation/resolution directives from being incorrectly materialized as assets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
