### PR TITLE
fix: only trim trailing newline when attachment directive is on its own line

### DIFF
--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -314,9 +314,12 @@ export function drainDirectiveDisplayBuffer(buffer: string): DirectiveDisplayDra
     if (!isValidDirective) {
       emitText += tag;
     } else {
-      // Trim the trailing newline before a stripped directive so consecutive
-      // tags don't leave a stack of blank lines in the streamed text.
-      if (emitText.endsWith('\n')) {
+      // Only trim the trailing newline when the directive occupied its own
+      // line (preceded by \n and followed by \n or end-of-buffer). This
+      // avoids corrupting inline text like "Hello\n<directive/>world" into
+      // "Helloworld".
+      const nextChar = buffer[end + 2];
+      if (emitText.endsWith('\n') && (nextChar === '\n' || nextChar === undefined)) {
         emitText = emitText.slice(0, -1);
       }
     }


### PR DESCRIPTION
Addresses feedback from PR #5274. The unconditional newline trim after stripping vellum-attachment directives could merge adjacent words (e.g. Hello\n<directive/>world → Helloworld). Now only removes the trailing newline when the directive occupied its own line (preceded by newline and followed by newline or end-of-buffer).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
