### PR TITLE
fix: sanitize attachment ID in video temp file path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -138,7 +138,8 @@ struct InlineVideoAttachmentView: View {
     private func safeTempURL() -> URL {
         let sanitized = (attachment.filename as NSString).lastPathComponent
         let safeName = sanitized.isEmpty ? "video" : sanitized
-        let uniqueName = attachment.id.isEmpty ? safeName : "\(attachment.id)-\(safeName)"
+        let sanitizedId = (attachment.id as NSString).lastPathComponent
+        let uniqueName = sanitizedId.isEmpty ? safeName : "\(sanitizedId)-\(safeName)"
         return FileManager.default.temporaryDirectory.appendingPathComponent(uniqueName)
     }
 


### PR DESCRIPTION
Addresses feedback from PR #5270. Sanitizes attachment.id with lastPathComponent before using it in the temp file path, preventing path traversal via crafted IPC attachment IDs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
