### PR TITLE
fix: use unscoped attachment lookup in HTTP endpoint

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -433,6 +433,32 @@ export function getAttachmentById(
 }
 
 /**
+ * Retrieve a single attachment by ID without assistant scoping.
+ * Used by the desktop HTTP endpoint where tenant isolation is not needed.
+ */
+export function getAttachmentByIdUnscoped(
+  attachmentId: string,
+): (StoredAttachment & { dataBase64: string }) | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .get();
+  if (!row) return null;
+  return {
+    id: row.id,
+    assistantId: row.assistantId,
+    originalFilename: row.originalFilename,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+    kind: row.kind,
+    dataBase64: row.dataBase64,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
  * Delete attachments from a specific candidate set that have no remaining
  * links in message_attachments. Only the given IDs are considered — this
  * prevents freshly uploaded (but not yet linked) attachments from being

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -118,7 +118,7 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
 }
 
 export function handleGetAttachment(attachmentId: string): Response {
-  const attachment = attachmentsStore.getAttachmentById("self", attachmentId);
+  const attachment = attachmentsStore.getAttachmentByIdUnscoped(attachmentId);
   if (!attachment) {
     return Response.json({ error: 'Attachment not found' }, { status: 404 });
   }


### PR DESCRIPTION
## Summary
- The `/v1/attachments/:id` HTTP endpoint hardcoded `assistantId: "self"` when looking up attachments, but some attachments are stored with `assistantId: "local-assistant"` — causing 404s for lazy-loaded video thumbnails and playback
- Added `getAttachmentByIdUnscoped()` to `attachments-store.ts` (matching the existing `getAttachmentsForMessageUnscoped` pattern used by `history_response`)
- Updated `handleGetAttachment` to use the unscoped lookup since this is a local desktop endpoint where tenant isolation is not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
