### PR TITLE
fix: calibrate payload size ceiling and update stale comments in browser-skill tests

### DIFF
--- a/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
+++ b/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
@@ -50,11 +50,12 @@ describe('browser skill cutover — startup tool payload', () => {
   test('serialized tool definitions payload still exceeds a reasonable floor', () => {
     const definitions = getAllToolDefinitions();
     const serialized = JSON.stringify(definitions);
-    // Startup payload is ~32 771 chars without browser tools.
-    // Floor at 30 000 catches accidental wholesale removal; ceiling ensures
-    // browser tools (~4 640 chars) haven't leaked back in.
+    // Startup payload is ~45 034 chars without browser tools.
+    // Floor at 30 000 catches accidental wholesale removal; ceiling at 47 000
+    // gives ~2 000 char headroom while still catching browser tool leakage
+    // (~4 640 chars would push it past the ceiling).
     expect(serialized.length).toBeGreaterThan(30_000);
-    expect(serialized.length).toBeLessThan(48_000);
+    expect(serialized.length).toBeLessThan(47_000);
   });
 
   test('no browser-categorised tools remain in startup registry', () => {

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -71,10 +71,11 @@ describe('browser skill migration end-state', () => {
       expect(defNames).not.toContain(name);
     }
 
-    // Payload ceiling: browser tools contribute ~4 640 chars.  If they leak
-    // back into startup definitions the payload would exceed 38 000.
+    // Payload ceiling: startup payload is ~45 034 chars.  Browser tools
+    // contribute ~4 640 chars — if they leak back in, the total would exceed
+    // 47 000.  The 2 000-char margin absorbs minor tool additions.
     const payloadSize = JSON.stringify(definitions).length;
-    expect(payloadSize).toBeLessThan(48_000);
+    expect(payloadSize).toBeLessThan(47_000);
   });
 
   // ── 2. Browser skill exists and is active ──────────────────────────


### PR DESCRIPTION
Addresses feedback from PR #5272. Determines the actual current payload size (45,034 chars) and sets the ceiling to 47,000 (actual + 2,000 margin) which still catches browser tool leakage (~4,640 chars). Updates stale comments that referenced old ~32,771 char payload size.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
